### PR TITLE
When importing, only check for reserved type names when importing a type

### DIFF
--- a/tests/baselines/reference/reservedNameOnInterfaceImport.errors.txt
+++ b/tests/baselines/reference/reservedNameOnInterfaceImport.errors.txt
@@ -1,0 +1,10 @@
+==== tests/cases/compiler/reservedNameOnInterfaceImport.ts (1 errors) ====
+    declare module test {
+        interface istring { }
+    
+        // Should error; 'test.istring' is a type, so this import conflicts with the 'string' type.
+        import string = test.istring;
+               ~~~~~~
+!!! Import name cannot be 'string'
+    }
+    

--- a/tests/baselines/reference/reservedNameOnInterfaceImport.js
+++ b/tests/baselines/reference/reservedNameOnInterfaceImport.js
@@ -1,0 +1,10 @@
+//// [reservedNameOnInterfaceImport.ts]
+declare module test {
+    interface istring { }
+
+    // Should error; 'test.istring' is a type, so this import conflicts with the 'string' type.
+    import string = test.istring;
+}
+
+
+//// [reservedNameOnInterfaceImport.js]

--- a/tests/baselines/reference/reservedNameOnModuleImport.js
+++ b/tests/baselines/reference/reservedNameOnModuleImport.js
@@ -1,0 +1,10 @@
+//// [reservedNameOnModuleImport.ts]
+declare module test {
+    module mstring { }
+
+    // Should be fine; this does not clobber any declared values.
+    export import string = mstring;
+}
+
+
+//// [reservedNameOnModuleImport.js]

--- a/tests/baselines/reference/reservedNameOnModuleImportWithInterface.errors.txt
+++ b/tests/baselines/reference/reservedNameOnModuleImportWithInterface.errors.txt
@@ -1,0 +1,11 @@
+==== tests/cases/compiler/reservedNameOnModuleImportWithInterface.ts (1 errors) ====
+    declare module test {
+        interface mi_string { }
+        module mi_string { }
+    
+        // Should error; imports both a type and a module, which means it conflicts with the 'string' type.
+        import string = mi_string;
+               ~~~~~~
+!!! Import name cannot be 'string'
+    }
+    

--- a/tests/baselines/reference/reservedNameOnModuleImportWithInterface.js
+++ b/tests/baselines/reference/reservedNameOnModuleImportWithInterface.js
@@ -1,0 +1,11 @@
+//// [reservedNameOnModuleImportWithInterface.ts]
+declare module test {
+    interface mi_string { }
+    module mi_string { }
+
+    // Should error; imports both a type and a module, which means it conflicts with the 'string' type.
+    import string = mi_string;
+}
+
+
+//// [reservedNameOnModuleImportWithInterface.js]

--- a/tests/cases/compiler/reservedNameOnInterfaceImport.ts
+++ b/tests/cases/compiler/reservedNameOnInterfaceImport.ts
@@ -1,0 +1,6 @@
+declare module test {
+    interface istring { }
+
+    // Should error; 'test.istring' is a type, so this import conflicts with the 'string' type.
+    import string = test.istring;
+}

--- a/tests/cases/compiler/reservedNameOnModuleImport.ts
+++ b/tests/cases/compiler/reservedNameOnModuleImport.ts
@@ -1,0 +1,6 @@
+declare module test {
+    module mstring { }
+
+    // Should be fine; this does not clobber any declared values.
+    export import string = mstring;
+}

--- a/tests/cases/compiler/reservedNameOnModuleImportWithInterface.ts
+++ b/tests/cases/compiler/reservedNameOnModuleImportWithInterface.ts
@@ -1,0 +1,7 @@
+declare module test {
+    interface mi_string { }
+    module mi_string { }
+
+    // Should error; imports both a type and a module, which means it conflicts with the 'string' type.
+    import string = mi_string;
+}


### PR DESCRIPTION
Given the following

```
declare module m {
    module s {}
    export import string = s;
}
```

we would previously give the error

```
Import name cannot be 'string'
```

when `string` is clearly not in conflict with any declared values.
