### PR TITLE
Condense all error spans to just the name for variable, class, interface, module, enum and enum member

### DIFF
--- a/tests/baselines/reference/ExportAssignment7.errors.txt
+++ b/tests/baselines/reference/ExportAssignment7.errors.txt
@@ -1,9 +1,8 @@
 ==== tests/cases/compiler/ExportAssignment7.ts (3 errors) ====
     export class C {
-    ~~~~~~~~~~~~~~~~
-    }
-    ~
+                 ~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+    }
     
     export = B;
     ~~~~~~~~~~~

--- a/tests/baselines/reference/TwoInternalModulesThatMergeEachWithExportedLocalVarsOfTheSameName.errors.txt
+++ b/tests/baselines/reference/TwoInternalModulesThatMergeEachWithExportedLocalVarsOfTheSameName.errors.txt
@@ -1,33 +1,20 @@
 ==== tests/cases/conformance/internalModules/DeclarationMerging/part1.ts (1 errors) ====
     export module A {
-    ~~~~~~~~~~~~~~~~~
+                  ~
+!!! Cannot compile external modules unless the '--module' flag is provided.
         export interface Point {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             x: number;
-    ~~~~~~~~~~~~~~~~~~
             y: number;
-    ~~~~~~~~~~~~~~~~~~
         }
-    ~~~~~
-    
     
         export module Utils {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~
             export function mirror<T extends Point>(p: T) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 return { x: p.y, y: p.x };
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             }
-    ~~~~~~~~~
         }
-    ~~~~~
-    
     
         export var Origin: Point = { x: 0, y: 0 };
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     }
-    ~
-!!! Cannot compile external modules unless the '--module' flag is provided.
     
 ==== tests/cases/conformance/internalModules/DeclarationMerging/part2.ts (3 errors) ====
     export module A {

--- a/tests/baselines/reference/ambiguousOverload.errors.txt
+++ b/tests/baselines/reference/ambiguousOverload.errors.txt
@@ -4,7 +4,7 @@
     function foof(bar: any): any { return bar };
     var x: number = foof("s", null);
     var y: string = foof("s", null);
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type 'string'.
     
     function foof2(bar: string, x): string;
@@ -12,5 +12,5 @@
     function foof2(bar: any): any { return bar };
     var x2: string = foof2("s", null);
     var y2: number = foof2("s", null);
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/arrayAssignmentTest1.errors.txt
+++ b/tests/baselines/reference/arrayAssignmentTest1.errors.txt
@@ -45,19 +45,19 @@
     var arr_c3: C3[] = [];
     
     var i1_error: I1 = []; // should be an error - is
-        ~~~~~~~~~~~~~~~~~
+        ~~~~~~~~
 !!! Type 'undefined[]' is not assignable to type 'I1':
 !!!   Property 'IM1' is missing in type 'undefined[]'.
     var c1_error: C1 = []; // should be an error - is
-        ~~~~~~~~~~~~~~~~~
+        ~~~~~~~~
 !!! Type 'undefined[]' is not assignable to type 'C1':
 !!!   Property 'IM1' is missing in type 'undefined[]'.
     var c2_error: C2 = []; // should be an error - is
-        ~~~~~~~~~~~~~~~~~
+        ~~~~~~~~
 !!! Type 'undefined[]' is not assignable to type 'C2':
 !!!   Property 'C2M1' is missing in type 'undefined[]'.
     var c3_error: C3 = []; // should be an error - is
-        ~~~~~~~~~~~~~~~~~
+        ~~~~~~~~
 !!! Type 'undefined[]' is not assignable to type 'C3':
 !!!   Property 'CM3M1' is missing in type 'undefined[]'.
     

--- a/tests/baselines/reference/arrayAssignmentTest5.errors.txt
+++ b/tests/baselines/reference/arrayAssignmentTest5.errors.txt
@@ -22,7 +22,7 @@
             public onEnter(line:string, state:IState, offset:number):IAction {
                 var lineTokens:ILineTokens= this.tokenize(line, state, true);
                 var tokens:IStateToken[]= lineTokens.tokens;
-                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    ~~~~~~
 !!! Type 'IToken[]' is not assignable to type 'IStateToken[]':
 !!!   Type 'IToken' is not assignable to type 'IStateToken':
 !!!     Property 'state' is missing in type 'IToken'.

--- a/tests/baselines/reference/arraySigChecking.errors.txt
+++ b/tests/baselines/reference/arraySigChecking.errors.txt
@@ -19,7 +19,7 @@
     }
     var myVar: myInt;
     var strArray: string[] = [myVar.voidFn()];
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~
 !!! Type 'void[]' is not assignable to type 'string[]':
 !!!   Type 'void' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/arrayTypeOfTypeOf.errors.txt
+++ b/tests/baselines/reference/arrayTypeOfTypeOf.errors.txt
@@ -9,7 +9,7 @@
 !!! '=' expected.
                                  ~
 !!! Expression expected.
-        ~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~
 !!! Type 'number' is not assignable to type '{ (arrayLength?: number): any[]; <T>(arrayLength: number): T[]; <T>(...items: T[]): T[]; new (arrayLength?: number): any[]; new <T>(arrayLength: number): T[]; new <T>(...items: T[]): T[]; isArray(arg: any): boolean; prototype: any[]; }':
 !!!   Property 'isArray' is missing in type 'Number'.
     var xs4: typeof Array<typeof x>;
@@ -17,5 +17,5 @@
 !!! '=' expected.
                                    ~
 !!! Expression expected.
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~
 !!! Type 'number' is not assignable to type '{ (arrayLength?: number): any[]; <T>(arrayLength: number): T[]; <T>(...items: T[]): T[]; new (arrayLength?: number): any[]; new <T>(arrayLength: number): T[]; new <T>(...items: T[]): T[]; isArray(arg: any): boolean; prototype: any[]; }'.

--- a/tests/baselines/reference/assignmentCompatBug2.errors.txt
+++ b/tests/baselines/reference/assignmentCompatBug2.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/compiler/assignmentCompatBug2.ts (5 errors) ====
     var b2: { b: number;} = { a: 0 }; // error
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type '{ a: number; }' is not assignable to type '{ b: number; }':
 !!!   Property 'b' is missing in type '{ a: number; }'.
     

--- a/tests/baselines/reference/assignmentToObject.errors.txt
+++ b/tests/baselines/reference/assignmentToObject.errors.txt
@@ -2,7 +2,7 @@
     var a = { toString: 5 };
     var b: {} = a;  // ok
     var c: Object = a;  // should be error
-        ~~~~~~~~~~~~~
+        ~
 !!! Type '{ toString: number; }' is not assignable to type 'Object':
 !!!   Types of property 'toString' are incompatible:
 !!!     Type 'number' is not assignable to type '() => string'.

--- a/tests/baselines/reference/assignmentToObjectAndFunction.errors.txt
+++ b/tests/baselines/reference/assignmentToObjectAndFunction.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/compiler/assignmentToObjectAndFunction.ts (3 errors) ====
     var errObj: Object = { toString: 0 }; // Error, incompatible toString
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~
 !!! Type '{ toString: number; }' is not assignable to type 'Object':
 !!!   Types of property 'toString' are incompatible:
 !!!     Type 'number' is not assignable to type '() => string'.
@@ -11,7 +11,7 @@
     }; // Ok, because toString is a subtype of Object's toString
     
     var errFun: Function = {}; // Error for no call signature
-        ~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~
 !!! Type '{}' is not assignable to type 'Function':
 !!!   Property 'apply' is missing in type '{}'.
     
@@ -35,7 +35,7 @@
     }
     
     var badFundule: Function = bad; // error
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~
 !!! Type 'typeof bad' is not assignable to type 'Function':
 !!!   Types of property 'apply' are incompatible:
 !!!     Type 'number' is not assignable to type '(thisArg: any, argArray?: any) => any'.

--- a/tests/baselines/reference/augmentedTypeAssignmentCompatIndexSignature.errors.txt
+++ b/tests/baselines/reference/augmentedTypeAssignmentCompatIndexSignature.errors.txt
@@ -14,19 +14,15 @@
     var f = () => { };
     
     var v1: {
-        ~~~~~
-        [n: number]: Foo
-    ~~~~~~~~~~~~~~~~~~~~
-    } = o; // Should be allowed
-    ~~~~~
+        ~~
 !!! Type '{}' is not assignable to type '{ [x: number]: Foo; }':
 !!!   Index signature is missing in type '{}'.
+        [n: number]: Foo
+    } = o; // Should be allowed
     
     var v2: {
-        ~~~~~
-        [n: number]: Bar
-    ~~~~~~~~~~~~~~~~~~~~
-    } = f; // Should be allowed
-    ~~~~~
+        ~~
 !!! Type '() => void' is not assignable to type '{ [x: number]: Bar; }':
 !!!   Index signature is missing in type '() => void'.
+        [n: number]: Bar
+    } = f; // Should be allowed

--- a/tests/baselines/reference/callOverloadViaElementAccessExpression.errors.txt
+++ b/tests/baselines/reference/callOverloadViaElementAccessExpression.errors.txt
@@ -9,8 +9,8 @@
     
     var c = new C();
     var r: string = c['foo'](1);
-        ~~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type 'string'.
     var r2: number = c['foo']('');
-        ~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/classExtendsItself.errors.txt
+++ b/tests/baselines/reference/classExtendsItself.errors.txt
@@ -1,12 +1,12 @@
 ==== tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItself.ts (3 errors) ====
     class C extends C { } // error
-    ~~~~~~~~~~~~~~~~~~~~~
+          ~
 !!! Type 'C' recursively references itself as a base type.
     
     class D<T> extends D<T> { } // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          ~
 !!! Type 'D<T>' recursively references itself as a base type.
     
     class E<T> extends E<string> { } // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          ~
 !!! Type 'E<T>' recursively references itself as a base type.

--- a/tests/baselines/reference/classExtendsItselfIndirectly.errors.txt
+++ b/tests/baselines/reference/classExtendsItselfIndirectly.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly.ts (2 errors) ====
     class C extends E { foo: string; } // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          ~
 !!! Type 'C' recursively references itself as a base type.
     
     class D extends C { bar: string; }
@@ -8,7 +8,7 @@
     class E extends D { baz: number; }
     
     class C2<T> extends E2<T> { foo: T; } // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          ~~
 !!! Type 'C2<T>' recursively references itself as a base type.
     
     class D2<T> extends C2<T> { bar: T; }

--- a/tests/baselines/reference/classExtendsItselfIndirectly2.errors.txt
+++ b/tests/baselines/reference/classExtendsItselfIndirectly2.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly2.ts (2 errors) ====
     class C extends N.E { foo: string; } // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          ~
 !!! Type 'C' recursively references itself as a base type.
     
     module M {
@@ -14,7 +14,7 @@
     
     module O {
         class C2<T> extends Q.E2<T> { foo: T; } // error
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~~
 !!! Type 'C2<T>' recursively references itself as a base type.
     
         module P {

--- a/tests/baselines/reference/classExtendsItselfIndirectly3.errors.txt
+++ b/tests/baselines/reference/classExtendsItselfIndirectly3.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly_file1.ts (1 errors) ====
     class C extends E { foo: string; } // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          ~
 !!! Type 'C' recursively references itself as a base type.
     
 ==== tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly_file2.ts (0 errors) ====
@@ -11,7 +11,7 @@
     
 ==== tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly_file4.ts (1 errors) ====
     class C2<T> extends E2<T> { foo: T; } // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          ~~
 !!! Type 'C2<T>' recursively references itself as a base type.
     
 ==== tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsItselfIndirectly_file5.ts (0 errors) ====

--- a/tests/baselines/reference/classInheritence.errors.txt
+++ b/tests/baselines/reference/classInheritence.errors.txt
@@ -1,5 +1,5 @@
 ==== tests/cases/compiler/classInheritence.ts (1 errors) ====
     class B extends A { }
     class A extends A { }
-    ~~~~~~~~~~~~~~~~~~~~~
+          ~
 !!! Type 'A' recursively references itself as a base type.

--- a/tests/baselines/reference/classMemberInitializerWithLamdaScoping3.errors.txt
+++ b/tests/baselines/reference/classMemberInitializerWithLamdaScoping3.errors.txt
@@ -6,23 +6,15 @@
         log(msg?: any): void;
     };
     export class Test1 {
-    ~~~~~~~~~~~~~~~~~~~~
+                 ~~~~~
+!!! Cannot compile external modules unless the '--module' flag is provided.
         constructor(private field1: string) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         }
-    ~~~~~
         messageHandler = () => {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             console.log(field1); // But this should be error as the field1 will resolve to var field1 
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                         ~~~~~~
 !!! Initializer of instance member variable 'messageHandler' cannot reference identifier 'field1' declared in the constructor.
                                  // but since this code would be generated inside constructor, in generated js
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                  // it would resolve to private field1 and thats not what user intended here. 
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         };
-    ~~~~~~
     }
-    ~
-!!! Cannot compile external modules unless the '--module' flag is provided.

--- a/tests/baselines/reference/classSideInheritance3.errors.txt
+++ b/tests/baselines/reference/classSideInheritance3.errors.txt
@@ -15,9 +15,9 @@
     }
     
     var r1: typeof A = B; // error
-        ~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'typeof B' is not assignable to type 'typeof A'.
     var r2: new (x: string) => A = B; // error
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'typeof B' is not assignable to type 'new (x: string) => A'.
     var r3: typeof A = C; // ok

--- a/tests/baselines/reference/collisionSuperAndLocalVarInAccessors.errors.txt
+++ b/tests/baselines/reference/collisionSuperAndLocalVarInAccessors.errors.txt
@@ -18,7 +18,7 @@
             ~~~~~
 !!! Accessors are only available when targeting ECMAScript 5 and higher.
             var _super = 10; // Should be error
-                ~~~~~~~~~~~
+                ~~~~~~
 !!! Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
             return 10;
         }
@@ -26,7 +26,7 @@
             ~~~~~
 !!! Accessors are only available when targeting ECMAScript 5 and higher.
             var _super = 10; // Should be error
-                ~~~~~~~~~~~
+                ~~~~~~
 !!! Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
         }
     }
@@ -36,7 +36,7 @@
 !!! Accessors are only available when targeting ECMAScript 5 and higher.
             var x = () => {
                 var _super = 10; // Should be error
-                    ~~~~~~~~~~~
+                    ~~~~~~
 !!! Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
             }
             return 10;
@@ -46,7 +46,7 @@
 !!! Accessors are only available when targeting ECMAScript 5 and higher.
             var x = () => {
                 var _super = 10; // Should be error
-                    ~~~~~~~~~~~
+                    ~~~~~~
 !!! Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
             }
         }

--- a/tests/baselines/reference/collisionSuperAndLocalVarInConstructor.errors.txt
+++ b/tests/baselines/reference/collisionSuperAndLocalVarInConstructor.errors.txt
@@ -9,7 +9,7 @@
         constructor() {
             super();
             var _super = 10; // Should be error 
-                ~~~~~~~~~~~
+                ~~~~~~
 !!! Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
         }
     }
@@ -18,7 +18,7 @@
             super();
             var x = () => {
                 var _super = 10; // Should be error
-                    ~~~~~~~~~~~
+                    ~~~~~~
 !!! Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
             }
         }

--- a/tests/baselines/reference/collisionSuperAndLocalVarInMethod.errors.txt
+++ b/tests/baselines/reference/collisionSuperAndLocalVarInMethod.errors.txt
@@ -8,7 +8,7 @@
     class b extends Foo {
         public foo() {
             var _super = 10; // Should be error 
-                ~~~~~~~~~~~
+                ~~~~~~
 !!! Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
         }
     }
@@ -16,7 +16,7 @@
         public foo() {
             var x = () => {
                 var _super = 10; // Should be error
-                    ~~~~~~~~~~~
+                    ~~~~~~
 !!! Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
             }
         }

--- a/tests/baselines/reference/collisionSuperAndLocalVarInProperty.errors.txt
+++ b/tests/baselines/reference/collisionSuperAndLocalVarInProperty.errors.txt
@@ -12,7 +12,7 @@
         public prop2 = {
             doStuff: () => {
                 var _super = 10; // Should be error 
-                    ~~~~~~~~~~~
+                    ~~~~~~
 !!! Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
             }
         }

--- a/tests/baselines/reference/commaOperatorOtherInvalidOperation.errors.txt
+++ b/tests/baselines/reference/commaOperatorOtherInvalidOperation.errors.txt
@@ -5,7 +5,7 @@
         return x, y;
     }
     var resultIsString: number = foo(1, "123"); //error here
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~~~
 !!! Type 'string' is not assignable to type 'number'.
     
     //TypeParameters
@@ -13,6 +13,6 @@
         var x: T1;
         var y: T2;
         var result: T1 = (x, y); //error here
-            ~~~~~~~~~~~~~~~~~~~
+            ~~~~~~
 !!! Type 'T2' is not assignable to type 'T1'.
     }

--- a/tests/baselines/reference/complicatedGenericRecursiveBaseClassReference.errors.txt
+++ b/tests/baselines/reference/complicatedGenericRecursiveBaseClassReference.errors.txt
@@ -1,11 +1,9 @@
 ==== tests/cases/compiler/complicatedGenericRecursiveBaseClassReference.ts (2 errors) ====
     class S18<B, A, C> extends S18<A[], { S19: A; (): A }[], C[]>
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    {
-    ~
-    }
-    ~
+          ~~~
 !!! Type 'S18<B, A, C>' recursively references itself as a base type.
+    {
+    }
     (new S18(123)).S18 = 0;
      ~~~~~~~~~~~~
 !!! Supplied parameters do not match any signature of call target.

--- a/tests/baselines/reference/conditionalExpression1.errors.txt
+++ b/tests/baselines/reference/conditionalExpression1.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/compiler/conditionalExpression1.ts (2 errors) ====
     var x: boolean = (true ? 1 : ""); // should be an error
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type '{}' is not assignable to type 'boolean'.
                       ~~~~~~~~~~~~~
 !!! No best common type exists between 'number' and 'string'.

--- a/tests/baselines/reference/conditionalOperatorWithoutIdenticalBCT.errors.txt
+++ b/tests/baselines/reference/conditionalOperatorWithoutIdenticalBCT.errors.txt
@@ -19,30 +19,30 @@
     
     //Be contextually typed and and bct is not identical
     var result2: A = true ? a : b;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~
 !!! Type '{}' is not assignable to type 'A':
 !!!   Property 'propertyA' is missing in type '{}'.
                      ~~~~~~~~~~~~
 !!! No best common type exists between 'A', 'A', and 'B'.
     var result3: B = true ? a : b;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~
 !!! Type '{}' is not assignable to type 'B':
 !!!   Property 'propertyB' is missing in type '{}'.
                      ~~~~~~~~~~~~
 !!! No best common type exists between 'B', 'A', and 'B'.
     
     var result4: (t: X) => number = true ? (m) => m.propertyX1 : (n) => n.propertyX2;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~
 !!! Type '{}' is not assignable to type '(t: X) => number'.
                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! No best common type exists between '(t: X) => number', '(m: X) => number', and '(n: X) => string'.
     var result5: (t: X) => string = true ? (m) => m.propertyX1 : (n) => n.propertyX2;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~
 !!! Type '{}' is not assignable to type '(t: X) => string'.
                                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! No best common type exists between '(t: X) => string', '(m: X) => number', and '(n: X) => string'.
     var result6: (t: X) => boolean = true ? (m) => m.propertyX1 : (n) => n.propertyX2;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~
 !!! Type '{}' is not assignable to type '(t: X) => boolean'.
                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! No best common type exists between '(t: X) => boolean', '(m: X) => number', and '(n: X) => string'.

--- a/tests/baselines/reference/constructorAsType.errors.txt
+++ b/tests/baselines/reference/constructorAsType.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/compiler/constructorAsType.ts (1 errors) ====
     var Person:new () => {name: string;} = function () {return {name:"joe"};};
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~
 !!! Type '() => { name: string; }' is not assignable to type 'new () => { name: string; }'.
     
     var Person2:{new() : {name:string;};};

--- a/tests/baselines/reference/contextualTyping.errors.txt
+++ b/tests/baselines/reference/contextualTyping.errors.txt
@@ -233,6 +233,6 @@
     interface A { x: string; }
     interface B extends A { }
     var x: B = { };
-        ~~~~~~~~~~
+        ~
 !!! Type '{}' is not assignable to type 'B':
 !!!   Property 'x' is missing in type '{}'.

--- a/tests/baselines/reference/contextualTypingOfArrayLiterals1.errors.txt
+++ b/tests/baselines/reference/contextualTypingOfArrayLiterals1.errors.txt
@@ -4,7 +4,7 @@
     }
     
     var x3: I = [new Date(), 1]; 
-        ~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type '{}[]' is not assignable to type 'I':
 !!!   Index signatures are incompatible:
 !!!     Type '{}' is not assignable to type 'Date':

--- a/tests/baselines/reference/contextualTypingOfConditionalExpression2.errors.txt
+++ b/tests/baselines/reference/contextualTypingOfConditionalExpression2.errors.txt
@@ -10,7 +10,7 @@
     }
     
     var x2: (a: A) => void = true ? (a: C) => a.foo : (b: number) => { };
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type '{}' is not assignable to type '(a: A) => void'.
                              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! No best common type exists between '(a: A) => void', '(a: C) => number', and '(b: number) => void'.

--- a/tests/baselines/reference/crashInsourcePropertyIsRelatableToTargetProperty.errors.txt
+++ b/tests/baselines/reference/crashInsourcePropertyIsRelatableToTargetProperty.errors.txt
@@ -10,7 +10,7 @@
         return null;
     }
     var a: D = foo("hi", []);
-        ~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type '(x: "hi", items: string[]) => typeof foo' is not assignable to type 'D':
 !!!   Property 'x' is missing in type '(x: "hi", items: string[]) => typeof foo'.
     

--- a/tests/baselines/reference/deleteOperator1.errors.txt
+++ b/tests/baselines/reference/deleteOperator1.errors.txt
@@ -3,5 +3,5 @@
     var x: boolean = delete a;
     var y: any = delete a;
     var z: number = delete a;
-        ~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'boolean' is not assignable to type 'number'.

--- a/tests/baselines/reference/dontShowCompilerGeneratedMembers.errors.txt
+++ b/tests/baselines/reference/dontShowCompilerGeneratedMembers.errors.txt
@@ -1,8 +1,9 @@
 ==== tests/cases/compiler/dontShowCompilerGeneratedMembers.ts (5 errors) ====
     var f: {
-        ~~~~
+        ~
+!!! Type 'number' is not assignable to type '{ <>(): any; x: number; }':
+!!!   Property 'x' is missing in type 'Number'.
         x: number;
-    ~~~~~~~~~~~~~~
         <-
         ~
 !!! Type parameter list cannot be empty.
@@ -10,9 +11,6 @@
 !!! '(' expected.
          ~
 !!! Type parameter declaration expected.
-    ~~~~~~
-!!! Type 'number' is not assignable to type '{ <>(): any; x: number; }':
-!!!   Property 'x' is missing in type 'Number'.
     };
     ~
 !!! Expression expected.

--- a/tests/baselines/reference/enumAssignability.errors.txt
+++ b/tests/baselines/reference/enumAssignability.errors.txt
@@ -32,30 +32,30 @@
     
         var b: number = e; // ok
         var c: string = e;
-            ~~~~~~~~~~~~~
+            ~
 !!! Type 'E' is not assignable to type 'string'.
         var d: boolean = e;
-            ~~~~~~~~~~~~~~
+            ~
 !!! Type 'E' is not assignable to type 'boolean'.
         var ee: Date = e;
-            ~~~~~~~~~~~~
+            ~~
 !!! Type 'E' is not assignable to type 'Date':
 !!!   Property 'toDateString' is missing in type 'Number'.
         var f: any = e; // ok
         var g: void = e;
-            ~~~~~~~~~~~
+            ~
 !!! Type 'E' is not assignable to type 'void'.
         var h: Object = e;
         var i: {} = e;
         var j: () => {} = e;
-            ~~~~~~~~~~~~~~~
+            ~
 !!! Type 'E' is not assignable to type '() => {}'.
         var k: Function = e;
-            ~~~~~~~~~~~~~~~
+            ~
 !!! Type 'E' is not assignable to type 'Function':
 !!!   Property 'apply' is missing in type 'Number'.
         var l: (x: number) => string = e;
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            ~
 !!! Type 'E' is not assignable to type '(x: number) => string'.
         ac = e;
         ~~
@@ -66,19 +66,19 @@
 !!! Type 'E' is not assignable to type 'I':
 !!!   Property 'foo' is missing in type 'Number'.
         var m: number[] = e;
-            ~~~~~~~~~~~~~~~
+            ~
 !!! Type 'E' is not assignable to type 'number[]':
 !!!   Property 'concat' is missing in type 'Number'.
         var n: { foo: string } = e;
-            ~~~~~~~~~~~~~~~~~~~~~~
+            ~
 !!! Type 'E' is not assignable to type '{ foo: string; }':
 !!!   Property 'foo' is missing in type 'Number'.
         var o: <T>(x: T) => T = e;
-            ~~~~~~~~~~~~~~~~~~~~~
+            ~
 !!! Type 'E' is not assignable to type '<T>(x: T) => T'.
         var p: Number = e;
         var q: String = e;
-            ~~~~~~~~~~~~~
+            ~
 !!! Type 'E' is not assignable to type 'String':
 !!!   Property 'charAt' is missing in type 'Number'.
     
@@ -95,10 +95,10 @@
             ~
 !!! Type 'E' is not assignable to type 'V'.
             var a: A = e;
-                ~~~~~~~~
+                ~
 !!! Type 'E' is not assignable to type 'A'.
             var b: B = e;
-                ~~~~~~~~
+                ~
 !!! Type 'E' is not assignable to type 'B'.
         }
     }

--- a/tests/baselines/reference/enumAssignmentCompat.errors.txt
+++ b/tests/baselines/reference/enumAssignmentCompat.errors.txt
@@ -25,24 +25,24 @@
     var x: WStatic = W;
     var y: typeof W = W;
     var z: number = W; // error
-        ~~~~~~~~~~~~~
+        ~
 !!! Type 'typeof W' is not assignable to type 'number'.
     var a: number = W.a;
     var b: typeof W = W.a; // error
-        ~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'W' is not assignable to type 'typeof W':
 !!!   Property 'D' is missing in type 'Number'.
     var c: typeof W.a = W.a;
     var d: typeof W = 3; // error
-        ~~~~~~~~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type 'typeof W'.
     var e: typeof W.a = 4;
     var f: WStatic = W.a; // error
-        ~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'W' is not assignable to type 'WStatic':
 !!!   Property 'a' is missing in type 'Number'.
     var g: WStatic = 5; // error
-        ~~~~~~~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type 'WStatic'.
     var h: W = 3;
     var i: W = W.a;

--- a/tests/baselines/reference/enumAssignmentCompat2.errors.txt
+++ b/tests/baselines/reference/enumAssignmentCompat2.errors.txt
@@ -24,24 +24,24 @@
     var x: WStatic = W;
     var y: typeof W = W;
     var z: number = W; // error
-        ~~~~~~~~~~~~~
+        ~
 !!! Type 'typeof W' is not assignable to type 'number'.
     var a: number = W.a;
     var b: typeof W = W.a; // error
-        ~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'W' is not assignable to type 'typeof W':
 !!!   Property 'a' is missing in type 'Number'.
     var c: typeof W.a = W.a;
     var d: typeof W = 3; // error
-        ~~~~~~~~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type 'typeof W'.
     var e: typeof W.a = 4;
     var f: WStatic = W.a; // error
-        ~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'W' is not assignable to type 'WStatic':
 !!!   Property 'a' is missing in type 'Number'.
     var g: WStatic = 5; // error
-        ~~~~~~~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type 'WStatic'.
     var h: W = 3;
     var i: W = W.a;

--- a/tests/baselines/reference/errorOnContextuallyTypedReturnType.errors.txt
+++ b/tests/baselines/reference/errorOnContextuallyTypedReturnType.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/compiler/errorOnContextuallyTypedReturnType.ts (1 errors) ====
     var n1: () => boolean = function () { }; // expect an error here
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type '() => void' is not assignable to type '() => boolean':
 !!!   Type 'void' is not assignable to type 'boolean'.
     var n2: () => boolean = function ():boolean { }; // expect an error here

--- a/tests/baselines/reference/everyTypeWithAnnotationAndInvalidInitializer.errors.txt
+++ b/tests/baselines/reference/everyTypeWithAnnotationAndInvalidInitializer.errors.txt
@@ -33,71 +33,71 @@
     }
     
     var aNumber: number = 'this is a string';
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~
 !!! Type 'string' is not assignable to type 'number'.
     var aString: string = 9.9;
-        ~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~
 !!! Type 'number' is not assignable to type 'string'.
     var aDate: Date = 9.9;
-        ~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'number' is not assignable to type 'Date':
 !!!   Property 'toDateString' is missing in type 'Number'.
     
     var aVoid: void = 9.9;
-        ~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'number' is not assignable to type 'void'.
     
     var anInterface: I = new D();
-        ~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~
 !!! Type 'D<{}>' is not assignable to type 'I':
 !!!   Property 'id' is missing in type 'D<{}>'.
     var aClass: C = new D();
-        ~~~~~~~~~~~~~~~~~~~
+        ~~~~~~
 !!! Type 'D<{}>' is not assignable to type 'C':
 !!!   Property 'id' is missing in type 'D<{}>'.
     var aGenericClass: D<string> = new C();
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~~
 !!! Type 'C' is not assignable to type 'D<string>':
 !!!   Property 'source' is missing in type 'C'.
     var anObjectLiteral: I = { id: 'a string' };
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~~~~
 !!! Type '{ id: string; }' is not assignable to type 'I':
 !!!   Types of property 'id' are incompatible:
 !!!     Type 'string' is not assignable to type 'number'.
     var anOtherObjectLiteral: { id: string } = new C();
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~~~~~~~~~
 !!! Type 'C' is not assignable to type '{ id: string; }':
 !!!   Types of property 'id' are incompatible:
 !!!     Type 'number' is not assignable to type 'string'.
     
     var aFunction: typeof F = F2;
-        ~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~
 !!! Type '(x: number) => boolean' is not assignable to type '(x: string) => number':
 !!!   Types of parameters 'x' and 'x' are incompatible:
 !!!     Type 'number' is not assignable to type 'string'.
     var anOtherFunction: (x: string) => number = F2;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~~~~
 !!! Type '(x: number) => boolean' is not assignable to type '(x: string) => number':
 !!!   Types of parameters 'x' and 'x' are incompatible:
 !!!     Type 'number' is not assignable to type 'string'.
     var aLambda: typeof F = (x) => 'a string';
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~
 !!! Type '(x: string) => string' is not assignable to type '(x: string) => number':
 !!!   Type 'string' is not assignable to type 'number'.
     
     var aModule: typeof M = N;
-        ~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~
 !!! Type 'typeof N' is not assignable to type 'typeof M':
 !!!   Types of property 'A' are incompatible:
 !!!     Type 'typeof A' is not assignable to type 'typeof A':
 !!!       Type 'A' is not assignable to type 'A':
 !!!         Property 'name' is missing in type 'A'.
     var aClassInModule: M.A = new N.A();
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~~~
 !!! Type 'A' is not assignable to type 'A':
 !!!   Property 'name' is missing in type 'A'.
     var aFunctionInModule: typeof M.F2 = F2;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~~~~~~
 !!! Type '(x: number) => boolean' is not assignable to type '(x: number) => string':
 !!!   Type 'boolean' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/extendAndImplementTheSameBaseType2.errors.txt
+++ b/tests/baselines/reference/extendAndImplementTheSameBaseType2.errors.txt
@@ -16,11 +16,11 @@
     
     var d: D = new D();
     var r: string = d.foo;
-        ~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type 'string'.
     var r2: number = d.foo;
     
     var r3: string = d.bar();
     var r4: number = d.bar();
-        ~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/extendGenericArray.errors.txt
+++ b/tests/baselines/reference/extendGenericArray.errors.txt
@@ -5,5 +5,5 @@
     
     var arr: string[] = [];
     var x: number = arr.foo();
-        ~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/extendGenericArray2.errors.txt
+++ b/tests/baselines/reference/extendGenericArray2.errors.txt
@@ -7,5 +7,5 @@
     
     var arr: string[] = [];
     var y: number = arr.x;
-        ~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/externModule.errors.txt
+++ b/tests/baselines/reference/externModule.errors.txt
@@ -11,75 +11,48 @@
         export class XDate {
         ~~~~~~
 !!! Statement expected.
-        ~~~~~~~~~~~~~~~~~~~~
+                     ~~~~~
+!!! Cannot compile external modules unless the '--module' flag is provided.
     		public getDay():number;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~
     		~~~~~~~~~~~~~~~~~~~~~~~
 !!! Function implementation expected.
     		public getXDate():number;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
     		~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! Function implementation expected.
     		// etc.
-    ~~~~~~~~~
-    
     
     	    // Called as a function
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    // Not supported anymore? public (): string;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    
-    ~~~~~
     	    // Called as a constructor
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    constructor(year: number, month: number);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    constructor(year: number, month: number, date: number);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    constructor(year: number, month: number, date: number, hours: number);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    constructor(year: number, month: number, date: number, hours: number, minutes: number);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    constructor(year: number, month: number, date: number, hours: number, minutes: number, seconds: number);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    constructor(year: number, month: number, date: number, hours: number, minutes: number, seconds: number, ms: number);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    constructor(value: number);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    constructor();
-    ~~~~~~~~~~~~~~~~~~~
     	    ~~~~~~~~~~~~~~
 !!! Constructor implementation expected.
     	    
-    ~~~~~
     	    static parse(string: string): number;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! Function implementation expected.
     	    static UTC(year: number, month: number): number;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    static UTC(year: number, month: number, date: number): number;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    static UTC(year: number, month: number, date: number, hours: number): number;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    static UTC(year: number, month: number, date: number, hours: number, minutes: number): number;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    static UTC(year: number, month: number, date: number, hours: number, minutes: number, seconds: number): number;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    static UTC(year: number, month: number, date: number, hours: number, minutes: number, seconds: number,
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     		         ms: number): number;
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! Function implementation expected.
     	    static now(): number;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
     	    ~~~~~~~~~~~~~~~~~~~~~
 !!! Function implementation expected.
         }
-    ~~~~~
-!!! Cannot compile external modules unless the '--module' flag is provided.
     }
     ~
 !!! Declaration or statement expected.

--- a/tests/baselines/reference/externalModuleWithoutCompilerFlag1.errors.txt
+++ b/tests/baselines/reference/externalModuleWithoutCompilerFlag1.errors.txt
@@ -2,7 +2,6 @@
     
     // Not on line 0 because we want to verify the error is placed in the appropriate location.
       export module M {
-      ~~~~~~~~~~~~~~~~~
-    }
-    ~
+                    ~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+    }

--- a/tests/baselines/reference/for-inStatementsInvalid.errors.txt
+++ b/tests/baselines/reference/for-inStatementsInvalid.errors.txt
@@ -15,7 +15,7 @@
 !!! Variable declarations of a 'for' statement must be of types 'string' or 'any'.
     
     for (var idx : number in {}) { }
-             ~~~~~~~~~~~~
+             ~~~
 !!! Variable declarations of a 'for' statement cannot use a type annotation.
     
     function fn(): void { }

--- a/tests/baselines/reference/forIn.errors.txt
+++ b/tests/baselines/reference/forIn.errors.txt
@@ -1,7 +1,7 @@
 ==== tests/cases/compiler/forIn.ts (2 errors) ====
     var arr = null;
     for (var i:number in arr) { // error
-             ~~~~~~~~
+             ~
 !!! Variable declarations of a 'for' statement cannot use a type annotation.
         var x1 = arr[i];
         var y1 = arr[i];

--- a/tests/baselines/reference/forInStatement4.errors.txt
+++ b/tests/baselines/reference/forInStatement4.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/compiler/forInStatement4.ts (1 errors) ====
     var expr: any;
     for (var a: number in expr) {
-             ~~~~~~~~~
+             ~
 !!! Variable declarations of a 'for' statement cannot use a type annotation.
     }

--- a/tests/baselines/reference/functionSignatureAssignmentCompat1.errors.txt
+++ b/tests/baselines/reference/functionSignatureAssignmentCompat1.errors.txt
@@ -9,7 +9,7 @@
     var parsers: Parsers;
     var c: ParserFunc = parsers.raw; // ok!
     var d: ParserFunc = parsers.readline; // not ok
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type '(delimiter?: string) => ParserFunc' is not assignable to type 'ParserFunc':
 !!!   Types of parameters 'delimiter' and 'eventEmitter' are incompatible:
 !!!     Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/genericArrayExtenstions.errors.txt
+++ b/tests/baselines/reference/genericArrayExtenstions.errors.txt
@@ -1,14 +1,11 @@
 ==== tests/cases/compiler/genericArrayExtenstions.ts (2 errors) ====
     export declare class ObservableArray<T> implements Array<T> { // MS.Entertainment.ObservableArray
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                         ~~~~~~~~~~~~~~~
+!!! Cannot compile external modules unless the '--module' flag is provided.
                          ~~~~~~~~~~~~~~~
 !!! Class 'ObservableArray<T>' incorrectly implements interface 'T[]':
 !!!   Property 'join' is missing in type 'ObservableArray<T>'.
     concat<U extends T[]>(...items: U[]): T[];
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     concat(...items: T[]): T[];
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
     }
-    ~
-!!! Cannot compile external modules unless the '--module' flag is provided.
     

--- a/tests/baselines/reference/genericArrayMethods1.errors.txt
+++ b/tests/baselines/reference/genericArrayMethods1.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/compiler/genericArrayMethods1.ts (1 errors) ====
     var x:string[] =  [0,1].slice(0); // this should be an error
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'number[]' is not assignable to type 'string[]':
 !!!   Type 'number' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/genericAssignmentCompatWithInterfaces1.errors.txt
+++ b/tests/baselines/reference/genericAssignmentCompatWithInterfaces1.errors.txt
@@ -11,7 +11,7 @@
     class A<T> implements Comparable<T> { compareTo(other: T) { return 1; } }
     var z = { x: new A<number>() };
     var a1: I<string> = { x: new A<number>() };
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type '{ x: A<number>; }' is not assignable to type 'I<string>':
 !!!   Types of property 'x' are incompatible:
 !!!     Type 'A<number>' is not assignable to type 'Comparable<string>':
@@ -20,11 +20,7 @@
 !!!           Types of parameters 'other' and 'other' are incompatible:
 !!!             Type 'number' is not assignable to type 'string'.
     var a2: I<string> = function (): { x: A<number> } {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-       var z = { x: new A<number>() }; return z;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    } ();
-    ~~~~
+        ~~
 !!! Type '{ x: A<number>; }' is not assignable to type 'I<string>':
 !!!   Types of property 'x' are incompatible:
 !!!     Type 'A<number>' is not assignable to type 'Comparable<string>':
@@ -32,8 +28,10 @@
 !!!         Type '(other: number) => number' is not assignable to type '(other: string) => number':
 !!!           Types of parameters 'other' and 'other' are incompatible:
 !!!             Type 'number' is not assignable to type 'string'.
+       var z = { x: new A<number>() }; return z;
+    } ();
     var a3: I<string> = z;
-        ~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type '{ x: A<number>; }' is not assignable to type 'I<string>':
 !!!   Types of property 'x' are incompatible:
 !!!     Type 'A<number>' is not assignable to type 'Comparable<string>':
@@ -42,7 +40,7 @@
 !!!           Types of parameters 'other' and 'other' are incompatible:
 !!!             Type 'number' is not assignable to type 'string'.
     var a4: I<string> = <K<number>>z;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'K<number>' is not assignable to type 'I<string>':
 !!!   Types of property 'x' are incompatible:
 !!!     Type 'A<number>' is not assignable to type 'Comparable<string>':

--- a/tests/baselines/reference/genericCallWithObjectTypeArgsAndIndexersErrors.errors.txt
+++ b/tests/baselines/reference/genericCallWithObjectTypeArgsAndIndexersErrors.errors.txt
@@ -26,6 +26,6 @@
         var d = r2[1];
         var e = r2['1'];
         var u: U = r2[1]; // ok
-            ~~~~~~~~~~~~
+            ~
 !!! Type 'T' is not assignable to type 'U'.
     }

--- a/tests/baselines/reference/genericCloneReturnTypes2.errors.txt
+++ b/tests/baselines/reference/genericCloneReturnTypes2.errors.txt
@@ -14,6 +14,6 @@
     var b: MyList<any> = a.clone(); // ok
     var c: MyList<string> = a.clone(); // bug was there was an error on this line
     var d: MyList<number> = a.clone(); // error
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'MyList<string>' is not assignable to type 'MyList<number>':
 !!!   Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/genericGetter.errors.txt
+++ b/tests/baselines/reference/genericGetter.errors.txt
@@ -10,5 +10,5 @@
     
     var c = new C<number>();
     var r: string = c.x;
-        ~~~~~~~~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type 'string'.

--- a/tests/baselines/reference/genericGetter3.errors.txt
+++ b/tests/baselines/reference/genericGetter3.errors.txt
@@ -12,5 +12,5 @@
     
     var c = new C<number>();
     var r: string = c.x;
-        ~~~~~~~~~~~~~~~
+        ~
 !!! Type 'A<number>' is not assignable to type 'string'.

--- a/tests/baselines/reference/genericTypeAssertions1.errors.txt
+++ b/tests/baselines/reference/genericTypeAssertions1.errors.txt
@@ -2,11 +2,11 @@
     class A<T> { foo(x: T) { }}
     var foo = new A<number>();
     var r: A<string> = <A<number>>new A(); // error
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'A<number>' is not assignable to type 'A<string>':
 !!!   Type 'number' is not assignable to type 'string'.
     var r2: A<number> = <A<A<number>>>foo; // error
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'A<A<number>>' is not assignable to type 'A<number>':
 !!!   Type 'A<number>' is not assignable to type 'number'.
                         ~~~~~~~~~~~~~~~~~

--- a/tests/baselines/reference/genericTypeAssertions2.errors.txt
+++ b/tests/baselines/reference/genericTypeAssertions2.errors.txt
@@ -9,14 +9,14 @@
     var foo = new A<number>();
     var r: A<string> = <B<string>>new B();
     var r2: A<number> = <B<string>>new B(); // error
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'B<string>' is not assignable to type 'A<number>':
 !!!   Types of property 'foo' are incompatible:
 !!!     Type '(x: string) => void' is not assignable to type '(x: number) => void':
 !!!       Types of parameters 'x' and 'x' are incompatible:
 !!!         Type 'string' is not assignable to type 'number'.
     var r3: B<number> = <A<number>>new B(); // error
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'A<number>' is not assignable to type 'B<number>':
 !!!   Property 'bar' is missing in type 'A<number>'.
     var r4: A<number> = <A<number>>new A();

--- a/tests/baselines/reference/genericTypeWithNonGenericBaseMisMatch.errors.txt
+++ b/tests/baselines/reference/genericTypeWithNonGenericBaseMisMatch.errors.txt
@@ -15,7 +15,7 @@
     }
     var x = new X<{ a: string }>();
     var i: I = x; // Should not be allowed -- type of 'f' is incompatible with 'I'
-        ~~~~~~~~
+        ~
 !!! Type 'X<{ a: string; }>' is not assignable to type 'I':
 !!!   Types of property 'f' are incompatible:
 !!!     Type '(a: { a: string; }) => void' is not assignable to type '(a: { a: number; }) => void':

--- a/tests/baselines/reference/implicitAnyFunctionInvocationWithAnyArguements.errors.txt
+++ b/tests/baselines/reference/implicitAnyFunctionInvocationWithAnyArguements.errors.txt
@@ -1,10 +1,10 @@
 ==== tests/cases/compiler/implicitAnyFunctionInvocationWithAnyArguements.ts (7 errors) ====
     // this should be errors
     var arg0 = null;  // error at "arg0"
-        ~~~~~~~~~~~
+        ~~~~
 !!! Variable 'arg0' implicitly has an 'any' type.
     var anyArray = [null, undefined];  // error at array literal
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~
 !!! Variable 'anyArray' implicitly has an 'any[]' type.
     var objL: { v; w; }             // error at "y,z"
                 ~~

--- a/tests/baselines/reference/implicitAnyWidenToAny.errors.txt
+++ b/tests/baselines/reference/implicitAnyWidenToAny.errors.txt
@@ -1,16 +1,16 @@
 ==== tests/cases/compiler/implicitAnyWidenToAny.ts (4 errors) ====
     // these should be errors
     var x = null;                        // error at "x"
-        ~~~~~~~~
+        ~
 !!! Variable 'x' implicitly has an 'any' type.
     var x1 = undefined;		             // error at "x1"
-        ~~~~~~~~~~~~~~
+        ~~
 !!! Variable 'x1' implicitly has an 'any' type.
     var widenArray = [null, undefined];  // error at "widenArray"
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~
 !!! Variable 'widenArray' implicitly has an 'any[]' type.
     var emptyArray = [];		         // error at "emptyArray"
-        ~~~~~~~~~~~~~~~
+        ~~~~~~~~~~
 !!! Variable 'emptyArray' implicitly has an 'any[]' type.
     
     // these should not be error

--- a/tests/baselines/reference/importAliasAnExternalModuleInsideAnInternalModule.errors.txt
+++ b/tests/baselines/reference/importAliasAnExternalModuleInsideAnInternalModule.errors.txt
@@ -8,10 +8,8 @@
     
 ==== tests/cases/compiler/importAliasAnExternalModuleInsideAnInternalModule_file0.ts (1 errors) ====
     export module m {
-    ~~~~~~~~~~~~~~~~~
-        export function foo() { }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    }
-    ~
+                  ~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+        export function foo() { }
+    }
     

--- a/tests/baselines/reference/incompatibleGenericTypes.errors.txt
+++ b/tests/baselines/reference/incompatibleGenericTypes.errors.txt
@@ -9,6 +9,6 @@
     var v1: I1<boolean>;
      
     var v2: I1<number> = v1;
-        ~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'I1<boolean>' is not assignable to type 'I1<number>':
 !!!   Type 'boolean' is not assignable to type 'number'.

--- a/tests/baselines/reference/incompatibleTypes.errors.txt
+++ b/tests/baselines/reference/incompatibleTypes.errors.txt
@@ -89,7 +89,7 @@
     }
     
     var o1: { a: { a: string; }; b: string; } = { e: 0, f: 0 };
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type '{ e: number; f: number; }' is not assignable to type '{ a: { a: string; }; b: string; }':
 !!!   Property 'a' is missing in type '{ e: number; f: number; }'.
     
@@ -98,10 +98,10 @@
     
     
     var i1c1: { (): string; } = 5;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~
 !!! Type 'number' is not assignable to type '() => string'.
     
     var fp1: () =>any = a => 0;
-        ~~~~~~~~~~~~~~~~~~~~~~
+        ~~~
 !!! Type '(a: any) => number' is not assignable to type '() => any'.
     

--- a/tests/baselines/reference/indirectSelfReference.errors.txt
+++ b/tests/baselines/reference/indirectSelfReference.errors.txt
@@ -1,5 +1,5 @@
 ==== tests/cases/compiler/indirectSelfReference.ts (1 errors) ====
     class a extends b{ }
-    ~~~~~~~~~~~~~~~~~~~~
+          ~
 !!! Type 'a' recursively references itself as a base type.
     class b extends a{ }

--- a/tests/baselines/reference/indirectSelfReferenceGeneric.errors.txt
+++ b/tests/baselines/reference/indirectSelfReferenceGeneric.errors.txt
@@ -1,5 +1,5 @@
 ==== tests/cases/compiler/indirectSelfReferenceGeneric.ts (1 errors) ====
     class a<T> extends b<T> { }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          ~
 !!! Type 'a<T>' recursively references itself as a base type.
     class b<T> extends a<T> { }

--- a/tests/baselines/reference/inheritedMembersAndIndexSignaturesFromDifferentBases.errors.txt
+++ b/tests/baselines/reference/inheritedMembersAndIndexSignaturesFromDifferentBases.errors.txt
@@ -16,7 +16,7 @@
     }
     
     interface D extends A, B, C { } // error because m is not a subtype of {a;}
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~
 !!! Property 'm' of type '{}' is not assignable to string index type '{ a: any; }'.
     
     interface E {
@@ -24,17 +24,17 @@
     }
     
     interface F extends A, B, E { } // error because 0 is not a subtype of {a; b;}
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~
 !!! Property '0' of type '{}' is not assignable to numeric index type '{ a: any; b: any; }'.
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~
 !!! Property '0' of type '{}' is not assignable to string index type '{ a: any; }'.
     
     interface G extends A, B, C, E { } // should only report one error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~
 !!! Property '0' of type '{}' is not assignable to numeric index type '{ a: any; b: any; }'.
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~
 !!! Property '0' of type '{}' is not assignable to string index type '{ a: any; }'.
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~
 !!! Property 'm' of type '{}' is not assignable to string index type '{ a: any; }'.
     
     interface H extends A, F { } // Should report no error at all because error is internal to F

--- a/tests/baselines/reference/inheritedStringIndexersFromDifferentBaseTypes2.errors.txt
+++ b/tests/baselines/reference/inheritedStringIndexersFromDifferentBaseTypes2.errors.txt
@@ -17,7 +17,7 @@
         [s: number]: {};
     }
     interface E extends A, D { } // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~
 !!! Numeric index type '{}' is not assignable to string index type '{ a: any; }'.
     
     interface F extends A, D {

--- a/tests/baselines/reference/innerTypeCheckOfLambdaArgument.errors.txt
+++ b/tests/baselines/reference/innerTypeCheckOfLambdaArgument.errors.txt
@@ -9,7 +9,7 @@
                     // this line should raise an error
                     // otherwise, there's a bug in overload resolution / partial typechecking
     		var k: string = 10; 
-    		    ~~~~~~~~~~~~~~
+    		    ~
 !!! Type 'number' is not assignable to type 'string'.
         }
     );

--- a/tests/baselines/reference/intTypeCheck.errors.txt
+++ b/tests/baselines/reference/intTypeCheck.errors.txt
@@ -110,19 +110,19 @@
         p7: function (pa1, pa2):any { return 0; }
     };
     var obj2: i1 = new Object();
-        ~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~
 !!! Type 'Object' is not assignable to type 'i1':
 !!!   Property 'p' is missing in type 'Object'.
     var obj3: i1 = new obj0;
                    ~~~~~~~~
 !!! Cannot use 'new' with an expression whose type lacks a call or construct signature.
     var obj4: i1 = new Base;
-        ~~~~~~~~~~~~~~~~~~~
+        ~~~~
 !!! Type 'Base' is not assignable to type 'i1':
 !!!   Property 'p' is missing in type 'Base'.
     var obj5: i1 = null;
     var obj6: i1 = function () { };
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~
 !!! Type '() => void' is not assignable to type 'i1':
 !!!   Property 'p' is missing in type '() => void'.
     //var obj7: i1 = function foo() { };
@@ -130,7 +130,7 @@
     var obj9: i1 = new <i1> anyVar;
                        ~
 !!! Expression expected.
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~
 !!! Type 'boolean' is not assignable to type 'i1':
 !!!   Property 'p' is missing in type 'Boolean'.
                         ~~
@@ -143,16 +143,16 @@
     //
     var obj11: i2;
     var obj12: i2 = {};
-        ~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type '{}' is not assignable to type 'i2'.
     var obj13: i2 = new Object();
-        ~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'Object' is not assignable to type 'i2'.
     var obj14: i2 = new obj11;
                     ~~~~~~~~~
 !!! Only a void function can be called with the 'new' keyword.
     var obj15: i2 = new Base;
-        ~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'Base' is not assignable to type 'i2'.
     var obj16: i2 = null;
     var obj17: i2 = function ():any { return 0; };
@@ -161,7 +161,7 @@
     var obj20: i2 = new <i2> anyVar;
                         ~
 !!! Expression expected.
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'boolean' is not assignable to type 'i2'.
                          ~~
 !!! Cannot find name 'i2'.
@@ -173,25 +173,25 @@
     //
     var obj22: i3;
     var obj23: i3 = {};
-        ~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type '{}' is not assignable to type 'i3'.
     var obj24: i3 = new Object();
-        ~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'Object' is not assignable to type 'i3'.
     var obj25: i3 = new obj22;
     var obj26: i3 = new Base;
-        ~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'Base' is not assignable to type 'i3'.
     var obj27: i3 = null;
     var obj28: i3 = function () { };
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type '() => void' is not assignable to type 'i3'.
     //var obj29: i3 = function foo() { };
     var obj30: i3 = <i3> anyVar;
     var obj31: i3 = new <i3> anyVar;
                         ~
 !!! Expression expected.
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'boolean' is not assignable to type 'i3'.
                          ~~
 !!! Cannot find name 'i3'.
@@ -204,19 +204,19 @@
     var obj33: i4;
     var obj34: i4 = {};
     var obj35: i4 = new Object();
-        ~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'Object' is not assignable to type 'i4':
 !!!   Index signature is missing in type 'Object'.
     var obj36: i4 = new obj33;
                     ~~~~~~~~~
 !!! Cannot use 'new' with an expression whose type lacks a call or construct signature.
     var obj37: i4 = new Base;
-        ~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'Base' is not assignable to type 'i4':
 !!!   Index signature is missing in type 'Base'.
     var obj38: i4 = null;
     var obj39: i4 = function () { };
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type '() => void' is not assignable to type 'i4':
 !!!   Index signature is missing in type '() => void'.
     //var obj40: i4 = function foo() { };
@@ -224,7 +224,7 @@
     var obj42: i4 = new <i4> anyVar;
                         ~
 !!! Expression expected.
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'boolean' is not assignable to type 'i4':
 !!!   Index signature is missing in type 'Boolean'.
                          ~~
@@ -237,23 +237,23 @@
     //
     var obj44: i5;
     var obj45: i5 = {};
-        ~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type '{}' is not assignable to type 'i5':
 !!!   Property 'p' is missing in type '{}'.
     var obj46: i5 = new Object();
-        ~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'Object' is not assignable to type 'i5':
 !!!   Property 'p' is missing in type 'Object'.
     var obj47: i5 = new obj44;
                     ~~~~~~~~~
 !!! Cannot use 'new' with an expression whose type lacks a call or construct signature.
     var obj48: i5 = new Base;
-        ~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'Base' is not assignable to type 'i5':
 !!!   Property 'p' is missing in type 'Base'.
     var obj49: i5 = null;
     var obj50: i5 = function () { };
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type '() => void' is not assignable to type 'i5':
 !!!   Property 'p' is missing in type '() => void'.
     //var obj51: i5 = function foo() { };
@@ -261,7 +261,7 @@
     var obj53: i5 = new <i5> anyVar;
                         ~
 !!! Expression expected.
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'boolean' is not assignable to type 'i5':
 !!!   Property 'p' is missing in type 'Boolean'.
                          ~~
@@ -274,20 +274,20 @@
     //
     var obj55: i6;
     var obj56: i6 = {};
-        ~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type '{}' is not assignable to type 'i6'.
     var obj57: i6 = new Object();
-        ~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'Object' is not assignable to type 'i6'.
     var obj58: i6 = new obj55;
                     ~~~~~~~~~
 !!! Only a void function can be called with the 'new' keyword.
     var obj59: i6 = new Base;
-        ~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'Base' is not assignable to type 'i6'.
     var obj60: i6 = null;
     var obj61: i6 = function () { };
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type '() => void' is not assignable to type 'i6':
 !!!   Type 'void' is not assignable to type 'number'.
     //var obj62: i6 = function foo() { };
@@ -295,7 +295,7 @@
     var obj64: i6 = new <i6> anyVar;
                         ~
 !!! Expression expected.
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'boolean' is not assignable to type 'i6'.
                          ~~
 !!! Cannot find name 'i6'.
@@ -307,10 +307,10 @@
     //
     var obj66: i7;
     var obj67: i7 = {};
-        ~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type '{}' is not assignable to type 'i7'.
     var obj68: i7 = new Object();
-        ~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'Object' is not assignable to type 'i7'.
     var obj69: i7 = new obj66;
     var obj70: i7 = <i7>new Base;
@@ -318,14 +318,14 @@
 !!! Neither type 'i7' nor type 'Base' is assignable to the other.
     var obj71: i7 = null;
     var obj72: i7 = function () { };
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type '() => void' is not assignable to type 'i7'.
     //var obj73: i7 = function foo() { };
     var obj74: i7 = <i7> anyVar;
     var obj75: i7 = new <i7> anyVar;
                         ~
 !!! Expression expected.
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'boolean' is not assignable to type 'i7'.
                          ~~
 !!! Cannot find name 'i7'.
@@ -338,19 +338,19 @@
     var obj77: i8;
     var obj78: i8 = {};
     var obj79: i8 = new Object();
-        ~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'Object' is not assignable to type 'i8':
 !!!   Index signature is missing in type 'Object'.
     var obj80: i8 = new obj77;
                     ~~~~~~~~~
 !!! Cannot use 'new' with an expression whose type lacks a call or construct signature.
     var obj81: i8 = new Base;
-        ~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'Base' is not assignable to type 'i8':
 !!!   Index signature is missing in type 'Base'.
     var obj82: i8 = null;
     var obj83: i8 = function () { };
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type '() => void' is not assignable to type 'i8':
 !!!   Index signature is missing in type '() => void'.
     //var obj84: i8 = function foo() { };
@@ -358,7 +358,7 @@
     var obj86: i8 = new <i8> anyVar;
                         ~
 !!! Expression expected.
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type 'boolean' is not assignable to type 'i8':
 !!!   Index signature is missing in type 'Boolean'.
                          ~~

--- a/tests/baselines/reference/interfaceDeclaration1.errors.txt
+++ b/tests/baselines/reference/interfaceDeclaration1.errors.txt
@@ -25,12 +25,10 @@
     }
     
     interface I5 extends I5 { 
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-        foo():void;
-    ~~~~~~~~~~~~~~~
-    }
-    ~
+              ~~
 !!! Type 'I5' recursively references itself as a base type.
+        foo():void;
+    }
     
     interface I6 {
     	():void;
@@ -51,7 +49,7 @@
     }
     
     interface i8 extends i9 { }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~~
 !!! Type 'i8' recursively references itself as a base type.
     interface i9 extends i8 { }
     

--- a/tests/baselines/reference/interfaceImplementation1.errors.txt
+++ b/tests/baselines/reference/interfaceImplementation1.errors.txt
@@ -39,12 +39,10 @@
     }
     
     var a:I4 = function(){ 
-        ~~~~~~~~~~~~~~~~~~~
-        return new C2();
-    ~~~~~~~~~~~~~~~~~~~~
-    }
-    ~
+        ~
 !!! Type '() => C2' is not assignable to type 'I4'.
+        return new C2();
+    }
     new a();
     
     /*var b:I4 = C2;

--- a/tests/baselines/reference/interfaceThatIndirectlyInheritsFromItself.errors.txt
+++ b/tests/baselines/reference/interfaceThatIndirectlyInheritsFromItself.errors.txt
@@ -1,11 +1,9 @@
 ==== tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatIndirectlyInheritsFromItself.ts (2 errors) ====
     interface Base extends Derived2 { // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        x: string;
-    ~~~~~~~~~~~~~~
-    }
-    ~
+              ~~~~
 !!! Type 'Base' recursively references itself as a base type.
+        x: string;
+    }
     
     interface Derived extends Base {
         y: string;
@@ -17,12 +15,10 @@
     
     module Generic {
         interface Base<T> extends Derived2<T> { // error
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            x: string;
-    ~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
+                  ~~~~
 !!! Type 'Base<T>' recursively references itself as a base type.
+            x: string;
+        }
     
         interface Derived<T> extends Base<T> {
             y: string;

--- a/tests/baselines/reference/interfaceThatInheritsFromItself.errors.txt
+++ b/tests/baselines/reference/interfaceThatInheritsFromItself.errors.txt
@@ -1,21 +1,18 @@
 ==== tests/cases/conformance/interfaces/interfaceDeclarations/interfaceThatInheritsFromItself.ts (8 errors) ====
     interface Foo extends Foo { // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    }
-    ~
+              ~~~
 !!! Type 'Foo' recursively references itself as a base type.
+    }
     
     interface Foo2<T> extends Foo2<T> { // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    }
-    ~
+              ~~~~
 !!! Type 'Foo2<T>' recursively references itself as a base type.
+    }
     
     interface Foo3<T> extends Foo3<string> { // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    }
-    ~
+              ~~~~
 !!! Type 'Foo3<T>' recursively references itself as a base type.
+    }
     
     interface Bar implements Bar { // error
                   ~~~~~~~~~~

--- a/tests/baselines/reference/invalidBooleanAssignments.errors.txt
+++ b/tests/baselines/reference/invalidBooleanAssignments.errors.txt
@@ -2,35 +2,35 @@
     var x = true;
     
     var a: number = x;
-        ~~~~~~~~~~~~~
+        ~
 !!! Type 'boolean' is not assignable to type 'number'.
     var b: string = x;
-        ~~~~~~~~~~~~~
+        ~
 !!! Type 'boolean' is not assignable to type 'string'.
     var c: void = x;
-        ~~~~~~~~~~~
+        ~
 !!! Type 'boolean' is not assignable to type 'void'.
     var d: typeof undefined = x;
     
     enum E { A }
     var e: E = x;
-        ~~~~~~~~
+        ~
 !!! Type 'boolean' is not assignable to type 'E'.
     
     class C { foo: string }
     var f: C = x;
-        ~~~~~~~~
+        ~
 !!! Type 'boolean' is not assignable to type 'C':
 !!!   Property 'foo' is missing in type 'Boolean'.
     
     interface I { bar: string }
     var g: I = x;
-        ~~~~~~~~
+        ~
 !!! Type 'boolean' is not assignable to type 'I':
 !!!   Property 'bar' is missing in type 'Boolean'.
     
     var h: { (): string } = x;
-        ~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'boolean' is not assignable to type '() => string'.
     var h2: { toString(): string } = x; // no error
     

--- a/tests/baselines/reference/invalidNumberAssignments.errors.txt
+++ b/tests/baselines/reference/invalidNumberAssignments.errors.txt
@@ -2,34 +2,34 @@
     var x = 1;
     
     var a: boolean = x;
-        ~~~~~~~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type 'boolean'.
     var b: string = x;
-        ~~~~~~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type 'string'.
     var c: void = x;
-        ~~~~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type 'void'.
     var d: typeof undefined = x;
     
     class C { foo: string; }
     var e: C = x;
-        ~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type 'C':
 !!!   Property 'foo' is missing in type 'Number'.
     
     interface I { bar: string; }
     var f: I = x;
-        ~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type 'I':
 !!!   Property 'bar' is missing in type 'Number'.
     
     var g: { baz: string } = 1;
-        ~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type '{ baz: string; }':
 !!!   Property 'baz' is missing in type 'Number'.
     var g2: { 0: number } = 1;
-        ~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'number' is not assignable to type '{ 0: number; }':
 !!!   Property '0' is missing in type 'Number'.
     

--- a/tests/baselines/reference/invalidStringAssignments.errors.txt
+++ b/tests/baselines/reference/invalidStringAssignments.errors.txt
@@ -2,34 +2,34 @@
     var x = '';
     
     var a: boolean = x;
-        ~~~~~~~~~~~~~~
+        ~
 !!! Type 'string' is not assignable to type 'boolean'.
     var b: number = x;
-        ~~~~~~~~~~~~~
+        ~
 !!! Type 'string' is not assignable to type 'number'.
     var c: void = x;
-        ~~~~~~~~~~~
+        ~
 !!! Type 'string' is not assignable to type 'void'.
     var d: typeof undefined = x;
     
     class C { foo: string; }
     var e: C = x;
-        ~~~~~~~~
+        ~
 !!! Type 'string' is not assignable to type 'C':
 !!!   Property 'foo' is missing in type 'String'.
     
     interface I { bar: string; }
     var f: I = x;
-        ~~~~~~~~
+        ~
 !!! Type 'string' is not assignable to type 'I':
 !!!   Property 'bar' is missing in type 'String'.
     
     var g: { baz: string } = 1;
-        ~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type '{ baz: string; }':
 !!!   Property 'baz' is missing in type 'Number'.
     var g2: { 0: number } = 1;
-        ~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'number' is not assignable to type '{ 0: number; }':
 !!!   Property '0' is missing in type 'Number'.
     
@@ -49,5 +49,5 @@
     
     enum E { A }
     var j: E = x;
-        ~~~~~~~~
+        ~
 !!! Type 'string' is not assignable to type 'E'.

--- a/tests/baselines/reference/invalidVoidAssignments.errors.txt
+++ b/tests/baselines/reference/invalidVoidAssignments.errors.txt
@@ -2,32 +2,32 @@
     var x: void;
     
     var a: boolean = x;
-        ~~~~~~~~~~~~~~
+        ~
 !!! Type 'void' is not assignable to type 'boolean'.
     var b: string = x;
-        ~~~~~~~~~~~~~
+        ~
 !!! Type 'void' is not assignable to type 'string'.
     var c: number = x;
-        ~~~~~~~~~~~~~
+        ~
 !!! Type 'void' is not assignable to type 'number'.
     var d: typeof undefined = x;
     
     class C { foo: string; }
     var e: C = x;
-        ~~~~~~~~
+        ~
 !!! Type 'void' is not assignable to type 'C'.
     
     interface I { bar: string; }
     var f: I = x;
-        ~~~~~~~~
+        ~
 !!! Type 'void' is not assignable to type 'I'.
     
     var g: { baz: string } = 1;
-        ~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type '{ baz: string; }':
 !!!   Property 'baz' is missing in type 'Number'.
     var g2: { 0: number } = 1;
-        ~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'number' is not assignable to type '{ 0: number; }':
 !!!   Property '0' is missing in type 'Number'.
     

--- a/tests/baselines/reference/memberOverride.errors.txt
+++ b/tests/baselines/reference/memberOverride.errors.txt
@@ -9,5 +9,5 @@
     }
     
     var n: number = x.a;
-        ~~~~~~~~~~~~~~~
+        ~
 !!! Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/mergedModuleDeclarationCodeGen.errors.txt
+++ b/tests/baselines/reference/mergedModuleDeclarationCodeGen.errors.txt
@@ -1,23 +1,15 @@
 ==== tests/cases/compiler/mergedModuleDeclarationCodeGen.ts (1 errors) ====
     export module X {
-    ~~~~~~~~~~~~~~~~~
-        export module Y {
-    ~~~~~~~~~~~~~~~~~~~~~
-            class A {
-    ~~~~~~~~~~~~~~~~~
-                constructor(Y: any) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                    new B();
-    ~~~~~~~~~~~~~~~~~~~~~~~~
-                }
-    ~~~~~~~~~~~~~
-            }
-    ~~~~~~~~~
-        }
-    ~~~~~
-    }
-    ~
+                  ~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+        export module Y {
+            class A {
+                constructor(Y: any) {
+                    new B();
+                }
+            }
+        }
+    }
     export module X {
         export module Y {
             export class B {

--- a/tests/baselines/reference/noImplicitAnyForIn.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyForIn.errors.txt
@@ -34,7 +34,7 @@
     var m = [1, 2, 3, 4, 5];
     // Should yield an implicit 'any' error.
     var n = [[]] || [];
-        ~~~~~~~~~~~~~~
+        ~
 !!! Variable 'n' implicitly has an 'any[][]' type.
     
     for (n[idx++] in m);

--- a/tests/baselines/reference/numericIndexerConstrainsPropertyDeclarations.errors.txt
+++ b/tests/baselines/reference/numericIndexerConstrainsPropertyDeclarations.errors.txt
@@ -97,51 +97,32 @@
     
     // error
     var b: { [x: number]: string; } = {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~
+!!! Type '{ [x: number]: {}; 1.0: string; 2.0: number; a: string; b: number; c: () => void; "d": string; "e": number; "3.0": string; "4.0": number; f: unknown; X: string; foo: () => string; }' is not assignable to type '{ [x: number]: string; }':
+!!!   Index signatures are incompatible:
+!!!     Type '{}' is not assignable to type 'string'.
         a: '',
-    ~~~~~~~~~~
         b: 1, 
-    ~~~~~~~~~~
         c: () => { }, 
-    ~~~~~~~~~~~~~~~~~~
         "d": '', 
-    ~~~~~~~~~~~~~
         "e": 1, 
-    ~~~~~~~~~~~~
         1.0: '',
-    ~~~~~~~~~~~~
         2.0: 1, 
-    ~~~~~~~~~~~~
         "3.0": '', 
-    ~~~~~~~~~~~~~~~
         "4.0": 1, 
-    ~~~~~~~~~~~~~~
         f: <Myn>null, 
-    ~~~~~~~~~~~~~~~~~~
             ~~~
 !!! Cannot find name 'Myn'.
-    
     
         get X() { 
             ~
 !!! Accessors are only available when targeting ECMAScript 5 and higher.
-    ~~~~~~~~~~~~~~
             return '';
-    ~~~~~~~~~~~~~~~~~~
         },
-    ~~~~~~
         set X(v) { }, 
             ~
 !!! Accessors are only available when targeting ECMAScript 5 and higher.
-    ~~~~~~~~~~~~~~~~~~
         foo() { 
-    ~~~~~~~~~~~~
             return '';
-    ~~~~~~~~~~~~~~~~~~
         }
-    ~~~~~
     }
-    ~
-!!! Type '{ [x: number]: {}; 1.0: string; 2.0: number; a: string; b: number; c: () => void; "d": string; "e": number; "3.0": string; "4.0": number; f: unknown; X: string; foo: () => string; }' is not assignable to type '{ [x: number]: string; }':
-!!!   Index signatures are incompatible:
-!!!     Type '{}' is not assignable to type 'string'.

--- a/tests/baselines/reference/numericIndexerConstrainsPropertyDeclarations2.errors.txt
+++ b/tests/baselines/reference/numericIndexerConstrainsPropertyDeclarations2.errors.txt
@@ -50,20 +50,14 @@
     
     // error
     var b: { [x: number]: A } = {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~
-        1.0: new A(), 
-    ~~~~~~~~~~~~~~~~~~
-        2.0: new B(), 
-    ~~~~~~~~~~~~~~~~~~
-        "2.5": new B(),
-    ~~~~~~~~~~~~~~~~~~~
-        3.0: 1,
-    ~~~~~~~~~~~
-        "4.0": ''
-    ~~~~~~~~~~~~~
-    }
-    ~
+        ~
 !!! Type '{ [x: number]: {}; 1.0: A; 2.0: B; 3.0: number; "2.5": B; "4.0": string; }' is not assignable to type '{ [x: number]: A; }':
 !!!   Index signatures are incompatible:
 !!!     Type '{}' is not assignable to type 'A':
 !!!       Property 'foo' is missing in type '{}'.
+        1.0: new A(), 
+        2.0: new B(), 
+        "2.5": new B(),
+        3.0: 1,
+        "4.0": ''
+    }

--- a/tests/baselines/reference/numericIndexerConstraint1.errors.txt
+++ b/tests/baselines/reference/numericIndexerConstraint1.errors.txt
@@ -2,7 +2,7 @@
     class Foo { foo() { } }
     var x: { [index: string]: number; };
     var result: Foo = x["one"]; // error
-        ~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~
 !!! Type 'number' is not assignable to type 'Foo':
 !!!   Property 'foo' is missing in type 'Number'.
     

--- a/tests/baselines/reference/numericIndexerConstraint5.errors.txt
+++ b/tests/baselines/reference/numericIndexerConstraint5.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/compiler/numericIndexerConstraint5.ts (1 errors) ====
     var x = { name: "x", 0: new Date() };
     var z: { [name: number]: string } = x;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type '{ 0: Date; name: string; }' is not assignable to type '{ [x: number]: string; }':
 !!!   Index signature is missing in type '{ 0: Date; name: string; }'.

--- a/tests/baselines/reference/numericIndexerTyping1.errors.txt
+++ b/tests/baselines/reference/numericIndexerTyping1.errors.txt
@@ -8,10 +8,10 @@
     
     var i: I;
     var r: string = i[1]; // error: numeric indexer returns the type of the string indexer
-        ~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'Date' is not assignable to type 'string'.
     
     var i2: I2;
     var r2: string = i2[1]; // error: numeric indexer returns the type of the string indexer
-        ~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'Date' is not assignable to type 'string'.

--- a/tests/baselines/reference/numericIndexerTyping2.errors.txt
+++ b/tests/baselines/reference/numericIndexerTyping2.errors.txt
@@ -8,10 +8,10 @@
     
     var i: I;
     var r: string = i[1]; // error: numeric indexer returns the type of the string indexer
-        ~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'Date' is not assignable to type 'string'.
     
     var i2: I2;
     var r2: string = i2[1]; // error: numeric indexer returns the type of the string indexere
-        ~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'Date' is not assignable to type 'string'.

--- a/tests/baselines/reference/objectLitStructuralTypeMismatch.errors.txt
+++ b/tests/baselines/reference/objectLitStructuralTypeMismatch.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/compiler/objectLitStructuralTypeMismatch.ts (1 errors) ====
     // Shouldn't compile
     var x: { a: number; } = { b: 5 };
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type '{ b: number; }' is not assignable to type '{ a: number; }':
 !!!   Property 'a' is missing in type '{ b: number; }'.

--- a/tests/baselines/reference/objectLiteralIndexerErrors.errors.txt
+++ b/tests/baselines/reference/objectLiteralIndexerErrors.errors.txt
@@ -12,7 +12,7 @@
     var c: any;
     
     var o1: { [s: string]: A;[n: number]: B; } = { x: b, 0: a }; // both indexers are A
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type '{ [x: string]: A; [x: number]: A; 0: A; x: B; }' is not assignable to type '{ [x: string]: A; [x: number]: B; }':
 !!!   Index signatures are incompatible:
 !!!     Type 'A' is not assignable to type 'B':

--- a/tests/baselines/reference/objectLiteralWithNumericPropertyName.errors.txt
+++ b/tests/baselines/reference/objectLiteralWithNumericPropertyName.errors.txt
@@ -3,12 +3,10 @@
         0: string;
     }
     var x: A = {
-        ~~~~~~~~
-        0: 3
-    ~~~~~~~~
-    };
-    ~
+        ~
 !!! Type '{ 0: number; }' is not assignable to type 'A':
 !!!   Types of property '0' are incompatible:
 !!!     Type 'number' is not assignable to type 'string'.
+        0: 3
+    };
     

--- a/tests/baselines/reference/optionalParamAssignmentCompat.errors.txt
+++ b/tests/baselines/reference/optionalParamAssignmentCompat.errors.txt
@@ -9,7 +9,7 @@
     var i2: I2;
     var c: I1 = i2.p1; // should be ok
     var d: I1 = i2.m1; // should error
-        ~~~~~~~~~~~~~
+        ~
 !!! Type '(p1?: string) => I1' is not assignable to type 'I1':
 !!!   Types of parameters 'p1' and 'p1' are incompatible:
 !!!     Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/optionalPropertiesTest.errors.txt
+++ b/tests/baselines/reference/optionalPropertiesTest.errors.txt
@@ -27,11 +27,11 @@
     interface i4 { M?: number; };
     
     var test1: i1 = {};
-        ~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type '{}' is not assignable to type 'i1':
 !!!   Property 'M' is missing in type '{}'.
     var test2: i3 = {};
-        ~~~~~~~~~~~~~~
+        ~~~~~
 !!! Type '{}' is not assignable to type 'i3':
 !!!   Property 'M' is missing in type '{}'.
     var test3: i2 = {};

--- a/tests/baselines/reference/overEagerReturnTypeSpecialization.errors.txt
+++ b/tests/baselines/reference/overEagerReturnTypeSpecialization.errors.txt
@@ -7,11 +7,10 @@
      
     declare var v1: I1<number>;
     var r1: I1<string> = v1.func(num => num.toString()) // Correctly returns an I1<string>
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-               .func(str => str.length);    // should error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'I1<number>' is not assignable to type 'I1<string>':
 !!!   Type 'number' is not assignable to type 'string'.
+               .func(str => str.length);    // should error
     
     var r2: I1<number> = v1.func(num => num.toString()) // Correctly returns an I1<string>
                .func(str => str.length);    // should be ok 

--- a/tests/baselines/reference/overload1.errors.txt
+++ b/tests/baselines/reference/overload1.errors.txt
@@ -26,7 +26,7 @@
     declare var x:O.I;
     
     var e:string=x.g(new O.A()); // matches overload but bad assignment
-        ~~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'C' is not assignable to type 'string'.
     var y:string=x.f(3); // good
     y=x.f("nope"); // can't assign number to string

--- a/tests/baselines/reference/overloadingOnConstants1.errors.txt
+++ b/tests/baselines/reference/overloadingOnConstants1.errors.txt
@@ -21,18 +21,18 @@
     
     // these are errors
     var htmlElement2: Derived1 = d2.createElement("yo")
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~
 !!! Type 'Base' is not assignable to type 'Derived1':
 !!!   Property 'bar' is missing in type 'Base'.
     var htmlCanvasElement2: Derived3 = d2.createElement("canvas");
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~~~~~~~
 !!! Type 'Derived1' is not assignable to type 'Derived3':
 !!!   Property 'biz' is missing in type 'Derived1'.
     var htmlDivElement2: Derived1 = d2.createElement("div");
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~~~~
 !!! Type 'Derived2' is not assignable to type 'Derived1':
 !!!   Property 'bar' is missing in type 'Derived2'.
     var htmlSpanElement2: Derived1 = d2.createElement("span");
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~~~~~~~~
 !!! Type 'Derived3' is not assignable to type 'Derived1':
 !!!   Property 'bar' is missing in type 'Derived3'.

--- a/tests/baselines/reference/overloadresolutionWithConstraintCheckingDeferred.errors.txt
+++ b/tests/baselines/reference/overloadresolutionWithConstraintCheckingDeferred.errors.txt
@@ -13,7 +13,7 @@
     declare function foo(arg: (x: B) => any): number;
     
     var result: number = foo(x => new G(x)); // No error, returns number
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~
 !!! Type 'string' is not assignable to type 'number'.
                                   ~~~~~~~~
 !!! Supplied parameters do not match any signature of call target.

--- a/tests/baselines/reference/parser0_004152.errors.txt
+++ b/tests/baselines/reference/parser0_004152.errors.txt
@@ -1,8 +1,8 @@
 ==== tests/cases/conformance/parser/ecmascript5/Fuzz/parser0_004152.ts (34 errors) ====
     export class Game {
-    ~~~~~~~~~~~~~~~~~~~
+                 ~~~~
+!!! Cannot compile external modules unless the '--module' flag is provided.
         private position = new DisplayPosition([), 3, 3, 3, 3, 3, 0, 3, 3, 3, 3, 3, 3, 0], NoMove, 0);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                                 ~
 !!! Expression or comma expected.
                                                  ~
@@ -68,9 +68,6 @@
                                                                                                    ~
 !!! Duplicate identifier '0'.
         private prevConfig: SeedCoords[][];
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                             ~~~~~~~~~~
 !!! Cannot find name 'SeedCoords'.
     }
-    ~
-!!! Cannot compile external modules unless the '--module' flag is provided.

--- a/tests/baselines/reference/parser509546.errors.txt
+++ b/tests/baselines/reference/parser509546.errors.txt
@@ -1,9 +1,7 @@
 ==== tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509546.ts (1 errors) ====
     export class Logger { 
-    ~~~~~~~~~~~~~~~~~~~~~~
-         public
-    ~~~~~~~~~~~
-    }
-    ~
+                 ~~~~~~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+         public
+    }
     

--- a/tests/baselines/reference/parser509546_1.errors.txt
+++ b/tests/baselines/reference/parser509546_1.errors.txt
@@ -1,9 +1,7 @@
 ==== tests/cases/conformance/parser/ecmascript5/RegressionTests/parser509546_1.ts (1 errors) ====
     export class Logger { 
-    ~~~~~~~~~~~~~~~~~~~~~~
-         public
-    ~~~~~~~~~~~
-    }
-    ~
+                 ~~~~~~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+         public
+    }
     

--- a/tests/baselines/reference/parser509546_2.errors.txt
+++ b/tests/baselines/reference/parser509546_2.errors.txt
@@ -2,10 +2,8 @@
     "use strict";
     
     export class Logger { 
-    ~~~~~~~~~~~~~~~~~~~~~~
-         public
-    ~~~~~~~~~~~
-    }
-    ~
+                 ~~~~~~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+         public
+    }
     

--- a/tests/baselines/reference/parser618973.errors.txt
+++ b/tests/baselines/reference/parser618973.errors.txt
@@ -1,12 +1,9 @@
 ==== tests/cases/conformance/parser/ecmascript5/RegressionTests/parser618973.ts (2 errors) ====
     export export class Foo {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~
            ~~~~~~
 !!! 'export' modifier already seen.
-      public Bar() {
-    ~~~~~~~~~~~~~~~~
-      }
-    ~~~
-    }
-    ~
+                        ~~~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+      public Bar() {
+      }
+    }

--- a/tests/baselines/reference/parserClass1.errors.txt
+++ b/tests/baselines/reference/parserClass1.errors.txt
@@ -1,22 +1,14 @@
 ==== tests/cases/conformance/parser/ecmascript5/ClassDeclarations/parserClass1.ts (2 errors) ====
         export class NullLogger implements ILogger {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                     ~~~~~~~~~~
+!!! Cannot compile external modules unless the '--module' flag is provided.
                                            ~~~~~~~
 !!! Cannot find name 'ILogger'.
             public information(): boolean { return false; }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             public debug(): boolean { return false; }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             public warning(): boolean { return false; }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             public error(): boolean { return false; }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             public fatal(): boolean { return false; }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             public log(s: string): void {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             }
-    ~~~~~~~~~
         }
-    ~~~~~
-!!! Cannot compile external modules unless the '--module' flag is provided.

--- a/tests/baselines/reference/parserClass2.errors.txt
+++ b/tests/baselines/reference/parserClass2.errors.txt
@@ -2,19 +2,15 @@
     
     
         export class LoggerAdapter implements ILogger {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                     ~~~~~~~~~~~~~
+!!! Cannot compile external modules unless the '--module' flag is provided.
                                               ~~~~~~~
 !!! Cannot find name 'ILogger'.
             constructor (public logger: ILogger) { 
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                         ~~~~~~~
 !!! Cannot find name 'ILogger'.
                 this._information = this.logger.information();
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                      ~~~~~~~~~~~~
 !!! Property '_information' does not exist on type 'LoggerAdapter'.
             }
-    ~~~~~~~~~
         }
-    ~~~~~
-!!! Cannot compile external modules unless the '--module' flag is provided.

--- a/tests/baselines/reference/parserEnum1.errors.txt
+++ b/tests/baselines/reference/parserEnum1.errors.txt
@@ -2,15 +2,10 @@
     
     
         export enum SignatureFlags {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            None = 0,
-    ~~~~~~~~~~~~~~~~~
-            IsIndexer = 1,
-    ~~~~~~~~~~~~~~~~~~~~~~
-            IsStringIndexer = 1 << 1,
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            IsNumberIndexer = 1 << 2,
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
+                    ~~~~~~~~~~~~~~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+            None = 0,
+            IsIndexer = 1,
+            IsStringIndexer = 1 << 1,
+            IsNumberIndexer = 1 << 2,
+        }

--- a/tests/baselines/reference/parserEnum2.errors.txt
+++ b/tests/baselines/reference/parserEnum2.errors.txt
@@ -2,15 +2,10 @@
     
     
         export enum SignatureFlags {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            None = 0,
-    ~~~~~~~~~~~~~~~~~
-            IsIndexer = 1,
-    ~~~~~~~~~~~~~~~~~~~~~~
-            IsStringIndexer = 1 << 1,
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            IsNumberIndexer = 1 << 2
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
+                    ~~~~~~~~~~~~~~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+            None = 0,
+            IsIndexer = 1,
+            IsStringIndexer = 1 << 1,
+            IsNumberIndexer = 1 << 2
+        }

--- a/tests/baselines/reference/parserEnum3.errors.txt
+++ b/tests/baselines/reference/parserEnum3.errors.txt
@@ -2,7 +2,6 @@
     
     
         export enum SignatureFlags {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
+                    ~~~~~~~~~~~~~~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+        }

--- a/tests/baselines/reference/parserEnum4.errors.txt
+++ b/tests/baselines/reference/parserEnum4.errors.txt
@@ -2,11 +2,9 @@
     
     
         export enum SignatureFlags {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    ~~~~~~~~~~~~~~
+!!! Cannot compile external modules unless the '--module' flag is provided.
             ,
-    ~~~~~~~~~
             ~
 !!! Enum member expected.
         }
-    ~~~~~
-!!! Cannot compile external modules unless the '--module' flag is provided.

--- a/tests/baselines/reference/parserExportAssignment7.errors.txt
+++ b/tests/baselines/reference/parserExportAssignment7.errors.txt
@@ -1,9 +1,8 @@
 ==== tests/cases/conformance/parser/ecmascript5/ExportAssignments/parserExportAssignment7.ts (3 errors) ====
     export class C {
-    ~~~~~~~~~~~~~~~~
-    }
-    ~
+                 ~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+    }
     
     export = B;
     ~~~~~~~~~~~

--- a/tests/baselines/reference/parserForInStatement5.errors.txt
+++ b/tests/baselines/reference/parserForInStatement5.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/conformance/parser/ecmascript5/Statements/parserForInStatement5.ts (2 errors) ====
     for (var a: number in X) {
-             ~~~~~~~~~
+             ~
 !!! Variable declarations of a 'for' statement cannot use a type annotation.
                           ~
 !!! Cannot find name 'X'.

--- a/tests/baselines/reference/parserForInStatement7.errors.txt
+++ b/tests/baselines/reference/parserForInStatement7.errors.txt
@@ -2,7 +2,7 @@
     for (var a: number = 1, b: string = "" in X) {
                                               ~
 !!! Only a single variable declaration is allowed in a 'for...in' statement.
-             ~~~~~~~~~~~~~
+             ~
 !!! Variable declarations of a 'for' statement cannot use a type annotation.
                                               ~
 !!! Cannot find name 'X'.

--- a/tests/baselines/reference/parserInterfaceDeclaration6.errors.txt
+++ b/tests/baselines/reference/parserInterfaceDeclaration6.errors.txt
@@ -1,8 +1,7 @@
 ==== tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration6.ts (2 errors) ====
     export export interface I {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
            ~~~~~~
 !!! 'export' modifier already seen.
-    }
-    ~
+                            ~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+    }

--- a/tests/baselines/reference/parserInterfaceDeclaration7.errors.txt
+++ b/tests/baselines/reference/parserInterfaceDeclaration7.errors.txt
@@ -1,6 +1,5 @@
 ==== tests/cases/conformance/parser/ecmascript5/InterfaceDeclarations/parserInterfaceDeclaration7.ts (1 errors) ====
     export interface I {
-    ~~~~~~~~~~~~~~~~~~~~
-    }
-    ~
+                     ~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+    }

--- a/tests/baselines/reference/parserModule1.errors.txt
+++ b/tests/baselines/reference/parserModule1.errors.txt
@@ -1,64 +1,34 @@
 ==== tests/cases/conformance/parser/ecmascript5/ModuleDeclarations/parserModule1.ts (1 errors) ====
         export module CompilerDiagnostics {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                      ~~~~~~~~~~~~~~~~~~~
+!!! Cannot compile external modules unless the '--module' flag is provided.
             export var debug = false;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             export interface IDiagnosticWriter {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 Alert(output: string): void;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
             }
-    ~~~~~~~~~
-    
     
             export var diagnosticWriter: IDiagnosticWriter = null;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    
     
             export var analysisPass: number = 0;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    
     
             export function Alert(output: string) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 if (diagnosticWriter) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                     diagnosticWriter.Alert(output);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 }
-    ~~~~~~~~~~~~~
             }
-    ~~~~~~~~~
-    
     
             export function debugPrint(s: string) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 if (debug) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~
                     Alert(s);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~
                 }
-    ~~~~~~~~~~~~~
             }
-    ~~~~~~~~~
-    
     
             export function assert(condition: boolean, s: string) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                 if (debug) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~
                     if (!condition) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                         Alert(s);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                     }
-    ~~~~~~~~~~~~~~~~~
                 }
-    ~~~~~~~~~~~~~
             }
-    ~~~~~~~~~
-    
     
         }
-    ~~~~~
-!!! Cannot compile external modules unless the '--module' flag is provided.

--- a/tests/baselines/reference/parserObjectCreation1.errors.txt
+++ b/tests/baselines/reference/parserObjectCreation1.errors.txt
@@ -1,5 +1,5 @@
 ==== tests/cases/conformance/parser/ecmascript5/Generics/parserObjectCreation1.ts (1 errors) ====
     var autoToken: number[] = new Array<number[]>(1);
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~~~~~~~
 !!! Type 'number[][]' is not assignable to type 'number[]':
 !!!   Type 'number[]' is not assignable to type 'number'.

--- a/tests/baselines/reference/privacyTypeParameterOfFunction.errors.txt
+++ b/tests/baselines/reference/privacyTypeParameterOfFunction.errors.txt
@@ -3,10 +3,9 @@
     }
     
     export class publicClass {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-    }
-    ~
+                 ~~~~~~~~~~~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+    }
     
     export interface publicInterfaceWithPrivateTypeParameters {
         // TypeParameter_0_of_constructor_signature_from_exported_interface_has_or_is_using_private_type_1

--- a/tests/baselines/reference/privacyTypeParametersOfClass.errors.txt
+++ b/tests/baselines/reference/privacyTypeParametersOfClass.errors.txt
@@ -3,10 +3,9 @@
     }
     
     export class publicClass {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-    }
-    ~
+                 ~~~~~~~~~~~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+    }
     
     // TypeParameter_0_of_exported_class_1_has_or_is_using_private_type_2
     export class publicClassWithPrivateTypeParameters<T extends privateClass> {

--- a/tests/baselines/reference/privacyTypeParametersOfInterface.errors.txt
+++ b/tests/baselines/reference/privacyTypeParametersOfInterface.errors.txt
@@ -3,10 +3,9 @@
     }
     
     export class publicClass {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-    }
-    ~
+                 ~~~~~~~~~~~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+    }
     
     class privateClassT<T> {
     }

--- a/tests/baselines/reference/propertiesAndIndexers.errors.txt
+++ b/tests/baselines/reference/propertiesAndIndexers.errors.txt
@@ -50,42 +50,26 @@
     }
     
     interface D extends B, C {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~
+!!! Numeric index type 'string' is not assignable to string index type 'number'.
+              ~
+!!! Property '4' of type 'boolean' is not assignable to string index type 'number'.
+              ~
+!!! Property '5' of type 'string' is not assignable to string index type 'number'.
+              ~
+!!! Property '6' of type '() => string' is not assignable to string index type 'number'.
         2: Z;
-    ~~~~~~~~~
-    ~~~~~~~~~
-    ~~~~~~~~~
-    ~~~~~~~~~
         ~~~~~
 !!! Property '2' of type 'Z' is not assignable to numeric index type 'string'.
         ~~~~~
 !!! Property '2' of type 'Z' is not assignable to string index type 'number'.
         Infinity: number;
-    ~~~~~~~~~~~~~~~~~~~~~
-    ~~~~~~~~~~~~~~~~~~~~~
-    ~~~~~~~~~~~~~~~~~~~~~
-    ~~~~~~~~~~~~~~~~~~~~~
         ~~~~~~~~~~~~~~~~~
 !!! Property 'Infinity' of type 'number' is not assignable to numeric index type 'string'.
         zoo: string;
-    ~~~~~~~~~~~~~~~~
-    ~~~~~~~~~~~~~~~~
-    ~~~~~~~~~~~~~~~~
-    ~~~~~~~~~~~~~~~~
         ~~~~~~~~~~~~
 !!! Property 'zoo' of type 'string' is not assignable to string index type 'number'.
     }
-    ~
-!!! Numeric index type 'string' is not assignable to string index type 'number'.
-    ~
-!!! Property '4' of type 'boolean' is not assignable to string index type 'number'.
-    ~
-!!! Property '5' of type 'string' is not assignable to string index type 'number'.
-    ~
-!!! Property '6' of type '() => string' is not assignable to string index type 'number'.
     
     class P {
         [n: string]: string

--- a/tests/baselines/reference/propertyParameterWithQuestionMark.errors.txt
+++ b/tests/baselines/reference/propertyParameterWithQuestionMark.errors.txt
@@ -5,7 +5,7 @@
     
     // x should not be an optional property
     var v: C = {}; // Should fail
-        ~~~~~~~~~
+        ~
 !!! Type '{}' is not assignable to type 'C':
 !!!   Property 'x' is missing in type '{}'.
     var v2: { x? }

--- a/tests/baselines/reference/qualify.errors.txt
+++ b/tests/baselines/reference/qualify.errors.txt
@@ -20,7 +20,7 @@
         }
         export module U {
             var z:I=3;
-                ~~~~~
+                ~
 !!! Type 'number' is not assignable to type 'I':
 !!!   Property 'p' is missing in type 'Number'.
             export interface I2 {
@@ -32,7 +32,7 @@
     module Peer {
         export module U2 {
             var z:T.U.I2=3;
-                ~~~~~~~~~~
+                ~
 !!! Type 'number' is not assignable to type 'I2':
 !!!   Property 'q' is missing in type 'Number'.
         }
@@ -50,21 +50,21 @@
             }
             var v1:I4;
             var v2:K1.I3=v1;
-                ~~~~~~~~~~~
+                ~~
 !!! Type 'I4' is not assignable to type 'I3':
 !!!   Property 'zeep' is missing in type 'I4'.
             var v3:K1.I3[]=v1;
-                ~~~~~~~~~~~~~
+                ~~
 !!! Type 'I4' is not assignable to type 'I3[]':
 !!!   Property 'concat' is missing in type 'I4'.
             var v4:()=>K1.I3=v1;
-                ~~~~~~~~~~~~~~~
+                ~~
 !!! Type 'I4' is not assignable to type '() => I3'.
             var v5:(k:K1.I3)=>void=v1;
-                ~~~~~~~~~~~~~~~~~~~~~
+                ~~
 !!! Type 'I4' is not assignable to type '(k: I3) => void'.
             var v6:{k:K1.I3;}=v1;
-                ~~~~~~~~~~~~~~~~
+                ~~
 !!! Type 'I4' is not assignable to type '{ k: I3; }':
 !!!   Property 'k' is missing in type 'I4'.
         }
@@ -76,7 +76,7 @@
     
     var y:I;
     var x:T.I=y;
-        ~~~~~~~
+        ~
 !!! Type 'I' is not assignable to type 'I':
 !!!   Property 'p' is missing in type 'I'.
     

--- a/tests/baselines/reference/recursiveBaseCheck.errors.txt
+++ b/tests/baselines/reference/recursiveBaseCheck.errors.txt
@@ -1,10 +1,9 @@
 ==== tests/cases/compiler/recursiveBaseCheck.ts (1 errors) ====
     declare module Module {
         class C extends D {
-        ~~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
+              ~
 !!! Type 'C' recursively references itself as a base type.
+        }
         export class B extends Module.C {
         }
         export class A extends Module.B {

--- a/tests/baselines/reference/recursiveBaseCheck2.errors.txt
+++ b/tests/baselines/reference/recursiveBaseCheck2.errors.txt
@@ -1,10 +1,9 @@
 ==== tests/cases/compiler/recursiveBaseCheck2.ts (1 errors) ====
     declare module Box2D.Collision.Shapes {
         export class b2CircleShape extends b2Shape {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
+                     ~~~~~~~~~~~~~
 !!! Type 'b2CircleShape' recursively references itself as a base type.
+        }
         export class b2Shape extends Box2D.Collision.Shapes.b2CircleShape {
         }
     }

--- a/tests/baselines/reference/recursiveBaseCheck3.errors.txt
+++ b/tests/baselines/reference/recursiveBaseCheck3.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/compiler/recursiveBaseCheck3.ts (2 errors) ====
     class A<T> extends C<T> { }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          ~
 !!! Type 'A<T>' recursively references itself as a base type.
     class C<T> extends A<T> { }
     

--- a/tests/baselines/reference/recursiveBaseCheck4.errors.txt
+++ b/tests/baselines/reference/recursiveBaseCheck4.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/compiler/recursiveBaseCheck4.ts (2 errors) ====
     class M<T> extends M<string> { }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          ~
 !!! Type 'M<T>' recursively references itself as a base type.
     (new M).blah;
             ~~~~

--- a/tests/baselines/reference/recursiveBaseCheck5.errors.txt
+++ b/tests/baselines/reference/recursiveBaseCheck5.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/compiler/recursiveBaseCheck5.ts (2 errors) ====
     interface I1<T> extends I2<string> { }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~~
 !!! Type 'I1<T>' recursively references itself as a base type.
     interface I2<T> extends I1<T> { }
     class X<T, U> implements I2<T> { }

--- a/tests/baselines/reference/recursiveBaseCheck6.errors.txt
+++ b/tests/baselines/reference/recursiveBaseCheck6.errors.txt
@@ -1,6 +1,6 @@
 ==== tests/cases/compiler/recursiveBaseCheck6.ts (2 errors) ====
     class S18<A> extends S18<{ S19: A; }>{ }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          ~~~
 !!! Type 'S18<A>' recursively references itself as a base type.
     (new S18()).blah;
                 ~~~~

--- a/tests/baselines/reference/recursiveFunctionTypes.errors.txt
+++ b/tests/baselines/reference/recursiveFunctionTypes.errors.txt
@@ -4,10 +4,10 @@
 !!! Type 'number' is not assignable to type '() => typeof fn'.
     
     var x: number = fn; // error
-        ~~~~~~~~~~~~~~
+        ~
 !!! Type '() => typeof fn' is not assignable to type 'number'.
     var y: () => number = fn; // ok
-        ~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type '() => typeof fn' is not assignable to type '() => number':
 !!!   Type '() => typeof fn' is not assignable to type 'number'.
     
@@ -23,7 +23,7 @@
     function f3(): I<typeof f3> { return f3; }
     
     var a: number = f3; // error
-        ~~~~~~~~~~~~~~
+        ~
 !!! Type '() => I<typeof f3>' is not assignable to type 'number'.
     
     class C {

--- a/tests/baselines/reference/recursiveInheritance.errors.txt
+++ b/tests/baselines/reference/recursiveInheritance.errors.txt
@@ -1,15 +1,13 @@
 ==== tests/cases/compiler/recursiveInheritance.ts (2 errors) ====
     
     interface I5 extends I5 { // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        foo():void;
-    ~~~~~~~~~~~~~~~
-    } 
-    ~
+              ~~
 !!! Type 'I5' recursively references itself as a base type.
+        foo():void;
+    } 
     
     interface i8 extends i9 { } // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+              ~~
 !!! Type 'i8' recursively references itself as a base type.
     interface i9 extends i8 { } // error
     

--- a/tests/baselines/reference/recursiveInheritanceGeneric.errors.txt
+++ b/tests/baselines/reference/recursiveInheritanceGeneric.errors.txt
@@ -1,8 +1,6 @@
 ==== tests/cases/compiler/recursiveInheritanceGeneric.ts (1 errors) ====
     interface I5<T> extends I5<T> { 
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        foo():void;
-    ~~~~~~~~~~~~~~~
-    }  
-    ~
+              ~~
 !!! Type 'I5<T>' recursively references itself as a base type.
+        foo():void;
+    }  

--- a/tests/baselines/reference/relativePathToDeclarationFile.errors.txt
+++ b/tests/baselines/reference/relativePathToDeclarationFile.errors.txt
@@ -9,12 +9,10 @@
     
 ==== tests/cases/conformance/externalModules/test/foo.d.ts (1 errors) ====
     export declare module M2 {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-    	export var x: boolean;
-    ~~~~~~~~~~~~~~~~~~~~~~~
-    }
-    ~
+                          ~~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+    	export var x: boolean;
+    }
     
 ==== tests/cases/conformance/externalModules/test/other.d.ts (0 errors) ====
     export declare module M2 {

--- a/tests/baselines/reference/scannerClass2.errors.txt
+++ b/tests/baselines/reference/scannerClass2.errors.txt
@@ -2,19 +2,15 @@
     
     
         export class LoggerAdapter implements ILogger {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                     ~~~~~~~~~~~~~
+!!! Cannot compile external modules unless the '--module' flag is provided.
                                               ~~~~~~~
 !!! Cannot find name 'ILogger'.
             constructor (public logger: ILogger) { 
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                                         ~~~~~~~
 !!! Cannot find name 'ILogger'.
                 this._information = this.logger.information();
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
                      ~~~~~~~~~~~~
 !!! Property '_information' does not exist on type 'LoggerAdapter'.
             }
-    ~~~~~~~~~
         }
-    ~~~~~
-!!! Cannot compile external modules unless the '--module' flag is provided.

--- a/tests/baselines/reference/scannerEnum1.errors.txt
+++ b/tests/baselines/reference/scannerEnum1.errors.txt
@@ -1,10 +1,7 @@
 ==== tests/cases/conformance/scanner/ecmascript5/scannerEnum1.ts (1 errors) ====
         export enum CodeGenTarget {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            ES3 = 0,
-    ~~~~~~~~~~~~~~~~
-            ES5 = 1,
-    ~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
+                    ~~~~~~~~~~~~~
 !!! Cannot compile external modules unless the '--module' flag is provided.
+            ES3 = 0,
+            ES5 = 1,
+        }

--- a/tests/baselines/reference/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.errors.txt
+++ b/tests/baselines/reference/staticMemberOfClassAndPublicMemberOfAnotherClassAssignment.errors.txt
@@ -21,7 +21,7 @@
     a = C;
     
     var b: B = new C(); // error name is missing
-        ~~~~~~~~~~~~~~
+        ~
 !!! Type 'C' is not assignable to type 'B':
 !!!   Property 'name' is missing in type 'C'.
     b = B; // error name is missing

--- a/tests/baselines/reference/stringIndexerConstrainsPropertyDeclarations.errors.txt
+++ b/tests/baselines/reference/stringIndexerConstrainsPropertyDeclarations.errors.txt
@@ -127,49 +127,30 @@
     
     // error
     var b: { [x: string]: string; } = {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~
+!!! Type '{ [x: string]: {}; 1.0: string; 2.0: number; a: string; b: number; c: () => void; "d": string; "e": number; "3.0": string; "4.0": number; f: MyString; X: string; foo: () => string; }' is not assignable to type '{ [x: string]: string; }':
+!!!   Index signatures are incompatible:
+!!!     Type '{}' is not assignable to type 'string'.
         a: '',
-    ~~~~~~~~~~
         b: 1, 
-    ~~~~~~~~~~
         c: () => { }, 
-    ~~~~~~~~~~~~~~~~~~
         "d": '', 
-    ~~~~~~~~~~~~~
         "e": 1, 
-    ~~~~~~~~~~~~
         1.0: '',
-    ~~~~~~~~~~~~
         2.0: 1, 
-    ~~~~~~~~~~~~
         "3.0": '', 
-    ~~~~~~~~~~~~~~~
         "4.0": 1, 
-    ~~~~~~~~~~~~~~
         f: <MyString>null, 
-    ~~~~~~~~~~~~~~~~~~~~~~~
-    
     
         get X() { 
             ~
 !!! Accessors are only available when targeting ECMAScript 5 and higher.
-    ~~~~~~~~~~~~~~
             return '';
-    ~~~~~~~~~~~~~~~~~~
         },
-    ~~~~~~
         set X(v) { }, 
             ~
 !!! Accessors are only available when targeting ECMAScript 5 and higher.
-    ~~~~~~~~~~~~~~~~~~
         foo() { 
-    ~~~~~~~~~~~~
             return '';
-    ~~~~~~~~~~~~~~~~~~
         }
-    ~~~~~
     }
-    ~
-!!! Type '{ [x: string]: {}; 1.0: string; 2.0: number; a: string; b: number; c: () => void; "d": string; "e": number; "3.0": string; "4.0": number; f: MyString; X: string; foo: () => string; }' is not assignable to type '{ [x: string]: string; }':
-!!!   Index signatures are incompatible:
-!!!     Type '{}' is not assignable to type 'string'.

--- a/tests/baselines/reference/stringIndexerConstrainsPropertyDeclarations2.errors.txt
+++ b/tests/baselines/reference/stringIndexerConstrainsPropertyDeclarations2.errors.txt
@@ -47,14 +47,11 @@
     
     // error
     var b: { [x: string]: A } = {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~
-        a: A,
-    ~~~~~~~~~
-        b: B
-    ~~~~~~~~
-    }
-    ~
+        ~
 !!! Type '{ [x: string]: typeof A; a: typeof A; b: typeof B; }' is not assignable to type '{ [x: string]: A; }':
 !!!   Index signatures are incompatible:
 !!!     Type 'typeof A' is not assignable to type 'A':
 !!!       Property 'foo' is missing in type 'typeof A'.
+        a: A,
+        b: B
+    }

--- a/tests/baselines/reference/targetTypeTest3.errors.txt
+++ b/tests/baselines/reference/targetTypeTest3.errors.txt
@@ -3,7 +3,7 @@
     
     
     var a : string[] = [1,2,"3"]; // should produce an error
-        ~~~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type '{}[]' is not assignable to type 'string[]':
 !!!   Type '{}' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/thisWhenTypeCheckFails.errors.txt
+++ b/tests/baselines/reference/thisWhenTypeCheckFails.errors.txt
@@ -3,7 +3,7 @@
         public n() {
             var k = () => {
                 var s: string = this.n();
-                    ~~~~~~~~~~~~~~~~~~~~
+                    ~
 !!! Type 'void' is not assignable to type 'string'.
             }
         }    

--- a/tests/baselines/reference/typeArgumentsShouldDisallowNonGenericOverloads.errors.txt
+++ b/tests/baselines/reference/typeArgumentsShouldDisallowNonGenericOverloads.errors.txt
@@ -9,8 +9,8 @@
     var y: string = foo("hi"); // return type should be 'string'
     
     var w: string = foo<string>("hi"); // should error
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'number' is not assignable to type 'string'.
     var z: number = foo("hi"); // should error
-        ~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/typeCheckingInsideFunctionExpressionInArray.errors.txt
+++ b/tests/baselines/reference/typeCheckingInsideFunctionExpressionInArray.errors.txt
@@ -1,7 +1,7 @@
 ==== tests/cases/compiler/typeCheckingInsideFunctionExpressionInArray.ts (4 errors) ====
     var functions = [function () {
       var k: string = 10;
-          ~~~~~~~~~~~~~~
+          ~
 !!! Type 'number' is not assignable to type 'string'.
         k = new Object();
         ~

--- a/tests/baselines/reference/typeInfer1.errors.txt
+++ b/tests/baselines/reference/typeInfer1.errors.txt
@@ -10,10 +10,8 @@
     }
     
     var yyyyyyyy: ITextWriter2 = {
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~
-        Moo: function() { return "cow"; }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    }
-    ~
+        ~~~~~~~~
 !!! Type '{ Moo: () => string; }' is not assignable to type 'ITextWriter2':
 !!!   Property 'Write' is missing in type '{ Moo: () => string; }'.
+        Moo: function() { return "cow"; }
+    }

--- a/tests/baselines/reference/typeName1.errors.txt
+++ b/tests/baselines/reference/typeName1.errors.txt
@@ -8,63 +8,63 @@
     }
     
     var x1:{ f(s:string):number;f(n:number):string; }=3;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'number' is not assignable to type '{ f(s: string): number; f(n: number): string; }':
 !!!   Property 'f' is missing in type 'Number'.
     var x2:{ f(s:string):number; } =3;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'number' is not assignable to type '{ f(s: string): number; }':
 !!!   Property 'f' is missing in type 'Number'.
     var x3:{ (s:string):number;(n:number):string; }=3;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'number' is not assignable to type '{ (s: string): number; (n: number): string; }'.
     var x4:{ x;y;z:number;f(n:number):string;f(s:string):number; }=3;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'number' is not assignable to type '{ x: any; y: any; z: number; f(n: number): string; f(s: string): number; }':
 !!!   Property 'x' is missing in type 'Number'.
     var x5:{ (s:string):number;(n:number):string;x;y;z:number;f(n:number):string;f(s:string):number; }=3;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'number' is not assignable to type '{ (s: string): number; (n: number): string; x: any; y: any; z: number; f(n: number): string; f(s: string): number; }':
 !!!   Property 'x' is missing in type 'Number'.
     var x6:{ z:number;f:{(n:number):string;(s:string):number;}; }=3;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'number' is not assignable to type '{ z: number; f: { (n: number): string; (s: string): number; }; }':
 !!!   Property 'z' is missing in type 'Number'.
     var x7:(s:string)=>boolean=3;
-        ~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'number' is not assignable to type '(s: string) => boolean'.
     var x8:{ z:I;[s:string]:{ x; y; };[n:number]:{x; y;};():boolean; }=3;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'number' is not assignable to type '{ (): boolean; [x: string]: { x: any; y: any; }; [x: number]: { x: any; y: any; }; z: I; }':
 !!!   Property 'z' is missing in type 'Number'.
              ~~~~
 !!! Property 'z' of type 'I' is not assignable to string index type '{ x: any; y: any; }'.
     var x9:I=3;
-        ~~~~~~
+        ~~
 !!! Type 'number' is not assignable to type 'I':
 !!!   Property 'k' is missing in type 'Number'.
     var x10:I[][][][]=3;
-        ~~~~~~~~~~~~~~~
+        ~~~
 !!! Type 'number' is not assignable to type 'I[][][][]':
 !!!   Property 'concat' is missing in type 'Number'.
     var x11:{z:I;x:boolean;}[][]=3;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~
 !!! Type 'number' is not assignable to type '{ z: I; x: boolean; }[][]':
 !!!   Property 'concat' is missing in type 'Number'.
     var x12:{z:I;x:boolean;y:(s:string)=>boolean;w:{ z:I;[s:string]:{ x; y; };[n:number]:{x; y;};():boolean; };}[][]=3;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~
 !!! Type 'number' is not assignable to type '{ z: I; x: boolean; y: (s: string) => boolean; w: { (): boolean; [x: string]: { x: any; y: any; }; [x: number]: { x: any; y: any; }; z: I; }; }[][]':
 !!!   Property 'concat' is missing in type 'Number'.
     var x13:{ new(): number; new(n:number):number; x: string; w: {y: number;}; (): {}; } = 3;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~
 !!! Type 'number' is not assignable to type '{ (): {}; new (): number; new (n: number): number; x: string; w: { y: number; }; }':
 !!!   Property 'x' is missing in type 'Number'.
     var x14:{ f(x:number):boolean; p; q; ():string; }=3;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~
 !!! Type 'number' is not assignable to type '{ (): string; f(x: number): boolean; p: any; q: any; }':
 !!!   Property 'f' is missing in type 'Number'.
     var x15:number=C;
-        ~~~~~~~~~~~~
+        ~~~
 !!! Type 'typeof C' is not assignable to type 'number'.
     
     

--- a/tests/baselines/reference/typeOfOperator1.errors.txt
+++ b/tests/baselines/reference/typeOfOperator1.errors.txt
@@ -2,5 +2,5 @@
     var x = 1;
     var y: string = typeof x;
     var z: number = typeof x;
-        ~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/typeofSimple.errors.txt
+++ b/tests/baselines/reference/typeofSimple.errors.txt
@@ -2,7 +2,7 @@
     var v = 3;
     var v2: typeof v;
     var v3: string = v2; // Not assignment compatible
-        ~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'number' is not assignable to type 'string'.
     
     interface I<T> { x: T; }

--- a/tests/baselines/reference/typesOnlyExternalModuleStillHasInstance.errors.txt
+++ b/tests/baselines/reference/typesOnlyExternalModuleStillHasInstance.errors.txt
@@ -4,7 +4,7 @@
     
     var x: typeof foo0 = {};
     var y: {M2: Object} = foo0;
-        ~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'typeof "tests/cases/conformance/externalModules/foo_0"' is not assignable to type '{ M2: Object; }':
 !!!   Property 'M2' is missing in type 'typeof "tests/cases/conformance/externalModules/foo_0"'.
     

--- a/tests/baselines/reference/typesWithPrivateConstructor.errors.txt
+++ b/tests/baselines/reference/typesWithPrivateConstructor.errors.txt
@@ -9,7 +9,7 @@
     
     var c = new C();
     var r: () => void = c.constructor;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'Function' is not assignable to type '() => void'.
     
     class C2 {

--- a/tests/baselines/reference/typesWithPublicConstructor.errors.txt
+++ b/tests/baselines/reference/typesWithPublicConstructor.errors.txt
@@ -7,7 +7,7 @@
     
     var c = new C();
     var r: () => void = c.constructor;
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~
 !!! Type 'Function' is not assignable to type '() => void'.
     
     class C2 {

--- a/tests/baselines/reference/widenToAny1.errors.txt
+++ b/tests/baselines/reference/widenToAny1.errors.txt
@@ -4,6 +4,6 @@
         return undefined;
     }
     var z1: number = foo1({ x: undefined, y: "def" });  // Best common type is any
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'string' is not assignable to type 'number'.
     

--- a/tests/baselines/reference/widenToAny2.errors.txt
+++ b/tests/baselines/reference/widenToAny2.errors.txt
@@ -3,6 +3,6 @@
         return undefined;
     }
     var z3:number = foo3([undefined, "def"]);  // Type is any, but should be string
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~
 !!! Type 'string' is not assignable to type 'number'.
     

--- a/tests/baselines/reference/widenedTypes.errors.txt
+++ b/tests/baselines/reference/widenedTypes.errors.txt
@@ -34,11 +34,11 @@
     
     // Highlights the difference between array literals and object literals
     var arr: string[] = [3, null]; // not assignable because null is not widened. BCT is {}
-        ~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~
 !!! Type 'number[]' is not assignable to type 'string[]':
 !!!   Type 'number' is not assignable to type 'string'.
     var obj: { [x: string]: string; } = { x: 3, y: null }; // assignable because null is widened, and therefore BCT is any
-        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        ~~~
 !!! Type '{ [x: string]: number; x: number; y: null; }' is not assignable to type '{ [x: string]: string; }':
 !!!   Index signatures are incompatible:
 !!!     Type 'number' is not assignable to type 'string'.


### PR DESCRIPTION
This is to minimize the error spans for many declaration kinds, to overwhelm the user less. There are a lot of baseline changes here, but many of them fall into broad categories (e.g. assignability errors are very common on var declarations). Let me know if any of the errors got less clear, or if you noticed errors that are still unclear.
