### PR TITLE
Aligning index signature type inference with assignability rules.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3075,8 +3075,9 @@ module ts {
                         inferFromProperties(source, target);
                         inferFromSignatures(source, target, SignatureKind.Call);
                         inferFromSignatures(source, target, SignatureKind.Construct);
-                        inferFromIndexTypes(source, target, IndexKind.String);
-                        inferFromIndexTypes(source, target, IndexKind.Number);
+                        inferFromIndexTypes(source, target, IndexKind.String, IndexKind.String);
+                        inferFromIndexTypes(source, target, IndexKind.Number, IndexKind.Number);
+                        inferFromIndexTypes(source, target, IndexKind.String, IndexKind.Number);
                         depth--;
                     }
                 }
@@ -3109,10 +3110,10 @@ module ts {
                 inferFromTypes(getReturnTypeOfSignature(source), getReturnTypeOfSignature(target));
             }
 
-            function inferFromIndexTypes(source: Type, target: Type, kind: IndexKind) {
-                var targetIndexType = getIndexTypeOfType(target, kind);
+            function inferFromIndexTypes(source: Type, target: Type, sourceKind: IndexKind, targetKind: IndexKind) {
+                var targetIndexType = getIndexTypeOfType(target, targetKind);
                 if (targetIndexType) {
-                    var sourceIndexType = getIndexTypeOfType(source, kind);
+                    var sourceIndexType = getIndexTypeOfType(source, sourceKind);
                     if (sourceIndexType) {
                         inferFromTypes(sourceIndexType, targetIndexType);
                     }

--- a/tests/baselines/reference/indexSignatureTypeInference.errors.txt
+++ b/tests/baselines/reference/indexSignatureTypeInference.errors.txt
@@ -1,0 +1,23 @@
+==== tests/cases/compiler/indexSignatureTypeInference.ts (1 errors) ====
+    interface NumberMap<T> {
+        [index: number]: T;
+    }
+    
+    interface StringMap<T> {
+        [index: string]: T;
+    }
+    
+    declare function numberMapToArray<T>(object: NumberMap<T>): T[];
+    declare function stringMapToArray<T>(object: StringMap<T>): T[];
+    
+    var numberMap: NumberMap<Function>;
+    var stringMap: StringMap<Function>;
+    
+    var v1: Function[];
+    var v1 = numberMapToArray(numberMap);  // Ok
+    var v1 = numberMapToArray(stringMap);  // Ok
+    var v1 = stringMapToArray(numberMap);  // Error expected here
+             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! Supplied parameters do not match any signature of call target.
+    var v1 = stringMapToArray(stringMap);  // Ok
+    

--- a/tests/baselines/reference/indexSignatureTypeInference.js
+++ b/tests/baselines/reference/indexSignatureTypeInference.js
@@ -1,0 +1,30 @@
+//// [indexSignatureTypeInference.ts]
+interface NumberMap<T> {
+    [index: number]: T;
+}
+
+interface StringMap<T> {
+    [index: string]: T;
+}
+
+declare function numberMapToArray<T>(object: NumberMap<T>): T[];
+declare function stringMapToArray<T>(object: StringMap<T>): T[];
+
+var numberMap: NumberMap<Function>;
+var stringMap: StringMap<Function>;
+
+var v1: Function[];
+var v1 = numberMapToArray(numberMap);  // Ok
+var v1 = numberMapToArray(stringMap);  // Ok
+var v1 = stringMapToArray(numberMap);  // Error expected here
+var v1 = stringMapToArray(stringMap);  // Ok
+
+
+//// [indexSignatureTypeInference.js]
+var numberMap;
+var stringMap;
+var v1;
+var v1 = numberMapToArray(numberMap);
+var v1 = numberMapToArray(stringMap);
+var v1 = stringMapToArray(numberMap);
+var v1 = stringMapToArray(stringMap);

--- a/tests/cases/compiler/indexSignatureTypeInference.ts
+++ b/tests/cases/compiler/indexSignatureTypeInference.ts
@@ -1,0 +1,19 @@
+interface NumberMap<T> {
+    [index: number]: T;
+}
+
+interface StringMap<T> {
+    [index: string]: T;
+}
+
+declare function numberMapToArray<T>(object: NumberMap<T>): T[];
+declare function stringMapToArray<T>(object: StringMap<T>): T[];
+
+var numberMap: NumberMap<Function>;
+var stringMap: StringMap<Function>;
+
+var v1: Function[];
+var v1 = numberMapToArray(numberMap);  // Ok
+var v1 = numberMapToArray(stringMap);  // Ok
+var v1 = stringMapToArray(numberMap);  // Error expected here
+var v1 = stringMapToArray(stringMap);  // Ok


### PR DESCRIPTION
Type inference now supports inferring from string index signatures to numeric index signatures.
Fixes #167.
