### PR TITLE
fix runtests/baseline generation on mac/unix

### DIFF
--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -104,4 +104,7 @@ if (runners.length === 0) {
     // runners.push(new GeneratedFourslashRunner());
 }
 
+// force the newLine to be the same as windows when running tests
+sys.newLine = '\r\n';
+
 runTests(runners);


### PR DESCRIPTION
force sys.newLine to be the same value when running tests.

I have signed a CLA already, I'm AdamFreidin on codeplex.
