### PR TITLE
Set the exit status for the process correctly when compilation fails

### DIFF
--- a/src/compiler/tc.ts
+++ b/src/compiler/tc.ts
@@ -227,4 +227,4 @@ module ts {
     }
 }
 
-ts.executeCommandLine(sys.args);
+process.exit(ts.executeCommandLine(sys.args));


### PR DESCRIPTION
Use the result of ts.executeCommandLine() as the node process' exit
status.

Can you point me at the right place to add a test for this?

Fixes #245
