### PR TITLE
Properly set exit code for process.

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -125,7 +125,11 @@ var sys: System = (function () {
                 return 0;
             },
             exit(exitCode?: number): void {
-                WScript.Quit(exitCode);
+                try {
+                    WScript.Quit(exitCode);
+                }
+                catch (e) {
+                }
             }
         };
     }

--- a/src/compiler/tc.ts
+++ b/src/compiler/tc.ts
@@ -227,4 +227,4 @@ module ts {
     }
 }
 
-ts.executeCommandLine(sys.args);
+sys.exit(ts.executeCommandLine(sys.args));


### PR DESCRIPTION
Supercedes #246.
Includes provisions for buggy behavior of WScript.Quit.
