### PR TITLE
Added ArrayBuffer.slice() to extensions.d.ts

### DIFF
--- a/src/lib/extensions.d.ts
+++ b/src/lib/extensions.d.ts
@@ -14,6 +14,11 @@ interface ArrayBuffer {
       * Read-only. The length of the ArrayBuffer (in bytes).
       */
     byteLength: number;
+
+    /**
+      * Returns a section of an ArrayBuffer.
+      */
+    slice(begin:number, end?:number): ArrayBuffer;
 }
 
 declare var ArrayBuffer: {


### PR DESCRIPTION
Covered by issue #310.

No tests updated – assuming that there are no tests checking the built output of `lib.d.ts`?
