### PR TITLE
move exportAssignSymbol to symbolLinks

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -443,13 +443,15 @@ module ts {
             return moduleSymbol;
         }
 
-        function getExportAssignmentSymbol(symbol: Symbol): Symbol {
+        function getExportAssignmentSymbol(symbol: Symbol): Symbol {            
             checkTypeOfExportAssignmentSymbol(symbol);
-            return symbol.exportAssignSymbol === unknownSymbol ? undefined : symbol.exportAssignSymbol;
+            var symbolLinks = getSymbolLinks(symbol);
+            return symbolLinks.exportAssignSymbol === unknownSymbol ? undefined : symbolLinks.exportAssignSymbol;
         }
 
         function checkTypeOfExportAssignmentSymbol(containerSymbol: Symbol): void {
-            if (!containerSymbol.exportAssignSymbol) {
+            var symbolLinks = getSymbolLinks(containerSymbol);
+            if (!symbolLinks.exportAssignSymbol) {
                 var exportInformation = collectExportInformationForSourceFileOrModule(containerSymbol);
                 if (exportInformation.exportAssignments.length) {
                     if (exportInformation.exportAssignments.length > 1) {
@@ -470,7 +472,7 @@ module ts {
                         var exportSymbol = resolveName(node, node.exportName.text, meaning, Diagnostics.Cannot_find_name_0, identifierToString(node.exportName));
                     }
                 }
-                containerSymbol.exportAssignSymbol = exportSymbol || unknownSymbol;
+                symbolLinks.exportAssignSymbol = exportSymbol || unknownSymbol;
             }
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -717,7 +717,6 @@ module ts {
         members?: SymbolTable;         // Class, interface or literal instance members
         exports?: SymbolTable;         // Module exports
         exportSymbol?: Symbol;         // Exported symbol associated with this symbol
-        exportAssignSymbol?: Symbol;   // Symbol exported from external module
         valueDeclaration?: Declaration // First value declaration of the symbol
     }
 
@@ -727,6 +726,7 @@ module ts {
         declaredType?: Type;           // Type of class, interface, enum, or type parameter
         mapper?: TypeMapper;           // Type mapper for instantiation alias
         referenced?: boolean;          // True if alias symbol has been referenced as a value
+        exportAssignSymbol?: Symbol;   // Symbol exported from external module
     }
 
     export interface TransientSymbol extends Symbol, SymbolLinks { }


### PR DESCRIPTION
`exportAssignSymbol` was the property on the symbol itself but it was assigned in the checker - this might lead to a unexpected consequences when `unknownSymbol` from one typecheck session leaked to another one
