### PR TITLE
Adding definitions to build output

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -135,7 +135,6 @@ function concatenateFiles(destinationFile, sourceFiles) {
 }
 
 var useDebugMode = true;
-var generateDeclarations = false;
 var host = (process.env.host || process.env.TYPESCRIPT_HOST || "node");
 var compilerFilename = "tsc.js";
 /* Compiles a file from a list of sources
@@ -146,7 +145,7 @@ var compilerFilename = "tsc.js";
     * @param useBuiltCompiler: true to use the built compiler, false to use the LKG
     * @param noOutFile: true to compile without using --out
     */
-function compileFile(outFile, sources, prereqs, prefixes, useBuiltCompiler, noOutFile) {
+function compileFile(outFile, sources, prereqs, prefixes, useBuiltCompiler, noOutFile, generateDeclarations) {
     file(outFile, prereqs, function() {
         var dir = useBuiltCompiler ? builtLocalDirectory : LKGDirectory;
         var options = "-removeComments --module commonjs -noImplicitAny ";
@@ -157,7 +156,7 @@ function compileFile(outFile, sources, prereqs, prefixes, useBuiltCompiler, noOu
         if (useDebugMode) {
             options += "--preserveConstEnums ";
         }
-        
+
         var cmd = host + " " + dir + compilerFilename + " " + options + " ";
         cmd = cmd + sources.join(" ") + (!noOutFile ? " -out " + outFile : "");
         if (useDebugMode) {
@@ -184,7 +183,7 @@ function compileFile(outFile, sources, prereqs, prefixes, useBuiltCompiler, noOu
             fs.unlinkSync(outFile);
             console.log("Compilation of " + outFile + " unsuccessful");
         });
-        ex.run();    
+        ex.run();
     }, {async: true});
 }
 
@@ -239,7 +238,7 @@ file(diagnosticInfoMapTs, [processDiagnosticMessagesJs, diagnosticMessagesJson],
     ex.addListener("cmdEnd", function() {
         complete();
     });
-    ex.run();    
+    ex.run();
 }, {async: true})
 
 
@@ -252,7 +251,8 @@ var tscFile = path.join(builtLocalDirectory, compilerFilename);
 compileFile(tscFile, compilerSources, [builtLocalDirectory, copyright].concat(compilerSources), [copyright], /*useBuiltCompiler:*/ false);
 
 var servicesFile = path.join(builtLocalDirectory, "typescriptServices.js");
-compileFile(servicesFile, servicesSources, [builtLocalDirectory, copyright].concat(servicesSources), [copyright], /*useBuiltCompiler:*/ true);
+var servicesDefinitionsFile = path.join(builtLocalDirectory, "typescriptServices.d.ts");
+compileFile(servicesFile, servicesSources, [builtLocalDirectory, copyright].concat(servicesSources), [copyright], /*useBuiltCompiler:*/ true, /*noOutFile:*/ false, /*generateDeclarations:*/ true);
 
 // Local target to build the compiler and services
 desc("Builds the full compiler and services");
@@ -275,11 +275,6 @@ task("clean", function() {
     jake.rmRf(builtDirectory);
 });
 
-// generate declarations for compiler and services
-desc("Generate declarations for compiler and services");
-task("declaration", function() {
-    generateDeclarations = true;
-});
 
 // Generate Markdown spec
 var word2mdJs = path.join(scriptsDirectory, "word2md.js");
@@ -314,7 +309,7 @@ task("generate-spec", [specMd])
 // Makes a new LKG. This target does not build anything, but errors if not all the outputs are present in the built/local directory
 desc("Makes a new LKG out of the built js files");
 task("LKG", ["clean", "release", "local"].concat(libraryTargets), function() {
-    var expectedFiles = [tscFile, servicesFile].concat(libraryTargets);
+    var expectedFiles = [tscFile, servicesFile, servicesDefinitionsFile].concat(libraryTargets);
     var missingFiles = expectedFiles.filter(function (f) {
         return !fs.existsSync(f);
     });
@@ -547,7 +542,7 @@ file(loggedIOJsPath, [builtLocalDirectory, loggedIOpath], function() {
         jake.rmRf(temp);
         complete();
     });
-    ex.run();    
+    ex.run();
 }, {async: true});
 
 var instrumenterPath = harnessDirectory + 'instrumenter.ts';


### PR DESCRIPTION
Adding typescript definitions files to build output.  

I use the typescript services in my [atom-typescript-tools](https://github.com/park9140/atom-typescript-tools) and need the typescript definitions in order to write typescript correctly.  

Sorry, about the removal of trailing whitespace, you guys should really add some style checking to the project to eliminate this kind of issue.
