### PR TITLE
Export ts to CommonJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"url" : "https://github.com/Microsoft/TypeScript.git"  
 	},
 	"preferGlobal" : true,
-	"main" : "./bin/tsc.js",
+	"main" : "./bin/typescriptServices.js",
 	"bin" : { 
 		"tsc" : "./bin/tsc" 
 	},

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2378,3 +2378,8 @@ module ts {
 
     initializeServices();
 }
+
+// Export API for NodeJS consumption
+if (typeof module !== "undefined" && module.exports) {
+    module.exports = ts;
+}

--- a/tests/cases/unittests/ls/nodeExport.ts
+++ b/tests/cases/unittests/ls/nodeExport.ts
@@ -1,0 +1,21 @@
+///<reference path='..\..\..\..\src\harness\harness.ts' />
+
+describe("nodeExport", () => {
+
+    it("ts is exported to commonjs", () => {
+        // Test always passes in non-nodejs test environments
+        if (typeof module === "undefined" || !module.exports) {
+            return;
+        }
+
+        var servicesFile = "./typescriptServices.js";
+        var ts = require(servicesFile);
+
+        // We test by some known function name
+        if (ts && ts.getDefaultCompilerOptions) {
+            return;
+        }
+         
+        throw new Error("ts should be exported from the language service");
+    });
+});


### PR DESCRIPTION
This is for #372

Exports the `ts` module from the language service so people can do `require('typescript')`. 

Notes: 
- To run the test put `runners.push(new UnitTestRunner(UnittestTestType.LanguageService));` in `runner.ts` and in `nodeExport.ts` use `it.only` and then `jake runtests`. 
