### PR TITLE
fix typo: sourcemap -> sourceMap

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -89,7 +89,7 @@ module ts {
             description: Diagnostics.Do_not_emit_comments_to_output,
         },
         {
-            name: "sourcemap",
+            name: "sourceMap",
             type: "boolean",
             description: Diagnostics.Generates_corresponding_map_file,
         },


### PR DESCRIPTION
sourceMap option no longer worked because code expects the M to be upper case, options structure had a lower case m
