### PR TITLE
Ability to modify the output filename extension

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -84,6 +84,10 @@ module ts {
             paramType: Diagnostics.DIRECTORY,
         },
         {
+            name: "outExt",
+            type: "string",
+        },
+        {
             name: "removeComments",
             type: "boolean",
             description: Diagnostics.Do_not_emit_comments_to_output,

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2462,7 +2462,8 @@ module ts {
 
         forEach(program.getSourceFiles(), sourceFile => {
             if (shouldEmitToOwnFile(sourceFile)) {
-                var jsFilePath = getOwnEmitOutputFilePath(sourceFile, ".js");
+                var jsFileExt = compilerOptions.outExt || ".js";
+                var jsFilePath = getOwnEmitOutputFilePath(sourceFile, jsFileExt);
                 emitFile(jsFilePath, sourceFile);
             }
         });

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -950,6 +950,7 @@ module ts {
         noResolve?: boolean;
         out?: string;
         outDir?: string;
+        outExt?: string;
         removeComments?: boolean;
         sourceMap?: boolean;
         sourceRoot?: string;


### PR DESCRIPTION
This is really a feature suggestion with a bit of code attached.

I would like `tsc` to accept an `outExt` parameter, so that I can differentiate generated-from-TS .js files from raw javascript files. This has all kinds of benefits, including easily `.gitignore`-ing files in a directory that contains both TypeScript sources and raw JavaScript (or, in my case, React components).

For example, calling `tsc --outExt .ts.js types.ts` will generate `types.ts.js` instead of `types.js`. Then, i can add `*.ts.js` to my gitignore and do `require("types.ts")` (which Node/Browserify will resolve to "types.ts.js") in my raw JavaScript code.

Does a PR like this have a chance to be accepted at all? If so, I'll go ahead and sign the Contribution License Agreement, but I prefer to avoid paperwork if this simply gets a "denied, we only accept bug fixes, sorry"-kind of response.

http://stackoverflow.com/questions/23408952/is-it-possible-to-have-typescript-output-in-different-file-extension shows that I'm not the only one looking for this. 

I'll be happy to add tests and diagnostic messages and all that, so that it's entirely neat and tidy.
