### PR TITLE
Rearranging members of Array<T> to improve error reporting.

### DIFF
--- a/src/lib/core.d.ts
+++ b/src/lib/core.d.ts
@@ -942,10 +942,23 @@ declare var JSON: JSON;
 
 interface Array<T> {
     /**
+      * Gets or sets the length of the array. This is a number one higher than the highest element defined in an array.
+      */
+    length: number;
+    /**
       * Returns a string representation of an array.
       */
     toString(): string;
     toLocaleString(): string;
+    /**
+      * Appends new elements to an array, and returns the new length of the array.
+      * @param items New elements of the Array.
+      */
+    push(...items: T[]): number;
+    /**
+      * Removes the last element from an array and returns it.
+      */
+    pop(): T;
     /**
       * Combines two or more arrays.
       * @param items Additional items to add to the end of array1.
@@ -961,15 +974,6 @@ interface Array<T> {
       * @param separator A string used to separate one element of an array from the next in the resulting String. If omitted, the array elements are separated with a comma.
       */
     join(separator?: string): string;
-    /**
-      * Removes the last element from an array and returns it.
-      */
-    pop(): T;
-    /**
-      * Appends new elements to an array, and returns the new length of the array.
-      * @param items New elements of the Array.
-      */
-    push(...items: T[]): number;
     /**
       * Reverses the elements in an Array. 
       */
@@ -1085,11 +1089,6 @@ interface Array<T> {
       * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
       */
     reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
-
-    /**
-      * Gets or sets the length of the array. This is a number one higher than the highest element defined in an array.
-      */
-    length: number;
 
     [n: number]: T;
 }

--- a/tests/baselines/reference/arrayAssignmentTest1.errors.txt
+++ b/tests/baselines/reference/arrayAssignmentTest1.errors.txt
@@ -128,25 +128,25 @@
     arr_any = f1; // should be an error - is
     ~~~~~~~
 !!! Type '() => C1' is not assignable to type 'any[]':
-!!!   Property 'concat' is missing in type '() => C1'.
+!!!   Property 'push' is missing in type '() => C1'.
     arr_any = o1; // should be an error - is
     ~~~~~~~
 !!! Type '{ one: number; }' is not assignable to type 'any[]':
-!!!   Property 'concat' is missing in type '{ one: number; }'.
+!!!   Property 'length' is missing in type '{ one: number; }'.
     arr_any = a1; // should be ok - is
     arr_any = c1; // should be an error - is
     ~~~~~~~
 !!! Type 'C1' is not assignable to type 'any[]':
-!!!   Property 'concat' is missing in type 'C1'.
+!!!   Property 'length' is missing in type 'C1'.
     arr_any = c2; // should be an error - is
     ~~~~~~~
 !!! Type 'C2' is not assignable to type 'any[]':
-!!!   Property 'concat' is missing in type 'C2'.
+!!!   Property 'length' is missing in type 'C2'.
     arr_any = c3; // should be an error - is
     ~~~~~~~
 !!! Type 'C3' is not assignable to type 'any[]':
-!!!   Property 'concat' is missing in type 'C3'.
+!!!   Property 'length' is missing in type 'C3'.
     arr_any = i1; // should be an error - is
     ~~~~~~~
 !!! Type 'I1' is not assignable to type 'any[]':
-!!!   Property 'concat' is missing in type 'I1'.
+!!!   Property 'length' is missing in type 'I1'.

--- a/tests/baselines/reference/arrayAssignmentTest2.errors.txt
+++ b/tests/baselines/reference/arrayAssignmentTest2.errors.txt
@@ -64,30 +64,30 @@
     arr_any = f1; // should be an error - is
     ~~~~~~~
 !!! Type '() => C1' is not assignable to type 'any[]':
-!!!   Property 'concat' is missing in type '() => C1'.
+!!!   Property 'push' is missing in type '() => C1'.
     arr_any = function () { return null;} // should be an error - is
     ~~~~~~~
 !!! Type '() => any' is not assignable to type 'any[]':
-!!!   Property 'concat' is missing in type '() => any'.
+!!!   Property 'push' is missing in type '() => any'.
     arr_any = o1; // should be an error - is
     ~~~~~~~
 !!! Type '{ one: number; }' is not assignable to type 'any[]':
-!!!   Property 'concat' is missing in type '{ one: number; }'.
+!!!   Property 'length' is missing in type '{ one: number; }'.
     arr_any = a1; // should be ok - is
     arr_any = c1; // should be an error - is
     ~~~~~~~
 !!! Type 'C1' is not assignable to type 'any[]':
-!!!   Property 'concat' is missing in type 'C1'.
+!!!   Property 'length' is missing in type 'C1'.
     arr_any = c2; // should be an error - is
     ~~~~~~~
 !!! Type 'C2' is not assignable to type 'any[]':
-!!!   Property 'concat' is missing in type 'C2'.
+!!!   Property 'length' is missing in type 'C2'.
     arr_any = c3; // should be an error - is
     ~~~~~~~
 !!! Type 'C3' is not assignable to type 'any[]':
-!!!   Property 'concat' is missing in type 'C3'.
+!!!   Property 'length' is missing in type 'C3'.
     arr_any = i1; // should be an error - is
     ~~~~~~~
 !!! Type 'I1' is not assignable to type 'any[]':
-!!!   Property 'concat' is missing in type 'I1'.
+!!!   Property 'length' is missing in type 'I1'.
     

--- a/tests/baselines/reference/arrayAssignmentTest4.errors.txt
+++ b/tests/baselines/reference/arrayAssignmentTest4.errors.txt
@@ -25,9 +25,9 @@
     arr_any = function () { return null;} // should be an error - is
     ~~~~~~~
 !!! Type '() => any' is not assignable to type 'any[]':
-!!!   Property 'concat' is missing in type '() => any'.
+!!!   Property 'push' is missing in type '() => any'.
     arr_any = c3; // should be an error - is
     ~~~~~~~
 !!! Type 'C3' is not assignable to type 'any[]':
-!!!   Property 'concat' is missing in type 'C3'.
+!!!   Property 'length' is missing in type 'C3'.
     

--- a/tests/baselines/reference/arraySigChecking.errors.txt
+++ b/tests/baselines/reference/arraySigChecking.errors.txt
@@ -30,7 +30,7 @@
 !!! Type 'number[][]' is not assignable to type 'number[][][]':
 !!!   Type 'number[]' is not assignable to type 'number[][]':
 !!!     Type 'number' is not assignable to type 'number[]':
-!!!       Property 'concat' is missing in type 'Number'.
+!!!       Property 'length' is missing in type 'Number'.
     
     function isEmpty(l: { length: number }) {
         return l.length === 0;

--- a/tests/baselines/reference/assignmentCompatability16.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability16.errors.txt
@@ -12,4 +12,4 @@
 !!! Type 'interfaceWithPublicAndOptional<number, string>' is not assignable to type '{ one: any[]; }':
 !!!   Types of property 'one' are incompatible:
 !!!     Type 'number' is not assignable to type 'any[]':
-!!!       Property 'concat' is missing in type 'Number'.
+!!!       Property 'length' is missing in type 'Number'.

--- a/tests/baselines/reference/assignmentCompatability17.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability17.errors.txt
@@ -12,4 +12,4 @@
 !!! Type 'interfaceWithPublicAndOptional<number, string>' is not assignable to type '{ two: any[]; }':
 !!!   Types of property 'two' are incompatible:
 !!!     Type 'string' is not assignable to type 'any[]':
-!!!       Property 'join' is missing in type 'String'.
+!!!       Property 'push' is missing in type 'String'.

--- a/tests/baselines/reference/assignmentCompatability18.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability18.errors.txt
@@ -12,4 +12,4 @@
 !!! Type 'interfaceWithPublicAndOptional<number, string>' is not assignable to type '{ one: number[]; }':
 !!!   Types of property 'one' are incompatible:
 !!!     Type 'number' is not assignable to type 'number[]':
-!!!       Property 'concat' is missing in type 'Number'.
+!!!       Property 'length' is missing in type 'Number'.

--- a/tests/baselines/reference/assignmentCompatability19.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability19.errors.txt
@@ -12,7 +12,4 @@
 !!! Type 'interfaceWithPublicAndOptional<number, string>' is not assignable to type '{ two: number[]; }':
 !!!   Types of property 'two' are incompatible:
 !!!     Type 'string' is not assignable to type 'number[]':
-!!!       Types of property 'concat' are incompatible:
-!!!         Type '(...strings: string[]) => string' is not assignable to type '{ <U extends number[]>(...items: U[]): number[]; (...items: number[]): number[]; }':
-!!!           Types of parameters 'strings' and 'items' are incompatible:
-!!!             Type 'string' is not assignable to type 'number'.
+!!!       Property 'push' is missing in type 'String'.

--- a/tests/baselines/reference/assignmentCompatability20.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability20.errors.txt
@@ -12,4 +12,4 @@
 !!! Type 'interfaceWithPublicAndOptional<number, string>' is not assignable to type '{ one: string[]; }':
 !!!   Types of property 'one' are incompatible:
 !!!     Type 'number' is not assignable to type 'string[]':
-!!!       Property 'concat' is missing in type 'Number'.
+!!!       Property 'length' is missing in type 'Number'.

--- a/tests/baselines/reference/assignmentCompatability21.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability21.errors.txt
@@ -12,4 +12,4 @@
 !!! Type 'interfaceWithPublicAndOptional<number, string>' is not assignable to type '{ two: string[]; }':
 !!!   Types of property 'two' are incompatible:
 !!!     Type 'string' is not assignable to type 'string[]':
-!!!       Property 'join' is missing in type 'String'.
+!!!       Property 'push' is missing in type 'String'.

--- a/tests/baselines/reference/assignmentCompatability22.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability22.errors.txt
@@ -12,4 +12,4 @@
 !!! Type 'interfaceWithPublicAndOptional<number, string>' is not assignable to type '{ one: boolean[]; }':
 !!!   Types of property 'one' are incompatible:
 !!!     Type 'number' is not assignable to type 'boolean[]':
-!!!       Property 'concat' is missing in type 'Number'.
+!!!       Property 'length' is missing in type 'Number'.

--- a/tests/baselines/reference/assignmentCompatability23.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability23.errors.txt
@@ -12,7 +12,4 @@
 !!! Type 'interfaceWithPublicAndOptional<number, string>' is not assignable to type '{ two: boolean[]; }':
 !!!   Types of property 'two' are incompatible:
 !!!     Type 'string' is not assignable to type 'boolean[]':
-!!!       Types of property 'concat' are incompatible:
-!!!         Type '(...strings: string[]) => string' is not assignable to type '{ <U extends boolean[]>(...items: U[]): boolean[]; (...items: boolean[]): boolean[]; }':
-!!!           Types of parameters 'strings' and 'items' are incompatible:
-!!!             Type 'string' is not assignable to type 'boolean'.
+!!!       Property 'push' is missing in type 'String'.

--- a/tests/baselines/reference/assignmentCompatability29.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability29.errors.txt
@@ -12,4 +12,4 @@
 !!! Type 'interfaceWithPublicAndOptional<number, string>' is not assignable to type '{ one: any[]; }':
 !!!   Types of property 'one' are incompatible:
 !!!     Type 'number' is not assignable to type 'any[]':
-!!!       Property 'concat' is missing in type 'Number'.
+!!!       Property 'length' is missing in type 'Number'.

--- a/tests/baselines/reference/assignmentCompatability30.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability30.errors.txt
@@ -12,4 +12,4 @@
 !!! Type 'interfaceWithPublicAndOptional<number, string>' is not assignable to type '{ one: number[]; }':
 !!!   Types of property 'one' are incompatible:
 !!!     Type 'number' is not assignable to type 'number[]':
-!!!       Property 'concat' is missing in type 'Number'.
+!!!       Property 'length' is missing in type 'Number'.

--- a/tests/baselines/reference/assignmentCompatability31.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability31.errors.txt
@@ -12,4 +12,4 @@
 !!! Type 'interfaceWithPublicAndOptional<number, string>' is not assignable to type '{ one: string[]; }':
 !!!   Types of property 'one' are incompatible:
 !!!     Type 'number' is not assignable to type 'string[]':
-!!!       Property 'concat' is missing in type 'Number'.
+!!!       Property 'length' is missing in type 'Number'.

--- a/tests/baselines/reference/assignmentCompatability32.errors.txt
+++ b/tests/baselines/reference/assignmentCompatability32.errors.txt
@@ -12,4 +12,4 @@
 !!! Type 'interfaceWithPublicAndOptional<number, string>' is not assignable to type '{ one: boolean[]; }':
 !!!   Types of property 'one' are incompatible:
 !!!     Type 'number' is not assignable to type 'boolean[]':
-!!!       Property 'concat' is missing in type 'Number'.
+!!!       Property 'length' is missing in type 'Number'.

--- a/tests/baselines/reference/enumAssignability.errors.txt
+++ b/tests/baselines/reference/enumAssignability.errors.txt
@@ -68,7 +68,7 @@
         var m: number[] = e;
             ~
 !!! Type 'E' is not assignable to type 'number[]':
-!!!   Property 'concat' is missing in type 'Number'.
+!!!   Property 'length' is missing in type 'Number'.
         var n: { foo: string } = e;
             ~
 !!! Type 'E' is not assignable to type '{ foo: string; }':

--- a/tests/baselines/reference/genericArrayExtenstions.errors.txt
+++ b/tests/baselines/reference/genericArrayExtenstions.errors.txt
@@ -4,7 +4,7 @@
 !!! Cannot compile external modules unless the '--module' flag is provided.
                          ~~~~~~~~~~~~~~~
 !!! Class 'ObservableArray<T>' incorrectly implements interface 'T[]':
-!!!   Property 'join' is missing in type 'ObservableArray<T>'.
+!!!   Property 'length' is missing in type 'ObservableArray<T>'.
     concat<U extends T[]>(...items: U[]): T[];
     concat(...items: T[]): T[];
     }

--- a/tests/baselines/reference/qualify.errors.txt
+++ b/tests/baselines/reference/qualify.errors.txt
@@ -56,7 +56,7 @@
             var v3:K1.I3[]=v1;
                 ~~
 !!! Type 'I4' is not assignable to type 'I3[]':
-!!!   Property 'concat' is missing in type 'I4'.
+!!!   Property 'length' is missing in type 'I4'.
             var v4:()=>K1.I3=v1;
                 ~~
 !!! Type 'I4' is not assignable to type '() => I3'.

--- a/tests/baselines/reference/restArgAssignmentCompat.errors.txt
+++ b/tests/baselines/reference/restArgAssignmentCompat.errors.txt
@@ -10,6 +10,6 @@
 !!! Type '(...x: number[]) => void' is not assignable to type '(x: number[], y: string) => void':
 !!!   Types of parameters 'x' and 'x' are incompatible:
 !!!     Type 'number' is not assignable to type 'number[]':
-!!!       Property 'concat' is missing in type 'Number'.
+!!!       Property 'length' is missing in type 'Number'.
     n([4], 'foo');
     

--- a/tests/baselines/reference/typeName1.errors.txt
+++ b/tests/baselines/reference/typeName1.errors.txt
@@ -46,15 +46,15 @@
     var x10:I[][][][]=3;
         ~~~
 !!! Type 'number' is not assignable to type 'I[][][][]':
-!!!   Property 'concat' is missing in type 'Number'.
+!!!   Property 'length' is missing in type 'Number'.
     var x11:{z:I;x:boolean;}[][]=3;
         ~~~
 !!! Type 'number' is not assignable to type '{ z: I; x: boolean; }[][]':
-!!!   Property 'concat' is missing in type 'Number'.
+!!!   Property 'length' is missing in type 'Number'.
     var x12:{z:I;x:boolean;y:(s:string)=>boolean;w:{ z:I;[s:string]:{ x; y; };[n:number]:{x; y;};():boolean; };}[][]=3;
         ~~~
 !!! Type 'number' is not assignable to type '{ z: I; x: boolean; y: (s: string) => boolean; w: { (): boolean; [x: string]: { x: any; y: any; }; [x: number]: { x: any; y: any; }; z: I; }; }[][]':
-!!!   Property 'concat' is missing in type 'Number'.
+!!!   Property 'length' is missing in type 'Number'.
     var x13:{ new(): number; new(n:number):number; x: string; w: {y: number;}; (): {}; } = 3;
         ~~~
 !!! Type 'number' is not assignable to type '{ (): {}; new (): number; new (n: number): number; x: string; w: { y: number; }; }':


### PR DESCRIPTION
Moving declarations of `length`, `push`, and `pop` to the top such that type mismatch errors are reported in terms of these well known properties (rather than the more esoteric `concat` and `join` we pick now).
