### PR TITLE
Include memory usage in -diagnostics report

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -14,7 +14,7 @@ interface System {
     createDirectory(directoryName: string): void;
     getExecutingFilePath(): string;
     getCurrentDirectory(): string;
-    getMemoryUsage(): number;
+    getMemoryUsage?(): number;
     exit(exitCode?: number): void;
 }
 
@@ -127,9 +127,6 @@ var sys: System = (function () {
             },
             getCurrentDirectory() {
                 return new ActiveXObject("WScript.Shell").CurrentDirectory;
-            },
-            getMemoryUsage() {
-                return 0;
             },
             exit(exitCode?: number): void {
                 try {

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -337,14 +337,14 @@ module ts {
 
         reportDiagnostics(errors);
         if (commandLine.options.diagnostics) {
-            var memoryUsed = sys.getMemoryUsage();
+            var memoryUsed = sys.getMemoryUsage ? sys.getMemoryUsage() : -1;
             reportCountStatistic("Files", program.getSourceFiles().length);
             reportCountStatistic("Lines", countLines(program));
             reportCountStatistic("Nodes", checker ? checker.getNodeCount() : 0);
             reportCountStatistic("Identifiers", checker ? checker.getIdentifierCount() : 0);
             reportCountStatistic("Symbols", checker ? checker.getSymbolCount() : 0);
             reportCountStatistic("Types", checker ? checker.getTypeCount() : 0);
-            if (memoryUsed) {
+            if (memoryUsed >= 0) {
                 reportStatisticalValue("Memory used", Math.round(memoryUsed / 1000) + "K");
             }
             reportTimeStatistic("Parse time", bindStart - parseStart);


### PR DESCRIPTION
The `-diagnostics` command line switch now includes memory usage in the reported statistics when running under node.js. If node.js was invoked with the `-expose-gc` flag, `global.gc()` is called before obtaining the allocated heap size to get a more accurate number. For example:

``` typescript
node -expose-gc tsc -diagnostics myProgram.ts
```

Note that memory usage is not reported with the cscript.exe host since it provides no way to obtain memory statistics.
