### PR TITLE
spelling fix: Idenfier -> Identifier

### DIFF
--- a/src/services/compiler/astHelpers.ts
+++ b/src/services/compiler/astHelpers.ts
@@ -732,14 +732,14 @@ module TypeScript.ASTHelpers {
         return false;
     }
 
-    export function getNameOfIdenfierOrQualifiedName(name: ISyntaxElement): string {
+    export function getNameOfIdentifierOrQualifiedName(name: ISyntaxElement): string {
         if (name.kind() === SyntaxKind.IdentifierName) {
             return (<ISyntaxToken>name).text();
         }
         else {
             Debug.assert(name.kind() == SyntaxKind.QualifiedName);
             var dotExpr = <QualifiedNameSyntax>name;
-            return getNameOfIdenfierOrQualifiedName(dotExpr.left) + "." + getNameOfIdenfierOrQualifiedName(dotExpr.right);
+            return getNameOfIdentifierOrQualifiedName(dotExpr.left) + "." + getNameOfIdentifierOrQualifiedName(dotExpr.right);
         }
     }
 

--- a/src/services/compiler/declarationEmitter.ts
+++ b/src/services/compiler/declarationEmitter.ts
@@ -969,7 +969,7 @@ module TypeScript {
                     this.declFile.WriteLine("require(" + (<ExternalModuleReferenceSyntax>importDeclAST.moduleReference).stringLiteral.text() + ");");
                 }
                 else {
-                    this.declFile.WriteLine(ASTHelpers.getNameOfIdenfierOrQualifiedName((<ModuleNameModuleReferenceSyntax>importDeclAST.moduleReference).moduleName) + ";");
+                    this.declFile.WriteLine(ASTHelpers.getNameOfIdentifierOrQualifiedName((<ModuleNameModuleReferenceSyntax>importDeclAST.moduleReference).moduleName) + ";");
                 }
             }
         }
@@ -1023,7 +1023,7 @@ module TypeScript {
                 this.declFile.Write(moduleDecl.stringLiteral.text());
             }
             else {
-                this.declFile.Write(ASTHelpers.getNameOfIdenfierOrQualifiedName(moduleDecl.name));
+                this.declFile.Write(ASTHelpers.getNameOfIdentifierOrQualifiedName(moduleDecl.name));
             }
 
             this.declFile.WriteLine(" {");


### PR DESCRIPTION
I don't think there's a good way of unit testing this change...

The symbol is "exported", so it's possible that a client of the language service would be calling it, (although I kind of doubt it would be used by anyone directly).
