### PR TITLE
Support resolution of any part of the RHS of an import

### DIFF
--- a/tests/baselines/reference/importOnAliasedIdentifiers.types
+++ b/tests/baselines/reference/importOnAliasedIdentifiers.types
@@ -19,11 +19,11 @@ module B {
 
     import Y = A; // Alias only for module A
 >Y : typeof A
->A : A
+>A : typeof A
 
     import Z = A.X; // Alias for both type and member A.X
 >Z : X
->A : A
+>A : typeof A
 >X : X
 
     var v: Z = Z;

--- a/tests/baselines/reference/internalImportUnInstantiatedModuleNotReferencingInstanceNoConflict.types
+++ b/tests/baselines/reference/internalImportUnInstantiatedModuleNotReferencingInstanceNoConflict.types
@@ -15,6 +15,6 @@ module B {
 
     import Y = A;
 >Y : Y
->A : number
+>A : A
 }
 


### PR DESCRIPTION
Right now resolveImport can resolve the entity name on the RHS of an import. But we only support resolving the whole entity name, not an arbitrary part of it. This change supports resolving an arbitrary part of an entity name. I've rewired resolveImport to call into this helper, and getTypeOfNode calls into it too now. This may be useful for the language service for go-to-definition.
