### PR TITLE
Fixes issue 439: Added exitCode enum to differentiate between different error conditions

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -22,6 +22,14 @@ interface FileWatcher {
     close(): void;
 }
 
+enum ExitCode {
+    Success,
+    ParseError,
+    SemanticError,
+    EmitError,
+    CommandLineError
+}
+
 declare var require: any;
 declare var module: any;
 declare var process: any;


### PR DESCRIPTION
Issue link: https://github.com/Microsoft/TypeScript/issues/439

As per the suggestions in the issue, added an enum to indicate the different exitCodes - (success, parseError, semanticError, emitError, commandLineError). Updated the corresponding code in tsc.ts to utilize the enum.
