### PR TITLE
Fix for importing modules from definitions

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1411,7 +1411,7 @@ module ts {
             return {
                 getSourceFile: (filename, languageVersion) => {
                     var sourceFile = getSourceFile(filename);
-                    return sourceFile ? sourceFile.getSourceFile() : null;
+                    return sourceFile && sourceFile.getSourceFile();
                 },
                 getCancellationToken: () => cancellationToken,
                 getCanonicalFileName: (filename) => useCaseSensitivefilenames ? filename : filename.toLowerCase(),


### PR DESCRIPTION
Please see #492 for bug description.

Removed assertion in `getSourceFile` since `processSourceFile` obviously expects `findSourceFile` to return falsy value from `findSourceFile` (which is wrapper around `getSourceFile` result) when file is not found, and not to fail in that case.
