### PR TITLE
Fix shouldAssert function

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -567,7 +567,7 @@ module ts {
         var currentAssertionLevel = AssertionLevel.None;
 
         export function shouldAssert(level: AssertionLevel): boolean {
-            return this.currentAssertionLevel >= level;
+            return currentAssertionLevel >= level;
         }
 
         export function assert(expression: any, message?: string, verboseDebugInfo?: () => string): void {


### PR DESCRIPTION
this.currentAssertionLevel is always undefined because the currentAssertionLevel isn't exported.
I removed the this keyword because I didn't want to make the currentAssertionLevel public.
