### PR TITLE
Add numeric indexer to HTMLElementCollection

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -1865,30 +1865,25 @@ declare var Window: {
     new(): Window;
 }
 
-interface FormData {
-    append(name: any, value: any, blobName?: string): void;
+interface HTMLCollection extends MSHTMLCollectionExtensions {
+    /**
+      * Sets or retrieves the number of objects in a collection.
+      */
+    length: number;
+    /**
+      * Retrieves an object from various collections.
+      */
+    item(nameOrIndex?: any, optionalIndex?: any): Element;
+    /**
+      * Retrieves a select object or an object from an options collection.
+      */
+    namedItem(name: string): Element;
+    // [name: string]: Element;
+    [index: number]: Element;
 }
-declare var FormData: {
-    prototype: FormData;
-    new (form?: HTMLFormElement): FormData;
-}
-
-interface SourceBuffer extends EventTarget {
-    updating: boolean;
-    appendWindowStart: number;
-    appendWindowEnd: number;
-    buffered: TimeRanges;
-    timestampOffset: number;
-    audioTracks: AudioTrackList;
-    appendBuffer(data: ArrayBufferView): void;
-    appendBuffer(data: ArrayBuffer): void;
-    remove(start: number, end: number): void;
-    abort(): void;
-    appendStream(stream: MSStream, maxSize?: number): void;
-}
-declare var SourceBuffer: {
-    prototype: SourceBuffer;
-    new(): SourceBuffer;
+declare var HTMLCollection: {
+    prototype: HTMLCollection;
+    new(): HTMLCollection;
 }
 
 interface NavigatorID {
@@ -3795,26 +3790,6 @@ interface MSCSSProperties extends CSSStyleDeclaration {
 declare var MSCSSProperties: {
     prototype: MSCSSProperties;
     new(): MSCSSProperties;
-}
-
-interface HTMLCollection extends MSHTMLCollectionExtensions {
-    /**
-      * Sets or retrieves the number of objects in a collection.
-      */
-    length: number;
-    /**
-      * Retrieves an object from various collections.
-      */
-    item(nameOrIndex?: any, optionalIndex?: any): Element;
-    /**
-      * Retrieves a select object or an object from an options collection.
-      */
-    namedItem(name: string): Element;
-    // [name: string]: Element;
-}
-declare var HTMLCollection: {
-    prototype: HTMLCollection;
-    new(): HTMLCollection;
 }
 
 interface SVGExternalResourcesRequired {
@@ -10222,6 +10197,14 @@ declare var MSManipulationEvent: {
     MS_MANIPULATION_STATE_CANCELLED: number;
 }
 
+interface FormData {
+    append(name: any, value: any, blobName?: string): void;
+}
+declare var FormData: {
+    prototype: FormData;
+    new(): FormData;
+}
+
 interface HTMLDataListElement extends HTMLElement {
     options: HTMLCollection;
 }
@@ -10638,6 +10621,23 @@ declare var NavigationEvent: {
 
 interface RandomSource {
     getRandomValues(array: ArrayBufferView): ArrayBufferView;
+}
+
+interface SourceBuffer extends EventTarget {
+    updating: boolean;
+    appendWindowStart: number;
+    appendWindowEnd: number;
+    buffered: TimeRanges;
+    timestampOffset: number;
+    audioTracks: AudioTrackList;
+    appendBuffer(data: ArrayBuffer): void;
+    remove(start: number, end: number): void;
+    abort(): void;
+    appendStream(stream: MSStream, maxSize?: number): void;
+}
+declare var SourceBuffer: {
+    prototype: SourceBuffer;
+    new(): SourceBuffer;
 }
 
 interface MSInputMethodContext extends EventTarget {


### PR DESCRIPTION
The change is adding `[index: number]: Element;` to HTMLCollection .

The definition of HTMLCollection has a string indexer, but we can not use it as it has a length property that is of type number; so we comment that out. 

there is no reason however to not include the numeric indexer.

the generation script moved it up, so this is why the change looks weird.
