### PR TITLE
Switch to createCompilerDiagnostic for an invalid root file

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3822,17 +3822,28 @@ module ts {
                 var start = refPos;
                 var length = refEnd - refPos;
             }
+            var diagnostic: DiagnosticMessage;
             if (hasExtension(filename)) {
                 if (!fileExtensionIs(filename, ".ts")) {
-                    errors.push(createFileDiagnostic(refFile, start, length, Diagnostics.File_0_must_have_extension_ts_or_d_ts, filename));
+                    diagnostic = Diagnostics.File_0_must_have_extension_ts_or_d_ts;
                 }
                 else if (!findSourceFile(filename, isDefaultLib, refFile, refPos, refEnd)) {
-                    errors.push(createFileDiagnostic(refFile, start, length, Diagnostics.File_0_not_found, filename));
+                    diagnostic = Diagnostics.File_0_not_found;
                 }
             }
             else {
                 if (!(findSourceFile(filename + ".ts", isDefaultLib, refFile, refPos, refEnd) || findSourceFile(filename + ".d.ts", isDefaultLib, refFile, refPos, refEnd))) {
-                    errors.push(createFileDiagnostic(refFile, start, length, Diagnostics.File_0_not_found, filename + ".ts"));
+                    diagnostic = Diagnostics.File_0_not_found;
+                    filename += ".ts";
+                }
+            }
+
+            if (diagnostic) {
+                if (refFile) {
+                    errors.push(createFileDiagnostic(refFile, start, length, diagnostic, filename));
+                }
+                else {
+                    errors.push(createCompilerDiagnostic(diagnostic, filename));
                 }
             }
         }

--- a/tests/baselines/reference/project/invalidRootFile/amd/invalidRootFile.errors.txt
+++ b/tests/baselines/reference/project/invalidRootFile/amd/invalidRootFile.errors.txt
@@ -1,0 +1,8 @@
+error TS6053: File 'a.ts' not found.
+error TS6053: File 'a.ts' not found.
+error TS6054: File 'a.t' must have extension '.ts' or '.d.ts'.
+
+
+!!! File 'a.ts' not found.
+!!! File 'a.ts' not found.
+!!! File 'a.t' must have extension '.ts' or '.d.ts'.

--- a/tests/baselines/reference/project/invalidRootFile/amd/invalidRootFile.json
+++ b/tests/baselines/reference/project/invalidRootFile/amd/invalidRootFile.json
@@ -1,0 +1,13 @@
+{
+    "scenario": "InvalidRootFile",
+    "projectRoot": "tests/cases/projects/InvalidRootFile",
+    "inputFiles": [
+        "a",
+        "a.t",
+        "a.ts"
+    ],
+    "resolvedInputFiles": [
+        "lib.d.ts"
+    ],
+    "emittedFiles": []
+}

--- a/tests/baselines/reference/project/invalidRootFile/node/invalidRootFile.errors.txt
+++ b/tests/baselines/reference/project/invalidRootFile/node/invalidRootFile.errors.txt
@@ -1,0 +1,8 @@
+error TS6053: File 'a.ts' not found.
+error TS6053: File 'a.ts' not found.
+error TS6054: File 'a.t' must have extension '.ts' or '.d.ts'.
+
+
+!!! File 'a.ts' not found.
+!!! File 'a.ts' not found.
+!!! File 'a.t' must have extension '.ts' or '.d.ts'.

--- a/tests/baselines/reference/project/invalidRootFile/node/invalidRootFile.json
+++ b/tests/baselines/reference/project/invalidRootFile/node/invalidRootFile.json
@@ -1,0 +1,13 @@
+{
+    "scenario": "InvalidRootFile",
+    "projectRoot": "tests/cases/projects/InvalidRootFile",
+    "inputFiles": [
+        "a",
+        "a.t",
+        "a.ts"
+    ],
+    "resolvedInputFiles": [
+        "lib.d.ts"
+    ],
+    "emittedFiles": []
+}

--- a/tests/cases/project/invalidRootFile.json
+++ b/tests/cases/project/invalidRootFile.json
@@ -1,0 +1,9 @@
+{
+    "scenario": "InvalidRootFile",
+    "projectRoot": "tests/cases/projects/InvalidRootFile",
+    "inputFiles": [
+        "a",
+        "a.t",
+        "a.ts"
+    ]
+}


### PR DESCRIPTION
Instead of reporting a file diagnostic when the user specifies a nonexistent file on the command line, we need to report a compiler diagnostic. This was found by the start/length assert in createFileDiagnostic, which was causing the compiler to crash. I think we should take this for release-1.1.
