### PR TITLE
fix documentation for {Ui,I}nt{8,16,32}Array

### DIFF
--- a/src/lib/extensions.d.ts
+++ b/src/lib/extensions.d.ts
@@ -63,14 +63,14 @@ interface Int8Array extends ArrayBufferView {
 
     /**
       * Sets a value or an array of values.
-      * @param A typed or untyped array of values to set.
+      * @param array A typed or untyped array of values to set.
       * @param offset The index in the current array at which the values are to be written.
       */
     set(array: Int8Array, offset?: number): void;
 
     /**
       * Sets a value or an array of values.
-      * @param A typed or untyped array of values to set.
+      * @param array A typed or untyped array of values to set.
       * @param offset The index in the current array at which the values are to be written.
       */
     set(array: number[], offset?: number): void;
@@ -121,14 +121,14 @@ interface Uint8Array extends ArrayBufferView {
 
     /**
       * Sets a value or an array of values.
-      * @param A typed or untyped array of values to set.
+      * @param array A typed or untyped array of values to set.
       * @param offset The index in the current array at which the values are to be written.
       */
     set(array: Uint8Array, offset?: number): void;
 
     /**
       * Sets a value or an array of values.
-      * @param A typed or untyped array of values to set.
+      * @param array A typed or untyped array of values to set.
       * @param offset The index in the current array at which the values are to be written.
       */
     set(array: number[], offset?: number): void;
@@ -179,14 +179,14 @@ interface Int16Array extends ArrayBufferView {
 
     /**
       * Sets a value or an array of values.
-      * @param A typed or untyped array of values to set.
+      * @param array A typed or untyped array of values to set.
       * @param offset The index in the current array at which the values are to be written.
       */
     set(array: Int16Array, offset?: number): void;
 
     /**
       * Sets a value or an array of values.
-      * @param A typed or untyped array of values to set.
+      * @param array A typed or untyped array of values to set.
       * @param offset The index in the current array at which the values are to be written.
       */
     set(array: number[], offset?: number): void;
@@ -237,14 +237,14 @@ interface Uint16Array extends ArrayBufferView {
 
     /**
       * Sets a value or an array of values.
-      * @param A typed or untyped array of values to set.
+      * @param array A typed or untyped array of values to set.
       * @param offset The index in the current array at which the values are to be written.
       */
     set(array: Uint16Array, offset?: number): void;
 
     /**
       * Sets a value or an array of values.
-      * @param A typed or untyped array of values to set.
+      * @param array A typed or untyped array of values to set.
       * @param offset The index in the current array at which the values are to be written.
       */
     set(array: number[], offset?: number): void;
@@ -295,14 +295,14 @@ interface Int32Array extends ArrayBufferView {
 
     /**
       * Sets a value or an array of values.
-      * @param A typed or untyped array of values to set.
+      * @param array A typed or untyped array of values to set.
       * @param offset The index in the current array at which the values are to be written.
       */
     set(array: Int32Array, offset?: number): void;
 
     /**
       * Sets a value or an array of values.
-      * @param A typed or untyped array of values to set.
+      * @param array A typed or untyped array of values to set.
       * @param offset The index in the current array at which the values are to be written.
       */
     set(array: number[], offset?: number): void;
@@ -353,14 +353,14 @@ interface Uint32Array extends ArrayBufferView {
 
     /**
       * Sets a value or an array of values.
-      * @param A typed or untyped array of values to set.
+      * @param array A typed or untyped array of values to set.
       * @param offset The index in the current array at which the values are to be written.
       */
     set(array: Uint32Array, offset?: number): void;
 
     /**
       * Sets a value or an array of values.
-      * @param A typed or untyped array of values to set.
+      * @param array A typed or untyped array of values to set.
       * @param offset The index in the current array at which the values are to be written.
       */
     set(array: number[], offset?: number): void;
@@ -411,14 +411,14 @@ interface Float32Array extends ArrayBufferView {
 
     /**
       * Sets a value or an array of values.
-      * @param A typed or untyped array of values to set.
+      * @param array A typed or untyped array of values to set.
       * @param offset The index in the current array at which the values are to be written.
       */
     set(array: Float32Array, offset?: number): void;
 
     /**
       * Sets a value or an array of values.
-      * @param A typed or untyped array of values to set.
+      * @param array A typed or untyped array of values to set.
       * @param offset The index in the current array at which the values are to be written.
       */
     set(array: number[], offset?: number): void;
@@ -469,14 +469,14 @@ interface Float64Array extends ArrayBufferView {
 
     /**
       * Sets a value or an array of values.
-      * @param A typed or untyped array of values to set.
+      * @param array A typed or untyped array of values to set.
       * @param offset The index in the current array at which the values are to be written.
       */
     set(array: Float64Array, offset?: number): void;
 
     /**
       * Sets a value or an array of values.
-      * @param A typed or untyped array of values to set.
+      * @param array A typed or untyped array of values to set.
       * @param offset The index in the current array at which the values are to be written.
       */
     set(array: number[], offset?: number): void;


### PR DESCRIPTION
`@param A ....` is not the right syntax, the first word after `@param` needs to match the parameter name.

I'm Adam Freidin on codeplex, CLA is complete.

(P.S., this was discovered using automatic means so I'm fairly confident that this is the only `@param` issue in the source, for ts.SyntaxKind.Method nodes at least).
