### PR TITLE
Do not print error codes by default

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -84,13 +84,13 @@ module ts {
             paramType: Diagnostics.DIRECTORY,
         },
         {
-            name: "printErrorCodes",
-            type: "boolean",
-        },
-        {
             name: "removeComments",
             type: "boolean",
             description: Diagnostics.Do_not_emit_comments_to_output,
+        },
+        {
+            name: "showDiagnosticCodes",
+            type: "boolean",
         },
         {
             name: "sourceMap",

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -84,6 +84,10 @@ module ts {
             paramType: Diagnostics.DIRECTORY,
         },
         {
+            name: "printErrorCodes",
+            type: "boolean",
+        },
+        {
             name: "removeComments",
             type: "boolean",
             description: Diagnostics.Do_not_emit_comments_to_output,

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -94,14 +94,12 @@ module ts {
             output += diagnostic.file.filename + "(" + loc.line + "," + loc.character + "): ";
         }
 
-        var category = DiagnosticCategory[diagnostic.category].toLowerCase();
-        output += category;
-
         if (options.showDiagnosticCodes) {
-            output += " TS" + diagnostic.code;
+            var category = DiagnosticCategory[diagnostic.category].toLowerCase();
+            output += category + " TS" + diagnostic.code + ": ";
         }
 
-        output += ": " + diagnostic.messageText + sys.newLine;
+        output += diagnostic.messageText + sys.newLine;
 
         sys.write(output);
     }

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -97,7 +97,7 @@ module ts {
         var category = DiagnosticCategory[diagnostic.category].toLowerCase();
         output += category;
 
-        if (options.printErrorCodes) {
+        if (options.showDiagnosticCodes) {
             output += " TS" + diagnostic.code;
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -987,8 +987,8 @@ module ts {
         noResolve?: boolean;
         out?: string;
         outDir?: string;
-        printErrorCodes?: boolean;
         removeComments?: boolean;
+        showDiagnosticCodes?: boolean;
         sourceMap?: boolean;
         sourceRoot?: string;
         target?: ScriptTarget;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -987,6 +987,7 @@ module ts {
         noResolve?: boolean;
         out?: string;
         outDir?: string;
+        printErrorCodes?: boolean;
         removeComments?: boolean;
         sourceMap?: boolean;
         sourceRoot?: string;


### PR DESCRIPTION
Adds a new compiler flag to emit error codes, and disable it by default. Fixes #693.
