### PR TITLE
add 'skipTrivia' parameter to scanner

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3815,7 +3815,7 @@ module ts {
                 : undefined);
         }
 
-        scanner = createScanner(languageVersion, sourceText, scanError, onComment);
+        scanner = createScanner(languageVersion, /*skipTrivia*/ true, sourceText, scanError, onComment);
         var rootNodeFlags: NodeFlags = 0;
         if (fileExtensionIs(filename, ".d.ts")) {
             rootNodeFlags = NodeFlags.DeclarationFile;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -12,6 +12,10 @@ module ts {
     export enum SyntaxKind {
         Unknown,
         EndOfFileToken,
+        SingleLineCommentTrivia,
+        MultiLineCommentTrivia,
+        NewLineTrivia,
+        WhitespaceTrivia,
         // Literals
         NumericLiteral,
         StringLiteral,

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -75,7 +75,7 @@ module ts {
         update(scriptSnapshot: TypeScript.IScriptSnapshot, version: string, isOpen: boolean, textChangeRange: TypeScript.TextChangeRange): SourceFile;
     }
 
-    var scanner: Scanner = createScanner(ScriptTarget.ES5);
+    var scanner: Scanner = createScanner(ScriptTarget.ES5, /*skipTrivia*/ true);
 
     var emptyArray: any[] = [];
 
@@ -4070,7 +4070,7 @@ module ts {
                 entries: []
             };
 
-            scanner = createScanner(ScriptTarget.ES5, text, onError, processComment);
+            scanner = createScanner(ScriptTarget.ES5, /*skipTrivia*/ true, text, onError, processComment);
 
             var token = SyntaxKind.Unknown;
             do {


### PR DESCRIPTION
Add `skipTriivia` parameter to`createScanner` function. When it is `true` - scanner will return only tokens, if it is `false` - both tokens and trivia.
This includes only change in the scanner so this logic can be used in formatting and classification. I've kept implementation of `skipTrivia` and `getCommentRanges` intact because switching them to use scanner has a negative perf impact - 2x emit time comparing to current implementation
