### PR TITLE
Add explict serialization logic for source maps to avoid using JSON

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -617,7 +617,9 @@ module ts {
                     function serializeStringArray(list: string[]): string {
                         var output = "";
                         for (var i = 0, n = list.length; i < n; i++) {
-                            if (i) output += ",";
+                            if (i) {
+                                output += ",";
+                            }
                             output += "\"" + escapeString(list[i]) + "\"";
                         }
                         return output;


### PR DESCRIPTION
JSON does not exist in cscript5.8, which causes the samples to fail to compile. we only use it to write the source map records which is fairly simple to serialize. this fixes #706
