### PR TITLE
use operator token when checking unary expressions in strict mode

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2174,10 +2174,10 @@ module ts {
                         // The identifier eval or arguments may not appear as the LeftHandSideExpression of an 
                         // Assignment operator(11.13) or of a PostfixExpression(11.3) or as the UnaryExpression 
                         // operated upon by a Prefix Increment(11.4.4) or a Prefix Decrement(11.4.5) operator
-                        if ((token === SyntaxKind.PlusPlusToken || token === SyntaxKind.MinusMinusToken) && isEvalOrArgumentsIdentifier(operand)) {
+                        if ((operator === SyntaxKind.PlusPlusToken || operator === SyntaxKind.MinusMinusToken) && isEvalOrArgumentsIdentifier(operand)) {
                             reportInvalidUseInStrictMode(<Identifier>operand);
                         }
-                        else if (token === SyntaxKind.DeleteKeyword && operand.kind === SyntaxKind.Identifier) {
+                        else if (operator === SyntaxKind.DeleteKeyword && operand.kind === SyntaxKind.Identifier) {
                             // When a delete operator occurs within strict mode code, a SyntaxError is thrown if its 
                             // UnaryExpression is a direct reference to a variable, function argument, or function name
                             grammarErrorOnNode(operand, Diagnostics.delete_cannot_be_called_on_an_identifier_in_strict_mode);

--- a/tests/baselines/reference/deleteOperatorInStrictMode.errors.txt
+++ b/tests/baselines/reference/deleteOperatorInStrictMode.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/compiler/deleteOperatorInStrictMode.ts(3,8): error TS1102: 'delete' cannot be called on an identifier in strict mode.
+
+
+==== tests/cases/compiler/deleteOperatorInStrictMode.ts (1 errors) ====
+    "use strict"
+    var a;
+    delete a;
+           ~
+!!! error TS1102: 'delete' cannot be called on an identifier in strict mode.

--- a/tests/baselines/reference/parserStrictMode15.errors.txt
+++ b/tests/baselines/reference/parserStrictMode15.errors.txt
@@ -1,8 +1,11 @@
+tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode15.ts(2,8): error TS1102: 'delete' cannot be called on an identifier in strict mode.
 tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode15.ts(2,8): error TS2304: Cannot find name 'a'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode15.ts (1 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode15.ts (2 errors) ====
     "use strict";
     delete a;
+           ~
+!!! error TS1102: 'delete' cannot be called on an identifier in strict mode.
            ~
 !!! error TS2304: Cannot find name 'a'.

--- a/tests/baselines/reference/parserStrictMode15.js
+++ b/tests/baselines/reference/parserStrictMode15.js
@@ -1,7 +1,0 @@
-//// [parserStrictMode15.ts]
-"use strict";
-delete a;
-
-//// [parserStrictMode15.js]
-"use strict";
-delete a;

--- a/tests/baselines/reference/parserStrictMode7.errors.txt
+++ b/tests/baselines/reference/parserStrictMode7.errors.txt
@@ -1,8 +1,11 @@
+tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode7.ts(2,3): error TS1100: Invalid use of 'eval' in strict mode.
 tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode7.ts(2,3): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 
 
-==== tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode7.ts (1 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode7.ts (2 errors) ====
     "use strict";
     ++eval;
+      ~~~~
+!!! error TS1100: Invalid use of 'eval' in strict mode.
       ~~~~
 !!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.

--- a/tests/baselines/reference/parserStrictMode7.js
+++ b/tests/baselines/reference/parserStrictMode7.js
@@ -1,7 +1,0 @@
-//// [parserStrictMode7.ts]
-"use strict";
-++eval;
-
-//// [parserStrictMode7.js]
-"use strict";
-++eval;

--- a/tests/baselines/reference/unaryOperatorsInStrictMode.errors.txt
+++ b/tests/baselines/reference/unaryOperatorsInStrictMode.errors.txt
@@ -1,0 +1,62 @@
+tests/cases/compiler/unaryOperatorsInStrictMode.ts(3,3): error TS1100: Invalid use of 'eval' in strict mode.
+tests/cases/compiler/unaryOperatorsInStrictMode.ts(4,3): error TS1100: Invalid use of 'eval' in strict mode.
+tests/cases/compiler/unaryOperatorsInStrictMode.ts(5,3): error TS1100: Invalid use of 'arguments' in strict mode.
+tests/cases/compiler/unaryOperatorsInStrictMode.ts(6,3): error TS1100: Invalid use of 'arguments' in strict mode.
+tests/cases/compiler/unaryOperatorsInStrictMode.ts(7,1): error TS1100: Invalid use of 'eval' in strict mode.
+tests/cases/compiler/unaryOperatorsInStrictMode.ts(8,1): error TS1100: Invalid use of 'eval' in strict mode.
+tests/cases/compiler/unaryOperatorsInStrictMode.ts(9,1): error TS1100: Invalid use of 'arguments' in strict mode.
+tests/cases/compiler/unaryOperatorsInStrictMode.ts(10,1): error TS1100: Invalid use of 'arguments' in strict mode.
+tests/cases/compiler/unaryOperatorsInStrictMode.ts(3,3): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
+tests/cases/compiler/unaryOperatorsInStrictMode.ts(4,3): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
+tests/cases/compiler/unaryOperatorsInStrictMode.ts(5,3): error TS2304: Cannot find name 'arguments'.
+tests/cases/compiler/unaryOperatorsInStrictMode.ts(6,3): error TS2304: Cannot find name 'arguments'.
+tests/cases/compiler/unaryOperatorsInStrictMode.ts(7,1): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
+tests/cases/compiler/unaryOperatorsInStrictMode.ts(8,1): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
+tests/cases/compiler/unaryOperatorsInStrictMode.ts(9,1): error TS2304: Cannot find name 'arguments'.
+tests/cases/compiler/unaryOperatorsInStrictMode.ts(10,1): error TS2304: Cannot find name 'arguments'.
+
+
+==== tests/cases/compiler/unaryOperatorsInStrictMode.ts (16 errors) ====
+    "use strict"
+    
+    ++eval;
+      ~~~~
+!!! error TS1100: Invalid use of 'eval' in strict mode.
+      ~~~~
+!!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
+    --eval;
+      ~~~~
+!!! error TS1100: Invalid use of 'eval' in strict mode.
+      ~~~~
+!!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
+    ++arguments;
+      ~~~~~~~~~
+!!! error TS1100: Invalid use of 'arguments' in strict mode.
+      ~~~~~~~~~
+!!! error TS2304: Cannot find name 'arguments'.
+    --arguments;
+      ~~~~~~~~~
+!!! error TS1100: Invalid use of 'arguments' in strict mode.
+      ~~~~~~~~~
+!!! error TS2304: Cannot find name 'arguments'.
+    eval++;
+    ~~~~
+!!! error TS1100: Invalid use of 'eval' in strict mode.
+    ~~~~
+!!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
+    eval--;
+    ~~~~
+!!! error TS1100: Invalid use of 'eval' in strict mode.
+    ~~~~
+!!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
+    arguments++;
+    ~~~~~~~~~
+!!! error TS1100: Invalid use of 'arguments' in strict mode.
+    ~~~~~~~~~
+!!! error TS2304: Cannot find name 'arguments'.
+    arguments--;
+    ~~~~~~~~~
+!!! error TS1100: Invalid use of 'arguments' in strict mode.
+    ~~~~~~~~~
+!!! error TS2304: Cannot find name 'arguments'.
+    

--- a/tests/cases/compiler/deleteOperatorInStrictMode.ts
+++ b/tests/cases/compiler/deleteOperatorInStrictMode.ts
@@ -1,0 +1,3 @@
+"use strict"
+var a;
+delete a;

--- a/tests/cases/compiler/unaryOperatorsInStrictMode.ts
+++ b/tests/cases/compiler/unaryOperatorsInStrictMode.ts
@@ -1,0 +1,10 @@
+"use strict"
+
+++eval;
+--eval;
+++arguments;
+--arguments;
+eval++;
+eval--;
+arguments++;
+arguments--;


### PR DESCRIPTION
fixes #734 
