### PR TITLE
Prevent non-TypeScript files from being added to tests.

### DIFF
--- a/src/harness/unittestrunner.ts
+++ b/src/harness/unittestrunner.ts
@@ -7,7 +7,7 @@ class UnitTestRunner extends RunnerBase {
     }
 
     public initializeTests() {
-        this.tests = this.enumerateFiles('tests/cases/unittests/services');
+        this.tests = this.enumerateFiles('tests/cases/unittests/services', /\.ts/i);
 
         var outfile = new Harness.Compiler.WriterAggregator()
         var outerr = new Harness.Compiler.WriterAggregator();


### PR DESCRIPTION
Current pattern adds `formatDiffTemplate.html`, `documentFormattingTests.json` and `ruleFormattingTests.json` from `tests/cases/unittests/services/formatting` to test suite instead of filtering them out.
