### PR TITLE
Removed Diagnostics from sys.ts in order to avoid cyclical build dependency

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -27,10 +27,6 @@ declare var module: any;
 declare var process: any;
 declare var global: any;
 
-enum SystemError {
-    UnsupportedFileEncoding
-}
-
 var sys: System = (function () {
 
     function getWScriptSystem(): System {
@@ -72,9 +68,7 @@ var sys: System = (function () {
                 return fileStream.ReadText();
             }
             catch (e) {
-                if (e.number === -2147024809) {
-                    e.systemError = SystemError.UnsupportedFileEncoding;
-                }
+                throw e;
             }
             finally {
                 fileStream.Close();

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -71,15 +71,6 @@ module ts {
 
         return true;
     }
-    
-    function getSystemErrorMessage(e: SystemError): string {
-        switch (e) {
-            case SystemError.UnsupportedFileEncoding:
-                return getDiagnosticText(Diagnostics.Unsupported_file_encoding);
-            default:
-                Debug.assert("Unreachable code in 'getSystemErrorMessage'");
-        }
-    }
 
     function countLines(program: Program): number {
         var count = 0;
@@ -151,14 +142,19 @@ module ts {
             // otherwise use toLowerCase as a canonical form.
             return sys.useCaseSensitiveFileNames ? fileName : fileName.toLowerCase();
         }
-
+        
+        // returned by CScript sys environment
+        var unsupportedFileEncodingErrorCode = -2147024809;
+        
         function getSourceFile(filename: string, languageVersion: ScriptTarget, onError?: (message: string) => void): SourceFile {
             try {
                 var text = sys.readFile(filename, options.charset);
             }
             catch (e) {
                 if (onError) {
-                    onError(e.systemError ? getSystemErrorMessage(e.systemError) : e.message);
+                    onError(e.number === unsupportedFileEncodingErrorCode ? 
+                                getDiagnosticText(Diagnostics.Unsupported_file_encoding) :
+                                e.message);
                 }
                 text = "";
             }


### PR DESCRIPTION
Specifically, processDiagnosticMessages.ts was dependent on sys.ts, which was dependent on the rest of the compiler, which meant that after merge, you could never compile processDiagnosticMessages.ts.
