### PR TITLE
Union type fixes and optimizations

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -644,7 +644,7 @@ module ts {
         getParentOfSymbol(symbol: Symbol): Symbol;
         getTypeOfSymbol(symbol: Symbol): Type;
         getPropertiesOfType(type: Type): Symbol[];
-        getApparentPropertyOfType(type: Type, propertyName: string): Symbol;
+        getPropertyOfType(type: Type, propertyName: string): Symbol;
         getSignaturesOfType(type: Type, kind: SignatureKind): Signature[];
         getIndexTypeOfType(type: Type, kind: IndexKind): Type;
         getReturnTypeOfSignature(signature: Signature): Type;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -572,7 +572,7 @@ module ts {
             return this.checker.getPropertiesOfType(this);
         }
         getProperty(propertyName: string): Symbol {
-            return this.checker.getApparentPropertyOfType(this, propertyName);
+            return this.checker.getPropertyOfType(this, propertyName);
         }
         getApparentProperties(): Symbol[] {
             return this.checker.getAugmentedPropertiesOfType(this);
@@ -4186,7 +4186,7 @@ module ts {
                     if (typeReference) {
                         var type = typeInfoResolver.getTypeOfNode(typeReference);
                         if (type) {
-                            var propertySymbol = typeInfoResolver.getApparentPropertyOfType(type, propertyName);
+                            var propertySymbol = typeInfoResolver.getPropertyOfType(type, propertyName);
                             if (propertySymbol) {
                                 result.push(propertySymbol);
                             }


### PR DESCRIPTION
This PR fixes issues relating to apparent types and union types and optimizes materialization of properties in union types. It also makes union types a separate kind of type, distinct from object types.

The following functions have changed:

| Function | Change |
| --- | --- |
| **getPropertiesOfType** | Returns property list of any kind of type |
| **getPropertyOfType** | Returns an (apparent) property of any kind of type |
| **getSignaturesOfType** | Returns (apparent) call signatures of any kind of type |
| **getIndexTypeOfType** | Returns an (apparent) index signature of any kind of type |
| getPropertiesOfObjectType | Returns property list of an object type |
| getAugmentedPropertiesOfType | Returns augmented property list of any kind of type |
| getPropertyOfObjectType | Returns a property of an object type |
| getSignaturesOfObjectOrUnionType | Returns call signatures of an object or union type |
| getIndexTypeOfObjectOrUnionType | Returns index signature of an object or union type |
| resolveObjectOrUnionTypeMembers | Resolves members of object or union types |

The functions in **bold** are the ones that code would typically use. They now automatically create synthetic results for union types and convert primitives and type parameters to their apparent types before performing the operation.

The ResolvedObjectType type has been renamed to ResolvedType because it now covers both object and union types. The ApparentType type is no longer needed and has been removed.

Materialization of union type properties previously happened in resolveObjectTypeMembers but is now done on demand per property through the getPropertyOfType function.
