### PR TITLE
Introduce .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# http://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.json]
+indent_size = 2
+
+[*.yml]
+indent_size = 2

--- a/package.json
+++ b/package.json
@@ -1,46 +1,46 @@
 {
-	"name": "typescript",
-	"author": "Microsoft Corp.",
-	"homepage": "http://typescriptlang.org/",
-	"version": "1.3.0",
-	"licenses": [
-		{
-			"type": "Apache License 2.0", 
-			"url": "https://github.com/Microsoft/TypeScript/blob/master/LICENSE.txt"
-		}
-	],
-	"description": "TypeScript is a language for application scale JavaScript development",
-	"keywords": [
-		"TypeScript", 
-		"Microsoft", 
-		"compiler", 
-		"language", 
-		"javascript"
-	],
-	"bugs": {
-		"url" : "https://github.com/Microsoft/TypeScript/issues"
-	},
-	"repository" : { 
-		"type" : "git",	
-		"url" : "https://github.com/Microsoft/TypeScript.git"  
-	},
-	"preferGlobal" : true,
-	"main" : "./bin/tsc.js",
-	"bin" : { 
-		"tsc" : "./bin/tsc" 
-	},
-	"engines" : { 
-		"node" : ">=0.8.0" 
-	},
-	"devDependencies": {
-		"jake" : "latest",
-		"mocha" : "latest",
-		"chai" : "latest",
-		"browserify" : "latest",
-		"istanbul": "latest",
-		"codeclimate-test-reporter": "latest"
-	},
-	"scripts": {
-		"test": "jake generate-code-coverage"
-	}
+  "name": "typescript",
+  "author": "Microsoft Corp.",
+  "homepage": "http://typescriptlang.org/",
+  "version": "1.3.0",
+  "licenses": [
+    {
+      "type": "Apache License 2.0",
+      "url": "https://github.com/Microsoft/TypeScript/blob/master/LICENSE.txt"
+    }
+  ],
+  "description": "TypeScript is a language for application scale JavaScript development",
+  "keywords": [
+    "TypeScript",
+    "Microsoft",
+    "compiler",
+    "language",
+    "javascript"
+  ],
+  "bugs": {
+    "url": "https://github.com/Microsoft/TypeScript/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/TypeScript.git"
+  },
+  "preferGlobal": true,
+  "main": "./bin/tsc.js",
+  "bin": {
+    "tsc": "./bin/tsc"
+  },
+  "engines": {
+    "node": ">=0.8.0"
+  },
+  "devDependencies": {
+    "browserify": "latest",
+    "chai": "latest",
+    "codeclimate-test-reporter": "latest",
+    "istanbul": "latest",
+    "jake": "latest",
+    "mocha": "latest"
+  },
+  "scripts": {
+    "test": "jake generate-code-coverage"
+  }
 }


### PR DESCRIPTION
See http://editorconfig.org/ for details.

package.json was changed to 2-space indentation here, because that's what npm commands will change it to, whenever a command is run. It's quite common for json files, so they've all been set the same, just like a bower.json file would be as well.
