### PR TITLE
use .pop() on an array instead of setting the length directly.  The latt...

### DIFF
--- a/src/services/syntax/scanner.ts
+++ b/src/services/syntax/scanner.ts
@@ -1628,13 +1628,12 @@ module TypeScript.Scanner {
                 var diagnostic = _tokenDiagnostics[tokenDiagnosticsLength - 1];
                 if (diagnostic.start() >= position) {
                     tokenDiagnosticsLength--;
+                    _tokenDiagnostics.pop();
                 }
                 else {
                     break;
                 }
             }
-
-            _tokenDiagnostics.length = tokenDiagnosticsLength;
         }
 
         function resetToPosition(absolutePosition: number): void {


### PR DESCRIPTION
...er causes v8 to stop optimizing the method.
