### PR TITLE
fix for issue #999

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -5247,7 +5247,7 @@ module ts {
             getFormattingEditsAfterKeystroke: getFormattingEditsAfterKeystroke,
             getEmitOutput: getEmitOutput,
             getSignatureAtPosition: getSignatureAtPosition,
-            getSourceFile: getSourceFile
+            getSourceFile: getCurrentSourceFile
         };
     }
 


### PR DESCRIPTION
Added a special version of getSourceFile for language service users. It makes sure that (a) the language service is in sync with its host and (b) that the file name uses normalized slashes.
