### PR TITLE
Fixed some methods using the wrong start time

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2572,7 +2572,7 @@ module ts {
                         session.symbols[entry.name] = symbol;
                     }
                 });
-                host.log("getCompletionsAtPosition: getCompletionEntriesFromSymbols: " + (new Date().getTime() - semanticStart));
+                host.log("getCompletionsAtPosition: getCompletionEntriesFromSymbols: " + (new Date().getTime() - start));
             }
 
             function isCompletionListBlocker(previousToken: Node): boolean {
@@ -2580,7 +2580,7 @@ module ts {
                 var result = isInStringOrRegularExpressionOrTemplateLiteral(previousToken) ||
                     isIdentifierDefinitionLocation(previousToken) ||
                     isRightOfIllegalDot(previousToken);
-                host.log("getCompletionsAtPosition: isCompletionListBlocker: " + (new Date().getTime() - semanticStart));
+                host.log("getCompletionsAtPosition: isCompletionListBlocker: " + (new Date().getTime() - start));
                 return result;
             }
 


### PR DESCRIPTION
Just noticed that `getCompletionEntriesFromSymbols` and `isCompletionListBlocker` where using the semanticStart time instead of the real start time.
