### PR TITLE
src/compiler/parser.ts exports function with return type of private interface

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1,6 +1,7 @@
 /// <reference path="types.ts"/>
 /// <reference path="core.ts"/>
 /// <reference path="scanner.ts"/>
+/// <reference path="checker.ts"/>
 
 module ts {
     var nodeConstructors = new Array<new () => Node>(SyntaxKind.Count);


### PR DESCRIPTION
Export ReferencePathMatchResult interface to fix 'error TS4060: Return type of exported function has or is using private name' when generating declarations from `src/compiler/*.ts`.

See #1111

Tests run just fine.

>   29974 passing (2m)
