### PR TITLE
Allow references to const enums if they are being preserved in the final...

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5152,7 +5152,7 @@ module ts {
 
             if (objectType === unknownType) return unknownType;
 
-            if (isConstEnumObjectType(objectType) && node.index.kind !== SyntaxKind.StringLiteral) {
+            if (isConstEnumObjectType(objectType) && node.index.kind !== SyntaxKind.StringLiteral && !compilerOptions.preserveConstEnums) {
                 error(node.index, Diagnostics.Index_expression_arguments_in_const_enums_must_be_of_type_string);
             }
 
@@ -6284,7 +6284,7 @@ module ts {
                 }
             }
 
-            if (isConstEnumObjectType(type)) {
+            if (isConstEnumObjectType(type) && !compilerOptions.preserveConstEnums) {
                 // enum object type for const enums are only permitted in:
                 // - 'left' in property access 
                 // - 'object' in indexed access
@@ -6972,7 +6972,7 @@ module ts {
                     case SyntaxKind.InterfaceDeclaration:
                         return SymbolFlags.ExportType;
                     case SyntaxKind.ModuleDeclaration:
-                        return (<ModuleDeclaration>d).name.kind === SyntaxKind.StringLiteral || getModuleInstanceState(d) !== ModuleInstanceState.NonInstantiated
+                        return (<ModuleDeclaration>d).name.kind === SyntaxKind.StringLiteral || getModuleInstanceState(d, compilerOptions) !== ModuleInstanceState.NonInstantiated
                             ? SymbolFlags.ExportNamespace | SymbolFlags.ExportValue
                             : SymbolFlags.ExportNamespace;
                     case SyntaxKind.ClassDeclaration:
@@ -7212,7 +7212,7 @@ module ts {
             }
 
             // Uninstantiated modules shouldnt do this check
-            if (node.kind === SyntaxKind.ModuleDeclaration && getModuleInstanceState(node) !== ModuleInstanceState.Instantiated) {
+            if (node.kind === SyntaxKind.ModuleDeclaration && getModuleInstanceState(node, compilerOptions) !== ModuleInstanceState.Instantiated) {
                 return;
             }
 
@@ -8928,7 +8928,7 @@ module ts {
         function initializeTypeChecker() {
             // Bind all source files and propagate errors
             forEach(program.getSourceFiles(), file => {
-                bindSourceFile(file);
+                bindSourceFile(file, compilerOptions);
                 forEach(file.semanticErrors, addDiagnostic);
             });
             // Initialize global symbol table

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1979,7 +1979,7 @@ module ts {
             }
 
             function emitModuleDeclaration(node: ModuleDeclaration) {
-                if (getModuleInstanceState(node) !== ModuleInstanceState.Instantiated) {
+                if (getModuleInstanceState(node, compilerOptions) !== ModuleInstanceState.Instantiated) {
                     return emitPinnedOrTripleSlashComments(node);
                 }
                 emitLeadingComments(node);

--- a/src/services/breakpoints.ts
+++ b/src/services/breakpoints.ts
@@ -7,7 +7,7 @@ module ts.BreakpointResolver {
     /**
      * Get the breakpoint span in given sourceFile
      */
-    export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: number) {
+    export function spanInSourceFileAtLocation(sourceFile: SourceFile, position: number, compilerOptions: CompilerOptions) {
         // Cannot set breakpoint in dts file
         if (sourceFile.flags & NodeFlags.DeclarationFile) {
             return undefined;
@@ -178,7 +178,7 @@ module ts.BreakpointResolver {
 
                     case SyntaxKind.ModuleDeclaration:
                         // span on complete module if it is instantiated
-                        if (getModuleInstanceState(node) !== ModuleInstanceState.Instantiated) {
+                        if (getModuleInstanceState(node, compilerOptions) !== ModuleInstanceState.Instantiated) {
                             return undefined;
                         }
 
@@ -351,7 +351,7 @@ module ts.BreakpointResolver {
             function spanInBlock(block: Block): TypeScript.TextSpan {
                 switch (block.parent.kind) {
                     case SyntaxKind.ModuleDeclaration:
-                        if (getModuleInstanceState(block.parent) !== ModuleInstanceState.Instantiated) {
+                        if (getModuleInstanceState(block.parent, compilerOptions) !== ModuleInstanceState.Instantiated) {
                             return undefined;
                         }
 
@@ -408,7 +408,7 @@ module ts.BreakpointResolver {
                 switch (node.parent.kind) {
                     case SyntaxKind.ModuleBlock:
                         // If this is not instantiated module block no bp span
-                        if (getModuleInstanceState(node.parent.parent) !== ModuleInstanceState.Instantiated) {
+                        if (getModuleInstanceState(node.parent.parent, compilerOptions) !== ModuleInstanceState.Instantiated) {
                             return undefined;
                         }
 

--- a/src/services/formatting/tokenRange.ts
+++ b/src/services/formatting/tokenRange.ts
@@ -44,8 +44,8 @@ module TypeScript.Services.Formatting {
 
 
             public toString(): string {
-                return "[tokenRangeStart=" + SyntaxKind[this.tokens[0]] + "," +
-                 "tokenRangeEnd=" + SyntaxKind[this.tokens[this.tokens.length - 1]] + "]";
+                return "[tokenRangeStart=" + this.tokens[0] + "," +
+                 "tokenRangeEnd=" + this.tokens[this.tokens.length - 1] + "]";
             }
         }
 
@@ -78,7 +78,7 @@ module TypeScript.Services.Formatting {
             }
 
             public toString(): string {
-                return "[singleTokenKind=" + SyntaxKind[this.token] + "]";
+                return "[singleTokenKind=" + this.token + "]";
             }
         }
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -4686,7 +4686,7 @@ module ts {
                     if ((<ModuleDeclaration>node).name.kind === SyntaxKind.StringLiteral) {
                         return SemanticMeaning.Namespace | SemanticMeaning.Value;
                     }
-                    else if (getModuleInstanceState(node) === ModuleInstanceState.Instantiated) {
+                    else if (getModuleInstanceState(node, program.getCompilerOptions()) === ModuleInstanceState.Instantiated) {
                         return SemanticMeaning.Namespace | SemanticMeaning.Value;
                     }
                     else {
@@ -4909,7 +4909,7 @@ module ts {
         function getBreakpointStatementAtPosition(filename: string, position: number) {
             // doesn't use compiler - no need to synchronize with host
             filename = ts.normalizeSlashes(filename);
-            return BreakpointResolver.spanInSourceFileAtLocation(getCurrentSourceFile(filename), position);
+            return BreakpointResolver.spanInSourceFileAtLocation(getCurrentSourceFile(filename), position, host.getCompilationSettings());
         }
 
         function getNavigationBarItems(filename: string): NavigationBarItem[] {
@@ -4963,7 +4963,7 @@ module ts {
                  */
                 function hasValueSideModule(symbol: Symbol): boolean {
                     return forEach(symbol.declarations, declaration => {
-                        return declaration.kind === SyntaxKind.ModuleDeclaration && getModuleInstanceState(declaration) == ModuleInstanceState.Instantiated;
+                        return declaration.kind === SyntaxKind.ModuleDeclaration && getModuleInstanceState(declaration, program.getCompilerOptions()) == ModuleInstanceState.Instantiated;
                     });
                 }
             }

--- a/src/services/syntax/syntaxKind.ts
+++ b/src/services/syntax/syntaxKind.ts
@@ -1,7 +1,7 @@
 // If you change anything in this enum, make sure you run SyntaxGenerator again!
 
 module TypeScript {
-    export enum SyntaxKind {
+    export const enum SyntaxKind {
         // Variable width tokens, trivia and lists.
         None,
         List,

--- a/tests/baselines/reference/preserveConstEnums1.js
+++ b/tests/baselines/reference/preserveConstEnums1.js
@@ -1,0 +1,25 @@
+//// [preserveConstEnums1.ts]
+const enum E {
+    Value = 1, Value2 = Value
+}
+
+// Referencing E as a value is allowed if preserveConstEnums is true.
+var s: string;
+var n: number;
+
+var x = E;
+var y = E[s];
+var z = E[n];
+
+//// [preserveConstEnums1.js]
+var E;
+(function (E) {
+    E[E["Value"] = 1] = "Value";
+    E[E["Value2"] = 1] = "Value2";
+})(E || (E = {}));
+// Referencing E as a value is allowed if preserveConstEnums is true.
+var s;
+var n;
+var x = E;
+var y = E[s];
+var z = E[n];

--- a/tests/baselines/reference/preserveConstEnums1.types
+++ b/tests/baselines/reference/preserveConstEnums1.types
@@ -1,0 +1,33 @@
+=== tests/cases/compiler/preserveConstEnums1.ts ===
+const enum E {
+>E : E
+
+    Value = 1, Value2 = Value
+>Value : E
+>Value2 : E
+>Value : E
+}
+
+// Referencing E as a value is allowed if preserveConstEnums is true.
+var s: string;
+>s : string
+
+var n: number;
+>n : number
+
+var x = E;
+>x : typeof E
+>E : typeof E
+
+var y = E[s];
+>y : any
+>E[s] : any
+>E : typeof E
+>s : string
+
+var z = E[n];
+>z : string
+>E[n] : string
+>E : typeof E
+>n : number
+

--- a/tests/baselines/reference/preserveConstEnums2.js
+++ b/tests/baselines/reference/preserveConstEnums2.js
@@ -1,0 +1,21 @@
+//// [preserveConstEnums2.ts]
+module M {
+  const enum E {
+    Value = 1, Value2 = Value
+  }
+}
+
+// Module M should be considered instantiated if we have preserveConstEnum set.
+var v = M;
+
+//// [preserveConstEnums2.js]
+var M;
+(function (M) {
+    var E;
+    (function (E) {
+        E[E["Value"] = 1] = "Value";
+        E[E["Value2"] = 1] = "Value2";
+    })(E || (E = {}));
+})(M || (M = {}));
+// Module M should be considered instantiated if we have preserveConstEnum set.
+var v = M;

--- a/tests/baselines/reference/preserveConstEnums2.types
+++ b/tests/baselines/reference/preserveConstEnums2.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/preserveConstEnums2.ts ===
+module M {
+>M : typeof M
+
+  const enum E {
+>E : E
+
+    Value = 1, Value2 = Value
+>Value : E
+>Value2 : E
+>Value : E
+  }
+}
+
+// Module M should be considered instantiated if we have preserveConstEnum set.
+var v = M;
+>v : typeof M
+>M : typeof M
+

--- a/tests/cases/compiler/preserveConstEnums1.ts
+++ b/tests/cases/compiler/preserveConstEnums1.ts
@@ -1,0 +1,12 @@
+// @preserveConstEnums: true
+const enum E {
+    Value = 1, Value2 = Value
+}
+
+// Referencing E as a value is allowed if preserveConstEnums is true.
+var s: string;
+var n: number;
+
+var x = E;
+var y = E[s];
+var z = E[n];

--- a/tests/cases/compiler/preserveConstEnums2.ts
+++ b/tests/cases/compiler/preserveConstEnums2.ts
@@ -1,0 +1,9 @@
+// @preserveConstEnums: true
+module M {
+  const enum E {
+    Value = 1, Value2 = Value
+  }
+}
+
+// Module M should be considered instantiated if we have preserveConstEnum set.
+var v = M;


### PR DESCRIPTION
... output.

This is useful for some of our scenarios where we're consuming the same const enum in two different ways.  One way being the normal const-enum case where we just use the constant values from it.  And, the other, being when we use it more for testing/code-gen purposes and we want to be able to reflect over the names and values in it.
