### PR TITLE
Fix indentation when multiple nested scopes are involved

### DIFF
--- a/src/services/smartIndenter.ts
+++ b/src/services/smartIndenter.ts
@@ -222,7 +222,8 @@ module ts.formatting {
             if (node.parent) {
                 switch (node.parent.kind) {
                     case SyntaxKind.TypeReference:
-                        if ((<TypeReferenceNode>node.parent).typeArguments) {
+                        if ((<TypeReferenceNode>node.parent).typeArguments &&
+                            rangeContainsStartEnd((<TypeReferenceNode>node.parent).typeArguments, node.getStart(sourceFile), node.getEnd())) {
                             return (<TypeReferenceNode>node.parent).typeArguments;
                         }
                         break;
@@ -236,21 +237,28 @@ module ts.formatting {
                     case SyntaxKind.Method:
                     case SyntaxKind.CallSignature:
                     case SyntaxKind.ConstructSignature:
-                        if ((<SignatureDeclaration>node.parent).typeParameters && node.end < (<SignatureDeclaration>node.parent).typeParameters.end) {
+                        var start = node.getStart(sourceFile);
+                        if ((<SignatureDeclaration>node.parent).typeParameters &&
+                            rangeContainsStartEnd((<SignatureDeclaration>node.parent).typeParameters, start, node.getEnd())) {
                             return (<SignatureDeclaration>node.parent).typeParameters;
                         }
-
-                        return (<SignatureDeclaration>node.parent).parameters;
+                        if (rangeContainsStartEnd((<SignatureDeclaration>node.parent).parameters, start, node.getEnd())) {
+                            return (<SignatureDeclaration>node.parent).parameters;
+                        }
+                        break;
                     case SyntaxKind.NewExpression:
                     case SyntaxKind.CallExpression:
-                        if ((<CallExpression>node.parent).typeArguments && node.end < (<CallExpression>node.parent).typeArguments.end) {
+                        var start = node.getStart(sourceFile);
+                        if ((<CallExpression>node.parent).typeArguments &&
+                            rangeContainsStartEnd((<CallExpression>node.parent).typeArguments, start, node.getEnd())) {
                             return (<CallExpression>node.parent).typeArguments;
                         }
-
-                        return (<CallExpression>node.parent).arguments;
+                        if (rangeContainsStartEnd((<CallExpression>node.parent).arguments, start, node.getEnd())) {
+                            return (<CallExpression>node.parent).arguments;
+                        }
+                        break;
                 }
             }
-
             return undefined;
         }
 

--- a/tests/cases/fourslash/formattingNestedScopes.ts
+++ b/tests/cases/fourslash/formattingNestedScopes.ts
@@ -1,0 +1,27 @@
+/// <reference path='fourslash.ts'/>
+
+/////*1*/        module      My.App      {
+/////*2*/export      var appModule =      angular.module("app", [
+/////*3*/            ]).config([() =>            {
+/////*4*/                        configureStates
+/////*5*/($stateProvider);
+/////*6*/}]).run(My.App.setup);
+/////*7*/      }
+
+
+format.document()
+
+goTo.marker("1");
+verify.currentLineContentIs("module My.App {");
+goTo.marker("2");
+verify.currentLineContentIs("    export var appModule = angular.module(\"app\", [");
+goTo.marker("3");
+verify.currentLineContentIs("    ]).config([() => {");
+goTo.marker("4");
+verify.currentLineContentIs("        configureStates");
+goTo.marker("5");
+verify.currentLineContentIs("            ($stateProvider);");
+goTo.marker("6");
+verify.currentLineContentIs("    }]).run(My.App.setup);");
+goTo.marker("7");
+verify.currentLineContentIs("}");

--- a/tests/cases/fourslash/smartIndentInCallExpressions.ts
+++ b/tests/cases/fourslash/smartIndentInCallExpressions.ts
@@ -1,0 +1,12 @@
+/// <reference path='fourslash.ts'/>
+
+////module My.App {
+////    export var appModule = angular.module("app", [
+////    ]).config([() => {
+////        configureStates/*1*/($stateProvider);
+////    }]).run(My.App.setup);
+////}
+
+goTo.marker("1")
+edit.insert("\n");
+verify.indentationIs(12); // 4 (module block) + 4 (function block) + 4 (call expression)


### PR DESCRIPTION
use `rangeContainsStartEnd` in implementation of `getContainingList` to determine if node range is in list range. this fixes #1201 
