### PR TITLE
Have the parser give real positions for empty tokens.

### DIFF
--- a/src/services/syntax/incrementalParser.ts
+++ b/src/services/syntax/incrementalParser.ts
@@ -592,6 +592,7 @@ module TypeScript.IncrementalParser {
             text: text,
             fileName: fileName,
             languageVersion: languageVersion,
+            absolutePosition: absolutePosition,
             currentNode: currentNode,
             currentToken: currentToken,
             currentContextualToken: currentContextualToken,


### PR DESCRIPTION
Previously this was difficult because we didn't know where empty tokens
would go due to the presense of skipped tokens.  Thanks to the recent
work i did to place skipped tokens on the _next_ real token we hit, this
became much simpler.
