### PR TITLE
handle regexes correctly in formatting

### DIFF
--- a/src/services/formatting.ts
+++ b/src/services/formatting.ts
@@ -505,7 +505,7 @@ module ts.formatting {
 
                 if (isToken(child)) {
                     // if child node is a token, it does not impact indentation, proceed it using parent indentation scope rules
-                    var tokenInfo = formattingScanner.readTokenInfo(node);
+                    var tokenInfo = formattingScanner.readTokenInfo(child);
                     Debug.assert(tokenInfo.token.end === child.end);
                     consumeTokenAndAdvanceScanner(tokenInfo, node, parentDynamicIndentation);
                     return inheritedIndentation;

--- a/src/services/formatting/formattingScanner.ts
+++ b/src/services/formatting/formattingScanner.ts
@@ -114,7 +114,8 @@ module ts.formatting {
         }
 
         function shouldRescanTemplateToken(container: Node): boolean {
-            return container.kind === SyntaxKind.TemplateSpan;
+            return container.kind === SyntaxKind.TemplateMiddle || 
+                container.kind === SyntaxKind.TemplateTail;
         }
 
         function startsWithSlashToken(t: SyntaxKind): boolean {

--- a/tests/cases/fourslash/formattingRegexes.ts
+++ b/tests/cases/fourslash/formattingRegexes.ts
@@ -1,0 +1,8 @@
+///<reference path="fourslash.ts"/>
+
+////removeAllButLast(sortedTypes, undefinedType, /keepNullableType**/ true)/*1*/
+
+goTo.marker("1");
+edit.insert(";");
+verify.currentLineContentIs("removeAllButLast(sortedTypes, undefinedType, /keepNullableType**/ true);");
+


### PR DESCRIPTION
`child` should be passed as an argument to `readTokenInfo` instead of `node`
