### PR TITLE
fix crash in getCompletionEntryDetails

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4379,8 +4379,8 @@ module ts {
         function getNarrowedTypeOfSymbol(symbol: Symbol, node: Node) {
             var type = getTypeOfSymbol(symbol);
             // Only narrow when symbol is variable of a structured type
-            if (node && node.parent && (symbol.flags & SymbolFlags.Variable && type.flags & TypeFlags.Structured)) {
-                loop: while (true) {
+            if (node && (symbol.flags & SymbolFlags.Variable && type.flags & TypeFlags.Structured)) {
+                loop: while (node.parent) {
                     var child = node;
                     node = node.parent;
                     var narrowedType = type;


### PR DESCRIPTION
`getNarrowedTypeOfSymbol` assumes that `node` should always have a parent. However often in semi-completed code `node` is SourceFile for which `parent` is `undefined`. This fixes #1286
Original crash happens as a result of interaction between calls to `getCompletionEntry` and `getCompletionEntryDetails` and I'm not sure that it can be reproduced in fourslash.
