### PR TITLE
Ensure getEmitOutput only check the file requested

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -85,7 +85,6 @@ module ts {
             getDiagnostics,
             getDeclarationDiagnostics,
             getGlobalDiagnostics,
-            checkProgram,
             getParentOfSymbol,
             getNarrowedTypeOfSymbol,
             getDeclaredTypeOfSymbol,
@@ -8634,10 +8633,6 @@ module ts {
             }
         }
 
-        function checkProgram() {
-            forEach(program.getSourceFiles(), checkSourceFile);
-        }
-
         function getSortedDiagnostics(): Diagnostic[]{
             Debug.assert(fullTypeCheck, "diagnostics are available only in the full typecheck mode");
 
@@ -8650,12 +8645,11 @@ module ts {
         }
 
         function getDiagnostics(sourceFile?: SourceFile): Diagnostic[]{
-
             if (sourceFile) {
                 checkSourceFile(sourceFile);
                 return filter(getSortedDiagnostics(), d => d.file === sourceFile);
             }
-            checkProgram();
+            forEach(program.getSourceFiles(), checkSourceFile);
             return getSortedDiagnostics();
         }
 
@@ -9173,9 +9167,9 @@ module ts {
             return isImportResolvedToValue(getSymbolOfNode(node));
         }
 
-        function hasSemanticErrors() {
+        function hasSemanticErrors(sourceFile?: SourceFile) {
             // Return true if there is any semantic error in a file or globally
-            return getDiagnostics().length > 0 || getGlobalDiagnostics().length > 0;
+            return getDiagnostics(sourceFile).length > 0 || getGlobalDiagnostics().length > 0;
         }
 
         function isEmitBlocked(sourceFile?: SourceFile): boolean {
@@ -9293,7 +9287,6 @@ module ts {
 
         function invokeEmitter(targetSourceFile?: SourceFile) {
             var resolver = createResolver();
-            checkProgram();
             return emitFiles(resolver, targetSourceFile);
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -861,7 +861,6 @@ module ts {
         getIdentifierCount(): number;
         getSymbolCount(): number;
         getTypeCount(): number;
-        checkProgram(): void;
         emitFiles(targetSourceFile?: SourceFile): EmitResult;
         getParentOfSymbol(symbol: Symbol): Symbol;
         getNarrowedTypeOfSymbol(symbol: Symbol, node: Node): Type;
@@ -973,7 +972,7 @@ module ts {
         isTopLevelValueImportWithEntityName(node: ImportDeclaration): boolean;
         getNodeCheckFlags(node: Node): NodeCheckFlags;
         getEnumMemberValue(node: EnumMember): number;
-        hasSemanticErrors(): boolean;
+        hasSemanticErrors(sourceFile?: SourceFile): boolean;
         isDeclarationVisible(node: Declaration): boolean;
         isImplementationOfOverload(node: FunctionLikeDeclaration): boolean;
         writeTypeOfDeclaration(declaration: AccessorDeclaration | VariableOrParameterDeclaration, enclosingDeclaration: Node, flags: TypeFormatFlags, writer: SymbolWriter): void;

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2217,11 +2217,10 @@ module FourSlash {
         // TODO (drosen): We need to enforce checking on these tests.
         var program = ts.createProgram([Harness.Compiler.fourslashFilename, fileName], { out: "fourslashTestOutput.js", noResolve: true }, host);
         var checker = ts.createTypeChecker(program, /*fullTypeCheckMode*/ true);
-        checker.checkProgram();
 
-        var errs = program.getDiagnostics().concat(checker.getDiagnostics());
-        if (errs.length > 0) {
-            throw new Error('Error compiling ' + fileName + ': ' + errs.map(e => e.messageText).join('\r\n'));
+        var errors = program.getDiagnostics().concat(checker.getDiagnostics());
+        if (errors.length > 0) {
+            throw new Error('Error compiling ' + fileName + ': ' + errors.map(e => e.messageText).join('\r\n'));
         }
         checker.emitFiles();
         result = result || ''; // Might have an empty fourslash file

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -801,7 +801,6 @@ module Harness {
                     useCaseSensitiveFileNames));
 
                 var checker = program.getTypeChecker(/*fullTypeCheckMode*/ true);
-                checker.checkProgram();
 
                 var isEmitBlocked = checker.isEmitBlocked();
 

--- a/tests/baselines/reference/getEmitOutputWithEarlySyntacticErrors.baseline
+++ b/tests/baselines/reference/getEmitOutputWithEarlySyntacticErrors.baseline
@@ -1,0 +1,2 @@
+EmitOutputStatus : AllOutputGenerationSkipped
+

--- a/tests/baselines/reference/getEmitOutputWithSemanticErrorsForMultipleFiles.baseline
+++ b/tests/baselines/reference/getEmitOutputWithSemanticErrorsForMultipleFiles.baseline
@@ -1,0 +1,8 @@
+EmitOutputStatus : Succeeded
+Filename : tests/cases/fourslash/inputFile1.js
+// File to emit, does not contain semantic errors
+// expected to be emitted correctelly regardless of the semantic errors in the other file
+var noErrors = true;
+Filename : tests/cases/fourslash/inputFile1.d.ts
+declare var noErrors: boolean;
+

--- a/tests/baselines/reference/getEmitOutputWithSemanticErrorsForMultipleFiles2.baseline
+++ b/tests/baselines/reference/getEmitOutputWithSemanticErrorsForMultipleFiles2.baseline
@@ -1,0 +1,8 @@
+EmitOutputStatus : DeclarationGenerationSkipped
+Filename : out.js
+// File to emit, does not contain semantic errors, but --out is passed
+// expected to not generate declarations because of the semantic errors in the other file
+var noErrors = true;
+// File not emitted, and contains semantic errors
+var semanticError = "string";
+

--- a/tests/baselines/reference/getEmitOutputWithSyntacticErrorsForMultipleFiles.baseline
+++ b/tests/baselines/reference/getEmitOutputWithSyntacticErrorsForMultipleFiles.baseline
@@ -1,0 +1,6 @@
+EmitOutputStatus : Succeeded
+Filename : tests/cases/fourslash/inputFile1.js
+// File to emit, does not contain syntactic errors
+// expected to be emitted correctelly regardless of the syntactic errors in the other file
+var noErrors = true;
+

--- a/tests/baselines/reference/getEmitOutputWithSyntacticErrorsForMultipleFiles2.baseline
+++ b/tests/baselines/reference/getEmitOutputWithSyntacticErrorsForMultipleFiles2.baseline
@@ -1,0 +1,2 @@
+EmitOutputStatus : AllOutputGenerationSkipped
+

--- a/tests/cases/fourslash/getEmitOutputWithEarlySemanticErrors.ts
+++ b/tests/cases/fourslash/getEmitOutputWithEarlySemanticErrors.ts
@@ -1,0 +1,10 @@
+﻿/// <reference path="fourslash.ts" />
+
+// @BaselineFile: getEmitOutputWithEarlySyntacticErrors.baseline
+
+// @Filename: inputFile1.ts
+// @emitThisFile: true
+//// // File contains early errors. All outputs should be skipped.
+//// const uninitialized_const_error;
+
+verify.baselineGetEmitOutput();

--- a/tests/cases/fourslash/getEmitOutputWithSemanticErrorsForMultipleFiles.ts
+++ b/tests/cases/fourslash/getEmitOutputWithSemanticErrorsForMultipleFiles.ts
@@ -1,0 +1,16 @@
+﻿/// <reference path="fourslash.ts" />
+
+// @BaselineFile: getEmitOutputWithSemanticErrorsForMultipleFiles.baseline
+// @declaration: true
+
+// @Filename: inputFile1.ts
+// @emitThisFile: true
+//// // File to emit, does not contain semantic errors
+//// // expected to be emitted correctelly regardless of the semantic errors in the other file
+//// var noErrors = true;
+
+// @Filename: inputFile2.ts
+//// // File not emitted, and contains semantic errors
+//// var semanticError: boolean = "string";
+
+verify.baselineGetEmitOutput();

--- a/tests/cases/fourslash/getEmitOutputWithSemanticErrorsForMultipleFiles2.ts
+++ b/tests/cases/fourslash/getEmitOutputWithSemanticErrorsForMultipleFiles2.ts
@@ -1,0 +1,17 @@
+﻿/// <reference path="fourslash.ts" />
+
+// @BaselineFile: getEmitOutputWithSemanticErrorsForMultipleFiles2.baseline
+// @declaration: true
+// @out: out.js
+
+// @Filename: inputFile1.ts
+// @emitThisFile: true
+//// // File to emit, does not contain semantic errors, but --out is passed
+//// // expected to not generate declarations because of the semantic errors in the other file
+//// var noErrors = true;
+
+// @Filename: inputFile2.ts
+//// // File not emitted, and contains semantic errors
+//// var semanticError: boolean = "string";
+
+verify.baselineGetEmitOutput();

--- a/tests/cases/fourslash/getEmitOutputWithSyntacticErrorsForMultipleFiles.ts
+++ b/tests/cases/fourslash/getEmitOutputWithSyntacticErrorsForMultipleFiles.ts
@@ -1,0 +1,15 @@
+﻿/// <reference path="fourslash.ts" />
+
+// @BaselineFile: getEmitOutputWithSyntacticErrorsForMultipleFiles.baseline
+
+// @Filename: inputFile1.ts
+// @emitThisFile: true
+//// // File to emit, does not contain syntactic errors
+//// // expected to be emitted correctelly regardless of the syntactic errors in the other file
+//// var noErrors = true;
+
+// @Filename: inputFile2.ts
+//// // File not emitted, and contains syntactic errors
+//// var syntactic Error;
+
+verify.baselineGetEmitOutput();

--- a/tests/cases/fourslash/getEmitOutputWithSyntacticErrorsForMultipleFiles2.ts
+++ b/tests/cases/fourslash/getEmitOutputWithSyntacticErrorsForMultipleFiles2.ts
@@ -1,0 +1,16 @@
+﻿/// <reference path="fourslash.ts" />
+
+// @BaselineFile: getEmitOutputWithSyntacticErrorsForMultipleFiles2.baseline
+// @out: out.js
+
+// @Filename: inputFile1.ts
+// @emitThisFile: true
+//// // File to emit, does not contain syntactic errors, but --out is passed
+//// // expected to not generate outputs because of the syntactic errors in the other file.
+//// var noErrors = true;
+
+// @Filename: inputFile2.ts
+//// // File not emitted, and contains syntactic errors
+//// var syntactic Error;
+
+verify.baselineGetEmitOutput();


### PR DESCRIPTION
Fix for #1330:
- Remove checkProgram as it is not needed and mostly subsumed in checker.getDiagnostics
- Ensure that checkSourceFile is only called in checker.getDiagnostics
- Add SourceFile as an argument to hasSemanticErrors to avoid a full typeCheck
- Update EmitFiles to specify the sourceFile if present
- Cleanup LanguageService.getEmitOutput to remove duplicated logic 
- Added some additional tests
