### PR TITLE
Extract reference comments out into their own diagnostics array.

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -943,7 +943,6 @@ module ts {
     }
 
     export function createSourceFile(filename: string, sourceText: string, languageVersion: ScriptTarget, version: string, isOpen: boolean = false): SourceFile {
-        var file: SourceFile;
         var scanner: Scanner;
         var token: SyntaxKind;
         var parsingContext: ParsingContext;
@@ -1101,22 +1100,22 @@ module ts {
             return getPositionFromLineAndCharacter(getLineStarts(), line, character);
         }
 
-        function error(message: DiagnosticMessage, arg0?: any, arg1?: any, arg2?: any): void {
+        function parseErrorAtCurrentToken(message: DiagnosticMessage, arg0?: any, arg1?: any, arg2?: any): void {
             var start = scanner.getTokenPos();
             var length = scanner.getTextPos() - start;
 
-            errorAtPosition(start, length, message, arg0, arg1, arg2);
+            parseErrorAtPosition(start, length, message, arg0, arg1, arg2);
         }
 
-        function errorAtPosition(start: number, length: number, message: DiagnosticMessage, arg0?: any, arg1?: any, arg2?: any): void {
-            var lastErrorPosition = file.parseDiagnostics.length
-                ? file.parseDiagnostics[file.parseDiagnostics.length - 1].start
+        function parseErrorAtPosition(start: number, length: number, message: DiagnosticMessage, arg0?: any, arg1?: any, arg2?: any): void {
+            var lastErrorPosition = sourceFile.parseDiagnostics.length
+                ? sourceFile.parseDiagnostics[sourceFile.parseDiagnostics.length - 1].start
                 : -1;
 
             // Don't report another error if it would just be at the same position as the last error.
             if (start !== lastErrorPosition) {
-                var diagnostic = createFileDiagnostic(file, start, length, message, arg0, arg1, arg2);
-                file.parseDiagnostics.push(diagnostic);
+                var diagnostic = createFileDiagnostic(sourceFile, start, length, message, arg0, arg1, arg2);
+                sourceFile.parseDiagnostics.push(diagnostic);
             }
 
             if (lookAheadMode === LookAheadMode.NoErrorYet) {
@@ -1126,7 +1125,7 @@ module ts {
 
         function scanError(message: DiagnosticMessage) {
             var pos = scanner.getTextPos();
-            errorAtPosition(pos, 0, message);
+            parseErrorAtPosition(pos, 0, message);
         }
 
         function onComment(pos: number, end: number) {
@@ -1165,7 +1164,7 @@ module ts {
             // Keep track of the state we'll need to rollback to if lookahead fails (or if the 
             // caller asked us to always reset our state).
             var saveToken = token;
-            var saveSyntacticErrorsLength = file.parseDiagnostics.length;
+            var saveSyntacticErrorsLength = sourceFile.parseDiagnostics.length;
 
             // Keep track of the current look ahead mode (this matters if we have nested 
             // speculative parsing).
@@ -1187,7 +1186,7 @@ module ts {
             lookAheadMode = saveLookAheadMode;
             if (!result || alwaysResetState) {
                 token = saveToken;
-                file.parseDiagnostics.length = saveSyntacticErrorsLength;
+                sourceFile.parseDiagnostics.length = saveSyntacticErrorsLength;
             }
 
             return result;
@@ -1236,10 +1235,10 @@ module ts {
 
             // Report specific message if provided with one.  Otherwise, report generic fallback message.
             if (diagnosticMessage) {
-                error(diagnosticMessage, arg0);
+                parseErrorAtCurrentToken(diagnosticMessage, arg0);
             }
             else {
-                error(Diagnostics._0_expected, tokenToString(kind));
+                parseErrorAtCurrentToken(Diagnostics._0_expected, tokenToString(kind));
             }
             return false;
         }
@@ -1307,10 +1306,10 @@ module ts {
 
         function createMissingNode(kind: SyntaxKind, reportAtCurrentPosition: boolean, diagnosticMessage: DiagnosticMessage, arg0?: any): Node {
             if (reportAtCurrentPosition) {
-                errorAtPosition(scanner.getStartPos(), 0, diagnosticMessage, arg0);
+                parseErrorAtPosition(scanner.getStartPos(), 0, diagnosticMessage, arg0);
             }
             else {
-                error(diagnosticMessage, arg0);
+                parseErrorAtCurrentToken(diagnosticMessage, arg0);
             }
 
             return createMissingNodeWithoutError(kind);
@@ -1601,7 +1600,7 @@ module ts {
 
         // Returns true if we should abort parsing.
         function abortParsingListOrMoveToNextToken(kind: ParsingContext) {
-            error(parsingContextErrors(kind));
+            parseErrorAtCurrentToken(parsingContextErrors(kind));
             if (isInSomeParsingContext()) {
                 return true;
             }
@@ -4206,13 +4205,13 @@ module ts {
                 var referencePathMatchResult = getFileReferenceFromReferencePath(comment, range);
                 if (referencePathMatchResult) {
                     var fileReference = referencePathMatchResult.fileReference;
-                    file.hasNoDefaultLib = referencePathMatchResult.isNoDefaultLib;
+                    sourceFile.hasNoDefaultLib = referencePathMatchResult.isNoDefaultLib;
                     var diagnosticMessage = referencePathMatchResult.diagnosticMessage;
                     if (fileReference) {
                         referencedFiles.push(fileReference);
                     }
                     if (diagnosticMessage) {
-                        file.parseDiagnostics.push(createFileDiagnostic(file, range.pos, range.end - range.pos, diagnosticMessage));
+                        sourceFile.referenceDiagnostics.push(createFileDiagnostic(sourceFile, range.pos, range.end - range.pos, diagnosticMessage));
                     }
                 }
                 else {
@@ -4220,7 +4219,7 @@ module ts {
                     var amdModuleNameMatchResult = amdModuleNameRegEx.exec(comment);
                     if(amdModuleNameMatchResult) {
                         if(amdModuleName) {
-                            file.parseDiagnostics.push(createFileDiagnostic(file, range.pos, range.end - range.pos, Diagnostics.An_AMD_module_cannot_have_multiple_name_assignments));
+                            sourceFile.referenceDiagnostics.push(createFileDiagnostic(sourceFile, range.pos, range.end - range.pos, Diagnostics.An_AMD_module_cannot_have_multiple_name_assignments));
                         }
                         amdModuleName = amdModuleNameMatchResult[2];
                     }
@@ -4241,7 +4240,7 @@ module ts {
         }
 
         function getExternalModuleIndicator() {
-            return forEach(file.statements, node =>
+            return forEach(sourceFile.statements, node =>
                 node.flags & NodeFlags.Export
                 || node.kind === SyntaxKind.ImportDeclaration && (<ImportDeclaration>node).moduleReference.kind === SyntaxKind.ExternalModuleReference
                 || node.kind === SyntaxKind.ExportAssignment
@@ -4252,15 +4251,15 @@ module ts {
         var syntacticDiagnostics: Diagnostic[];
         function getSyntacticDiagnostics() {
             if (syntacticDiagnostics === undefined) {
-                if (file.parseDiagnostics.length > 0) {
+                if (sourceFile.parseDiagnostics.length > 0) {
                     // Don't bother doing any grammar checks if there are already parser errors.  
                     // Otherwise we may end up with too many cascading errors.
-                    syntacticDiagnostics = file.parseDiagnostics;
+                    syntacticDiagnostics = sourceFile.referenceDiagnostics.concat(sourceFile.parseDiagnostics);
                 }
                 else {
                     // No parser errors were reported.  Perform our stricter grammar checks.
-                    syntacticDiagnostics = file.grammarDiagnostics;
-                    checkGrammar(sourceText, languageVersion, file);
+                    checkGrammar(sourceText, languageVersion, sourceFile);
+                    syntacticDiagnostics = sourceFile.referenceDiagnostics.concat(sourceFile.grammarDiagnostics);
                 }
             }
 
@@ -4273,32 +4272,37 @@ module ts {
         if (fileExtensionIs(filename, ".d.ts")) {
             rootNodeFlags = NodeFlags.DeclarationFile;
         }
-        file = <SourceFile>createRootNode(SyntaxKind.SourceFile, 0, sourceText.length, rootNodeFlags);
-        file.filename = normalizePath(filename);
-        file.text = sourceText;
-        file.getLineAndCharacterFromPosition = getLineAndCharacterFromSourcePosition;
-        file.getPositionFromLineAndCharacter = getPositionFromSourceLineAndCharacter;
-        file.getLineStarts = getLineStarts;
-        file.getSyntacticDiagnostics = getSyntacticDiagnostics;
-        file.parseDiagnostics = [];
-        file.grammarDiagnostics = [];
-        file.semanticDiagnostics = [];
+
+        var sourceFile = <SourceFile>createRootNode(SyntaxKind.SourceFile, 0, sourceText.length, rootNodeFlags);
+
+        sourceFile.getLineAndCharacterFromPosition = getLineAndCharacterFromSourcePosition;
+        sourceFile.getPositionFromLineAndCharacter = getPositionFromSourceLineAndCharacter;
+        sourceFile.getLineStarts = getLineStarts;
+        sourceFile.getSyntacticDiagnostics = getSyntacticDiagnostics;
+
+        sourceFile.filename = normalizePath(filename);
+        sourceFile.text = sourceText;
+
+        sourceFile.referenceDiagnostics = [];
+        sourceFile.parseDiagnostics = [];
+        sourceFile.grammarDiagnostics = [];
+        sourceFile.semanticDiagnostics = [];
 
         var referenceComments = processReferenceComments(); 
-        file.referencedFiles = referenceComments.referencedFiles;
-        file.amdDependencies = referenceComments.amdDependencies;
-        file.amdModuleName = referenceComments.amdModuleName;
+        sourceFile.referencedFiles = referenceComments.referencedFiles;
+        sourceFile.amdDependencies = referenceComments.amdDependencies;
+        sourceFile.amdModuleName = referenceComments.amdModuleName;
 
-        file.statements = parseList(ParsingContext.SourceElements, /*checkForStrictMode*/ true, parseSourceElement);
-        file.externalModuleIndicator = getExternalModuleIndicator();
+        sourceFile.statements = parseList(ParsingContext.SourceElements, /*checkForStrictMode*/ true, parseSourceElement);
+        sourceFile.externalModuleIndicator = getExternalModuleIndicator();
 
-        file.nodeCount = nodeCount;
-        file.identifierCount = identifierCount;
-        file.version = version;
-        file.isOpen = isOpen;
-        file.languageVersion = languageVersion;
-        file.identifiers = identifiers;
-        return file;
+        sourceFile.nodeCount = nodeCount;
+        sourceFile.identifierCount = identifierCount;
+        sourceFile.version = version;
+        sourceFile.isOpen = isOpen;
+        sourceFile.languageVersion = languageVersion;
+        sourceFile.identifiers = identifiers;
+        return sourceFile;
     }
 
     function isLeftHandSideExpression(expr: Expression): boolean {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -795,17 +795,24 @@ module ts {
         amdDependencies: string[];
         amdModuleName: string;
         referencedFiles: FileReference[];
-        semanticDiagnostics: Diagnostic[];
+
+        // Diagnostics reported about the "///<reference" comments in the file.
+        referenceDiagnostics: Diagnostic[];
 
         // Parse errors refer specifically to things the parser could not understand at all (like 
-        // missing tokens, or tokens it didn't know how to deal with). Grammar errors are for 
-        // things the parser understood, but either the ES6 or TS grammars do not allow (like 
-        // putting an 'public' modifier on a 'class declaration').
+        // missing tokens, or tokens it didn't know how to deal with).
         parseDiagnostics: Diagnostic[];
+
+        // Grammar errors are for  things the parser understood, but either the ES6 or TS grammars
+        // do not allow (like putting an 'public' modifier on a 'class declaration').
         grammarDiagnostics: Diagnostic[];
 
-        // Returns all 
+        // Returns all syntactic diagnostics (i.e. the reference, parser and grammar diagnostics).
         getSyntacticDiagnostics(): Diagnostic[];
+
+        // File level diagnostics reported by the binder.
+        semanticDiagnostics: Diagnostic[];
+
         hasNoDefaultLib: boolean;
         externalModuleIndicator: Node; // The first node that causes this file to be an external module
         nodeCount: number;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -732,9 +732,12 @@ module ts {
         public amdDependencies: string[];
         public amdModuleName: string;
         public referencedFiles: FileReference[];
+
+        public referenceDiagnostics: Diagnostic[];
         public parseDiagnostics: Diagnostic[];
         public grammarDiagnostics: Diagnostic[];
         public semanticDiagnostics: Diagnostic[];
+
         public hasNoDefaultLib: boolean;
         public externalModuleIndicator: Node; // The first node that causes this file to be an external module
         public nodeCount: number;


### PR DESCRIPTION
Only actual parse errors are stored in parseDiagnostics.  Reference errors are stored in a separate
array now.
