### PR TITLE
Don't emit __extends if one is already in scope

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7886,7 +7886,7 @@ module ts {
             var staticType = <ObjectType>getTypeOfSymbol(symbol);
             var baseTypeNode = getClassBaseTypeNode(node);
             if (baseTypeNode) {
-                emitExtends = emitExtends || !isInAmbientContext(node);
+                emitExtends = emitExtends || !(isInAmbientContext(node) || resolveName(node.parent, escapeIdentifier('__extends'), SymbolFlags.Value, undefined, undefined));
                 checkTypeReference(baseTypeNode);
             }
             if (type.baseTypes.length) {

--- a/tests/baselines/reference/__extends.js
+++ b/tests/baselines/reference/__extends.js
@@ -1,0 +1,20 @@
+//// [__extends.ts]
+var __extends;
+
+class A { }
+class B extends A { }
+
+//// [__extends.js]
+var __extends;
+var A = (function () {
+    function A() {
+    }
+    return A;
+})();
+var B = (function (_super) {
+    __extends(B, _super);
+    function B() {
+        _super.apply(this, arguments);
+    }
+    return B;
+})(A);

--- a/tests/baselines/reference/__extends.types
+++ b/tests/baselines/reference/__extends.types
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/__extends.ts ===
+var __extends;
+>__extends : any
+
+class A { }
+>A : A
+
+class B extends A { }
+>B : B
+>A : A
+

--- a/tests/baselines/reference/__extendsAmbient.js
+++ b/tests/baselines/reference/__extendsAmbient.js
@@ -1,0 +1,19 @@
+//// [__extendsAmbient.ts]
+declare var __extends;
+
+class A { }
+class B extends A { }
+
+//// [__extendsAmbient.js]
+var A = (function () {
+    function A() {
+    }
+    return A;
+})();
+var B = (function (_super) {
+    __extends(B, _super);
+    function B() {
+        _super.apply(this, arguments);
+    }
+    return B;
+})(A);

--- a/tests/baselines/reference/__extendsAmbient.types
+++ b/tests/baselines/reference/__extendsAmbient.types
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/__extendsAmbient.ts ===
+declare var __extends;
+>__extends : any
+
+class A { }
+>A : A
+
+class B extends A { }
+>B : B
+>A : A
+

--- a/tests/baselines/reference/__extendsModule.js
+++ b/tests/baselines/reference/__extendsModule.js
@@ -1,0 +1,32 @@
+//// [__extendsModule.ts]
+
+module M {
+  export var __extends;
+}
+
+class A { }
+class B extends A { }
+
+//// [__extendsModule.js]
+var __extends = this.__extends || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    __.prototype = b.prototype;
+    d.prototype = new __();
+};
+var M;
+(function (M) {
+    M.__extends;
+})(M || (M = {}));
+var A = (function () {
+    function A() {
+    }
+    return A;
+})();
+var B = (function (_super) {
+    __extends(B, _super);
+    function B() {
+        _super.apply(this, arguments);
+    }
+    return B;
+})(A);

--- a/tests/baselines/reference/__extendsModule.types
+++ b/tests/baselines/reference/__extendsModule.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/__extendsModule.ts ===
+
+module M {
+>M : typeof M
+
+  export var __extends;
+>__extends : any
+}
+
+class A { }
+>A : A
+
+class B extends A { }
+>B : B
+>A : A
+

--- a/tests/baselines/reference/__extendsMultifile.js
+++ b/tests/baselines/reference/__extendsMultifile.js
@@ -1,0 +1,25 @@
+//// [tests/cases/compiler/__extendsMultifile.ts] ////
+
+//// [foo.ts]
+
+declare var __extends;
+
+//// [bar.ts]
+class A { }
+class B extends A { }
+
+
+//// [foo.js]
+//// [bar.js]
+var A = (function () {
+    function A() {
+    }
+    return A;
+})();
+var B = (function (_super) {
+    __extends(B, _super);
+    function B() {
+        _super.apply(this, arguments);
+    }
+    return B;
+})(A);

--- a/tests/baselines/reference/__extendsMultifile.types
+++ b/tests/baselines/reference/__extendsMultifile.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/foo.ts ===
+
+declare var __extends;
+>__extends : any
+
+=== tests/cases/compiler/bar.ts ===
+class A { }
+>A : A
+
+class B extends A { }
+>B : B
+>A : A
+

--- a/tests/cases/compiler/__extends.ts
+++ b/tests/cases/compiler/__extends.ts
@@ -1,0 +1,4 @@
+var __extends;
+
+class A { }
+class B extends A { }

--- a/tests/cases/compiler/__extendsAmbient.ts
+++ b/tests/cases/compiler/__extendsAmbient.ts
@@ -1,0 +1,4 @@
+declare var __extends;
+
+class A { }
+class B extends A { }

--- a/tests/cases/compiler/__extendsModule.ts
+++ b/tests/cases/compiler/__extendsModule.ts
@@ -1,0 +1,7 @@
+
+module M {
+  export var __extends;
+}
+
+class A { }
+class B extends A { }

--- a/tests/cases/compiler/__extendsMultifile.ts
+++ b/tests/cases/compiler/__extendsMultifile.ts
@@ -1,0 +1,7 @@
+
+// @Filename: foo.ts
+declare var __extends;
+
+// @Filename: bar.ts
+class A { }
+class B extends A { }


### PR DESCRIPTION
Addresses #1350 and probably some other suggestions as well.

This changes the "do we need to emit __extends" logic to see if a symbol named `__extends` is already in visible scope at the site of the class declaration.