### PR TITLE
Remove redundant initialization code from the constructor of SyntaxTreeCache

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1649,7 +1649,6 @@ module ts {
         private currentSourceFile: SourceFile = null;
 
         constructor(private host: LanguageServiceHost) {
-            this.hostCache = new HostCache(host);
         }
 
         private initialize(filename: string) {


### PR DESCRIPTION
All calls to SyntaxTreeCache begin with `initialize` method that re-creates `SyntaxTreeCache` so this initial creation will be dropped on the floor. Also this fixes #1338. If so happens that code will be replaced right before calling `dispose` - then managed side will shutdown old engine and create a new one + create new shim for the language service. Code that I've removed tried to fetch project information from the managed side and died because of NullReferenceException since managed side does not set current project when calling `dispose`.
