### PR TITLE
Add 'dev mode' to the language service

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -15,7 +15,7 @@
 
 module ts {
 
-    export var ScriptAPIVersion = "1.4"
+    export var servicesVersion = "0.4"
 
     export interface Node {
         getSourceFile(): SourceFile;

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -870,8 +870,8 @@ module ts {
         /*
          * Returns script API version.
          */
-        public getApiVersion(): string {
-            return ScriptAPIVersion;
+        public getServicesVersion(): string {
+            return servicesVersion;
         }
 
         public createLanguageServiceShim(host: LanguageServiceShimHost): LanguageServiceShim {


### PR DESCRIPTION
This PR adds a a few points that can be consumed by consumes of language service. These points are not hooked up to the VS part yet, current assumption about their behavior is following:
- trace - writes a string to debug output
- error - brings a popup with a  given text

also I've added an extra method `getApiVersion` that can be used to check the version of API and thus to validate assumptions about the its shape  
