### PR TITLE
Check if the symbol exists before checking its visibility in isEntityNameVisible.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1012,7 +1012,7 @@ module ts {
             var symbol = resolveName(enclosingDeclaration, (<Identifier>firstIdentifier).text, meaning, /*nodeNotFoundErrorMessage*/ undefined, /*nameArg*/ undefined);
 
             // Verify if the symbol is accessible
-            return hasVisibleDeclarations(symbol) || <SymbolVisibilityResult>{
+            return (symbol && hasVisibleDeclarations(symbol)) || <SymbolVisibilityResult>{
                 accessibility: SymbolAccessibility.NotAccessible,
                 errorSymbolName: getTextOfNode(firstIdentifier),
                 errorNode: firstIdentifier


### PR DESCRIPTION
Should fix #1348.
