### PR TITLE
Put the actual parsing logic at the top of createSourceFile instead of the bottom.

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -48,12 +48,6 @@ module ts {
         return node;
     }
 
-    interface ReferenceComments {
-        referencedFiles: FileReference[];
-        amdDependencies: string[];
-        amdModuleName: string;
-    }
-
     export function getSourceFileOfNode(node: Node): SourceFile {
         while (node && node.kind !== SyntaxKind.SourceFile) node = node.parent;
         return <SourceFile>node;


### PR DESCRIPTION
This makes it vastly simpler to fix up that logic since you no longer have to go find
the end of the function first.
