### PR TITLE
Only set parents for parse trees in the LS for the syntactic trees.

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1021,12 +1021,17 @@ module ts {
         // walk over the nodes and set parent references
         var parent: Node = sourceFile;
         function walk(n: Node): void {
-            n.parent = parent;
+            // walk down setting parents that differ from the parent we think it should be.  This
+            // allows us to quickly bail out of setting parents for subtrees during incremental 
+            // parsing
+            if (n.parent !== parent) {
+                n.parent = parent;
 
-            var saveParent = parent;
-            parent = n;
-            forEachChild(n, walk);
-            parent = saveParent;
+                var saveParent = parent;
+                parent = n;
+                forEachChild(n, walk);
+                parent = saveParent;
+            }
         }
 
         forEachChild(sourceFile, walk);

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -865,11 +865,11 @@ module ts {
                 }
             }
 
-            return SourceFileObject.createSourceFileObject(this.filename, scriptSnapshot, this.languageVersion, version, isOpen);
+            return createLanguageServiceSourceFile(this.filename, scriptSnapshot, this.languageVersion, version, isOpen, /*setNodeParents:*/ true);
         }
 
-        public static createSourceFileObject(filename: string, scriptSnapshot: IScriptSnapshot, languageVersion: ScriptTarget, version: string, isOpen: boolean) {
-            var newSourceFile = <SourceFileObject><any>createSourceFile(filename, scriptSnapshot.getText(0, scriptSnapshot.getLength()), languageVersion, /*setParentNodes:*/ true);
+        public static createSourceFileObject(filename: string, scriptSnapshot: IScriptSnapshot, languageVersion: ScriptTarget, version: string, isOpen: boolean, setParentNodes: boolean) {
+            var newSourceFile = <SourceFileObject><any>createSourceFile(filename, scriptSnapshot.getText(0, scriptSnapshot.getLength()), languageVersion, setParentNodes);
             newSourceFile.version = version;
             newSourceFile.isOpen = isOpen;
             newSourceFile.scriptSnapshot = scriptSnapshot;
@@ -1679,7 +1679,7 @@ module ts {
                 var scriptSnapshot = this.hostCache.getScriptSnapshot(filename);
 
                 var start = new Date().getTime();
-                sourceFile = createLanguageServiceSourceFile(filename, scriptSnapshot, getDefaultCompilerOptions(), version, /*isOpen*/ true);
+                sourceFile = createLanguageServiceSourceFile(filename, scriptSnapshot, getDefaultCompilerOptions().target, version, /*isOpen*/ true, /*setNodeParents:*/ true);
                 this.host.log("SyntaxTreeCache.Initialize: createSourceFile: " + (new Date().getTime() - start));
 
                 var start = new Date().getTime();
@@ -1692,7 +1692,7 @@ module ts {
 
                 var start = new Date().getTime();
                 sourceFile = !editRange 
-                    ? createLanguageServiceSourceFile(filename, scriptSnapshot, getDefaultCompilerOptions(), version, /*isOpen*/ true)
+                    ? createLanguageServiceSourceFile(filename, scriptSnapshot, getDefaultCompilerOptions().target, version, /*isOpen*/ true, /*setNodeParents:*/ true)
                     : this.currentSourceFile.update(scriptSnapshot, version, /*isOpen*/ true, editRange);
                 this.host.log("SyntaxTreeCache.Initialize: updateSourceFile: " + (new Date().getTime() - start));
 
@@ -1718,8 +1718,8 @@ module ts {
         }
     }
 
-    export function createLanguageServiceSourceFile(filename: string, scriptSnapshot: IScriptSnapshot, settings: CompilerOptions, version: string, isOpen: boolean): SourceFile {
-        return SourceFileObject.createSourceFileObject(filename, scriptSnapshot, settings.target, version, isOpen);
+    export function createLanguageServiceSourceFile(filename: string, scriptSnapshot: IScriptSnapshot, scriptTarget: ScriptTarget, version: string, isOpen: boolean, setNodeParents: boolean): SourceFile {
+        return SourceFileObject.createSourceFileObject(filename, scriptSnapshot, scriptTarget, version, isOpen, setNodeParents);
     }
 
     export function createDocumentRegistry(): DocumentRegistry {
@@ -1769,7 +1769,7 @@ module ts {
             var bucket = getBucketForCompilationSettings(compilationSettings, /*createIfMissing*/ true);
             var entry = lookUp(bucket, filename);
             if (!entry) {
-                var sourceFile = createLanguageServiceSourceFile(filename, scriptSnapshot, compilationSettings, version, isOpen);
+                var sourceFile = createLanguageServiceSourceFile(filename, scriptSnapshot, compilationSettings.target, version, isOpen, /*setNodeParents:*/ false);
 
                 bucket[filename] = entry = {
                     sourceFile: sourceFile,

--- a/tests/cases/unittests/incrementalParser.ts
+++ b/tests/cases/unittests/incrementalParser.ts
@@ -18,10 +18,7 @@ module ts {
     }
 
     function createTree(text: IScriptSnapshot, version: string) {
-        var options: CompilerOptions = {};
-        options.target = ScriptTarget.ES5;
-
-        return createLanguageServiceSourceFile(/*fileName:*/ "", text, options, version, /*isOpen:*/ true)
+        return createLanguageServiceSourceFile(/*fileName:*/ "", text, ScriptTarget.ES5, version, /*isOpen:*/ true, /*setNodeParents:*/ true)
     }
 
     // NOTE: 'reusedElements' is the expected count of elements reused from the old tree to the new


### PR DESCRIPTION
we don't need this for the semantic trees because the compiler will set them all during
the binding.
