### PR TITLE
Type guards should not affect values of type any

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4622,8 +4622,8 @@ module ts {
         // Get the narrowed type of a given symbol at a given location
         function getNarrowedTypeOfSymbol(symbol: Symbol, node: Node) {
             var type = getTypeOfSymbol(symbol);
-            // Only narrow when symbol is variable of a structured type
-            if (node && (symbol.flags & SymbolFlags.Variable && type.flags & TypeFlags.Structured)) {
+            // Only narrow when symbol is variable of an object, union, or type parameter type
+            if (node && symbol.flags & SymbolFlags.Variable && type.flags & (TypeFlags.ObjectType | TypeFlags.Union | TypeFlags.TypeParameter)) {
                 loop: while (node.parent) {
                     var child = node;
                     node = node.parent;
@@ -6587,12 +6587,12 @@ module ts {
             return numberType;
         }
 
-        // Return true if type is any, an object type, a type parameter, or a union type composed of only those kinds of types
+        // Return true if type an object type, a type parameter, or a union type composed of only those kinds of types
         function isStructuredType(type: Type): boolean {
             if (type.flags & TypeFlags.Union) {
                 return !forEach((<UnionType>type).types, t => !isStructuredType(t));
             }
-            return (type.flags & TypeFlags.Structured) !== 0;
+            return (type.flags & (TypeFlags.ObjectType | TypeFlags.TypeParameter)) !== 0;
         }
 
         function isConstEnumObjectType(type: Type): boolean {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1240,7 +1240,6 @@ module ts {
         StringLike = String | StringLiteral,
         NumberLike = Number | Enum,
         ObjectType = Class | Interface | Reference | Tuple | Anonymous,
-        Structured = ObjectType | Union | TypeParameter
     }
 
     // Properties common to all types

--- a/tests/baselines/reference/typeGuardsWithAny.js
+++ b/tests/baselines/reference/typeGuardsWithAny.js
@@ -1,12 +1,18 @@
 //// [typeGuardsWithAny.ts]
 var x: any = { p: 0 };
 if (x instanceof Object) {
-    x.p; // No error, type any is not narrowed
+    x.p; // No error, type any unaffected by type guard
+}
+else {
+    x.p; // No error, type any unaffected by type guard
 }
 
 
 //// [typeGuardsWithAny.js]
 var x = { p: 0 };
 if (x instanceof Object) {
-    x.p; // No error, type any is not narrowed
+    x.p; // No error, type any unaffected by type guard
+}
+else {
+    x.p; // No error, type any unaffected by type guard
 }

--- a/tests/baselines/reference/typeGuardsWithAny.types
+++ b/tests/baselines/reference/typeGuardsWithAny.types
@@ -9,7 +9,13 @@ if (x instanceof Object) {
 >x : any
 >Object : ObjectConstructor
 
-    x.p; // No error, type any is not narrowed
+    x.p; // No error, type any unaffected by type guard
+>x.p : any
+>x : any
+>p : any
+}
+else {
+    x.p; // No error, type any unaffected by type guard
 >x.p : any
 >x : any
 >p : any

--- a/tests/cases/conformance/expressions/typeGuards/typeGuardsWithAny.ts
+++ b/tests/cases/conformance/expressions/typeGuards/typeGuardsWithAny.ts
@@ -1,4 +1,7 @@
 var x: any = { p: 0 };
 if (x instanceof Object) {
-    x.p; // No error, type any is not narrowed
+    x.p; // No error, type any unaffected by type guard
+}
+else {
+    x.p; // No error, type any unaffected by type guard
 }


### PR DESCRIPTION
This PR changes type guards to not affect values of type any.

Fixes #1426.
