### PR TITLE
Make initial inferences from parameterless function expressions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3372,7 +3372,7 @@ module ts {
         }
 
         function isContextSensitiveFunctionLikeDeclaration(node: FunctionLikeDeclaration) {
-            return !node.typeParameters && !forEach(node.parameters, p => p.type);
+            return !node.typeParameters && node.parameters.length && !forEach(node.parameters, p => p.type);
         }
 
         function getTypeWithoutConstructors(type: Type): Type {

--- a/tests/baselines/reference/contextualTypingWithFixedTypeParameters1.errors.txt
+++ b/tests/baselines/reference/contextualTypingWithFixedTypeParameters1.errors.txt
@@ -1,14 +1,9 @@
 tests/cases/compiler/contextualTypingWithFixedTypeParameters1.ts(2,22): error TS2339: Property 'foo' does not exist on type 'string'.
-tests/cases/compiler/contextualTypingWithFixedTypeParameters1.ts(3,10): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
-  Type argument candidate 'string' is not a valid type argument because it is not a supertype of candidate 'number'.
 
 
-==== tests/cases/compiler/contextualTypingWithFixedTypeParameters1.ts (2 errors) ====
+==== tests/cases/compiler/contextualTypingWithFixedTypeParameters1.ts (1 errors) ====
     var f10: <T>(x: T, b: () => (a: T) => void, y: T) => T;
     f10('', () => a => a.foo, ''); // a is string
                          ~~~
 !!! error TS2339: Property 'foo' does not exist on type 'string'.
     var r9 = f10('', () => (a => a.foo), 1); // error
-             ~~~
-!!! error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
-!!! error TS2453:   Type argument candidate 'string' is not a valid type argument because it is not a supertype of candidate 'number'.

--- a/tests/baselines/reference/inferenceFromParameterlessLambda.js
+++ b/tests/baselines/reference/inferenceFromParameterlessLambda.js
@@ -1,0 +1,17 @@
+//// [inferenceFromParameterlessLambda.ts]
+function foo<T>(o: Take<T>, i: Make<T>) { }
+interface Make<T> {
+    (): T;
+}
+interface Take<T> {
+    (n: T): void;
+}
+// Infer string from second argument because it isn't context sensitive
+foo(n => n.length, () => 'hi');
+
+
+//// [inferenceFromParameterlessLambda.js]
+function foo(o, i) {
+}
+// Infer string from second argument because it isn't context sensitive
+foo(function (n) { return n.length; }, function () { return 'hi'; });

--- a/tests/baselines/reference/inferenceFromParameterlessLambda.types
+++ b/tests/baselines/reference/inferenceFromParameterlessLambda.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/inferenceFromParameterlessLambda.ts ===
+function foo<T>(o: Take<T>, i: Make<T>) { }
+>foo : <T>(o: Take<T>, i: Make<T>) => void
+>T : T
+>o : Take<T>
+>Take : Take<T>
+>T : T
+>i : Make<T>
+>Make : Make<T>
+>T : T
+
+interface Make<T> {
+>Make : Make<T>
+>T : T
+
+    (): T;
+>T : T
+}
+interface Take<T> {
+>Take : Take<T>
+>T : T
+
+    (n: T): void;
+>n : T
+>T : T
+}
+// Infer string from second argument because it isn't context sensitive
+foo(n => n.length, () => 'hi');
+>foo(n => n.length, () => 'hi') : void
+>foo : <T>(o: Take<T>, i: Make<T>) => void
+>n => n.length : (n: string) => number
+>n : string
+>n.length : number
+>n : string
+>length : number
+>() => 'hi' : () => string
+

--- a/tests/cases/compiler/inferenceFromParameterlessLambda.ts
+++ b/tests/cases/compiler/inferenceFromParameterlessLambda.ts
@@ -1,0 +1,9 @@
+function foo<T>(o: Take<T>, i: Make<T>) { }
+interface Make<T> {
+    (): T;
+}
+interface Take<T> {
+    (n: T): void;
+}
+// Infer string from second argument because it isn't context sensitive
+foo(n => n.length, () => 'hi');


### PR DESCRIPTION
With this PR parameterless function expressions are not considered context sensitive and are therefore included in the initial round of type argument inference.

Fixes #1185.
