### PR TITLE
Actually fail the surrounding jake task on errors in compileFile()

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -242,7 +242,7 @@ function compileFile(outFile, sources, prereqs, prefixes, useBuiltCompiler, noOu
         });
         ex.addListener("error", function() {
             fs.unlinkSync(outFile);
-            console.log("Compilation of " + outFile + " unsuccessful");
+            fail("Compilation of " + outFile + " unsuccessful");
         });
         ex.run();
     }, {async: true});


### PR DESCRIPTION
Will cause builds to actually fail now. See #1459

fail() already prints to console so a separate print isn't needed.

```
> jake generate-code-coverage
node bin/tsc.js --module commonjs -noImplicitAny -removeComments --preserveConstEnums --out scripts/processDiagnosticMessages.js -sourcemap -mapRoot file:////home/travis/build/Microsoft/TypeScript/scripts scripts/processDiagnosticMessages.ts
scripts/processDiagnosticMessages.ts(18,9): error TS2304: Cannot find name 'sys'.
scripts/processDiagnosticMessages.ts(19,9): error TS2304: Cannot find name 'sys'.
scripts/processDiagnosticMessages.ts(19,30): error TS2304: Cannot find name 'sys'.
scripts/processDiagnosticMessages.ts(20,9): error TS2304: Cannot find name 'sys'.
scripts/processDiagnosticMessages.ts(20,88): error TS2304: Cannot find name 'sys'.
scripts/processDiagnosticMessages.ts(24,25): error TS2304: Cannot find name 'sys'.
scripts/processDiagnosticMessages.ts(25,20): error TS2304: Cannot find name 'sys'.
scripts/processDiagnosticMessages.ts(37,5): error TS2304: Cannot find name 'sys'.
jake aborted.
Error: Compilation of scripts/processDiagnosticMessages.js unsuccessful
    at api.fail (/home/travis/build/Microsoft/TypeScript/node_modules/jake/lib/api.js:336:18)
    at null.<anonymous> (/home/travis/build/Microsoft/TypeScript/Jakefile:245:13)
(See full trace by running task with --trace)
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
The command "npm test" exited with 1.
```
