### PR TITLE
Fixed "TypeError: invalid data" when executables run by exec exited with non-zero code.

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -447,8 +447,7 @@ function exec(cmd, completeHandler) {
         complete();
     });
     ex.addListener("error", function(e, status) {
-        process.stderr.write(status);
-        process.stderr.write(e);
+        console.error("Process exited with code " + status);
         complete();
     })
     try{


### PR DESCRIPTION
The original error was because process.stderr only allows writing Strings or Buffers, but status is a Number.

Also, the message parameter of the "error" handler is just the amalgam of all output written to stderr. This is already logged by the "stderr" handler, so there's no need to write it to process.stderr again.

Before:

```
> jake generate-code-coverage


  17 failing
jake aborted.
TypeError: invalid data
    at WriteStream.Socket.write (net.js:614:11)
    at null.<anonymous> (C:\Stuff\Sources\TypeScript\Jakefile:450:24)
(See full trace by running task with --trace)
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```

After:

```
> jake generate-code-coverage


  17 failing
Process exited with code 17
```
