### PR TITLE
Fail the surrounding Jake task if exec'd tool has non-zero exit code.

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -465,14 +465,10 @@ function exec(cmd, completeHandler) {
         complete();
     });
     ex.addListener("error", function(e, status) {
-        console.error("Process exited with code " + status);
-        complete();
+        fail("Process exited with code " + status);
     })
-    try{
-        ex.run();
-    } catch(e) {
-        console.log('Exception: ' + e)
-    }
+
+    ex.run();
 }
 
 function cleanTestDirs() {


### PR DESCRIPTION
A side-effect of #1500 is that Travis builds won't fail on test failures, because the "error" handler calls complete() instead of fail(). Before the change in #1500 the handler would throw an uncaught TypeError before it could call complete(), so it would cause the jake task to fail. This change makes exec() properly call fail() in this case.

Also, errors from starting the task (file not found, etc.) used to be swallowed but now aren't.

```
> jake generate-code-coverage


  17 failing
jake aborted.
Error: Process exited with code 17
    at api.fail (C:\Stuff\Sources\TypeScript\node_modules\jake\lib\api.js:336:18)
    at null.<anonymous> (C:\Stuff\Sources\TypeScript\Jakefile:468:9)
(See full trace by running task with --trace)
npm ERR! Test failed.  See above for more details.
npm ERR! not ok code 0
```
