### PR TITLE
Better errors for types with same name

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1095,11 +1095,11 @@ module ts {
                     }
                 }
 
-                // Get qualified name if there is an enclosing declaration and it is not a
-                // type parameter or we have a flag telling us to
-                var needFullyQualifiedName = (enclosingDeclaration && !(symbol.flags & SymbolFlags.TypeParameter));
-                var useFullyQualifiedFlag = TypeFormatFlags.UseFullyQualifiedType & typeFlags;
-                if (needFullyQualifiedName || useFullyQualifiedFlag) {
+                // Get qualified name if the symbol is not a type parameter
+                // and we have an enclosing declaration or a typeformat flag
+                var typeParameter = (symbol.flags & SymbolFlags.TypeParameter);
+                var typeFormatFlag = TypeFormatFlags.UseFullyQualifiedType & typeFlags;
+                if (!typeParameter && (enclosingDeclaration || typeFormatFlag)) {
                     walkSymbol(symbol, meaning);
                     return;
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3482,7 +3482,7 @@ module ts {
                         }
                     }
                 }
-                else if (source.flags & TypeFlags.TypeParameter && target.flags & TypeFlags.TypeParameter) {
+                else if (source.flags & TypeFlags.TypeParameter && target.flags & TypeFlags.TypeParameter) {getFullyQualifiedName
                     if (result = typeParameterRelatedTo(<TypeParameter>source, <TypeParameter>target, reportErrors)) {
                         return result;
                     }
@@ -3517,7 +3517,6 @@ module ts {
                         // a more insightful error message
                         reportError(headMessage, getFullyQualifiedName(source.symbol), getFullyQualifiedName(target.symbol));
                     }
-                    //reportError(headMessage, typeToString(source), typeToString(target));
                 }
                 return Ternary.False;
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1097,10 +1097,10 @@ module ts {
 
                 // Get qualified name if the symbol is not a type parameter
                 // and there is an enclosing declaration or we specifically
-				// asked for it
-                var typeParameter = (symbol.flags & SymbolFlags.TypeParameter);
+                // asked for it
+                var isTypeParameter = symbol.flags & SymbolFlags.TypeParameter;
                 var typeFormatFlag = TypeFormatFlags.UseFullyQualifiedType & typeFlags;
-                if (!typeParameter && (enclosingDeclaration || typeFormatFlag)) {
+                if (!isTypeParameter && (enclosingDeclaration || typeFormatFlag)) {
                     walkSymbol(symbol, meaning);
                     return;
                 }
@@ -1123,6 +1123,7 @@ module ts {
                         writeTypeReference(<TypeReference>type, flags);
                     }
                     else if (type.flags & (TypeFlags.Class | TypeFlags.Interface | TypeFlags.Enum | TypeFlags.TypeParameter)) {
+                        // The specified symbol flags need to be reinterpreted as type flags
                         buildSymbolDisplay(type.symbol, writer, enclosingDeclaration, SymbolFlags.Type, SymbolFormatFlags.None, flags);
                     }
                     else if (type.flags & TypeFlags.Tuple) {
@@ -1204,6 +1205,7 @@ module ts {
                         // If type is an anonymous type literal in a type alias declaration, use type alias name
                         var typeAlias = getTypeAliasForTypeLiteral(type);
                         if (typeAlias) {
+                            // The specified symbol flags need to be reinterpreted as type flags
                             buildSymbolDisplay(typeAlias, writer, enclosingDeclaration, SymbolFlags.Type, SymbolFormatFlags.None, flags);
                         }
                         else {
@@ -1238,10 +1240,10 @@ module ts {
                     }
                 }
 
-                function writeTypeofSymbol(type: ObjectType, flags?: TypeFormatFlags) {
+                function writeTypeofSymbol(type: ObjectType, typeFormatFlags?: TypeFormatFlags) {
                     writeKeyword(writer, SyntaxKind.TypeOfKeyword);
                     writeSpace(writer);
-                    buildSymbolDisplay(type.symbol, writer, enclosingDeclaration, SymbolFlags.Value, SymbolFormatFlags.None, flags);
+                    buildSymbolDisplay(type.symbol, writer, enclosingDeclaration, SymbolFlags.Value, SymbolFormatFlags.None, typeFormatFlags);
                 }
 
                 function getIndexerParameterName(type: ObjectType, indexKind: IndexKind, fallbackName: string): string {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1096,7 +1096,8 @@ module ts {
                 }
 
                 // Get qualified name if the symbol is not a type parameter
-                // and we spe
+                // and there is an enclosing declaration or we specifically
+				// asked for it
                 var typeParameter = (symbol.flags & SymbolFlags.TypeParameter);
                 var typeFormatFlag = TypeFormatFlags.UseFullyQualifiedType & typeFlags;
                 if (!typeParameter && (enclosingDeclaration || typeFormatFlag)) {
@@ -1122,7 +1123,7 @@ module ts {
                         writeTypeReference(<TypeReference>type, flags);
                     }
                     else if (type.flags & (TypeFlags.Class | TypeFlags.Interface | TypeFlags.Enum | TypeFlags.TypeParameter)) {
-                        buildSymbolDisplay(type.symbol, writer, enclosingDeclaration, SymbolFlags.Type, /*flags*/ None, flags);
+                        buildSymbolDisplay(type.symbol, writer, enclosingDeclaration, SymbolFlags.Type, SymbolFormatFlags.None, flags);
                     }
                     else if (type.flags & TypeFlags.Tuple) {
                         writeTupleType(<TupleType>type);
@@ -1203,7 +1204,7 @@ module ts {
                         // If type is an anonymous type literal in a type alias declaration, use type alias name
                         var typeAlias = getTypeAliasForTypeLiteral(type);
                         if (typeAlias) {
-                            buildSymbolDisplay(typeAlias, writer, enclosingDeclaration, SymbolFlags.Type, /*flags*/ None, flags);
+                            buildSymbolDisplay(typeAlias, writer, enclosingDeclaration, SymbolFlags.Type, SymbolFormatFlags.None, flags);
                         }
                         else {
                             // Recursive usage, use any
@@ -1240,7 +1241,7 @@ module ts {
                 function writeTypeofSymbol(type: ObjectType, flags?: TypeFormatFlags) {
                     writeKeyword(writer, SyntaxKind.TypeOfKeyword);
                     writeSpace(writer);
-                    buildSymbolDisplay(type.symbol, writer, enclosingDeclaration, SymbolFlags.Value, /*flags*/ None, flags);
+                    buildSymbolDisplay(type.symbol, writer, enclosingDeclaration, SymbolFlags.Value, SymbolFormatFlags.None, flags);
                 }
 
                 function getIndexerParameterName(type: ObjectType, indexKind: IndexKind, fallbackName: string): string {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3482,7 +3482,7 @@ module ts {
                         }
                     }
                 }
-                else if (source.flags & TypeFlags.TypeParameter && target.flags & TypeFlags.TypeParameter) {getFullyQualifiedName
+                else if (source.flags & TypeFlags.TypeParameter && target.flags & TypeFlags.TypeParameter) {
                     if (result = typeParameterRelatedTo(<TypeParameter>source, <TypeParameter>target, reportErrors)) {
                         return result;
                     }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1095,13 +1095,11 @@ module ts {
                     }
                 }
 
-                // Get qualified name 
-                if ((enclosingDeclaration &&
-                    // TypeParameters do not need qualification
-                    !(symbol.flags & SymbolFlags.TypeParameter))
-                    // unless we use a format flag specifying that we want it
-                    || TypeFormatFlags.UseFullyQualifiedType & typeFlags) {
-
+                // Get qualified name if there is an enclosing declaration and it is not a
+                // type parameter or we have a flag telling us to
+                var needFullyQualifiedName = (enclosingDeclaration && !(symbol.flags & SymbolFlags.TypeParameter));
+                var useFullyQualifiedFlag = TypeFormatFlags.UseFullyQualifiedType & typeFlags;
+                if (needFullyQualifiedName || useFullyQualifiedFlag) {
                     walkSymbol(symbol, meaning);
                     return;
                 }
@@ -1124,7 +1122,7 @@ module ts {
                         writeTypeReference(<TypeReference>type, flags);
                     }
                     else if (type.flags & (TypeFlags.Class | TypeFlags.Interface | TypeFlags.Enum | TypeFlags.TypeParameter)) {
-                        buildSymbolDisplay(type.symbol, writer, enclosingDeclaration, SymbolFlags.Type, undefined, flags);
+                        buildSymbolDisplay(type.symbol, writer, enclosingDeclaration, SymbolFlags.Type, /*flags*/ undefined, flags);
                     }
                     else if (type.flags & TypeFlags.Tuple) {
                         writeTupleType(<TupleType>type);
@@ -1205,7 +1203,7 @@ module ts {
                         // If type is an anonymous type literal in a type alias declaration, use type alias name
                         var typeAlias = getTypeAliasForTypeLiteral(type);
                         if (typeAlias) {
-                            buildSymbolDisplay(typeAlias, writer, enclosingDeclaration, SymbolFlags.Type, undefined, flags);
+                            buildSymbolDisplay(typeAlias, writer, enclosingDeclaration, SymbolFlags.Type, /*flags*/ undefined, flags);
                         }
                         else {
                             // Recursive usage, use any
@@ -1242,7 +1240,7 @@ module ts {
                 function writeTypeofSymbol(type: ObjectType, flags?: TypeFormatFlags) {
                     writeKeyword(writer, SyntaxKind.TypeOfKeyword);
                     writeSpace(writer);
-                    buildSymbolDisplay(type.symbol, writer, enclosingDeclaration, SymbolFlags.Value, undefined, flags);
+                    buildSymbolDisplay(type.symbol, writer, enclosingDeclaration, SymbolFlags.Value, /*flags*/ undefined, flags);
                 }
 
                 function getIndexerParameterName(type: ObjectType, indexKind: IndexKind, fallbackName: string): string {
@@ -3512,11 +3510,11 @@ module ts {
                     headMessage = headMessage || Diagnostics.Type_0_is_not_assignable_to_type_1;
                     var sourceType = typeToString(source);
                     var targetType = typeToString(target);
-                    if (sourceType !== targetType) {
-                        reportError(headMessage, sourceType, targetType);
-                    } else {
-                        reportError(headMessage, typeToString(source, undefined, TypeFormatFlags.UseFullyQualifiedType), typeToString(target, undefined, TypeFormatFlags.UseFullyQualifiedType));
+                    if (sourceType === targetType) {
+                        sourceType = typeToString(source, /*enclosingDeclaration*/ undefined, TypeFormatFlags.UseFullyQualifiedType);
+                        targetType = typeToString(target, /*enclosingDeclaration*/ undefined, TypeFormatFlags.UseFullyQualifiedType);
                     }
+                    reportError(headMessage, sourceType, targetType);
                 }
                 return Ternary.False;
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1096,7 +1096,7 @@ module ts {
                 }
 
                 // Get qualified name if the symbol is not a type parameter
-                // and we have an enclosing declaration or a typeformat flag
+                // and we spe
                 var typeParameter = (symbol.flags & SymbolFlags.TypeParameter);
                 var typeFormatFlag = TypeFormatFlags.UseFullyQualifiedType & typeFlags;
                 if (!typeParameter && (enclosingDeclaration || typeFormatFlag)) {
@@ -1122,7 +1122,7 @@ module ts {
                         writeTypeReference(<TypeReference>type, flags);
                     }
                     else if (type.flags & (TypeFlags.Class | TypeFlags.Interface | TypeFlags.Enum | TypeFlags.TypeParameter)) {
-                        buildSymbolDisplay(type.symbol, writer, enclosingDeclaration, SymbolFlags.Type, /*flags*/ undefined, flags);
+                        buildSymbolDisplay(type.symbol, writer, enclosingDeclaration, SymbolFlags.Type, /*flags*/ None, flags);
                     }
                     else if (type.flags & TypeFlags.Tuple) {
                         writeTupleType(<TupleType>type);
@@ -1203,7 +1203,7 @@ module ts {
                         // If type is an anonymous type literal in a type alias declaration, use type alias name
                         var typeAlias = getTypeAliasForTypeLiteral(type);
                         if (typeAlias) {
-                            buildSymbolDisplay(typeAlias, writer, enclosingDeclaration, SymbolFlags.Type, /*flags*/ undefined, flags);
+                            buildSymbolDisplay(typeAlias, writer, enclosingDeclaration, SymbolFlags.Type, /*flags*/ None, flags);
                         }
                         else {
                             // Recursive usage, use any
@@ -1240,7 +1240,7 @@ module ts {
                 function writeTypeofSymbol(type: ObjectType, flags?: TypeFormatFlags) {
                     writeKeyword(writer, SyntaxKind.TypeOfKeyword);
                     writeSpace(writer);
-                    buildSymbolDisplay(type.symbol, writer, enclosingDeclaration, SymbolFlags.Value, /*flags*/ undefined, flags);
+                    buildSymbolDisplay(type.symbol, writer, enclosingDeclaration, SymbolFlags.Value, /*flags*/ None, flags);
                 }
 
                 function getIndexerParameterName(type: ObjectType, indexKind: IndexKind, fallbackName: string): string {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3508,7 +3508,16 @@ module ts {
                 }
                 if (reportErrors) {
                     headMessage = headMessage || Diagnostics.Type_0_is_not_assignable_to_type_1;
-                    reportError(headMessage, typeToString(source), typeToString(target));
+                    var sourceType = typeToString(source);
+                    var targetType = typeToString(target);
+                    if (sourceType !== targetType) {
+                        reportError(headMessage, sourceType, targetType);
+                    } else {
+                        // If the types are incompatible but have the same name, use the qualified names to give
+                        // a more insightful error message
+                        reportError(headMessage, getFullyQualifiedName(source.symbol), getFullyQualifiedName(target.symbol));
+                    }
+                    //reportError(headMessage, typeToString(source), typeToString(target));
                 }
                 return Ternary.False;
             }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1074,6 +1074,7 @@ module ts {
         WriteOwnNameForAnyLike          = 0x00000010,  // Write symbol's own name instead of 'any' for any like types (eg. unknown, __resolving__ etc)
         WriteTypeArgumentsOfSignature   = 0x00000020,  // Write the type arguments instead of type parameters of the signature
         InElementType                   = 0x00000040,  // Writing an array or union element type
+        UseFullyQualifiedType           = 0x00000080,  // Write out the fully qualified type name (eg. Module.Type, instead of Type)
     }
 
     export const enum SymbolFormatFlags {

--- a/tests/baselines/reference/clodulesDerivedClasses.errors.txt
+++ b/tests/baselines/reference/clodulesDerivedClasses.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/clodulesDerivedClasses.ts(9,7): error TS2417: Class static side 'typeof Path' incorrectly extends base class static side 'typeof Shape'.
   Types of property 'Utils' are incompatible.
-    Type 'typeof Utils' is not assignable to type 'typeof Utils'.
+    Type 'Path.Utils' is not assignable to type 'Shape.Utils'.
       Property 'convert' is missing in type 'typeof Utils'.
 
 
@@ -17,7 +17,7 @@ tests/cases/compiler/clodulesDerivedClasses.ts(9,7): error TS2417: Class static 
           ~~~~
 !!! error TS2417: Class static side 'typeof Path' incorrectly extends base class static side 'typeof Shape'.
 !!! error TS2417:   Types of property 'Utils' are incompatible.
-!!! error TS2417:     Type 'typeof Utils' is not assignable to type 'typeof Utils'.
+!!! error TS2417:     Type 'Path.Utils' is not assignable to type 'Shape.Utils'.
 !!! error TS2417:       Property 'convert' is missing in type 'typeof Utils'.
         name: string;
     

--- a/tests/baselines/reference/clodulesDerivedClasses.errors.txt
+++ b/tests/baselines/reference/clodulesDerivedClasses.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/clodulesDerivedClasses.ts(9,7): error TS2417: Class static side 'typeof Path' incorrectly extends base class static side 'typeof Shape'.
   Types of property 'Utils' are incompatible.
-    Type 'Path.Utils' is not assignable to type 'Shape.Utils'.
+    Type 'typeof Path.Utils' is not assignable to type 'typeof Shape.Utils'.
       Property 'convert' is missing in type 'typeof Utils'.
 
 
@@ -17,7 +17,7 @@ tests/cases/compiler/clodulesDerivedClasses.ts(9,7): error TS2417: Class static 
           ~~~~
 !!! error TS2417: Class static side 'typeof Path' incorrectly extends base class static side 'typeof Shape'.
 !!! error TS2417:   Types of property 'Utils' are incompatible.
-!!! error TS2417:     Type 'Path.Utils' is not assignable to type 'Shape.Utils'.
+!!! error TS2417:     Type 'typeof Path.Utils' is not assignable to type 'typeof Shape.Utils'.
 !!! error TS2417:       Property 'convert' is missing in type 'typeof Utils'.
         name: string;
     

--- a/tests/baselines/reference/differentTypesWithSameName.errors.txt
+++ b/tests/baselines/reference/differentTypesWithSameName.errors.txt
@@ -1,0 +1,22 @@
+tests/cases/compiler/differentTypesWithSameName.ts(16,15): error TS2345: Argument of type 'variable' is not assignable to parameter of type 'm.variable'.
+
+
+==== tests/cases/compiler/differentTypesWithSameName.ts (1 errors) ====
+    module m {
+      export class variable{
+        s: string;
+      }
+      export function doSomething(v: m.variable) {
+        
+      }
+    }
+    
+    class variable {
+     t: number;
+    }
+    
+    
+    var v: variable = new variable();
+    m.doSomething(v);
+                  ~
+!!! error TS2345: Argument of type 'variable' is not assignable to parameter of type 'm.variable'.

--- a/tests/baselines/reference/differentTypesWithSameName.js
+++ b/tests/baselines/reference/differentTypesWithSameName.js
@@ -1,0 +1,38 @@
+//// [differentTypesWithSameName.ts]
+module m {
+  export class variable{
+    s: string;
+  }
+  export function doSomething(v: m.variable) {
+    
+  }
+}
+
+class variable {
+ t: number;
+}
+
+
+var v: variable = new variable();
+m.doSomething(v);
+
+//// [differentTypesWithSameName.js]
+var m;
+(function (m) {
+    var variable = (function () {
+        function variable() {
+        }
+        return variable;
+    })();
+    m.variable = variable;
+    function doSomething(v) {
+    }
+    m.doSomething = doSomething;
+})(m || (m = {}));
+var variable = (function () {
+    function variable() {
+    }
+    return variable;
+})();
+var v = new variable();
+m.doSomething(v);

--- a/tests/baselines/reference/everyTypeWithAnnotationAndInvalidInitializer.errors.txt
+++ b/tests/baselines/reference/everyTypeWithAnnotationAndInvalidInitializer.errors.txt
@@ -25,7 +25,7 @@ tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAnd
   Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts(50,5): error TS2322: Type 'typeof N' is not assignable to type 'typeof M'.
   Types of property 'A' are incompatible.
-    Type 'N.A' is not assignable to type 'M.A'.
+    Type 'typeof N.A' is not assignable to type 'typeof M.A'.
       Type 'N.A' is not assignable to type 'M.A'.
         Property 'name' is missing in type 'A'.
 tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts(51,5): error TS2322: Type 'N.A' is not assignable to type 'M.A'.
@@ -124,7 +124,7 @@ tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAnd
         ~~~~~~~
 !!! error TS2322: Type 'typeof N' is not assignable to type 'typeof M'.
 !!! error TS2322:   Types of property 'A' are incompatible.
-!!! error TS2322:     Type 'N.A' is not assignable to type 'M.A'.
+!!! error TS2322:     Type 'typeof N.A' is not assignable to type 'typeof M.A'.
 !!! error TS2322:       Type 'N.A' is not assignable to type 'M.A'.
 !!! error TS2322:         Property 'name' is missing in type 'A'.
     var aClassInModule: M.A = new N.A();

--- a/tests/baselines/reference/everyTypeWithAnnotationAndInvalidInitializer.errors.txt
+++ b/tests/baselines/reference/everyTypeWithAnnotationAndInvalidInitializer.errors.txt
@@ -25,10 +25,10 @@ tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAnd
   Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts(50,5): error TS2322: Type 'typeof N' is not assignable to type 'typeof M'.
   Types of property 'A' are incompatible.
-    Type 'typeof A' is not assignable to type 'typeof A'.
-      Type 'A' is not assignable to type 'A'.
+    Type 'N.A' is not assignable to type 'M.A'.
+      Type 'N.A' is not assignable to type 'M.A'.
         Property 'name' is missing in type 'A'.
-tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts(51,5): error TS2322: Type 'A' is not assignable to type 'A'.
+tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts(51,5): error TS2322: Type 'N.A' is not assignable to type 'M.A'.
 tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts(52,5): error TS2322: Type '(x: number) => boolean' is not assignable to type '(x: number) => string'.
   Type 'boolean' is not assignable to type 'string'.
 
@@ -124,12 +124,12 @@ tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAnd
         ~~~~~~~
 !!! error TS2322: Type 'typeof N' is not assignable to type 'typeof M'.
 !!! error TS2322:   Types of property 'A' are incompatible.
-!!! error TS2322:     Type 'typeof A' is not assignable to type 'typeof A'.
-!!! error TS2322:       Type 'A' is not assignable to type 'A'.
+!!! error TS2322:     Type 'N.A' is not assignable to type 'M.A'.
+!!! error TS2322:       Type 'N.A' is not assignable to type 'M.A'.
 !!! error TS2322:         Property 'name' is missing in type 'A'.
     var aClassInModule: M.A = new N.A();
         ~~~~~~~~~~~~~~
-!!! error TS2322: Type 'A' is not assignable to type 'A'.
+!!! error TS2322: Type 'N.A' is not assignable to type 'M.A'.
     var aFunctionInModule: typeof M.F2 = F2;
         ~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '(x: number) => boolean' is not assignable to type '(x: number) => string'.

--- a/tests/baselines/reference/qualify.errors.txt
+++ b/tests/baselines/reference/qualify.errors.txt
@@ -10,7 +10,7 @@ tests/cases/compiler/qualify.ts(47,13): error TS2322: Type 'I4' is not assignabl
 tests/cases/compiler/qualify.ts(48,13): error TS2322: Type 'I4' is not assignable to type '(k: I3) => void'.
 tests/cases/compiler/qualify.ts(49,13): error TS2322: Type 'I4' is not assignable to type '{ k: I3; }'.
   Property 'k' is missing in type 'I4'.
-tests/cases/compiler/qualify.ts(58,5): error TS2322: Type 'I' is not assignable to type 'I'.
+tests/cases/compiler/qualify.ts(58,5): error TS2322: Type 'I' is not assignable to type 'T.I'.
   Property 'p' is missing in type 'I'.
 
 
@@ -93,7 +93,7 @@ tests/cases/compiler/qualify.ts(58,5): error TS2322: Type 'I' is not assignable 
     var y:I;
     var x:T.I=y;
         ~
-!!! error TS2322: Type 'I' is not assignable to type 'I'.
+!!! error TS2322: Type 'I' is not assignable to type 'T.I'.
 !!! error TS2322:   Property 'p' is missing in type 'I'.
     
     

--- a/tests/cases/compiler/differentTypesWithSameName.ts
+++ b/tests/cases/compiler/differentTypesWithSameName.ts
@@ -1,0 +1,16 @@
+module m {
+  export class variable{
+    s: string;
+  }
+  export function doSomething(v: m.variable) {
+    
+  }
+}
+
+class variable {
+ t: number;
+}
+
+
+var v: variable = new variable();
+m.doSomething(v);


### PR DESCRIPTION
Fix for issue #1419. Added a pretty unobtrusive fix but I'm wondering if I need to have more complicated logic (like typeToString() does) to handle certain cases that simply calling getFullyQualifiedName doesn't take care of.  