### PR TITLE
extract map copying logic to a separate function

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3651,7 +3651,7 @@ module ts {
                     var maybeCache = maybeStack[depth];
                     // If result is definitely true, copy assumptions to global cache, else copy to next level up
                     var destinationCache = result === Ternary.True || depth === 0 ? relation : maybeStack[depth - 1];
-                    copyMap(maybeCache, destinationCache);
+                    copyMap(/*source*/maybeCache, /*target*/destinationCache);
                 }
                 else {
                     // A false result goes straight into global cache (when something is false under assumptions it

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3651,9 +3651,7 @@ module ts {
                     var maybeCache = maybeStack[depth];
                     // If result is definitely true, copy assumptions to global cache, else copy to next level up
                     var destinationCache = result === Ternary.True || depth === 0 ? relation : maybeStack[depth - 1];
-                    for (var p in maybeCache) {
-                        destinationCache[p] = maybeCache[p];
-                    }
+                    copyMap(maybeCache, destinationCache);
                 }
                 else {
                     // A false result goes straight into global cache (when something is false under assumptions it

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -208,6 +208,12 @@ module ts {
         return result;
     }
 
+    export function copyMap<T>(source: Map<T>, target: Map<T>): void {
+        for (var p in source) {
+            target[p] = source[p];
+        }
+    }
+
     /**
      * Creates a map from the elements of an array.
      *


### PR DESCRIPTION
in v8 presence of `for-in` over objects being used as dictionaries prevents functions from being optimized (https://github.com/petkaantonov/bluebird/wiki/Optimization-killers). `objectTypeRelatedTo` is a hot path so it is highly desirable for this function to be optimized