### PR TITLE
fixes #1593

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5231,7 +5231,10 @@ module ts {
                 }
             }
             else {
-                if (!((options.allowNonTsExtensions && findSourceFile(filename, isDefaultLib, refFile, refPos, refEnd)) || findSourceFile(filename + ".ts", isDefaultLib, refFile, refPos, refEnd) || findSourceFile(filename + ".d.ts", isDefaultLib, refFile, refPos, refEnd))) {
+                if(options.allowNonTsExtensions && !findSourceFile(filename, isDefaultLib, refFile, refPos, refEnd)) {
+                    diagnostic = Diagnostics.File_0_not_found;
+                }
+                else if (!findSourceFile(filename + ".ts", isDefaultLib, refFile, refPos, refEnd) && !findSourceFile(filename + ".d.ts", isDefaultLib, refFile, refPos, refEnd)) {
                     diagnostic = Diagnostics.File_0_not_found;
                     filename += ".ts";
                 }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5231,7 +5231,7 @@ module ts {
                 }
             }
             else {
-                if (!(findSourceFile(filename + ".ts", isDefaultLib, refFile, refPos, refEnd) || findSourceFile(filename + ".d.ts", isDefaultLib, refFile, refPos, refEnd))) {
+                if (!((options.allowNonTsExtensions && findSourceFile(filename, isDefaultLib, refFile, refPos, refEnd)) || findSourceFile(filename + ".ts", isDefaultLib, refFile, refPos, refEnd) || findSourceFile(filename + ".d.ts", isDefaultLib, refFile, refPos, refEnd))) {
                     diagnostic = Diagnostics.File_0_not_found;
                     filename += ".ts";
                 }


### PR DESCRIPTION
Change makes sure that the ```allowNonTsExtensions``` flag is also honoured for files without a file extension.