### PR TITLE
Fix harness issues with recompiling emitted .d.ts

### DIFF
--- a/src/harness/compilerRunner.ts
+++ b/src/harness/compilerRunner.ts
@@ -61,12 +61,6 @@ class CompilerBaselineRunner extends RunnerBase {
             var otherFiles: { unitName: string; content: string }[];
             var harnessCompiler: Harness.Compiler.HarnessCompiler;
 
-            var declFileCompilationResult: {
-                declInputFiles: { unitName: string; content: string }[];
-                declOtherFiles: { unitName: string; content: string }[];
-                declResult: Harness.Compiler.CompilerResult;
-            };
-
             var createNewInstance = false;
 
             before(() => {
@@ -143,7 +137,6 @@ class CompilerBaselineRunner extends RunnerBase {
                 toBeCompiled = undefined;
                 otherFiles = undefined;
                 harnessCompiler = undefined;
-                declFileCompilationResult = undefined;
             });
 
             function getByteOrderMarkText(file: Harness.Compiler.GeneratedFile): string {
@@ -177,13 +170,6 @@ class CompilerBaselineRunner extends RunnerBase {
                         return record;
                     });
                 }
-            });
-
-            // Compile .d.ts files
-            it('Correct compiler generated.d.ts for ' + fileName, () => {
-                declFileCompilationResult = harnessCompiler.compileDeclarationFiles(toBeCompiled, otherFiles, result, function (settings) {
-                    harnessCompiler.setCompilerSettings(tcSettings);
-                }, options);
             });
 
 
@@ -222,6 +208,10 @@ class CompilerBaselineRunner extends RunnerBase {
                                 jsCode += result.declFilesCode[i].code;
                             }
                         }
+
+                        var declFileCompilationResult = harnessCompiler.compileDeclarationFiles(toBeCompiled, otherFiles, result, function (settings) {
+                            harnessCompiler.setCompilerSettings(tcSettings);
+                        }, options);
 
                         if (declFileCompilationResult && declFileCompilationResult.declResult.errors.length) {
                             jsCode += '\r\n\r\n//// [DtsFileErrors]\r\n';

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1127,29 +1127,27 @@ module Harness {
                     }
 
                     function findResultCodeFile(fileName: string) {
-                        var dTsFileName = ts.forEach(result.program.getSourceFiles(), sourceFile => {
-                            if (sourceFile.filename === fileName) {
-                                // Is this file going to be emitted separately
-                                var sourceFileName: string;
-                                if (ts.isExternalModule(sourceFile) || !options.out) {
-                                    if (options.outDir) {
-                                        var sourceFilePath = ts.getNormalizedAbsolutePath(sourceFile.filename, result.currentDirectoryForProgram);
-                                        sourceFilePath = sourceFilePath.replace(result.program.getCommonSourceDirectory(), "");
-                                        sourceFileName = ts.combinePaths(options.outDir, sourceFilePath);
-                                    }
-                                    else {
-                                        sourceFileName = sourceFile.filename;
-                                    }
-                                }
-                                else {
-                                    // Goes to single --out file
-                                    sourceFileName = options.out;
-                                }
-
-                                return ts.removeFileExtension(sourceFileName) + ".d.ts";
+                        var sourceFile = result.program.getSourceFile(fileName);
+                        assert(sourceFile, "Program has no source file with name '" + fileName + "'");
+                        // Is this file going to be emitted separately
+                        var sourceFileName: string;
+                        if (ts.isExternalModule(sourceFile) || !options.out) {
+                            if (options.outDir) {
+                                var sourceFilePath = ts.getNormalizedAbsolutePath(sourceFile.filename, result.currentDirectoryForProgram);
+                                sourceFilePath = sourceFilePath.replace(result.program.getCommonSourceDirectory(), "");
+                                sourceFileName = ts.combinePaths(options.outDir, sourceFilePath);
                             }
-                        });
+                            else {
+                                sourceFileName = sourceFile.filename;
+                            }
+                        }
+                        else {
+                            // Goes to single --out file
+                            sourceFileName = options.out;
+                        }
 
+                        var dTsFileName = ts.removeFileExtension(sourceFileName) + ".d.ts";
+                        
                         return ts.forEach(result.declFilesCode, declFile => declFile.fileName === dTsFileName ? declFile : undefined);
                     }
 

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -28,12 +28,6 @@ module RWC {
             var compilerOptions: ts.CompilerOptions;
             var baselineOpts: Harness.Baseline.BaselineOptions = { Subfolder: 'rwc' };
             var baseName = /(.*)\/(.*).json/.exec(ts.normalizeSlashes(jsonPath))[2];
-            // Compile .d.ts files
-            var declFileCompilationResult: {
-                declInputFiles: { unitName: string; content: string }[];
-                declOtherFiles: { unitName: string; content: string }[];
-                declResult: Harness.Compiler.CompilerResult;
-            };
 
             after(() => {
                 // Mocha holds onto the closure environment of the describe callback even after the test is done.
@@ -44,7 +38,6 @@ module RWC {
                 compilerOptions = undefined;
                 baselineOpts = undefined;
                 baseName = undefined;
-                declFileCompilationResult = undefined;
             });
 
             it('can compile', () => {
@@ -103,11 +96,6 @@ module RWC {
                 }
             });
 
-            // Baselines
-            it('Correct compiler generated.d.ts', () => {
-                declFileCompilationResult = Harness.Compiler.getCompiler().compileDeclarationFiles(inputFiles, otherFiles, compilerResult, /*settingscallback*/ undefined, compilerOptions);
-            });
-
 
             it('has the expected emitted code', () => {
                 Harness.Baseline.runBaseline('has the expected emitted code', baseName + '.output.js', () => {
@@ -152,9 +140,12 @@ module RWC {
                 }, false, baselineOpts);
             });
 
-            it('has no errors in generated declaration files', () => {
+            // Ideally, a generated declaration file will have no errors. But we allow generated
+            // declaration file errors as part of the baseline.
+            it('has the expected errors in generated declaration files', () => {
                 if (compilerOptions.declaration && !compilerResult.errors.length) {
-                    Harness.Baseline.runBaseline('has no errors in generated declaration files', baseName + '.dts.errors.txt', () => {
+                    Harness.Baseline.runBaseline('has the expected errors in generated declaration files', baseName + '.dts.errors.txt', () => {
+                        var declFileCompilationResult = Harness.Compiler.getCompiler().compileDeclarationFiles(inputFiles, otherFiles, compilerResult, /*settingscallback*/ undefined, compilerOptions);
                         if (declFileCompilationResult.declResult.errors.length === 0) {
                             return null;
                         }


### PR DESCRIPTION
When the harness recompiles the .d.ts files that it emitted, it gets its list of files by looking up the input files in the program. It uses program.getSourceFiles() and iterates until it finds a source file with the same name as the input file. However, in case insensitive environments, it might not find anything if the case did not match. This broke the rwcRunner.

So I switched it to program.getSourceFile, which respects the case [in]sensitivity of the environment.

I also cleaned up an unnecessary it block from the harness.