### PR TITLE
consider type parameters always visible

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1575,7 +1575,6 @@ module ts {
                     case SyntaxKind.IndexSignature:
                     case SyntaxKind.Parameter:
                     case SyntaxKind.ModuleBlock:
-                    case SyntaxKind.TypeParameter:
                     case SyntaxKind.FunctionType:
                     case SyntaxKind.ConstructorType:
                     case SyntaxKind.TypeLiteral:
@@ -1585,7 +1584,9 @@ module ts {
                     case SyntaxKind.UnionType:
                     case SyntaxKind.ParenthesizedType:
                         return isDeclarationVisible(<Declaration>node.parent);
-
+                    
+                    // Type parameters are always visible
+                    case SyntaxKind.TypeParameter:
                     // Source file is always visible
                     case SyntaxKind.SourceFile:
                         return true;

--- a/tests/baselines/reference/visibilityOfTypeParameters.js
+++ b/tests/baselines/reference/visibilityOfTypeParameters.js
@@ -1,0 +1,24 @@
+//// [visibilityOfTypeParameters.ts]
+
+export class MyClass {
+    protected myMethod<T>(val: T): T {
+        return val;
+    }
+}
+
+//// [visibilityOfTypeParameters.js]
+var MyClass = (function () {
+    function MyClass() {
+    }
+    MyClass.prototype.myMethod = function (val) {
+        return val;
+    };
+    return MyClass;
+})();
+exports.MyClass = MyClass;
+
+
+//// [visibilityOfTypeParameters.d.ts]
+export declare class MyClass {
+    protected myMethod<T>(val: T): T;
+}

--- a/tests/baselines/reference/visibilityOfTypeParameters.types
+++ b/tests/baselines/reference/visibilityOfTypeParameters.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/visibilityOfTypeParameters.ts ===
+
+export class MyClass {
+>MyClass : MyClass
+
+    protected myMethod<T>(val: T): T {
+>myMethod : <T>(val: T) => T
+>T : T
+>val : T
+>T : T
+>T : T
+
+        return val;
+>val : T
+    }
+}

--- a/tests/cases/compiler/visibilityOfTypeParameters.ts
+++ b/tests/cases/compiler/visibilityOfTypeParameters.ts
@@ -1,0 +1,8 @@
+// @module:commonjs
+//@declaration: true
+
+export class MyClass {
+    protected myMethod<T>(val: T): T {
+        return val;
+    }
+}


### PR DESCRIPTION
Type parameters belong to the entity that declares them and don't have their own visibility so they should always considered public. Fixes #1445 