### PR TITLE
Fixes #1618: "getElementsByTagName('svg')" does not returns NodeList of SVGSVGElement, but generic NodeList.

### DIFF
--- a/bin/lib.d.ts
+++ b/bin/lib.d.ts
@@ -3310,6 +3310,7 @@ interface Document extends Node, NodeSelector, MSEventAttachmentTarget, Document
     getElementsByTagName(name: "style"): NodeListOf<HTMLStyleElement>;
     getElementsByTagName(name: "sub"): NodeListOf<HTMLPhraseElement>;
     getElementsByTagName(name: "sup"): NodeListOf<HTMLPhraseElement>;
+    getElementsByTagName(name: "svg"): NodeListOf<SVGSVGElement>;
     getElementsByTagName(name: "table"): NodeListOf<HTMLTableElement>;
     getElementsByTagName(name: "tbody"): NodeListOf<HTMLTableSectionElement>;
     getElementsByTagName(name: "td"): NodeListOf<HTMLTableDataCellElement>;
@@ -4721,6 +4722,7 @@ interface Element extends Node, NodeSelector, ElementTraversal, GlobalEventHandl
     getElementsByTagName(name: "style"): NodeListOf<HTMLStyleElement>;
     getElementsByTagName(name: "sub"): NodeListOf<HTMLPhraseElement>;
     getElementsByTagName(name: "sup"): NodeListOf<HTMLPhraseElement>;
+    getElementsByTagName(name: "svg"): NodeListOf<SVGSVGElement>;
     getElementsByTagName(name: "table"): NodeListOf<HTMLTableElement>;
     getElementsByTagName(name: "tbody"): NodeListOf<HTMLTableSectionElement>;
     getElementsByTagName(name: "td"): NodeListOf<HTMLTableDataCellElement>;

--- a/bin/lib.dom.d.ts
+++ b/bin/lib.dom.d.ts
@@ -2160,6 +2160,7 @@ interface Document extends Node, NodeSelector, MSEventAttachmentTarget, Document
     getElementsByTagName(name: "style"): NodeListOf<HTMLStyleElement>;
     getElementsByTagName(name: "sub"): NodeListOf<HTMLPhraseElement>;
     getElementsByTagName(name: "sup"): NodeListOf<HTMLPhraseElement>;
+    getElementsByTagName(name: "svg"): NodeListOf<SVGSVGElement>;
     getElementsByTagName(name: "table"): NodeListOf<HTMLTableElement>;
     getElementsByTagName(name: "tbody"): NodeListOf<HTMLTableSectionElement>;
     getElementsByTagName(name: "td"): NodeListOf<HTMLTableDataCellElement>;
@@ -3571,6 +3572,7 @@ interface Element extends Node, NodeSelector, ElementTraversal, GlobalEventHandl
     getElementsByTagName(name: "style"): NodeListOf<HTMLStyleElement>;
     getElementsByTagName(name: "sub"): NodeListOf<HTMLPhraseElement>;
     getElementsByTagName(name: "sup"): NodeListOf<HTMLPhraseElement>;
+    getElementsByTagName(name: "svg"): NodeListOf<SVGSVGElement>;
     getElementsByTagName(name: "table"): NodeListOf<HTMLTableElement>;
     getElementsByTagName(name: "tbody"): NodeListOf<HTMLTableSectionElement>;
     getElementsByTagName(name: "td"): NodeListOf<HTMLTableDataCellElement>;

--- a/bin/lib.es6.d.ts
+++ b/bin/lib.es6.d.ts
@@ -6286,6 +6286,7 @@ interface Document extends Node, NodeSelector, MSEventAttachmentTarget, Document
     getElementsByTagName(name: "style"): NodeListOf<HTMLStyleElement>;
     getElementsByTagName(name: "sub"): NodeListOf<HTMLPhraseElement>;
     getElementsByTagName(name: "sup"): NodeListOf<HTMLPhraseElement>;
+    getElementsByTagName(name: "svg"): NodeListOf<SVGSVGElement>;
     getElementsByTagName(name: "table"): NodeListOf<HTMLTableElement>;
     getElementsByTagName(name: "tbody"): NodeListOf<HTMLTableSectionElement>;
     getElementsByTagName(name: "td"): NodeListOf<HTMLTableDataCellElement>;
@@ -7697,6 +7698,7 @@ interface Element extends Node, NodeSelector, ElementTraversal, GlobalEventHandl
     getElementsByTagName(name: "style"): NodeListOf<HTMLStyleElement>;
     getElementsByTagName(name: "sub"): NodeListOf<HTMLPhraseElement>;
     getElementsByTagName(name: "sup"): NodeListOf<HTMLPhraseElement>;
+    getElementsByTagName(name: "svg"): NodeListOf<SVGSVGElement>;
     getElementsByTagName(name: "table"): NodeListOf<HTMLTableElement>;
     getElementsByTagName(name: "tbody"): NodeListOf<HTMLTableSectionElement>;
     getElementsByTagName(name: "td"): NodeListOf<HTMLTableDataCellElement>;


### PR DESCRIPTION
Fixes #1618