### PR TITLE
Added commandLineParser.ts to the generated node module

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -58,6 +58,7 @@ var servicesSources = [
     "checker.ts",
     "emitter.ts",
     "program.ts",
+    "commandLineParser.ts",
     "diagnosticInformationMap.generated.ts"
 ].map(function (f) {
     return path.join(compilerDirectory, f);
@@ -102,6 +103,7 @@ var internalDefinitionsRoots = [
     "compiler/core.d.ts",
     "compiler/sys.d.ts",
     "compiler/utilities.d.ts",
+    "compiler/commandLineParser.d.ts",
     "services/utilities.d.ts",
 ];
 


### PR DESCRIPTION
Added commandLineParser.ts to the generated node module, and added thetype information for commandLineParser.ts to typescript_internal.d.ts.