### PR TITLE
Improved union type guards

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4709,13 +4709,21 @@ module ts {
                 if (!isTypeSubtypeOf(rightType, globalFunctionType)) {
                     return type;
                 }
+                // Target type is type of prototype property
                 var prototypeProperty = getPropertyOfType(rightType, "prototype");
                 if (!prototypeProperty) {
                     return type;
                 }
-                var prototypeType = getTypeOfSymbol(prototypeProperty);
-                // Narrow to type of prototype property if it is a subtype of current type
-                return isTypeSubtypeOf(prototypeType, type) ? prototypeType : type;
+                var targetType = getTypeOfSymbol(prototypeProperty);
+                // Narrow to target type if it is a subtype of current type
+                if (isTypeSubtypeOf(targetType, type)) {
+                    return targetType;
+                }
+                // If current type is a union type, remove all constituents that aren't subtypes of target type
+                if (type.flags && TypeFlags.Union) {
+                    return getUnionType(filter((<UnionType>type).types, t => isTypeSubtypeOf(t, targetType)));
+                }
+                return type;
             }
 
             // Narrow the given type based on the given expression having the assumed boolean value

--- a/tests/baselines/reference/TypeGuardWithArrayUnion.js
+++ b/tests/baselines/reference/TypeGuardWithArrayUnion.js
@@ -1,0 +1,23 @@
+//// [TypeGuardWithArrayUnion.ts]
+class Message {
+    value: string;
+}
+
+function saySize(message: Message | Message[]) {
+    if (message instanceof Array) {
+        return message.length;  // Should have type Message[] here
+    }
+}
+
+
+//// [TypeGuardWithArrayUnion.js]
+var Message = (function () {
+    function Message() {
+    }
+    return Message;
+})();
+function saySize(message) {
+    if (message instanceof Array) {
+        return message.length; // Should have type Message[] here
+    }
+}

--- a/tests/baselines/reference/TypeGuardWithArrayUnion.types
+++ b/tests/baselines/reference/TypeGuardWithArrayUnion.types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/expressions/typeGuards/TypeGuardWithArrayUnion.ts ===
+class Message {
+>Message : Message
+
+    value: string;
+>value : string
+}
+
+function saySize(message: Message | Message[]) {
+>saySize : (message: Message | Message[]) => number
+>message : Message | Message[]
+>Message : Message
+>Message : Message
+
+    if (message instanceof Array) {
+>message instanceof Array : boolean
+>message : Message | Message[]
+>Array : ArrayConstructor
+
+        return message.length;  // Should have type Message[] here
+>message.length : number
+>message : Message[]
+>length : number
+    }
+}
+

--- a/tests/baselines/reference/typeGuardOfFormInstanceOf.types
+++ b/tests/baselines/reference/typeGuardOfFormInstanceOf.types
@@ -124,9 +124,9 @@ var r2: D1 | C2 = c2Ord1 instanceof C1 && c2Ord1; // C2 | D1
 >r2 : C2 | D1
 >D1 : D1
 >C2 : C2
->c2Ord1 instanceof C1 && c2Ord1 : C2 | D1
+>c2Ord1 instanceof C1 && c2Ord1 : D1
 >c2Ord1 instanceof C1 : boolean
 >c2Ord1 : C2 | D1
 >C1 : typeof C1
->c2Ord1 : C2 | D1
+>c2Ord1 : D1
 

--- a/tests/baselines/reference/typeGuardOfFormInstanceOfOnInterface.types
+++ b/tests/baselines/reference/typeGuardOfFormInstanceOfOnInterface.types
@@ -154,9 +154,9 @@ var r2: D1 | C2 = c2Ord1 instanceof c1 && c2Ord1; // C2 | D1
 >r2 : C2 | D1
 >D1 : D1
 >C2 : C2
->c2Ord1 instanceof c1 && c2Ord1 : C2 | D1
+>c2Ord1 instanceof c1 && c2Ord1 : D1
 >c2Ord1 instanceof c1 : boolean
 >c2Ord1 : C2 | D1
 >c1 : C1
->c2Ord1 : C2 | D1
+>c2Ord1 : D1
 

--- a/tests/cases/conformance/expressions/typeGuards/TypeGuardWithArrayUnion.ts
+++ b/tests/cases/conformance/expressions/typeGuards/TypeGuardWithArrayUnion.ts
@@ -1,0 +1,9 @@
+class Message {
+    value: string;
+}
+
+function saySize(message: Message | Message[]) {
+    if (message instanceof Array) {
+        return message.length;  // Should have type Message[] here
+    }
+}


### PR DESCRIPTION
Fixes #1587.

This PR improves handing of union types in type guards. Specifically, when a type guard of the form `x instanceof C` is true, the type of `x` is narrowed as follows:

* If `C` is a subtype of the type of `x`, the type of `x` is narrowed to `C`.
* Otherwise, if `x` is of a union type, all types that are not subtypes of `C` are removed from the type of `x`.

In the example
```typescript
class Message {
    value: string;
}

function saySize(message: Message | Message[]) {
    if (message instanceof Array) {
        return message.length;  // message of type Message[] here
    }
}
```
the `Message` type is removed under the type guard because it is not a subtype of `Array`.