### PR TITLE
do not apply format on enter for the first line

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -68,7 +68,9 @@ module ts.formatting {
 
     export function formatOnEnter(position: number, sourceFile: SourceFile, rulesProvider: RulesProvider, options: FormatCodeOptions): TextChange[] {
         var line = sourceFile.getLineAndCharacterFromPosition(position).line;
-        Debug.assert(line >= 2);
+        if (line === 1) {
+            return [];
+        }
         // get the span for the previous\current line
         var span = {
             // get start position for the previous line


### PR DESCRIPTION
Fixes #1663. New behavior is the same with old formatter. It is an open question whether comitting completion on Enter should also trigger formatting (this is something that should be addressed on VS side) but I would still pick this change to make script side of the code more robust