### PR TITLE
Lexical classification for template strings

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -5817,7 +5817,7 @@ module ts {
                                 }
                             }
                             else {
-                                Debug.assert(token === SyntaxKind.CloseBraceToken, "Should have been an open brace. Was: " + token);
+                                Debug.assert(lastTemplateStackToken === SyntaxKind.OpenBraceToken, "Should have been an open brace. Was: " + token);
                                 templateStack.pop();
                             }
                         }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1479,7 +1479,7 @@ module ts {
     }
 
     export interface Classifier {
-        getClassificationsForLine(text: string, lexState: EndOfLineState, classifyKeywordsInGenerics?: boolean): ClassificationResult;
+        getClassificationsForLine(text: string, lexState: EndOfLineState, syntacticClassifierAbsent?: boolean): ClassificationResult;
     }
 
     export interface DocumentRegistry {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1451,8 +1451,8 @@ module ts {
         InMultiLineCommentTrivia,
         InSingleQuoteStringLiteral,
         InDoubleQuoteStringLiteral,
-        InTemplateHeadLiteral, // this could also be a NoSubstitutionTemplateLiteral
-        InTemplateMiddleLiteral, //this could also be a TemplateTail
+        InTemplateHeadOrNoSubstitutionTemplate,
+        InTemplateMiddleOrTail,
         InTemplateSubstitutionPosition,
     }
 
@@ -5699,20 +5699,22 @@ module ts {
                     text = "/*\n" + text;
                     offset = 3;
                     break;
-                case EndOfLineState.InTemplateHeadLiteral:
+                case EndOfLineState.InTemplateHeadOrNoSubstitutionTemplate:
                     if (syntacticClassifierAbsent) {
                         text = "`\n" + text;
                         offset = 2;
                     }
                     break;
-                case EndOfLineState.InTemplateMiddleLiteral:
+                case EndOfLineState.InTemplateMiddleOrTail:
                     if (syntacticClassifierAbsent) {
-                        text = "${\n" + text;
-                        offset = 3;
+                        text = "}\n" + text;
+                        offset = 2;
                     }
                     // fallthrough
                 case EndOfLineState.InTemplateSubstitutionPosition:
-                    templateStack = [SyntaxKind.TemplateHead];
+                    if (syntacticClassifierAbsent) {
+                        templateStack = [SyntaxKind.TemplateHead];
+                    }
                     break;
             }
 
@@ -5868,11 +5870,14 @@ module ts {
                     }
                     else if (isTemplateLiteralKind(token) && syntacticClassifierAbsent) {
                         if (scanner.isUnterminated()) {
-                            if (token === SyntaxKind.TemplateMiddle) {
-                                result.finalLexState = EndOfLineState.InTemplateMiddleLiteral;
+                            if (token === SyntaxKind.TemplateTail) {
+                                result.finalLexState = EndOfLineState.InTemplateMiddleOrTail;
+                            }
+                            else if (token === SyntaxKind.NoSubstitutionTemplateLiteral) {
+                                result.finalLexState = EndOfLineState.InTemplateHeadOrNoSubstitutionTemplate;
                             }
                             else {
-                                result.finalLexState = EndOfLineState.InTemplateHeadLiteral;
+                                Debug.fail("Only 'NoSubstitutionTemplateLiteral's and 'TemplateTail's can be unterminated; got SyntaxKind #" + token);
                             }
                         }
                     }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -5679,6 +5679,8 @@ module ts {
             return true;
         }
         
+        // If there is a syntactic classifier ('syntacticClassifierAbsent' is false),
+        // we will be more conservative in order to avoid conflicting with the syntactic classifier.
         function getClassificationsForLine(text: string, lexState: EndOfLineState, syntacticClassifierAbsent?: boolean): ClassificationResult {
             var offset = 0;
             var token = SyntaxKind.Unknown;

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -161,7 +161,7 @@ module ts {
     }
 
     export interface ClassifierShim extends Shim {
-        getClassificationsForLine(text: string, lexState: EndOfLineState, classifyKeywordsInGenerics?: boolean): string;
+        getClassificationsForLine(text: string, lexState: EndOfLineState, syntacticClassifierAbsent?: boolean): string;
     }
 
     export interface CoreServicesShim extends Shim {


### PR DESCRIPTION
This PR adds lexical classification support for template strings in the absence of a syntactic classifier.

It will break in the presence of
* Nested template strings that span multiple lines.
* Nested expressions composed of curly braces, where the closing curly falls on the next line.

But otherwise it is a fairly good approximation.