### PR TITLE
Include missing optional properties in contextually typed object literals

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5455,6 +5455,16 @@ module ts {
                 }
             }
 
+            // If object literal is contextually typed, add missing optional properties from the contextual type
+            // such that the resulting type becomes a subtype in cases where only optional properties were omitted
+            if (contextualType) {
+                forEach(getPropertiesOfObjectType(contextualType), p => {
+                    if (p.flags & SymbolFlags.Optional && !hasProperty(properties, p.name)) {
+                        properties[p.name] = p;
+                    }
+                });
+            }
+
             var stringIndexType = getIndexType(IndexKind.String);
             var numberIndexType = getIndexType(IndexKind.Number);
             var result = createAnonymousType(node.symbol, properties, emptyArray, emptyArray, stringIndexType, numberIndexType);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5455,9 +5455,10 @@ module ts {
                 }
             }
 
-            // If object literal is contextually typed, add missing optional properties from the contextual type
-            // such that the resulting type becomes a subtype in cases where only optional properties were omitted
-            if (contextualType) {
+            // If object literal is contextually (but not inferentially) typed, copy missing optional properties from
+            // the contextual type such that the resulting type becomes a subtype in cases where only optional properties
+            // were omitted. There is no need to create new property objects as nothing in them needs to change.
+            if (contextualType && !isInferentialContext(contextualMapper)) {
                 forEach(getPropertiesOfObjectType(contextualType), p => {
                     if (p.flags & SymbolFlags.Optional && !hasProperty(properties, p.name)) {
                         properties[p.name] = p;

--- a/tests/baselines/reference/assignmentCompatBug2.errors.txt
+++ b/tests/baselines/reference/assignmentCompatBug2.errors.txt
@@ -2,10 +2,10 @@ tests/cases/compiler/assignmentCompatBug2.ts(1,5): error TS2322: Type '{ a: numb
   Property 'b' is missing in type '{ a: number; }'.
 tests/cases/compiler/assignmentCompatBug2.ts(3,1): error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
   Property 'b' is missing in type '{ a: number; }'.
-tests/cases/compiler/assignmentCompatBug2.ts(15,1): error TS2322: Type '{ f: (n: number) => number; g: (s: string) => number; }' is not assignable to type '{ f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; }'.
-  Property 'm' is missing in type '{ f: (n: number) => number; g: (s: string) => number; }'.
-tests/cases/compiler/assignmentCompatBug2.ts(20,1): error TS2322: Type '{ f: (n: number) => number; m: number; }' is not assignable to type '{ f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; }'.
-  Property 'g' is missing in type '{ f: (n: number) => number; m: number; }'.
+tests/cases/compiler/assignmentCompatBug2.ts(15,1): error TS2322: Type '{ f: (n: number) => number; g: (s: string) => number; n?: number; k?(a: any): any; }' is not assignable to type '{ f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; }'.
+  Property 'm' is missing in type '{ f: (n: number) => number; g: (s: string) => number; n?: number; k?(a: any): any; }'.
+tests/cases/compiler/assignmentCompatBug2.ts(20,1): error TS2322: Type '{ f: (n: number) => number; m: number; n?: number; k?(a: any): any; }' is not assignable to type '{ f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; }'.
+  Property 'g' is missing in type '{ f: (n: number) => number; m: number; n?: number; k?(a: any): any; }'.
 tests/cases/compiler/assignmentCompatBug2.ts(33,1): error TS2322: Type '{ f: (n: number) => number; g: (s: string) => number; n: number; k: (a: any) => any; }' is not assignable to type '{ f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; }'.
   Property 'm' is missing in type '{ f: (n: number) => number; g: (s: string) => number; n: number; k: (a: any) => any; }'.
 
@@ -33,16 +33,16 @@ tests/cases/compiler/assignmentCompatBug2.ts(33,1): error TS2322: Type '{ f: (n:
     
     b3 = {
     ~~
-!!! error TS2322: Type '{ f: (n: number) => number; g: (s: string) => number; }' is not assignable to type '{ f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; }'.
-!!! error TS2322:   Property 'm' is missing in type '{ f: (n: number) => number; g: (s: string) => number; }'.
+!!! error TS2322: Type '{ f: (n: number) => number; g: (s: string) => number; n?: number; k?(a: any): any; }' is not assignable to type '{ f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; }'.
+!!! error TS2322:   Property 'm' is missing in type '{ f: (n: number) => number; g: (s: string) => number; n?: number; k?(a: any): any; }'.
         f: (n) => { return 0; },
         g: (s) => { return 0; },
     }; // error
     
     b3 = {
     ~~
-!!! error TS2322: Type '{ f: (n: number) => number; m: number; }' is not assignable to type '{ f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; }'.
-!!! error TS2322:   Property 'g' is missing in type '{ f: (n: number) => number; m: number; }'.
+!!! error TS2322: Type '{ f: (n: number) => number; m: number; n?: number; k?(a: any): any; }' is not assignable to type '{ f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; }'.
+!!! error TS2322:   Property 'g' is missing in type '{ f: (n: number) => number; m: number; n?: number; k?(a: any): any; }'.
         f: (n) => { return 0; },
         m: 0,
     }; // error

--- a/tests/baselines/reference/assignmentCompatWithObjectMembers3.types
+++ b/tests/baselines/reference/assignmentCompatWithObjectMembers3.types
@@ -51,13 +51,13 @@ var b: { foo: string; baz?: string }
 var a2: S2 = { foo: '' };
 >a2 : S2
 >S2 : S2
->{ foo: '' } : { foo: string; }
+>{ foo: '' } : { foo: string; bar?: string; }
 >foo : string
 
 var b2: T2 = { foo: '' };
 >b2 : T2
 >T2 : T2
->{ foo: '' } : { foo: string; }
+>{ foo: '' } : { foo: string; baz?: string; }
 >foo : string
 
 s = t;

--- a/tests/baselines/reference/assignmentCompatability1.types
+++ b/tests/baselines/reference/assignmentCompatability1.types
@@ -12,7 +12,7 @@ module __test1__ {
 >U : U
 >obj4 : interfaceWithPublicAndOptional<number, string>
 >interfaceWithPublicAndOptional : interfaceWithPublicAndOptional<T, U>
->{ one: 1 } : { one: number; }
+>{ one: 1 } : { one: number; two?: string; }
 >one : number
 
     export var __val__obj4 = obj4;

--- a/tests/baselines/reference/assignmentCompatability2.types
+++ b/tests/baselines/reference/assignmentCompatability2.types
@@ -12,7 +12,7 @@ module __test1__ {
 >U : U
 >obj4 : interfaceWithPublicAndOptional<number, string>
 >interfaceWithPublicAndOptional : interfaceWithPublicAndOptional<T, U>
->{ one: 1 } : { one: number; }
+>{ one: 1 } : { one: number; two?: string; }
 >one : number
 
     export var __val__obj4 = obj4;

--- a/tests/baselines/reference/assignmentCompatability3.types
+++ b/tests/baselines/reference/assignmentCompatability3.types
@@ -12,7 +12,7 @@ module __test1__ {
 >U : U
 >obj4 : interfaceWithPublicAndOptional<number, string>
 >interfaceWithPublicAndOptional : interfaceWithPublicAndOptional<T, U>
->{ one: 1 } : { one: number; }
+>{ one: 1 } : { one: number; two?: string; }
 >one : number
 
     export var __val__obj4 = obj4;

--- a/tests/baselines/reference/assignmentCompatability4.types
+++ b/tests/baselines/reference/assignmentCompatability4.types
@@ -12,7 +12,7 @@ module __test1__ {
 >U : U
 >obj4 : interfaceWithPublicAndOptional<number, string>
 >interfaceWithPublicAndOptional : interfaceWithPublicAndOptional<T, U>
->{ one: 1 } : { one: number; }
+>{ one: 1 } : { one: number; two?: string; }
 >one : number
 
     export var __val__obj4 = obj4;

--- a/tests/baselines/reference/assignmentCompatability5.types
+++ b/tests/baselines/reference/assignmentCompatability5.types
@@ -12,7 +12,7 @@ module __test1__ {
 >U : U
 >obj4 : interfaceWithPublicAndOptional<number, string>
 >interfaceWithPublicAndOptional : interfaceWithPublicAndOptional<T, U>
->{ one: 1 } : { one: number; }
+>{ one: 1 } : { one: number; two?: string; }
 >one : number
 
     export var __val__obj4 = obj4;

--- a/tests/baselines/reference/assignmentCompatability6.types
+++ b/tests/baselines/reference/assignmentCompatability6.types
@@ -12,7 +12,7 @@ module __test1__ {
 >U : U
 >obj4 : interfaceWithPublicAndOptional<number, string>
 >interfaceWithPublicAndOptional : interfaceWithPublicAndOptional<T, U>
->{ one: 1 } : { one: number; }
+>{ one: 1 } : { one: number; two?: string; }
 >one : number
 
     export var __val__obj4 = obj4;
@@ -29,7 +29,7 @@ module __test2__ {
 >T : T
 >obj3 : interfaceWithOptional<number>
 >interfaceWithOptional : interfaceWithOptional<T>
->{ } : {}
+>{ } : { one?: number; }
 
     export var __val__obj3 = obj3;
 >__val__obj3 : interfaceWithOptional<number>

--- a/tests/baselines/reference/assignmentCompatability7.types
+++ b/tests/baselines/reference/assignmentCompatability7.types
@@ -12,7 +12,7 @@ module __test1__ {
 >U : U
 >obj4 : interfaceWithPublicAndOptional<number, string>
 >interfaceWithPublicAndOptional : interfaceWithPublicAndOptional<T, U>
->{ one: 1 } : { one: number; }
+>{ one: 1 } : { one: number; two?: string; }
 >one : number
 
     export var __val__obj4 = obj4;
@@ -32,7 +32,7 @@ module __test2__ {
 >U : U
 >obj4 : interfaceWithPublicAndOptional<number, string>
 >interfaceWithPublicAndOptional : interfaceWithPublicAndOptional<T, U>
->{ one: 1 } : { one: number; }
+>{ one: 1 } : { one: number; two?: string; }
 >one : number
 
     export var __val__obj4 = obj4;

--- a/tests/baselines/reference/assignmentCompatability8.types
+++ b/tests/baselines/reference/assignmentCompatability8.types
@@ -12,7 +12,7 @@ module __test1__ {
 >U : U
 >obj4 : interfaceWithPublicAndOptional<number, string>
 >interfaceWithPublicAndOptional : interfaceWithPublicAndOptional<T, U>
->{ one: 1 } : { one: number; }
+>{ one: 1 } : { one: number; two?: string; }
 >one : number
 
     export var __val__obj4 = obj4;

--- a/tests/baselines/reference/assignmentCompatability9.types
+++ b/tests/baselines/reference/assignmentCompatability9.types
@@ -12,7 +12,7 @@ module __test1__ {
 >U : U
 >obj4 : interfaceWithPublicAndOptional<number, string>
 >interfaceWithPublicAndOptional : interfaceWithPublicAndOptional<T, U>
->{ one: 1 } : { one: number; }
+>{ one: 1 } : { one: number; two?: string; }
 >one : number
 
     export var __val__obj4 = obj4;

--- a/tests/baselines/reference/getterSetterNonAccessor.types
+++ b/tests/baselines/reference/getterSetterNonAccessor.types
@@ -14,8 +14,8 @@ Object.defineProperty({}, "0", <PropertyDescriptor>({
 >{} : {}
 ><PropertyDescriptor>({          get: getFunc,          set: setFunc,          configurable: true      }) : PropertyDescriptor
 >PropertyDescriptor : PropertyDescriptor
->({          get: getFunc,          set: setFunc,          configurable: true      }) : { get: () => any; set: (v: any) => void; configurable: boolean; }
->{          get: getFunc,          set: setFunc,          configurable: true      } : { get: () => any; set: (v: any) => void; configurable: boolean; }
+>({          get: getFunc,          set: setFunc,          configurable: true      }) : { get: () => any; set: (v: any) => void; configurable: boolean; enumerable?: boolean; value?: any; writable?: boolean; }
+>{          get: getFunc,          set: setFunc,          configurable: true      } : { get: () => any; set: (v: any) => void; configurable: boolean; enumerable?: boolean; value?: any; writable?: boolean; }
 
           get: getFunc,
 >get : () => any

--- a/tests/baselines/reference/intTypeCheck.errors.txt
+++ b/tests/baselines/reference/intTypeCheck.errors.txt
@@ -39,8 +39,8 @@ tests/cases/compiler/intTypeCheck.ts(146,5): error TS2322: Type 'boolean' is not
 tests/cases/compiler/intTypeCheck.ts(146,21): error TS1109: Expression expected.
 tests/cases/compiler/intTypeCheck.ts(146,22): error TS2304: Cannot find name 'i4'.
 tests/cases/compiler/intTypeCheck.ts(147,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
-tests/cases/compiler/intTypeCheck.ts(152,5): error TS2322: Type '{}' is not assignable to type 'i5'.
-  Property 'p' is missing in type '{}'.
+tests/cases/compiler/intTypeCheck.ts(152,5): error TS2322: Type '{ p1?: any; p2?: string; p4?(): any; p5?(): void; p7?(pa1: any, pa2: any): void; }' is not assignable to type 'i5'.
+  Property 'p' is missing in type '{ p1?: any; p2?: string; p4?(): any; p5?(): void; p7?(pa1: any, pa2: any): void; }'.
 tests/cases/compiler/intTypeCheck.ts(153,5): error TS2322: Type 'Object' is not assignable to type 'i5'.
   Property 'p' is missing in type 'Object'.
 tests/cases/compiler/intTypeCheck.ts(154,17): error TS2351: Cannot use 'new' with an expression whose type lacks a call or construct signature.
@@ -313,8 +313,8 @@ tests/cases/compiler/intTypeCheck.ts(203,17): error TS2351: Cannot use 'new' wit
     var obj44: i5;
     var obj45: i5 = {};
         ~~~~~
-!!! error TS2322: Type '{}' is not assignable to type 'i5'.
-!!! error TS2322:   Property 'p' is missing in type '{}'.
+!!! error TS2322: Type '{ p1?: any; p2?: string; p4?(): any; p5?(): void; p7?(pa1: any, pa2: any): void; }' is not assignable to type 'i5'.
+!!! error TS2322:   Property 'p' is missing in type '{ p1?: any; p2?: string; p4?(): any; p5?(): void; p7?(pa1: any, pa2: any): void; }'.
     var obj46: i5 = new Object();
         ~~~~~
 !!! error TS2322: Type 'Object' is not assignable to type 'i5'.

--- a/tests/baselines/reference/interfaceContextualType.types
+++ b/tests/baselines/reference/interfaceContextualType.types
@@ -34,27 +34,27 @@ class Bug {
 >{} : { [x: string]: undefined; }
 
         this.values['comments'] = { italic: true };
->this.values['comments'] = { italic: true } : { italic: boolean; }
+>this.values['comments'] = { italic: true } : { italic: boolean; bold?: boolean; }
 >this.values['comments'] : IOptions
 >this.values : IMap
 >this : Bug
 >values : IMap
->{ italic: true } : { italic: boolean; }
+>{ italic: true } : { italic: boolean; bold?: boolean; }
 >italic : boolean
     }
     shouldBeOK() {
 >shouldBeOK : () => void
 
         this.values = {
->this.values = {            comments: { italic: true }        } : { [x: string]: { italic: boolean; }; comments: { italic: boolean; }; }
+>this.values = {            comments: { italic: true }        } : { [x: string]: { italic: boolean; bold?: boolean; }; comments: { italic: boolean; bold?: boolean; }; }
 >this.values : IMap
 >this : Bug
 >values : IMap
->{            comments: { italic: true }        } : { [x: string]: { italic: boolean; }; comments: { italic: boolean; }; }
+>{            comments: { italic: true }        } : { [x: string]: { italic: boolean; bold?: boolean; }; comments: { italic: boolean; bold?: boolean; }; }
 
             comments: { italic: true }
->comments : { italic: boolean; }
->{ italic: true } : { italic: boolean; }
+>comments : { italic: boolean; bold?: boolean; }
+>{ italic: true } : { italic: boolean; bold?: boolean; }
 >italic : boolean
 
         };

--- a/tests/baselines/reference/objectLitGetterSetter.types
+++ b/tests/baselines/reference/objectLitGetterSetter.types
@@ -11,8 +11,8 @@
 >obj : {}
 ><PropertyDescriptor>({                get: function () {                    eval("public = 1;");                    return 11;                },                set: function (v) {                }            }) : PropertyDescriptor
 >PropertyDescriptor : PropertyDescriptor
->({                get: function () {                    eval("public = 1;");                    return 11;                },                set: function (v) {                }            }) : { get: () => number; set: (v: any) => void; }
->{                get: function () {                    eval("public = 1;");                    return 11;                },                set: function (v) {                }            } : { get: () => number; set: (v: any) => void; }
+>({                get: function () {                    eval("public = 1;");                    return 11;                },                set: function (v) {                }            }) : { get: () => number; set: (v: any) => void; configurable?: boolean; enumerable?: boolean; value?: any; writable?: boolean; }
+>{                get: function () {                    eval("public = 1;");                    return 11;                },                set: function (v) {                }            } : { get: () => number; set: (v: any) => void; configurable?: boolean; enumerable?: boolean; value?: any; writable?: boolean; }
 
                 get: function () {
 >get : () => number

--- a/tests/baselines/reference/objectLiteralContextualTyping.js
+++ b/tests/baselines/reference/objectLiteralContextualTyping.js
@@ -1,0 +1,29 @@
+//// [objectLiteralContextualTyping.ts]
+// Test related to #1774
+
+interface Item {
+    name: string;
+    description?: string;
+}
+
+declare function foo(item: Item): string;
+declare function foo(item: any): number;
+
+var x = foo({ name: "Sprocket" });
+var x: string;
+
+var y = foo({ name: "Sprocket", description: "Bumpy wheel" });
+var y: string;
+
+var z = foo({ a: 10 });
+var z: number;
+
+
+//// [objectLiteralContextualTyping.js]
+// Test related to #1774
+var x = foo({ name: "Sprocket" });
+var x;
+var y = foo({ name: "Sprocket", description: "Bumpy wheel" });
+var y;
+var z = foo({ a: 10 });
+var z;

--- a/tests/baselines/reference/objectLiteralContextualTyping.js
+++ b/tests/baselines/reference/objectLiteralContextualTyping.js
@@ -1,5 +1,5 @@
 //// [objectLiteralContextualTyping.ts]
-// Test related to #1774
+// Tests related to #1774
 
 interface Item {
     name: string;
@@ -15,15 +15,27 @@ var x: string;
 var y = foo({ name: "Sprocket", description: "Bumpy wheel" });
 var y: string;
 
-var z = foo({ a: 10 });
+var z = foo({ name: "Sprocket", description: false });
 var z: number;
+
+var w = foo({ a: 10 });
+var w: number;
+
+declare function bar<T>(param: { x?: T }): T;
+
+var b = bar({});
+var b: {};
 
 
 //// [objectLiteralContextualTyping.js]
-// Test related to #1774
+// Tests related to #1774
 var x = foo({ name: "Sprocket" });
 var x;
 var y = foo({ name: "Sprocket", description: "Bumpy wheel" });
 var y;
-var z = foo({ a: 10 });
+var z = foo({ name: "Sprocket", description: false });
 var z;
+var w = foo({ a: 10 });
+var w;
+var b = bar({});
+var b;

--- a/tests/baselines/reference/objectLiteralContextualTyping.types
+++ b/tests/baselines/reference/objectLiteralContextualTyping.types
@@ -1,0 +1,53 @@
+=== tests/cases/conformance/expressions/contextualTyping/objectLiteralContextualTyping.ts ===
+// Test related to #1774
+
+interface Item {
+>Item : Item
+
+    name: string;
+>name : string
+
+    description?: string;
+>description : string
+}
+
+declare function foo(item: Item): string;
+>foo : { (item: Item): string; (item: any): number; }
+>item : Item
+>Item : Item
+
+declare function foo(item: any): number;
+>foo : { (item: Item): string; (item: any): number; }
+>item : any
+
+var x = foo({ name: "Sprocket" });
+>x : string
+>foo({ name: "Sprocket" }) : string
+>foo : { (item: Item): string; (item: any): number; }
+>{ name: "Sprocket" } : { name: string; description?: string; }
+>name : string
+
+var x: string;
+>x : string
+
+var y = foo({ name: "Sprocket", description: "Bumpy wheel" });
+>y : string
+>foo({ name: "Sprocket", description: "Bumpy wheel" }) : string
+>foo : { (item: Item): string; (item: any): number; }
+>{ name: "Sprocket", description: "Bumpy wheel" } : { name: string; description: string; }
+>name : string
+>description : string
+
+var y: string;
+>y : string
+
+var z = foo({ a: 10 });
+>z : number
+>foo({ a: 10 }) : number
+>foo : { (item: Item): string; (item: any): number; }
+>{ a: 10 } : { a: number; }
+>a : number
+
+var z: number;
+>z : number
+

--- a/tests/baselines/reference/objectLiteralContextualTyping.types
+++ b/tests/baselines/reference/objectLiteralContextualTyping.types
@@ -1,5 +1,5 @@
 === tests/cases/conformance/expressions/contextualTyping/objectLiteralContextualTyping.ts ===
-// Test related to #1774
+// Tests related to #1774
 
 interface Item {
 >Item : Item
@@ -41,13 +41,41 @@ var y = foo({ name: "Sprocket", description: "Bumpy wheel" });
 var y: string;
 >y : string
 
-var z = foo({ a: 10 });
+var z = foo({ name: "Sprocket", description: false });
 >z : number
+>foo({ name: "Sprocket", description: false }) : number
+>foo : { (item: Item): string; (item: any): number; }
+>{ name: "Sprocket", description: false } : { name: string; description: boolean; }
+>name : string
+>description : boolean
+
+var z: number;
+>z : number
+
+var w = foo({ a: 10 });
+>w : number
 >foo({ a: 10 }) : number
 >foo : { (item: Item): string; (item: any): number; }
 >{ a: 10 } : { a: number; }
 >a : number
 
-var z: number;
->z : number
+var w: number;
+>w : number
+
+declare function bar<T>(param: { x?: T }): T;
+>bar : <T>(param: { x?: T; }) => T
+>T : T
+>param : { x?: T; }
+>x : T
+>T : T
+>T : T
+
+var b = bar({});
+>b : {}
+>bar({}) : {}
+>bar : <T>(param: { x?: T; }) => T
+>{} : { x?: {}; }
+
+var b: {};
+>b : {}
 

--- a/tests/baselines/reference/optionalAccessorsInInterface1.types
+++ b/tests/baselines/reference/optionalAccessorsInInterface1.types
@@ -21,7 +21,7 @@ defineMyProperty({}, "name", { get: function () { return 5; } });
 >defineMyProperty({}, "name", { get: function () { return 5; } }) : any
 >defineMyProperty : (o: any, p: string, attributes: MyPropertyDescriptor) => any
 >{} : {}
->{ get: function () { return 5; } } : { get: () => number; }
+>{ get: function () { return 5; } } : { get: () => number; set?(v: any): void; }
 >get : () => number
 >function () { return 5; } : () => number
 
@@ -47,7 +47,7 @@ defineMyProperty2({}, "name", { get: function () { return 5; } });
 >defineMyProperty2({}, "name", { get: function () { return 5; } }) : any
 >defineMyProperty2 : (o: any, p: string, attributes: MyPropertyDescriptor2) => any
 >{} : {}
->{ get: function () { return 5; } } : { get: () => number; }
+>{ get: function () { return 5; } } : { get: () => number; set?: (v: any) => void; }
 >get : () => number
 >function () { return 5; } : () => number
 

--- a/tests/baselines/reference/optionalPropertiesTest.errors.txt
+++ b/tests/baselines/reference/optionalPropertiesTest.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/optionalPropertiesTest.ts(14,1): error TS2322: Type '{ name: string; }' is not assignable to type 'IFoo'.
-  Property 'id' is missing in type '{ name: string; }'.
+tests/cases/compiler/optionalPropertiesTest.ts(14,1): error TS2322: Type '{ name: string; print?(): void; }' is not assignable to type 'IFoo'.
+  Property 'id' is missing in type '{ name: string; print?(): void; }'.
 tests/cases/compiler/optionalPropertiesTest.ts(25,5): error TS2322: Type '{}' is not assignable to type 'i1'.
   Property 'M' is missing in type '{}'.
 tests/cases/compiler/optionalPropertiesTest.ts(26,5): error TS2322: Type '{}' is not assignable to type 'i3'.
@@ -24,8 +24,8 @@ tests/cases/compiler/optionalPropertiesTest.ts(40,1): error TS2322: Type 'i2' is
     foo = { id: 1234, name: "test" };  // Ok
     foo = { name: "test" };            // Error, id missing
     ~~~
-!!! error TS2322: Type '{ name: string; }' is not assignable to type 'IFoo'.
-!!! error TS2322:   Property 'id' is missing in type '{ name: string; }'.
+!!! error TS2322: Type '{ name: string; print?(): void; }' is not assignable to type 'IFoo'.
+!!! error TS2322:   Property 'id' is missing in type '{ name: string; print?(): void; }'.
     foo = {id: 1234, print:()=>{}}	   // Ok
     
     var s = foo.name || "default";

--- a/tests/baselines/reference/overloadBindingAcrossDeclarationBoundaries.types
+++ b/tests/baselines/reference/overloadBindingAcrossDeclarationBoundaries.types
@@ -105,17 +105,17 @@ var a1 = a.a({});
 >a.a : { (o: Opt1): Opt1; (o: Opt2): Opt2; (o: Opt3): Opt3; (o: Opt4): Opt4; }
 >a : A
 >a : { (o: Opt1): Opt1; (o: Opt2): Opt2; (o: Opt3): Opt3; (o: Opt4): Opt4; }
->{} : {}
+>{} : { r?: any; }
 
 var a1 = a({});
 >a1 : Opt3
 >a({}) : Opt3
 >a : A
->{} : {}
+>{} : { r?: any; }
 
 var a1 = new a({});
 >a1 : Opt3
 >new a({}) : Opt3
 >a : A
->{} : {}
+>{} : { r?: any; }
 

--- a/tests/baselines/reference/overloadBindingAcrossDeclarationBoundaries2.types
+++ b/tests/baselines/reference/overloadBindingAcrossDeclarationBoundaries2.types
@@ -108,17 +108,17 @@ var a1 = a.a({});
 >a.a : { (o: Opt1): Opt1; (o: Opt2): Opt2; (o: Opt3): Opt3; (o: Opt4): Opt4; }
 >a : A
 >a : { (o: Opt1): Opt1; (o: Opt2): Opt2; (o: Opt3): Opt3; (o: Opt4): Opt4; }
->{} : {}
+>{} : { r?: any; }
 
 var a1 = a({});
 >a1 : Opt3
 >a({}) : Opt3
 >a : A
->{} : {}
+>{} : { r?: any; }
 
 var a1 = new a({});
 >a1 : Opt3
 >new a({}) : Opt3
 >a : A
->{} : {}
+>{} : { r?: any; }
 

--- a/tests/baselines/reference/typeAnnotationBestCommonTypeInArrayLiteral.types
+++ b/tests/baselines/reference/typeAnnotationBestCommonTypeInArrayLiteral.types
@@ -23,16 +23,16 @@ interface IMenuItem {
 var menuData: IMenuItem[] = [
 >menuData : IMenuItem[]
 >IMenuItem : IMenuItem
->[    {        "id": "ourLogo",        "type": "image",        "link": "",        "icon": "modules/menu/logo.svg"    }, {        "id": "productName",        "type": "default",        "link": "",        "text": "Product Name"    }] : ({ "id": string; "type": string; "link": string; "icon": string; } | { "id": string; "type": string; "link": string; "text": string; })[]
+>[    {        "id": "ourLogo",        "type": "image",        "link": "",        "icon": "modules/menu/logo.svg"    }, {        "id": "productName",        "type": "default",        "link": "",        "text": "Product Name"    }] : ({ "id": string; "type": string; "link": string; "icon": string; classes?: string; text?: string; } | { "id": string; "type": string; "link": string; "text": string; classes?: string; icon?: string; })[]
     {
->{        "id": "ourLogo",        "type": "image",        "link": "",        "icon": "modules/menu/logo.svg"    } : { "id": string; "type": string; "link": string; "icon": string; }
+>{        "id": "ourLogo",        "type": "image",        "link": "",        "icon": "modules/menu/logo.svg"    } : { "id": string; "type": string; "link": string; "icon": string; classes?: string; text?: string; }
 
         "id": "ourLogo",
         "type": "image",
         "link": "",
         "icon": "modules/menu/logo.svg"
     }, {
->{        "id": "productName",        "type": "default",        "link": "",        "text": "Product Name"    } : { "id": string; "type": string; "link": string; "text": string; }
+>{        "id": "productName",        "type": "default",        "link": "",        "text": "Product Name"    } : { "id": string; "type": string; "link": string; "text": string; classes?: string; icon?: string; }
 
         "id": "productName",
         "type": "default",

--- a/tests/baselines/reference/underscoreTest1.types
+++ b/tests/baselines/reference/underscoreTest1.types
@@ -1317,11 +1317,11 @@ compiled2({ epithet: "stooge" });
 >epithet : string
 
 _.templateSettings = {
->_.templateSettings = {    interpolate: /\{\{(.+?)\}\}/g} : { interpolate: RegExp; }
+>_.templateSettings = {    interpolate: /\{\{(.+?)\}\}/g} : { interpolate: RegExp; evaluate?: RegExp; escape?: RegExp; }
 >_.templateSettings : Underscore.TemplateSettings
 >_ : Underscore.Static
 >templateSettings : Underscore.TemplateSettings
->{    interpolate: /\{\{(.+?)\}\}/g} : { interpolate: RegExp; }
+>{    interpolate: /\{\{(.+?)\}\}/g} : { interpolate: RegExp; evaluate?: RegExp; escape?: RegExp; }
 
     interpolate: /\{\{(.+?)\}\}/g
 >interpolate : RegExp
@@ -1347,7 +1347,7 @@ _.template("Using 'with': <%= data.answer %>", { answer: 'no' }, { variable: 'da
 >template : { (templateString: string): (data: any) => string; (templateString: string, data: any, settings?: Underscore.TemplateSettings): string; }
 >{ answer: 'no' } : { answer: string; }
 >answer : string
->{ variable: 'data' } : { variable: string; }
+>{ variable: 'data' } : { variable: string; evaluate?: RegExp; interpolate?: RegExp; escape?: RegExp; }
 >variable : string
 
 === tests/cases/compiler/underscoreTest1_underscore.ts ===

--- a/tests/cases/conformance/expressions/contextualTyping/objectLiteralContextualTyping.ts
+++ b/tests/cases/conformance/expressions/contextualTyping/objectLiteralContextualTyping.ts
@@ -1,0 +1,18 @@
+// Test related to #1774
+
+interface Item {
+    name: string;
+    description?: string;
+}
+
+declare function foo(item: Item): string;
+declare function foo(item: any): number;
+
+var x = foo({ name: "Sprocket" });
+var x: string;
+
+var y = foo({ name: "Sprocket", description: "Bumpy wheel" });
+var y: string;
+
+var z = foo({ a: 10 });
+var z: number;

--- a/tests/cases/conformance/expressions/contextualTyping/objectLiteralContextualTyping.ts
+++ b/tests/cases/conformance/expressions/contextualTyping/objectLiteralContextualTyping.ts
@@ -1,4 +1,4 @@
-// Test related to #1774
+// Tests related to #1774
 
 interface Item {
     name: string;
@@ -14,5 +14,13 @@ var x: string;
 var y = foo({ name: "Sprocket", description: "Bumpy wheel" });
 var y: string;
 
-var z = foo({ a: 10 });
+var z = foo({ name: "Sprocket", description: false });
 var z: number;
+
+var w = foo({ a: 10 });
+var w: number;
+
+declare function bar<T>(param: { x?: T }): T;
+
+var b = bar({});
+var b: {};


### PR DESCRIPTION
Fixes #1723.

In #919 we tightened the subtyping rules to require optional properties to be present in subtypes. That's still the right thing to do, but it can have unintended consequences for overload resolution (which relies on subtyping) in combination with object literals.

With this PR, when an object literal is contextually typed by a type T, any optional properties in T that are omitted in the object literal are included in the resulting type, thus ensuring the resulting type is a subtype of T when all that was omitted was optional properties (whew!). For example
```typescript
interface Item {
    name: string;
    description?: string;
}

declare function foo(item: Item): string;
declare function foo(item: any): number;

var x = foo({ name: "Sprocket" });  // x of type string
var y = foo({ name: "Sprocket", description: "Bumpy wheel" });  // y of type string
var z = foo({ a: 10 });  // z of type number
```
In the first call to foo above, contextual typing of the object literal adds the missing optional property. Thus, the argument expression becomes a subtype of Item, and the first overload is chosen (as one would expect).

This change does at times affect error reporting. For example
```typescript
var f: Item = { naem: "Hello" };
```
Here we'll now report
```
t.ts(11,5): error TS2322: Type '{ naem: string; description?: string; }' is not assignable to type 'Item'.
  Property 'name' is missing in type '{ naem: string; description?: string; }'.
```
Depending on your point of view it may be surprising that the reported type includes an optional property that you didn't actually write (but which is there because of your context).