### PR TITLE
Es6 modules parsing

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -287,6 +287,7 @@ module ts {
         TypeArguments,           // Type arguments in type argument list
         TupleElementTypes,       // Element types in tuple element type list
         HeritageClauses,         // Heritage clauses for a class or interface declaration.
+        NamedImportBindings,     // Named import bindings
         Count                    // Number of parsing contexts
     }
 
@@ -306,7 +307,7 @@ module ts {
             case ParsingContext.TypeMembers:            return Diagnostics.Property_or_signature_expected;
             case ParsingContext.ClassMembers:           return Diagnostics.Unexpected_token_A_constructor_method_accessor_or_property_was_expected;
             case ParsingContext.EnumMembers:            return Diagnostics.Enum_member_expected;
-            case ParsingContext.TypeReferences:     return Diagnostics.Type_reference_expected;
+            case ParsingContext.TypeReferences:         return Diagnostics.Type_reference_expected;
             case ParsingContext.VariableDeclarations:   return Diagnostics.Variable_declaration_expected;
             case ParsingContext.ObjectBindingElements:  return Diagnostics.Property_destructuring_pattern_expected;
             case ParsingContext.ArrayBindingElements:   return Diagnostics.Array_element_destructuring_pattern_expected;
@@ -318,6 +319,7 @@ module ts {
             case ParsingContext.TypeArguments:          return Diagnostics.Type_argument_expected;
             case ParsingContext.TupleElementTypes:      return Diagnostics.Type_expected;
             case ParsingContext.HeritageClauses:        return Diagnostics.Unexpected_token_expected;
+            case ParsingContext.NamedImportBindings:    return Diagnostics.Identifier_expected;
         }
     };
 
@@ -1450,6 +1452,8 @@ module ts {
                     return token === SyntaxKind.CommaToken || isStartOfType();
                 case ParsingContext.HeritageClauses:
                     return isHeritageClause();
+                case ParsingContext.NamedImportBindings:
+                    return isIdentifier();
             }
 
             Debug.fail("Non-exhaustive case in 'isListElement'.");
@@ -1486,6 +1490,7 @@ module ts {
                 case ParsingContext.EnumMembers:
                 case ParsingContext.ObjectLiteralMembers:
                 case ParsingContext.ObjectBindingElements:
+                case ParsingContext.NamedImportBindings:
                     return token === SyntaxKind.CloseBraceToken;
                 case ParsingContext.SwitchClauseStatements:
                     return token === SyntaxKind.CloseBraceToken || token === SyntaxKind.CaseKeyword || token === SyntaxKind.DefaultKeyword;
@@ -4522,7 +4527,8 @@ module ts {
             parseExpected(SyntaxKind.ImportKeyword);
 
             if (token === SyntaxKind.StringLiteral ||
-                token === SyntaxKind.AsteriskToken) {
+                token === SyntaxKind.AsteriskToken ||
+                token === SyntaxKind.OpenBraceToken) {
                 return parseES6StyleImportDeclaration(fullStart, modifiers);
             }
             var node = <ImportDeclaration>createNode(SyntaxKind.ImportDeclaration, fullStart);
@@ -4613,6 +4619,41 @@ module ts {
                 nameSpaceImport.name = parseIdentifier();
                 return finishNode(nameSpaceImport);
             }
+            else {
+                // NameSpaceImport:
+                //  * as ImportedBinding
+                var namedImports = <NamedImports>createNode(SyntaxKind.NamedImports);
+
+                // NamedImports:
+                //  { }
+                //  { ImportsList }
+                //  { ImportsList, }
+
+                // ImportsList:
+                //  ImportSpecifier
+                //  ImportsList, ImportSpecifier
+                parseExpected(SyntaxKind.OpenBraceToken);
+                namedImports.namedBindings = parseDelimitedList(ParsingContext.NamedImportBindings, parseBinding);
+                parseExpected(SyntaxKind.CloseBraceToken);
+                return finishNode(namedImports);
+            }
+        }
+
+        function parseBinding(): Binding {
+            var node = <Binding>createNode(SyntaxKind.ImportedBinding);
+            // ImportSpecifier:
+            //  ImportedBinding
+            //  IdentifierName as ImportedBinding
+            var name = parseIdentifier();
+            if (parseOptional(SyntaxKind.AsKeyword)) {
+                node.identifierName = name;
+                node.name = parseIdentifier();
+            }
+            else {
+                node.name = name;
+            }
+
+            return finishNode(node);
         }
 
         function parseExportAssignmentTail(fullStart: number, modifiers: ModifiersArray): ExportAssignment {
@@ -4644,8 +4685,8 @@ module ts {
                     // Not true keywords so ensure an identifier follows
                     return lookAhead(nextTokenIsIdentifierOrKeyword);
                 case SyntaxKind.ImportKeyword:
-                    // Not true keywords so ensure an identifier follows or is string literal or asterisk
-                    return lookAhead(nextTokenIsIdentifierOrKeywordOrStringLiteralOrAsterisk) ;
+                    // Not true keywords so ensure an identifier follows or is string literal or asterisk or open brace
+                    return lookAhead(nextTokenIsIdentifierOrKeywordOrStringLiteralOrAsteriskOrOpenBrace) ;
                 case SyntaxKind.ModuleKeyword:
                     // Not a true keyword so ensure an identifier or string literal follows
                     return lookAhead(nextTokenIsIdentifierOrKeywordOrStringLiteral);
@@ -4676,10 +4717,10 @@ module ts {
             return isIdentifierOrKeyword() || token === SyntaxKind.StringLiteral;
         }
 
-        function nextTokenIsIdentifierOrKeywordOrStringLiteralOrAsterisk() {
+        function nextTokenIsIdentifierOrKeywordOrStringLiteralOrAsteriskOrOpenBrace() {
             nextToken();
             return isIdentifierOrKeyword() || token === SyntaxKind.StringLiteral ||
-                token === SyntaxKind.AsteriskToken;
+                token === SyntaxKind.AsteriskToken || token === SyntaxKind.OpenBraceToken;
         }
 
         function nextTokenIsEqualsTokenOrDeclarationStart() {

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -38,6 +38,7 @@ module ts {
 
     var textToToken: Map<SyntaxKind> = {
         "any": SyntaxKind.AnyKeyword,
+        "as": SyntaxKind.AsKeyword,
         "boolean": SyntaxKind.BooleanKeyword,
         "break": SyntaxKind.BreakKeyword,
         "case": SyntaxKind.CaseKeyword,
@@ -58,6 +59,7 @@ module ts {
         "false": SyntaxKind.FalseKeyword,
         "finally": SyntaxKind.FinallyKeyword,
         "for": SyntaxKind.ForKeyword,
+        "from": SyntaxKind.FromKeyword,
         "function": SyntaxKind.FunctionKeyword,
         "get": SyntaxKind.GetKeyword,
         "if": SyntaxKind.IfKeyword,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -233,6 +233,7 @@ module ts {
         ImportDeclaration,
         ExportAssignment,
         ES6StyleImportDeclaration,
+        StarExports,
 
         // Module references
         ExternalModuleReference,
@@ -892,6 +893,10 @@ module ts {
 
     export interface NamedImports extends ImportClause {
         namedBindings: NodeArray<Binding>;
+    }
+
+    export interface StarExports extends Declaration, ModuleElement {
+        moduleSpecifier: StringLiteralExpression;
     }
 
     export interface ExportAssignment extends Statement, ModuleElement {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -236,6 +236,9 @@ module ts {
         StarExports,
         ExportClause,
         ExportBinding,
+        DefaultFunctionDeclaration,
+        DefaultClassDeclaration,
+        DefaultAssignmentExpression,
 
         // Module references
         ExternalModuleReference,
@@ -904,6 +907,16 @@ module ts {
     export interface ExportClauseDeclaration extends Declaration, ModuleElement {
         namedBindings: NodeArray<Binding>;
         moduleSpecifier?: StringLiteralExpression;
+    }
+
+    export interface DefaultFunctionDeclaration extends FunctionLikeDeclaration, ModuleElement {
+    }
+
+    export interface DefaultClassDeclaration extends ClassDeclaration, ModuleElement {
+    }
+
+    export interface DefaultAssignmentExpression extends Statement, ModuleElement {
+        expression: Expression;
     }
 
     export interface ExportAssignment extends Statement, ModuleElement {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -230,6 +230,7 @@ module ts {
         ModuleBlock,
         ImportDeclaration,
         ExportAssignment,
+        ES6StyleImportDeclaration,
 
         // Module references
         ExternalModuleReference,
@@ -859,6 +860,10 @@ module ts {
 
     export interface ExternalModuleReference extends Node {
         expression?: Expression;
+    }
+
+    export interface ES6StyleImportDeclaration extends Declaration, ModuleElement {
+        moduleSpecifier: StringLiteralExpression;
     }
 
     export interface ExportAssignment extends Statement, ModuleElement {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -886,6 +886,10 @@ module ts {
     export interface NameSpaceImport extends ImportClause, Binding {
     }
 
+    export interface NamedImports extends ImportClause {
+        namedBindings: NodeArray<Binding>;
+    }
+
     export interface ExportAssignment extends Statement, ModuleElement {
         exportName: Identifier;
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -234,6 +234,8 @@ module ts {
         ExportAssignment,
         ES6StyleImportDeclaration,
         StarExports,
+        ExportClause,
+        ExportBinding,
 
         // Module references
         ExternalModuleReference,
@@ -897,6 +899,11 @@ module ts {
 
     export interface StarExports extends Declaration, ModuleElement {
         moduleSpecifier: StringLiteralExpression;
+    }
+    
+    export interface ExportClauseDeclaration extends Declaration, ModuleElement {
+        namedBindings: NodeArray<Binding>;
+        moduleSpecifier?: StringLiteralExpression;
     }
 
     export interface ExportAssignment extends Statement, ModuleElement {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -129,6 +129,8 @@ module ts {
         PublicKeyword,
         StaticKeyword,
         YieldKeyword,
+        FromKeyword,
+        AsKeyword,
         // TypeScript keywords
         AnyKeyword,
         BooleanKeyword,
@@ -234,6 +236,12 @@ module ts {
 
         // Module references
         ExternalModuleReference,
+
+        // Import clauses
+        ImportedDefaultBinding,
+        NameSpaceImport,
+        NamedImports,
+        ImportedBinding,
 
         // Clauses
         CaseClause,
@@ -863,7 +871,19 @@ module ts {
     }
 
     export interface ES6StyleImportDeclaration extends Declaration, ModuleElement {
+        importClause?: ImportClause;
         moduleSpecifier: StringLiteralExpression;
+    }
+
+    export interface Binding extends Node {
+        name: Identifier;
+        identifierName?: Identifier;
+    }
+
+    export interface ImportClause extends Node {
+    }
+
+    export interface NameSpaceImport extends ImportClause, Binding {
     }
 
     export interface ExportAssignment extends Statement, ModuleElement {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -881,6 +881,10 @@ module ts {
     }
 
     export interface ImportClause extends Node {
+        defaultBinding?: Binding;
+    }
+
+    export interface ImportedDefaultBinding extends ImportClause, Binding {
     }
 
     export interface NameSpaceImport extends ImportClause, Binding {

--- a/tests/baselines/reference/es6ExportClause.js
+++ b/tests/baselines/reference/es6ExportClause.js
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/es6ExportClause.ts] ////
+
+//// [es6ExportClause_0.ts]
+
+export var a = 10;
+export var x = a;
+export var m = a;
+
+//// [es6ExportClause_1.ts]
+var a1 = 10;
+var x1 = a1;
+var m1 = a1;
+export { };
+export { a1 };
+export { a1 as b1 };
+export { x1, a1 as y1 };
+export { x1 as z1,  };
+export { m1,  };
+export { } from "es6ExportClause_0";
+export { a } from "es6ExportClause_0";
+export { a as b } from "es6ExportClause_0";
+export { x, a as y } from "es6ExportClause_0";
+export { x as z,  } from "es6ExportClause_0";
+export { m,  } from "es6ExportClause_0";
+
+//// [es6ExportClause_0.js]
+exports.a = 10;
+exports.x = exports.a;
+exports.m = exports.a;
+//// [es6ExportClause_1.js]
+var a1 = 10;
+var x1 = a1;
+var m1 = a1;

--- a/tests/baselines/reference/es6ExportClause.types
+++ b/tests/baselines/reference/es6ExportClause.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/es6ExportClause_0.ts ===
+
+export var a = 10;
+>a : number
+
+export var x = a;
+>x : number
+>a : number
+
+export var m = a;
+>m : number
+>a : number
+
+=== tests/cases/compiler/es6ExportClause_1.ts ===
+var a1 = 10;
+>a1 : number
+
+var x1 = a1;
+>x1 : number
+>a1 : number
+
+var m1 = a1;
+>m1 : number
+>a1 : number
+
+export { };
+export { a1 };
+export { a1 as b1 };
+export { x1, a1 as y1 };
+export { x1 as z1,  };
+export { m1,  };
+export { } from "es6ExportClause_0";
+export { a } from "es6ExportClause_0";
+export { a as b } from "es6ExportClause_0";
+export { x, a as y } from "es6ExportClause_0";
+export { x as z,  } from "es6ExportClause_0";
+export { m,  } from "es6ExportClause_0";

--- a/tests/baselines/reference/es6ExportClauseErrors.errors.txt
+++ b/tests/baselines/reference/es6ExportClauseErrors.errors.txt
@@ -1,0 +1,49 @@
+tests/cases/compiler/es6ExportClauseErrors.ts(2,17): error TS1141: String literal expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(3,10): error TS1003: Identifier expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(3,12): error TS1109: Expression expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(4,16): error TS1003: Identifier expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(4,18): error TS1109: Expression expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(5,10): error TS1003: Identifier expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(5,12): error TS2304: Cannot find name 'as'.
+tests/cases/compiler/es6ExportClauseErrors.ts(5,15): error TS1005: ';' expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(5,15): error TS2304: Cannot find name 'b'.
+tests/cases/compiler/es6ExportClauseErrors.ts(5,17): error TS1128: Declaration or statement expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(6,10): error TS1003: Identifier expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(6,12): error TS2304: Cannot find name 'as'.
+tests/cases/compiler/es6ExportClauseErrors.ts(6,17): error TS1109: Expression expected.
+
+
+==== tests/cases/compiler/es6ExportClauseErrors.ts (13 errors) ====
+    
+    export { } from 10;
+                    ~~
+!!! error TS1141: String literal expected.
+    export { * };
+             ~
+!!! error TS1003: Identifier expected.
+               ~
+!!! error TS1109: Expression expected.
+    export { a1 as * };
+                   ~
+!!! error TS1003: Identifier expected.
+                     ~
+!!! error TS1109: Expression expected.
+    export { * as b };
+             ~
+!!! error TS1003: Identifier expected.
+               ~~
+!!! error TS2304: Cannot find name 'as'.
+                  ~
+!!! error TS1005: ';' expected.
+                  ~
+!!! error TS2304: Cannot find name 'b'.
+                    ~
+!!! error TS1128: Declaration or statement expected.
+    export { * as * };
+             ~
+!!! error TS1003: Identifier expected.
+               ~~
+!!! error TS2304: Cannot find name 'as'.
+                    ~
+!!! error TS1109: Expression expected.
+    

--- a/tests/baselines/reference/es6ExportClauseInEs5.js
+++ b/tests/baselines/reference/es6ExportClauseInEs5.js
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/es6ExportClauseInEs5.ts] ////
+
+//// [es6ExportClauseInEs5_0.ts]
+
+export var a = 10;
+export var x = a;
+export var m = a;
+
+//// [es6ExportClauseInEs5_1.ts]
+var a1 = 10;
+var x1 = a1;
+var m1 = a1;
+export { };
+export { a1 };
+export { a1 as b1 };
+export { x1, a1 as y1 };
+export { x1 as z1,  };
+export { m1,  };
+export { } from "es6ExportClauseInEs5_0";
+export { a } from "es6ExportClauseInEs5_0";
+export { a as b } from "es6ExportClauseInEs5_0";
+export { x, a as y } from "es6ExportClauseInEs5_0";
+export { x as z,  } from "es6ExportClauseInEs5_0";
+export { m,  } from "es6ExportClauseInEs5_0";
+
+//// [es6ExportClauseInEs5_0.js]
+exports.a = 10;
+exports.x = exports.a;
+exports.m = exports.a;
+//// [es6ExportClauseInEs5_1.js]
+var a1 = 10;
+var x1 = a1;
+var m1 = a1;

--- a/tests/baselines/reference/es6ExportClauseInEs5.types
+++ b/tests/baselines/reference/es6ExportClauseInEs5.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/es6ExportClauseInEs5_0.ts ===
+
+export var a = 10;
+>a : number
+
+export var x = a;
+>x : number
+>a : number
+
+export var m = a;
+>m : number
+>a : number
+
+=== tests/cases/compiler/es6ExportClauseInEs5_1.ts ===
+var a1 = 10;
+>a1 : number
+
+var x1 = a1;
+>x1 : number
+>a1 : number
+
+var m1 = a1;
+>m1 : number
+>a1 : number
+
+export { };
+export { a1 };
+export { a1 as b1 };
+export { x1, a1 as y1 };
+export { x1 as z1,  };
+export { m1,  };
+export { } from "es6ExportClauseInEs5_0";
+export { a } from "es6ExportClauseInEs5_0";
+export { a as b } from "es6ExportClauseInEs5_0";
+export { x, a as y } from "es6ExportClauseInEs5_0";
+export { x as z,  } from "es6ExportClauseInEs5_0";
+export { m,  } from "es6ExportClauseInEs5_0";

--- a/tests/baselines/reference/es6ExportDefaultAnonymousClassDeclaration.js
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousClassDeclaration.js
@@ -1,0 +1,10 @@
+//// [es6ExportDefaultAnonymousClassDeclaration.ts]
+
+export default class {
+    member = 10;
+}
+
+//// [es6ExportDefaultAnonymousClassDeclaration.js]
+
+
+//// [es6ExportDefaultAnonymousClassDeclaration.d.ts]

--- a/tests/baselines/reference/es6ExportDefaultAnonymousClassDeclaration.types
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousClassDeclaration.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/es6ExportDefaultAnonymousClassDeclaration.ts ===
+
+No type information for this code.export default class {
+No type information for this code.    member = 10;
+No type information for this code.}
+No type information for this code.

--- a/tests/baselines/reference/es6ExportDefaultAnonymousClassDeclarationInEs5.js
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousClassDeclarationInEs5.js
@@ -1,0 +1,10 @@
+//// [es6ExportDefaultAnonymousClassDeclarationInEs5.ts]
+
+export default class {
+    member = 10;
+}
+
+//// [es6ExportDefaultAnonymousClassDeclarationInEs5.js]
+
+
+//// [es6ExportDefaultAnonymousClassDeclarationInEs5.d.ts]

--- a/tests/baselines/reference/es6ExportDefaultAnonymousClassDeclarationInEs5.types
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousClassDeclarationInEs5.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/es6ExportDefaultAnonymousClassDeclarationInEs5.ts ===
+
+No type information for this code.export default class {
+No type information for this code.    member = 10;
+No type information for this code.}
+No type information for this code.

--- a/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclaration.js
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclaration.js
@@ -1,0 +1,9 @@
+//// [es6ExportDefaultAnonymousFunctionDeclaration.ts]
+
+export default function () {
+}
+
+//// [es6ExportDefaultAnonymousFunctionDeclaration.js]
+
+
+//// [es6ExportDefaultAnonymousFunctionDeclaration.d.ts]

--- a/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclaration.types
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclaration.types
@@ -1,0 +1,5 @@
+=== tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclaration.ts ===
+
+No type information for this code.export default function () {
+No type information for this code.}
+No type information for this code.

--- a/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclarationInEs5.js
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclarationInEs5.js
@@ -1,0 +1,9 @@
+//// [es6ExportDefaultAnonymousFunctionDeclarationInEs5.ts]
+
+export default function () {
+}
+
+//// [es6ExportDefaultAnonymousFunctionDeclarationInEs5.js]
+
+
+//// [es6ExportDefaultAnonymousFunctionDeclarationInEs5.d.ts]

--- a/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclarationInEs5.types
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclarationInEs5.types
@@ -1,0 +1,5 @@
+=== tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclarationInEs5.ts ===
+
+No type information for this code.export default function () {
+No type information for this code.}
+No type information for this code.

--- a/tests/baselines/reference/es6ExportDefaultAssignment.js
+++ b/tests/baselines/reference/es6ExportDefaultAssignment.js
@@ -1,0 +1,13 @@
+//// [es6ExportDefaultAssignment.ts]
+
+function b() {
+}
+export default b();
+
+//// [es6ExportDefaultAssignment.js]
+function b() {
+}
+
+
+//// [es6ExportDefaultAssignment.d.ts]
+declare function b(): void;

--- a/tests/baselines/reference/es6ExportDefaultAssignment.types
+++ b/tests/baselines/reference/es6ExportDefaultAssignment.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/es6ExportDefaultAssignment.ts ===
+
+function b() {
+>b : () => void
+}
+export default b();

--- a/tests/baselines/reference/es6ExportDefaultAssignmentInEs5.js
+++ b/tests/baselines/reference/es6ExportDefaultAssignmentInEs5.js
@@ -1,0 +1,13 @@
+//// [es6ExportDefaultAssignmentInEs5.ts]
+
+function b() {
+}
+export default b();
+
+//// [es6ExportDefaultAssignmentInEs5.js]
+function b() {
+}
+
+
+//// [es6ExportDefaultAssignmentInEs5.d.ts]
+declare function b(): void;

--- a/tests/baselines/reference/es6ExportDefaultAssignmentInEs5.types
+++ b/tests/baselines/reference/es6ExportDefaultAssignmentInEs5.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/es6ExportDefaultAssignmentInEs5.ts ===
+
+function b() {
+>b : () => void
+}
+export default b();

--- a/tests/baselines/reference/es6ExportDefaultClassDeclaration.js
+++ b/tests/baselines/reference/es6ExportDefaultClassDeclaration.js
@@ -1,0 +1,10 @@
+//// [es6ExportDefaultClassDeclaration.ts]
+
+export default class c {
+    member = 10;
+}
+
+//// [es6ExportDefaultClassDeclaration.js]
+
+
+//// [es6ExportDefaultClassDeclaration.d.ts]

--- a/tests/baselines/reference/es6ExportDefaultClassDeclaration.types
+++ b/tests/baselines/reference/es6ExportDefaultClassDeclaration.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/es6ExportDefaultClassDeclaration.ts ===
+
+No type information for this code.export default class c {
+No type information for this code.    member = 10;
+No type information for this code.}
+No type information for this code.

--- a/tests/baselines/reference/es6ExportDefaultClassDeclarationInEs5.js
+++ b/tests/baselines/reference/es6ExportDefaultClassDeclarationInEs5.js
@@ -1,0 +1,10 @@
+//// [es6ExportDefaultClassDeclarationInEs5.ts]
+
+export default class c {
+    member = 10;
+}
+
+//// [es6ExportDefaultClassDeclarationInEs5.js]
+
+
+//// [es6ExportDefaultClassDeclarationInEs5.d.ts]

--- a/tests/baselines/reference/es6ExportDefaultClassDeclarationInEs5.types
+++ b/tests/baselines/reference/es6ExportDefaultClassDeclarationInEs5.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/es6ExportDefaultClassDeclarationInEs5.ts ===
+
+No type information for this code.export default class c {
+No type information for this code.    member = 10;
+No type information for this code.}
+No type information for this code.

--- a/tests/baselines/reference/es6ExportDefaultFunctionDeclaration.js
+++ b/tests/baselines/reference/es6ExportDefaultFunctionDeclaration.js
@@ -1,0 +1,9 @@
+//// [es6ExportDefaultFunctionDeclaration.ts]
+
+export default function b() {
+}
+
+//// [es6ExportDefaultFunctionDeclaration.js]
+
+
+//// [es6ExportDefaultFunctionDeclaration.d.ts]

--- a/tests/baselines/reference/es6ExportDefaultFunctionDeclaration.types
+++ b/tests/baselines/reference/es6ExportDefaultFunctionDeclaration.types
@@ -1,0 +1,5 @@
+=== tests/cases/compiler/es6ExportDefaultFunctionDeclaration.ts ===
+
+No type information for this code.export default function b() {
+No type information for this code.}
+No type information for this code.

--- a/tests/baselines/reference/es6ExportDefaultFunctionDeclarationInEs5.js
+++ b/tests/baselines/reference/es6ExportDefaultFunctionDeclarationInEs5.js
@@ -1,0 +1,9 @@
+//// [es6ExportDefaultFunctionDeclarationInEs5.ts]
+
+export default function b() {
+}
+
+//// [es6ExportDefaultFunctionDeclarationInEs5.js]
+
+
+//// [es6ExportDefaultFunctionDeclarationInEs5.d.ts]

--- a/tests/baselines/reference/es6ExportDefaultFunctionDeclarationInEs5.types
+++ b/tests/baselines/reference/es6ExportDefaultFunctionDeclarationInEs5.types
@@ -1,0 +1,5 @@
+=== tests/cases/compiler/es6ExportDefaultFunctionDeclarationInEs5.ts ===
+
+No type information for this code.export default function b() {
+No type information for this code.}
+No type information for this code.

--- a/tests/baselines/reference/es6ImportDefaultBinding.js
+++ b/tests/baselines/reference/es6ImportDefaultBinding.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/es6ImportDefaultBinding.ts] ////
+
+//// [es6ImportDefaultBinding_0.ts]
+
+export var a = 10;
+
+//// [es6ImportDefaultBinding_1.ts]
+import defaultBinding from "es6ImportDefaultBinding_0";
+
+//// [es6ImportDefaultBinding_0.js]
+exports.a = 10;
+//// [es6ImportDefaultBinding_1.js]

--- a/tests/baselines/reference/es6ImportDefaultBinding.types
+++ b/tests/baselines/reference/es6ImportDefaultBinding.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/es6ImportDefaultBinding_0.ts ===
+
+export var a = 10;
+>a : number
+
+=== tests/cases/compiler/es6ImportDefaultBinding_1.ts ===
+import defaultBinding from "es6ImportDefaultBinding_0";
+No type information for this code.

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImport.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImport.js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport.ts] ////
+
+//// [es6ImportDefaultBindingFollowedWithNamedImport_0.ts]
+
+export var a = 10;
+export var x = a;
+export var m = a;
+
+//// [es6ImportDefaultBindingFollowedWithNamedImport_1.ts]
+import defaultBinding, { } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+import defaultBinding, { a } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+import defaultBinding, { a as b } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+import defaultBinding, { x, a as y } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+import defaultBinding, { x as z,  } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+import defaultBinding, { m,  } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+
+//// [es6ImportDefaultBindingFollowedWithNamedImport_0.js]
+exports.a = 10;
+exports.x = exports.a;
+exports.m = exports.a;
+//// [es6ImportDefaultBindingFollowedWithNamedImport_1.js]

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImport.types
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImport.types
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport_0.ts ===
+
+export var a = 10;
+>a : number
+
+export var x = a;
+>x : number
+>a : number
+
+export var m = a;
+>m : number
+>a : number
+
+=== tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport_1.ts ===
+import defaultBinding, { } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+No type information for this code.import defaultBinding, { a } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+No type information for this code.import defaultBinding, { a as b } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+No type information for this code.import defaultBinding, { x, a as y } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+No type information for this code.import defaultBinding, { x as z,  } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+No type information for this code.import defaultBinding, { m,  } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+No type information for this code.

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImportInEs5.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImportInEs5.js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportInEs5.ts] ////
+
+//// [es6ImportDefaultBindingFollowedWithNamedImportInEs5_0.ts]
+
+export var a = 10;
+export var x = a;
+export var m = a;
+
+//// [es6ImportDefaultBindingFollowedWithNamedImportInEs5_1.ts]
+import defaultBinding, { } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+import defaultBinding, { a } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+import defaultBinding, { a as b } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+import defaultBinding, { x, a as y } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+import defaultBinding, { x as z,  } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+import defaultBinding, { m,  } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+
+//// [es6ImportDefaultBindingFollowedWithNamedImportInEs5_0.js]
+exports.a = 10;
+exports.x = exports.a;
+exports.m = exports.a;
+//// [es6ImportDefaultBindingFollowedWithNamedImportInEs5_1.js]

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImportInEs5.types
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImportInEs5.types
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportInEs5_0.ts ===
+
+export var a = 10;
+>a : number
+
+export var x = a;
+>x : number
+>a : number
+
+export var m = a;
+>m : number
+>a : number
+
+=== tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportInEs5_1.ts ===
+import defaultBinding, { } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+No type information for this code.import defaultBinding, { a } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+No type information for this code.import defaultBinding, { a as b } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+No type information for this code.import defaultBinding, { x, a as y } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+No type information for this code.import defaultBinding, { x as z,  } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+No type information for this code.import defaultBinding, { m,  } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+No type information for this code.

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBinding.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBinding.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding.ts] ////
+
+//// [es6ImportDefaultBindingFollowedWithNamespaceBinding_0.ts]
+
+export var a = 10;
+
+//// [es6ImportDefaultBindingFollowedWithNamespaceBinding_1.ts]
+import defaultBinding, * as nameSpaceBinding  from "es6ImportDefaultBindingFollowedWithNamespaceBinding_0";
+
+//// [es6ImportDefaultBindingFollowedWithNamespaceBinding_0.js]
+exports.a = 10;
+//// [es6ImportDefaultBindingFollowedWithNamespaceBinding_1.js]

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBinding.types
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBinding.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding_0.ts ===
+
+export var a = 10;
+>a : number
+
+=== tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding_1.ts ===
+import defaultBinding, * as nameSpaceBinding  from "es6ImportDefaultBindingFollowedWithNamespaceBinding_0";
+No type information for this code.

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5.ts] ////
+
+//// [es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0.ts]
+
+export var a = 10;
+
+//// [es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_1.ts]
+import defaultBinding, * as nameSpaceBinding  from "es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0";
+
+//// [es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0.js]
+exports.a = 10;
+//// [es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_1.js]

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5.types
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0.ts ===
+
+export var a = 10;
+>a : number
+
+=== tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_1.ts ===
+import defaultBinding, * as nameSpaceBinding  from "es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0";
+No type information for this code.

--- a/tests/baselines/reference/es6ImportDefaultBindingInEs5.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingInEs5.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/es6ImportDefaultBindingInEs5.ts] ////
+
+//// [es6ImportDefaultBindingInEs5_0.ts]
+
+export var a = 10;
+
+//// [es6ImportDefaultBindingInEs5_1.ts]
+import defaultBinding from "es6ImportDefaultBindingInEs5_0";
+
+//// [es6ImportDefaultBindingInEs5_0.js]
+exports.a = 10;
+//// [es6ImportDefaultBindingInEs5_1.js]

--- a/tests/baselines/reference/es6ImportDefaultBindingInEs5.types
+++ b/tests/baselines/reference/es6ImportDefaultBindingInEs5.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/es6ImportDefaultBindingInEs5_0.ts ===
+
+export var a = 10;
+>a : number
+
+=== tests/cases/compiler/es6ImportDefaultBindingInEs5_1.ts ===
+import defaultBinding from "es6ImportDefaultBindingInEs5_0";
+No type information for this code.

--- a/tests/baselines/reference/es6ImportNameSpaceImport.js
+++ b/tests/baselines/reference/es6ImportNameSpaceImport.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/es6ImportNameSpaceImport.ts] ////
+
+//// [es6ImportNameSpaceImport_0.ts]
+
+export var a = 10;
+
+//// [es6ImportNameSpaceImport_1.ts]
+import * as nameSpaceBinding from "es6ImportNameSpaceImport_0";
+
+//// [es6ImportNameSpaceImport_0.js]
+exports.a = 10;
+//// [es6ImportNameSpaceImport_1.js]

--- a/tests/baselines/reference/es6ImportNameSpaceImport.types
+++ b/tests/baselines/reference/es6ImportNameSpaceImport.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/es6ImportNameSpaceImport_0.ts ===
+
+export var a = 10;
+>a : number
+
+=== tests/cases/compiler/es6ImportNameSpaceImport_1.ts ===
+import * as nameSpaceBinding from "es6ImportNameSpaceImport_0";
+No type information for this code.

--- a/tests/baselines/reference/es6ImportNameSpaceImportInEs5.js
+++ b/tests/baselines/reference/es6ImportNameSpaceImportInEs5.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/es6ImportNameSpaceImportInEs5.ts] ////
+
+//// [es6ImportNameSpaceImportInEs5_0.ts]
+
+export var a = 10;  
+
+//// [es6ImportNameSpaceImportInEs5_1.ts]
+import * as nameSpaceBinding from "es6ImportNameSpaceImportInEs5_0";
+
+//// [es6ImportNameSpaceImportInEs5_0.js]
+exports.a = 10;
+//// [es6ImportNameSpaceImportInEs5_1.js]

--- a/tests/baselines/reference/es6ImportNameSpaceImportInEs5.types
+++ b/tests/baselines/reference/es6ImportNameSpaceImportInEs5.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/es6ImportNameSpaceImportInEs5_0.ts ===
+
+export var a = 10;  
+>a : number
+
+=== tests/cases/compiler/es6ImportNameSpaceImportInEs5_1.ts ===
+import * as nameSpaceBinding from "es6ImportNameSpaceImportInEs5_0";
+No type information for this code.

--- a/tests/baselines/reference/es6ImportNamedImport.js
+++ b/tests/baselines/reference/es6ImportNamedImport.js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/es6ImportNamedImport.ts] ////
+
+//// [es6ImportNamedImport_0.ts]
+
+export var a = 10;
+export var x = a;
+export var m = a;
+
+//// [es6ImportNamedImport_1.ts]
+import { } from "es6ImportNamedImport_0";
+import { a } from "es6ImportNamedImport_0";
+import { a as b } from "es6ImportNamedImport_0";
+import { x, a as y } from "es6ImportNamedImport_0";
+import { x as z,  } from "es6ImportNamedImport_0";
+import { m,  } from "es6ImportNamedImport_0";
+
+//// [es6ImportNamedImport_0.js]
+exports.a = 10;
+exports.x = exports.a;
+exports.m = exports.a;
+//// [es6ImportNamedImport_1.js]

--- a/tests/baselines/reference/es6ImportNamedImport.types
+++ b/tests/baselines/reference/es6ImportNamedImport.types
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/es6ImportNamedImport_0.ts ===
+
+export var a = 10;
+>a : number
+
+export var x = a;
+>x : number
+>a : number
+
+export var m = a;
+>m : number
+>a : number
+
+=== tests/cases/compiler/es6ImportNamedImport_1.ts ===
+import { } from "es6ImportNamedImport_0";
+No type information for this code.import { a } from "es6ImportNamedImport_0";
+No type information for this code.import { a as b } from "es6ImportNamedImport_0";
+No type information for this code.import { x, a as y } from "es6ImportNamedImport_0";
+No type information for this code.import { x as z,  } from "es6ImportNamedImport_0";
+No type information for this code.import { m,  } from "es6ImportNamedImport_0";
+No type information for this code.

--- a/tests/baselines/reference/es6ImportNamedImportInEs5.js
+++ b/tests/baselines/reference/es6ImportNamedImportInEs5.js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/es6ImportNamedImportInEs5.ts] ////
+
+//// [es6ImportNamedImportInEs5_0.ts]
+
+export var a = 10;
+export var x = a;
+export var m = a;
+
+//// [es6ImportNamedImportInEs5_1.ts]
+import { } from "es6ImportNamedImportInEs5_0";
+import { a } from "es6ImportNamedImportInEs5_0";
+import { a as b } from "es6ImportNamedImportInEs5_0";
+import { x, a as y } from "es6ImportNamedImportInEs5_0";
+import { x as z,  } from "es6ImportNamedImportInEs5_0";
+import { m,  } from "es6ImportNamedImportInEs5_0";
+
+//// [es6ImportNamedImportInEs5_0.js]
+exports.a = 10;
+exports.x = exports.a;
+exports.m = exports.a;
+//// [es6ImportNamedImportInEs5_1.js]

--- a/tests/baselines/reference/es6ImportNamedImportInEs5.types
+++ b/tests/baselines/reference/es6ImportNamedImportInEs5.types
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/es6ImportNamedImportInEs5_0.ts ===
+
+export var a = 10;
+>a : number
+
+export var x = a;
+>x : number
+>a : number
+
+export var m = a;
+>m : number
+>a : number
+
+=== tests/cases/compiler/es6ImportNamedImportInEs5_1.ts ===
+import { } from "es6ImportNamedImportInEs5_0";
+No type information for this code.import { a } from "es6ImportNamedImportInEs5_0";
+No type information for this code.import { a as b } from "es6ImportNamedImportInEs5_0";
+No type information for this code.import { x, a as y } from "es6ImportNamedImportInEs5_0";
+No type information for this code.import { x as z,  } from "es6ImportNamedImportInEs5_0";
+No type information for this code.import { m,  } from "es6ImportNamedImportInEs5_0";
+No type information for this code.

--- a/tests/baselines/reference/es6ImportNamedImportParsingError.errors.txt
+++ b/tests/baselines/reference/es6ImportNamedImportParsingError.errors.txt
@@ -1,0 +1,32 @@
+tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(1,10): error TS1003: Identifier expected.
+tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(1,12): error TS1128: Declaration or statement expected.
+tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(1,14): error TS2304: Cannot find name 'from'.
+tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(1,19): error TS1005: ';' expected.
+tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(2,22): error TS1005: '=' expected.
+tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(2,24): error TS2304: Cannot find name 'from'.
+tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(2,29): error TS1005: ';' expected.
+
+
+==== tests/cases/compiler/es6ImportNamedImportParsingError_0.ts (0 errors) ====
+    
+    export var a = 10;
+    export var x = a;
+    export var m = a;
+    
+==== tests/cases/compiler/es6ImportNamedImportParsingError_1.ts (7 errors) ====
+    import { * } from "es6ImportNamedImportParsingError_0";
+             ~
+!!! error TS1003: Identifier expected.
+               ~
+!!! error TS1128: Declaration or statement expected.
+                 ~~~~
+!!! error TS2304: Cannot find name 'from'.
+                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1005: ';' expected.
+    import defaultBinding, from "es6ImportNamedImportParsingError_0";
+                         ~
+!!! error TS1005: '=' expected.
+                           ~~~~
+!!! error TS2304: Cannot find name 'from'.
+                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS1005: ';' expected.

--- a/tests/baselines/reference/es6ImportNamedImportParsingError.errors.txt
+++ b/tests/baselines/reference/es6ImportNamedImportParsingError.errors.txt
@@ -2,9 +2,8 @@ tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(1,10): error TS1003: 
 tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(1,12): error TS1128: Declaration or statement expected.
 tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(1,14): error TS2304: Cannot find name 'from'.
 tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(1,19): error TS1005: ';' expected.
-tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(2,22): error TS1005: '=' expected.
-tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(2,24): error TS2304: Cannot find name 'from'.
-tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(2,29): error TS1005: ';' expected.
+tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(2,24): error TS1005: '{' expected.
+tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(2,29): error TS1005: ',' expected.
 
 
 ==== tests/cases/compiler/es6ImportNamedImportParsingError_0.ts (0 errors) ====
@@ -13,7 +12,7 @@ tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(2,29): error TS1005: 
     export var x = a;
     export var m = a;
     
-==== tests/cases/compiler/es6ImportNamedImportParsingError_1.ts (7 errors) ====
+==== tests/cases/compiler/es6ImportNamedImportParsingError_1.ts (6 errors) ====
     import { * } from "es6ImportNamedImportParsingError_0";
              ~
 !!! error TS1003: Identifier expected.
@@ -24,9 +23,7 @@ tests/cases/compiler/es6ImportNamedImportParsingError_1.ts(2,29): error TS1005: 
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1005: ';' expected.
     import defaultBinding, from "es6ImportNamedImportParsingError_0";
-                         ~
-!!! error TS1005: '=' expected.
                            ~~~~
-!!! error TS2304: Cannot find name 'from'.
+!!! error TS1005: '{' expected.
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1005: ';' expected.
+!!! error TS1005: ',' expected.

--- a/tests/baselines/reference/es6ImportParseErrors.errors.txt
+++ b/tests/baselines/reference/es6ImportParseErrors.errors.txt
@@ -1,0 +1,8 @@
+tests/cases/compiler/es6ImportParseErrors.ts(2,1): error TS1128: Declaration or statement expected.
+
+
+==== tests/cases/compiler/es6ImportParseErrors.ts (1 errors) ====
+    
+    import 10;
+    ~~~~~~
+!!! error TS1128: Declaration or statement expected.

--- a/tests/baselines/reference/es6ImportWithoutFromClause.js
+++ b/tests/baselines/reference/es6ImportWithoutFromClause.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/es6ImportWithoutFromClause.ts] ////
+
+//// [es6ImportWithoutFromClause_0.ts]
+
+export var a = 10;
+
+//// [es6ImportWithoutFromClause_1.ts]
+import "es6ImportWithoutFromClause_0";
+
+//// [es6ImportWithoutFromClause_0.js]
+exports.a = 10;
+//// [es6ImportWithoutFromClause_1.js]

--- a/tests/baselines/reference/es6ImportWithoutFromClause.types
+++ b/tests/baselines/reference/es6ImportWithoutFromClause.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/es6ImportWithoutFromClause_0.ts ===
+
+export var a = 10;
+>a : number
+
+=== tests/cases/compiler/es6ImportWithoutFromClause_1.ts ===
+import "es6ImportWithoutFromClause_0";
+No type information for this code.

--- a/tests/baselines/reference/es6ImportWithoutFromClauseInEs5.js
+++ b/tests/baselines/reference/es6ImportWithoutFromClauseInEs5.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/es6ImportWithoutFromClauseInEs5.ts] ////
+
+//// [es6ImportWithoutFromClauseInEs5_0.ts]
+
+export var a = 10;
+
+//// [es6ImportWithoutFromClauseInEs5_1.ts]
+import "es6ImportWithoutFromClauseInEs5_0";
+
+//// [es6ImportWithoutFromClauseInEs5_0.js]
+exports.a = 10;
+//// [es6ImportWithoutFromClauseInEs5_1.js]

--- a/tests/baselines/reference/es6ImportWithoutFromClauseInEs5.types
+++ b/tests/baselines/reference/es6ImportWithoutFromClauseInEs5.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/es6ImportWithoutFromClauseInEs5_0.ts ===
+
+export var a = 10;
+>a : number
+
+=== tests/cases/compiler/es6ImportWithoutFromClauseInEs5_1.ts ===
+import "es6ImportWithoutFromClauseInEs5_0";
+No type information for this code.

--- a/tests/baselines/reference/es6StarExports.js
+++ b/tests/baselines/reference/es6StarExports.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/es6StarExports.ts] ////
+
+//// [es6StarExports_0.ts]
+
+export var a = 10;
+
+//// [es6StarExports_1.ts]
+export * from "es6StarExports_0";
+
+//// [es6StarExports_0.js]
+exports.a = 10;
+//// [es6StarExports_1.js]

--- a/tests/baselines/reference/es6StarExports.types
+++ b/tests/baselines/reference/es6StarExports.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/es6StarExports_0.ts ===
+
+export var a = 10;
+>a : number
+
+=== tests/cases/compiler/es6StarExports_1.ts ===
+export * from "es6StarExports_0";
+No type information for this code.

--- a/tests/baselines/reference/es6StarExportsErrors.errors.txt
+++ b/tests/baselines/reference/es6StarExportsErrors.errors.txt
@@ -1,0 +1,8 @@
+tests/cases/compiler/es6StarExportsErrors.ts(2,15): error TS1141: String literal expected.
+
+
+==== tests/cases/compiler/es6StarExportsErrors.ts (1 errors) ====
+    
+    export * from 10;
+                  ~~
+!!! error TS1141: String literal expected.

--- a/tests/baselines/reference/es6StarExportsInEs5.js
+++ b/tests/baselines/reference/es6StarExportsInEs5.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/es6StarExportsInEs5.ts] ////
+
+//// [es6StarExportsInEs5_0.ts]
+
+export var a = 10;
+
+//// [es6StarExportsInEs5_1.ts]
+export * from "es6StarExportsInEs5_0";
+
+//// [es6StarExportsInEs5_0.js]
+exports.a = 10;
+//// [es6StarExportsInEs5_1.js]

--- a/tests/baselines/reference/es6StarExportsInEs5.types
+++ b/tests/baselines/reference/es6StarExportsInEs5.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/es6StarExportsInEs5_0.ts ===
+
+export var a = 10;
+>a : number
+
+=== tests/cases/compiler/es6StarExportsInEs5_1.ts ===
+export * from "es6StarExportsInEs5_0";
+No type information for this code.

--- a/tests/cases/compiler/es6ExportClause.ts
+++ b/tests/cases/compiler/es6ExportClause.ts
@@ -1,0 +1,24 @@
+// @target: es6
+// @module: commonjs
+
+// @filename: es6ExportClause_0.ts
+export var a = 10;
+export var x = a;
+export var m = a;
+
+// @filename: es6ExportClause_1.ts
+var a1 = 10;
+var x1 = a1;
+var m1 = a1;
+export { };
+export { a1 };
+export { a1 as b1 };
+export { x1, a1 as y1 };
+export { x1 as z1,  };
+export { m1,  };
+export { } from "es6ExportClause_0";
+export { a } from "es6ExportClause_0";
+export { a as b } from "es6ExportClause_0";
+export { x, a as y } from "es6ExportClause_0";
+export { x as z,  } from "es6ExportClause_0";
+export { m,  } from "es6ExportClause_0";

--- a/tests/cases/compiler/es6ExportClauseErrors.ts
+++ b/tests/cases/compiler/es6ExportClauseErrors.ts
@@ -1,0 +1,8 @@
+// @target: es6
+// @module: commonjs
+
+export { } from 10;
+export { * };
+export { a1 as * };
+export { * as b };
+export { * as * };

--- a/tests/cases/compiler/es6ExportClauseInEs5.ts
+++ b/tests/cases/compiler/es6ExportClauseInEs5.ts
@@ -1,0 +1,24 @@
+// @target: es5
+// @module: commonjs
+
+// @filename: es6ExportClauseInEs5_0.ts
+export var a = 10;
+export var x = a;
+export var m = a;
+
+// @filename: es6ExportClauseInEs5_1.ts
+var a1 = 10;
+var x1 = a1;
+var m1 = a1;
+export { };
+export { a1 };
+export { a1 as b1 };
+export { x1, a1 as y1 };
+export { x1 as z1,  };
+export { m1,  };
+export { } from "es6ExportClauseInEs5_0";
+export { a } from "es6ExportClauseInEs5_0";
+export { a as b } from "es6ExportClauseInEs5_0";
+export { x, a as y } from "es6ExportClauseInEs5_0";
+export { x as z,  } from "es6ExportClauseInEs5_0";
+export { m,  } from "es6ExportClauseInEs5_0";

--- a/tests/cases/compiler/es6ExportDefaultAnonymousClassDeclaration.ts
+++ b/tests/cases/compiler/es6ExportDefaultAnonymousClassDeclaration.ts
@@ -1,0 +1,7 @@
+// @target: es6
+// @module: commonjs
+// @declaration: true
+
+export default class {
+    member = 10;
+}

--- a/tests/cases/compiler/es6ExportDefaultAnonymousClassDeclarationInEs5.ts
+++ b/tests/cases/compiler/es6ExportDefaultAnonymousClassDeclarationInEs5.ts
@@ -1,0 +1,7 @@
+// @target: es5
+// @module: commonjs
+// @declaration: true
+
+export default class {
+    member = 10;
+}

--- a/tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclaration.ts
+++ b/tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclaration.ts
@@ -1,0 +1,6 @@
+// @target: es6
+// @module: commonjs
+// @declaration: true
+
+export default function () {
+}

--- a/tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclarationInEs5.ts
+++ b/tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclarationInEs5.ts
@@ -1,0 +1,6 @@
+// @target: es5
+// @module: commonjs
+// @declaration: true
+
+export default function () {
+}

--- a/tests/cases/compiler/es6ExportDefaultAssignment.ts
+++ b/tests/cases/compiler/es6ExportDefaultAssignment.ts
@@ -1,0 +1,7 @@
+// @target: es6
+// @module: commonjs
+// @declaration: true
+
+function b() {
+}
+export default b();

--- a/tests/cases/compiler/es6ExportDefaultAssignmentInEs5.ts
+++ b/tests/cases/compiler/es6ExportDefaultAssignmentInEs5.ts
@@ -1,0 +1,7 @@
+// @target: es5
+// @module: commonjs
+// @declaration: true
+
+function b() {
+}
+export default b();

--- a/tests/cases/compiler/es6ExportDefaultClassDeclaration.ts
+++ b/tests/cases/compiler/es6ExportDefaultClassDeclaration.ts
@@ -1,0 +1,7 @@
+// @target: es6
+// @module: commonjs
+// @declaration: true
+
+export default class c {
+    member = 10;
+}

--- a/tests/cases/compiler/es6ExportDefaultClassDeclarationInEs5.ts
+++ b/tests/cases/compiler/es6ExportDefaultClassDeclarationInEs5.ts
@@ -1,0 +1,7 @@
+// @target: es5
+// @module: commonjs
+// @declaration: true
+
+export default class c {
+    member = 10;
+}

--- a/tests/cases/compiler/es6ExportDefaultFunctionDeclaration.ts
+++ b/tests/cases/compiler/es6ExportDefaultFunctionDeclaration.ts
@@ -1,0 +1,6 @@
+// @target: es6
+// @module: commonjs
+// @declaration: true
+
+export default function b() {
+}

--- a/tests/cases/compiler/es6ExportDefaultFunctionDeclarationInEs5.ts
+++ b/tests/cases/compiler/es6ExportDefaultFunctionDeclarationInEs5.ts
@@ -1,0 +1,6 @@
+// @target: es5
+// @module: commonjs
+// @declaration: true
+
+export default function b() {
+}

--- a/tests/cases/compiler/es6ImportDefaultBinding.ts
+++ b/tests/cases/compiler/es6ImportDefaultBinding.ts
@@ -1,0 +1,8 @@
+// @target: es6
+// @module: commonjs
+
+// @filename: es6ImportDefaultBinding_0.ts
+export var a = 10;
+
+// @filename: es6ImportDefaultBinding_1.ts
+import defaultBinding from "es6ImportDefaultBinding_0";

--- a/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport.ts
+++ b/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport.ts
@@ -1,0 +1,15 @@
+// @target: es6
+// @module: commonjs
+
+// @filename: es6ImportDefaultBindingFollowedWithNamedImport_0.ts
+export var a = 10;
+export var x = a;
+export var m = a;
+
+// @filename: es6ImportDefaultBindingFollowedWithNamedImport_1.ts
+import defaultBinding, { } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+import defaultBinding, { a } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+import defaultBinding, { a as b } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+import defaultBinding, { x, a as y } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+import defaultBinding, { x as z,  } from "es6ImportDefaultBindingFollowedWithNamedImport_0";
+import defaultBinding, { m,  } from "es6ImportDefaultBindingFollowedWithNamedImport_0";

--- a/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportInEs5.ts
+++ b/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportInEs5.ts
@@ -1,0 +1,15 @@
+// @target: es5
+// @module: commonjs
+
+// @filename: es6ImportDefaultBindingFollowedWithNamedImportInEs5_0.ts
+export var a = 10;
+export var x = a;
+export var m = a;
+
+// @filename: es6ImportDefaultBindingFollowedWithNamedImportInEs5_1.ts
+import defaultBinding, { } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+import defaultBinding, { a } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+import defaultBinding, { a as b } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+import defaultBinding, { x, a as y } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+import defaultBinding, { x as z,  } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";
+import defaultBinding, { m,  } from "es6ImportDefaultBindingFollowedWithNamedImportInEs5_0";

--- a/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding.ts
+++ b/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding.ts
@@ -1,0 +1,8 @@
+// @target: es6
+// @module: commonjs
+
+// @filename: es6ImportDefaultBindingFollowedWithNamespaceBinding_0.ts
+export var a = 10;
+
+// @filename: es6ImportDefaultBindingFollowedWithNamespaceBinding_1.ts
+import defaultBinding, * as nameSpaceBinding  from "es6ImportDefaultBindingFollowedWithNamespaceBinding_0";

--- a/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5.ts
+++ b/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5.ts
@@ -1,0 +1,8 @@
+// @target: es5
+// @module: commonjs
+
+// @filename: es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0.ts
+export var a = 10;
+
+// @filename: es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_1.ts
+import defaultBinding, * as nameSpaceBinding  from "es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0";

--- a/tests/cases/compiler/es6ImportDefaultBindingInEs5.ts
+++ b/tests/cases/compiler/es6ImportDefaultBindingInEs5.ts
@@ -1,0 +1,8 @@
+// @target: es5
+// @module: commonjs
+
+// @filename: es6ImportDefaultBindingInEs5_0.ts
+export var a = 10;
+
+// @filename: es6ImportDefaultBindingInEs5_1.ts
+import defaultBinding from "es6ImportDefaultBindingInEs5_0";

--- a/tests/cases/compiler/es6ImportNameSpaceImport.ts
+++ b/tests/cases/compiler/es6ImportNameSpaceImport.ts
@@ -1,0 +1,8 @@
+// @target: es6
+// @module: commonjs
+
+// @filename: es6ImportNameSpaceImport_0.ts
+export var a = 10;
+
+// @filename: es6ImportNameSpaceImport_1.ts
+import * as nameSpaceBinding from "es6ImportNameSpaceImport_0";

--- a/tests/cases/compiler/es6ImportNameSpaceImportInEs5.ts
+++ b/tests/cases/compiler/es6ImportNameSpaceImportInEs5.ts
@@ -1,0 +1,8 @@
+// @target: es5
+// @module: commonjs
+
+// @filename: es6ImportNameSpaceImportInEs5_0.ts
+export var a = 10;  
+
+// @filename: es6ImportNameSpaceImportInEs5_1.ts
+import * as nameSpaceBinding from "es6ImportNameSpaceImportInEs5_0";

--- a/tests/cases/compiler/es6ImportNamedImport.ts
+++ b/tests/cases/compiler/es6ImportNamedImport.ts
@@ -1,0 +1,15 @@
+// @target: es6
+// @module: commonjs
+
+// @filename: es6ImportNamedImport_0.ts
+export var a = 10;
+export var x = a;
+export var m = a;
+
+// @filename: es6ImportNamedImport_1.ts
+import { } from "es6ImportNamedImport_0";
+import { a } from "es6ImportNamedImport_0";
+import { a as b } from "es6ImportNamedImport_0";
+import { x, a as y } from "es6ImportNamedImport_0";
+import { x as z,  } from "es6ImportNamedImport_0";
+import { m,  } from "es6ImportNamedImport_0";

--- a/tests/cases/compiler/es6ImportNamedImportInEs5.ts
+++ b/tests/cases/compiler/es6ImportNamedImportInEs5.ts
@@ -1,0 +1,15 @@
+// @target: es5
+// @module: commonjs
+
+// @filename: es6ImportNamedImportInEs5_0.ts
+export var a = 10;
+export var x = a;
+export var m = a;
+
+// @filename: es6ImportNamedImportInEs5_1.ts
+import { } from "es6ImportNamedImportInEs5_0";
+import { a } from "es6ImportNamedImportInEs5_0";
+import { a as b } from "es6ImportNamedImportInEs5_0";
+import { x, a as y } from "es6ImportNamedImportInEs5_0";
+import { x as z,  } from "es6ImportNamedImportInEs5_0";
+import { m,  } from "es6ImportNamedImportInEs5_0";

--- a/tests/cases/compiler/es6ImportNamedImportParsingError.ts
+++ b/tests/cases/compiler/es6ImportNamedImportParsingError.ts
@@ -1,0 +1,11 @@
+// @target: es6
+// @module: commonjs
+
+// @filename: es6ImportNamedImportParsingError_0.ts
+export var a = 10;
+export var x = a;
+export var m = a;
+
+// @filename: es6ImportNamedImportParsingError_1.ts
+import { * } from "es6ImportNamedImportParsingError_0";
+import defaultBinding, from "es6ImportNamedImportParsingError_0";

--- a/tests/cases/compiler/es6ImportParseErrors.ts
+++ b/tests/cases/compiler/es6ImportParseErrors.ts
@@ -1,0 +1,4 @@
+// @target: es6
+// @module: commonjs
+
+import 10;

--- a/tests/cases/compiler/es6ImportWithoutFromClause.ts
+++ b/tests/cases/compiler/es6ImportWithoutFromClause.ts
@@ -1,0 +1,8 @@
+// @target: es6
+// @module: commonjs
+
+// @filename: es6ImportWithoutFromClause_0.ts
+export var a = 10;
+
+// @filename: es6ImportWithoutFromClause_1.ts
+import "es6ImportWithoutFromClause_0";

--- a/tests/cases/compiler/es6ImportWithoutFromClauseInEs5.ts
+++ b/tests/cases/compiler/es6ImportWithoutFromClauseInEs5.ts
@@ -1,0 +1,8 @@
+// @target: es5
+// @module: commonjs
+
+// @filename: es6ImportWithoutFromClauseInEs5_0.ts
+export var a = 10;
+
+// @filename: es6ImportWithoutFromClauseInEs5_1.ts
+import "es6ImportWithoutFromClauseInEs5_0";

--- a/tests/cases/compiler/es6StarExports.ts
+++ b/tests/cases/compiler/es6StarExports.ts
@@ -1,0 +1,8 @@
+// @target: es6
+// @module: commonjs
+
+// @filename: es6StarExports_0.ts
+export var a = 10;
+
+// @filename: es6StarExports_1.ts
+export * from "es6StarExports_0";

--- a/tests/cases/compiler/es6StarExportsErrors.ts
+++ b/tests/cases/compiler/es6StarExportsErrors.ts
@@ -1,0 +1,4 @@
+// @target: es6
+// @module: commonjs
+
+export * from 10;

--- a/tests/cases/compiler/es6StarExportsInEs5.ts
+++ b/tests/cases/compiler/es6StarExportsInEs5.ts
@@ -1,0 +1,8 @@
+// @target: es5
+// @module: commonjs
+
+// @filename: es6StarExportsInEs5_0.ts
+export var a = 10;
+
+// @filename: es6StarExportsInEs5_1.ts
+export * from "es6StarExportsInEs5_0";


### PR DESCRIPTION
Parsing for ES6 export and import syntax. 
This change is only for parsing side. Symbol binding, resolution, emit, declaration emit each will be in separate pull request for easy reviews.