### PR TITLE
Use transient symbols when computing the indexers for object literals

### DIFF
--- a/tests/baselines/reference/objectLiteralIndexerNoImplicitAny.js
+++ b/tests/baselines/reference/objectLiteralIndexerNoImplicitAny.js
@@ -1,0 +1,13 @@
+//// [objectLiteralIndexerNoImplicitAny.ts]
+interface I {
+    [s: string]: any;
+}
+
+var x: I = {
+    p: null
+}
+
+//// [objectLiteralIndexerNoImplicitAny.js]
+var x = {
+    p: null
+};

--- a/tests/baselines/reference/objectLiteralIndexerNoImplicitAny.types
+++ b/tests/baselines/reference/objectLiteralIndexerNoImplicitAny.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/objectLiteralIndexerNoImplicitAny.ts ===
+interface I {
+>I : I
+
+    [s: string]: any;
+>s : string
+}
+
+var x: I = {
+>x : I
+>I : I
+>{    p: null} : { [x: string]: null; p: null; }
+
+    p: null
+>p : null
+}

--- a/tests/cases/compiler/objectLiteralIndexerNoImplicitAny.ts
+++ b/tests/cases/compiler/objectLiteralIndexerNoImplicitAny.ts
@@ -1,0 +1,8 @@
+﻿//@noImplicitAny: true
+interface I {
+    [s: string]: any;
+}
+
+var x: I = {
+    p: null
+}


### PR DESCRIPTION
Compiling the following with --noImplicitAny gives an error for widening:
```ts
interface I {
    [s: string]: any;
}

var x: I = {
    p: null
}
```
This is because when we compute the indexer for the object literal, we call getTypeOfSymbol on the original symbol for p. This causes p to widen, even though it should not. The fix is to use the TransientSymbol for p, created by checkObjectLiteral. This causes getTypeOfSymbol to short circuit and not widen. I'm not sure if this is the most correct fix, but it's how it worked before.