### PR TITLE
Added test for contextually typing parameters in super calls.

### DIFF
--- a/tests/baselines/reference/superCallParameterContextualTyping3.js
+++ b/tests/baselines/reference/superCallParameterContextualTyping3.js
@@ -1,0 +1,67 @@
+//// [superCallParameterContextualTyping3.ts]
+interface ContextualType<T> {
+    method(parameter: T): void;
+}
+
+class CBase<T>  {
+    constructor(param: ContextualType<T>) {
+    }
+
+    foo(param: ContextualType<T>) {
+    }
+}
+
+class C extends CBase<string> {
+    constructor() {
+        // Should be okay.
+        // 'p' should have type 'string'.
+        super({
+            method(p) {
+                p.length;
+            }
+        });
+
+        // Should be okay.
+        // 'p' should have type 'string'.
+        super.foo({
+            method(p) {
+                p.length;
+            }
+        });
+    }
+}
+
+//// [superCallParameterContextualTyping3.js]
+var __extends = this.__extends || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    __.prototype = b.prototype;
+    d.prototype = new __();
+};
+var CBase = (function () {
+    function CBase(param) {
+    }
+    CBase.prototype.foo = function (param) {
+    };
+    return CBase;
+})();
+var C = (function (_super) {
+    __extends(C, _super);
+    function C() {
+        // Should be okay.
+        // 'p' should have type 'string'.
+        _super.call(this, {
+            method: function (p) {
+                p.length;
+            }
+        });
+        // Should be okay.
+        // 'p' should have type 'string'.
+        _super.prototype.foo.call(this, {
+            method: function (p) {
+                p.length;
+            }
+        });
+    }
+    return C;
+})(CBase);

--- a/tests/baselines/reference/superCallParameterContextualTyping3.types
+++ b/tests/baselines/reference/superCallParameterContextualTyping3.types
@@ -1,0 +1,73 @@
+=== tests/cases/conformance/expressions/contextualTyping/superCallParameterContextualTyping3.ts ===
+interface ContextualType<T> {
+>ContextualType : ContextualType<T>
+>T : T
+
+    method(parameter: T): void;
+>method : (parameter: T) => void
+>parameter : T
+>T : T
+}
+
+class CBase<T>  {
+>CBase : CBase<T>
+>T : T
+
+    constructor(param: ContextualType<T>) {
+>param : ContextualType<T>
+>ContextualType : ContextualType<T>
+>T : T
+    }
+
+    foo(param: ContextualType<T>) {
+>foo : (param: ContextualType<T>) => void
+>param : ContextualType<T>
+>ContextualType : ContextualType<T>
+>T : T
+    }
+}
+
+class C extends CBase<string> {
+>C : C
+>CBase : CBase<T>
+
+    constructor() {
+        // Should be okay.
+        // 'p' should have type 'string'.
+        super({
+>super({            method(p) {                p.length;            }        }) : void
+>super : typeof CBase
+>{            method(p) {                p.length;            }        } : { method(p: string): void; }
+
+            method(p) {
+>method : (p: string) => void
+>p : string
+
+                p.length;
+>p.length : number
+>p : string
+>length : number
+            }
+        });
+
+        // Should be okay.
+        // 'p' should have type 'string'.
+        super.foo({
+>super.foo({            method(p) {                p.length;            }        }) : void
+>super.foo : (param: ContextualType<string>) => void
+>super : CBase<string>
+>foo : (param: ContextualType<string>) => void
+>{            method(p) {                p.length;            }        } : { method(p: string): void; }
+
+            method(p) {
+>method : (p: string) => void
+>p : string
+
+                p.length;
+>p.length : number
+>p : string
+>length : number
+            }
+        });
+    }
+}

--- a/tests/cases/conformance/expressions/contextualTyping/superCallParameterContextualTyping3.ts
+++ b/tests/cases/conformance/expressions/contextualTyping/superCallParameterContextualTyping3.ts
@@ -1,0 +1,31 @@
+﻿interface ContextualType<T> {
+    method(parameter: T): void;
+}
+
+class CBase<T>  {
+    constructor(param: ContextualType<T>) {
+    }
+
+    foo(param: ContextualType<T>) {
+    }
+}
+
+class C extends CBase<string> {
+    constructor() {
+        // Should be okay.
+        // 'p' should have type 'string'.
+        super({
+            method(p) {
+                p.length;
+            }
+        });
+
+        // Should be okay.
+        // 'p' should have type 'string'.
+        super.foo({
+            method(p) {
+                p.length;
+            }
+        });
+    }
+}


### PR DESCRIPTION
Should indicate that #1425 is fixed.