### PR TITLE
Change the default LS target to ES5 from ES6

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1418,9 +1418,9 @@ module ts {
     }
 
     export function getDefaultCompilerOptions(): CompilerOptions {
-        // Set "ScriptTarget.Latest" target by default for language service
+        // Always default to "ScriptTarget.ES5" for the language service
         return {
-            target: ScriptTarget.Latest,
+            target: ScriptTarget.ES5,
             module: ModuleKind.None,
         };
     }


### PR DESCRIPTION
Fixes ##1722. This allows the VS Language Service to default to ES5, instead of ES6 (latest)