### PR TITLE
Remove certain lazyily initialized fields from the public DTS.

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -194,7 +194,7 @@ var compilerFilename = "tsc.js";
     * @param keepComments: false to compile using --removeComments
     * @param callback: a function to execute after the compilation process ends
     */
-function compileFile(outFile, sources, prereqs, prefixes, useBuiltCompiler, noOutFile, generateDeclarations, outDir, preserveConstEnums, keepComments, noResolve, callback) {
+function compileFile(outFile, sources, prereqs, prefixes, useBuiltCompiler, noOutFile, generateDeclarations, outDir, preserveConstEnums, keepComments, noResolve, stripInternal, callback) {
     file(outFile, prereqs, function() {
         var dir = useBuiltCompiler ? builtLocalDirectory : LKGDirectory;
         var options = "--module commonjs -noImplicitAny";
@@ -225,6 +225,10 @@ function compileFile(outFile, sources, prereqs, prefixes, useBuiltCompiler, noOu
 
         if (useDebugMode) {
             options += " -sourcemap -mapRoot file:///" + path.resolve(path.dirname(outFile));
+        }
+
+        if (stripInternal) {
+            options += " --stripInternal"
         }
 
         var cmd = host + " " + dir + compilerFilename + " " + options + " ";
@@ -331,7 +335,8 @@ compileFile(servicesFile, servicesSources,[builtLocalDirectory, copyright].conca
             /*outDir*/ undefined,
             /*preserveConstEnums*/ true,
             /*keepComments*/ false,
-            /*noResolve*/ false);
+            /*noResolve*/ false,
+            /*stripInternal*/ false);
 
 var nodeDefinitionsFile = path.join(builtLocalDirectory, "typescript.d.ts");
 var standaloneDefinitionsFile = path.join(builtLocalDirectory, "typescriptServices.d.ts");
@@ -347,6 +352,7 @@ compileFile(nodeDefinitionsFile, servicesSources,[builtLocalDirectory, copyright
             /*preserveConstEnums*/ true,
             /*keepComments*/ true,
             /*noResolve*/ true,
+            /*stripInternal*/ true,
             /*callback*/ function () {
                 function makeDefinitionFiles(definitionsRoots, standaloneDefinitionsFile, nodeDefinitionsFile) {
                     // Create the standalone definition file

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -891,22 +891,6 @@ module ts {
         amdModuleName: string;
         referencedFiles: FileReference[];
 
-        // Diagnostics reported about the "///<reference" comments in the file.
-        referenceDiagnostics: Diagnostic[];
-
-        // Parse errors refer specifically to things the parser could not understand at all (like 
-        // missing tokens, or tokens it didn't know how to deal with).
-        parseDiagnostics: Diagnostic[];
-
-        //getSyntacticDiagnostics(): Diagnostic[];
-
-        // File level diagnostics reported by the binder.
-        semanticDiagnostics: Diagnostic[];
-
-        // Returns all syntactic diagnostics (i.e. the reference, parser and grammar diagnostics).
-        // This field should never be used directly, use getSyntacticDiagnostics function instead.
-        syntacticDiagnostics: Diagnostic[];
-
         hasNoDefaultLib: boolean;
         externalModuleIndicator: Node; // The first node that causes this file to be an external module
         nodeCount: number;
@@ -915,6 +899,25 @@ module ts {
         languageVersion: ScriptTarget;
         identifiers: Map<string>;
 
+        // @internal
+        // Diagnostics reported about the "///<reference" comments in the file.
+        referenceDiagnostics: Diagnostic[];
+        
+        // @internal
+        // Parse errors refer specifically to things the parser could not understand at all (like 
+        // missing tokens, or tokens it didn't know how to deal with).
+        parseDiagnostics: Diagnostic[];
+        
+        // @internal
+        // File level diagnostics reported by the binder.
+        semanticDiagnostics: Diagnostic[];
+        
+        // @internal
+        // Returns all syntactic diagnostics (i.e. the reference, parser and grammar diagnostics).
+        // This field should never be used directly, use getSyntacticDiagnostics function instead.
+        syntacticDiagnostics: Diagnostic[];
+
+        // @internal
         // Stores a line map for the file.
         // This field should never be used directly to obtain line map, use getLineMap function instead.
         lineMap: number[];

--- a/tests/baselines/reference/APISample_compile.js
+++ b/tests/baselines/reference/APISample_compile.js
@@ -728,10 +728,6 @@ declare module "typescript" {
         amdDependencies: string[];
         amdModuleName: string;
         referencedFiles: FileReference[];
-        referenceDiagnostics: Diagnostic[];
-        parseDiagnostics: Diagnostic[];
-        semanticDiagnostics: Diagnostic[];
-        syntacticDiagnostics: Diagnostic[];
         hasNoDefaultLib: boolean;
         externalModuleIndicator: Node;
         nodeCount: number;
@@ -739,7 +735,6 @@ declare module "typescript" {
         symbolCount: number;
         languageVersion: ScriptTarget;
         identifiers: Map<string>;
-        lineMap: number[];
     }
     interface ScriptReferenceHost {
         getCompilerOptions(): CompilerOptions;
@@ -1186,6 +1181,7 @@ declare module "typescript" {
         target?: ScriptTarget;
         version?: boolean;
         watch?: boolean;
+        stripInternal?: boolean;
         [option: string]: string | number | boolean;
     }
     const enum ModuleKind {
@@ -1216,6 +1212,7 @@ declare module "typescript" {
         description?: DiagnosticMessage;
         paramType?: DiagnosticMessage;
         error?: DiagnosticMessage;
+        experimental?: boolean;
     }
     const enum CharacterCodes {
         nullCharacter = 0,

--- a/tests/baselines/reference/APISample_compile.types
+++ b/tests/baselines/reference/APISample_compile.types
@@ -2219,22 +2219,6 @@ declare module "typescript" {
 >referencedFiles : FileReference[]
 >FileReference : FileReference
 
-        referenceDiagnostics: Diagnostic[];
->referenceDiagnostics : Diagnostic[]
->Diagnostic : Diagnostic
-
-        parseDiagnostics: Diagnostic[];
->parseDiagnostics : Diagnostic[]
->Diagnostic : Diagnostic
-
-        semanticDiagnostics: Diagnostic[];
->semanticDiagnostics : Diagnostic[]
->Diagnostic : Diagnostic
-
-        syntacticDiagnostics: Diagnostic[];
->syntacticDiagnostics : Diagnostic[]
->Diagnostic : Diagnostic
-
         hasNoDefaultLib: boolean;
 >hasNoDefaultLib : boolean
 
@@ -2258,9 +2242,6 @@ declare module "typescript" {
         identifiers: Map<string>;
 >identifiers : Map<string>
 >Map : Map<T>
-
-        lineMap: number[];
->lineMap : number[]
     }
     interface ScriptReferenceHost {
 >ScriptReferenceHost : ScriptReferenceHost
@@ -3818,6 +3799,9 @@ declare module "typescript" {
         watch?: boolean;
 >watch : boolean
 
+        stripInternal?: boolean;
+>stripInternal : boolean
+
         [option: string]: string | number | boolean;
 >option : string
     }
@@ -3898,6 +3882,9 @@ declare module "typescript" {
         error?: DiagnosticMessage;
 >error : DiagnosticMessage
 >DiagnosticMessage : DiagnosticMessage
+
+        experimental?: boolean;
+>experimental : boolean
     }
     const enum CharacterCodes {
 >CharacterCodes : CharacterCodes

--- a/tests/baselines/reference/APISample_linter.js
+++ b/tests/baselines/reference/APISample_linter.js
@@ -757,10 +757,6 @@ declare module "typescript" {
         amdDependencies: string[];
         amdModuleName: string;
         referencedFiles: FileReference[];
-        referenceDiagnostics: Diagnostic[];
-        parseDiagnostics: Diagnostic[];
-        semanticDiagnostics: Diagnostic[];
-        syntacticDiagnostics: Diagnostic[];
         hasNoDefaultLib: boolean;
         externalModuleIndicator: Node;
         nodeCount: number;
@@ -768,7 +764,6 @@ declare module "typescript" {
         symbolCount: number;
         languageVersion: ScriptTarget;
         identifiers: Map<string>;
-        lineMap: number[];
     }
     interface ScriptReferenceHost {
         getCompilerOptions(): CompilerOptions;
@@ -1215,6 +1210,7 @@ declare module "typescript" {
         target?: ScriptTarget;
         version?: boolean;
         watch?: boolean;
+        stripInternal?: boolean;
         [option: string]: string | number | boolean;
     }
     const enum ModuleKind {
@@ -1245,6 +1241,7 @@ declare module "typescript" {
         description?: DiagnosticMessage;
         paramType?: DiagnosticMessage;
         error?: DiagnosticMessage;
+        experimental?: boolean;
     }
     const enum CharacterCodes {
         nullCharacter = 0,

--- a/tests/baselines/reference/APISample_linter.types
+++ b/tests/baselines/reference/APISample_linter.types
@@ -2349,22 +2349,6 @@ declare module "typescript" {
 >referencedFiles : FileReference[]
 >FileReference : FileReference
 
-        referenceDiagnostics: Diagnostic[];
->referenceDiagnostics : Diagnostic[]
->Diagnostic : Diagnostic
-
-        parseDiagnostics: Diagnostic[];
->parseDiagnostics : Diagnostic[]
->Diagnostic : Diagnostic
-
-        semanticDiagnostics: Diagnostic[];
->semanticDiagnostics : Diagnostic[]
->Diagnostic : Diagnostic
-
-        syntacticDiagnostics: Diagnostic[];
->syntacticDiagnostics : Diagnostic[]
->Diagnostic : Diagnostic
-
         hasNoDefaultLib: boolean;
 >hasNoDefaultLib : boolean
 
@@ -2388,9 +2372,6 @@ declare module "typescript" {
         identifiers: Map<string>;
 >identifiers : Map<string>
 >Map : Map<T>
-
-        lineMap: number[];
->lineMap : number[]
     }
     interface ScriptReferenceHost {
 >ScriptReferenceHost : ScriptReferenceHost
@@ -3948,6 +3929,9 @@ declare module "typescript" {
         watch?: boolean;
 >watch : boolean
 
+        stripInternal?: boolean;
+>stripInternal : boolean
+
         [option: string]: string | number | boolean;
 >option : string
     }
@@ -4028,6 +4012,9 @@ declare module "typescript" {
         error?: DiagnosticMessage;
 >error : DiagnosticMessage
 >DiagnosticMessage : DiagnosticMessage
+
+        experimental?: boolean;
+>experimental : boolean
     }
     const enum CharacterCodes {
 >CharacterCodes : CharacterCodes

--- a/tests/baselines/reference/APISample_transform.js
+++ b/tests/baselines/reference/APISample_transform.js
@@ -758,10 +758,6 @@ declare module "typescript" {
         amdDependencies: string[];
         amdModuleName: string;
         referencedFiles: FileReference[];
-        referenceDiagnostics: Diagnostic[];
-        parseDiagnostics: Diagnostic[];
-        semanticDiagnostics: Diagnostic[];
-        syntacticDiagnostics: Diagnostic[];
         hasNoDefaultLib: boolean;
         externalModuleIndicator: Node;
         nodeCount: number;
@@ -769,7 +765,6 @@ declare module "typescript" {
         symbolCount: number;
         languageVersion: ScriptTarget;
         identifiers: Map<string>;
-        lineMap: number[];
     }
     interface ScriptReferenceHost {
         getCompilerOptions(): CompilerOptions;
@@ -1216,6 +1211,7 @@ declare module "typescript" {
         target?: ScriptTarget;
         version?: boolean;
         watch?: boolean;
+        stripInternal?: boolean;
         [option: string]: string | number | boolean;
     }
     const enum ModuleKind {
@@ -1246,6 +1242,7 @@ declare module "typescript" {
         description?: DiagnosticMessage;
         paramType?: DiagnosticMessage;
         error?: DiagnosticMessage;
+        experimental?: boolean;
     }
     const enum CharacterCodes {
         nullCharacter = 0,

--- a/tests/baselines/reference/APISample_transform.types
+++ b/tests/baselines/reference/APISample_transform.types
@@ -2297,22 +2297,6 @@ declare module "typescript" {
 >referencedFiles : FileReference[]
 >FileReference : FileReference
 
-        referenceDiagnostics: Diagnostic[];
->referenceDiagnostics : Diagnostic[]
->Diagnostic : Diagnostic
-
-        parseDiagnostics: Diagnostic[];
->parseDiagnostics : Diagnostic[]
->Diagnostic : Diagnostic
-
-        semanticDiagnostics: Diagnostic[];
->semanticDiagnostics : Diagnostic[]
->Diagnostic : Diagnostic
-
-        syntacticDiagnostics: Diagnostic[];
->syntacticDiagnostics : Diagnostic[]
->Diagnostic : Diagnostic
-
         hasNoDefaultLib: boolean;
 >hasNoDefaultLib : boolean
 
@@ -2336,9 +2320,6 @@ declare module "typescript" {
         identifiers: Map<string>;
 >identifiers : Map<string>
 >Map : Map<T>
-
-        lineMap: number[];
->lineMap : number[]
     }
     interface ScriptReferenceHost {
 >ScriptReferenceHost : ScriptReferenceHost
@@ -3896,6 +3877,9 @@ declare module "typescript" {
         watch?: boolean;
 >watch : boolean
 
+        stripInternal?: boolean;
+>stripInternal : boolean
+
         [option: string]: string | number | boolean;
 >option : string
     }
@@ -3976,6 +3960,9 @@ declare module "typescript" {
         error?: DiagnosticMessage;
 >error : DiagnosticMessage
 >DiagnosticMessage : DiagnosticMessage
+
+        experimental?: boolean;
+>experimental : boolean
     }
     const enum CharacterCodes {
 >CharacterCodes : CharacterCodes

--- a/tests/baselines/reference/APISample_watcher.js
+++ b/tests/baselines/reference/APISample_watcher.js
@@ -795,10 +795,6 @@ declare module "typescript" {
         amdDependencies: string[];
         amdModuleName: string;
         referencedFiles: FileReference[];
-        referenceDiagnostics: Diagnostic[];
-        parseDiagnostics: Diagnostic[];
-        semanticDiagnostics: Diagnostic[];
-        syntacticDiagnostics: Diagnostic[];
         hasNoDefaultLib: boolean;
         externalModuleIndicator: Node;
         nodeCount: number;
@@ -806,7 +802,6 @@ declare module "typescript" {
         symbolCount: number;
         languageVersion: ScriptTarget;
         identifiers: Map<string>;
-        lineMap: number[];
     }
     interface ScriptReferenceHost {
         getCompilerOptions(): CompilerOptions;
@@ -1253,6 +1248,7 @@ declare module "typescript" {
         target?: ScriptTarget;
         version?: boolean;
         watch?: boolean;
+        stripInternal?: boolean;
         [option: string]: string | number | boolean;
     }
     const enum ModuleKind {
@@ -1283,6 +1279,7 @@ declare module "typescript" {
         description?: DiagnosticMessage;
         paramType?: DiagnosticMessage;
         error?: DiagnosticMessage;
+        experimental?: boolean;
     }
     const enum CharacterCodes {
         nullCharacter = 0,

--- a/tests/baselines/reference/APISample_watcher.types
+++ b/tests/baselines/reference/APISample_watcher.types
@@ -2475,22 +2475,6 @@ declare module "typescript" {
 >referencedFiles : FileReference[]
 >FileReference : FileReference
 
-        referenceDiagnostics: Diagnostic[];
->referenceDiagnostics : Diagnostic[]
->Diagnostic : Diagnostic
-
-        parseDiagnostics: Diagnostic[];
->parseDiagnostics : Diagnostic[]
->Diagnostic : Diagnostic
-
-        semanticDiagnostics: Diagnostic[];
->semanticDiagnostics : Diagnostic[]
->Diagnostic : Diagnostic
-
-        syntacticDiagnostics: Diagnostic[];
->syntacticDiagnostics : Diagnostic[]
->Diagnostic : Diagnostic
-
         hasNoDefaultLib: boolean;
 >hasNoDefaultLib : boolean
 
@@ -2514,9 +2498,6 @@ declare module "typescript" {
         identifiers: Map<string>;
 >identifiers : Map<string>
 >Map : Map<T>
-
-        lineMap: number[];
->lineMap : number[]
     }
     interface ScriptReferenceHost {
 >ScriptReferenceHost : ScriptReferenceHost
@@ -4074,6 +4055,9 @@ declare module "typescript" {
         watch?: boolean;
 >watch : boolean
 
+        stripInternal?: boolean;
+>stripInternal : boolean
+
         [option: string]: string | number | boolean;
 >option : string
     }
@@ -4154,6 +4138,9 @@ declare module "typescript" {
         error?: DiagnosticMessage;
 >error : DiagnosticMessage
 >DiagnosticMessage : DiagnosticMessage
+
+        experimental?: boolean;
+>experimental : boolean
     }
     const enum CharacterCodes {
 >CharacterCodes : CharacterCodes

--- a/tests/cases/compiler/APISample_compile.ts
+++ b/tests/cases/compiler/APISample_compile.ts
@@ -1,5 +1,6 @@
 ﻿// @module: commonjs
 // @includebuiltfile: typescript.d.ts
+// @stripInternal:true
 
 /*
  * Note: This test is a public API sample. The sample sources can be found 

--- a/tests/cases/compiler/APISample_linter.ts
+++ b/tests/cases/compiler/APISample_linter.ts
@@ -1,5 +1,6 @@
 ﻿// @module: commonjs
 // @includebuiltfile: typescript.d.ts
+// @stripInternal:true
 
 /*
  * Note: This test is a public API sample. The sample sources can be found 

--- a/tests/cases/compiler/APISample_transform.ts
+++ b/tests/cases/compiler/APISample_transform.ts
@@ -1,5 +1,6 @@
 ﻿// @module: commonjs
 // @includebuiltfile: typescript.d.ts
+// @stripInternal:true
 
 /*
  * Note: This test is a public API sample. The sample sources can be found 

--- a/tests/cases/compiler/APISample_watcher.ts
+++ b/tests/cases/compiler/APISample_watcher.ts
@@ -1,5 +1,6 @@
 ﻿// @module: commonjs
 // @includebuiltfile: typescript.d.ts
+// @stripInternal:true
 
 /*
  * Note: This test is a public API sample. The sample sources can be found 


### PR DESCRIPTION
These should not be accessed directly.  They should be obtained by calling into the appropriate
helper functions.