### PR TITLE
Fix error in intl.d.ts

### DIFF
--- a/src/lib/intl.d.ts
+++ b/src/lib/intl.d.ts
@@ -82,7 +82,7 @@ declare module Intl {
         second?: string;
         timeZoneName?: string;
         formatMatcher?: string;
-        hour12: boolean;
+        hour12?: boolean;
     }
 
     interface ResolvedDateTimeFormatOptions {


### PR DESCRIPTION
All formatting options to `Intl.DateTimeFormat#format` are optional.