### PR TITLE
Es6 export parsing

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8660,7 +8660,10 @@ module ts {
             // Grammar checking
             checkGrammarClassDeclarationHeritageClauses(node);
 
-            checkTypeNameIsReserved(node.name, Diagnostics.Class_name_cannot_be_0);
+            // TODO(shkamat): Fix this later for anonymous class declaration
+            if (node.name) {
+                checkTypeNameIsReserved(node.name, Diagnostics.Class_name_cannot_be_0);
+            }
             checkTypeParameters(node.typeParameters);
             checkCollisionWithCapturedThisVariable(node, node.name);
             checkCollisionWithRequireExportsInGeneratedCode(node, node.name);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -240,6 +240,7 @@ module ts {
         ExportAll,
         ExportClauseDeclaration,
         ExportClause,
+        DefaultAssignmentExpression,
 
         // Module references
         ExternalModuleReference,
@@ -302,8 +303,9 @@ module ts {
         Let =               0x00000800,  // Variable declaration
         Const =             0x00001000,  // Variable declaration
         OctalLiteral =      0x00002000,
+        Default =           0x00004000,  // default
 
-        Modifier = Export | Ambient | Public | Private | Protected | Static,
+        Modifier = Export | Ambient | Public | Private | Protected | Static | Default,
         AccessibilityModifier = Public | Private | Protected,
         BlockScoped = Let | Const
     }
@@ -913,6 +915,10 @@ module ts {
     export interface ExportClauseDeclaration extends Declaration, ModuleElement {
         exportClause: ExportClause;
         moduleSpecifier?: StringLiteralExpression;
+    }
+
+    export interface DefaultAssignmentExpression extends Statement, ModuleElement {
+        expression: Expression;
     }
 
     export interface ExportAssignment extends Statement, ModuleElement {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -237,6 +237,7 @@ module ts {
         NamespaceImport,
         NamedImports,
         ImportSpecifier,
+        ExportAll,
 
         // Module references
         ExternalModuleReference,
@@ -899,6 +900,10 @@ module ts {
     export interface ImportSpecifier extends Declaration {
         propertyName?: Identifier; // Property name to be imported from module
         name: Identifier; // element name to be imported in the scope
+    }
+
+    export interface ExportAll extends Declaration, ModuleElement {
+        moduleSpecifier: StringLiteralExpression;
     }
 
     export interface ExportAssignment extends Statement, ModuleElement {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -236,8 +236,10 @@ module ts {
         ImportClause,
         NamespaceImport,
         NamedImports,
-        ImportSpecifier,
+        ImportOrExportSpecifier,
         ExportAll,
+        ExportClauseDeclaration,
+        ExportClause,
 
         // Module references
         ExternalModuleReference,
@@ -894,16 +896,23 @@ module ts {
     }
 
     export interface NamedImports extends Node {
-        elements: NodeArray<ImportSpecifier>;
+        elements: NodeArray<ImportOrExportSpecifier>;
     }
 
-    export interface ImportSpecifier extends Declaration {
+    export interface ImportOrExportSpecifier extends Declaration {
         propertyName?: Identifier; // Property name to be imported from module
         name: Identifier; // element name to be imported in the scope
     }
 
     export interface ExportAll extends Declaration, ModuleElement {
         moduleSpecifier: StringLiteralExpression;
+    }
+
+    export type ExportClause = NamedImports;
+    
+    export interface ExportClauseDeclaration extends Declaration, ModuleElement {
+        exportClause: ExportClause;
+        moduleSpecifier?: StringLiteralExpression;
     }
 
     export interface ExportAssignment extends Statement, ModuleElement {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -286,6 +286,10 @@ module ts {
         return !!(getCombinedNodeFlags(node) & NodeFlags.Let);
     }
 
+    export function isDefault(node: Node): boolean {
+        return !!(node.flags & NodeFlags.Default);
+    }
+
     export function isPrologueDirective(node: Node): boolean {
         return node.kind === SyntaxKind.ExpressionStatement && (<ExpressionStatement>node).expression.kind === SyntaxKind.StringLiteral;
     }
@@ -838,6 +842,7 @@ module ts {
             case SyntaxKind.ExportKeyword:
             case SyntaxKind.DeclareKeyword:
             case SyntaxKind.ConstKeyword:
+            case SyntaxKind.DefaultKeyword:
                 return true;
         }
         return false;

--- a/tests/baselines/reference/es6ExportClause.js
+++ b/tests/baselines/reference/es6ExportClause.js
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/es6ExportClause.ts] ////
+
+//// [es6ExportClause_0.ts]
+
+export var a = 10;
+export var x = a;
+export var m = a;
+
+//// [es6ExportClause_1.ts]
+var a1 = 10;
+var x1 = a1;
+var m1 = a1;
+export { };
+export { a1 };
+export { a1 as b1 };
+export { x1, a1 as y1 };
+export { x1 as z1,  };
+export { m1,  };
+export { } from "es6ExportClause_0";
+export { a } from "es6ExportClause_0";
+export { a as b } from "es6ExportClause_0";
+export { x, a as y } from "es6ExportClause_0";
+export { x as z,  } from "es6ExportClause_0";
+export { m,  } from "es6ExportClause_0";
+
+//// [es6ExportClause_0.js]
+exports.a = 10;
+exports.x = exports.a;
+exports.m = exports.a;
+//// [es6ExportClause_1.js]
+var a1 = 10;
+var x1 = a1;
+var m1 = a1;

--- a/tests/baselines/reference/es6ExportClause.types
+++ b/tests/baselines/reference/es6ExportClause.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/es6ExportClause_0.ts ===
+
+export var a = 10;
+>a : number
+
+export var x = a;
+>x : number
+>a : number
+
+export var m = a;
+>m : number
+>a : number
+
+=== tests/cases/compiler/es6ExportClause_1.ts ===
+var a1 = 10;
+>a1 : number
+
+var x1 = a1;
+>x1 : number
+>a1 : number
+
+var m1 = a1;
+>m1 : number
+>a1 : number
+
+export { };
+export { a1 };
+export { a1 as b1 };
+export { x1, a1 as y1 };
+export { x1 as z1,  };
+export { m1,  };
+export { } from "es6ExportClause_0";
+export { a } from "es6ExportClause_0";
+export { a as b } from "es6ExportClause_0";
+export { x, a as y } from "es6ExportClause_0";
+export { x as z,  } from "es6ExportClause_0";
+export { m,  } from "es6ExportClause_0";

--- a/tests/baselines/reference/es6ExportClauseErrors.errors.txt
+++ b/tests/baselines/reference/es6ExportClauseErrors.errors.txt
@@ -1,0 +1,49 @@
+tests/cases/compiler/es6ExportClauseErrors.ts(2,17): error TS1141: String literal expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(3,10): error TS1003: Identifier expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(3,12): error TS1109: Expression expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(4,16): error TS1003: Identifier expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(4,18): error TS1109: Expression expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(5,10): error TS1003: Identifier expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(5,12): error TS2304: Cannot find name 'as'.
+tests/cases/compiler/es6ExportClauseErrors.ts(5,15): error TS1005: ';' expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(5,15): error TS2304: Cannot find name 'b'.
+tests/cases/compiler/es6ExportClauseErrors.ts(5,17): error TS1128: Declaration or statement expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(6,10): error TS1003: Identifier expected.
+tests/cases/compiler/es6ExportClauseErrors.ts(6,12): error TS2304: Cannot find name 'as'.
+tests/cases/compiler/es6ExportClauseErrors.ts(6,17): error TS1109: Expression expected.
+
+
+==== tests/cases/compiler/es6ExportClauseErrors.ts (13 errors) ====
+    
+    export { } from 10;
+                    ~~
+!!! error TS1141: String literal expected.
+    export { * };
+             ~
+!!! error TS1003: Identifier expected.
+               ~
+!!! error TS1109: Expression expected.
+    export { a1 as * };
+                   ~
+!!! error TS1003: Identifier expected.
+                     ~
+!!! error TS1109: Expression expected.
+    export { * as b };
+             ~
+!!! error TS1003: Identifier expected.
+               ~~
+!!! error TS2304: Cannot find name 'as'.
+                  ~
+!!! error TS1005: ';' expected.
+                  ~
+!!! error TS2304: Cannot find name 'b'.
+                    ~
+!!! error TS1128: Declaration or statement expected.
+    export { * as * };
+             ~
+!!! error TS1003: Identifier expected.
+               ~~
+!!! error TS2304: Cannot find name 'as'.
+                    ~
+!!! error TS1109: Expression expected.
+    

--- a/tests/baselines/reference/es6ExportClauseInEs5.js
+++ b/tests/baselines/reference/es6ExportClauseInEs5.js
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/es6ExportClauseInEs5.ts] ////
+
+//// [es6ExportClauseInEs5_0.ts]
+
+export var a = 10;
+export var x = a;
+export var m = a;
+
+//// [es6ExportClauseInEs5_1.ts]
+var a1 = 10;
+var x1 = a1;
+var m1 = a1;
+export { };
+export { a1 };
+export { a1 as b1 };
+export { x1, a1 as y1 };
+export { x1 as z1,  };
+export { m1,  };
+export { } from "es6ExportClauseInEs5_0";
+export { a } from "es6ExportClauseInEs5_0";
+export { a as b } from "es6ExportClauseInEs5_0";
+export { x, a as y } from "es6ExportClauseInEs5_0";
+export { x as z,  } from "es6ExportClauseInEs5_0";
+export { m,  } from "es6ExportClauseInEs5_0";
+
+//// [es6ExportClauseInEs5_0.js]
+exports.a = 10;
+exports.x = exports.a;
+exports.m = exports.a;
+//// [es6ExportClauseInEs5_1.js]
+var a1 = 10;
+var x1 = a1;
+var m1 = a1;

--- a/tests/baselines/reference/es6ExportClauseInEs5.types
+++ b/tests/baselines/reference/es6ExportClauseInEs5.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/es6ExportClauseInEs5_0.ts ===
+
+export var a = 10;
+>a : number
+
+export var x = a;
+>x : number
+>a : number
+
+export var m = a;
+>m : number
+>a : number
+
+=== tests/cases/compiler/es6ExportClauseInEs5_1.ts ===
+var a1 = 10;
+>a1 : number
+
+var x1 = a1;
+>x1 : number
+>a1 : number
+
+var m1 = a1;
+>m1 : number
+>a1 : number
+
+export { };
+export { a1 };
+export { a1 as b1 };
+export { x1, a1 as y1 };
+export { x1 as z1,  };
+export { m1,  };
+export { } from "es6ExportClauseInEs5_0";
+export { a } from "es6ExportClauseInEs5_0";
+export { a as b } from "es6ExportClauseInEs5_0";
+export { x, a as y } from "es6ExportClauseInEs5_0";
+export { x as z,  } from "es6ExportClauseInEs5_0";
+export { m,  } from "es6ExportClauseInEs5_0";

--- a/tests/baselines/reference/es6ExportDefaultAnonymousClassDeclaration.js
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousClassDeclaration.js
@@ -1,0 +1,44 @@
+//// [es6ExportDefaultAnonymousClassDeclaration.ts]
+
+export default class {
+    member = 10;
+}
+
+//// [es6ExportDefaultAnonymousClassDeclaration.js]
+var  = (function () {
+    function () {
+        this.member = 10;
+    }
+    return ;
+})();
+exports. = ;
+
+
+//// [es6ExportDefaultAnonymousClassDeclaration.d.ts]
+export declare class  {
+    member: number;
+}
+
+
+//// [DtsFileErrors]
+
+
+tests/cases/compiler/es6ExportDefaultAnonymousClassDeclaration.d.ts(1,1): error TS1128: Declaration or statement expected.
+tests/cases/compiler/es6ExportDefaultAnonymousClassDeclaration.d.ts(1,8): error TS2304: Cannot find name 'declare'.
+tests/cases/compiler/es6ExportDefaultAnonymousClassDeclaration.d.ts(1,16): error TS1005: ';' expected.
+tests/cases/compiler/es6ExportDefaultAnonymousClassDeclaration.d.ts(2,13): error TS2304: Cannot find name 'number'.
+
+
+==== tests/cases/compiler/es6ExportDefaultAnonymousClassDeclaration.d.ts (4 errors) ====
+    export declare class  {
+    ~~~~~~
+!!! error TS1128: Declaration or statement expected.
+           ~~~~~~~
+!!! error TS2304: Cannot find name 'declare'.
+                   ~~~~~
+!!! error TS1005: ';' expected.
+        member: number;
+                ~~~~~~
+!!! error TS2304: Cannot find name 'number'.
+    }
+    

--- a/tests/baselines/reference/es6ExportDefaultAnonymousClassDeclaration.types
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousClassDeclaration.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/es6ExportDefaultAnonymousClassDeclaration.ts ===
+
+export default class {
+    member = 10;
+>member : number
+}

--- a/tests/baselines/reference/es6ExportDefaultAnonymousClassDeclarationInEs5.js
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousClassDeclarationInEs5.js
@@ -1,0 +1,44 @@
+//// [es6ExportDefaultAnonymousClassDeclarationInEs5.ts]
+
+export default class {
+    member = 10;
+}
+
+//// [es6ExportDefaultAnonymousClassDeclarationInEs5.js]
+var  = (function () {
+    function () {
+        this.member = 10;
+    }
+    return ;
+})();
+exports. = ;
+
+
+//// [es6ExportDefaultAnonymousClassDeclarationInEs5.d.ts]
+export declare class  {
+    member: number;
+}
+
+
+//// [DtsFileErrors]
+
+
+tests/cases/compiler/es6ExportDefaultAnonymousClassDeclarationInEs5.d.ts(1,1): error TS1128: Declaration or statement expected.
+tests/cases/compiler/es6ExportDefaultAnonymousClassDeclarationInEs5.d.ts(1,8): error TS2304: Cannot find name 'declare'.
+tests/cases/compiler/es6ExportDefaultAnonymousClassDeclarationInEs5.d.ts(1,16): error TS1005: ';' expected.
+tests/cases/compiler/es6ExportDefaultAnonymousClassDeclarationInEs5.d.ts(2,13): error TS2304: Cannot find name 'number'.
+
+
+==== tests/cases/compiler/es6ExportDefaultAnonymousClassDeclarationInEs5.d.ts (4 errors) ====
+    export declare class  {
+    ~~~~~~
+!!! error TS1128: Declaration or statement expected.
+           ~~~~~~~
+!!! error TS2304: Cannot find name 'declare'.
+                   ~~~~~
+!!! error TS1005: ';' expected.
+        member: number;
+                ~~~~~~
+!!! error TS2304: Cannot find name 'number'.
+    }
+    

--- a/tests/baselines/reference/es6ExportDefaultAnonymousClassDeclarationInEs5.types
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousClassDeclarationInEs5.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/es6ExportDefaultAnonymousClassDeclarationInEs5.ts ===
+
+export default class {
+    member = 10;
+>member : number
+}

--- a/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclaration.js
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclaration.js
@@ -1,0 +1,26 @@
+//// [es6ExportDefaultAnonymousFunctionDeclaration.ts]
+
+export default function () {
+}
+
+//// [es6ExportDefaultAnonymousFunctionDeclaration.js]
+function () {
+}
+exports. = ;
+
+
+//// [es6ExportDefaultAnonymousFunctionDeclaration.d.ts]
+export declare function (): void;
+
+
+//// [DtsFileErrors]
+
+
+tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclaration.d.ts(1,25): error TS1003: Identifier expected.
+
+
+==== tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclaration.d.ts (1 errors) ====
+    export declare function (): void;
+                            ~
+!!! error TS1003: Identifier expected.
+    

--- a/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclaration.types
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclaration.types
@@ -1,0 +1,5 @@
+=== tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclaration.ts ===
+
+No type information for this code.export default function () {
+No type information for this code.}
+No type information for this code.

--- a/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclarationInEs5.js
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclarationInEs5.js
@@ -1,0 +1,26 @@
+//// [es6ExportDefaultAnonymousFunctionDeclarationInEs5.ts]
+
+export default function () {
+}
+
+//// [es6ExportDefaultAnonymousFunctionDeclarationInEs5.js]
+function () {
+}
+exports. = ;
+
+
+//// [es6ExportDefaultAnonymousFunctionDeclarationInEs5.d.ts]
+export declare function (): void;
+
+
+//// [DtsFileErrors]
+
+
+tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclarationInEs5.d.ts(1,25): error TS1003: Identifier expected.
+
+
+==== tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclarationInEs5.d.ts (1 errors) ====
+    export declare function (): void;
+                            ~
+!!! error TS1003: Identifier expected.
+    

--- a/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclarationInEs5.types
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclarationInEs5.types
@@ -1,0 +1,5 @@
+=== tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclarationInEs5.ts ===
+
+No type information for this code.export default function () {
+No type information for this code.}
+No type information for this code.

--- a/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclarationOverload.js
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclarationOverload.js
@@ -1,0 +1,15 @@
+//// [es6ExportDefaultAnonymousFunctionDeclarationOverload.ts]
+
+//export default function (a: string): string;
+//export default function (a: number): number;
+//export default function (a: any): any {
+//}
+
+//// [es6ExportDefaultAnonymousFunctionDeclarationOverload.js]
+//export default function (a: string): string;
+//export default function (a: number): number;
+//export default function (a: any): any {
+//} 
+
+
+//// [es6ExportDefaultAnonymousFunctionDeclarationOverload.d.ts]

--- a/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclarationOverload.types
+++ b/tests/baselines/reference/es6ExportDefaultAnonymousFunctionDeclarationOverload.types
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclarationOverload.ts ===
+
+No type information for this code.//export default function (a: string): string;
+No type information for this code.//export default function (a: number): number;
+No type information for this code.//export default function (a: any): any {
+No type information for this code.//}
+No type information for this code.

--- a/tests/baselines/reference/es6ExportDefaultAssignment.js
+++ b/tests/baselines/reference/es6ExportDefaultAssignment.js
@@ -1,0 +1,12 @@
+//// [es6ExportDefaultAssignment.ts]
+
+function b() {
+}
+export default b();
+
+//// [es6ExportDefaultAssignment.js]
+function b() {
+}
+
+
+//// [es6ExportDefaultAssignment.d.ts]

--- a/tests/baselines/reference/es6ExportDefaultAssignment.types
+++ b/tests/baselines/reference/es6ExportDefaultAssignment.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/es6ExportDefaultAssignment.ts ===
+
+function b() {
+>b : () => void
+}
+export default b();

--- a/tests/baselines/reference/es6ExportDefaultAssignmentInEs5.js
+++ b/tests/baselines/reference/es6ExportDefaultAssignmentInEs5.js
@@ -1,0 +1,12 @@
+//// [es6ExportDefaultAssignmentInEs5.ts]
+
+function b() {
+}
+export default b();
+
+//// [es6ExportDefaultAssignmentInEs5.js]
+function b() {
+}
+
+
+//// [es6ExportDefaultAssignmentInEs5.d.ts]

--- a/tests/baselines/reference/es6ExportDefaultAssignmentInEs5.types
+++ b/tests/baselines/reference/es6ExportDefaultAssignmentInEs5.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/es6ExportDefaultAssignmentInEs5.ts ===
+
+function b() {
+>b : () => void
+}
+export default b();

--- a/tests/baselines/reference/es6ExportDefaultAssignmentWithIn.js
+++ b/tests/baselines/reference/es6ExportDefaultAssignmentWithIn.js
@@ -1,0 +1,18 @@
+//// [es6ExportDefaultAssignmentWithIn.ts]
+
+function b() {
+    return {
+        a: 10
+    };
+}
+export default a in b();
+
+//// [es6ExportDefaultAssignmentWithIn.js]
+function b() {
+    return {
+        a: 10
+    };
+}
+
+
+//// [es6ExportDefaultAssignmentWithIn.d.ts]

--- a/tests/baselines/reference/es6ExportDefaultAssignmentWithIn.types
+++ b/tests/baselines/reference/es6ExportDefaultAssignmentWithIn.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/es6ExportDefaultAssignmentWithIn.ts ===
+
+function b() {
+>b : () => { a: number; }
+
+    return {
+>{        a: 10    } : { a: number; }
+
+        a: 10
+>a : number
+
+    };
+}
+export default a in b();

--- a/tests/baselines/reference/es6ExportDefaultClassDeclaration.js
+++ b/tests/baselines/reference/es6ExportDefaultClassDeclaration.js
@@ -1,0 +1,20 @@
+//// [es6ExportDefaultClassDeclaration.ts]
+
+export default class c {
+    member = 10;
+}
+
+//// [es6ExportDefaultClassDeclaration.js]
+var c = (function () {
+    function c() {
+        this.member = 10;
+    }
+    return c;
+})();
+exports.c = c;
+
+
+//// [es6ExportDefaultClassDeclaration.d.ts]
+export declare class c {
+    member: number;
+}

--- a/tests/baselines/reference/es6ExportDefaultClassDeclaration.types
+++ b/tests/baselines/reference/es6ExportDefaultClassDeclaration.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/es6ExportDefaultClassDeclaration.ts ===
+
+export default class c {
+>c : c
+
+    member = 10;
+>member : number
+}

--- a/tests/baselines/reference/es6ExportDefaultClassDeclarationInEs5.js
+++ b/tests/baselines/reference/es6ExportDefaultClassDeclarationInEs5.js
@@ -1,0 +1,20 @@
+//// [es6ExportDefaultClassDeclarationInEs5.ts]
+
+export default class c {
+    member = 10;
+}
+
+//// [es6ExportDefaultClassDeclarationInEs5.js]
+var c = (function () {
+    function c() {
+        this.member = 10;
+    }
+    return c;
+})();
+exports.c = c;
+
+
+//// [es6ExportDefaultClassDeclarationInEs5.d.ts]
+export declare class c {
+    member: number;
+}

--- a/tests/baselines/reference/es6ExportDefaultClassDeclarationInEs5.types
+++ b/tests/baselines/reference/es6ExportDefaultClassDeclarationInEs5.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/es6ExportDefaultClassDeclarationInEs5.ts ===
+
+export default class c {
+>c : c
+
+    member = 10;
+>member : number
+}

--- a/tests/baselines/reference/es6ExportDefaultFunctionDeclaration.js
+++ b/tests/baselines/reference/es6ExportDefaultFunctionDeclaration.js
@@ -1,0 +1,13 @@
+//// [es6ExportDefaultFunctionDeclaration.ts]
+
+export default function b() {
+}
+
+//// [es6ExportDefaultFunctionDeclaration.js]
+function b() {
+}
+exports.b = b;
+
+
+//// [es6ExportDefaultFunctionDeclaration.d.ts]
+export declare function b(): void;

--- a/tests/baselines/reference/es6ExportDefaultFunctionDeclaration.types
+++ b/tests/baselines/reference/es6ExportDefaultFunctionDeclaration.types
@@ -1,0 +1,5 @@
+=== tests/cases/compiler/es6ExportDefaultFunctionDeclaration.ts ===
+
+export default function b() {
+>b : () => void
+}

--- a/tests/baselines/reference/es6ExportDefaultFunctionDeclarationInEs5.js
+++ b/tests/baselines/reference/es6ExportDefaultFunctionDeclarationInEs5.js
@@ -1,0 +1,13 @@
+//// [es6ExportDefaultFunctionDeclarationInEs5.ts]
+
+export default function b() {
+}
+
+//// [es6ExportDefaultFunctionDeclarationInEs5.js]
+function b() {
+}
+exports.b = b;
+
+
+//// [es6ExportDefaultFunctionDeclarationInEs5.d.ts]
+export declare function b(): void;

--- a/tests/baselines/reference/es6ExportDefaultFunctionDeclarationInEs5.types
+++ b/tests/baselines/reference/es6ExportDefaultFunctionDeclarationInEs5.types
@@ -1,0 +1,5 @@
+=== tests/cases/compiler/es6ExportDefaultFunctionDeclarationInEs5.ts ===
+
+export default function b() {
+>b : () => void
+}

--- a/tests/baselines/reference/es6ExportDefaultFunctionDeclarationOverload.js
+++ b/tests/baselines/reference/es6ExportDefaultFunctionDeclarationOverload.js
@@ -1,0 +1,15 @@
+//// [es6ExportDefaultFunctionDeclarationOverload.ts]
+export default function b(a: string): string;
+export default function b(a: number): number;
+export default function b(a: any): any {
+}
+
+//// [es6ExportDefaultFunctionDeclarationOverload.js]
+function b(a) {
+}
+exports.b = b;
+
+
+//// [es6ExportDefaultFunctionDeclarationOverload.d.ts]
+export declare function b(a: string): string;
+export declare function b(a: number): number;

--- a/tests/baselines/reference/es6ExportDefaultFunctionDeclarationOverload.types
+++ b/tests/baselines/reference/es6ExportDefaultFunctionDeclarationOverload.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/es6ExportDefaultFunctionDeclarationOverload.ts ===
+export default function b(a: string): string;
+>b : { (a: string): string; (a: number): number; }
+>a : string
+
+export default function b(a: number): number;
+>b : { (a: string): string; (a: number): number; }
+>a : number
+
+export default function b(a: any): any {
+>b : { (a: string): string; (a: number): number; }
+>a : any
+}

--- a/tests/baselines/reference/es6StarExports.js
+++ b/tests/baselines/reference/es6StarExports.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/es6StarExports.ts] ////
+
+//// [es6StarExports_0.ts]
+
+export var a = 10;
+
+//// [es6StarExports_1.ts]
+export * from "es6StarExports_0";
+
+//// [es6StarExports_0.js]
+exports.a = 10;
+//// [es6StarExports_1.js]

--- a/tests/baselines/reference/es6StarExports.types
+++ b/tests/baselines/reference/es6StarExports.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/es6StarExports_0.ts ===
+
+export var a = 10;
+>a : number
+
+=== tests/cases/compiler/es6StarExports_1.ts ===
+export * from "es6StarExports_0";
+No type information for this code.

--- a/tests/baselines/reference/es6StarExportsErrors.errors.txt
+++ b/tests/baselines/reference/es6StarExportsErrors.errors.txt
@@ -1,0 +1,8 @@
+tests/cases/compiler/es6StarExportsErrors.ts(2,15): error TS1141: String literal expected.
+
+
+==== tests/cases/compiler/es6StarExportsErrors.ts (1 errors) ====
+    
+    export * from 10;
+                  ~~
+!!! error TS1141: String literal expected.

--- a/tests/baselines/reference/es6StarExportsInEs5.js
+++ b/tests/baselines/reference/es6StarExportsInEs5.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/es6StarExportsInEs5.ts] ////
+
+//// [es6StarExportsInEs5_0.ts]
+
+export var a = 10;
+
+//// [es6StarExportsInEs5_1.ts]
+export * from "es6StarExportsInEs5_0";
+
+//// [es6StarExportsInEs5_0.js]
+exports.a = 10;
+//// [es6StarExportsInEs5_1.js]

--- a/tests/baselines/reference/es6StarExportsInEs5.types
+++ b/tests/baselines/reference/es6StarExportsInEs5.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/es6StarExportsInEs5_0.ts ===
+
+export var a = 10;
+>a : number
+
+=== tests/cases/compiler/es6StarExportsInEs5_1.ts ===
+export * from "es6StarExportsInEs5_0";
+No type information for this code.

--- a/tests/cases/compiler/es6ExportClause.ts
+++ b/tests/cases/compiler/es6ExportClause.ts
@@ -1,0 +1,24 @@
+// @target: es6
+// @module: commonjs
+
+// @filename: es6ExportClause_0.ts
+export var a = 10;
+export var x = a;
+export var m = a;
+
+// @filename: es6ExportClause_1.ts
+var a1 = 10;
+var x1 = a1;
+var m1 = a1;
+export { };
+export { a1 };
+export { a1 as b1 };
+export { x1, a1 as y1 };
+export { x1 as z1,  };
+export { m1,  };
+export { } from "es6ExportClause_0";
+export { a } from "es6ExportClause_0";
+export { a as b } from "es6ExportClause_0";
+export { x, a as y } from "es6ExportClause_0";
+export { x as z,  } from "es6ExportClause_0";
+export { m,  } from "es6ExportClause_0";

--- a/tests/cases/compiler/es6ExportClauseErrors.ts
+++ b/tests/cases/compiler/es6ExportClauseErrors.ts
@@ -1,0 +1,8 @@
+// @target: es6
+// @module: commonjs
+
+export { } from 10;
+export { * };
+export { a1 as * };
+export { * as b };
+export { * as * };

--- a/tests/cases/compiler/es6ExportClauseInEs5.ts
+++ b/tests/cases/compiler/es6ExportClauseInEs5.ts
@@ -1,0 +1,24 @@
+// @target: es5
+// @module: commonjs
+
+// @filename: es6ExportClauseInEs5_0.ts
+export var a = 10;
+export var x = a;
+export var m = a;
+
+// @filename: es6ExportClauseInEs5_1.ts
+var a1 = 10;
+var x1 = a1;
+var m1 = a1;
+export { };
+export { a1 };
+export { a1 as b1 };
+export { x1, a1 as y1 };
+export { x1 as z1,  };
+export { m1,  };
+export { } from "es6ExportClauseInEs5_0";
+export { a } from "es6ExportClauseInEs5_0";
+export { a as b } from "es6ExportClauseInEs5_0";
+export { x, a as y } from "es6ExportClauseInEs5_0";
+export { x as z,  } from "es6ExportClauseInEs5_0";
+export { m,  } from "es6ExportClauseInEs5_0";

--- a/tests/cases/compiler/es6ExportDefaultAnonymousClassDeclaration.ts
+++ b/tests/cases/compiler/es6ExportDefaultAnonymousClassDeclaration.ts
@@ -1,0 +1,7 @@
+// @target: es6
+// @module: commonjs
+// @declaration: true
+
+export default class {
+    member = 10;
+}

--- a/tests/cases/compiler/es6ExportDefaultAnonymousClassDeclarationInEs5.ts
+++ b/tests/cases/compiler/es6ExportDefaultAnonymousClassDeclarationInEs5.ts
@@ -1,0 +1,7 @@
+// @target: es5
+// @module: commonjs
+// @declaration: true
+
+export default class {
+    member = 10;
+}

--- a/tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclaration.ts
+++ b/tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclaration.ts
@@ -1,0 +1,6 @@
+// @target: es6
+// @module: commonjs
+// @declaration: true
+
+export default function () {
+}

--- a/tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclarationInEs5.ts
+++ b/tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclarationInEs5.ts
@@ -1,0 +1,6 @@
+// @target: es5
+// @module: commonjs
+// @declaration: true
+
+export default function () {
+}

--- a/tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclarationOverload.ts
+++ b/tests/cases/compiler/es6ExportDefaultAnonymousFunctionDeclarationOverload.ts
@@ -1,0 +1,8 @@
+// @target: es6
+// @module: commonjs
+// @declaration: true
+
+//export default function (a: string): string;
+//export default function (a: number): number;
+//export default function (a: any): any {
+//}

--- a/tests/cases/compiler/es6ExportDefaultAssignment.ts
+++ b/tests/cases/compiler/es6ExportDefaultAssignment.ts
@@ -1,0 +1,7 @@
+// @target: es6
+// @module: commonjs
+// @declaration: true
+
+function b() {
+}
+export default b();

--- a/tests/cases/compiler/es6ExportDefaultAssignmentInEs5.ts
+++ b/tests/cases/compiler/es6ExportDefaultAssignmentInEs5.ts
@@ -1,0 +1,7 @@
+// @target: es5
+// @module: commonjs
+// @declaration: true
+
+function b() {
+}
+export default b();

--- a/tests/cases/compiler/es6ExportDefaultAssignmentWithIn.ts
+++ b/tests/cases/compiler/es6ExportDefaultAssignmentWithIn.ts
@@ -1,0 +1,10 @@
+// @target: es6
+// @module: commonjs
+// @declaration: true
+
+function b() {
+    return {
+        a: 10
+    };
+}
+export default a in b();

--- a/tests/cases/compiler/es6ExportDefaultClassDeclaration.ts
+++ b/tests/cases/compiler/es6ExportDefaultClassDeclaration.ts
@@ -1,0 +1,7 @@
+// @target: es6
+// @module: commonjs
+// @declaration: true
+
+export default class c {
+    member = 10;
+}

--- a/tests/cases/compiler/es6ExportDefaultClassDeclarationInEs5.ts
+++ b/tests/cases/compiler/es6ExportDefaultClassDeclarationInEs5.ts
@@ -1,0 +1,7 @@
+// @target: es5
+// @module: commonjs
+// @declaration: true
+
+export default class c {
+    member = 10;
+}

--- a/tests/cases/compiler/es6ExportDefaultFunctionDeclaration.ts
+++ b/tests/cases/compiler/es6ExportDefaultFunctionDeclaration.ts
@@ -1,0 +1,6 @@
+// @target: es6
+// @module: commonjs
+// @declaration: true
+
+export default function b() {
+}

--- a/tests/cases/compiler/es6ExportDefaultFunctionDeclarationInEs5.ts
+++ b/tests/cases/compiler/es6ExportDefaultFunctionDeclarationInEs5.ts
@@ -1,0 +1,6 @@
+// @target: es5
+// @module: commonjs
+// @declaration: true
+
+export default function b() {
+}

--- a/tests/cases/compiler/es6ExportDefaultFunctionDeclarationOverload.ts
+++ b/tests/cases/compiler/es6ExportDefaultFunctionDeclarationOverload.ts
@@ -1,0 +1,7 @@
+// @target: es6
+// @module: commonjs
+// @declaration: true
+export default function b(a: string): string;
+export default function b(a: number): number;
+export default function b(a: any): any {
+}

--- a/tests/cases/compiler/es6StarExports.ts
+++ b/tests/cases/compiler/es6StarExports.ts
@@ -1,0 +1,8 @@
+// @target: es6
+// @module: commonjs
+
+// @filename: es6StarExports_0.ts
+export var a = 10;
+
+// @filename: es6StarExports_1.ts
+export * from "es6StarExports_0";

--- a/tests/cases/compiler/es6StarExportsErrors.ts
+++ b/tests/cases/compiler/es6StarExportsErrors.ts
@@ -1,0 +1,4 @@
+// @target: es6
+// @module: commonjs
+
+export * from 10;

--- a/tests/cases/compiler/es6StarExportsInEs5.ts
+++ b/tests/cases/compiler/es6StarExportsInEs5.ts
@@ -1,0 +1,8 @@
+// @target: es5
+// @module: commonjs
+
+// @filename: es6StarExportsInEs5_0.ts
+export var a = 10;
+
+// @filename: es6StarExportsInEs5_1.ts
+export * from "es6StarExportsInEs5_0";


### PR DESCRIPTION
Parsing of syntax for 
export * from "mod"
export {a.. } from "mod"
export { a...}
export default function/class syntax
export default Assignment

TODO: decide on ambient export default syntax and parse it correctly
Should we allow default anonymous function overloads