### PR TITLE
Make references appearing after non-trivia trigger an error

### DIFF
--- a/src/compiler/diagnosticInformationMap.generated.ts
+++ b/src/compiler/diagnosticInformationMap.generated.ts
@@ -455,5 +455,6 @@ module ts {
         yield_expressions_are_not_currently_supported: { code: 9000, category: DiagnosticCategory.Error, key: "'yield' expressions are not currently supported." },
         Generators_are_not_currently_supported: { code: 9001, category: DiagnosticCategory.Error, key: "Generators are not currently supported." },
         The_arguments_object_cannot_be_referenced_in_an_arrow_function_Consider_using_a_standard_function_expression: { code: 9002, category: DiagnosticCategory.Error, key: "The 'arguments' object cannot be referenced in an arrow function. Consider using a standard function expression." },
+        References_must_appear_before_any_other_code: { code: 9003, category: DiagnosticCategory.Error, key: "References must appear before any other code." },
     };
 }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1813,5 +1813,9 @@
     "The 'arguments' object cannot be referenced in an arrow function. Consider using a standard function expression.": {
         "category": "Error",
         "code": 9002
+    },
+    "References must appear before any other code.": {
+      "category": "Error",
+      "code": 9003
     }
 }


### PR DESCRIPTION
This implements the error as discussed in #1920.

I know I have not yet submitted a CLA. I have sent it to my employer asking them to sign it and I am waiting on it back. I know this will not be merged until a CLA is submitted, and I will submit it ASAP. 