### PR TITLE
disallow let to be used as name in let\const in ES6

### DIFF
--- a/src/compiler/diagnosticInformationMap.generated.ts
+++ b/src/compiler/diagnosticInformationMap.generated.ts
@@ -380,6 +380,7 @@ module ts {
         const_enum_member_initializer_was_evaluated_to_a_non_finite_value: { code: 4086, category: DiagnosticCategory.Error, key: "'const' enum member initializer was evaluated to a non-finite value." },
         const_enum_member_initializer_was_evaluated_to_disallowed_value_NaN: { code: 4087, category: DiagnosticCategory.Error, key: "'const' enum member initializer was evaluated to disallowed value 'NaN'." },
         Property_0_does_not_exist_on_const_enum_1: { code: 4088, category: DiagnosticCategory.Error, key: "Property '{0}' does not exist on 'const' enum '{1}'." },
+        let_is_not_allowed_to_be_used_as_a_name_in_let_or_const_declarations: { code: 4089, category: DiagnosticCategory.Error, key: "'let' is not allowed to be used as a name in 'let' or 'const' declarations." },
         The_current_host_does_not_support_the_0_option: { code: 5001, category: DiagnosticCategory.Error, key: "The current host does not support the '{0}' option." },
         Cannot_find_the_common_subdirectory_path_for_the_input_files: { code: 5009, category: DiagnosticCategory.Error, key: "Cannot find the common subdirectory path for the input files." },
         Cannot_read_file_0_Colon_1: { code: 5012, category: DiagnosticCategory.Error, key: "Cannot read file '{0}': {1}" },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1513,6 +1513,10 @@
         "category": "Error",
         "code": 4088
     },
+    "'let' is not allowed to be used as a name in 'let' or 'const' declarations.": {
+        "category": "Error",
+        "code": 4089
+    },
     "The current host does not support the '{0}' option.": {
         "category": "Error",
         "code": 5001

--- a/tests/baselines/reference/letInLetOrConstDeclarations.errors.txt
+++ b/tests/baselines/reference/letInLetOrConstDeclarations.errors.txt
@@ -1,0 +1,23 @@
+tests/cases/compiler/letInLetOrConstDeclarations.ts(2,9): error TS4089: 'let' is not allowed to be used as a name in 'let' or 'const' declarations.
+tests/cases/compiler/letInLetOrConstDeclarations.ts(3,14): error TS4089: 'let' is not allowed to be used as a name in 'let' or 'const' declarations.
+tests/cases/compiler/letInLetOrConstDeclarations.ts(6,11): error TS4089: 'let' is not allowed to be used as a name in 'let' or 'const' declarations.
+
+
+==== tests/cases/compiler/letInLetOrConstDeclarations.ts (3 errors) ====
+    {
+        let let = 1; // should error
+            ~~~
+!!! error TS4089: 'let' is not allowed to be used as a name in 'let' or 'const' declarations.
+        for (let let in []) { } // should error
+                 ~~~
+!!! error TS4089: 'let' is not allowed to be used as a name in 'let' or 'const' declarations.
+    }
+    {
+        const let = 1; // should error
+              ~~~
+!!! error TS4089: 'let' is not allowed to be used as a name in 'let' or 'const' declarations.
+    }
+    {
+        function let() { // should be ok
+        }
+    }

--- a/tests/baselines/reference/letInLetOrConstDeclarations.js
+++ b/tests/baselines/reference/letInLetOrConstDeclarations.js
@@ -1,0 +1,25 @@
+//// [letInLetOrConstDeclarations.ts]
+{
+    let let = 1; // should error
+    for (let let in []) { } // should error
+}
+{
+    const let = 1; // should error
+}
+{
+    function let() { // should be ok
+    }
+}
+
+//// [letInLetOrConstDeclarations.js]
+{
+    let let = 1; // should error
+    for (let let in []) { } // should error
+}
+{
+    const let = 1; // should error
+}
+{
+    function let() {
+    }
+}

--- a/tests/cases/compiler/letInLetOrConstDeclarations.ts
+++ b/tests/cases/compiler/letInLetOrConstDeclarations.ts
@@ -1,0 +1,12 @@
+// @target: es6
+{
+    let let = 1; // should error
+    for (let let in []) { } // should error
+}
+{
+    const let = 1; // should error
+}
+{
+    function let() { // should be ok
+    }
+}


### PR DESCRIPTION
per ES6 spec. 
```
LexicalDeclaration : LetOrConst BindingList ;

It is a Syntax Error if the BoundNames of BindingList contains "let".

...

It is a Syntax Error if the BoundNames of ForDeclaration contains "let".
```
Fixes #1727 