### PR TITLE
Fix type definition of `CustomEvent` constructor

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -6840,13 +6840,17 @@ declare var CSSImportRule: {
     new(): CSSImportRule;
 }
 
+interface CustomEventInit extends EventInit {
+    detail?: any;
+}
+
 interface CustomEvent extends Event {
     detail: any;
     initCustomEvent(typeArg: string, canBubbleArg: boolean, cancelableArg: boolean, detailArg: any): void;
 }
 declare var CustomEvent: {
     prototype: CustomEvent;
-    new(): CustomEvent;
+    new(type: string, eventInitDict?: CustomEventInit): CustomEvent;
 }
 
 interface HTMLBaseFontElement extends HTMLElement, DOML2DeprecatedColorProperty {
@@ -7320,6 +7324,11 @@ interface SVGUseElement extends SVGElement, SVGStylable, SVGTransformable, SVGLa
 declare var SVGUseElement: {
     prototype: SVGUseElement;
     new(): SVGUseElement;
+}
+
+interface EventInit {
+    bubbles?: boolean;
+    cancelable?: boolean;
 }
 
 interface Event {


### PR DESCRIPTION
Like #1837, I think CustomEvent constructor needs parameters.
The followings are links I checked.

https://dom.spec.whatwg.org/#interface-customevent
https://developer.mozilla.org/en/docs/Web/API/CustomEvent

http://html5index.org/DOM%20-%20EventInit.html
http://html5index.org/DOM%20-%20CustomEventInit.html