### PR TITLE
Add a new project root option (fixes #1513).

### DIFF
--- a/bin/typescript.d.ts
+++ b/bin/typescript.d.ts
@@ -1134,6 +1134,7 @@ declare module "typescript" {
         outDir?: string;
         preserveConstEnums?: boolean;
         project?: string;
+        projectRoot?: string;
         removeComments?: boolean;
         sourceMap?: boolean;
         sourceRoot?: string;

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -159,7 +159,15 @@ module ts {
             shortName: "w",
             type: "boolean",
             description: Diagnostics.Watch_input_files,
-        }
+        },
+        {
+            name: "projectRoot",
+            type: "string",
+            isFilePath: true,
+            description: Diagnostics.Specifies_the_directory_where_the_project_root_is_Paths_to_source_map_sources_will_appear_relative_to_this_directory,
+            paramType: Diagnostics.DIRECTORY,
+        },
+
     ];
     
     export function parseCommandLine(commandLine: string[]): ParsedCommandLine {

--- a/src/compiler/diagnosticInformationMap.generated.ts
+++ b/src/compiler/diagnosticInformationMap.generated.ts
@@ -436,6 +436,7 @@ module ts {
         File_0_must_have_extension_ts_or_d_ts: { code: 6054, category: DiagnosticCategory.Error, key: "File '{0}' must have extension '.ts' or '.d.ts'." },
         Suppress_noImplicitAny_errors_for_indexing_objects_lacking_index_signatures: { code: 6055, category: DiagnosticCategory.Message, key: "Suppress noImplicitAny errors for indexing objects lacking index signatures." },
         Do_not_emit_declarations_for_code_that_has_an_internal_annotation: { code: 6056, category: DiagnosticCategory.Message, key: "Do not emit declarations for code that has an '@internal' annotation." },
+        Specifies_the_directory_where_the_project_root_is_Paths_to_source_map_sources_will_appear_relative_to_this_directory: { code: 6057, category: DiagnosticCategory.Message, key: "Specifies the directory where the project root is. Paths to source map sources will appear relative to this directory." },
         Variable_0_implicitly_has_an_1_type: { code: 7005, category: DiagnosticCategory.Error, key: "Variable '{0}' implicitly has an '{1}' type." },
         Parameter_0_implicitly_has_an_1_type: { code: 7006, category: DiagnosticCategory.Error, key: "Parameter '{0}' implicitly has an '{1}' type." },
         Member_0_implicitly_has_an_1_type: { code: 7008, category: DiagnosticCategory.Error, key: "Member '{0}' implicitly has an '{1}' type." },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1737,6 +1737,10 @@
         "category": "Message",
         "code": 6056
     },
+    "Specifies the directory where the project root is. Paths to source map sources will appear relative to this directory.": {
+        "category": "Message",
+        "code": 6057
+    },
 
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1784,9 +1784,11 @@ module ts {
 
                 function recordNewSourceFileStart(node: SourceFile) {
                     // Add the file to tsFilePaths
-                    // If sourceroot option: Use the relative path corresponding to the common directory path 
-                    // otherwise source locations relative to map file location
-                    var sourcesDirectoryPath = compilerOptions.sourceRoot ? host.getCommonSourceDirectory() : sourceMapDir;
+                    // If sourceroot option: use the relative path corresponding to the project root (if specified) or the common directory path 
+                    // Otherwise source locations relative to map file location
+                    var sourcesDirectoryPath = compilerOptions.sourceRoot
+                        ? compilerOptions.projectRoot || host.getCommonSourceDirectory()
+                        : sourceMapDir;
 
                     sourceMapData.sourceMapSources.push(getRelativePathToDirectoryOrUrl(sourcesDirectoryPath,
                         node.fileName,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1474,6 +1474,7 @@ module ts {
         outDir?: string;
         preserveConstEnums?: boolean;
         project?: string;
+        projectRoot?: string;
         removeComments?: boolean;
         sourceMap?: boolean;
         sourceRoot?: string;


### PR DESCRIPTION
When generating source maps, if the sourceRoot option is specified and the
projectRoot is specified, then the filenames that appear in the "sources" field
of the source map are relative to the projectRoot.