### PR TITLE
Make 'syntacticClassifierAbsent' non-optional.

### DIFF
--- a/tests/cases/unittests/services/colorization.ts
+++ b/tests/cases/unittests/services/colorization.ts
@@ -43,7 +43,7 @@ describe('Colorization', function () {
     }
 
     function testLexicalClassification(text: string, initialEndOfLineState: ts.EndOfLineState, ...expectedEntries: ClassificationEntry[]): void {
-        var result = classifier.getClassificationsForLine(text, initialEndOfLineState);
+        var result = classifier.getClassificationsForLine(text, initialEndOfLineState, /*syntacticClassifierAbsent*/ false);
 
         for (var i = 0, n = expectedEntries.length; i < n; i++) {
             var expectedEntry = expectedEntries[i];


### PR DESCRIPTION
The parameter was already made non-optional in `master`, but this just updates its use within our unit tests.

We'll need to update the managed side in light of this.