### PR TITLE
Emit arrow functions with expression bodies 'as is' when targetting ES6 ...

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -3883,6 +3883,17 @@ module ts {
             }
 
             function emitExpressionFunctionBody(node: FunctionLikeDeclaration, body: Expression) {
+                if (languageVersion < ScriptTarget.ES6) {
+                    emitDownLevelExpressionFunctionBody(node, body);
+                    return;
+                }
+
+                // For es6 and higher we can emit the expression as is.
+                write(" ");
+                emit(body);
+            }
+
+            function emitDownLevelExpressionFunctionBody(node: FunctionLikeDeclaration, body: Expression) {
                 write(" {");
                 scopeEmitStart(node);
 

--- a/tests/baselines/reference/computedPropertyNamesContextualType1_ES6.js
+++ b/tests/baselines/reference/computedPropertyNamesContextualType1_ES6.js
@@ -12,5 +12,5 @@ var o: I = {
 //// [computedPropertyNamesContextualType1_ES6.js]
 var o = {
     ["" + 0](y) { return y.length; },
-    ["" + 1]: y => { return y.length; }
+    ["" + 1]: y => y.length
 };

--- a/tests/baselines/reference/computedPropertyNamesContextualType2_ES6.js
+++ b/tests/baselines/reference/computedPropertyNamesContextualType2_ES6.js
@@ -12,5 +12,5 @@ var o: I = {
 //// [computedPropertyNamesContextualType2_ES6.js]
 var o = {
     [+"foo"](y) { return y.length; },
-    [+"bar"]: y => { return y.length; }
+    [+"bar"]: y => y.length
 };

--- a/tests/baselines/reference/computedPropertyNamesContextualType3_ES6.js
+++ b/tests/baselines/reference/computedPropertyNamesContextualType3_ES6.js
@@ -11,5 +11,5 @@ var o: I = {
 //// [computedPropertyNamesContextualType3_ES6.js]
 var o = {
     [+"foo"](y) { return y.length; },
-    [+"bar"]: y => { return y.length; }
+    [+"bar"]: y => y.length
 };

--- a/tests/baselines/reference/emitArrowFunctionES6.js
+++ b/tests/baselines/reference/emitArrowFunctionES6.js
@@ -14,5 +14,5 @@ var f2 = (x, y) => { };
 var f3 = (x, y, ...rest) => { };
 var f4 = (x, y, z = 10) => { };
 function foo(func) { }
-foo(() => { return true; });
+foo(() => true);
 foo(() => { return false; });

--- a/tests/baselines/reference/parenthesizedContexualTyping3.js
+++ b/tests/baselines/reference/parenthesizedContexualTyping3.js
@@ -25,11 +25,11 @@ var h = tempFun `${ (x => x) } ${ (((x => x))) } ${ undefined }`
 function tempFun(tempStrs, g, x) {
     return g(x);
 }
-var a = tempFun `${x => { return x; }}  ${10}`;
-var b = tempFun `${(x => { return x; })}  ${10}`;
-var c = tempFun `${((x => { return x; }))} ${10}`;
-var d = tempFun `${x => { return x; }} ${x => { return x; }} ${10}`;
-var e = tempFun `${x => { return x; }} ${(x => { return x; })} ${10}`;
-var f = tempFun `${x => { return x; }} ${((x => { return x; }))} ${10}`;
-var g = tempFun `${(x => { return x; })} ${(((x => { return x; })))} ${10}`;
-var h = tempFun `${(x => { return x; })} ${(((x => { return x; })))} ${undefined}`;
+var a = tempFun `${x => x}  ${10}`;
+var b = tempFun `${(x => x)}  ${10}`;
+var c = tempFun `${((x => x))} ${10}`;
+var d = tempFun `${x => x} ${x => x} ${10}`;
+var e = tempFun `${x => x} ${(x => x)} ${10}`;
+var f = tempFun `${x => x} ${((x => x))} ${10}`;
+var g = tempFun `${(x => x)} ${(((x => x)))} ${10}`;
+var h = tempFun `${(x => x)} ${(((x => x)))} ${undefined}`;

--- a/tests/baselines/reference/symbolProperty20.js
+++ b/tests/baselines/reference/symbolProperty20.js
@@ -11,6 +11,6 @@ var i: I = {
 
 //// [symbolProperty20.js]
 var i = {
-    [Symbol.iterator]: s => { return s; },
+    [Symbol.iterator]: s => s,
     [Symbol.toStringTag](n) { return n; }
 };

--- a/tests/baselines/reference/symbolProperty22.js
+++ b/tests/baselines/reference/symbolProperty22.js
@@ -8,4 +8,4 @@ declare function foo<T, U>(p1: T, p2: I<T, U>): U;
 foo("", { [Symbol.unscopables]: s => s.length });
 
 //// [symbolProperty22.js]
-foo("", { [Symbol.unscopables]: s => { return s.length; } });
+foo("", { [Symbol.unscopables]: s => s.length });

--- a/tests/baselines/reference/taggedTemplateStringsTypeArgumentInferenceES6.js
+++ b/tests/baselines/reference/taggedTemplateStringsTypeArgumentInferenceES6.js
@@ -106,34 +106,34 @@ function someGenerics1b(n, m) { }
 someGenerics1b `${3}`;
 // Generic tag with argument of function type whose parameter is of type parameter type
 function someGenerics2a(strs, n) { }
-someGenerics2a `${(n) => { return n; }}`;
+someGenerics2a `${(n) => n}`;
 function someGenerics2b(strs, n) { }
-someGenerics2b `${(n, x) => { return n; }}`;
+someGenerics2b `${(n, x) => n}`;
 // Generic tag with argument of function type whose parameter is not of type parameter type but body/return type uses type parameter
 function someGenerics3(strs, producer) { }
-someGenerics3 `${() => { return ''; }}`;
-someGenerics3 `${() => { return undefined; }}`;
-someGenerics3 `${() => { return 3; }}`;
+someGenerics3 `${() => ''}`;
+someGenerics3 `${() => undefined}`;
+someGenerics3 `${() => 3}`;
 // 2 parameter generic tag with argument 1 of type parameter type and argument 2 of function type whose parameter is of type parameter type
 function someGenerics4(strs, n, f) { }
-someGenerics4 `${4}${() => { return null; }}`;
-someGenerics4 `${''}${() => { return 3; }}`;
+someGenerics4 `${4}${() => null}`;
+someGenerics4 `${''}${() => 3}`;
 someGenerics4 `${null}${null}`;
 // 2 parameter generic tag with argument 2 of type parameter type and argument 1 of function type whose parameter is of type parameter type
 function someGenerics5(strs, n, f) { }
-someGenerics5 `${4} ${() => { return null; }}`;
-someGenerics5 `${''}${() => { return 3; }}`;
+someGenerics5 `${4} ${() => null}`;
+someGenerics5 `${''}${() => 3}`;
 someGenerics5 `${null}${null}`;
 // Generic tag with multiple arguments of function types that each have parameters of the same generic type
 function someGenerics6(strs, a, b, c) { }
-someGenerics6 `${n => { return n; }}${n => { return n; }}${n => { return n; }}`;
-someGenerics6 `${n => { return n; }}${n => { return n; }}${n => { return n; }}`;
-someGenerics6 `${(n) => { return n; }}${(n) => { return n; }}${(n) => { return n; }}`;
+someGenerics6 `${n => n}${n => n}${n => n}`;
+someGenerics6 `${n => n}${n => n}${n => n}`;
+someGenerics6 `${(n) => n}${(n) => n}${(n) => n}`;
 // Generic tag with multiple arguments of function types that each have parameters of different generic type
 function someGenerics7(strs, a, b, c) { }
-someGenerics7 `${n => { return n; }}${n => { return n; }}${n => { return n; }}`;
-someGenerics7 `${n => { return n; }}${n => { return n; }}${n => { return n; }}`;
-someGenerics7 `${(n) => { return n; }}${(n) => { return n; }}${(n) => { return n; }}`;
+someGenerics7 `${n => n}${n => n}${n => n}`;
+someGenerics7 `${n => n}${n => n}${n => n}`;
+someGenerics7 `${(n) => n}${(n) => n}${(n) => n}`;
 // Generic tag with argument of generic function type
 function someGenerics8(strs, n) { return n; }
 var x = someGenerics8 `${someGenerics7}`;

--- a/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution3_ES6.js
+++ b/tests/baselines/reference/taggedTemplateStringsWithOverloadResolution3_ES6.js
@@ -109,5 +109,5 @@ fn4 `${null}${null}`; // Error
 fn4 `${true}${null}`;
 fn4 `${null}${true}`;
 function fn5() { return undefined; }
-fn5 `${(n) => { return n.toFixed(); }}`; // will error; 'n' should have type 'string'.
-fn5 `${(n) => { return n.substr(0); }}`;
+fn5 `${(n) => n.toFixed()}`; // will error; 'n' should have type 'string'.
+fn5 `${(n) => n.substr(0)}`;

--- a/tests/baselines/reference/templateStringInArrowFunctionES6.js
+++ b/tests/baselines/reference/templateStringInArrowFunctionES6.js
@@ -2,4 +2,4 @@
 var x = x => `abc${ x }def`;
 
 //// [templateStringInArrowFunctionES6.js]
-var x = x => { return `abc${x}def`; };
+var x = x => `abc${x}def`;

--- a/tests/baselines/reference/templateStringWithEmbeddedArrowFunctionES6.js
+++ b/tests/baselines/reference/templateStringWithEmbeddedArrowFunctionES6.js
@@ -2,4 +2,4 @@
 var x = `abc${ x => x }def`;
 
 //// [templateStringWithEmbeddedArrowFunctionES6.js]
-var x = `abc${x => { return x; }}def`;
+var x = `abc${x => x}def`;


### PR DESCRIPTION
...or higher.