### PR TITLE
Add maxResultCount optional field to NavtoRequestArgs.  Change

### DIFF
--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -208,9 +208,9 @@ module ts.server {
             return response.body[0];
         }
 
-        getNavigateToItems(searchTerm: string): NavigateToItem[] {
+        getNavigateToItems(searchValue: string): NavigateToItem[] {
             var args: protocol.NavtoRequestArgs = {
-                searchTerm,
+                searchValue,
                 file: this.host.getScriptFileNames()[0]
             };
 

--- a/src/server/protocol.d.ts
+++ b/src/server/protocol.d.ts
@@ -676,7 +676,11 @@ declare module ts.server.protocol {
           * Search term to navigate to from current location; term can
           * be '.*' or an identifier prefix.
           */
-        searchTerm: string;
+        searchValue: string;
+        /**
+          *  Optional limit on the number of items to return.
+          */
+        maxResultCount?: number;
     }
 
     /**

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -82,7 +82,6 @@ module ts.server {
         private watchedFiles: WatchedFile[] = [];
         private nextFileToCheck = 0;
         private watchTimer: NodeJS.Timer;
-        private static fileDeleted = 34;
 
         // average async stat takes about 30 microseconds
         // set chunk size to do 30 files in < 1 millisecond
@@ -111,13 +110,7 @@ module ts.server {
 
             fs.stat(watchedFile.fileName,(err, stats) => {
                 if (err) {
-                    var msg = err.message;
-                    if (err.errno) {
-                        msg += " errno: " + err.errno.toString();
-                    }
-                    if (err.errno == WatchedFileSet.fileDeleted) {
-                        watchedFile.callback(watchedFile.fileName);
-                    }
+                    watchedFile.callback(watchedFile.fileName);
                 }
                 else if (watchedFile.mtime.getTime() != stats.mtime.getTime()) {
                     watchedFile.mtime = WatchedFileSet.getModifiedTime(watchedFile.fileName);

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -489,7 +489,7 @@ module ts.server {
             var file = ts.normalizePath(fileName);
             var project = this.projectService.getProjectForFile(file);
             if (!project) {
-                throw Errors.NoProject;
+                return undefined;
             }
 
             var compilerService = project.compilerService;
@@ -732,6 +732,9 @@ module ts.server {
                     case CommandNames.Completions: {
                         var completionsArgs = <protocol.CompletionsRequestArgs>request.arguments;
                         response = this.getCompletions(request.arguments.line, request.arguments.col, completionsArgs.prefix, request.arguments.file);
+                        if (!response) {
+                            errorMessage = "No completions at this location";
+                        }
                         break;
                     }
                     case CommandNames.CompletionDetails: {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -52,30 +52,6 @@ module ts.server {
             return 1;
         }
     }
-
-    function sortNavItems(items: ts.NavigateToItem[]) {
-        return items.sort((a, b) => {
-            if (a.matchKind < b.matchKind) {
-                return -1;
-            }
-            else if (a.matchKind == b.matchKind) {
-                var lowa = a.name.toLowerCase();
-                var lowb = b.name.toLowerCase();
-                if (lowa < lowb) {
-                    return -1;
-                }
-                else if (lowa == lowb) {
-                    return 0;
-                }
-                else {
-                    return 1;
-                }
-            }
-            else {
-                return 1;
-            }
-        })
-    }
        
     function formatDiag(fileName: string, project: Project, diag: ts.Diagnostic) {
         return {
@@ -404,7 +380,7 @@ module ts.server {
             var position = compilerService.host.lineColToPosition(file, line, col);
             var quickInfo = compilerService.languageService.getQuickInfoAtPosition(file, position);
             if (!quickInfo) {
-                throw Errors.NoContent;
+                return undefined;
             }
 
             var displayString = ts.displayPartsToString(quickInfo.displayParts);
@@ -625,7 +601,7 @@ module ts.server {
             return this.decorateNavigationBarItem(project, fileName, items);
         }
 
-        getNavigateToItems(searchTerm: string, fileName: string): protocol.NavtoItem[] {
+        getNavigateToItems(searchValue: string, fileName: string, maxResultCount?: number): protocol.NavtoItem[] {
             var file = ts.normalizePath(fileName);
             var project = this.projectService.getProjectForFile(file);
             if (!project) {
@@ -633,7 +609,7 @@ module ts.server {
             }
 
             var compilerService = project.compilerService;
-            var navItems = sortNavItems(compilerService.languageService.getNavigateToItems(searchTerm));
+            var navItems = compilerService.languageService.getNavigateToItems(searchValue, maxResultCount);
             if (!navItems) {
                 throw Errors.NoContent;
             }
@@ -690,6 +666,7 @@ module ts.server {
             try {
                 var request = <protocol.Request>JSON.parse(message);
                 var response: any;
+                var errorMessage: string;
                 switch (request.command) {
                     case CommandNames.Definition: { 
                         var defArgs = <protocol.FileLocationRequestArgs>request.arguments;
@@ -714,6 +691,9 @@ module ts.server {
                     case CommandNames.Quickinfo: {
                         var quickinfoArgs = <protocol.FileLocationRequestArgs>request.arguments;
                         response = this.getQuickInfo(quickinfoArgs.line, quickinfoArgs.col, quickinfoArgs.file);
+                        if (!response) {
+                            errorMessage = "No info at this location";
+                        }
                         break;
                     }
                     case CommandNames.Format: {
@@ -765,7 +745,7 @@ module ts.server {
                     }
                     case CommandNames.Navto: {
                         var navtoArgs = <protocol.NavtoRequestArgs>request.arguments;
-                        response = this.getNavigateToItems(navtoArgs.searchTerm, navtoArgs.file);
+                        response = this.getNavigateToItems(navtoArgs.searchValue, navtoArgs.file, navtoArgs.maxResultCount);
                         break;
                     }
                     case CommandNames.Brace: {
@@ -787,6 +767,9 @@ module ts.server {
 
                 if (response) {
                     this.output(response, request.command, request.seq);
+                }
+                else if (errorMessage) {
+                    this.output(undefined, request.command, request.seq, errorMessage);
                 }
 
             } catch (err) {


### PR DESCRIPTION
session.ts to use this field.  Remove sort of nav items from getNavigateToItems in
sesion.ts because LS now does the sort.  Removed no content throw in
quick info as this happens frequently with Sublime (every cursor move
calls quick info, and quick info is only available on symbols).  Added
mechanism for other commands to avoid throwing and instead return a
specific error message, so that we don't make the log unreadable (as it
was with hundreds of quick info stack traces).