### PR TITLE
Fixes overly-aggressive auto-collapse for "Collapse to Definitions"

### DIFF
--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -32,15 +32,7 @@ module ts {
             }
 
             function autoCollapse(node: Node) {
-                switch (node.kind) {
-                    case SyntaxKind.ModuleBlock:
-                    case SyntaxKind.ClassDeclaration:
-                    case SyntaxKind.InterfaceDeclaration:
-                    case SyntaxKind.EnumDeclaration:
-                        return false;
-                }
-
-                return true;
+                return isFunctionBlock(node) && node.parent.kind !== SyntaxKind.ArrowFunction;
             }
 
             var depth = 0;


### PR DESCRIPTION
Fix for #1259. Updates `autoCollapse` to only automatically collapse Function Blocks (excluding arrow-function bodies) to be more consistent with languages such as C#.