### PR TITLE
Fix export * merging to not overwrite original members

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -727,24 +727,24 @@ module ts {
             return symbol.flags & SymbolFlags.Module ? getExportsOfModule(symbol) : symbol.exports;
         }
 
-        function getExportsOfModule(symbol: Symbol): SymbolTable {
-            var links = getSymbolLinks(symbol);
-            return links.resolvedExports || (links.resolvedExports = getExportsForModule(symbol));
+        function getExportsOfModule(moduleSymbol: Symbol): SymbolTable {
+            var links = getSymbolLinks(moduleSymbol);
+            return links.resolvedExports || (links.resolvedExports = getExportsForModule(moduleSymbol));
         }
 
-        function getExportsForModule(symbol: Symbol): SymbolTable {
+        function getExportsForModule(moduleSymbol: Symbol): SymbolTable {
             var result: SymbolTable;
             var visitedSymbols: Symbol[] = [];
-            visit(symbol);
-            return result;
+            visit(moduleSymbol);
+            return result || moduleSymbol.exports;
 
             function visit(symbol: Symbol) {
                 if (!contains(visitedSymbols, symbol)) {
                     visitedSymbols.push(symbol);
-                    if (!result) {
-                        result = symbol.exports;
-                    }
-                    else {
+                    if (symbol !== moduleSymbol) {
+                        if (!result) {
+                            result = cloneSymbolTable(moduleSymbol.exports);
+                        }
                         extendSymbolTable(result, symbol.exports);
                     }
                     forEach(symbol.declarations, node => {


### PR DESCRIPTION
Computing the merged set of exports for an external module with `export *` statements inadvertently overwrites the original set of exports. This PR fixes the issue.