### PR TITLE
Update project structure on idle after change

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -206,7 +206,10 @@ module ts.server {
         }
 
     };
-
+    var ioSession = new IOSession(ts.sys, logger);
+    process.on('uncaughtException', function(err: Error) {
+        ioSession.logError(err, "unknown");
+    });
     // Start listening
-    new IOSession(ts.sys, logger).listen();
+    ioSession.listen();
 }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -181,18 +181,29 @@ module ts.server {
         }
 
         semanticCheck(file: string, project: Project) {
-            var diags = project.compilerService.languageService.getSemanticDiagnostics(file);
-            if (diags) {
-                var bakedDiags = diags.map((diag) => formatDiag(file, project, diag));
-                this.event({ file: file, diagnostics: bakedDiags }, "semanticDiag");
+            try {
+                var diags = project.compilerService.languageService.getSemanticDiagnostics(file);
+
+                if (diags) {
+                    var bakedDiags = diags.map((diag) => formatDiag(file, project, diag));
+                    this.event({ file: file, diagnostics: bakedDiags }, "semanticDiag");
+                }
+            }
+            catch (err) {
+                this.logError(err, "semantic check");
             }
         }
 
         syntacticCheck(file: string, project: Project) {
-            var diags = project.compilerService.languageService.getSyntacticDiagnostics(file);
-            if (diags) {
-                var bakedDiags = diags.map((diag) => formatDiag(file, project, diag));
-                this.event({ file: file, diagnostics: bakedDiags }, "syntaxDiag");
+            try {
+                var diags = project.compilerService.languageService.getSyntacticDiagnostics(file);
+                if (diags) {
+                    var bakedDiags = diags.map((diag) => formatDiag(file, project, diag));
+                    this.event({ file: file, diagnostics: bakedDiags }, "syntaxDiag");
+                }
+            }
+            catch (err) {
+                this.logError(err, "syntactic check");
             }
         }
 
@@ -553,10 +564,7 @@ module ts.server {
                     compilerService.host.editScript(file, start, end, insertString);
                     this.changeSeq++;
                 }
-                // update project structure on idle commented out
-                // until we can have the host return only the root files
-                // from getScriptFileNames()
-                //this.updateProjectStructure(this.changeSeq, (n) => n == this.changeSeq);
+                this.updateProjectStructure(this.changeSeq, (n) => n == this.changeSeq);
             }
         }
 


### PR DESCRIPTION
Update project structure after change.  After each change a timer is started.  If timer finishes before another change takes place, project structure will be updated to reflect any changes in reference comments or import statements.