### PR TITLE
Print times in a manner more consistent with the 1.3 compiler.

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3,6 +3,7 @@
 
 module ts {
     /* @internal */ export var emitTime = 0;
+    /* @internal */ export var ioReadTime = 0;
 
     export function createCompilerHost(options: CompilerOptions): CompilerHost {
         var currentDirectory: string;
@@ -19,7 +20,9 @@ module ts {
 
         function getSourceFile(fileName: string, languageVersion: ScriptTarget, onError?: (message: string) => void): SourceFile {
             try {
+                var start = new Date().getTime();
                 var text = sys.readFile(fileName, options.charset);
+                ioReadTime += new Date().getTime() - start;
             }
             catch (e) {
                 if (onError) {


### PR DESCRIPTION
This allows us to more accurately compare and constrast times between that
compiler and the current one.