### PR TITLE
Added missing MouseEvent constructor.

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -2985,6 +2985,7 @@ interface MouseEvent extends UIEvent {
 declare var MouseEvent: {
     prototype: MouseEvent;
     new(): MouseEvent;
+    new(type: string, options: MouseEventInit): MouseEvent;
 }
 
 interface RangeException {


### PR DESCRIPTION
Documented here: https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent

Fixes #674.