### PR TITLE
look through the entire chain of name scopes to ensure that name is uniq...

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1693,8 +1693,20 @@ module ts {
             }
 
             function isExistingName(location: Node, name: string) {
-                return !resolver.isUnknownIdentifier(location, name) ||
-                    (currentScopeNames && hasProperty(currentScopeNames, name));
+                if (!resolver.isUnknownIdentifier(location, name)) {
+                    return true;
+                }
+                if (currentScopeNames && hasProperty(currentScopeNames, name)) {
+                    return true;
+                }
+                var frame = lastFrame;
+                while (frame) {
+                    if (hasProperty(frame.names, name)) {
+                        return true;
+                    }
+                    frame = frame.previous;
+                }
+                return false;
             }
 
             function initializeEmitterWithSourceMaps() {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1693,12 +1693,29 @@ module ts {
             }
 
             function isExistingName(location: Node, name: string) {
+                // check if resolver is aware of this name (if name was seen during the typecheck)
                 if (!resolver.isUnknownIdentifier(location, name)) {
                     return true;
                 }
+
+                // check if name is present in generated names that were introduced by the emitter
                 if (currentScopeNames && hasProperty(currentScopeNames, name)) {
                     return true;
                 }
+
+                // check generated names in outer scopes
+                // var x;
+                // function foo() {
+                //    let x; // 1
+                //    function bar() {
+                //        {
+                //            let x; // 2
+                //        }
+                //        console.log(x); // 3
+                //    }
+                //}
+                // here both x(1) and x(2) should be renamed and their names should be different
+                // so x in (3) will refer to x(1)
                 var frame = lastFrame;
                 while (frame) {
                     if (hasProperty(frame.names, name)) {

--- a/tests/baselines/reference/downlevelLetConst19.js
+++ b/tests/baselines/reference/downlevelLetConst19.js
@@ -1,0 +1,39 @@
+//// [downlevelLetConst19.ts]
+'use strict'
+declare function use(a: any);
+var x;
+function a() {
+  {
+    let x;
+    use(x);
+
+    function b() {
+        {
+            let x;
+            use(x);
+        }
+        use(x);
+    }
+  }
+  use(x)
+}
+use(x)
+
+//// [downlevelLetConst19.js]
+'use strict';
+var x;
+function a() {
+    {
+        var _x;
+        use(_x);
+        function b() {
+            {
+                var _x_1;
+                use(_x_1);
+            }
+            use(_x);
+        }
+    }
+    use(x);
+}
+use(x);

--- a/tests/baselines/reference/downlevelLetConst19.types
+++ b/tests/baselines/reference/downlevelLetConst19.types
@@ -1,0 +1,47 @@
+=== tests/cases/compiler/downlevelLetConst19.ts ===
+'use strict'
+declare function use(a: any);
+>use : (a: any) => any
+>a : any
+
+var x;
+>x : any
+
+function a() {
+>a : () => void
+  {
+    let x;
+>x : any
+
+    use(x);
+>use(x) : any
+>use : (a: any) => any
+>x : any
+
+    function b() {
+>b : () => void
+        {
+            let x;
+>x : any
+
+            use(x);
+>use(x) : any
+>use : (a: any) => any
+>x : any
+        }
+        use(x);
+>use(x) : any
+>use : (a: any) => any
+>x : any
+    }
+  }
+  use(x)
+>use(x) : any
+>use : (a: any) => any
+>x : any
+}
+use(x)
+>use(x) : any
+>use : (a: any) => any
+>x : any
+

--- a/tests/cases/compiler/downlevelLetConst19.ts
+++ b/tests/cases/compiler/downlevelLetConst19.ts
@@ -1,0 +1,19 @@
+'use strict'
+declare function use(a: any);
+var x;
+function a() {
+  {
+    let x;
+    use(x);
+
+    function b() {
+        {
+            let x;
+            use(x);
+        }
+        use(x);
+    }
+  }
+  use(x)
+}
+use(x)


### PR DESCRIPTION
...ue.
Effectively `ScopeFrame` is analogous to locals for generated names so to ensure that name is unique we need to check the entire chain of scope frames.

*NOTE:*
Set of names in scopes in populated incrementally as we traverse the tree in depth first manner  - this means that in cases like this when we dive into nested function scope before we process subsequent `let x = 1` we'll say that `let x = true` in nested scope does not require renaming because `x` was not yet added  to the set of generated names so `console.log(x)` in `b` will print `true`. However for this case we should already report 'use before def' error meaning that we do not guarantee that emit will be 100% correct.
 
```typescript
declare function use(a: any);
function a() {
    function b() {
        {
            let x = true;
        }
        console.log(x);
    }
    let x = 1;
}
```  

Given that the only generated names that be used across multiple name scopes are renamed let\const bindings and they should always be declared before usage I have not found any other scenarios where this behavior might lead to semantically incorrect emit. If such exists we can always switch to crude yet simple and effective schema - any generated name can appear in file only once. Results of codegen with this approach will always be correct but not very user friendly i.e when original `let x` will become `var _x_67`