### PR TITLE
Add assert for unexpected syntaxkind and a conservative temporary fix.

### DIFF
--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -97,13 +97,17 @@ module ts.NavigationBar {
         function sortNodes(nodes: Node[]): Node[] {
             return nodes.slice(0).sort((n1: Declaration, n2: Declaration) => {
 
-                Debug.assert(n1.name.kind === SyntaxKind.Identifier || n1.name.kind === SyntaxKind.StringLiteral, `Expected n1.name is a ${n1.name.kind},\ 
+                if (n1.name) {
+                    Debug.assert(n1.name.kind === SyntaxKind.Identifier || n1.name.kind === SyntaxKind.StringLiteral, `Expected n1.name is a ${n1.name.kind},\
  where SyntaxKind.ComputedPropertyName is ${SyntaxKind.ComputedPropertyName} and SyntaxKind.BindingPattern is ${SyntaxKind.ArrayBindingPattern} or\
  ${SyntaxKind.ObjectBindingPattern}`);
+                }
 
-                Debug.assert(n2.name.kind === SyntaxKind.Identifier || n2.name.kind === SyntaxKind.StringLiteral, `Expected n2.name is a ${n2.name.kind},\
+                if (n2.name) {
+                    Debug.assert(n2.name.kind === SyntaxKind.Identifier || n2.name.kind === SyntaxKind.StringLiteral, `Expected n2.name is a ${n2.name.kind},\
  where SyntaxKind.ComputedPropertyName is ${SyntaxKind.ComputedPropertyName} and SyntaxKind.BindingPattern is ${SyntaxKind.ArrayBindingPattern} or\
  ${SyntaxKind.ObjectBindingPattern}`);
+                }
 
                 if (n1.name && (<Identifier>n1.name).text && n2.name) {
                     // TODO(jfreeman): How do we sort declarations with computed names?

--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -96,7 +96,16 @@ module ts.NavigationBar {
          
         function sortNodes(nodes: Node[]): Node[] {
             return nodes.slice(0).sort((n1: Declaration, n2: Declaration) => {
-                if (n1.name && n2.name) {
+
+                Debug.assert(n1.name.kind === SyntaxKind.Identifier || n1.name.kind === SyntaxKind.StringLiteral, `Expected n1.name is a ${n1.name.kind},\ 
+ where SyntaxKind.ComputedPropertyName is ${SyntaxKind.ComputedPropertyName} and SyntaxKind.BindingPattern is ${SyntaxKind.ArrayBindingPattern} or\
+ ${SyntaxKind.ObjectBindingPattern}`);
+
+                Debug.assert(n2.name.kind === SyntaxKind.Identifier || n2.name.kind === SyntaxKind.StringLiteral, `Expected n2.name is a ${n2.name.kind},\
+ where SyntaxKind.ComputedPropertyName is ${SyntaxKind.ComputedPropertyName} and SyntaxKind.BindingPattern is ${SyntaxKind.ArrayBindingPattern} or\
+ ${SyntaxKind.ObjectBindingPattern}`);
+
+                if (n1.name && (<Identifier>n1.name).text && n2.name) {
                     // TODO(jfreeman): How do we sort declarations with computed names?
                     return (<Identifier>n1.name).text.localeCompare((<Identifier>n2.name).text);
                 }


### PR DESCRIPTION
Conservative fix for a crash in the navbar and adding instrumentation for a better fix.

TypeError: Unable to get property 'localeCompare' of undefined or null reference
at Anonymous function (:20435:25)
at sortNodes (:20433:17)
at getChildNodes (:20424:17)
at createSourceFileItem (:20639:21)
at createTopLevelItem (:20601:25)
at getItemsWorker (:20491:21)
at getNavigationBarItems (:20379:13)
at getNavigationBarItems (:26732:13)
at Anonymous function (:28077:17)
at simpleForwardCall (:27843:9)
at forwardJSONCall (:27857:13)
at forwardJSONCall (:27888:13)
at getNavigationBarItems (:28076:13)
