### PR TITLE
Fix watch to honor tsconfig.json setting

### DIFF
--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -250,7 +250,7 @@ module ts {
 
             var compileResult = compile(rootFileNames, compilerOptions, compilerHost);
 
-            if (!commandLine.options.watch) {
+            if (!compilerOptions.watch) {
                 return sys.exit(compileResult.exitStatus);
             }
 
@@ -269,7 +269,7 @@ module ts {
             }
             // Use default host function
             var sourceFile = hostGetSourceFile(fileName, languageVersion, onError);
-            if (sourceFile && commandLine.options.watch) {
+            if (sourceFile && compilerOptions.watch) {
                 // Attach a file watcher
                 sourceFile.fileWatcher = sys.watchFile(sourceFile.fileName, () => sourceFileChanged(sourceFile));
             }


### PR DESCRIPTION
Currently if you have {"watch": true} set in your compilerOptions in tsconfig.json it is ignored, as only the command-line watch setting is checked.  Thus when you run just "tsc" on the command line it simply runs and exits.  With the change the config setting is honored.