### PR TITLE
Allows type guards with switch statement (need help..)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4853,6 +4853,13 @@ module ts {
                                 narrowedType = narrowType(type, (<ConditionalExpression>node).condition, /*assumeTrue*/ child === (<ConditionalExpression>node).whenTrue);
                             }
                             break;
+                        case SyntaxKind.CaseClause:
+                            // In a case clause of a switch statement using typeof 
+                            var parent = (<CaseClause>node).parent;
+                            if((<SwitchStatement>parent).expression.kind === SyntaxKind.TypeOfExpression){
+                                narrowedType = checkExpression((<TypeOfExpression>(<CaseClause>node).expression).text);
+                            }
+                            break;
                         case SyntaxKind.BinaryExpression:
                             // In the right operand of an && or ||, narrow based on left operand
                             if (child === (<BinaryExpression>node).right) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8605,7 +8605,7 @@ module ts {
                             // since LHS will be block scoped name instead of function scoped
                             if (!namesShareScope) {
                                 var name = symbolToString(localDeclarationSymbol);
-                                error(getErrorSpanForNode(node), Diagnostics.Cannot_initialize_outer_scoped_variable_0_in_the_same_scope_as_block_scoped_declaration_1, name, name);
+                                error(node, Diagnostics.Cannot_initialize_outer_scoped_variable_0_in_the_same_scope_as_block_scoped_declaration_1, name, name);
                             }
                         }
                     }
@@ -11817,19 +11817,11 @@ module ts {
             return sourceFile.parseDiagnostics.length > 0;
         }
 
-        function scanToken(scanner: Scanner, pos: number) {
-            scanner.setTextPos(pos);
-            scanner.scan();
-            var start = scanner.getTokenPos();
-            return start;
-        }
-
         function grammarErrorOnFirstToken(node: Node, message: DiagnosticMessage, arg0?: any, arg1?: any, arg2?: any): boolean {
             var sourceFile = getSourceFileOfNode(node);
             if (!hasParseDiagnostics(sourceFile)) {
-                var scanner = createScanner(languageVersion, /*skipTrivia*/ true, sourceFile.text);
-                var start = scanToken(scanner, node.pos);
-                diagnostics.add(createFileDiagnostic(sourceFile, start, scanner.getTextPos() - start, message, arg0, arg1, arg2));
+                var span = getSpanOfTokenAtPosition(sourceFile, node.pos);
+                diagnostics.add(createFileDiagnostic(sourceFile, span.start, span.length, message, arg0, arg1, arg2));
                 return true;
             }
         }
@@ -11844,9 +11836,7 @@ module ts {
         function grammarErrorOnNode(node: Node, message: DiagnosticMessage, arg0?: any, arg1?: any, arg2?: any): boolean {
             var sourceFile = getSourceFileOfNode(node);
             if (!hasParseDiagnostics(sourceFile)) {
-                var span = getErrorSpanForNode(node);
-                var start = span.end > span.pos ? skipTrivia(sourceFile.text, span.pos) : span.pos;
-                diagnostics.add(createFileDiagnostic(sourceFile, start, span.end - start, message, arg0, arg1, arg2));
+                diagnostics.add(createDiagnosticForNode(node, message, arg0, arg1, arg2));
                 return true;
             }
         }
@@ -11983,9 +11973,8 @@ module ts {
         function grammarErrorAfterFirstToken(node: Node, message: DiagnosticMessage, arg0?: any, arg1?: any, arg2?: any): boolean {
             var sourceFile = getSourceFileOfNode(node);
             if (!hasParseDiagnostics(sourceFile)) {
-                var scanner = createScanner(languageVersion, /*skipTrivia*/ true, sourceFile.text);
-                scanToken(scanner, node.pos);
-                diagnostics.add(createFileDiagnostic(sourceFile, scanner.getTextPos(), 0, message, arg0, arg1, arg2));
+                var span = getSpanOfTokenAtPosition(sourceFile, node.pos);
+                diagnostics.add(createFileDiagnostic(sourceFile, textSpanEnd(span), /*length*/ 0, message, arg0, arg1, arg2));
                 return true;
             }
         }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -423,13 +423,11 @@ module ts {
                 return;
             }
 
-            var firstExternalModule = forEach(files, f => isExternalModule(f) ? f : undefined);
-            if (firstExternalModule && !options.module) {
-                // We cannot use createDiagnosticFromNode because nodes do not have parents yet
-                var externalModuleErrorSpan = getErrorSpanForNode(firstExternalModule.externalModuleIndicator);
-                var errorStart = skipTrivia(firstExternalModule.text, externalModuleErrorSpan.pos);
-                var errorLength = externalModuleErrorSpan.end - errorStart;
-                diagnostics.add(createFileDiagnostic(firstExternalModule, errorStart, errorLength, Diagnostics.Cannot_compile_external_modules_unless_the_module_flag_is_provided));
+            var firstExternalModuleSourceFile = forEach(files, f => isExternalModule(f) ? f : undefined);
+            if (firstExternalModuleSourceFile && !options.module) {
+                // We cannot use createDiagnosticFromNode because nodes do not have parents yet       
+                var span = getErrorSpanForNode(firstExternalModuleSourceFile, firstExternalModuleSourceFile.externalModuleIndicator);
+                diagnostics.add(createFileDiagnostic(firstExternalModuleSourceFile, span.start, span.length, Diagnostics.Cannot_compile_external_modules_unless_the_module_flag_is_provided));
             }
 
             // there has to be common source directory if user specified --outdir || --sourcRoot
@@ -437,7 +435,7 @@ module ts {
             if (options.outDir || // there is --outDir specified
                 options.sourceRoot || // there is --sourceRoot specified
                 (options.mapRoot &&  // there is --mapRoot Specified and there would be multiple js files generated
-                    (!options.out || firstExternalModule !== undefined))) {
+                    (!options.out || firstExternalModuleSourceFile !== undefined))) {
 
                 var commonPathComponents: string[];
                 forEach(files, sourceFile => {

--- a/tests/baselines/reference/ambientErrors.errors.txt
+++ b/tests/baselines/reference/ambientErrors.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/ambient/ambientErrors.ts(2,15): error TS1039: Initializers are not allowed in ambient contexts.
-tests/cases/conformance/ambient/ambientErrors.ts(6,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/conformance/ambient/ambientErrors.ts(6,18): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
 tests/cases/conformance/ambient/ambientErrors.ts(17,22): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
 tests/cases/conformance/ambient/ambientErrors.ts(20,24): error TS1184: An implementation cannot be declared in ambient contexts.
 tests/cases/conformance/ambient/ambientErrors.ts(24,5): error TS1066: Ambient enum elements can only have integer literal initializers.
@@ -25,7 +25,7 @@ tests/cases/conformance/ambient/ambientErrors.ts(57,5): error TS2309: An export 
     // Ambient functions with invalid overloads
     declare function fn(x: number): string;
     declare function fn(x: 'foo'): number;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                     ~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     
     // Ambient functions with duplicate signatures

--- a/tests/baselines/reference/anyIdenticalToItself.errors.txt
+++ b/tests/baselines/reference/anyIdenticalToItself.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/compiler/anyIdenticalToItself.ts(1,1): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/compiler/anyIdenticalToItself.ts(1,10): error TS2394: Overload signature is not compatible with function implementation.
 tests/cases/compiler/anyIdenticalToItself.ts(6,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/anyIdenticalToItself.ts(10,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 
 
 ==== tests/cases/compiler/anyIdenticalToItself.ts (3 errors) ====
     function foo(x: any);
-    ~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
     function foo(x: any);
     function foo(x: any, y: number) { }

--- a/tests/baselines/reference/assignLambdaToNominalSubtypeOfFunction.errors.txt
+++ b/tests/baselines/reference/assignLambdaToNominalSubtypeOfFunction.errors.txt
@@ -16,7 +16,7 @@ tests/cases/compiler/assignLambdaToNominalSubtypeOfFunction.ts(8,4): error TS234
 !!! error TS2345: Argument of type '(a: any, b: any) => boolean' is not assignable to parameter of type 'IResultCallback'.
 !!! error TS2345:   Property 'x' is missing in type '(a: any, b: any) => boolean'.
     fn(function (a, b) { return true; })
-       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+       ~~~~~~~~
 !!! error TS2345: Argument of type '(a: any, b: any) => boolean' is not assignable to parameter of type 'IResultCallback'.
 !!! error TS2345:   Property 'x' is missing in type '(a: any, b: any) => boolean'.
     

--- a/tests/baselines/reference/collisionSuperAndLocalFunctionInAccessors.errors.txt
+++ b/tests/baselines/reference/collisionSuperAndLocalFunctionInAccessors.errors.txt
@@ -1,13 +1,13 @@
 tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(4,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(9,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(15,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(16,9): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(16,18): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
 tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(20,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(21,9): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(21,18): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
 tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(26,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(28,13): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(28,22): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
 tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(33,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(35,13): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(35,22): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
 
 
 ==== tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts (10 errors) ====
@@ -33,20 +33,18 @@ tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(35,13): error 
             ~~~~~
 !!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
             function _super() { // Should be error
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            }
-    ~~~~~~~~~
+                     ~~~~~~
 !!! error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+            }
             return 10;
         }
         set prop2(val: number) {
             ~~~~~
 !!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
             function _super() { // Should be error
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            }
-    ~~~~~~~~~
+                     ~~~~~~
 !!! error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+            }
         }
     }
     class c extends Foo {
@@ -55,10 +53,9 @@ tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(35,13): error 
 !!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
             var x = () => {
                 function _super() { // Should be error
-                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                }
-    ~~~~~~~~~~~~~
+                         ~~~~~~
 !!! error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+                }
             }
             return 10;
         }
@@ -67,10 +64,9 @@ tests/cases/compiler/collisionSuperAndLocalFunctionInAccessors.ts(35,13): error 
 !!! error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
             var x = () => {
                 function _super() { // Should be error
-                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                }
-    ~~~~~~~~~~~~~
+                         ~~~~~~
 !!! error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+                }
             }
         }
     }

--- a/tests/baselines/reference/collisionSuperAndLocalFunctionInConstructor.errors.txt
+++ b/tests/baselines/reference/collisionSuperAndLocalFunctionInConstructor.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/collisionSuperAndLocalFunctionInConstructor.ts(12,9): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
-tests/cases/compiler/collisionSuperAndLocalFunctionInConstructor.ts(20,13): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+tests/cases/compiler/collisionSuperAndLocalFunctionInConstructor.ts(12,18): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+tests/cases/compiler/collisionSuperAndLocalFunctionInConstructor.ts(20,22): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
 
 
 ==== tests/cases/compiler/collisionSuperAndLocalFunctionInConstructor.ts (2 errors) ====
@@ -15,10 +15,9 @@ tests/cases/compiler/collisionSuperAndLocalFunctionInConstructor.ts(20,13): erro
         constructor() {
             super();
             function _super() { // Should be error
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            }
-    ~~~~~~~~~
+                     ~~~~~~
 !!! error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+            }
         }
     }
     class c extends Foo {
@@ -26,10 +25,9 @@ tests/cases/compiler/collisionSuperAndLocalFunctionInConstructor.ts(20,13): erro
             super();
             var x = () => {
                 function _super() { // Should be error
-                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                }
-    ~~~~~~~~~~~~~
+                         ~~~~~~
 !!! error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+                }
             }
         }
     }

--- a/tests/baselines/reference/collisionSuperAndLocalFunctionInMethod.errors.txt
+++ b/tests/baselines/reference/collisionSuperAndLocalFunctionInMethod.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/collisionSuperAndLocalFunctionInMethod.ts(13,9): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
-tests/cases/compiler/collisionSuperAndLocalFunctionInMethod.ts(22,13): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+tests/cases/compiler/collisionSuperAndLocalFunctionInMethod.ts(13,18): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+tests/cases/compiler/collisionSuperAndLocalFunctionInMethod.ts(22,22): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
 
 
 ==== tests/cases/compiler/collisionSuperAndLocalFunctionInMethod.ts (2 errors) ====
@@ -16,10 +16,9 @@ tests/cases/compiler/collisionSuperAndLocalFunctionInMethod.ts(22,13): error TS2
     class b extends Foo {
         public foo() {
             function _super() { // should be error
-            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-            } 
-    ~~~~~~~~~
+                     ~~~~~~
 !!! error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+            } 
         }
         _super() { // No Error
         }
@@ -28,10 +27,9 @@ tests/cases/compiler/collisionSuperAndLocalFunctionInMethod.ts(22,13): error TS2
         public foo() {
             var x = () => {
                 function _super() { // should be error
-                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                } 
-    ~~~~~~~~~~~~~
+                         ~~~~~~
 !!! error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+                } 
             }
         }
         _super() { // No error

--- a/tests/baselines/reference/collisionSuperAndLocalFunctionInProperty.errors.txt
+++ b/tests/baselines/reference/collisionSuperAndLocalFunctionInProperty.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/collisionSuperAndLocalFunctionInProperty.ts(14,13): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+tests/cases/compiler/collisionSuperAndLocalFunctionInProperty.ts(14,22): error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
 
 
 ==== tests/cases/compiler/collisionSuperAndLocalFunctionInProperty.ts (1 errors) ====
@@ -16,10 +16,9 @@ tests/cases/compiler/collisionSuperAndLocalFunctionInProperty.ts(14,13): error T
         public prop2 = {
             doStuff: () => {
                 function _super() { // error
-                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-                } 
-    ~~~~~~~~~~~~~
+                         ~~~~~~
 !!! error TS2401: Duplicate identifier '_super'. Compiler uses '_super' to capture base class reference.
+                } 
             }
         }
     }

--- a/tests/baselines/reference/constantOverloadFunctionNoSubtypeError.errors.txt
+++ b/tests/baselines/reference/constantOverloadFunctionNoSubtypeError.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/compiler/constantOverloadFunctionNoSubtypeError.ts(6,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
-tests/cases/compiler/constantOverloadFunctionNoSubtypeError.ts(7,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
-tests/cases/compiler/constantOverloadFunctionNoSubtypeError.ts(8,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/compiler/constantOverloadFunctionNoSubtypeError.ts(6,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/compiler/constantOverloadFunctionNoSubtypeError.ts(7,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/compiler/constantOverloadFunctionNoSubtypeError.ts(8,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
 
 
 ==== tests/cases/compiler/constantOverloadFunctionNoSubtypeError.ts (3 errors) ====
@@ -10,13 +10,13 @@ tests/cases/compiler/constantOverloadFunctionNoSubtypeError.ts(8,1): error TS238
     class Derived3 extends Base { biz() { } }
     
     function foo(tagName: 'canvas'): Derived3;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function foo(tagName:  'div'): Derived2;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function foo(tagName: 'span'): Derived1;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function foo(tagName: number): Base;
     function foo(tagName: any): Base {

--- a/tests/baselines/reference/crashInsourcePropertyIsRelatableToTargetProperty.errors.txt
+++ b/tests/baselines/reference/crashInsourcePropertyIsRelatableToTargetProperty.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/crashInsourcePropertyIsRelatableToTargetProperty.ts(5,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/compiler/crashInsourcePropertyIsRelatableToTargetProperty.ts(5,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
 tests/cases/compiler/crashInsourcePropertyIsRelatableToTargetProperty.ts(9,5): error TS2322: Type '(x: "hi", items: string[]) => typeof foo' is not assignable to type 'D'.
   Property 'x' is missing in type '(x: "hi", items: string[]) => typeof foo'.
 
@@ -9,7 +9,7 @@ tests/cases/compiler/crashInsourcePropertyIsRelatableToTargetProperty.ts(9,5): e
     }
     class D extends C { }
     function foo(x: "hi", items: string[]): typeof foo;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function foo(x: string, items: string[]): typeof foo {
         return null;

--- a/tests/baselines/reference/exportAssignDottedName.errors.txt
+++ b/tests/baselines/reference/exportAssignDottedName.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/externalModules/foo1.ts(1,1): error TS1148: Cannot compile external modules unless the '--module' flag is provided.
+tests/cases/conformance/externalModules/foo1.ts(1,17): error TS1148: Cannot compile external modules unless the '--module' flag is provided.
 tests/cases/conformance/externalModules/foo2.ts(2,14): error TS1005: ';' expected.
 tests/cases/conformance/externalModules/foo2.ts(2,15): error TS2304: Cannot find name 'x'.
 
@@ -13,10 +13,8 @@ tests/cases/conformance/externalModules/foo2.ts(2,15): error TS2304: Cannot find
     
 ==== tests/cases/conformance/externalModules/foo1.ts (1 errors) ====
     export function x(){
-    ~~~~~~~~~~~~~~~~~~~~
-    	return true;
-    ~~~~~~~~~~~~~
-    }
-    ~
+                    ~
 !!! error TS1148: Cannot compile external modules unless the '--module' flag is provided.
+    	return true;
+    }
     

--- a/tests/baselines/reference/exportAssignImportedIdentifier.errors.txt
+++ b/tests/baselines/reference/exportAssignImportedIdentifier.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/externalModules/foo1.ts(1,1): error TS1148: Cannot compile external modules unless the '--module' flag is provided.
+tests/cases/conformance/externalModules/foo1.ts(1,17): error TS1148: Cannot compile external modules unless the '--module' flag is provided.
 
 
 ==== tests/cases/conformance/externalModules/foo3.ts (0 errors) ====
@@ -6,12 +6,10 @@ tests/cases/conformance/externalModules/foo1.ts(1,1): error TS1148: Cannot compi
     var x = foo2(); // should be boolean
 ==== tests/cases/conformance/externalModules/foo1.ts (1 errors) ====
     export function x(){
-    ~~~~~~~~~~~~~~~~~~~~
-    	return true;
-    ~~~~~~~~~~~~~
-    }
-    ~
+                    ~
 !!! error TS1148: Cannot compile external modules unless the '--module' flag is provided.
+    	return true;
+    }
     
 ==== tests/cases/conformance/externalModules/foo2.ts (0 errors) ====
     import foo1 = require('./foo1');

--- a/tests/baselines/reference/functionAndInterfaceWithSeparateErrors.errors.txt
+++ b/tests/baselines/reference/functionAndInterfaceWithSeparateErrors.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/compiler/functionAndInterfaceWithSeparateErrors.ts(1,1): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/compiler/functionAndInterfaceWithSeparateErrors.ts(1,10): error TS2394: Overload signature is not compatible with function implementation.
 tests/cases/compiler/functionAndInterfaceWithSeparateErrors.ts(6,5): error TS2411: Property 'prop' of type 'number' is not assignable to string index type 'string'.
 
 
 ==== tests/cases/compiler/functionAndInterfaceWithSeparateErrors.ts (2 errors) ====
     function Foo(s: string);
-    ~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
     function Foo(n: number) { }
     

--- a/tests/baselines/reference/functionImplementationErrors.errors.txt
+++ b/tests/baselines/reference/functionImplementationErrors.errors.txt
@@ -1,15 +1,15 @@
 tests/cases/conformance/functions/functionImplementationErrors.ts(2,10): error TS2354: No best common type exists among return expressions.
-tests/cases/conformance/functions/functionImplementationErrors.ts(6,10): error TS2354: No best common type exists among return expressions.
+tests/cases/conformance/functions/functionImplementationErrors.ts(6,19): error TS2354: No best common type exists among return expressions.
 tests/cases/conformance/functions/functionImplementationErrors.ts(10,10): error TS2354: No best common type exists among return expressions.
 tests/cases/conformance/functions/functionImplementationErrors.ts(16,10): error TS2354: No best common type exists among return expressions.
 tests/cases/conformance/functions/functionImplementationErrors.ts(25,16): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
 tests/cases/conformance/functions/functionImplementationErrors.ts(30,17): error TS2373: Initializer of parameter 'n' cannot reference identifier 'm' declared after it.
 tests/cases/conformance/functions/functionImplementationErrors.ts(35,17): error TS2373: Initializer of parameter 'n' cannot reference identifier 'm' declared after it.
 tests/cases/conformance/functions/functionImplementationErrors.ts(40,28): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
-tests/cases/conformance/functions/functionImplementationErrors.ts(49,1): error TS2354: No best common type exists among return expressions.
+tests/cases/conformance/functions/functionImplementationErrors.ts(49,10): error TS2354: No best common type exists among return expressions.
 tests/cases/conformance/functions/functionImplementationErrors.ts(53,10): error TS2354: No best common type exists among return expressions.
 tests/cases/conformance/functions/functionImplementationErrors.ts(57,11): error TS2354: No best common type exists among return expressions.
-tests/cases/conformance/functions/functionImplementationErrors.ts(61,1): error TS2354: No best common type exists among return expressions.
+tests/cases/conformance/functions/functionImplementationErrors.ts(61,10): error TS2354: No best common type exists among return expressions.
 tests/cases/conformance/functions/functionImplementationErrors.ts(65,11): error TS2354: No best common type exists among return expressions.
 tests/cases/conformance/functions/functionImplementationErrors.ts(69,11): error TS2354: No best common type exists among return expressions.
 
@@ -17,23 +17,17 @@ tests/cases/conformance/functions/functionImplementationErrors.ts(69,11): error 
 ==== tests/cases/conformance/functions/functionImplementationErrors.ts (14 errors) ====
     // FunctionExpression with no return type annotation with multiple return statements with unrelated types
     var f1 = function () {
-             ~~~~~~~~~~~~~
-        return '';
-    ~~~~~~~~~~~~~~
-        return 3;
-    ~~~~~~~~~~~~~
-    };
-    ~
+             ~~~~~~~~
 !!! error TS2354: No best common type exists among return expressions.
+        return '';
+        return 3;
+    };
     var f2 = function x() {
-             ~~~~~~~~~~~~~~
-        return '';
-    ~~~~~~~~~~~~~~
-        return 3;
-    ~~~~~~~~~~~~~
-    };
-    ~
+                      ~
 !!! error TS2354: No best common type exists among return expressions.
+        return '';
+        return 3;
+    };
     var f3 = () => {
              ~~~~~~~
         return '';
@@ -46,20 +40,14 @@ tests/cases/conformance/functions/functionImplementationErrors.ts(69,11): error 
     
     // FunctionExpression with no return type annotation with return branch of number[] and other of string[]
     var f4 = function () {
-             ~~~~~~~~~~~~~
-        if (true) {
-    ~~~~~~~~~~~~~~~
-            return [''];
-    ~~~~~~~~~~~~~~~~~~~~
-        } else {
-    ~~~~~~~~~~~~
-            return [1];
-    ~~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-    }
-    ~
+             ~~~~~~~~
 !!! error TS2354: No best common type exists among return expressions.
+        if (true) {
+            return [''];
+        } else {
+            return [1];
+        }
+    }
     
     // Function implemetnation with non -void return type annotation with no return
     function f5(): number {
@@ -95,23 +83,17 @@ tests/cases/conformance/functions/functionImplementationErrors.ts(69,11): error 
     class Derived1 extends Base { private m; }
     class Derived2 extends Base { private n; }
     function f8() {
-    ~~~~~~~~~~~~~~~
+             ~~
+!!! error TS2354: No best common type exists among return expressions.
         return new Derived1();
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
         return new Derived2();    
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     }
-    ~
-!!! error TS2354: No best common type exists among return expressions.
     var f9 = function () {
-             ~~~~~~~~~~~~~
-        return new Derived1();
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-        return new Derived2();
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-    };
-    ~
+             ~~~~~~~~
 !!! error TS2354: No best common type exists among return expressions.
+        return new Derived1();
+        return new Derived2();
+    };
     var f10 = () => {
               ~~~~~~~
         return new Derived1();
@@ -122,23 +104,17 @@ tests/cases/conformance/functions/functionImplementationErrors.ts(69,11): error 
     ~
 !!! error TS2354: No best common type exists among return expressions.
     function f11() {
-    ~~~~~~~~~~~~~~~~
+             ~~~
+!!! error TS2354: No best common type exists among return expressions.
         return new Base();
-    ~~~~~~~~~~~~~~~~~~~~~~
         return new AnotherClass();
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     }
-    ~
-!!! error TS2354: No best common type exists among return expressions.
     var f12 = function () {
-              ~~~~~~~~~~~~~
-        return new Base();
-    ~~~~~~~~~~~~~~~~~~~~~~
-        return new AnotherClass();
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    };
-    ~
+              ~~~~~~~~
 !!! error TS2354: No best common type exists among return expressions.
+        return new Base();
+        return new AnotherClass();
+    };
     var f13 = () => {
               ~~~~~~~
         return new Base();

--- a/tests/baselines/reference/functionOverloadErrors.errors.txt
+++ b/tests/baselines/reference/functionOverloadErrors.errors.txt
@@ -8,9 +8,9 @@ tests/cases/conformance/functions/functionOverloadErrors.ts(75,21): error TS2383
 tests/cases/conformance/functions/functionOverloadErrors.ts(79,14): error TS2383: Overload signatures must all be exported or not exported.
 tests/cases/conformance/functions/functionOverloadErrors.ts(85,18): error TS2384: Overload signatures must all be ambient or non-ambient.
 tests/cases/conformance/functions/functionOverloadErrors.ts(90,18): error TS2384: Overload signatures must all be ambient or non-ambient.
-tests/cases/conformance/functions/functionOverloadErrors.ts(94,1): error TS2394: Overload signature is not compatible with function implementation.
-tests/cases/conformance/functions/functionOverloadErrors.ts(99,1): error TS2394: Overload signature is not compatible with function implementation.
-tests/cases/conformance/functions/functionOverloadErrors.ts(103,1): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/conformance/functions/functionOverloadErrors.ts(94,10): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/conformance/functions/functionOverloadErrors.ts(99,10): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/conformance/functions/functionOverloadErrors.ts(103,10): error TS2394: Overload signature is not compatible with function implementation.
 tests/cases/conformance/functions/functionOverloadErrors.ts(116,19): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
 
 
@@ -129,20 +129,20 @@ tests/cases/conformance/functions/functionOverloadErrors.ts(116,19): error TS237
     
     //Function overloads with fewer params than implementation signature
     function fewerParams();
-    ~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~~~~~~~~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
     function fewerParams(n: string) {
     }
     
     //Function implementation whose parameter types are not assignable to all corresponding overload signature parameters
     function fn13(n: string);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
     function fn13(n: number) { }
     
     //Function overloads where return types are not all subtype of implementation return type
     function fn14(n: string): string;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
     function fn14() {
         return 3;

--- a/tests/baselines/reference/functionOverloads11.errors.txt
+++ b/tests/baselines/reference/functionOverloads11.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/functionOverloads11.ts(1,1): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/compiler/functionOverloads11.ts(1,10): error TS2394: Overload signature is not compatible with function implementation.
 
 
 ==== tests/cases/compiler/functionOverloads11.ts (1 errors) ====
     function foo():number;
-    ~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
     function foo():string { return "" }
     

--- a/tests/baselines/reference/functionOverloads17.errors.txt
+++ b/tests/baselines/reference/functionOverloads17.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/functionOverloads17.ts(1,1): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/compiler/functionOverloads17.ts(1,10): error TS2394: Overload signature is not compatible with function implementation.
 
 
 ==== tests/cases/compiler/functionOverloads17.ts (1 errors) ====
     function foo():{a:number;}
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
     function foo():{a:string;} { return {a:""} }
     

--- a/tests/baselines/reference/functionOverloads18.errors.txt
+++ b/tests/baselines/reference/functionOverloads18.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/functionOverloads18.ts(1,1): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/compiler/functionOverloads18.ts(1,10): error TS2394: Overload signature is not compatible with function implementation.
 
 
 ==== tests/cases/compiler/functionOverloads18.ts (1 errors) ====
     function foo(bar:{a:number;});
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
     function foo(bar:{a:string;}) { return {a:""} }
     

--- a/tests/baselines/reference/functionOverloads19.errors.txt
+++ b/tests/baselines/reference/functionOverloads19.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/functionOverloads19.ts(1,1): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/compiler/functionOverloads19.ts(1,10): error TS2394: Overload signature is not compatible with function implementation.
 
 
 ==== tests/cases/compiler/functionOverloads19.ts (1 errors) ====
     function foo(bar:{b:string;});
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
     function foo(bar:{a:string;});
     function foo(bar:{a:any;}) { return {a:""} }

--- a/tests/baselines/reference/functionOverloads20.errors.txt
+++ b/tests/baselines/reference/functionOverloads20.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/functionOverloads20.ts(1,1): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/compiler/functionOverloads20.ts(1,10): error TS2394: Overload signature is not compatible with function implementation.
 
 
 ==== tests/cases/compiler/functionOverloads20.ts (1 errors) ====
     function foo(bar:{a:number;}): number;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
     function foo(bar:{a:string;}): string;
     function foo(bar:{a:any;}): string {return ""}

--- a/tests/baselines/reference/functionOverloads22.errors.txt
+++ b/tests/baselines/reference/functionOverloads22.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/compiler/functionOverloads22.ts(2,1): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/compiler/functionOverloads22.ts(2,10): error TS2394: Overload signature is not compatible with function implementation.
 
 
 ==== tests/cases/compiler/functionOverloads22.ts (1 errors) ====
     function foo(bar:number):{a:number;}[];
     function foo(bar:string):{a:number; b:string;}[];
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
     function foo(bar:any):{a:any;b?:any;}[] { return [{a:""}] }
     

--- a/tests/baselines/reference/functionOverloads4.errors.txt
+++ b/tests/baselines/reference/functionOverloads4.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/compiler/functionOverloads4.ts(1,1): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/compiler/functionOverloads4.ts(1,10): error TS2394: Overload signature is not compatible with function implementation.
 
 
 ==== tests/cases/compiler/functionOverloads4.ts (1 errors) ====
     function foo():number;
-    ~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
     function foo():string { return "a" }

--- a/tests/baselines/reference/functionWithMultipleReturnStatements.errors.txt
+++ b/tests/baselines/reference/functionWithMultipleReturnStatements.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts(4,1): error TS2354: No best common type exists among return expressions.
-tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts(12,1): error TS2354: No best common type exists among return expressions.
-tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts(22,1): error TS2354: No best common type exists among return expressions.
-tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts(31,1): error TS2354: No best common type exists among return expressions.
-tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts(43,1): error TS2354: No best common type exists among return expressions.
-tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts(48,1): error TS2354: No best common type exists among return expressions.
-tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts(56,1): error TS2354: No best common type exists among return expressions.
+tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts(4,10): error TS2354: No best common type exists among return expressions.
+tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts(12,10): error TS2354: No best common type exists among return expressions.
+tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts(22,10): error TS2354: No best common type exists among return expressions.
+tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts(31,10): error TS2354: No best common type exists among return expressions.
+tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts(43,10): error TS2354: No best common type exists among return expressions.
+tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts(48,10): error TS2354: No best common type exists among return expressions.
+tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts(56,10): error TS2354: No best common type exists among return expressions.
 tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts(56,13): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements.ts(56,26): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 
@@ -14,126 +14,80 @@ tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMulti
     // it is an error if there is no single BCT, these are error cases
     
     function f1() {
-    ~~~~~~~~~~~~~~~
-        if (true) {
-    ~~~~~~~~~~~~~~~
-            return 1;
-    ~~~~~~~~~~~~~~~~~
-        } else {
-    ~~~~~~~~~~~~
-            return '';
-    ~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-    }
-    ~
+             ~~
 !!! error TS2354: No best common type exists among return expressions.
+        if (true) {
+            return 1;
+        } else {
+            return '';
+        }
+    }
     
     function f2() {
-    ~~~~~~~~~~~~~~~
-        if (true) {
-    ~~~~~~~~~~~~~~~
-            return 1;
-    ~~~~~~~~~~~~~~~~~
-        } else if (false) {
-    ~~~~~~~~~~~~~~~~~~~~~~~
-            return 2;
-    ~~~~~~~~~~~~~~~~~
-        } else {
-    ~~~~~~~~~~~~
-            return '';
-    ~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-    }
-    ~
+             ~~
 !!! error TS2354: No best common type exists among return expressions.
+        if (true) {
+            return 1;
+        } else if (false) {
+            return 2;
+        } else {
+            return '';
+        }
+    }
     
     function f3() {
-    ~~~~~~~~~~~~~~~
-        try {
-    ~~~~~~~~~
-            return 1;
-    ~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-        catch (e) {
-    ~~~~~~~~~~~~~~~
-            return '';
-    ~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-    }
-    ~
+             ~~
 !!! error TS2354: No best common type exists among return expressions.
+        try {
+            return 1;
+        }
+        catch (e) {
+            return '';
+        }
+    }
     
     function f4() {
-    ~~~~~~~~~~~~~~~
-        try {
-    ~~~~~~~~~
-            return 1;
-    ~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-        catch (e) {
-    ~~~~~~~~~~~~~~~
-    
-    
-        }
-    ~~~~~
-        finally {
-    ~~~~~~~~~~~~~
-            return '';
-    ~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-    }
-    ~
+             ~~
 !!! error TS2354: No best common type exists among return expressions.
+        try {
+            return 1;
+        }
+        catch (e) {
+    
+        }
+        finally {
+            return '';
+        }
+    }
     
     function f5() {
-    ~~~~~~~~~~~~~~~
-        return 1;
-    ~~~~~~~~~~~~~
-        return '';
-    ~~~~~~~~~~~~~~
-    }
-    ~
+             ~~
 !!! error TS2354: No best common type exists among return expressions.
+        return 1;
+        return '';
+    }
     
     function f6<T, U>(x: T, y:U) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        if (true) {
-    ~~~~~~~~~~~~~~~
-            return x;
-    ~~~~~~~~~~~~~~~~~
-        } else {
-    ~~~~~~~~~~~~
-            return y;
-    ~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-    }
-    ~
+             ~~
 !!! error TS2354: No best common type exists among return expressions.
+        if (true) {
+            return x;
+        } else {
+            return y;
+        }
+    }
     
     function f8<T extends U, U extends V, V>(x: T, y: U) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~
+!!! error TS2354: No best common type exists among return expressions.
                 ~~~~~~~~~~~
 !!! error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
                              ~~~~~~~~~~~
 !!! error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
         if (true) {
-    ~~~~~~~~~~~~~~~
             return x;
-    ~~~~~~~~~~~~~~~~~
         } else {
-    ~~~~~~~~~~~~
             return y;
-    ~~~~~~~~~~~~~~~~~
         }
-    ~~~~~
     }
-    ~
-!!! error TS2354: No best common type exists among return expressions.
     

--- a/tests/baselines/reference/functionWithMultipleReturnStatements2.errors.txt
+++ b/tests/baselines/reference/functionWithMultipleReturnStatements2.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements2.ts(58,1): error TS2354: No best common type exists among return expressions.
-tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements2.ts(67,1): error TS2354: No best common type exists among return expressions.
+tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements2.ts(58,10): error TS2354: No best common type exists among return expressions.
+tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements2.ts(67,10): error TS2354: No best common type exists among return expressions.
 
 
 ==== tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMultipleReturnStatements2.ts (2 errors) ====
@@ -61,37 +61,25 @@ tests/cases/conformance/types/typeRelationships/bestCommonType/functionWithMulti
     var b: { x: number; z?: number };
     // returns typeof a
     function f9() {
-    ~~~~~~~~~~~~~~~
-        if (true) {
-    ~~~~~~~~~~~~~~~
-            return a;
-    ~~~~~~~~~~~~~~~~~
-        } else {
-    ~~~~~~~~~~~~
-            return b;
-    ~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-    }
-    ~
+             ~~
 !!! error TS2354: No best common type exists among return expressions.
+        if (true) {
+            return a;
+        } else {
+            return b;
+        }
+    }
     
     // returns typeof b
     function f10() {
-    ~~~~~~~~~~~~~~~~
-        if (true) {
-    ~~~~~~~~~~~~~~~
-            return b;
-    ~~~~~~~~~~~~~~~~~
-        } else {
-    ~~~~~~~~~~~~
-            return a;
-    ~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-    }
-    ~
+             ~~~
 !!! error TS2354: No best common type exists among return expressions.
+        if (true) {
+            return b;
+        } else {
+            return a;
+        }
+    }
     
     // returns number => void
     function f11() {

--- a/tests/baselines/reference/functionWithNoBestCommonType1.errors.txt
+++ b/tests/baselines/reference/functionWithNoBestCommonType1.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/compiler/functionWithNoBestCommonType1.ts(1,10): error TS2354: No best common type exists among return expressions.
+
+
+==== tests/cases/compiler/functionWithNoBestCommonType1.ts (1 errors) ====
+    function foo() {
+             ~~~
+!!! error TS2354: No best common type exists among return expressions.
+        return true;
+        return bar();
+    }
+    
+    function bar(): void {
+    }

--- a/tests/baselines/reference/functionWithNoBestCommonType1.js
+++ b/tests/baselines/reference/functionWithNoBestCommonType1.js
@@ -1,0 +1,16 @@
+//// [functionWithNoBestCommonType1.ts]
+function foo() {
+    return true;
+    return bar();
+}
+
+function bar(): void {
+}
+
+//// [functionWithNoBestCommonType1.js]
+function foo() {
+    return true;
+    return bar();
+}
+function bar() {
+}

--- a/tests/baselines/reference/functionWithNoBestCommonType2.errors.txt
+++ b/tests/baselines/reference/functionWithNoBestCommonType2.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/compiler/functionWithNoBestCommonType2.ts(1,9): error TS2354: No best common type exists among return expressions.
+
+
+==== tests/cases/compiler/functionWithNoBestCommonType2.ts (1 errors) ====
+    var v = function () {
+            ~~~~~~~~
+!!! error TS2354: No best common type exists among return expressions.
+       return true;
+       return bar();
+    };
+    
+    function bar(): void {
+    }

--- a/tests/baselines/reference/functionWithNoBestCommonType2.js
+++ b/tests/baselines/reference/functionWithNoBestCommonType2.js
@@ -1,0 +1,16 @@
+//// [functionWithNoBestCommonType2.ts]
+var v = function () {
+   return true;
+   return bar();
+};
+
+function bar(): void {
+}
+
+//// [functionWithNoBestCommonType2.js]
+var v = function () {
+    return true;
+    return bar();
+};
+function bar() {
+}

--- a/tests/baselines/reference/implicitAnyAmbients.errors.txt
+++ b/tests/baselines/reference/implicitAnyAmbients.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/implicitAnyAmbients.ts(3,9): error TS7005: Variable 'x' implicitly has an 'any' type.
-tests/cases/compiler/implicitAnyAmbients.ts(6,5): error TS7010: 'f', which lacks return-type annotation, implicitly has an 'any' return type.
+tests/cases/compiler/implicitAnyAmbients.ts(6,14): error TS7010: 'f', which lacks return-type annotation, implicitly has an 'any' return type.
 tests/cases/compiler/implicitAnyAmbients.ts(6,16): error TS7006: Parameter 'x' implicitly has an 'any' type.
-tests/cases/compiler/implicitAnyAmbients.ts(7,5): error TS7010: 'f2', which lacks return-type annotation, implicitly has an 'any' return type.
+tests/cases/compiler/implicitAnyAmbients.ts(7,14): error TS7010: 'f2', which lacks return-type annotation, implicitly has an 'any' return type.
 tests/cases/compiler/implicitAnyAmbients.ts(11,9): error TS7010: 'foo', which lacks return-type annotation, implicitly has an 'any' return type.
 tests/cases/compiler/implicitAnyAmbients.ts(12,9): error TS7010: 'foo2', which lacks return-type annotation, implicitly has an 'any' return type.
 tests/cases/compiler/implicitAnyAmbients.ts(17,9): error TS7010: 'foo', which lacks return-type annotation, implicitly has an 'any' return type.
@@ -18,12 +18,12 @@ tests/cases/compiler/implicitAnyAmbients.ts(23,13): error TS7005: Variable 'y' i
         var y: any;
     
         function f(x); // error 
-        ~~~~~~~~~~~~~~
+                 ~
 !!! error TS7010: 'f', which lacks return-type annotation, implicitly has an 'any' return type.
                    ~
 !!! error TS7006: Parameter 'x' implicitly has an 'any' type.
         function f2(x: any); // error
-        ~~~~~~~~~~~~~~~~~~~~
+                 ~~
 !!! error TS7010: 'f2', which lacks return-type annotation, implicitly has an 'any' return type.
         function f3(x: any): any;
     

--- a/tests/baselines/reference/implicitAnyCastedValue.errors.txt
+++ b/tests/baselines/reference/implicitAnyCastedValue.errors.txt
@@ -4,7 +4,7 @@ tests/cases/compiler/implicitAnyCastedValue.ts(12,16): error TS1056: Accessors a
 tests/cases/compiler/implicitAnyCastedValue.ts(26,5): error TS7008: Member 'getValue' implicitly has an 'any' type.
 tests/cases/compiler/implicitAnyCastedValue.ts(28,16): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/implicitAnyCastedValue.ts(32,16): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/compiler/implicitAnyCastedValue.ts(41,1): error TS7010: 'notCastedNull', which lacks return-type annotation, implicitly has an 'any' return type.
+tests/cases/compiler/implicitAnyCastedValue.ts(41,10): error TS7010: 'notCastedNull', which lacks return-type annotation, implicitly has an 'any' return type.
 tests/cases/compiler/implicitAnyCastedValue.ts(53,24): error TS7006: Parameter 'x' implicitly has an 'any' type.
 tests/cases/compiler/implicitAnyCastedValue.ts(62,24): error TS7006: Parameter 'x' implicitly has an 'any' type.
 
@@ -63,12 +63,10 @@ tests/cases/compiler/implicitAnyCastedValue.ts(62,24): error TS7006: Parameter '
     }
     
     function notCastedNull() {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
-        return null;  // this should be an error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    }
-    ~
+             ~~~~~~~~~~~~~
 !!! error TS7010: 'notCastedNull', which lacks return-type annotation, implicitly has an 'any' return type.
+        return null;  // this should be an error
+    }
     
     function returnTypeBar(): any {
         return null;  // this should not be an error

--- a/tests/baselines/reference/implicitAnyDeclareFunctionExprWithoutFormalType.errors.txt
+++ b/tests/baselines/reference/implicitAnyDeclareFunctionExprWithoutFormalType.errors.txt
@@ -2,9 +2,9 @@ tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts(2,15): e
 tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts(3,15): error TS7006: Parameter 'll1' implicitly has an 'any' type.
 tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts(4,33): error TS7006: Parameter 'myParam' implicitly has an 'any' type.
 tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts(5,14): error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
-tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts(8,15): error TS7010: 'temp', which lacks return-type annotation, implicitly has an 'any' return type.
+tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts(8,24): error TS7010: 'temp', which lacks return-type annotation, implicitly has an 'any' return type.
 tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts(9,15): error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
-tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts(10,15): error TS7010: 'temp', which lacks return-type annotation, implicitly has an 'any' return type.
+tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts(10,24): error TS7010: 'temp', which lacks return-type annotation, implicitly has an 'any' return type.
 tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts(11,15): error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
 
 
@@ -25,13 +25,13 @@ tests/cases/compiler/implicitAnyDeclareFunctionExprWithoutFormalType.ts(11,15): 
     
     // these should be error for implicit any return type
     var lambda5 = function temp() { return null; }
-                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                           ~~~~
 !!! error TS7010: 'temp', which lacks return-type annotation, implicitly has an 'any' return type.
     var lambda6 = () => { return null; }
                   ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS7011: Function expression, which lacks return-type annotation, implicitly has an 'any' return type.
     var lambda7 = function temp() { return undefined; }
-                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                           ~~~~
 !!! error TS7010: 'temp', which lacks return-type annotation, implicitly has an 'any' return type.
     var lambda8 = () => { return undefined; }
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/baselines/reference/implicitAnyFromCircularInference.errors.txt
+++ b/tests/baselines/reference/implicitAnyFromCircularInference.errors.txt
@@ -36,12 +36,10 @@ tests/cases/compiler/implicitAnyFromCircularInference.ts(46,5): error TS7023: 'x
     
     // Error expected
     var f1 = function () {
-             ~~~~~~~~~~~~~
-        return f1();
-    ~~~~~~~~~~~~~~~~
-    };
-    ~
+             ~~~~~~~~
 !!! error TS7024: Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+        return f1();
+    };
     
     // Error expected
     var f2 = () => f2();

--- a/tests/baselines/reference/implicitAnyFunctionReturnNullOrUndefined.errors.txt
+++ b/tests/baselines/reference/implicitAnyFunctionReturnNullOrUndefined.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/implicitAnyFunctionReturnNullOrUndefined.ts(2,1): error TS7010: 'nullWidenFunction', which lacks return-type annotation, implicitly has an 'any' return type.
-tests/cases/compiler/implicitAnyFunctionReturnNullOrUndefined.ts(3,1): error TS7010: 'undefinedWidenFunction', which lacks return-type annotation, implicitly has an 'any' return type.
+tests/cases/compiler/implicitAnyFunctionReturnNullOrUndefined.ts(2,10): error TS7010: 'nullWidenFunction', which lacks return-type annotation, implicitly has an 'any' return type.
+tests/cases/compiler/implicitAnyFunctionReturnNullOrUndefined.ts(3,10): error TS7010: 'undefinedWidenFunction', which lacks return-type annotation, implicitly has an 'any' return type.
 tests/cases/compiler/implicitAnyFunctionReturnNullOrUndefined.ts(6,5): error TS7010: 'nullWidenFuncOfC', which lacks return-type annotation, implicitly has an 'any' return type.
 tests/cases/compiler/implicitAnyFunctionReturnNullOrUndefined.ts(10,5): error TS7010: 'underfinedWidenFuncOfC', which lacks return-type annotation, implicitly has an 'any' return type.
 
@@ -7,10 +7,10 @@ tests/cases/compiler/implicitAnyFunctionReturnNullOrUndefined.ts(10,5): error TS
 ==== tests/cases/compiler/implicitAnyFunctionReturnNullOrUndefined.ts (4 errors) ====
     // this should be an error
     function nullWidenFunction() { return null;}             // error at "nullWidenFunction"
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~~~~~~~~~~~~~~~
 !!! error TS7010: 'nullWidenFunction', which lacks return-type annotation, implicitly has an 'any' return type.
     function undefinedWidenFunction() { return undefined; }  // error at "undefinedWidenFunction"
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS7010: 'undefinedWidenFunction', which lacks return-type annotation, implicitly has an 'any' return type.
     
     class C {

--- a/tests/baselines/reference/implicitAnyInAmbientDeclaration2.d.errors.txt
+++ b/tests/baselines/reference/implicitAnyInAmbientDeclaration2.d.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/implicitAnyInAmbientDeclaration2.d.ts(1,1): error TS7010: 'foo', which lacks return-type annotation, implicitly has an 'any' return type.
+tests/cases/compiler/implicitAnyInAmbientDeclaration2.d.ts(1,18): error TS7010: 'foo', which lacks return-type annotation, implicitly has an 'any' return type.
 tests/cases/compiler/implicitAnyInAmbientDeclaration2.d.ts(1,22): error TS7006: Parameter 'x' implicitly has an 'any' type.
 tests/cases/compiler/implicitAnyInAmbientDeclaration2.d.ts(2,13): error TS7005: Variable 'bar' implicitly has an 'any' type.
 tests/cases/compiler/implicitAnyInAmbientDeclaration2.d.ts(4,5): error TS7008: Member 'publicMember' implicitly has an 'any' type.
@@ -10,7 +10,7 @@ tests/cases/compiler/implicitAnyInAmbientDeclaration2.d.ts(13,24): error TS7006:
 
 ==== tests/cases/compiler/implicitAnyInAmbientDeclaration2.d.ts (8 errors) ====
     declare function foo(x);  // this should be an error
-    ~~~~~~~~~~~~~~~~~~~~~~~~
+                     ~~~
 !!! error TS7010: 'foo', which lacks return-type annotation, implicitly has an 'any' return type.
                          ~
 !!! error TS7006: Parameter 'x' implicitly has an 'any' type.

--- a/tests/baselines/reference/inferredFunctionReturnTypeIsEmptyType.errors.txt
+++ b/tests/baselines/reference/inferredFunctionReturnTypeIsEmptyType.errors.txt
@@ -1,22 +1,15 @@
-tests/cases/compiler/inferredFunctionReturnTypeIsEmptyType.ts(1,1): error TS2354: No best common type exists among return expressions.
+tests/cases/compiler/inferredFunctionReturnTypeIsEmptyType.ts(1,10): error TS2354: No best common type exists among return expressions.
 
 
 ==== tests/cases/compiler/inferredFunctionReturnTypeIsEmptyType.ts (1 errors) ====
     function foo() {
-    ~~~~~~~~~~~~~~~~
-        if (true) {
-    ~~~~~~~~~~~~~~~
-            return 42;
-    ~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-        else {
-    ~~~~~~~~~~
-            return "42";
-    ~~~~~~~~~~~~~~~~~~~~
-        }
-    ~~~~~
-    };
-    ~
+             ~~~
 !!! error TS2354: No best common type exists among return expressions.
+        if (true) {
+            return 42;
+        }
+        else {
+            return "42";
+        }
+    };
     

--- a/tests/baselines/reference/noImplicitAnyFunctions.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyFunctions.errors.txt
@@ -1,14 +1,14 @@
-tests/cases/compiler/noImplicitAnyFunctions.ts(2,1): error TS7010: 'f1', which lacks return-type annotation, implicitly has an 'any' return type.
+tests/cases/compiler/noImplicitAnyFunctions.ts(2,18): error TS7010: 'f1', which lacks return-type annotation, implicitly has an 'any' return type.
 tests/cases/compiler/noImplicitAnyFunctions.ts(6,13): error TS7006: Parameter 'x' implicitly has an 'any' type.
-tests/cases/compiler/noImplicitAnyFunctions.ts(17,1): error TS7010: 'f6', which lacks return-type annotation, implicitly has an 'any' return type.
-tests/cases/compiler/noImplicitAnyFunctions.ts(19,1): error TS7010: 'f6', which lacks return-type annotation, implicitly has an 'any' return type.
+tests/cases/compiler/noImplicitAnyFunctions.ts(17,10): error TS7010: 'f6', which lacks return-type annotation, implicitly has an 'any' return type.
+tests/cases/compiler/noImplicitAnyFunctions.ts(19,10): error TS7010: 'f6', which lacks return-type annotation, implicitly has an 'any' return type.
 tests/cases/compiler/noImplicitAnyFunctions.ts(19,24): error TS7006: Parameter 'y' implicitly has an 'any' type.
 
 
 ==== tests/cases/compiler/noImplicitAnyFunctions.ts (5 errors) ====
     
     declare function f1();
-    ~~~~~~~~~~~~~~~~~~~~~~
+                     ~~
 !!! error TS7010: 'f1', which lacks return-type annotation, implicitly has an 'any' return type.
     
     declare function f2(): any;
@@ -27,15 +27,13 @@ tests/cases/compiler/noImplicitAnyFunctions.ts(19,24): error TS7006: Parameter '
     }
     
     function f6(x: string, y: number);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~
 !!! error TS7010: 'f6', which lacks return-type annotation, implicitly has an 'any' return type.
     function f6(x: string, y: string): any;
     function f6(x: string, y) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~
+!!! error TS7010: 'f6', which lacks return-type annotation, implicitly has an 'any' return type.
                            ~
 !!! error TS7006: Parameter 'y' implicitly has an 'any' type.
         return null;
-    ~~~~~~~~~~~~~~~~
     }
-    ~
-!!! error TS7010: 'f6', which lacks return-type annotation, implicitly has an 'any' return type.

--- a/tests/baselines/reference/noImplicitAnyModule.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyModule.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/noImplicitAnyModule.ts(5,9): error TS7013: Construct signature, which lacks return-type annotation, implicitly has an 'any' return type.
 tests/cases/compiler/noImplicitAnyModule.ts(10,18): error TS7006: Parameter 'x' implicitly has an 'any' type.
 tests/cases/compiler/noImplicitAnyModule.ts(11,9): error TS7010: 'g', which lacks return-type annotation, implicitly has an 'any' return type.
-tests/cases/compiler/noImplicitAnyModule.ts(18,5): error TS7010: 'f', which lacks return-type annotation, implicitly has an 'any' return type.
+tests/cases/compiler/noImplicitAnyModule.ts(18,14): error TS7010: 'f', which lacks return-type annotation, implicitly has an 'any' return type.
 
 
 ==== tests/cases/compiler/noImplicitAnyModule.ts (4 errors) ====
@@ -29,7 +29,7 @@ tests/cases/compiler/noImplicitAnyModule.ts(18,5): error TS7010: 'f', which lack
     
         // Should return error for implicit any on return type.
         function f(x: number);
-        ~~~~~~~~~~~~~~~~~~~~~~
+                 ~
 !!! error TS7010: 'f', which lacks return-type annotation, implicitly has an 'any' return type.
     }
     

--- a/tests/baselines/reference/noImplicitAnyWithOverloads.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyWithOverloads.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/noImplicitAnyWithOverloads.ts(2,5): error TS7008: Member 'foo' implicitly has an 'any' type.
-tests/cases/compiler/noImplicitAnyWithOverloads.ts(6,1): error TS7010: 'callb', which lacks return-type annotation, implicitly has an 'any' return type.
-tests/cases/compiler/noImplicitAnyWithOverloads.ts(7,1): error TS7010: 'callb', which lacks return-type annotation, implicitly has an 'any' return type.
+tests/cases/compiler/noImplicitAnyWithOverloads.ts(6,10): error TS7010: 'callb', which lacks return-type annotation, implicitly has an 'any' return type.
+tests/cases/compiler/noImplicitAnyWithOverloads.ts(7,10): error TS7010: 'callb', which lacks return-type annotation, implicitly has an 'any' return type.
 tests/cases/compiler/noImplicitAnyWithOverloads.ts(8,16): error TS7006: Parameter 'a' implicitly has an 'any' type.
 
 
@@ -13,10 +13,10 @@ tests/cases/compiler/noImplicitAnyWithOverloads.ts(8,16): error TS7006: Paramete
     interface B { }
     
     function callb(lam: (l: A) => void);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~~~
 !!! error TS7010: 'callb', which lacks return-type annotation, implicitly has an 'any' return type.
     function callb(lam: (n: B) => void);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~~~
 !!! error TS7010: 'callb', which lacks return-type annotation, implicitly has an 'any' return type.
     function callb(a) { }
                    ~

--- a/tests/baselines/reference/overloadAssignmentCompat.errors.txt
+++ b/tests/baselines/reference/overloadAssignmentCompat.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/overloadAssignmentCompat.ts(35,1): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/compiler/overloadAssignmentCompat.ts(35,10): error TS2394: Overload signature is not compatible with function implementation.
 
 
 ==== tests/cases/compiler/overloadAssignmentCompat.ts (1 errors) ====
@@ -37,7 +37,7 @@ tests/cases/compiler/overloadAssignmentCompat.ts(35,1): error TS2394: Overload s
     
     // error - signatures are not assignment compatible
     function foo():number; 
-    ~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
     function foo():string { return "a" };
     

--- a/tests/baselines/reference/overloadOnConstConstraintChecks4.errors.txt
+++ b/tests/baselines/reference/overloadOnConstConstraintChecks4.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/overloadOnConstConstraintChecks4.ts(9,1): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/compiler/overloadOnConstConstraintChecks4.ts(9,10): error TS2394: Overload signature is not compatible with function implementation.
 
 
 ==== tests/cases/compiler/overloadOnConstConstraintChecks4.ts (1 errors) ====
@@ -11,7 +11,7 @@ tests/cases/compiler/overloadOnConstConstraintChecks4.ts(9,1): error TS2394: Ove
     function foo(name: 'hi'): B;
     function foo(name: 'bye'): C;
     function foo(name: string): A; // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
     function foo(name: any): Z {
         return null;

--- a/tests/baselines/reference/overloadOnConstDuplicateOverloads1.errors.txt
+++ b/tests/baselines/reference/overloadOnConstDuplicateOverloads1.errors.txt
@@ -1,13 +1,13 @@
-tests/cases/compiler/overloadOnConstDuplicateOverloads1.ts(1,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
-tests/cases/compiler/overloadOnConstDuplicateOverloads1.ts(2,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/compiler/overloadOnConstDuplicateOverloads1.ts(1,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/compiler/overloadOnConstDuplicateOverloads1.ts(2,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
 
 
 ==== tests/cases/compiler/overloadOnConstDuplicateOverloads1.ts (2 errors) ====
     function foo(a: 'hi', x: string);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function foo(a: 'hi', x: string);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function foo(a: any, x: any) {
     }

--- a/tests/baselines/reference/overloadOnConstantsInvalidOverload1.errors.txt
+++ b/tests/baselines/reference/overloadOnConstantsInvalidOverload1.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/overloadOnConstantsInvalidOverload1.ts(6,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
-tests/cases/compiler/overloadOnConstantsInvalidOverload1.ts(7,1): error TS2381: A signature with an implementation cannot use a string literal type.
+tests/cases/compiler/overloadOnConstantsInvalidOverload1.ts(6,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/compiler/overloadOnConstantsInvalidOverload1.ts(7,10): error TS2381: A signature with an implementation cannot use a string literal type.
 tests/cases/compiler/overloadOnConstantsInvalidOverload1.ts(11,5): error TS2345: Argument of type 'string' is not assignable to parameter of type '"SPAN"'.
 
 
@@ -10,15 +10,13 @@ tests/cases/compiler/overloadOnConstantsInvalidOverload1.ts(11,5): error TS2345:
     class Derived3 extends Base { biz() { } }
     
     function foo(name: "SPAN"): Derived1;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function foo(name: "DIV"): Derived2 {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        return null;
-    ~~~~~~~~~~~~~~~~
-    }
-    ~
+             ~~~
 !!! error TS2381: A signature with an implementation cannot use a string literal type.
+        return null;
+    }
     
     foo("HI");
         ~~~~

--- a/tests/baselines/reference/overloadingOnConstants2.errors.txt
+++ b/tests/baselines/reference/overloadingOnConstants2.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/compiler/overloadingOnConstants2.ts(8,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
-tests/cases/compiler/overloadingOnConstants2.ts(9,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/compiler/overloadingOnConstants2.ts(8,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/compiler/overloadingOnConstants2.ts(9,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
 tests/cases/compiler/overloadingOnConstants2.ts(15,13): error TS2345: Argument of type 'string' is not assignable to parameter of type '"bye"'.
-tests/cases/compiler/overloadingOnConstants2.ts(19,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/compiler/overloadingOnConstants2.ts(19,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
 
 
 ==== tests/cases/compiler/overloadingOnConstants2.ts (4 errors) ====
@@ -13,10 +13,10 @@ tests/cases/compiler/overloadingOnConstants2.ts(19,1): error TS2382: Specialized
        private y = 1;
     }
     function foo(x: "hi", items: string[]): D;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function foo(x: "bye", items: string[]): E;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function foo(x: string, items: string[]): C {
        return null;
@@ -30,7 +30,7 @@ tests/cases/compiler/overloadingOnConstants2.ts(19,1): error TS2382: Specialized
     
     //function bar(x: "hi", items: string[]): D;
     function bar(x: "bye", items: string[]): E;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function bar(x: string, items: string[]): C;
     function bar(x: string, items: string[]): C {

--- a/tests/baselines/reference/overloadingOnConstantsInImplementation.errors.txt
+++ b/tests/baselines/reference/overloadingOnConstantsInImplementation.errors.txt
@@ -1,17 +1,16 @@
-tests/cases/compiler/overloadingOnConstantsInImplementation.ts(1,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
-tests/cases/compiler/overloadingOnConstantsInImplementation.ts(2,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
-tests/cases/compiler/overloadingOnConstantsInImplementation.ts(3,1): error TS2381: A signature with an implementation cannot use a string literal type.
+tests/cases/compiler/overloadingOnConstantsInImplementation.ts(1,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/compiler/overloadingOnConstantsInImplementation.ts(2,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/compiler/overloadingOnConstantsInImplementation.ts(3,10): error TS2381: A signature with an implementation cannot use a string literal type.
 
 
 ==== tests/cases/compiler/overloadingOnConstantsInImplementation.ts (3 errors) ====
     function foo(a: 'hi', x: string);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function foo(a: 'hi', x: string);
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function foo(a: 'hi', x: any) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    }
-    ~
+             ~~~
 !!! error TS2381: A signature with an implementation cannot use a string literal type.
+    }

--- a/tests/baselines/reference/parserArgumentList1.errors.txt
+++ b/tests/baselines/reference/parserArgumentList1.errors.txt
@@ -1,21 +1,17 @@
-tests/cases/conformance/parser/ecmascript5/parserArgumentList1.ts(1,1): error TS1148: Cannot compile external modules unless the '--module' flag is provided.
+tests/cases/conformance/parser/ecmascript5/parserArgumentList1.ts(1,17): error TS1148: Cannot compile external modules unless the '--module' flag is provided.
 tests/cases/conformance/parser/ecmascript5/parserArgumentList1.ts(1,35): error TS2304: Cannot find name 'HTMLElement'.
 tests/cases/conformance/parser/ecmascript5/parserArgumentList1.ts(2,42): error TS2304: Cannot find name '_classNameRegexp'.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/parserArgumentList1.ts (3 errors) ====
     export function removeClass (node:HTMLElement, className:string) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    ~~~~~~~~~~~
+!!! error TS1148: Cannot compile external modules unless the '--module' flag is provided.
                                       ~~~~~~~~~~~
 !!! error TS2304: Cannot find name 'HTMLElement'.
     	node.className = node.className.replace(_classNameRegexp(className), function (everything, leftDelimiter, name, rightDelimiter) {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	                                        ~~~~~~~~~~~~~~~~
 !!! error TS2304: Cannot find name '_classNameRegexp'.
     		return leftDelimiter.length + rightDelimiter.length === 2 ? ' ' : '';
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     	});
-    ~~~~
     }
-    ~
-!!! error TS1148: Cannot compile external modules unless the '--module' flag is provided.

--- a/tests/baselines/reference/parserModifierOnStatementInBlock1.errors.txt
+++ b/tests/baselines/reference/parserModifierOnStatementInBlock1.errors.txt
@@ -1,15 +1,13 @@
-tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock1.ts(1,1): error TS1148: Cannot compile external modules unless the '--module' flag is provided.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock1.ts(1,17): error TS1148: Cannot compile external modules unless the '--module' flag is provided.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock1.ts(2,4): error TS1184: Modifiers cannot appear here.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock1.ts (2 errors) ====
     export function foo() {
-    ~~~~~~~~~~~~~~~~~~~~~~~
+                    ~~~
+!!! error TS1148: Cannot compile external modules unless the '--module' flag is provided.
        export var x = this;
-    ~~~~~~~~~~~~~~~~~~~~~~~
        ~~~~~~
 !!! error TS1184: Modifiers cannot appear here.
     }
-    ~
-!!! error TS1148: Cannot compile external modules unless the '--module' flag is provided.
     

--- a/tests/baselines/reference/parserModifierOnStatementInBlock3.errors.txt
+++ b/tests/baselines/reference/parserModifierOnStatementInBlock3.errors.txt
@@ -1,17 +1,14 @@
-tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock3.ts(1,1): error TS1148: Cannot compile external modules unless the '--module' flag is provided.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock3.ts(1,17): error TS1148: Cannot compile external modules unless the '--module' flag is provided.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock3.ts(2,4): error TS1184: Modifiers cannot appear here.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserModifierOnStatementInBlock3.ts (2 errors) ====
     export function foo() {
-    ~~~~~~~~~~~~~~~~~~~~~~~
+                    ~~~
+!!! error TS1148: Cannot compile external modules unless the '--module' flag is provided.
        export function bar() {
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~
        ~~~~~~
 !!! error TS1184: Modifiers cannot appear here.
        }
-    ~~~~
     }
-    ~
-!!! error TS1148: Cannot compile external modules unless the '--module' flag is provided.
     

--- a/tests/baselines/reference/parserParameterList15.errors.txt
+++ b/tests/baselines/reference/parserParameterList15.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList15.ts(1,1): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList15.ts(1,10): error TS2394: Overload signature is not compatible with function implementation.
 tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList15.ts(1,14): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/ParameterLists/parserParameterList15.ts (2 errors) ====
     function foo(a = 4);
-    ~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
                  ~~~~~
 !!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.

--- a/tests/baselines/reference/parserUnaryExpression2.errors.txt
+++ b/tests/baselines/reference/parserUnaryExpression2.errors.txt
@@ -3,5 +3,5 @@ tests/cases/conformance/parser/ecmascript5/Expressions/parserUnaryExpression2.ts
 
 ==== tests/cases/conformance/parser/ecmascript5/Expressions/parserUnaryExpression2.ts (1 errors) ====
     ++function(e) { }
-      ~~~~~~~~~~~~~~~
+      ~~~~~~~~
 !!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.

--- a/tests/baselines/reference/recursiveFunctionTypes.errors.txt
+++ b/tests/baselines/reference/recursiveFunctionTypes.errors.txt
@@ -7,7 +7,7 @@ tests/cases/compiler/recursiveFunctionTypes.ts(12,16): error TS2355: A function 
 tests/cases/compiler/recursiveFunctionTypes.ts(17,5): error TS2322: Type '() => I<typeof f3>' is not assignable to type 'number'.
 tests/cases/compiler/recursiveFunctionTypes.ts(22,5): error TS2345: Argument of type 'number' is not assignable to parameter of type '(t: typeof g) => void'.
 tests/cases/compiler/recursiveFunctionTypes.ts(25,1): error TS2322: Type 'number' is not assignable to type '() => any'.
-tests/cases/compiler/recursiveFunctionTypes.ts(30,1): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/compiler/recursiveFunctionTypes.ts(30,10): error TS2394: Overload signature is not compatible with function implementation.
 tests/cases/compiler/recursiveFunctionTypes.ts(33,1): error TS2346: Supplied parameters do not match any signature of call target.
 tests/cases/compiler/recursiveFunctionTypes.ts(34,4): error TS2345: Argument of type 'string' is not assignable to parameter of type '{ (): typeof f6; (a: typeof f6): () => number; }'.
 tests/cases/compiler/recursiveFunctionTypes.ts(42,1): error TS2346: Supplied parameters do not match any signature of call target.
@@ -62,7 +62,7 @@ tests/cases/compiler/recursiveFunctionTypes.ts(43,4): error TS2345: Argument of 
     
     function f6(): typeof f6;
     function f6(a: typeof f6): () => number;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
     function f6(a?: any) { return f6; }
     

--- a/tests/baselines/reference/specializedOverloadWithRestParameters.errors.txt
+++ b/tests/baselines/reference/specializedOverloadWithRestParameters.errors.txt
@@ -1,19 +1,19 @@
-tests/cases/compiler/specializedOverloadWithRestParameters.ts(3,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
-tests/cases/compiler/specializedOverloadWithRestParameters.ts(8,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/compiler/specializedOverloadWithRestParameters.ts(3,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/compiler/specializedOverloadWithRestParameters.ts(8,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
 
 
 ==== tests/cases/compiler/specializedOverloadWithRestParameters.ts (2 errors) ====
     class Base { foo() { } }
     class Derived1 extends Base { bar() { } }
     function f(tagName: 'span', ...args): Derived1;   // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function f(tagName: number, ...args): Base;
     function f(tagName: any): Base {
         return null;
     }
     function g(tagName: 'span', arg): Derived1;    // error
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function g(tagName: number, arg): Base;
     function g(tagName: any): Base {

--- a/tests/baselines/reference/specializedSignatureIsNotSubtypeOfNonSpecializedSignature.errors.txt
+++ b/tests/baselines/reference/specializedSignatureIsNotSubtypeOfNonSpecializedSignature.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/specializedSignatureIsNotSubtypeOfNonSpecializedSignature.ts(4,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/conformance/types/objectTypeLiteral/callSignatures/specializedSignatureIsNotSubtypeOfNonSpecializedSignature.ts(4,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/specializedSignatureIsNotSubtypeOfNonSpecializedSignature.ts(8,5): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/specializedSignatureIsNotSubtypeOfNonSpecializedSignature.ts(14,5): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/specializedSignatureIsNotSubtypeOfNonSpecializedSignature.ts(20,5): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
@@ -17,7 +17,7 @@ tests/cases/conformance/types/objectTypeLiteral/callSignatures/specializedSignat
     // All the below should be errors
     
     function foo(x: 'a');
-    ~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function foo(x: number) { }
     

--- a/tests/baselines/reference/stringLiteralTypeIsSubtypeOfString.errors.txt
+++ b/tests/baselines/reference/stringLiteralTypeIsSubtypeOfString.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(22,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(26,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(30,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(34,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(38,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(76,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
-tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(89,1): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(22,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(26,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(30,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(34,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(38,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(76,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
+tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(89,10): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(93,17): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(94,17): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLiteralTypeIsSubtypeOfString.ts(95,17): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
@@ -36,31 +36,31 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLite
     function f4(x: any) { }
     
     function f5(x: 'a');
-    ~~~~~~~~~~~~~~~~~~~~
+             ~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function f5(x: number);
     function f5(x: any) { }
     
     function f6(x: 'a');
-    ~~~~~~~~~~~~~~~~~~~~
+             ~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function f6(x: boolean);
     function f6(x: any) { }
     
     function f7(x: 'a');
-    ~~~~~~~~~~~~~~~~~~~~
+             ~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function f7(x: Date);
     function f7(x: any) { }
     
     function f8(x: 'a');
-    ~~~~~~~~~~~~~~~~~~~~
+             ~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function f8(x: RegExp);
     function f8(x: any) { }
     
     function f9(x: 'a');
-    ~~~~~~~~~~~~~~~~~~~~
+             ~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function f9(x: () => {});
     function f9(x: any) { }
@@ -100,7 +100,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLite
     
     // BUG 831846
     function f11(x: 'a');
-    ~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function f11(x: I);
     function f11(x: any) { }
@@ -115,7 +115,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/stringLite
     
     enum E { A }
     function f14(x: 'a');
-    ~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
     function f14(x: E);
     function f14(x: any) { }

--- a/tests/baselines/reference/stringLiteralTypesInImplementationSignatures.errors.txt
+++ b/tests/baselines/reference/stringLiteralTypesInImplementationSignatures.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts(3,1): error TS2381: A signature with an implementation cannot use a string literal type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts(4,9): error TS2381: A signature with an implementation cannot use a string literal type.
+tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts(3,10): error TS2381: A signature with an implementation cannot use a string literal type.
+tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts(4,18): error TS2381: A signature with an implementation cannot use a string literal type.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts(5,10): error TS2381: A signature with an implementation cannot use a string literal type.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts(8,5): error TS2381: A signature with an implementation cannot use a string literal type.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts(12,5): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
@@ -7,7 +7,7 @@ tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralType
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts(17,5): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts(18,5): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts(22,5): error TS2381: A signature with an implementation cannot use a string literal type.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts(23,8): error TS2381: A signature with an implementation cannot use a string literal type.
+tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts(23,17): error TS2381: A signature with an implementation cannot use a string literal type.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures.ts(24,8): error TS2381: A signature with an implementation cannot use a string literal type.
 
 
@@ -15,10 +15,10 @@ tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralType
     // String literal types are only valid in overload signatures
     
     function foo(x: 'hi') { }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2381: A signature with an implementation cannot use a string literal type.
     var f = function foo(x: 'hi') { }
-            ~~~~~~~~~~~~~~~~~~~~~~~~~
+                     ~~~
 !!! error TS2381: A signature with an implementation cannot use a string literal type.
     var f2 = (x: 'hi', y: 'hi') => { }
              ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -53,7 +53,7 @@ tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralType
         ~~~~~~~~~~~~~~~~
 !!! error TS2381: A signature with an implementation cannot use a string literal type.
         a: function foo(x: 'hi', y: 'hi') { },
-           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    ~~~
 !!! error TS2381: A signature with an implementation cannot use a string literal type.
         b: (x: 'hi') => { }
            ~~~~~~~~~~~~~~~~

--- a/tests/baselines/reference/stringLiteralTypesInImplementationSignatures2.errors.txt
+++ b/tests/baselines/reference/stringLiteralTypesInImplementationSignatures2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures2.ts(4,1): error TS2381: A signature with an implementation cannot use a string literal type.
+tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures2.ts(4,10): error TS2381: A signature with an implementation cannot use a string literal type.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures2.ts(8,5): error TS2381: A signature with an implementation cannot use a string literal type.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures2.ts(12,5): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralTypesInImplementationSignatures2.ts(13,5): error TS2382: Specialized overload signature is not assignable to any non-specialized signature.
@@ -19,7 +19,7 @@ tests/cases/conformance/types/objectTypeLiteral/callSignatures/stringLiteralType
     
     function foo(x: any);
     function foo(x: 'hi') { }
-    ~~~~~~~~~~~~~~~~~~~~~~~~~
+             ~~~
 !!! error TS2381: A signature with an implementation cannot use a string literal type.
     
     class C {

--- a/tests/baselines/reference/targetTypeVoidFunc.errors.txt
+++ b/tests/baselines/reference/targetTypeVoidFunc.errors.txt
@@ -4,7 +4,7 @@ tests/cases/compiler/targetTypeVoidFunc.ts(2,12): error TS2322: Type '() => void
 ==== tests/cases/compiler/targetTypeVoidFunc.ts (1 errors) ====
     function f1(): { new (): number; } {
         return function () { return; }
-               ~~~~~~~~~~~~~~~~~~~~~~~
+               ~~~~~~~~
 !!! error TS2322: Type '() => void' is not assignable to type 'new () => number'.
     }; 
     

--- a/tests/baselines/reference/templateStringInFunctionParameterType.errors.txt
+++ b/tests/baselines/reference/templateStringInFunctionParameterType.errors.txt
@@ -1,15 +1,15 @@
-tests/cases/conformance/es6/templates/templateStringInFunctionParameterType.ts(1,1): error TS2394: Overload signature is not compatible with function implementation.
 tests/cases/conformance/es6/templates/templateStringInFunctionParameterType.ts(1,10): error TS2391: Function implementation is missing or not immediately following the declaration.
+tests/cases/conformance/es6/templates/templateStringInFunctionParameterType.ts(1,10): error TS2394: Overload signature is not compatible with function implementation.
 tests/cases/conformance/es6/templates/templateStringInFunctionParameterType.ts(1,12): error TS1138: Parameter declaration expected.
 tests/cases/conformance/es6/templates/templateStringInFunctionParameterType.ts(1,19): error TS1005: ';' expected.
 
 
 ==== tests/cases/conformance/es6/templates/templateStringInFunctionParameterType.ts (4 errors) ====
     function f(`hello`);
-    ~~~~~~~~~~~
-!!! error TS2394: Overload signature is not compatible with function implementation.
              ~
 !!! error TS2391: Function implementation is missing or not immediately following the declaration.
+             ~
+!!! error TS2394: Overload signature is not compatible with function implementation.
                ~~~~~~~
 !!! error TS1138: Parameter declaration expected.
                       ~

--- a/tests/baselines/reference/templateStringInFunctionParameterTypeES6.errors.txt
+++ b/tests/baselines/reference/templateStringInFunctionParameterTypeES6.errors.txt
@@ -1,15 +1,15 @@
-tests/cases/conformance/es6/templates/templateStringInFunctionParameterTypeES6.ts(1,1): error TS2394: Overload signature is not compatible with function implementation.
 tests/cases/conformance/es6/templates/templateStringInFunctionParameterTypeES6.ts(1,10): error TS2391: Function implementation is missing or not immediately following the declaration.
+tests/cases/conformance/es6/templates/templateStringInFunctionParameterTypeES6.ts(1,10): error TS2394: Overload signature is not compatible with function implementation.
 tests/cases/conformance/es6/templates/templateStringInFunctionParameterTypeES6.ts(1,12): error TS1138: Parameter declaration expected.
 tests/cases/conformance/es6/templates/templateStringInFunctionParameterTypeES6.ts(1,19): error TS1005: ';' expected.
 
 
 ==== tests/cases/conformance/es6/templates/templateStringInFunctionParameterTypeES6.ts (4 errors) ====
     function f(`hello`);
-    ~~~~~~~~~~~
-!!! error TS2394: Overload signature is not compatible with function implementation.
              ~
 !!! error TS2391: Function implementation is missing or not immediately following the declaration.
+             ~
+!!! error TS2394: Overload signature is not compatible with function implementation.
                ~~~~~~~
 !!! error TS1138: Parameter declaration expected.
                       ~

--- a/tests/baselines/reference/voidAsNonAmbiguousReturnType.errors.txt
+++ b/tests/baselines/reference/voidAsNonAmbiguousReturnType.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/voidAsNonAmbiguousReturnType_0.ts(1,1): error TS2394: Overload signature is not compatible with function implementation.
+tests/cases/compiler/voidAsNonAmbiguousReturnType_0.ts(1,17): error TS2394: Overload signature is not compatible with function implementation.
 
 
 ==== tests/cases/compiler/voidAsNonAmbiguousReturnType_1.ts (0 errors) ====
@@ -11,7 +11,7 @@ tests/cases/compiler/voidAsNonAmbiguousReturnType_0.ts(1,1): error TS2394: Overl
     
 ==== tests/cases/compiler/voidAsNonAmbiguousReturnType_0.ts (1 errors) ====
     export function mkdirSync(path: string, mode?: number): void;
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    ~~~~~~~~~
 !!! error TS2394: Overload signature is not compatible with function implementation.
     export function mkdirSync(path: string, mode?: string): void {}
     

--- a/tests/cases/compiler/functionWithNoBestCommonType1.ts
+++ b/tests/cases/compiler/functionWithNoBestCommonType1.ts
@@ -1,0 +1,7 @@
+function foo() {
+    return true;
+    return bar();
+}
+
+function bar(): void {
+}

--- a/tests/cases/compiler/functionWithNoBestCommonType2.ts
+++ b/tests/cases/compiler/functionWithNoBestCommonType2.ts
@@ -1,0 +1,7 @@
+var v = function () {
+   return true;
+   return bar();
+};
+
+function bar(): void {
+}


### PR DESCRIPTION
Hi. This PR resolves issue #2214 allowing the following code to work
```
function logNumber(v: number) { console.log("number:", v); }
function logString(v: string) { console.log("string:", v); }

function foo1(v: number|string) {
    switch (typeof v) {
        case 'number':
            logNumber(v);
            break;
        case 'string':
            logString(v);
            break;
        default:
            throw new Error("unsupported type");
    }
}
```

I need some help (I'm kinda new to this..)

1. TypeOfExpression doesn't have a member "text" but the Javascript equivalent does. What can I cast TypeOfExpression to to get access to "text"?

2. I'm not sure where I should be writing tests.. (Or what a .types file is)

3. This might be too permissive. In the previous example, if I were to have a case 'Watermelon' it would still work. Should I check to see that the type is a subset of v's type?

Thank you!