### PR TITLE
Allow switch statement type guards (need help..)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4853,6 +4853,13 @@ module ts {
                                 narrowedType = narrowType(type, (<ConditionalExpression>node).condition, /*assumeTrue*/ child === (<ConditionalExpression>node).whenTrue);
                             }
                             break;
+                        case SyntaxKind.CaseClause:
+                            // In a case clause of a switch statement using typeof 
+                            var parent = (<CaseClause>node).parent;
+                            if((<SwitchStatement>parent).expression.kind === SyntaxKind.TypeOfExpression){
+                                narrowedType = checkExpression((<TypeOfExpression>(<CaseClause>node).expression).text);
+                            }
+                            break;
                         case SyntaxKind.BinaryExpression:
                             // In the right operand of an && or ||, narrow based on left operand
                             if (child === (<BinaryExpression>node).right) {


### PR DESCRIPTION
Hi. This PR resolves issue #2214 allowing the following code to work
```
function logNumber(v: number) { console.log("number:", v); }
function logString(v: string) { console.log("string:", v); }

function foo1(v: number|string) {
    switch (typeof v) {
        case 'number':
            logNumber(v);
            break;
        case 'string':
            logString(v);
            break;
        default:
            throw new Error("unsupported type");
    }
}
```

I need some help (I'm kinda new to this..)

1. TypeOfExpression doesn't have a member "text" but the Javascript equivalent does. What can I cast TypeOfExpression to to get access to "text"?

2. I'm not sure where I should be writing tests.. (Or what a .types file is)

3. This might be too permissive. In the previous example, if I were to have a case 'Watermelon' it would still work. Should I check to see that the type is a subset of v's type?

Thank you!