### PR TITLE
Let const in catchclause

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9160,7 +9160,7 @@ module ts {
                     else {
                         var identifierName = (<Identifier>catchClause.variableDeclaration.name).text;
                         var locals = catchClause.block.locals;
-                        if (locals && locals[identifierName]) {
+                        if (locals && hasProperty(locals, identifierName)) {
                             var localSymbol = locals[identifierName]
                             if (localSymbol && (localSymbol.flags & SymbolFlags.BlockScopedVariable) !== 0) {
                                 grammarErrorOnNode(localSymbol.valueDeclaration, Diagnostics.Cannot_redeclare_identifier_0_in_catch_clause, identifierName);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9158,6 +9158,15 @@ module ts {
                         grammarErrorOnFirstToken(catchClause.variableDeclaration.initializer, Diagnostics.Catch_clause_variable_cannot_have_an_initializer);
                     }
                     else {
+                        var identifierName = (<Identifier>catchClause.variableDeclaration.name).text;
+                        var locals = catchClause.block.locals;
+                        if (locals && locals[identifierName]) {
+                            var localSymbol = locals[identifierName]
+                            if (localSymbol && (localSymbol.flags & SymbolFlags.BlockScopedVariable) !== 0) {
+                                grammarErrorOnNode(localSymbol.valueDeclaration, Diagnostics.Cannot_redeclare_identifier_0_in_catch_clause, identifierName);
+                            }
+                        }
+
                         // It is a SyntaxError if a TryStatement with a Catch occurs within strict code and the Identifier of the
                         // Catch production is eval or arguments
                         checkGrammarEvalOrArgumentsInStrictMode(node, <Identifier>catchClause.variableDeclaration.name);

--- a/src/compiler/diagnosticInformationMap.generated.ts
+++ b/src/compiler/diagnosticInformationMap.generated.ts
@@ -337,6 +337,7 @@ module ts {
         The_iterator_returned_by_the_right_hand_side_of_a_for_of_statement_must_have_a_next_method: { code: 2489, category: DiagnosticCategory.Error, key: "The iterator returned by the right-hand side of a 'for...of' statement must have a 'next()' method." },
         The_type_returned_by_the_next_method_of_an_iterator_must_have_a_value_property: { code: 2490, category: DiagnosticCategory.Error, key: "The type returned by the 'next()' method of an iterator must have a 'value' property." },
         The_left_hand_side_of_a_for_in_statement_cannot_be_a_destructuring_pattern: { code: 2491, category: DiagnosticCategory.Error, key: "The left-hand side of a 'for...in' statement cannot be a destructuring pattern." },
+        Cannot_redeclare_identifier_0_in_catch_clause: { code: 2492, category: DiagnosticCategory.Error, key: "Cannot redeclare identifier '{0}' in catch clause" },
         Import_declaration_0_is_using_private_name_1: { code: 4000, category: DiagnosticCategory.Error, key: "Import declaration '{0}' is using private name '{1}'." },
         Type_parameter_0_of_exported_class_has_or_is_using_private_name_1: { code: 4002, category: DiagnosticCategory.Error, key: "Type parameter '{0}' of exported class has or is using private name '{1}'." },
         Type_parameter_0_of_exported_interface_has_or_is_using_private_name_1: { code: 4004, category: DiagnosticCategory.Error, key: "Type parameter '{0}' of exported interface has or is using private name '{1}'." },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1339,6 +1339,10 @@
         "category": "Error",
         "code": 2491
     },
+    "Cannot redeclare identifier '{0}' in catch clause": {
+        "category": "Error",
+        "code": 2492
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/tests/baselines/reference/redeclareParameterInCatchBlock.errors.txt
+++ b/tests/baselines/reference/redeclareParameterInCatchBlock.errors.txt
@@ -1,0 +1,31 @@
+tests/cases/compiler/redeclareParameterInCatchBlock.ts(5,11): error TS2492: Cannot redeclare identifier 'e' in catch clause
+tests/cases/compiler/redeclareParameterInCatchBlock.ts(11,9): error TS2492: Cannot redeclare identifier 'e' in catch clause
+
+
+==== tests/cases/compiler/redeclareParameterInCatchBlock.ts (2 errors) ====
+    
+    try {
+    
+    } catch(e) {
+        const e = null;
+              ~
+!!! error TS2492: Cannot redeclare identifier 'e' in catch clause
+    }
+    
+    try {
+    
+    } catch(e) {
+        let e;
+            ~
+!!! error TS2492: Cannot redeclare identifier 'e' in catch clause
+    }
+    
+    try {
+    
+    } catch(e) {
+        function test() {
+            let e;
+        }
+    }
+    
+    

--- a/tests/baselines/reference/redeclareParameterInCatchBlock.js
+++ b/tests/baselines/reference/redeclareParameterInCatchBlock.js
@@ -1,0 +1,42 @@
+//// [redeclareParameterInCatchBlock.ts]
+
+try {
+
+} catch(e) {
+    const e = null;
+}
+
+try {
+
+} catch(e) {
+    let e;
+}
+
+try {
+
+} catch(e) {
+    function test() {
+        let e;
+    }
+}
+
+
+
+//// [redeclareParameterInCatchBlock.js]
+try {
+}
+catch (e) {
+    const e = null;
+}
+try {
+}
+catch (e) {
+    let e;
+}
+try {
+}
+catch (e) {
+    function test() {
+        let e;
+    }
+}

--- a/tests/cases/compiler/redeclareParameterInCatchBlock.ts
+++ b/tests/cases/compiler/redeclareParameterInCatchBlock.ts
@@ -1,0 +1,22 @@
+// @target: es6
+
+try {
+
+} catch(e) {
+    const e = null;
+}
+
+try {
+
+} catch(e) {
+    let e;
+}
+
+try {
+
+} catch(e) {
+    function test() {
+        let e;
+    }
+}
+


### PR DESCRIPTION
This is my attempt at solving #2186.
If this isn't the right way of solving this, feel free to close this PR.

I didn't implement this part:
>It is a Syntax Error if any element of the BoundNames of CatchParameter also occurs in the VarDeclaredNames of Block

Because it felt like a breaking change (but that might not be a bad thing in ES6 mode though)
but I couldn't find a browser which actually did this, tried IE 11, Firefox Nightly and Chrome (Stable).
And the spec also mentions (B.3.5): 
>The Block of a Catch clause may contain var declarations that bind a name that is also bound by the CatchParameter

So I'm not sure if a var should error (or am I totally not understanding the spec here?)

Tests are coming :)