### PR TITLE
Fixed jake runtests-browser on node 0.12

### DIFF
--- a/tests/webTestServer.ts
+++ b/tests/webTestServer.ts
@@ -281,8 +281,6 @@ if ((browser && browser === 'chrome')) {
 console.log('Using browser: ' + browserPath);
 
 var queryString = grep ? "?grep=" + grep : '';
-child_process.spawn(browserPath, ['http://localhost:' + port + '/tests/webTestResults.html' + queryString], (err: Error, stdout: any, stderr: any) => {
-    console.log("ERR: " + err.message);
-    console.log("STDOUT: " + stdout.toString());
-    console.log("STDERR: " + stderr.toString());
+child_process.spawn(browserPath, ['http://localhost:' + port + '/tests/webTestResults.html' + queryString], {
+    stdio: 'inherit'
 });


### PR DESCRIPTION
Tested on 0.12 and 0.10 and fixes #2096
Output is witten to the terminal without the ERR and STDOUT prefixes.
Not sure when a browser would do that though, but I tested it with a manual script.