### PR TITLE
Fix for #2268 createDiagnosticCollection should be @internal

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1207,6 +1207,7 @@ module ts {
         }
     }
 
+    // @internal
     export function createDiagnosticCollection(): DiagnosticCollection {
         var nonFileDiagnostics: Diagnostic[] = [];
         var fileDiagnostics: Map<Diagnostic[]> = {};


### PR DESCRIPTION
DiagnosticsCollection interface is marked @internal in [src/compiler/types.ts](https://github.com/Microsoft/TypeScript/blob/c6cd57d18c85e59b2fbe9d316725748a0af8ac2b/src/compiler/types.ts#L1761), so this should be @internal too.

Otherwise it causes compilation errors whenever the generated type definitions for LS is used.

See #2268 for more details.