### PR TITLE
`Storage.getItem` now returns `string` instead of `any`

### DIFF
--- a/bin/lib.d.ts
+++ b/bin/lib.d.ts
@@ -7321,7 +7321,7 @@ interface MSHTMLCollectionExtensions {
 
 interface Storage extends MSStorageExtensions {
     length: number;
-    getItem(key: string): any;
+    getItem(key: string): string;
     [key: string]: any;
     setItem(key: string, data: string): void;
     clear(): void;

--- a/bin/lib.dom.d.ts
+++ b/bin/lib.dom.d.ts
@@ -6171,7 +6171,7 @@ interface MSHTMLCollectionExtensions {
 
 interface Storage extends MSStorageExtensions {
     length: number;
-    getItem(key: string): any;
+    getItem(key: string): string;
     [key: string]: any;
     setItem(key: string, data: string): void;
     clear(): void;

--- a/bin/lib.es6.d.ts
+++ b/bin/lib.es6.d.ts
@@ -10303,7 +10303,7 @@ interface MSHTMLCollectionExtensions {
 
 interface Storage extends MSStorageExtensions {
     length: number;
-    getItem(key: string): any;
+    getItem(key: string): string;
     [key: string]: any;
     setItem(key: string, data: string): void;
     clear(): void;

--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -5327,7 +5327,7 @@ interface MSHTMLCollectionExtensions {
 
 interface Storage extends MSStorageExtensions {
     length: number;
-    getItem(key: string): any;
+    getItem(key: string): string;
     [key: string]: any;
     setItem(key: string, data: string): void;
     clear(): void;


### PR DESCRIPTION
This amends the return type of `getItem` on the `Storage` interface to be `string` rather than `any`.  This brings the definition in line with the W3C `Storage` definition [here](http://dev.w3.org/html5/webstorage/#storage-0).

There appeared to be 4 independent definitions of `Storage` in the TypeScript repo and so I amended each in the exact same way. I hope this is correct?  (I'm mindful that only the `src\lib\dom.generated.d.ts` file sits outside `bin`.)
