### PR TITLE
Fixing signature for new Event.

### DIFF
--- a/bin/lib.d.ts
+++ b/bin/lib.d.ts
@@ -9336,9 +9336,13 @@ interface Event {
     AT_TARGET: number;
     BUBBLING_PHASE: number;
 }
+interface EventInit {
+    bubbles: boolean;
+    cancelable: boolean;
+}
 declare var Event: {
     prototype: Event;
-    new(): Event;
+    new(type: string, eventInit?: EventInit): Event;
     CAPTURING_PHASE: number;
     AT_TARGET: number;
     BUBBLING_PHASE: number;

--- a/bin/lib.dom.d.ts
+++ b/bin/lib.dom.d.ts
@@ -8186,9 +8186,13 @@ interface Event {
     AT_TARGET: number;
     BUBBLING_PHASE: number;
 }
+interface EventInit {
+    bubbles: boolean;
+    cancelable: boolean;
+}
 declare var Event: {
     prototype: Event;
-    new(): Event;
+    new(type: string, eventInit?: EventInit): Event;
     CAPTURING_PHASE: number;
     AT_TARGET: number;
     BUBBLING_PHASE: number;

--- a/bin/lib.es6.d.ts
+++ b/bin/lib.es6.d.ts
@@ -12318,9 +12318,13 @@ interface Event {
     AT_TARGET: number;
     BUBBLING_PHASE: number;
 }
+interface EventInit {
+    bubbles: boolean;
+    cancelable: boolean;
+}
 declare var Event: {
     prototype: Event;
-    new(): Event;
+    new(type: string, eventInit?: EventInit): Event;
     CAPTURING_PHASE: number;
     AT_TARGET: number;
     BUBBLING_PHASE: number;

--- a/bin/lib.webworker.d.ts
+++ b/bin/lib.webworker.d.ts
@@ -999,9 +999,13 @@ interface Event {
     AT_TARGET: number;
     BUBBLING_PHASE: number;
 }
+interface EventInit {
+    bubbles: boolean;
+    cancelable: boolean;
+}
 declare var Event: {
     prototype: Event;
-    new(): Event;
+    new(type: string, eventInit?: EventInit): Event;
     CAPTURING_PHASE: number;
     AT_TARGET: number;
     BUBBLING_PHASE: number;


### PR DESCRIPTION
new Event need two parameters, one medatory and one optional.
event = new Event(typeArg, eventInit);

Ref: https://developer.mozilla.org/en-US/docs/Web/API/Event/Event