### PR TITLE
use Value meaning as a filter when resolving names to prevent skipping o...

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11072,7 +11072,7 @@ module ts {
 
             var symbol = declarationSymbol ||
                 getNodeLinks(n).resolvedSymbol ||
-                resolveName(n, n.text, SymbolFlags.BlockScopedVariable | SymbolFlags.Alias, /*nodeNotFoundMessage*/ undefined, /*nameArg*/ undefined);
+                resolveName(n, n.text, SymbolFlags.Value | SymbolFlags.Alias, /*nodeNotFoundMessage*/ undefined, /*nameArg*/ undefined);
 
             var isLetOrConst =
                 symbol &&

--- a/tests/baselines/reference/letConstMatchingParameterNames.js
+++ b/tests/baselines/reference/letConstMatchingParameterNames.js
@@ -1,0 +1,28 @@
+//// [letConstMatchingParameterNames.ts]
+let parent = true;
+const parent2 = true;
+declare function use(a: any);
+
+function a() {
+    
+    let parent = 1;
+    const parent2 = 2;
+
+    function b(parent: string, parent2: number) {
+        use(parent);
+        use(parent2);
+    }
+}
+
+
+//// [letConstMatchingParameterNames.js]
+var parent = true;
+var parent2 = true;
+function a() {
+    var _parent = 1;
+    var _parent2 = 2;
+    function b(parent, parent2) {
+        use(parent);
+        use(parent2);
+    }
+}

--- a/tests/baselines/reference/letConstMatchingParameterNames.types
+++ b/tests/baselines/reference/letConstMatchingParameterNames.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/letConstMatchingParameterNames.ts ===
+let parent = true;
+>parent : boolean
+
+const parent2 = true;
+>parent2 : boolean
+
+declare function use(a: any);
+>use : (a: any) => any
+>a : any
+
+function a() {
+>a : () => void
+    
+    let parent = 1;
+>parent : number
+
+    const parent2 = 2;
+>parent2 : number
+
+    function b(parent: string, parent2: number) {
+>b : (parent: string, parent2: number) => void
+>parent : string
+>parent2 : number
+
+        use(parent);
+>use(parent) : any
+>use : (a: any) => any
+>parent : string
+
+        use(parent2);
+>use(parent2) : any
+>use : (a: any) => any
+>parent2 : number
+    }
+}
+

--- a/tests/cases/compiler/letConstMatchingParameterNames.ts
+++ b/tests/cases/compiler/letConstMatchingParameterNames.ts
@@ -1,0 +1,15 @@
+// @target: es5
+let parent = true;
+const parent2 = true;
+declare function use(a: any);
+
+function a() {
+    
+    let parent = 1;
+    const parent2 = 2;
+
+    function b(parent: string, parent2: number) {
+        use(parent);
+        use(parent2);
+    }
+}


### PR DESCRIPTION
...ther value in favor of block-scoped variables.