### PR TITLE
do not rename property names that match with names of let\const bindings

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1211,7 +1211,7 @@ module ts {
         // Returns the constant value this property access resolves to, or 'undefined' for a non-constant
         getConstantValue(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): number;
         isUnknownIdentifier(location: Node, name: string): boolean;
-        getBlockScopedVariableId(node: Identifier): number;
+        getBlockScopedVariableId(n: Identifier, isValueOfShorthandPropertyAssignment: boolean): number;
     }
 
     export const enum SymbolFlags {

--- a/tests/baselines/reference/APISample_compile.js
+++ b/tests/baselines/reference/APISample_compile.js
@@ -947,7 +947,7 @@ declare module "typescript" {
         isEntityNameVisible(entityName: EntityName, enclosingDeclaration: Node): SymbolVisibilityResult;
         getConstantValue(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): number;
         isUnknownIdentifier(location: Node, name: string): boolean;
-        getBlockScopedVariableId(node: Identifier): number;
+        getBlockScopedVariableId(n: Identifier, isValueOfShorthandPropertyAssignment: boolean): number;
     }
     const enum SymbolFlags {
         FunctionScopedVariable = 1,

--- a/tests/baselines/reference/APISample_compile.types
+++ b/tests/baselines/reference/APISample_compile.types
@@ -3080,10 +3080,11 @@ declare module "typescript" {
 >Node : Node
 >name : string
 
-        getBlockScopedVariableId(node: Identifier): number;
->getBlockScopedVariableId : (node: Identifier) => number
->node : Identifier
+        getBlockScopedVariableId(n: Identifier, isValueOfShorthandPropertyAssignment: boolean): number;
+>getBlockScopedVariableId : (n: Identifier, isValueOfShorthandPropertyAssignment: boolean) => number
+>n : Identifier
 >Identifier : Identifier
+>isValueOfShorthandPropertyAssignment : boolean
     }
     const enum SymbolFlags {
 >SymbolFlags : SymbolFlags

--- a/tests/baselines/reference/APISample_linter.js
+++ b/tests/baselines/reference/APISample_linter.js
@@ -978,7 +978,7 @@ declare module "typescript" {
         isEntityNameVisible(entityName: EntityName, enclosingDeclaration: Node): SymbolVisibilityResult;
         getConstantValue(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): number;
         isUnknownIdentifier(location: Node, name: string): boolean;
-        getBlockScopedVariableId(node: Identifier): number;
+        getBlockScopedVariableId(n: Identifier, isValueOfShorthandPropertyAssignment: boolean): number;
     }
     const enum SymbolFlags {
         FunctionScopedVariable = 1,

--- a/tests/baselines/reference/APISample_linter.types
+++ b/tests/baselines/reference/APISample_linter.types
@@ -3226,10 +3226,11 @@ declare module "typescript" {
 >Node : Node
 >name : string
 
-        getBlockScopedVariableId(node: Identifier): number;
->getBlockScopedVariableId : (node: Identifier) => number
->node : Identifier
+        getBlockScopedVariableId(n: Identifier, isValueOfShorthandPropertyAssignment: boolean): number;
+>getBlockScopedVariableId : (n: Identifier, isValueOfShorthandPropertyAssignment: boolean) => number
+>n : Identifier
 >Identifier : Identifier
+>isValueOfShorthandPropertyAssignment : boolean
     }
     const enum SymbolFlags {
 >SymbolFlags : SymbolFlags

--- a/tests/baselines/reference/APISample_transform.js
+++ b/tests/baselines/reference/APISample_transform.js
@@ -979,7 +979,7 @@ declare module "typescript" {
         isEntityNameVisible(entityName: EntityName, enclosingDeclaration: Node): SymbolVisibilityResult;
         getConstantValue(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): number;
         isUnknownIdentifier(location: Node, name: string): boolean;
-        getBlockScopedVariableId(node: Identifier): number;
+        getBlockScopedVariableId(n: Identifier, isValueOfShorthandPropertyAssignment: boolean): number;
     }
     const enum SymbolFlags {
         FunctionScopedVariable = 1,

--- a/tests/baselines/reference/APISample_transform.types
+++ b/tests/baselines/reference/APISample_transform.types
@@ -3176,10 +3176,11 @@ declare module "typescript" {
 >Node : Node
 >name : string
 
-        getBlockScopedVariableId(node: Identifier): number;
->getBlockScopedVariableId : (node: Identifier) => number
->node : Identifier
+        getBlockScopedVariableId(n: Identifier, isValueOfShorthandPropertyAssignment: boolean): number;
+>getBlockScopedVariableId : (n: Identifier, isValueOfShorthandPropertyAssignment: boolean) => number
+>n : Identifier
 >Identifier : Identifier
+>isValueOfShorthandPropertyAssignment : boolean
     }
     const enum SymbolFlags {
 >SymbolFlags : SymbolFlags

--- a/tests/baselines/reference/APISample_watcher.js
+++ b/tests/baselines/reference/APISample_watcher.js
@@ -1016,7 +1016,7 @@ declare module "typescript" {
         isEntityNameVisible(entityName: EntityName, enclosingDeclaration: Node): SymbolVisibilityResult;
         getConstantValue(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): number;
         isUnknownIdentifier(location: Node, name: string): boolean;
-        getBlockScopedVariableId(node: Identifier): number;
+        getBlockScopedVariableId(n: Identifier, isValueOfShorthandPropertyAssignment: boolean): number;
     }
     const enum SymbolFlags {
         FunctionScopedVariable = 1,

--- a/tests/baselines/reference/APISample_watcher.types
+++ b/tests/baselines/reference/APISample_watcher.types
@@ -3349,10 +3349,11 @@ declare module "typescript" {
 >Node : Node
 >name : string
 
-        getBlockScopedVariableId(node: Identifier): number;
->getBlockScopedVariableId : (node: Identifier) => number
->node : Identifier
+        getBlockScopedVariableId(n: Identifier, isValueOfShorthandPropertyAssignment: boolean): number;
+>getBlockScopedVariableId : (n: Identifier, isValueOfShorthandPropertyAssignment: boolean) => number
+>n : Identifier
 >Identifier : Identifier
+>isValueOfShorthandPropertyAssignment : boolean
     }
     const enum SymbolFlags {
 >SymbolFlags : SymbolFlags

--- a/tests/baselines/reference/propertyInitializedWithRenamedLet.js
+++ b/tests/baselines/reference/propertyInitializedWithRenamedLet.js
@@ -2,8 +2,8 @@
 var x;
 if (true) {
     let x;
-    var obj1 = { x: x }; // Should be { x: _x }, emits as { _x: _x }
-    var obj2 = { x }; // Should be { x: _x }, emits as { _x: x }
+    var obj1 = { x: x }; // Should be { x: _x }
+    var obj2 = { x }; // Should be { x: _x }
 }
 
 //// [propertyInitializedWithRenamedLet.js]
@@ -12,8 +12,8 @@ if (true) {
     var _x;
     var obj1 = {
         x: _x
-    }; // Should be { x: _x }, emits as { _x: _x }
+    }; // Should be { x: _x }
     var obj2 = {
         x: _x
-    }; // Should be { x: _x }, emits as { _x: x }
+    }; // Should be { x: _x }
 }

--- a/tests/baselines/reference/propertyInitializedWithRenamedLet.js
+++ b/tests/baselines/reference/propertyInitializedWithRenamedLet.js
@@ -1,0 +1,19 @@
+//// [propertyInitializedWithRenamedLet.ts]
+var x;
+if (true) {
+    let x;
+    var obj1 = { x: x }; // Should be { x: _x }, emits as { _x: _x }
+    var obj2 = { x }; // Should be { x: _x }, emits as { _x: x }
+}
+
+//// [propertyInitializedWithRenamedLet.js]
+var x;
+if (true) {
+    var _x;
+    var obj1 = {
+        x: _x
+    }; // Should be { x: _x }, emits as { _x: _x }
+    var obj2 = {
+        x: _x
+    }; // Should be { x: _x }, emits as { _x: x }
+}

--- a/tests/baselines/reference/propertyInitializedWithRenamedLet.types
+++ b/tests/baselines/reference/propertyInitializedWithRenamedLet.types
@@ -6,13 +6,13 @@ if (true) {
     let x;
 >x : any
 
-    var obj1 = { x: x }; // Should be { x: _x }, emits as { _x: _x }
+    var obj1 = { x: x }; // Should be { x: _x }
 >obj1 : { x: any; }
 >{ x: x } : { x: any; }
 >x : any
 >x : any
 
-    var obj2 = { x }; // Should be { x: _x }, emits as { _x: x }
+    var obj2 = { x }; // Should be { x: _x }
 >obj2 : { x: any; }
 >{ x } : { x: any; }
 >x : any

--- a/tests/baselines/reference/propertyInitializedWithRenamedLet.types
+++ b/tests/baselines/reference/propertyInitializedWithRenamedLet.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/propertyInitializedWithRenamedLet.ts ===
+var x;
+>x : any
+
+if (true) {
+    let x;
+>x : any
+
+    var obj1 = { x: x }; // Should be { x: _x }, emits as { _x: _x }
+>obj1 : { x: any; }
+>{ x: x } : { x: any; }
+>x : any
+>x : any
+
+    var obj2 = { x }; // Should be { x: _x }, emits as { _x: x }
+>obj2 : { x: any; }
+>{ x } : { x: any; }
+>x : any
+}

--- a/tests/cases/compiler/propertyInitializedWithRenamedLet.ts
+++ b/tests/cases/compiler/propertyInitializedWithRenamedLet.ts
@@ -2,6 +2,6 @@
 var x;
 if (true) {
     let x;
-    var obj1 = { x: x }; // Should be { x: _x }, emits as { _x: _x }
-    var obj2 = { x }; // Should be { x: _x }, emits as { _x: x }
+    var obj1 = { x: x }; // Should be { x: _x }
+    var obj2 = { x }; // Should be { x: _x }
 }

--- a/tests/cases/compiler/propertyInitializedWithRenamedLet.ts
+++ b/tests/cases/compiler/propertyInitializedWithRenamedLet.ts
@@ -1,0 +1,7 @@
+// @target:es5
+var x;
+if (true) {
+    let x;
+    var obj1 = { x: x }; // Should be { x: _x }, emits as { _x: _x }
+    var obj2 = { x }; // Should be { x: _x }, emits as { _x: x }
+}


### PR DESCRIPTION
Fixes #2350