### PR TITLE
Make sure type parameters stay fixed throughout the inference process

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4379,6 +4379,8 @@ module ts {
                     }
                 }
 
+                Debug.assert(!!downfallType, "If there is no common supertype, each type should have a downfallType");
+
                 if (score > bestSupertypeScore) {
                     bestSupertype = types[i];
                     bestSupertypeDownfallType = downfallType;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6344,7 +6344,11 @@ module ts {
 
             // Clear out all the inference results from the last time inferTypeArguments was called on this context
             for (let i = 0; i < typeParameters.length; i++) {
-                context.inferredTypes[i] = undefined;
+                // As an optimization, we don't have to clear (and later recompute) inferred types
+                // for type parameters that have already been fixed on the previous call to inferTypeArguments
+                if (!context.inferences[i].isFixed) {
+                    context.inferredTypes[i] = undefined;
+                }
             }
 
             // We perform two passes over the arguments. In the first pass we infer from all arguments, but use

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4372,8 +4372,11 @@ module ts {
         }
 
         function reportNoCommonSupertypeError(types: Type[], errorLocation: Node, errorMessageChainHead: DiagnosticMessageChain): void {
+            // The downfallType/bestSupertypeDownfallType is the first type that caused a particular candidate
+            // to not be the common supertype. So if it weren't for this one downfallType (and possibly others),
+            // the type in question could have been the common supertype.
             let bestSupertype: Type;
-            let bestSupertypeDownfallType: Type; // The type that caused bestSupertype not to be the common supertype
+            let bestSupertypeDownfallType: Type;
             let bestSupertypeScore = 0;
 
             for (let i = 0; i < types.length; i++) {
@@ -4575,9 +4578,9 @@ module ts {
                 inferences.push({ primary: undefined, secondary: undefined, isFixed: false });
             }
             return {
-                typeParameters: typeParameters,
-                inferUnionTypes: inferUnionTypes,
-                inferences: inferences,
+                typeParameters,
+                inferUnionTypes,
+                inferences,
                 inferredTypes: new Array(typeParameters.length),
             };
         }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1485,6 +1485,8 @@ module ts {
     export interface TypeInferences {
         primary: Type[];    // Inferences made directly to a type parameter
         secondary: Type[];  // Inferences made to a type parameter in a union type
+        isFixed: boolean;   // Whether the type parameter is fixed, as defined in section 4.12.2 of the TypeScript spec
+                            // If a type parameter is fixed, no more inferences can be made for the type parameter
     }
 
     export interface InferenceContext {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1482,6 +1482,7 @@ module ts {
         (t: Type): Type;
     }
 
+    // @internal
     export interface TypeInferences {
         primary: Type[];    // Inferences made directly to a type parameter
         secondary: Type[];  // Inferences made to a type parameter in a union type
@@ -1489,6 +1490,7 @@ module ts {
                             // If a type parameter is fixed, no more inferences can be made for the type parameter
     }
 
+    // @internal
     export interface InferenceContext {
         typeParameters: TypeParameter[];    // Type parameters for which inferences are made
         inferUnionTypes: boolean;           // Infer union types for disjoint candidates (otherwise undefinedType)

--- a/tests/baselines/reference/APISample_compile.js
+++ b/tests/baselines/reference/APISample_compile.js
@@ -1172,18 +1172,6 @@ declare module "typescript" {
     interface TypeMapper {
         (t: Type): Type;
     }
-    interface TypeInferences {
-        primary: Type[];
-        secondary: Type[];
-        isFixed: boolean;
-    }
-    interface InferenceContext {
-        typeParameters: TypeParameter[];
-        inferUnionTypes: boolean;
-        inferences: TypeInferences[];
-        inferredTypes: Type[];
-        failedTypeParameterIndex?: number;
-    }
     interface DiagnosticMessage {
         key: string;
         category: DiagnosticCategory;

--- a/tests/baselines/reference/APISample_compile.js
+++ b/tests/baselines/reference/APISample_compile.js
@@ -1175,6 +1175,7 @@ declare module "typescript" {
     interface TypeInferences {
         primary: Type[];
         secondary: Type[];
+        isFixed: boolean;
     }
     interface InferenceContext {
         typeParameters: TypeParameter[];

--- a/tests/baselines/reference/APISample_compile.types
+++ b/tests/baselines/reference/APISample_compile.types
@@ -3757,41 +3757,6 @@ declare module "typescript" {
 >Type : Type
 >Type : Type
     }
-    interface TypeInferences {
->TypeInferences : TypeInferences
-
-        primary: Type[];
->primary : Type[]
->Type : Type
-
-        secondary: Type[];
->secondary : Type[]
->Type : Type
-
-        isFixed: boolean;
->isFixed : boolean
-    }
-    interface InferenceContext {
->InferenceContext : InferenceContext
-
-        typeParameters: TypeParameter[];
->typeParameters : TypeParameter[]
->TypeParameter : TypeParameter
-
-        inferUnionTypes: boolean;
->inferUnionTypes : boolean
-
-        inferences: TypeInferences[];
->inferences : TypeInferences[]
->TypeInferences : TypeInferences
-
-        inferredTypes: Type[];
->inferredTypes : Type[]
->Type : Type
-
-        failedTypeParameterIndex?: number;
->failedTypeParameterIndex : number
-    }
     interface DiagnosticMessage {
 >DiagnosticMessage : DiagnosticMessage
 

--- a/tests/baselines/reference/APISample_compile.types
+++ b/tests/baselines/reference/APISample_compile.types
@@ -3767,6 +3767,9 @@ declare module "typescript" {
         secondary: Type[];
 >secondary : Type[]
 >Type : Type
+
+        isFixed: boolean;
+>isFixed : boolean
     }
     interface InferenceContext {
 >InferenceContext : InferenceContext

--- a/tests/baselines/reference/APISample_linter.js
+++ b/tests/baselines/reference/APISample_linter.js
@@ -1206,6 +1206,7 @@ declare module "typescript" {
     interface TypeInferences {
         primary: Type[];
         secondary: Type[];
+        isFixed: boolean;
     }
     interface InferenceContext {
         typeParameters: TypeParameter[];

--- a/tests/baselines/reference/APISample_linter.js
+++ b/tests/baselines/reference/APISample_linter.js
@@ -1203,18 +1203,6 @@ declare module "typescript" {
     interface TypeMapper {
         (t: Type): Type;
     }
-    interface TypeInferences {
-        primary: Type[];
-        secondary: Type[];
-        isFixed: boolean;
-    }
-    interface InferenceContext {
-        typeParameters: TypeParameter[];
-        inferUnionTypes: boolean;
-        inferences: TypeInferences[];
-        inferredTypes: Type[];
-        failedTypeParameterIndex?: number;
-    }
     interface DiagnosticMessage {
         key: string;
         category: DiagnosticCategory;

--- a/tests/baselines/reference/APISample_linter.types
+++ b/tests/baselines/reference/APISample_linter.types
@@ -3913,6 +3913,9 @@ declare module "typescript" {
         secondary: Type[];
 >secondary : Type[]
 >Type : Type
+
+        isFixed: boolean;
+>isFixed : boolean
     }
     interface InferenceContext {
 >InferenceContext : InferenceContext

--- a/tests/baselines/reference/APISample_linter.types
+++ b/tests/baselines/reference/APISample_linter.types
@@ -3903,41 +3903,6 @@ declare module "typescript" {
 >Type : Type
 >Type : Type
     }
-    interface TypeInferences {
->TypeInferences : TypeInferences
-
-        primary: Type[];
->primary : Type[]
->Type : Type
-
-        secondary: Type[];
->secondary : Type[]
->Type : Type
-
-        isFixed: boolean;
->isFixed : boolean
-    }
-    interface InferenceContext {
->InferenceContext : InferenceContext
-
-        typeParameters: TypeParameter[];
->typeParameters : TypeParameter[]
->TypeParameter : TypeParameter
-
-        inferUnionTypes: boolean;
->inferUnionTypes : boolean
-
-        inferences: TypeInferences[];
->inferences : TypeInferences[]
->TypeInferences : TypeInferences
-
-        inferredTypes: Type[];
->inferredTypes : Type[]
->Type : Type
-
-        failedTypeParameterIndex?: number;
->failedTypeParameterIndex : number
-    }
     interface DiagnosticMessage {
 >DiagnosticMessage : DiagnosticMessage
 

--- a/tests/baselines/reference/APISample_transform.js
+++ b/tests/baselines/reference/APISample_transform.js
@@ -1207,6 +1207,7 @@ declare module "typescript" {
     interface TypeInferences {
         primary: Type[];
         secondary: Type[];
+        isFixed: boolean;
     }
     interface InferenceContext {
         typeParameters: TypeParameter[];

--- a/tests/baselines/reference/APISample_transform.js
+++ b/tests/baselines/reference/APISample_transform.js
@@ -1204,18 +1204,6 @@ declare module "typescript" {
     interface TypeMapper {
         (t: Type): Type;
     }
-    interface TypeInferences {
-        primary: Type[];
-        secondary: Type[];
-        isFixed: boolean;
-    }
-    interface InferenceContext {
-        typeParameters: TypeParameter[];
-        inferUnionTypes: boolean;
-        inferences: TypeInferences[];
-        inferredTypes: Type[];
-        failedTypeParameterIndex?: number;
-    }
     interface DiagnosticMessage {
         key: string;
         category: DiagnosticCategory;

--- a/tests/baselines/reference/APISample_transform.types
+++ b/tests/baselines/reference/APISample_transform.types
@@ -3863,6 +3863,9 @@ declare module "typescript" {
         secondary: Type[];
 >secondary : Type[]
 >Type : Type
+
+        isFixed: boolean;
+>isFixed : boolean
     }
     interface InferenceContext {
 >InferenceContext : InferenceContext

--- a/tests/baselines/reference/APISample_transform.types
+++ b/tests/baselines/reference/APISample_transform.types
@@ -3853,41 +3853,6 @@ declare module "typescript" {
 >Type : Type
 >Type : Type
     }
-    interface TypeInferences {
->TypeInferences : TypeInferences
-
-        primary: Type[];
->primary : Type[]
->Type : Type
-
-        secondary: Type[];
->secondary : Type[]
->Type : Type
-
-        isFixed: boolean;
->isFixed : boolean
-    }
-    interface InferenceContext {
->InferenceContext : InferenceContext
-
-        typeParameters: TypeParameter[];
->typeParameters : TypeParameter[]
->TypeParameter : TypeParameter
-
-        inferUnionTypes: boolean;
->inferUnionTypes : boolean
-
-        inferences: TypeInferences[];
->inferences : TypeInferences[]
->TypeInferences : TypeInferences
-
-        inferredTypes: Type[];
->inferredTypes : Type[]
->Type : Type
-
-        failedTypeParameterIndex?: number;
->failedTypeParameterIndex : number
-    }
     interface DiagnosticMessage {
 >DiagnosticMessage : DiagnosticMessage
 

--- a/tests/baselines/reference/APISample_watcher.js
+++ b/tests/baselines/reference/APISample_watcher.js
@@ -1241,18 +1241,6 @@ declare module "typescript" {
     interface TypeMapper {
         (t: Type): Type;
     }
-    interface TypeInferences {
-        primary: Type[];
-        secondary: Type[];
-        isFixed: boolean;
-    }
-    interface InferenceContext {
-        typeParameters: TypeParameter[];
-        inferUnionTypes: boolean;
-        inferences: TypeInferences[];
-        inferredTypes: Type[];
-        failedTypeParameterIndex?: number;
-    }
     interface DiagnosticMessage {
         key: string;
         category: DiagnosticCategory;

--- a/tests/baselines/reference/APISample_watcher.js
+++ b/tests/baselines/reference/APISample_watcher.js
@@ -1244,6 +1244,7 @@ declare module "typescript" {
     interface TypeInferences {
         primary: Type[];
         secondary: Type[];
+        isFixed: boolean;
     }
     interface InferenceContext {
         typeParameters: TypeParameter[];

--- a/tests/baselines/reference/APISample_watcher.types
+++ b/tests/baselines/reference/APISample_watcher.types
@@ -4036,6 +4036,9 @@ declare module "typescript" {
         secondary: Type[];
 >secondary : Type[]
 >Type : Type
+
+        isFixed: boolean;
+>isFixed : boolean
     }
     interface InferenceContext {
 >InferenceContext : InferenceContext

--- a/tests/baselines/reference/APISample_watcher.types
+++ b/tests/baselines/reference/APISample_watcher.types
@@ -4026,41 +4026,6 @@ declare module "typescript" {
 >Type : Type
 >Type : Type
     }
-    interface TypeInferences {
->TypeInferences : TypeInferences
-
-        primary: Type[];
->primary : Type[]
->Type : Type
-
-        secondary: Type[];
->secondary : Type[]
->Type : Type
-
-        isFixed: boolean;
->isFixed : boolean
-    }
-    interface InferenceContext {
->InferenceContext : InferenceContext
-
-        typeParameters: TypeParameter[];
->typeParameters : TypeParameter[]
->TypeParameter : TypeParameter
-
-        inferUnionTypes: boolean;
->inferUnionTypes : boolean
-
-        inferences: TypeInferences[];
->inferences : TypeInferences[]
->TypeInferences : TypeInferences
-
-        inferredTypes: Type[];
->inferredTypes : Type[]
->Type : Type
-
-        failedTypeParameterIndex?: number;
->failedTypeParameterIndex : number
-    }
     interface DiagnosticMessage {
 >DiagnosticMessage : DiagnosticMessage
 

--- a/tests/baselines/reference/typeParameterFixingWithConstraints.js
+++ b/tests/baselines/reference/typeParameterFixingWithConstraints.js
@@ -1,0 +1,21 @@
+//// [typeParameterFixingWithConstraints.ts]
+interface IBar {
+    [barId: string]: any;
+}
+
+interface IFoo {
+    foo<TBar extends IBar>(bar: TBar, bar1: (bar: TBar) => TBar, bar2: (bar: TBar) => TBar): TBar;
+}
+
+var foo: IFoo;
+foo.foo({ bar: null }, bar => null, bar => null);
+
+//// [typeParameterFixingWithConstraints.js]
+var foo;
+foo.foo({
+    bar: null
+}, function (bar) {
+    return null;
+}, function (bar) {
+    return null;
+});

--- a/tests/baselines/reference/typeParameterFixingWithConstraints.types
+++ b/tests/baselines/reference/typeParameterFixingWithConstraints.types
@@ -1,0 +1,44 @@
+=== tests/cases/compiler/typeParameterFixingWithConstraints.ts ===
+interface IBar {
+>IBar : IBar
+
+    [barId: string]: any;
+>barId : string
+}
+
+interface IFoo {
+>IFoo : IFoo
+
+    foo<TBar extends IBar>(bar: TBar, bar1: (bar: TBar) => TBar, bar2: (bar: TBar) => TBar): TBar;
+>foo : <TBar extends IBar>(bar: TBar, bar1: (bar: TBar) => TBar, bar2: (bar: TBar) => TBar) => TBar
+>TBar : TBar
+>IBar : IBar
+>bar : TBar
+>TBar : TBar
+>bar1 : (bar: TBar) => TBar
+>bar : TBar
+>TBar : TBar
+>TBar : TBar
+>bar2 : (bar: TBar) => TBar
+>bar : TBar
+>TBar : TBar
+>TBar : TBar
+>TBar : TBar
+}
+
+var foo: IFoo;
+>foo : IFoo
+>IFoo : IFoo
+
+foo.foo({ bar: null }, bar => null, bar => null);
+>foo.foo({ bar: null }, bar => null, bar => null) : IBar
+>foo.foo : <TBar extends IBar>(bar: TBar, bar1: (bar: TBar) => TBar, bar2: (bar: TBar) => TBar) => TBar
+>foo : IFoo
+>foo : <TBar extends IBar>(bar: TBar, bar1: (bar: TBar) => TBar, bar2: (bar: TBar) => TBar) => TBar
+>{ bar: null } : { [x: string]: null; bar: null; }
+>bar : null
+>bar => null : (bar: IBar) => any
+>bar : IBar
+>bar => null : (bar: IBar) => any
+>bar : IBar
+

--- a/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments.js
+++ b/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments.js
@@ -1,0 +1,28 @@
+//// [typeParameterFixingWithContextSensitiveArguments.ts]
+function f<T, U>(y: T, f: (x: T) => U, x: T): [T, U] { return [y, f(x)]; }
+interface A { a: A; }
+interface B extends A { b; }
+
+var a: A, b: B;
+
+var d = f(b, x => x.a, a); // type [A, A]
+var d2 = f(b, x => x.a, null); // type [B, A]
+var d3 = f(b, x => x.b, null); // type [B, any]
+
+//// [typeParameterFixingWithContextSensitiveArguments.js]
+function f(y, f, x) {
+    return [
+        y,
+        f(x)
+    ];
+}
+var a, b;
+var d = f(b, function (x) {
+    return x.a;
+}, a); // type [A, A]
+var d2 = f(b, function (x) {
+    return x.a;
+}, null); // type [B, A]
+var d3 = f(b, function (x) {
+    return x.b;
+}, null); // type [B, any]

--- a/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments.types
+++ b/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments.types
@@ -1,0 +1,71 @@
+=== tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments.ts ===
+function f<T, U>(y: T, f: (x: T) => U, x: T): [T, U] { return [y, f(x)]; }
+>f : <T, U>(y: T, f: (x: T) => U, x: T) => [T, U]
+>T : T
+>U : U
+>y : T
+>T : T
+>f : (x: T) => U
+>x : T
+>T : T
+>U : U
+>x : T
+>T : T
+>T : T
+>U : U
+>[y, f(x)] : [T, U]
+>y : T
+>f(x) : U
+>f : (x: T) => U
+>x : T
+
+interface A { a: A; }
+>A : A
+>a : A
+>A : A
+
+interface B extends A { b; }
+>B : B
+>A : A
+>b : any
+
+var a: A, b: B;
+>a : A
+>A : A
+>b : B
+>B : B
+
+var d = f(b, x => x.a, a); // type [A, A]
+>d : [A, A]
+>f(b, x => x.a, a) : [A, A]
+>f : <T, U>(y: T, f: (x: T) => U, x: T) => [T, U]
+>b : B
+>x => x.a : (x: A) => A
+>x : A
+>x.a : A
+>x : A
+>a : A
+>a : A
+
+var d2 = f(b, x => x.a, null); // type [B, A]
+>d2 : [B, A]
+>f(b, x => x.a, null) : [B, A]
+>f : <T, U>(y: T, f: (x: T) => U, x: T) => [T, U]
+>b : B
+>x => x.a : (x: B) => A
+>x : B
+>x.a : A
+>x : B
+>a : A
+
+var d3 = f(b, x => x.b, null); // type [B, any]
+>d3 : [B, any]
+>f(b, x => x.b, null) : [B, any]
+>f : <T, U>(y: T, f: (x: T) => U, x: T) => [T, U]
+>b : B
+>x => x.b : (x: B) => any
+>x : B
+>x.b : any
+>x : B
+>b : any
+

--- a/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments2.errors.txt
+++ b/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments2.errors.txt
@@ -1,0 +1,15 @@
+tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments2.ts(7,25): error TS2345: Argument of type '(x: A) => A' is not assignable to parameter of type '(x: A) => B'.
+  Type 'A' is not assignable to type 'B'.
+
+
+==== tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments2.ts (1 errors) ====
+    function f<T, U>(y: T, y1: U, p: (z: U) => T, p1: (x: T) => U): [T, U] { return [y, p1(y)]; }
+    interface A { a: A; }
+    interface B extends A { b; }
+    
+    var a: A, b: B;
+    
+    var d = f(a, b, x => x, x => x); // A => A not assignable to A => B
+                            ~~~~~~
+!!! error TS2345: Argument of type '(x: A) => A' is not assignable to parameter of type '(x: A) => B'.
+!!! error TS2345:   Type 'A' is not assignable to type 'B'.

--- a/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments2.js
+++ b/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments2.js
@@ -1,0 +1,22 @@
+//// [typeParameterFixingWithContextSensitiveArguments2.ts]
+function f<T, U>(y: T, y1: U, p: (z: U) => T, p1: (x: T) => U): [T, U] { return [y, p1(y)]; }
+interface A { a: A; }
+interface B extends A { b; }
+
+var a: A, b: B;
+
+var d = f(a, b, x => x, x => x); // A => A not assignable to A => B
+
+//// [typeParameterFixingWithContextSensitiveArguments2.js]
+function f(y, y1, p, p1) {
+    return [
+        y,
+        p1(y)
+    ];
+}
+var a, b;
+var d = f(a, b, function (x) {
+    return x;
+}, function (x) {
+    return x;
+}); // A => A not assignable to A => B

--- a/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments3.errors.txt
+++ b/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments3.errors.txt
@@ -1,0 +1,15 @@
+tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments3.ts(7,29): error TS2345: Argument of type '(t2: A) => A' is not assignable to parameter of type '(t2: A) => B'.
+  Type 'A' is not assignable to type 'B'.
+
+
+==== tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments3.ts (1 errors) ====
+    function f<T, U>(t1: T, u1: U, pf1: (u2: U) => T, pf2: (t2: T) => U): [T, U] { return [t1, pf2(t1)]; }
+    interface A { a: A; }
+    interface B extends A { b: B; }
+    
+    var a: A, b: B;
+    
+    var d = f(a, b, u2 => u2.b, t2 => t2);
+                                ~~~~~~~~
+!!! error TS2345: Argument of type '(t2: A) => A' is not assignable to parameter of type '(t2: A) => B'.
+!!! error TS2345:   Type 'A' is not assignable to type 'B'.

--- a/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments3.js
+++ b/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments3.js
@@ -1,0 +1,22 @@
+//// [typeParameterFixingWithContextSensitiveArguments3.ts]
+function f<T, U>(t1: T, u1: U, pf1: (u2: U) => T, pf2: (t2: T) => U): [T, U] { return [t1, pf2(t1)]; }
+interface A { a: A; }
+interface B extends A { b: B; }
+
+var a: A, b: B;
+
+var d = f(a, b, u2 => u2.b, t2 => t2);
+
+//// [typeParameterFixingWithContextSensitiveArguments3.js]
+function f(t1, u1, pf1, pf2) {
+    return [
+        t1,
+        pf2(t1)
+    ];
+}
+var a, b;
+var d = f(a, b, function (u2) {
+    return u2.b;
+}, function (t2) {
+    return t2;
+});

--- a/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments4.js
+++ b/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments4.js
@@ -1,0 +1,22 @@
+//// [typeParameterFixingWithContextSensitiveArguments4.ts]
+function f<T, U>(y: T, y1: U, p: (z: U) => T, p1: (x: T) => U): [T, U] { return [y, p1(y)]; }
+interface A { a: A; }
+interface B extends A { b; }
+
+var a: A, b: B;
+
+var d = f(a, b, x => x, x => <any>x); // Type [A, B]
+
+//// [typeParameterFixingWithContextSensitiveArguments4.js]
+function f(y, y1, p, p1) {
+    return [
+        y,
+        p1(y)
+    ];
+}
+var a, b;
+var d = f(a, b, function (x) {
+    return x;
+}, function (x) {
+    return x;
+}); // Type [A, B]

--- a/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments4.types
+++ b/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments4.types
@@ -1,0 +1,55 @@
+=== tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments4.ts ===
+function f<T, U>(y: T, y1: U, p: (z: U) => T, p1: (x: T) => U): [T, U] { return [y, p1(y)]; }
+>f : <T, U>(y: T, y1: U, p: (z: U) => T, p1: (x: T) => U) => [T, U]
+>T : T
+>U : U
+>y : T
+>T : T
+>y1 : U
+>U : U
+>p : (z: U) => T
+>z : U
+>U : U
+>T : T
+>p1 : (x: T) => U
+>x : T
+>T : T
+>U : U
+>T : T
+>U : U
+>[y, p1(y)] : [T, U]
+>y : T
+>p1(y) : U
+>p1 : (x: T) => U
+>y : T
+
+interface A { a: A; }
+>A : A
+>a : A
+>A : A
+
+interface B extends A { b; }
+>B : B
+>A : A
+>b : any
+
+var a: A, b: B;
+>a : A
+>A : A
+>b : B
+>B : B
+
+var d = f(a, b, x => x, x => <any>x); // Type [A, B]
+>d : [A, B]
+>f(a, b, x => x, x => <any>x) : [A, B]
+>f : <T, U>(y: T, y1: U, p: (z: U) => T, p1: (x: T) => U) => [T, U]
+>a : A
+>b : B
+>x => x : (x: B) => B
+>x : B
+>x : B
+>x => <any>x : (x: A) => any
+>x : A
+><any>x : any
+>x : A
+

--- a/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments5.js
+++ b/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments5.js
@@ -1,0 +1,22 @@
+//// [typeParameterFixingWithContextSensitiveArguments5.ts]
+function f<T, U>(t1: T, u1: U, pf1: (u2: U) => T, pf2: (t2: T) => U): [T, U] { return [t1, pf2(t1)]; }
+interface A { a: A; }
+interface B extends A { b: any; }
+
+var a: A, b: B;
+
+var d = f(a, b, u2 => u2.b, t2 => t2);
+
+//// [typeParameterFixingWithContextSensitiveArguments5.js]
+function f(t1, u1, pf1, pf2) {
+    return [
+        t1,
+        pf2(t1)
+    ];
+}
+var a, b;
+var d = f(a, b, function (u2) {
+    return u2.b;
+}, function (t2) {
+    return t2;
+});

--- a/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments5.types
+++ b/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments5.types
@@ -1,0 +1,56 @@
+=== tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments5.ts ===
+function f<T, U>(t1: T, u1: U, pf1: (u2: U) => T, pf2: (t2: T) => U): [T, U] { return [t1, pf2(t1)]; }
+>f : <T, U>(t1: T, u1: U, pf1: (u2: U) => T, pf2: (t2: T) => U) => [T, U]
+>T : T
+>U : U
+>t1 : T
+>T : T
+>u1 : U
+>U : U
+>pf1 : (u2: U) => T
+>u2 : U
+>U : U
+>T : T
+>pf2 : (t2: T) => U
+>t2 : T
+>T : T
+>U : U
+>T : T
+>U : U
+>[t1, pf2(t1)] : [T, U]
+>t1 : T
+>pf2(t1) : U
+>pf2 : (t2: T) => U
+>t1 : T
+
+interface A { a: A; }
+>A : A
+>a : A
+>A : A
+
+interface B extends A { b: any; }
+>B : B
+>A : A
+>b : any
+
+var a: A, b: B;
+>a : A
+>A : A
+>b : B
+>B : B
+
+var d = f(a, b, u2 => u2.b, t2 => t2);
+>d : [any, B]
+>f(a, b, u2 => u2.b, t2 => t2) : [any, B]
+>f : <T, U>(t1: T, u1: U, pf1: (u2: U) => T, pf2: (t2: T) => U) => [T, U]
+>a : A
+>b : B
+>u2 => u2.b : (u2: B) => any
+>u2 : B
+>u2.b : any
+>u2 : B
+>b : any
+>t2 => t2 : (t2: any) => any
+>t2 : any
+>t2 : any
+

--- a/tests/cases/compiler/typeParameterFixingWithConstraints.ts
+++ b/tests/cases/compiler/typeParameterFixingWithConstraints.ts
@@ -1,0 +1,10 @@
+interface IBar {
+    [barId: string]: any;
+}
+
+interface IFoo {
+    foo<TBar extends IBar>(bar: TBar, bar1: (bar: TBar) => TBar, bar2: (bar: TBar) => TBar): TBar;
+}
+
+var foo: IFoo;
+foo.foo({ bar: null }, bar => null, bar => null);

--- a/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments.ts
+++ b/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments.ts
@@ -1,0 +1,9 @@
+function f<T, U>(y: T, f: (x: T) => U, x: T): [T, U] { return [y, f(x)]; }
+interface A { a: A; }
+interface B extends A { b; }
+
+var a: A, b: B;
+
+var d = f(b, x => x.a, a); // type [A, A]
+var d2 = f(b, x => x.a, null); // type [B, A]
+var d3 = f(b, x => x.b, null); // type [B, any]

--- a/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments2.ts
+++ b/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments2.ts
@@ -1,0 +1,7 @@
+function f<T, U>(y: T, y1: U, p: (z: U) => T, p1: (x: T) => U): [T, U] { return [y, p1(y)]; }
+interface A { a: A; }
+interface B extends A { b; }
+
+var a: A, b: B;
+
+var d = f(a, b, x => x, x => x); // A => A not assignable to A => B

--- a/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments3.ts
+++ b/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments3.ts
@@ -1,0 +1,7 @@
+function f<T, U>(t1: T, u1: U, pf1: (u2: U) => T, pf2: (t2: T) => U): [T, U] { return [t1, pf2(t1)]; }
+interface A { a: A; }
+interface B extends A { b: B; }
+
+var a: A, b: B;
+
+var d = f(a, b, u2 => u2.b, t2 => t2);

--- a/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments4.ts
+++ b/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments4.ts
@@ -1,0 +1,7 @@
+function f<T, U>(y: T, y1: U, p: (z: U) => T, p1: (x: T) => U): [T, U] { return [y, p1(y)]; }
+interface A { a: A; }
+interface B extends A { b; }
+
+var a: A, b: B;
+
+var d = f(a, b, x => x, x => <any>x); // Type [A, B]

--- a/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments5.ts
+++ b/tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments5.ts
@@ -1,0 +1,7 @@
+function f<T, U>(t1: T, u1: U, pf1: (u2: U) => T, pf2: (t2: T) => U): [T, U] { return [t1, pf2(t1)]; }
+interface A { a: A; }
+interface B extends A { b: any; }
+
+var a: A, b: B;
+
+var d = f(a, b, u2 => u2.b, t2 => t2);


### PR DESCRIPTION
This fixes #2182 and fixes #2127.

The problem is essentially that after we fix a type parameter during type argument inference, we may unfix it later. This happens because the inference context that we use to store the results gets forgotten on every iteration of type argument inference. The main part of this change is to make the inference context persist throughout the processing of signature.

As an example, if you have:
```ts
declare function f<T>(x: T, y: (p: T) => T, z: (p: T) => T): T;
f(0, x => null, x => null);
```
Right now, T will be inferred to any, because we do 3 passes (one for each argument in this case). The results from each pass are as follows:

1. T is inferred to be number because of the 0
2. T is fixed because we pass a lambda for the second argument, so we do not infer from the null
3. T eventually gets fixed when we get to z for a similar reason, but we've forgotten that it got fixed in parameter y, so we've inferred from the null in the first lambda, and so we get any

This also had a very unusual effect with constraints, which led to a crash. Namely, when it comes time to fix a type parameter, and the type we were going to infer is not assignable to the constraint, we infer the constraint instead, and we fix the type parameter. Then later we may infer back from that constraint, thereby adding an inference candidate that should never have been added. As a result, we have no common supertype among candidates, when really we should only have had one candidate.

The moral of the story is that when a type parameter gets fixed, it should stay fixed. This change is not totally complete, in that fixedness does not get persisted between overloads, but that is a phenomenon for another day.