### PR TITLE
Add .gitattributes to override GitHub Linguist language classification 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js linguist-language=TypeScript


### PR DESCRIPTION
Per https://github.com/github/linguist#overrides should hopefully get our repo classified as TypeScript instead of JavaScript.