### PR TITLE
Remove CodeClimate stuff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,3 @@ node_js:
   - '0.10'
 
 sudo: false
-
-before_script: npm install -g codeclimate-test-reporter
-
-after_script:
-  - cat coverage/lcov.info | codeclimate
-
-addons:
-  code_climate:
-    repo_token: 9852ac5362c8cc38c07ca5adc0f94c20c6c79bd78e17933dc284598a65338656

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
         "mocha": "latest",
         "chai": "latest",
         "browserify": "latest",
-        "istanbul": "latest",
+        "istanbul": "latest"
     },
     "scripts": {
         "test": "jake runtests"

--- a/package.json
+++ b/package.json
@@ -39,9 +39,8 @@
         "chai": "latest",
         "browserify": "latest",
         "istanbul": "latest",
-        "codeclimate-test-reporter": "latest"
     },
     "scripts": {
-        "test": "jake generate-code-coverage"
+        "test": "jake runtests"
     }
 }


### PR DESCRIPTION
We aren't using this since our repo setup doesn't work with their tools. The jake task will still exist for manual code coverage support.