### PR TITLE
Add toolsversion to shim so we can read it from VS.

### DIFF
--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -834,4 +834,4 @@ module TypeScript.Services {
     export var TypeScriptServicesFactory = ts.TypeScriptServicesFactory;
 }
 
-let toolsVersion = "1.4.3.0";
+let toolsVersion = "1.4";

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -834,4 +834,4 @@ module TypeScript.Services {
     export var TypeScriptServicesFactory = ts.TypeScriptServicesFactory;
 }
 
-let toolsVerions = "1.4.3.0";
+let toolsVersion = "1.4.3.0";

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -833,3 +833,5 @@ module ts {
 module TypeScript.Services {
     export var TypeScriptServicesFactory = ts.TypeScriptServicesFactory;
 }
+
+let toolsVerions = "1.4.3.0";


### PR DESCRIPTION
Add toolsversion to shim so we can read it from VS. This makes it easier to warn for breaking changes, when the language service script is updated.