### PR TITLE
Fix emit destructuring in declaration file

### DIFF
--- a/tests/baselines/reference/emitDestructuringInDeclarationFile.js
+++ b/tests/baselines/reference/emitDestructuringInDeclarationFile.js
@@ -1,0 +1,47 @@
+//// [emitDestructuringInDeclarationFile.ts]
+var {a, b} = { a:10, b:"10"};
+var {c, d}: {c:string, d:string} = { c:"true", d:"false" };
+let {k, j} = { k:true, j:{a:10}};
+
+var a1 = ["string", 10];
+var [x] = a1;
+var [x, y] = a1;
+var [x, y, z] = a1;
+let [x1] = a1;
+
+//// [emitDestructuringInDeclarationFile.js]
+var _a = {
+    a: 10,
+    b: "10"
+}, a = _a.a, b = _a.b;
+var _b = {
+    c: "true",
+    d: "false"
+}, c = _b.c, d = _b.d;
+var _c = {
+    k: true,
+    j: {
+        a: 10
+    }
+}, k = _c.k, j = _c.j;
+var a1 = [
+    "string",
+    10
+];
+var x = a1[0];
+var x = a1[0], y = a1[1];
+var x = a1[0], y = a1[1], z = a1[2];
+var x1 = a1[0];
+
+
+//// [emitDestructuringInDeclarationFile.d.ts]
+declare var a: number, b: string;
+declare var c: string, d: string;
+declare let k: boolean, j: {
+    a: number;
+};
+declare var a1: (string | number)[];
+declare var x: string | number;
+declare var x: string | number, y: string | number;
+declare var x: string | number, y: string | number, z: string | number;
+declare let x1: string | number;

--- a/tests/baselines/reference/emitDestructuringInDeclarationFile.types
+++ b/tests/baselines/reference/emitDestructuringInDeclarationFile.types
@@ -1,0 +1,49 @@
+=== tests/cases/conformance/es6/destructuring/emitDestructuringInDeclarationFile.ts ===
+var {a, b} = { a:10, b:"10"};
+>a : number
+>b : string
+>{ a:10, b:"10"} : { a: number; b: string; }
+>a : number
+>b : string
+
+var {c, d}: {c:string, d:string} = { c:"true", d:"false" };
+>c : string
+>d : string
+>c : string
+>d : string
+>{ c:"true", d:"false" } : { c: string; d: string; }
+>c : string
+>d : string
+
+let {k, j} = { k:true, j:{a:10}};
+>k : boolean
+>j : { a: number; }
+>{ k:true, j:{a:10}} : { k: boolean; j: { a: number; }; }
+>k : boolean
+>j : { a: number; }
+>{a:10} : { a: number; }
+>a : number
+
+var a1 = ["string", 10];
+>a1 : (string | number)[]
+>["string", 10] : (string | number)[]
+
+var [x] = a1;
+>x : string | number
+>a1 : (string | number)[]
+
+var [x, y] = a1;
+>x : string | number
+>y : string | number
+>a1 : (string | number)[]
+
+var [x, y, z] = a1;
+>x : string | number
+>y : string | number
+>z : string | number
+>a1 : (string | number)[]
+
+let [x1] = a1;
+>x1 : string | number
+>a1 : (string | number)[]
+

--- a/tests/baselines/reference/emitDestructuringInDeclarationFile1.errors.txt
+++ b/tests/baselines/reference/emitDestructuringInDeclarationFile1.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/conformance/es6/destructuring/emitDestructuringInDeclarationFile1.ts(6,16): error TS1182: A destructuring declaration must have an initializer.
+
+
+==== tests/cases/conformance/es6/destructuring/emitDestructuringInDeclarationFile1.ts (1 errors) ====
+    module M {
+        export class c { }
+        export var {b} = {
+            b: new c()
+        };
+        export var {a}: { a: c };
+                   ~~~
+!!! error TS1182: A destructuring declaration must have an initializer.
+    }
+    

--- a/tests/baselines/reference/emitDestructuringInDeclarationFile1.js
+++ b/tests/baselines/reference/emitDestructuringInDeclarationFile1.js
@@ -1,0 +1,33 @@
+//// [emitDestructuringInDeclarationFile1.ts]
+module M {
+    export class c { }
+    export var {b} = {
+        b: new c()
+    };
+    export var {a}: { a: c };
+}
+
+
+//// [emitDestructuringInDeclarationFile1.js]
+var M;
+(function (M) {
+    var c = (function () {
+        function c() {
+        }
+        return c;
+    })();
+    M.c = c;
+    M.b = ({
+        b: new c()
+    }).b;
+    M.a = (void 0).a;
+})(M || (M = {}));
+
+
+//// [emitDestructuringInDeclarationFile1.d.ts]
+declare module M {
+    class c {
+    }
+    var b: c;
+    var a: c;
+}

--- a/tests/baselines/reference/emitDestructuringInDeclarationFile2.errors.txt
+++ b/tests/baselines/reference/emitDestructuringInDeclarationFile2.errors.txt
@@ -1,0 +1,20 @@
+tests/cases/conformance/es6/destructuring/emitDestructuringInDeclarationFile2.ts(3,16): error TS4025: Exported variable '{b}' has or is using private name 'c'.
+tests/cases/conformance/es6/destructuring/emitDestructuringInDeclarationFile2.ts(6,16): error TS1182: A destructuring declaration must have an initializer.
+tests/cases/conformance/es6/destructuring/emitDestructuringInDeclarationFile2.ts(6,16): error TS4025: Exported variable '{a}' has or is using private name 'c'.
+
+
+==== tests/cases/conformance/es6/destructuring/emitDestructuringInDeclarationFile2.ts (3 errors) ====
+    module M {
+        class c { }
+        export var {b} = {
+                   ~~~
+!!! error TS4025: Exported variable '{b}' has or is using private name 'c'.
+            b: new c()
+        };
+        export var {a}: { a: c };
+                   ~~~
+!!! error TS1182: A destructuring declaration must have an initializer.
+                   ~~~
+!!! error TS4025: Exported variable '{a}' has or is using private name 'c'.
+    }
+    

--- a/tests/baselines/reference/emitDestructuringInDeclarationFile2.js
+++ b/tests/baselines/reference/emitDestructuringInDeclarationFile2.js
@@ -1,0 +1,23 @@
+//// [emitDestructuringInDeclarationFile2.ts]
+module M {
+    class c { }
+    export var {b} = {
+        b: new c()
+    };
+    export var {a}: { a: c };
+}
+
+
+//// [emitDestructuringInDeclarationFile2.js]
+var M;
+(function (M) {
+    var c = (function () {
+        function c() {
+        }
+        return c;
+    })();
+    M.b = ({
+        b: new c()
+    }).b;
+    M.a = (void 0).a;
+})(M || (M = {}));

--- a/tests/baselines/reference/emitDestructuringWithInitializerInDeclarationFile.js
+++ b/tests/baselines/reference/emitDestructuringWithInitializerInDeclarationFile.js
@@ -1,0 +1,68 @@
+//// [emitDestructuringWithInitializerInDeclarationFile.ts]
+class C { }
+class D extends C { }
+var {s = '10', c} = { s: 'bar', c: true };
+var [s1 = '10', c1] = ['hello', 'word'];
+var {s2 = { prop1: new C(), prop2: new C() }, c2} = { s2: { prop1: new D(), prop2: new D() }, c2: false };
+var [[s3 = [], c3]] = [[[10,20], "blah"]];
+
+//// [emitDestructuringWithInitializerInDeclarationFile.js]
+var __extends = this.__extends || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    __.prototype = b.prototype;
+    d.prototype = new __();
+};
+var C = (function () {
+    function C() {
+    }
+    return C;
+})();
+var D = (function (_super) {
+    __extends(D, _super);
+    function D() {
+        _super.apply(this, arguments);
+    }
+    return D;
+})(C);
+var _a = {
+    s: 'bar',
+    c: true
+}, _b = _a.s, s = _b === void 0 ? '10' : _b, c = _a.c;
+var _c = [
+    'hello',
+    'word'
+], _d = _c[0], s1 = _d === void 0 ? '10' : _d, c1 = _c[1];
+var _e = {
+    s2: {
+        prop1: new D(),
+        prop2: new D()
+    },
+    c2: false
+}, _f = _e.s2, s2 = _f === void 0 ? {
+    prop1: new C(),
+    prop2: new C()
+} : _f, c2 = _e.c2;
+var _g = ([
+    [
+        [
+            10,
+            20
+        ],
+        "blah"
+    ]
+])[0], _h = _g[0], s3 = _h === void 0 ? [] : _h, c3 = _g[1];
+
+
+//// [emitDestructuringWithInitializerInDeclarationFile.d.ts]
+declare class C {
+}
+declare class D extends C {
+}
+declare var s: string, c: boolean;
+declare var s1: string, c1: string;
+declare var s2: {
+    prop1: D;
+    prop2: D;
+}, c2: boolean;
+declare var s3: number[], c3: string;

--- a/tests/baselines/reference/emitDestructuringWithInitializerInDeclarationFile.types
+++ b/tests/baselines/reference/emitDestructuringWithInitializerInDeclarationFile.types
@@ -1,0 +1,49 @@
+=== tests/cases/conformance/es6/destructuring/emitDestructuringWithInitializerInDeclarationFile.ts ===
+class C { }
+>C : C
+
+class D extends C { }
+>D : D
+>C : C
+
+var {s = '10', c} = { s: 'bar', c: true };
+>s : string
+>c : boolean
+>{ s: 'bar', c: true } : { s: string; c: boolean; }
+>s : string
+>c : boolean
+
+var [s1 = '10', c1] = ['hello', 'word'];
+>s1 : string
+>c1 : string
+>['hello', 'word'] : [string, string]
+
+var {s2 = { prop1: new C(), prop2: new C() }, c2} = { s2: { prop1: new D(), prop2: new D() }, c2: false };
+>s2 : { prop1: D; prop2: D; }
+>{ prop1: new C(), prop2: new C() } : { prop1: C; prop2: C; }
+>prop1 : C
+>new C() : C
+>C : typeof C
+>prop2 : C
+>new C() : C
+>C : typeof C
+>c2 : boolean
+>{ s2: { prop1: new D(), prop2: new D() }, c2: false } : { s2: { prop1: D; prop2: D; }; c2: boolean; }
+>s2 : { prop1: D; prop2: D; }
+>{ prop1: new D(), prop2: new D() } : { prop1: D; prop2: D; }
+>prop1 : D
+>new D() : D
+>D : typeof D
+>prop2 : D
+>new D() : D
+>D : typeof D
+>c2 : boolean
+
+var [[s3 = [], c3]] = [[[10,20], "blah"]];
+>s3 : number[]
+>[] : undefined[]
+>c3 : string
+>[[[10,20], "blah"]] : [[number[], string]]
+>[[10,20], "blah"] : [number[], string]
+>[10,20] : number[]
+

--- a/tests/baselines/reference/emitNestedDestructuringInDeclarationFile1.js
+++ b/tests/baselines/reference/emitNestedDestructuringInDeclarationFile1.js
@@ -1,0 +1,56 @@
+//// [emitNestedDestructuringInDeclarationFile1.ts]
+var { a, b: {c, d}} = { a: 10, b: { c: true, d: "hello" } };
+var { y: {w: {id1: {x}, id2}, z}} = { y: { w: { id1: { x: 10 }, id2: "world" }, z: true } };
+
+var [[j]] = [[{}]];
+var [[foo, bar]] = [[10, 20, "undefined"]];
+var [[foo1, bar1, [baz]]] = [[false, true, ["undefined"]]];
+
+//// [emitNestedDestructuringInDeclarationFile1.js]
+var _a = {
+    a: 10,
+    b: {
+        c: true,
+        d: "hello"
+    }
+}, a = _a.a, _b = _a.b, c = _b.c, d = _b.d;
+var _c = ({
+    y: {
+        w: {
+            id1: {
+                x: 10
+            },
+            id2: "world"
+        },
+        z: true
+    }
+}).y, _d = _c.w, x = _d.id1.x, id2 = _d.id2, z = _c.z;
+var j = ([
+    [
+        {}
+    ]
+])[0][0];
+var _e = ([
+    [
+        10,
+        20,
+        "undefined"
+    ]
+])[0], foo = _e[0], bar = _e[1];
+var _f = ([
+    [
+        false,
+        true,
+        [
+            "undefined"
+        ]
+    ]
+])[0], foo1 = _f[0], bar1 = _f[1], baz = _f[2][0];
+
+
+//// [emitNestedDestructuringInDeclarationFile1.d.ts]
+declare var a: number, c: boolean, d: string;
+declare var x: number, id2: string, z: boolean;
+declare var j: {};
+declare var foo: number, bar: number;
+declare var foo1: boolean, bar1: boolean, baz: string;

--- a/tests/baselines/reference/emitNestedDestructuringInDeclarationFile1.types
+++ b/tests/baselines/reference/emitNestedDestructuringInDeclarationFile1.types
@@ -1,0 +1,51 @@
+=== tests/cases/conformance/es6/destructuring/emitNestedDestructuringInDeclarationFile1.ts ===
+var { a, b: {c, d}} = { a: 10, b: { c: true, d: "hello" } };
+>a : number
+>b : unknown
+>c : boolean
+>d : string
+>{ a: 10, b: { c: true, d: "hello" } } : { a: number; b: { c: boolean; d: string; }; }
+>a : number
+>b : { c: boolean; d: string; }
+>{ c: true, d: "hello" } : { c: boolean; d: string; }
+>c : boolean
+>d : string
+
+var { y: {w: {id1: {x}, id2}, z}} = { y: { w: { id1: { x: 10 }, id2: "world" }, z: true } };
+>y : unknown
+>w : unknown
+>id1 : unknown
+>x : number
+>id2 : string
+>z : boolean
+>{ y: { w: { id1: { x: 10 }, id2: "world" }, z: true } } : { y: { w: { id1: { x: number; }; id2: string; }; z: boolean; }; }
+>y : { w: { id1: { x: number; }; id2: string; }; z: boolean; }
+>{ w: { id1: { x: 10 }, id2: "world" }, z: true } : { w: { id1: { x: number; }; id2: string; }; z: boolean; }
+>w : { id1: { x: number; }; id2: string; }
+>{ id1: { x: 10 }, id2: "world" } : { id1: { x: number; }; id2: string; }
+>id1 : { x: number; }
+>{ x: 10 } : { x: number; }
+>x : number
+>id2 : string
+>z : boolean
+
+var [[j]] = [[{}]];
+>j : {}
+>[[{}]] : [[{}]]
+>[{}] : [{}]
+>{} : {}
+
+var [[foo, bar]] = [[10, 20, "undefined"]];
+>foo : number
+>bar : number
+>[[10, 20, "undefined"]] : [[number, number, string]]
+>[10, 20, "undefined"] : [number, number, string]
+
+var [[foo1, bar1, [baz]]] = [[false, true, ["undefined"]]];
+>foo1 : boolean
+>bar1 : boolean
+>baz : string
+>[[false, true, ["undefined"]]] : [[boolean, boolean, [string]]]
+>[false, true, ["undefined"]] : [boolean, boolean, [string]]
+>["undefined"] : [string]
+

--- a/tests/baselines/reference/emitNestedDestructuringInDeclarationFile2.js
+++ b/tests/baselines/reference/emitNestedDestructuringInDeclarationFile2.js
@@ -1,0 +1,33 @@
+//// [emitNestedDestructuringInDeclarationFile2.ts]
+var [[j]] = [[{}]];
+var [[foo, bar]] = [[10, 20, "undefined"]];
+var [[foo1, bar1, [baz]]] = [[false, true, ["undefined"]]];
+
+//// [emitNestedDestructuringInDeclarationFile2.js]
+var j = ([
+    [
+        {}
+    ]
+])[0][0];
+var _a = ([
+    [
+        10,
+        20,
+        "undefined"
+    ]
+])[0], foo = _a[0], bar = _a[1];
+var _b = ([
+    [
+        false,
+        true,
+        [
+            "undefined"
+        ]
+    ]
+])[0], foo1 = _b[0], bar1 = _b[1], baz = _b[2][0];
+
+
+//// [emitNestedDestructuringInDeclarationFile2.d.ts]
+declare var j: {};
+declare var foo: number, bar: number;
+declare var foo1: boolean, bar1: boolean, baz: string;

--- a/tests/baselines/reference/emitNestedDestructuringInDeclarationFile2.types
+++ b/tests/baselines/reference/emitNestedDestructuringInDeclarationFile2.types
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/es6/destructuring/emitNestedDestructuringInDeclarationFile2.ts ===
+var [[j]] = [[{}]];
+>j : {}
+>[[{}]] : [[{}]]
+>[{}] : [{}]
+>{} : {}
+
+var [[foo, bar]] = [[10, 20, "undefined"]];
+>foo : number
+>bar : number
+>[[10, 20, "undefined"]] : [[number, number, string]]
+>[10, 20, "undefined"] : [number, number, string]
+
+var [[foo1, bar1, [baz]]] = [[false, true, ["undefined"]]];
+>foo1 : boolean
+>bar1 : boolean
+>baz : string
+>[[false, true, ["undefined"]]] : [[boolean, boolean, [string]]]
+>[false, true, ["undefined"]] : [boolean, boolean, [string]]
+>["undefined"] : [string]
+

--- a/tests/baselines/reference/emitNestedDestructuringInDeclarationFile3.js
+++ b/tests/baselines/reference/emitNestedDestructuringInDeclarationFile3.js
@@ -1,0 +1,42 @@
+//// [emitNestedDestructuringInDeclarationFile3.ts]
+var {a: [b, c]} = { a: [10, "HI"] };
+var [{x, y}, {t:{z}}] = [{ x: true, y: 200 }, {t:{z: "string" }}];
+var [[[foo, bar, {baz}], e1], e2] = [[[10, "bar", { baz: "baz" }], true], 2000];
+
+//// [emitNestedDestructuringInDeclarationFile3.js]
+var _a = ({
+    a: [
+        10,
+        "HI"
+    ]
+}).a, b = _a[0], c = _a[1];
+var _b = [
+    {
+        x: true,
+        y: 200
+    },
+    {
+        t: {
+            z: "string"
+        }
+    }
+], _c = _b[0], x = _c.x, y = _c.y, z = _b[1].t.z;
+var _d = [
+    [
+        [
+            10,
+            "bar",
+            {
+                baz: "baz"
+            }
+        ],
+        true
+    ],
+    2000
+], _e = _d[0], _f = _e[0], foo = _f[0], bar = _f[1], baz = _f[2].baz, e1 = _e[1], e2 = _d[1];
+
+
+//// [emitNestedDestructuringInDeclarationFile3.d.ts]
+declare var b: number, c: string;
+declare var x: boolean, y: number, z: string;
+declare var foo: number, bar: string, baz: string, e1: boolean, e2: number;

--- a/tests/baselines/reference/emitNestedDestructuringInDeclarationFile3.types
+++ b/tests/baselines/reference/emitNestedDestructuringInDeclarationFile3.types
@@ -1,0 +1,35 @@
+=== tests/cases/conformance/es6/destructuring/emitNestedDestructuringInDeclarationFile3.ts ===
+var {a: [b, c]} = { a: [10, "HI"] };
+>a : unknown
+>b : number
+>c : string
+>{ a: [10, "HI"] } : { a: [number, string]; }
+>a : [number, string]
+>[10, "HI"] : [number, string]
+
+var [{x, y}, {t:{z}}] = [{ x: true, y: 200 }, {t:{z: "string" }}];
+>x : boolean
+>y : number
+>t : unknown
+>z : string
+>[{ x: true, y: 200 }, {t:{z: "string" }}] : [{ x: boolean; y: number; }, { t: { z: string; }; }]
+>{ x: true, y: 200 } : { x: boolean; y: number; }
+>x : boolean
+>y : number
+>{t:{z: "string" }} : { t: { z: string; }; }
+>t : { z: string; }
+>{z: "string" } : { z: string; }
+>z : string
+
+var [[[foo, bar, {baz}], e1], e2] = [[[10, "bar", { baz: "baz" }], true], 2000];
+>foo : number
+>bar : string
+>baz : string
+>e1 : boolean
+>e2 : number
+>[[[10, "bar", { baz: "baz" }], true], 2000] : [[[number, string, { baz: string; }], boolean], number]
+>[[10, "bar", { baz: "baz" }], true] : [[number, string, { baz: string; }], boolean]
+>[10, "bar", { baz: "baz" }] : [number, string, { baz: string; }]
+>{ baz: "baz" } : { baz: string; }
+>baz : string
+

--- a/tests/baselines/reference/emitRestDestructuringInDeclarationFile.js
+++ b/tests/baselines/reference/emitRestDestructuringInDeclarationFile.js
@@ -1,0 +1,24 @@
+//// [emitRestDestructuringInDeclarationFile.ts]
+var [a, b, ...rest] = [1, 2, 3, "string"];
+var [a1, b1, [...rest]] = [1, 2, [3, "string"]];
+
+//// [emitRestDestructuringInDeclarationFile.js]
+var _a = [
+    1,
+    2,
+    3,
+    "string"
+], a = _a[0], b = _a[1], rest = _a.slice(2);
+var _b = [
+    1,
+    2,
+    [
+        3,
+        "string"
+    ]
+], a1 = _b[0], b1 = _b[1], _c = _b[2], rest = _c.slice(0);
+
+
+//// [emitRestDestructuringInDeclarationFile.d.ts]
+declare var a: string | number, b: string | number, rest: (string | number)[];
+declare var a1: number, b1: number, rest: (string | number)[];

--- a/tests/baselines/reference/emitRestDestructuringInDeclarationFile.types
+++ b/tests/baselines/reference/emitRestDestructuringInDeclarationFile.types
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/es6/destructuring/emitRestDestructuringInDeclarationFile.ts ===
+var [a, b, ...rest] = [1, 2, 3, "string"];
+>a : string | number
+>b : string | number
+>rest : (string | number)[]
+>[1, 2, 3, "string"] : (string | number)[]
+
+var [a1, b1, [...rest]] = [1, 2, [3, "string"]];
+>a1 : number
+>b1 : number
+>rest : (string | number)[]
+>[1, 2, [3, "string"]] : [number, number, (string | number)[]]
+>[3, "string"] : (string | number)[]
+

--- a/tests/cases/conformance/es6/destructuring/emitDestructuringInDeclarationFile.ts
+++ b/tests/cases/conformance/es6/destructuring/emitDestructuringInDeclarationFile.ts
@@ -1,0 +1,10 @@
+// @declaration: true
+var {a, b} = { a:10, b:"10"};
+var {c, d}: {c:string, d:string} = { c:"true", d:"false" };
+let {k, j} = { k:true, j:{a:10}};
+
+var a1 = ["string", 10];
+var [x] = a1;
+var [x, y] = a1;
+var [x, y, z] = a1;
+let [x1] = a1;

--- a/tests/cases/conformance/es6/destructuring/emitDestructuringInDeclarationFile1.ts
+++ b/tests/cases/conformance/es6/destructuring/emitDestructuringInDeclarationFile1.ts
@@ -1,0 +1,9 @@
+// @declaration: true
+// @module: amd
+module M {
+    export class c { }
+    export var {b} = {
+        b: new c()
+    };
+    export var {a}: { a: c };
+}

--- a/tests/cases/conformance/es6/destructuring/emitDestructuringInDeclarationFile2.ts
+++ b/tests/cases/conformance/es6/destructuring/emitDestructuringInDeclarationFile2.ts
@@ -1,0 +1,9 @@
+// @declaration: true
+// @module: amd
+module M {
+    class c { }
+    export var {b} = {
+        b: new c()
+    };
+    export var {a}: { a: c };
+}

--- a/tests/cases/conformance/es6/destructuring/emitDestructuringWithInitializerInDeclarationFile.ts
+++ b/tests/cases/conformance/es6/destructuring/emitDestructuringWithInitializerInDeclarationFile.ts
@@ -1,0 +1,7 @@
+// @declaration: true
+class C { }
+class D extends C { }
+var {s = '10', c} = { s: 'bar', c: true };
+var [s1 = '10', c1] = ['hello', 'word'];
+var {s2 = { prop1: new C(), prop2: new C() }, c2} = { s2: { prop1: new D(), prop2: new D() }, c2: false };
+var [[s3 = [], c3]] = [[[10,20], "blah"]];

--- a/tests/cases/conformance/es6/destructuring/emitNestedDestructuringInDeclarationFile1.ts
+++ b/tests/cases/conformance/es6/destructuring/emitNestedDestructuringInDeclarationFile1.ts
@@ -1,0 +1,7 @@
+// @declaration: true
+var { a, b: {c, d}} = { a: 10, b: { c: true, d: "hello" } };
+var { y: {w: {id1: {x}, id2}, z}} = { y: { w: { id1: { x: 10 }, id2: "world" }, z: true } };
+
+var [[j]] = [[{}]];
+var [[foo, bar]] = [[10, 20, "undefined"]];
+var [[foo1, bar1, [baz]]] = [[false, true, ["undefined"]]];

--- a/tests/cases/conformance/es6/destructuring/emitNestedDestructuringInDeclarationFile2.ts
+++ b/tests/cases/conformance/es6/destructuring/emitNestedDestructuringInDeclarationFile2.ts
@@ -1,0 +1,4 @@
+// @declaration: true
+var [[j]] = [[{}]];
+var [[foo, bar]] = [[10, 20, "undefined"]];
+var [[foo1, bar1, [baz]]] = [[false, true, ["undefined"]]];

--- a/tests/cases/conformance/es6/destructuring/emitNestedDestructuringInDeclarationFile3.ts
+++ b/tests/cases/conformance/es6/destructuring/emitNestedDestructuringInDeclarationFile3.ts
@@ -1,0 +1,4 @@
+// @declaration: true
+var {a: [b, c]} = { a: [10, "HI"] };
+var [{x, y}, {t:{z}}] = [{ x: true, y: 200 }, {t:{z: "string" }}];
+var [[[foo, bar, {baz}], e1], e2] = [[[10, "bar", { baz: "baz" }], true], 2000];

--- a/tests/cases/conformance/es6/destructuring/emitRestDestructuringInDeclarationFile.ts
+++ b/tests/cases/conformance/es6/destructuring/emitRestDestructuringInDeclarationFile.ts
@@ -1,0 +1,3 @@
+// @declaration: true
+var [a, b, ...rest] = [1, 2, 3, "string"];
+var [a1, b1, [...rest]] = [1, 2, [3, "string"]];


### PR DESCRIPTION
Fix following issue #2023.

Additional suggestion regarding emitting destructing in declaration file is allow destructuring in parameter position in ambient context so that language service can provide better signature help using information from .d.ts