### PR TITLE
Expose setParentNodes on createCompilerHost

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -10,7 +10,7 @@ module ts {
     /** The version of the TypeScript compiler release */
     export let version = "1.5.0.0";
 
-    export function createCompilerHost(options: CompilerOptions): CompilerHost {
+    export function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost {
         let currentDirectory: string;
         let existingDirectories: Map<boolean> = {};
 
@@ -38,7 +38,7 @@ module ts {
                 }
                 text = "";
             }
-            return text !== undefined ? createSourceFile(fileName, text, languageVersion) : undefined;
+            return text !== undefined ? createSourceFile(fileName, text, languageVersion, setParentNodes) : undefined;
         }
 
         function directoryExists(directoryPath: string): boolean {

--- a/tests/baselines/reference/APISample_compile.js
+++ b/tests/baselines/reference/APISample_compile.js
@@ -1472,7 +1472,7 @@ declare module "typescript" {
 declare module "typescript" {
     /** The version of the TypeScript compiler release */
     let version: string;
-    function createCompilerHost(options: CompilerOptions): CompilerHost;
+    function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost;
     function getPreEmitDiagnostics(program: Program): Diagnostic[];
     function flattenDiagnosticMessageText(messageText: string | DiagnosticMessageChain, newLine: string): string;
     function createProgram(rootNames: string[], options: CompilerOptions, host?: CompilerHost): Program;

--- a/tests/baselines/reference/APISample_compile.types
+++ b/tests/baselines/reference/APISample_compile.types
@@ -4714,10 +4714,11 @@ declare module "typescript" {
     let version: string;
 >version : string
 
-    function createCompilerHost(options: CompilerOptions): CompilerHost;
->createCompilerHost : (options: CompilerOptions) => CompilerHost
+    function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost;
+>createCompilerHost : (options: CompilerOptions, setParentNodes?: boolean) => CompilerHost
 >options : CompilerOptions
 >CompilerOptions : CompilerOptions
+>setParentNodes : boolean
 >CompilerHost : CompilerHost
 
     function getPreEmitDiagnostics(program: Program): Diagnostic[];

--- a/tests/baselines/reference/APISample_linter.js
+++ b/tests/baselines/reference/APISample_linter.js
@@ -1503,7 +1503,7 @@ declare module "typescript" {
 declare module "typescript" {
     /** The version of the TypeScript compiler release */
     let version: string;
-    function createCompilerHost(options: CompilerOptions): CompilerHost;
+    function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost;
     function getPreEmitDiagnostics(program: Program): Diagnostic[];
     function flattenDiagnosticMessageText(messageText: string | DiagnosticMessageChain, newLine: string): string;
     function createProgram(rootNames: string[], options: CompilerOptions, host?: CompilerHost): Program;

--- a/tests/baselines/reference/APISample_linter.types
+++ b/tests/baselines/reference/APISample_linter.types
@@ -4860,10 +4860,11 @@ declare module "typescript" {
     let version: string;
 >version : string
 
-    function createCompilerHost(options: CompilerOptions): CompilerHost;
->createCompilerHost : (options: CompilerOptions) => CompilerHost
+    function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost;
+>createCompilerHost : (options: CompilerOptions, setParentNodes?: boolean) => CompilerHost
 >options : CompilerOptions
 >CompilerOptions : CompilerOptions
+>setParentNodes : boolean
 >CompilerHost : CompilerHost
 
     function getPreEmitDiagnostics(program: Program): Diagnostic[];

--- a/tests/baselines/reference/APISample_transform.js
+++ b/tests/baselines/reference/APISample_transform.js
@@ -1504,7 +1504,7 @@ declare module "typescript" {
 declare module "typescript" {
     /** The version of the TypeScript compiler release */
     let version: string;
-    function createCompilerHost(options: CompilerOptions): CompilerHost;
+    function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost;
     function getPreEmitDiagnostics(program: Program): Diagnostic[];
     function flattenDiagnosticMessageText(messageText: string | DiagnosticMessageChain, newLine: string): string;
     function createProgram(rootNames: string[], options: CompilerOptions, host?: CompilerHost): Program;

--- a/tests/baselines/reference/APISample_transform.types
+++ b/tests/baselines/reference/APISample_transform.types
@@ -4810,10 +4810,11 @@ declare module "typescript" {
     let version: string;
 >version : string
 
-    function createCompilerHost(options: CompilerOptions): CompilerHost;
->createCompilerHost : (options: CompilerOptions) => CompilerHost
+    function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost;
+>createCompilerHost : (options: CompilerOptions, setParentNodes?: boolean) => CompilerHost
 >options : CompilerOptions
 >CompilerOptions : CompilerOptions
+>setParentNodes : boolean
 >CompilerHost : CompilerHost
 
     function getPreEmitDiagnostics(program: Program): Diagnostic[];

--- a/tests/baselines/reference/APISample_watcher.js
+++ b/tests/baselines/reference/APISample_watcher.js
@@ -1541,7 +1541,7 @@ declare module "typescript" {
 declare module "typescript" {
     /** The version of the TypeScript compiler release */
     let version: string;
-    function createCompilerHost(options: CompilerOptions): CompilerHost;
+    function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost;
     function getPreEmitDiagnostics(program: Program): Diagnostic[];
     function flattenDiagnosticMessageText(messageText: string | DiagnosticMessageChain, newLine: string): string;
     function createProgram(rootNames: string[], options: CompilerOptions, host?: CompilerHost): Program;

--- a/tests/baselines/reference/APISample_watcher.types
+++ b/tests/baselines/reference/APISample_watcher.types
@@ -4983,10 +4983,11 @@ declare module "typescript" {
     let version: string;
 >version : string
 
-    function createCompilerHost(options: CompilerOptions): CompilerHost;
->createCompilerHost : (options: CompilerOptions) => CompilerHost
+    function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost;
+>createCompilerHost : (options: CompilerOptions, setParentNodes?: boolean) => CompilerHost
 >options : CompilerOptions
 >CompilerOptions : CompilerOptions
+>setParentNodes : boolean
 >CompilerHost : CompilerHost
 
     function getPreEmitDiagnostics(program: Program): Diagnostic[];


### PR DESCRIPTION
If you are using createCompilerHost to create a program, there is no way to set the parent nodes. expose the value on the host creation function.