### PR TITLE
Add libraryTargets to prereqs of instrumenter

### DIFF
--- a/Jakefile
+++ b/Jakefile
@@ -720,7 +720,7 @@ file(loggedIOJsPath, [builtLocalDirectory, loggedIOpath], function() {
 
 var instrumenterPath = harnessDirectory + 'instrumenter.ts';
 var instrumenterJsPath = builtLocalDirectory + 'instrumenter.js';
-compileFile(instrumenterJsPath, [instrumenterPath], [tscFile, instrumenterPath], [], /*useBuiltCompiler*/ true);
+compileFile(instrumenterJsPath, [instrumenterPath], [tscFile, instrumenterPath].concat(libraryTargets), [], /*useBuiltCompiler*/ true);
 
 desc("Builds an instrumented tsc.js");
 task('tsc-instrumented', [loggedIOJsPath, instrumenterJsPath, tscFile], function() {


### PR DESCRIPTION
When you run `jake tsc-instrumented` in a clean environment, it fails because lib.d.ts is not placed in built\local. This change places it in built\local before tsc-instrumented