### PR TITLE
Add support to TypeScript server for tsconfig.json files.

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -10,6 +10,22 @@ module ts {
     /** The version of the TypeScript compiler release */
     export let version = "1.5.0.0";
 
+    export function findConfigFile(searchPath: string): string {
+        var fileName = "tsconfig.json";
+        while (true) {
+            if (sys.fileExists(fileName)) {
+                return fileName;
+            }
+            var parentPath = getDirectoryPath(searchPath);
+            if (parentPath === searchPath) {
+                break;
+            }
+            searchPath = parentPath;
+            fileName = "../" + fileName;
+        }
+        return undefined;
+    }
+
     export function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost {
         let currentDirectory: string;
         let existingDirectories: Map<boolean> = {};

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -132,23 +132,6 @@ module ts {
         return typeof JSON === "object" && typeof JSON.parse === "function";
     }
 
-    function findConfigFile(): string {
-        var searchPath = normalizePath(sys.getCurrentDirectory());
-        var fileName = "tsconfig.json";
-        while (true) {
-            if (sys.fileExists(fileName)) {
-                return fileName;
-            }
-            var parentPath = getDirectoryPath(searchPath);
-            if (parentPath === searchPath) {
-                break;
-            }
-            searchPath = parentPath;
-            fileName = "../" + fileName;
-        }
-        return undefined;
-    }
-
     export function executeCommandLine(args: string[]): void {
         var commandLine = parseCommandLine(args);
         var configFileName: string;                 // Configuration file name (if any)
@@ -198,7 +181,8 @@ module ts {
             }
         }
         else if (commandLine.fileNames.length === 0 && isJSONSupported()) {
-            configFileName = findConfigFile();
+            var searchPath = normalizePath(sys.getCurrentDirectory());
+            configFileName = findConfigFile(searchPath);
         }
 
         if (commandLine.fileNames.length === 0 && !configFileName) {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -508,6 +508,16 @@ module ts.server {
             this.printProjects();
         }
 
+        gcConfiguredProjects() {
+            var configuredProjects: Project[] = [];
+            for (var i = 0, len = this.configuredProjects.length; i < len; i++) {
+                if (this.configuredProjects[i].openRefCount > 0) {
+                    configuredProjects.push(this.configuredProjects[i]);
+                }
+            }
+            this.configuredProjects = configuredProjects;
+        }
+
         setConfiguredProjectRoot(info: ScriptInfo) {
              for (var i = 0, len = this.configuredProjects.length; i < len; i++) {
                  let configuredProject = this.configuredProjects[i];
@@ -555,6 +565,7 @@ module ts.server {
                     this.openFileRoots.push(info);
                 }
             }
+            this.gcConfiguredProjects();
         }
 
         /**

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -550,7 +550,7 @@ module ts.server {
             }
 
             return completions.entries.reduce((result: protocol.CompletionEntry[], entry: ts.CompletionEntry) => {
-                if (completions.isMemberCompletion || entry.name.indexOf(prefix) == 0) {
+                if (completions.isMemberCompletion || (entry.name.toLowerCase().indexOf(prefix.toLowerCase()) == 0)) {
                     result.push(entry);
                 }
                 return result;

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -554,7 +554,7 @@ module ts.server {
                     result.push(entry);
                 }
                 return result;
-            }, []);
+            }, []).sort((a, b) => a.name.localeCompare(b.name));
         }
 
         getCompletionEntryDetails(line: number, offset: number,

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -1,0 +1,17 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "noImplicitAny": true,
+        "removeComments": true,
+        "preserveConstEnums": true,
+        "out": "../../built/local/tsserver.js",
+        "sourceMap": true
+    },
+    "files": [
+        "node.d.ts",
+        "editorServices.ts",
+        "protocol.d.ts",
+        "server.ts",
+        "session.ts"
+    ]
+}

--- a/tests/baselines/reference/APISample_compile.js
+++ b/tests/baselines/reference/APISample_compile.js
@@ -1475,6 +1475,7 @@ declare module "typescript" {
 declare module "typescript" {
     /** The version of the TypeScript compiler release */
     let version: string;
+    function findConfigFile(searchPath: string): string;
     function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost;
     function getPreEmitDiagnostics(program: Program): Diagnostic[];
     function flattenDiagnosticMessageText(messageText: string | DiagnosticMessageChain, newLine: string): string;

--- a/tests/baselines/reference/APISample_compile.types
+++ b/tests/baselines/reference/APISample_compile.types
@@ -4736,6 +4736,10 @@ declare module "typescript" {
     let version: string;
 >version : string
 
+    function findConfigFile(searchPath: string): string;
+>findConfigFile : (searchPath: string) => string
+>searchPath : string
+
     function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost;
 >createCompilerHost : (options: CompilerOptions, setParentNodes?: boolean) => CompilerHost
 >options : CompilerOptions

--- a/tests/baselines/reference/APISample_linter.js
+++ b/tests/baselines/reference/APISample_linter.js
@@ -1506,6 +1506,7 @@ declare module "typescript" {
 declare module "typescript" {
     /** The version of the TypeScript compiler release */
     let version: string;
+    function findConfigFile(searchPath: string): string;
     function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost;
     function getPreEmitDiagnostics(program: Program): Diagnostic[];
     function flattenDiagnosticMessageText(messageText: string | DiagnosticMessageChain, newLine: string): string;

--- a/tests/baselines/reference/APISample_linter.types
+++ b/tests/baselines/reference/APISample_linter.types
@@ -4882,6 +4882,10 @@ declare module "typescript" {
     let version: string;
 >version : string
 
+    function findConfigFile(searchPath: string): string;
+>findConfigFile : (searchPath: string) => string
+>searchPath : string
+
     function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost;
 >createCompilerHost : (options: CompilerOptions, setParentNodes?: boolean) => CompilerHost
 >options : CompilerOptions

--- a/tests/baselines/reference/APISample_transform.js
+++ b/tests/baselines/reference/APISample_transform.js
@@ -1507,6 +1507,7 @@ declare module "typescript" {
 declare module "typescript" {
     /** The version of the TypeScript compiler release */
     let version: string;
+    function findConfigFile(searchPath: string): string;
     function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost;
     function getPreEmitDiagnostics(program: Program): Diagnostic[];
     function flattenDiagnosticMessageText(messageText: string | DiagnosticMessageChain, newLine: string): string;

--- a/tests/baselines/reference/APISample_transform.types
+++ b/tests/baselines/reference/APISample_transform.types
@@ -4832,6 +4832,10 @@ declare module "typescript" {
     let version: string;
 >version : string
 
+    function findConfigFile(searchPath: string): string;
+>findConfigFile : (searchPath: string) => string
+>searchPath : string
+
     function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost;
 >createCompilerHost : (options: CompilerOptions, setParentNodes?: boolean) => CompilerHost
 >options : CompilerOptions

--- a/tests/baselines/reference/APISample_watcher.js
+++ b/tests/baselines/reference/APISample_watcher.js
@@ -1544,6 +1544,7 @@ declare module "typescript" {
 declare module "typescript" {
     /** The version of the TypeScript compiler release */
     let version: string;
+    function findConfigFile(searchPath: string): string;
     function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost;
     function getPreEmitDiagnostics(program: Program): Diagnostic[];
     function flattenDiagnosticMessageText(messageText: string | DiagnosticMessageChain, newLine: string): string;

--- a/tests/baselines/reference/APISample_watcher.types
+++ b/tests/baselines/reference/APISample_watcher.types
@@ -5005,6 +5005,10 @@ declare module "typescript" {
     let version: string;
 >version : string
 
+    function findConfigFile(searchPath: string): string;
+>findConfigFile : (searchPath: string) => string
+>searchPath : string
+
     function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost;
 >createCompilerHost : (options: CompilerOptions, setParentNodes?: boolean) => CompilerHost
 >options : CompilerOptions


### PR DESCRIPTION
When a file F is opened by the host, the server will now check whether F is configured by a tsconfig.json file and, if so, use the specified project as the context for F.  

Still TODO, monitor tsconfig.json files for changes and update configuration.  For now, programmers will need to restart their editor to pick up the tsconfig.json file changes.