### PR TITLE
Emit, even in the presence of declaration errors and noEmitOnError.

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -87,11 +87,6 @@ module ts {
 
     export function getPreEmitDiagnostics(program: Program): Diagnostic[] {
         let diagnostics = program.getSyntacticDiagnostics().concat(program.getGlobalDiagnostics()).concat(program.getSemanticDiagnostics());
-
-        if (program.getCompilerOptions().declaration) {
-            diagnostics.concat(program.getDeclarationDiagnostics());
-        }
-
         return sortAndDeduplicateDiagnostics(diagnostics);
     }
 


### PR DESCRIPTION
We're reverting to the previous behavior we had until there is more consensus
on the best way to deal with this issue.