### PR TITLE
Revert "Emit, even in the presence of declaration errors and noEmitOnError

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -87,6 +87,11 @@ module ts {
 
     export function getPreEmitDiagnostics(program: Program): Diagnostic[] {
         let diagnostics = program.getSyntacticDiagnostics().concat(program.getGlobalDiagnostics()).concat(program.getSemanticDiagnostics());
+
+        if (program.getCompilerOptions().declaration) {
+            diagnostics.concat(program.getDeclarationDiagnostics());
+        }
+
         return sortAndDeduplicateDiagnostics(diagnostics);
     }
 


### PR DESCRIPTION
This reverts commit 19517ac0ddf8e7ed67ee1328f379071d8e8feb51.

The impact of this change is that we will now no longer emit in the presence of declaration errors, if the user has noEmitOnError set to true.  

Performance-wise, this seems to add about 1% to the overall compile time (i tested using the compiler).  This seems like a reasonable cost in order to implement the noEmitOnError feature correctly.  