### PR TITLE
Add signature help to Typescript server

### DIFF
--- a/src/server/protocol.d.ts
+++ b/src/server/protocol.d.ts
@@ -644,7 +644,7 @@ declare module ts.server.protocol {
         separatorDisplayParts: SymbolDisplayPart[];
         
         /**
-         * The signatiure helps items for the parameters. 
+         * The signature helps items for the parameters. 
          */        
         parameters: SignatureHelpParameter[];
                 
@@ -655,17 +655,17 @@ declare module ts.server.protocol {
     }
     
     /**
-     * Signation help items found in the response of a signature help request.
+     * Signature help items found in the response of a signature help request.
      */
     export interface SignatureHelpItems {
       
         /**
-         * The signaure help items.    
+         * The signature help items.    
          */        
         items: SignatureHelpItem[];
                 
         /**
-         * @steveluc
+         * The span for which signature help should appear on a signature 
          */        
         applicableSpan: TextSpan;
                 
@@ -680,7 +680,7 @@ declare module ts.server.protocol {
         argumentIndex: number;
         
         /**
-         * The argument counts
+         * The argument count
          */        
         argumentCount: number;
     }

--- a/src/server/protocol.d.ts
+++ b/src/server/protocol.d.ts
@@ -593,6 +593,122 @@ declare module ts.server.protocol {
     }
 
     /**
+     * Signature help information for a single parameter    
+     */    
+    interface SignatureHelpParameter {
+        
+        /**
+         * The parameter's name
+         */        
+        name: string;
+                
+        /**
+          * Documentation of the parameter.
+          */
+        documentation: SymbolDisplayPart[];
+                
+        /**
+          * Display parts of the parameter.
+          */
+        displayParts: SymbolDisplayPart[];
+                
+        /**
+         * Whether the parameter is optional or not.         
+         */        
+        isOptional: boolean;
+    }
+        
+    /**
+     * Represents a single signature to show in signature help.    
+     */    
+    interface SignatureHelpItem {
+      
+        /**
+         * Whether the signature accepts a variable number of arguments. 
+         */        
+        isVariadic: boolean;
+        
+        /**
+         * The prefix display parts.
+         */        
+        prefixDisplayParts: SymbolDisplayPart[];
+        
+        /**
+         * The suffix disaply parts.
+         */        
+        suffixDisplayParts: SymbolDisplayPart[];
+        
+        /**
+         * The separator display parts.
+         */        
+        separatorDisplayParts: SymbolDisplayPart[];
+        
+        /**
+         * The signatiure helps items for the parameters. 
+         */        
+        parameters: SignatureHelpParameter[];
+                
+        /**
+         * The signature's documentation
+         */
+        documentation: SymbolDisplayPart[];
+    }
+    
+    /**
+     * Signation help items found in the response of a signature help request.
+     */
+    interface SignatureHelpItems {
+      
+        /**
+         * The signaure help items.    
+         */        
+        items: SignatureHelpItem[];
+                
+        /**
+         * @steveluc
+         */        
+        applicableSpan: TextSpan;
+                
+        /**
+         * The item selected in the set of available help items. 
+         */        
+        selectedItemIndex: number;
+                
+        /**
+         * The argument selected in the set of parameters.
+         */        
+        argumentIndex: number;
+        
+        /**
+         * The argument counts
+         */        
+        argumentCount: number;
+    }
+
+    /**
+     * Arguments of a signature help request.
+     */
+    export interface SignatureHelpRequestArgs extends FileLocationRequestArgs {
+      
+    }
+    
+    /**
+      * Signature help request; value of command field is "signatureHelp".
+      * Given a file location (file, line, col), return the signature 
+      * help.
+      */
+    export interface SignatureHelpRequest extends FileLocationRequest {
+        arguments: SignatureHelpRequestArgs;
+    }
+
+    /**
+     * Repsonse object for a SignatureHelpRequest.
+     */  
+    export interface SignatureHelpResponse extends Response {
+        body?: SignatureHelpItems;
+    }
+    
+    /**
       * Arguments for geterr messages.
       */
     export interface GeterrRequestArgs {

--- a/src/server/protocol.d.ts
+++ b/src/server/protocol.d.ts
@@ -595,7 +595,7 @@ declare module ts.server.protocol {
     /**
      * Signature help information for a single parameter    
      */    
-    interface SignatureHelpParameter {
+    export interface SignatureHelpParameter {
         
         /**
          * The parameter's name
@@ -621,7 +621,7 @@ declare module ts.server.protocol {
     /**
      * Represents a single signature to show in signature help.    
      */    
-    interface SignatureHelpItem {
+    export interface SignatureHelpItem {
       
         /**
          * Whether the signature accepts a variable number of arguments. 
@@ -657,7 +657,7 @@ declare module ts.server.protocol {
     /**
      * Signation help items found in the response of a signature help request.
      */
-    interface SignatureHelpItems {
+    export interface SignatureHelpItems {
       
         /**
          * The signaure help items.    

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -80,6 +80,7 @@ module ts.server {
         export var Close = "close";
         export var Completions = "completions";
         export var CompletionDetails = "completionEntryDetails";
+        export var SignatureHelp = "signatureHelp";        
         export var Configure = "configure";
         export var Definition = "definition";
         export var Format = "format";
@@ -577,6 +578,35 @@ module ts.server {
             }, []);
         }
 
+        getSignatureHelpItems(line: number, offset: number, fileName: string): protocol.SignatureHelpItems {
+            var file = ts.normalizePath(fileName);
+            var project = this.projectService.getProjectForFile(file);
+            if (!project) {
+                throw Errors.NoProject;
+            }
+            
+            var compilerService = project.compilerService;
+            var position = compilerService.host.lineOffsetToPosition(file, line, offset);
+            var helpItems = compilerService.languageService.getSignatureHelpItems(file, position);
+            if (!helpItems) {
+                return undefined;
+            }
+            
+            var span = helpItems.applicableSpan;
+            var result:protocol.SignatureHelpItems = {
+                items: helpItems.items,
+                applicableSpan: {
+                    start: compilerService.host.positionToLineOffset(file, span.start),
+                    end: compilerService.host.positionToLineOffset(file, span.start + span.length)
+                },
+                selectedItemIndex: helpItems.selectedItemIndex,
+                argumentIndex: helpItems.argumentIndex,
+                argumentCount: helpItems.argumentCount,
+            }
+            
+            return result;
+        }
+                
         getDiagnostics(delay: number, fileNames: string[]) {
             var checkList = fileNames.reduce((accum: PendingErrorCheck[], fileName: string) => {
                 fileName = ts.normalizePath(fileName);
@@ -790,6 +820,11 @@ module ts.server {
                                                            completionDetailsArgs.entryNames,completionDetailsArgs.file);
                         break;
                     }
+                    case CommandNames.SignatureHelp: {
+                        var signatureHelpArgs = <protocol.SignatureHelpRequestArgs>request.arguments;
+                        response = this.getSignatureHelpItems(signatureHelpArgs.line, signatureHelpArgs.offset, signatureHelpArgs.file);
+                        break;
+                    }    
                     case CommandNames.Geterr: {
                         var geterrArgs = <protocol.GeterrRequestArgs>request.arguments;
                         response = this.getDiagnostics(geterrArgs.delay, geterrArgs.files);

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -593,7 +593,7 @@ module ts.server {
             }
             
             var span = helpItems.applicableSpan;
-            var result:protocol.SignatureHelpItems = {
+            var result: protocol.SignatureHelpItems = {
                 items: helpItems.items,
                 applicableSpan: {
                     start: compilerService.host.positionToLineOffset(file, span.start),

--- a/tests/cases/fourslash/server/signatureHelp.ts
+++ b/tests/cases/fourslash/server/signatureHelp.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts"/>
+
+////function foo(data: number) {
+////}
+////
+////function bar {
+////    foo(/*1*/)
+////}
+
+goTo.marker('1');
+verify.signatureHelpPresent();
+verify.signatureHelpCountIs(1);
+verify.signatureHelpArgumentCountIs(0);
+
+verify.currentSignatureParameterCountIs(1);
+verify.currentSignatureHelpDocCommentIs('');


### PR DESCRIPTION
Enclosed a pull request to add signature help support to the TypeScript server. I tried to follow the style I found in the existing code (e.g. expose the language service API, no extra abstraction).

There is one thing I left open: I don't know the meaning of applicableSpan in SignatureHelpItems. Can someone of you fill in the comment.

Thanks Dirk