### PR TITLE
Add full format options to configure request and remove ability from open request

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -443,11 +443,14 @@ module ts.server {
                 }
             }
             else {
+                if (args.hostInfo !== undefined) {
+                    this.hostConfiguration.hostInfo = args.hostInfo;
+                    this.log("Host information " + args.hostInfo, "Info");                    
+                }
                 if (args.formatOptions) {
                     mergeFormatOptions(this.hostConfiguration.formatCodeOptions, args.formatOptions);                    
+                    this.log("Format host information updated", "Info");
                 }
-                this.hostConfiguration.hostInfo = args.hostInfo;
-                this.log("Host information " + args.hostInfo, "Info");
             }
         }
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1,5 +1,7 @@
 /// <reference path="..\compiler\commandLineParser.ts" />
 /// <reference path="..\services\services.ts" />
+/// <reference path="protocol.d.ts" />
+/// <reference path="session.ts" />
 /// <reference path="node.d.ts" />
 
 module ts.server {
@@ -15,6 +17,16 @@ module ts.server {
     }
 
     var lineCollectionCapacity = 4;
+    
+    function mergeFormatOptions(formatCodeOptions: FormatCodeOptions, formatOptions: protocol.FormatOptions): void {
+        var hasOwnProperty = Object.prototype.hasOwnProperty;
+        Object.keys(formatOptions).forEach((key) => {
+            var codeKey = key.charAt(0).toUpperCase() + key.substring(1);
+            if (hasOwnProperty.call(formatCodeOptions, codeKey)) {
+                formatCodeOptions[codeKey] = formatOptions[key];
+            }
+        });
+    }
 
     class ScriptInfo {
         svc: ScriptVersionCache;
@@ -27,12 +39,9 @@ module ts.server {
             this.svc = ScriptVersionCache.fromString(content);
         }
 
-        setFormatOptions(tabSize?: number, indentSize?: number) {
-            if (tabSize) {
-                this.formatCodeOptions.TabSize = tabSize;
-            }
-            if (indentSize) {
-                this.formatCodeOptions.IndentSize = indentSize;
+        setFormatOptions(formatOptions: protocol.FormatOptions): void {
+            if (formatOptions) {
+                mergeFormatOptions(this.formatCodeOptions, formatOptions);
             }
         }
 
@@ -429,13 +438,14 @@ module ts.server {
             if (args.file) {
                 var info = this.filenameToScriptInfo[args.file];
                 if (info) {
-                    info.setFormatOptions(args.tabSize, args.indentSize);
-                    this.log("Host configuration update for file " + args.file + " tab size " + args.tabSize);
+                    info.setFormatOptions(args.formatOptions);
+                    this.log("Host configuration update for file " + args.file);
                 }
             }
             else {
-                this.hostConfiguration.formatCodeOptions.TabSize = args.tabSize;
-                this.hostConfiguration.formatCodeOptions.IndentSize = args.indentSize;
+                if (args.formatOptions) {
+                    mergeFormatOptions(this.hostConfiguration.formatCodeOptions, args.formatOptions);                    
+                }
                 this.hostConfiguration.hostInfo = args.hostInfo;
                 this.log("Host information " + args.hostInfo, "Info");
             }

--- a/src/server/protocol.d.ts
+++ b/src/server/protocol.d.ts
@@ -300,22 +300,74 @@ declare module ts.server.protocol {
     }
 
     /**
+     * Editor options
+     */
+    export interface EditorOptions {
+      
+        /** Number of spaces for each tab. Default value is 4. */
+        tabSize?: number;
+        
+        /** Number of spaces to indent during formatting. Default value is 4. */
+        indentSize?: number;
+        
+        /** The new line character to be used. Default value is the OS line delimiter. */
+        newLineCharacter?: string;
+        
+        /** Whether tabs should be converted to spaces. Default value is true. */
+        convertTabsToSpaces?: boolean;        
+    }
+        
+    /**
+     * Format options
+     */
+    export interface FormatOptions extends EditorOptions {
+      
+        /** Defines space handling after a comma delimiter. Default value is true. */
+        insertSpaceAfterCommaDelimiter?: boolean;
+        
+        /** Defines space handling after a semicolon in a for statemen. Default value is true */
+        insertSpaceAfterSemicolonInForStatements?: boolean;
+        
+        /** Defines space handling after a binary operator. Default value is true. */
+        insertSpaceBeforeAndAfterBinaryOperators?: boolean;
+        
+        /** Defines space handling after keywords in control flow statement. Default value is true. */
+        insertSpaceAfterKeywordsInControlFlowStatements?: boolean;
+        
+        /** Defines space handling after function keyword for anonymous functions. Default value is false. */
+        insertSpaceAfterFunctionKeywordForAnonymousFunctions?: boolean;
+        
+        /** Defines space handling after opening and before closing non empty parenthesis. Default value is false. */
+        insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis?: boolean;
+        
+        /** Defines whether an open brace is put onto a new line for functions or not. Default value is false. */
+        placeOpenBraceOnNewLineForFunctions?: boolean;
+        
+        /** Defines whether an open brace is put onto a new line for control blocks or not. Default value is false. */
+        placeOpenBraceOnNewLineForControlBlocks?: boolean;
+        
+        /** Index operator */
+        [key:string] : string | number | boolean;
+    }
+  
+    /**
       * Information found in a configure request.
       */
     export interface ConfigureRequestArguments {
-        /** Number of spaces for each tab */
-        tabSize: number;
-        /** Number of spaces to indent during formatting */
-        indentSize: number;
+      
         /** 
           * Information about the host, for example 'Emacs 24.4' or
           * 'Sublime Text version 3075'
           */
-        hostInfo: string;
+        hostInfo?: string;
+        
         /**
           * If present, tab settings apply only to this file.
           */
         file?: string;
+        
+        /** The format options to use during formatting and other code editing features. */
+        formatOptions?: FormatOptions;        
     }
 
     /**
@@ -337,10 +389,6 @@ declare module ts.server.protocol {
       *  Information found in an "open" request.
       */
     export interface OpenRequestArgs extends FileRequestArgs {
-        /** Initial tab size of file. */
-        tabSize?: number;
-        /** Number of spaces to indent during formatting */
-        indentSize?: number;
     }
 
     /**

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -397,12 +397,9 @@ module ts.server {
             };
         }
 
-        openClientFile(fileName: string, tabSize?: number, indentSize?: number) {
+        openClientFile(fileName: string) {
             var file = ts.normalizePath(fileName);
-            var info = this.projectService.openClientFile(file);
-            if (info) {
-                info.setFormatOptions(tabSize, indentSize);
-            }
+            this.projectService.openClientFile(file);
         }
 
         getQuickInfo(line: number, offset: number, fileName: string): protocol.QuickInfoResponseBody {
@@ -759,7 +756,7 @@ module ts.server {
                     }
                     case CommandNames.Open: {
                         var openArgs = <protocol.OpenRequestArgs>request.arguments;
-                        this.openClientFile(openArgs.file,openArgs.tabSize, openArgs.indentSize);
+                        this.openClientFile(openArgs.file);
                         responseRequired = false;
                         break;
                     }


### PR DESCRIPTION
This is a follow up pull request from #2468. I followed @steveluc suggestion:

So my vote is just provide formatting options on configure, even removing them from open, because the editor may know that the server’s defaults are correct and because the editor may decide to send a configuration message for each file immediately after the open message.

I started a new pull request since the new one doesn't have much in common with the old one. I closed the old one.