### PR TITLE
Emit decorators when --target ES3

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -3757,10 +3757,6 @@ module ts {
             }
             
             function emitDecoratorsOfClass(node: ClassDeclaration) {
-                if (languageVersion < ScriptTarget.ES5) {
-                    return;
-                }
-
                 emitDecoratorsOfMembers(node, /*staticFlag*/ 0);
                 emitDecoratorsOfMembers(node, NodeFlags.Static);
                 emitDecoratorsOfConstructor(node);


### PR DESCRIPTION
When targeting ES3, we should still emit decorators even though we give an error that they are not supported in ES3.