### PR TITLE
Make elaborateErrors persist throughout type relation checks

### DIFF
--- a/tests/baselines/reference/chainedCallsWithTypeParameterConstrainedToOtherTypeParameter.errors.txt
+++ b/tests/baselines/reference/chainedCallsWithTypeParameterConstrainedToOtherTypeParameter.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/compiler/chainedCallsWithTypeParameterConstrainedToOtherTypeParameter.ts(19,59): error TS2345: Argument of type '(c: C) => B' is not assignable to parameter of type '(x: C) => C'.
   Type 'B' is not assignable to type 'C'.
+    Property 'z' is missing in type 'B'.
 
 
 ==== tests/cases/compiler/chainedCallsWithTypeParameterConstrainedToOtherTypeParameter.ts (1 errors) ====
@@ -25,3 +26,4 @@ tests/cases/compiler/chainedCallsWithTypeParameterConstrainedToOtherTypeParamete
                                                               ~~~~~~~~~~
 !!! error TS2345: Argument of type '(c: C) => B' is not assignable to parameter of type '(x: C) => C'.
 !!! error TS2345:   Type 'B' is not assignable to type 'C'.
+!!! error TS2345:     Property 'z' is missing in type 'B'.

--- a/tests/baselines/reference/contextualTypingOfGenericFunctionTypedArguments1.errors.txt
+++ b/tests/baselines/reference/contextualTypingOfGenericFunctionTypedArguments1.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/compiler/contextualTypingOfGenericFunctionTypedArguments1.ts(16,32): error TS2345: Argument of type '(x: number) => string' is not assignable to parameter of type '(x: number) => Date'.
   Type 'string' is not assignable to type 'Date'.
+    Property 'toDateString' is missing in type 'String'.
 tests/cases/compiler/contextualTypingOfGenericFunctionTypedArguments1.ts(17,32): error TS2345: Argument of type '(x: number) => string' is not assignable to parameter of type '(x: number) => Date'.
   Type 'string' is not assignable to type 'Date'.
 
@@ -24,6 +25,7 @@ tests/cases/compiler/contextualTypingOfGenericFunctionTypedArguments1.ts(17,32):
                                    ~
 !!! error TS2345: Argument of type '(x: number) => string' is not assignable to parameter of type '(x: number) => Date'.
 !!! error TS2345:   Type 'string' is not assignable to type 'Date'.
+!!! error TS2345:     Property 'toDateString' is missing in type 'String'.
     var r6 = _.forEach<number>(c2, (x) => { return x.toFixed() }); 
                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number) => string' is not assignable to parameter of type '(x: number) => Date'.

--- a/tests/baselines/reference/genericCallWithGenericSignatureArguments2.errors.txt
+++ b/tests/baselines/reference/genericCallWithGenericSignatureArguments2.errors.txt
@@ -5,6 +5,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGen
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(25,23): error TS2345: Argument of type '(a: T) => T' is not assignable to parameter of type '(x: Date) => Date'.
   Types of parameters 'a' and 'x' are incompatible.
     Type 'T' is not assignable to type 'Date'.
+      Property 'toDateString' is missing in type 'RegExp'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(37,36): error TS2345: Argument of type '(x: E) => F' is not assignable to parameter of type '(x: E) => E'.
   Type 'F' is not assignable to type 'E'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(50,21): error TS2345: Argument of type 'Date' is not assignable to parameter of type 'T'.
@@ -53,6 +54,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGen
 !!! error TS2345: Argument of type '(a: T) => T' is not assignable to parameter of type '(x: Date) => Date'.
 !!! error TS2345:   Types of parameters 'a' and 'x' are incompatible.
 !!! error TS2345:     Type 'T' is not assignable to type 'Date'.
+!!! error TS2345:       Property 'toDateString' is missing in type 'RegExp'.
             var r7b = foo2((a) => a, (b) => b); // valid, T is inferred to be Date
         }
     

--- a/tests/baselines/reference/genericCombinators2.errors.txt
+++ b/tests/baselines/reference/genericCombinators2.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/compiler/genericCombinators2.ts(15,43): error TS2345: Argument of type '(x: number, y: string) => string' is not assignable to parameter of type '(x: number, y: string) => Date'.
   Type 'string' is not assignable to type 'Date'.
+    Property 'toDateString' is missing in type 'String'.
 tests/cases/compiler/genericCombinators2.ts(16,43): error TS2345: Argument of type '(x: number, y: string) => string' is not assignable to parameter of type '(x: number, y: string) => Date'.
   Type 'string' is not assignable to type 'Date'.
 
@@ -23,6 +24,7 @@ tests/cases/compiler/genericCombinators2.ts(16,43): error TS2345: Argument of ty
                                               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, y: string) => string' is not assignable to parameter of type '(x: number, y: string) => Date'.
 !!! error TS2345:   Type 'string' is not assignable to type 'Date'.
+!!! error TS2345:     Property 'toDateString' is missing in type 'String'.
     var r5b = _.map<number, string, Date>(c2, rf1);
                                               ~~~
 !!! error TS2345: Argument of type '(x: number, y: string) => string' is not assignable to parameter of type '(x: number, y: string) => Date'.

--- a/tests/baselines/reference/incompatibleTypes.errors.txt
+++ b/tests/baselines/reference/incompatibleTypes.errors.txt
@@ -17,6 +17,7 @@ tests/cases/compiler/incompatibleTypes.ts(33,7): error TS2420: Class 'C4' incorr
 tests/cases/compiler/incompatibleTypes.ts(42,5): error TS2345: Argument of type 'C1' is not assignable to parameter of type 'IFoo2'.
   Types of property 'p1' are incompatible.
     Type '() => string' is not assignable to type '(s: string) => number'.
+      Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/incompatibleTypes.ts(49,5): error TS2345: Argument of type '{ e: number; f: number; }' is not assignable to parameter of type '{ c: { b: string; }; d: string; }'.
   Property 'c' is missing in type '{ e: number; f: number; }'.
 tests/cases/compiler/incompatibleTypes.ts(66,5): error TS2322: Type '{ e: number; f: number; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
@@ -92,6 +93,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
 !!! error TS2345: Argument of type 'C1' is not assignable to parameter of type 'IFoo2'.
 !!! error TS2345:   Types of property 'p1' are incompatible.
 !!! error TS2345:     Type '() => string' is not assignable to type '(s: string) => number'.
+!!! error TS2345:       Type 'string' is not assignable to type 'number'.
     
     
     function of1(n: { a: { a: string; }; b: string; }): number;

--- a/tests/baselines/reference/interfaceAssignmentCompat.errors.txt
+++ b/tests/baselines/reference/interfaceAssignmentCompat.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/compiler/interfaceAssignmentCompat.ts(32,18): error TS2345: Argument of type '(a: IFrenchEye, b: IFrenchEye) => number' is not assignable to parameter of type '(a: IEye, b: IEye) => number'.
   Types of parameters 'a' and 'a' are incompatible.
     Type 'IFrenchEye' is not assignable to type 'IEye'.
+      Property 'color' is missing in type 'IFrenchEye'.
 tests/cases/compiler/interfaceAssignmentCompat.ts(37,29): error TS2339: Property '_map' does not exist on type 'typeof Color'.
 tests/cases/compiler/interfaceAssignmentCompat.ts(42,13): error TS2322: Type 'IEye' is not assignable to type 'IFrenchEye'.
   Property 'coleur' is missing in type 'IEye'.
@@ -45,6 +46,7 @@ tests/cases/compiler/interfaceAssignmentCompat.ts(44,9): error TS2322: Type 'IEy
 !!! error TS2345: Argument of type '(a: IFrenchEye, b: IFrenchEye) => number' is not assignable to parameter of type '(a: IEye, b: IEye) => number'.
 !!! error TS2345:   Types of parameters 'a' and 'a' are incompatible.
 !!! error TS2345:     Type 'IFrenchEye' is not assignable to type 'IEye'.
+!!! error TS2345:       Property 'color' is missing in type 'IFrenchEye'.
             // type of z inferred from specialized array type
             var z=x.sort(CompareEyes); // ok
     

--- a/tests/baselines/reference/overloadresolutionWithConstraintCheckingDeferred.errors.txt
+++ b/tests/baselines/reference/overloadresolutionWithConstraintCheckingDeferred.errors.txt
@@ -6,6 +6,7 @@ tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts(16,38):
 tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts(18,27): error TS2345: Argument of type '(x: D) => G<D>' is not assignable to parameter of type '(x: B) => any'.
   Types of parameters 'x' and 'x' are incompatible.
     Type 'D' is not assignable to type 'B'.
+      Property 'x' is missing in type 'D'.
 tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts(19,12): error TS2344: Type 'D' does not satisfy the constraint 'A'.
 
 
@@ -49,4 +50,5 @@ tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts(19,12):
 !!! error TS2345: Argument of type '(x: D) => G<D>' is not assignable to parameter of type '(x: B) => any'.
 !!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2345:     Type 'D' is not assignable to type 'B'.
+!!! error TS2345:       Property 'x' is missing in type 'D'.
     

--- a/tests/baselines/reference/overloadsWithProvisionalErrors.errors.txt
+++ b/tests/baselines/reference/overloadsWithProvisionalErrors.errors.txt
@@ -1,8 +1,10 @@
 tests/cases/compiler/overloadsWithProvisionalErrors.ts(6,6): error TS2345: Argument of type '(s: string) => {}' is not assignable to parameter of type '(s: string) => { a: number; b: number; }'.
   Type '{}' is not assignable to type '{ a: number; b: number; }'.
+    Property 'a' is missing in type '{}'.
 tests/cases/compiler/overloadsWithProvisionalErrors.ts(7,17): error TS2304: Cannot find name 'blah'.
 tests/cases/compiler/overloadsWithProvisionalErrors.ts(8,6): error TS2345: Argument of type '(s: string) => { a: any; }' is not assignable to parameter of type '(s: string) => { a: number; b: number; }'.
   Type '{ a: any; }' is not assignable to type '{ a: number; b: number; }'.
+    Property 'b' is missing in type '{ a: any; }'.
 tests/cases/compiler/overloadsWithProvisionalErrors.ts(8,17): error TS2304: Cannot find name 'blah'.
 
 
@@ -16,6 +18,7 @@ tests/cases/compiler/overloadsWithProvisionalErrors.ts(8,17): error TS2304: Cann
          ~~~~~~~~~
 !!! error TS2345: Argument of type '(s: string) => {}' is not assignable to parameter of type '(s: string) => { a: number; b: number; }'.
 !!! error TS2345:   Type '{}' is not assignable to type '{ a: number; b: number; }'.
+!!! error TS2345:     Property 'a' is missing in type '{}'.
     func(s => ({ a: blah, b: 3 })); // Only error inside the function, but not outside (since it would be applicable if not for the provisional error)
                     ~~~~
 !!! error TS2304: Cannot find name 'blah'.
@@ -23,5 +26,6 @@ tests/cases/compiler/overloadsWithProvisionalErrors.ts(8,17): error TS2304: Cann
          ~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(s: string) => { a: any; }' is not assignable to parameter of type '(s: string) => { a: number; b: number; }'.
 !!! error TS2345:   Type '{ a: any; }' is not assignable to type '{ a: number; b: number; }'.
+!!! error TS2345:     Property 'b' is missing in type '{ a: any; }'.
                     ~~~~
 !!! error TS2304: Cannot find name 'blah'.

--- a/tests/baselines/reference/promiseChaining1.errors.txt
+++ b/tests/baselines/reference/promiseChaining1.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/compiler/promiseChaining1.ts(7,50): error TS2345: Argument of type '(x: S) => string' is not assignable to parameter of type '(x: S) => Function'.
   Type 'string' is not assignable to type 'Function'.
+    Property 'apply' is missing in type 'String'.
 
 
 ==== tests/cases/compiler/promiseChaining1.ts (1 errors) ====
@@ -13,6 +14,7 @@ tests/cases/compiler/promiseChaining1.ts(7,50): error TS2345: Argument of type '
                                                      ~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: S) => string' is not assignable to parameter of type '(x: S) => Function'.
 !!! error TS2345:   Type 'string' is not assignable to type 'Function'.
+!!! error TS2345:     Property 'apply' is missing in type 'String'.
             return new Chain2(result);
         }
     }

--- a/tests/baselines/reference/promiseChaining2.errors.txt
+++ b/tests/baselines/reference/promiseChaining2.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/compiler/promiseChaining2.ts(7,45): error TS2345: Argument of type '(x: S) => string' is not assignable to parameter of type '(x: S) => Function'.
   Type 'string' is not assignable to type 'Function'.
+    Property 'apply' is missing in type 'String'.
 
 
 ==== tests/cases/compiler/promiseChaining2.ts (1 errors) ====
@@ -13,6 +14,7 @@ tests/cases/compiler/promiseChaining2.ts(7,45): error TS2345: Argument of type '
                                                 ~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: S) => string' is not assignable to parameter of type '(x: S) => Function'.
 !!! error TS2345:   Type 'string' is not assignable to type 'Function'.
+!!! error TS2345:     Property 'apply' is missing in type 'String'.
             return new Chain2(result);
         }
     }

--- a/tests/baselines/reference/promisePermutations.errors.txt
+++ b/tests/baselines/reference/promisePermutations.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/compiler/promisePermutations.ts(74,70): error TS2345: Argument of type '(x: number) => IPromise<number>' is not assignable to parameter of type '(value: IPromise<number>) => IPromise<number>'.
   Types of parameters 'x' and 'value' are incompatible.
     Type 'number' is not assignable to type 'IPromise<number>'.
+      Property 'then' is missing in type 'Number'.
 tests/cases/compiler/promisePermutations.ts(79,19): error TS2345: Argument of type '(x: number, y?: string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'x' and 'value' are incompatible.
     Type 'number' is not assignable to type 'string'.
@@ -54,6 +55,10 @@ tests/cases/compiler/promisePermutations.ts(152,12): error TS2453: The type argu
   Type argument candidate 'Promise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
     Types of property 'then' are incompatible.
       Type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }' is not assignable to type '{ <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
+        Types of parameters 'success' and 'success' are incompatible.
+          Type '(value: string) => IPromise<any>' is not assignable to type '(value: number) => Promise<any>'.
+            Types of parameters 'value' and 'value' are incompatible.
+              Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations.ts(156,21): error TS2345: Argument of type '{ (x: number): IPromise<number>; (x: string): IPromise<string>; }' is not assignable to parameter of type '(value: number) => IPromise<string>'.
   Type 'IPromise<number>' is not assignable to type 'IPromise<string>'.
     Type 'number' is not assignable to type 'string'.
@@ -65,6 +70,12 @@ tests/cases/compiler/promisePermutations.ts(159,21): error TS2345: Argument of t
     Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/promisePermutations.ts(160,21): error TS2345: Argument of type '{ (x: number): Promise<number>; (x: string): Promise<string>; }' is not assignable to parameter of type '(value: number) => IPromise<string>'.
   Type 'Promise<number>' is not assignable to type 'IPromise<string>'.
+    Types of property 'then' are incompatible.
+      Type '{ <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }' is not assignable to type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }'.
+        Types of parameters 'success' and 'success' are incompatible.
+          Type '(value: number) => Promise<any>' is not assignable to type '(value: string) => IPromise<any>'.
+            Types of parameters 'value' and 'value' are incompatible.
+              Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/promisePermutations.ts (33 errors) ====
@@ -146,6 +157,7 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2345: Argument of t
 !!! error TS2345: Argument of type '(x: number) => IPromise<number>' is not assignable to parameter of type '(value: IPromise<number>) => IPromise<number>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
 !!! error TS2345:     Type 'number' is not assignable to type 'IPromise<number>'.
+!!! error TS2345:       Property 'then' is missing in type 'Number'.
     
     var r4: IPromise<string>;
     var sIPromise: (x: any) => IPromise<string>;
@@ -305,6 +317,10 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2345: Argument of t
 !!! error TS2453:   Type argument candidate 'Promise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
 !!! error TS2453:     Types of property 'then' are incompatible.
 !!! error TS2453:       Type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }' is not assignable to type '{ <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
+!!! error TS2453:         Types of parameters 'success' and 'success' are incompatible.
+!!! error TS2453:           Type '(value: string) => IPromise<any>' is not assignable to type '(value: number) => Promise<any>'.
+!!! error TS2453:             Types of parameters 'value' and 'value' are incompatible.
+!!! error TS2453:               Type 'string' is not assignable to type 'number'.
     var s10g = s10.then(testFunctionP, nIPromise, sIPromise).then(sPromise, sIPromise, sIPromise); // ok
     
     var r11: IPromise<number>;
@@ -328,6 +344,12 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2345: Argument of t
                         ~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ (x: number): Promise<number>; (x: string): Promise<string>; }' is not assignable to parameter of type '(value: number) => IPromise<string>'.
 !!! error TS2345:   Type 'Promise<number>' is not assignable to type 'IPromise<string>'.
+!!! error TS2345:     Types of property 'then' are incompatible.
+!!! error TS2345:       Type '{ <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }' is not assignable to type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }'.
+!!! error TS2345:         Types of parameters 'success' and 'success' are incompatible.
+!!! error TS2345:           Type '(value: number) => Promise<any>' is not assignable to type '(value: string) => IPromise<any>'.
+!!! error TS2345:             Types of parameters 'value' and 'value' are incompatible.
+!!! error TS2345:               Type 'number' is not assignable to type 'string'.
     
     var r12 = testFunction12(x => x);
     var r12a = r12.then(testFunction12, testFunction12, testFunction12); // ok

--- a/tests/baselines/reference/promisePermutations2.errors.txt
+++ b/tests/baselines/reference/promisePermutations2.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/compiler/promisePermutations2.ts(73,70): error TS2345: Argument of type '(x: number) => IPromise<number>' is not assignable to parameter of type '(value: IPromise<number>) => IPromise<number>'.
   Types of parameters 'x' and 'value' are incompatible.
     Type 'number' is not assignable to type 'IPromise<number>'.
+      Property 'then' is missing in type 'Number'.
 tests/cases/compiler/promisePermutations2.ts(78,19): error TS2345: Argument of type '(x: number, y?: string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'x' and 'value' are incompatible.
     Type 'number' is not assignable to type 'string'.
@@ -54,6 +55,10 @@ tests/cases/compiler/promisePermutations2.ts(151,12): error TS2453: The type arg
   Type argument candidate 'Promise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
     Types of property 'then' are incompatible.
       Type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }' is not assignable to type '<U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void) => Promise<U>'.
+        Types of parameters 'success' and 'success' are incompatible.
+          Type '(value: string) => IPromise<any>' is not assignable to type '(value: number) => any'.
+            Types of parameters 'value' and 'value' are incompatible.
+              Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations2.ts(155,21): error TS2345: Argument of type '{ (x: number): IPromise<number>; (x: string): IPromise<string>; }' is not assignable to parameter of type '(value: number) => IPromise<string>'.
   Type 'IPromise<number>' is not assignable to type 'IPromise<string>'.
     Type 'number' is not assignable to type 'string'.
@@ -65,6 +70,12 @@ tests/cases/compiler/promisePermutations2.ts(158,21): error TS2345: Argument of 
     Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of type '{ (x: number): Promise<number>; (x: string): Promise<string>; }' is not assignable to parameter of type '(value: number) => IPromise<string>'.
   Type 'Promise<number>' is not assignable to type 'IPromise<string>'.
+    Types of property 'then' are incompatible.
+      Type '<U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void) => Promise<U>' is not assignable to type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }'.
+        Types of parameters 'success' and 'success' are incompatible.
+          Type '(value: number) => any' is not assignable to type '(value: string) => IPromise<any>'.
+            Types of parameters 'value' and 'value' are incompatible.
+              Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/promisePermutations2.ts (33 errors) ====
@@ -145,6 +156,7 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
 !!! error TS2345: Argument of type '(x: number) => IPromise<number>' is not assignable to parameter of type '(value: IPromise<number>) => IPromise<number>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
 !!! error TS2345:     Type 'number' is not assignable to type 'IPromise<number>'.
+!!! error TS2345:       Property 'then' is missing in type 'Number'.
     
     var r4: IPromise<string>;
     var sIPromise: (x: any) => IPromise<string>;
@@ -304,6 +316,10 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
 !!! error TS2453:   Type argument candidate 'Promise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
 !!! error TS2453:     Types of property 'then' are incompatible.
 !!! error TS2453:       Type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }' is not assignable to type '<U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void) => Promise<U>'.
+!!! error TS2453:         Types of parameters 'success' and 'success' are incompatible.
+!!! error TS2453:           Type '(value: string) => IPromise<any>' is not assignable to type '(value: number) => any'.
+!!! error TS2453:             Types of parameters 'value' and 'value' are incompatible.
+!!! error TS2453:               Type 'string' is not assignable to type 'number'.
     var s10g = s10.then(testFunctionP, nIPromise, sIPromise).then(sPromise, sIPromise, sIPromise); // ok
     
     var r11: IPromise<number>;
@@ -327,6 +343,12 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
                         ~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ (x: number): Promise<number>; (x: string): Promise<string>; }' is not assignable to parameter of type '(value: number) => IPromise<string>'.
 !!! error TS2345:   Type 'Promise<number>' is not assignable to type 'IPromise<string>'.
+!!! error TS2345:     Types of property 'then' are incompatible.
+!!! error TS2345:       Type '<U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void) => Promise<U>' is not assignable to type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }'.
+!!! error TS2345:         Types of parameters 'success' and 'success' are incompatible.
+!!! error TS2345:           Type '(value: number) => any' is not assignable to type '(value: string) => IPromise<any>'.
+!!! error TS2345:             Types of parameters 'value' and 'value' are incompatible.
+!!! error TS2345:               Type 'number' is not assignable to type 'string'.
     
     var r12 = testFunction12(x => x);
     var r12a = r12.then(testFunction12, testFunction12, testFunction12); // ok

--- a/tests/baselines/reference/promisePermutations3.errors.txt
+++ b/tests/baselines/reference/promisePermutations3.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/compiler/promisePermutations3.ts(68,69): error TS2345: Argument of type '(x: number) => IPromise<number>' is not assignable to parameter of type '(value: IPromise<number>) => IPromise<number>'.
   Types of parameters 'x' and 'value' are incompatible.
     Type 'number' is not assignable to type 'IPromise<number>'.
+      Property 'then' is missing in type 'Number'.
 tests/cases/compiler/promisePermutations3.ts(73,70): error TS2345: Argument of type '(x: number) => IPromise<number>' is not assignable to parameter of type '(value: IPromise<number>) => IPromise<number>'.
   Types of parameters 'x' and 'value' are incompatible.
     Type 'number' is not assignable to type 'IPromise<number>'.
@@ -57,6 +58,10 @@ tests/cases/compiler/promisePermutations3.ts(151,12): error TS2453: The type arg
   Type argument candidate 'Promise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
     Types of property 'then' are incompatible.
       Type '<U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void) => IPromise<U>' is not assignable to type '{ <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
+        Types of parameters 'success' and 'success' are incompatible.
+          Type '(value: string) => any' is not assignable to type '(value: number) => Promise<any>'.
+            Types of parameters 'value' and 'value' are incompatible.
+              Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations3.ts(155,21): error TS2345: Argument of type '{ (x: number): IPromise<number>; (x: string): IPromise<string>; }' is not assignable to parameter of type '(value: number) => IPromise<string>'.
   Type 'IPromise<number>' is not assignable to type 'IPromise<string>'.
     Type 'number' is not assignable to type 'string'.
@@ -68,8 +73,15 @@ tests/cases/compiler/promisePermutations3.ts(158,21): error TS2345: Argument of 
     Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/promisePermutations3.ts(159,21): error TS2345: Argument of type '{ (x: number): Promise<number>; (x: string): Promise<string>; }' is not assignable to parameter of type '(value: number) => IPromise<string>'.
   Type 'Promise<number>' is not assignable to type 'IPromise<string>'.
+    Types of property 'then' are incompatible.
+      Type '{ <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }' is not assignable to type '<U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void) => IPromise<U>'.
+        Types of parameters 'success' and 'success' are incompatible.
+          Type '(value: number) => Promise<any>' is not assignable to type '(value: string) => any'.
+            Types of parameters 'value' and 'value' are incompatible.
+              Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of type '{ <T>(x: T): IPromise<T>; <T>(x: T, y: T): Promise<T>; }' is not assignable to parameter of type '(value: (x: any) => any) => Promise<any>'.
   Type 'IPromise<any>' is not assignable to type 'Promise<any>'.
+    Property 'done' is optional in type 'IPromise<any>' but required in type 'Promise<any>'.
 
 
 ==== tests/cases/compiler/promisePermutations3.ts (35 errors) ====
@@ -145,6 +157,7 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
 !!! error TS2345: Argument of type '(x: number) => IPromise<number>' is not assignable to parameter of type '(value: IPromise<number>) => IPromise<number>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
 !!! error TS2345:     Type 'number' is not assignable to type 'IPromise<number>'.
+!!! error TS2345:       Property 'then' is missing in type 'Number'.
     var s3: Promise<number>;
     var s3a = s3.then(testFunction3, testFunction3, testFunction3);
     var s3b = s3.then(testFunction3P, testFunction3P, testFunction3P);
@@ -313,6 +326,10 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
 !!! error TS2453:   Type argument candidate 'Promise<number>' is not a valid type argument because it is not a supertype of candidate 'IPromise<string>'.
 !!! error TS2453:     Types of property 'then' are incompatible.
 !!! error TS2453:       Type '<U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void) => IPromise<U>' is not assignable to type '{ <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
+!!! error TS2453:         Types of parameters 'success' and 'success' are incompatible.
+!!! error TS2453:           Type '(value: string) => any' is not assignable to type '(value: number) => Promise<any>'.
+!!! error TS2453:             Types of parameters 'value' and 'value' are incompatible.
+!!! error TS2453:               Type 'string' is not assignable to type 'number'.
     var s10g = s10.then(testFunctionP, nIPromise, sIPromise).then(sPromise, sIPromise, sIPromise); // ok
     
     var r11: IPromise<number>;
@@ -336,6 +353,12 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
                         ~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ (x: number): Promise<number>; (x: string): Promise<string>; }' is not assignable to parameter of type '(value: number) => IPromise<string>'.
 !!! error TS2345:   Type 'Promise<number>' is not assignable to type 'IPromise<string>'.
+!!! error TS2345:     Types of property 'then' are incompatible.
+!!! error TS2345:       Type '{ <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }' is not assignable to type '<U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void) => IPromise<U>'.
+!!! error TS2345:         Types of parameters 'success' and 'success' are incompatible.
+!!! error TS2345:           Type '(value: number) => Promise<any>' is not assignable to type '(value: string) => any'.
+!!! error TS2345:             Types of parameters 'value' and 'value' are incompatible.
+!!! error TS2345:               Type 'number' is not assignable to type 'string'.
     
     var r12 = testFunction12(x => x);
     var r12a = r12.then(testFunction12, testFunction12, testFunction12); // ok
@@ -345,4 +368,5 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
                         ~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ <T>(x: T): IPromise<T>; <T>(x: T, y: T): Promise<T>; }' is not assignable to parameter of type '(value: (x: any) => any) => Promise<any>'.
 !!! error TS2345:   Type 'IPromise<any>' is not assignable to type 'Promise<any>'.
+!!! error TS2345:     Property 'done' is optional in type 'IPromise<any>' but required in type 'Promise<any>'.
     var s12c = s12.then(testFunction12P, testFunction12, testFunction12); // ok

--- a/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments2.errors.txt
+++ b/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments2.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments2.ts(7,25): error TS2345: Argument of type '(x: A) => A' is not assignable to parameter of type '(x: A) => B'.
   Type 'A' is not assignable to type 'B'.
+    Property 'b' is missing in type 'A'.
 
 
 ==== tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments2.ts (1 errors) ====
@@ -13,3 +14,4 @@ tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments2.ts(7,25):
                             ~~~~~~
 !!! error TS2345: Argument of type '(x: A) => A' is not assignable to parameter of type '(x: A) => B'.
 !!! error TS2345:   Type 'A' is not assignable to type 'B'.
+!!! error TS2345:     Property 'b' is missing in type 'A'.

--- a/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments3.errors.txt
+++ b/tests/baselines/reference/typeParameterFixingWithContextSensitiveArguments3.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments3.ts(7,29): error TS2345: Argument of type '(t2: A) => A' is not assignable to parameter of type '(t2: A) => B'.
   Type 'A' is not assignable to type 'B'.
+    Property 'b' is missing in type 'A'.
 
 
 ==== tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments3.ts (1 errors) ====
@@ -13,3 +14,4 @@ tests/cases/compiler/typeParameterFixingWithContextSensitiveArguments3.ts(7,29):
                                 ~~~~~~~~
 !!! error TS2345: Argument of type '(t2: A) => A' is not assignable to parameter of type '(t2: A) => B'.
 !!! error TS2345:   Type 'A' is not assignable to type 'B'.
+!!! error TS2345:     Property 'b' is missing in type 'A'.


### PR DESCRIPTION
We have a concept of elaborating errors when we do relation checking. This means that if you have done a type comparison in a context where you don't want to report errors, and then later you redo the comparison with errors, then you may need to redo the comparison to get all the errors.

The previous logic allows us to elaborate errors one level, but this change makes it so that we elaborate errors throughout the whole type comparison. As a result, we get more detailed errors in some cases.