### PR TITLE
Comments for setParentNodes

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -26,6 +26,11 @@ module ts {
         return undefined;
     }
 
+    /**
+     * @param setParentNodes Whether or not parent references should be set on nodes.
+     *                       This is useful when one desires parent references, but the semantic information of binding is unnecessary.
+     */
+    export function createCompilerHost(options: CompilerOptions, setParentNodes = true): CompilerHost {
     export function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost {
         let currentDirectory: string;
         let existingDirectories: Map<boolean> = {};


### PR DESCRIPTION
createCompilerHost in program.ts needs clearer comments for its setParentNodes argument.

Please see [former PR 2427](https://github.com/Microsoft/TypeScript/pull/2427) for previous comments. This pull request has been created because of an unnecessary merge complication in the old one.