### PR TITLE
Ignore projectoutput folder since this will be deleted by jake command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,11 +37,13 @@ tests/*.js
 tests/*.js.map
 tests/*.d.ts
 *.config
+
 scripts/debug.bat
 scripts/run.bat
 scripts/word2md.js
 scripts/ior.js
 scripts/*.js.map
+tests/baselines/local/projectOutput/
 coverage/
 internal/
 **/.DS_Store


### PR DESCRIPTION
Due to jake-runtests aborts before finishing deletion of projectOutput directory (this is the case when you don't have mocha patch), when comparing baselines, projectOutput directory will be considered in the comparison.