### PR TITLE
Fix: File watchers not being disposed in -watch mode

### DIFF
--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -276,6 +276,7 @@ module ts {
 
         // If a source file changes, mark it as unwatched and start the recompilation timer
         function sourceFileChanged(sourceFile: SourceFile) {
+            sourceFile.fileWatcher.close();
             sourceFile.fileWatcher = undefined;
             startTimer();
         }


### PR DESCRIPTION
This PR fixes the command-line driver to properly dispose file watchers for modified files in -watch mode. We currently don't, which causes node.js to output a diagnostic after 10 watchers have been attached to the same file:

```
C:\temp>tsc -w t.ts
message TS6042: Compilation complete. Watching for file changes.
message TS6032: File change detected. Starting incremental compilation...
message TS6042: Compilation complete. Watching for file changes.
message TS6032: File change detected. Starting incremental compilation...
message TS6042: Compilation complete. Watching for file changes.
message TS6032: File change detected. Starting incremental compilation...
message TS6042: Compilation complete. Watching for file changes.
message TS6032: File change detected. Starting incremental compilation...
message TS6042: Compilation complete. Watching for file changes.
message TS6032: File change detected. Starting incremental compilation...
message TS6042: Compilation complete. Watching for file changes.
message TS6032: File change detected. Starting incremental compilation...
message TS6042: Compilation complete. Watching for file changes.
message TS6032: File change detected. Starting incremental compilation...
message TS6042: Compilation complete. Watching for file changes.
message TS6032: File change detected. Starting incremental compilation...
message TS6042: Compilation complete. Watching for file changes.
message TS6032: File change detected. Starting incremental compilation...
message TS6042: Compilation complete. Watching for file changes.
message TS6032: File change detected. Starting incremental compilation...
(node) warning: possible EventEmitter memory leak detected. 11 listeners added.
Use emitter.setMaxListeners() to increase limit.
Trace
    at StatWatcher.addListener (events.js:160:15)
    at Object.fs.watchFile (fs.js:1175:8)
    at Object.watchFile (C:\ts\built\local\tsc.js:1425:25)
    at Object.getSourceFile (C:\ts\built\local\tsc.js:24739:49)
    at findSourceFile (C:\ts\built\local\tsc.js:24037:62)
    at processSourceFile (C:\ts\built\local\tsc.js:24012:27)
    at processRootFile (C:\ts\built\local\tsc.js:23987:13)
    at C:\ts\built\local\tsc.js:23882:56
    at Object.forEach (C:\ts\built\local\tsc.js:608:30)
    at Object.createProgram (C:\ts\built\local\tsc.js:23882:12)
message TS6042: Compilation complete. Watching for file changes.
```

We don't have test coverage for -watch, but I have manually verified the fix.