### PR TITLE
JSX Support

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -397,10 +397,21 @@ module ts {
                 }
             }
             else {
-                var sysFiles = host.readDirectory(basePath, ".ts");
+                var sysFiles = host.readDirectory(basePath, ".ts").concat(host.readDirectory(basePath, ".tsx"));
                 for (var i = 0; i < sysFiles.length; i++) {
                     var name = sysFiles[i];
-                    if (!fileExtensionIs(name, ".d.ts") || !contains(sysFiles, name.substr(0, name.length - 5) + ".ts")) {
+                    if (fileExtensionIs(name, ".d.ts")) {
+                        let baseName = name.substr(0, name.length - ".d.ts".length);
+                        if (!contains(sysFiles, baseName + ".tsx") && !contains(sysFiles, baseName + ".ts")) {
+                            files.push(name);
+                        }
+                    }
+                    else if (fileExtensionIs(name, ".ts")) {
+                        if (!contains(sysFiles, name + "x")) {
+                            files.push(name)
+                        }
+                    }
+                    else {
                         files.push(name);
                     }
                 }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -653,9 +653,9 @@ module ts {
     /**
      *  List of supported extensions in order of file resolution precedence.
      */
-    export const supportedExtensions = [".ts", ".d.ts"];
+    export const supportedExtensions = [".tsx", ".ts", ".d.ts"];
 
-    const extensionsToRemove = [".d.ts", ".ts", ".js"];
+    const extensionsToRemove = [".d.ts", ".ts", ".tsx", ".js"];
     export function removeFileExtension(path: string): string {
         for (let ext of extensionsToRemove) {
             if (fileExtensionIs(path, ext)) {

--- a/src/compiler/diagnosticInformationMap.generated.ts
+++ b/src/compiler/diagnosticInformationMap.generated.ts
@@ -545,5 +545,11 @@ module ts {
         Only_identifiers_Slashqualified_names_with_optional_type_arguments_are_currently_supported_in_a_class_extends_clauses: { code: 9002, category: DiagnosticCategory.Error, key: "Only identifiers/qualified-names with optional type arguments are currently supported in a class 'extends' clauses." },
         class_expressions_are_not_currently_supported: { code: 9003, category: DiagnosticCategory.Error, key: "'class' expressions are not currently supported." },
         class_declarations_are_only_supported_directly_inside_a_module_or_as_a_top_level_declaration: { code: 9004, category: DiagnosticCategory.Error, key: "'class' declarations are only supported directly inside a module or as a top level declaration." },
+        JSX_attributes_must_only_be_assigned_a_non_empty_expression: { code: 17000, category: DiagnosticCategory.Error, key: "JSX attributes must only be assigned a non-empty 'expression'." },
+        JSX_elements_cannot_have_multiple_attributes_with_the_same_name: { code: 17001, category: DiagnosticCategory.Error, key: "JSX elements cannot have multiple attributes with the same name." },
+        Expected_corresponding_JSX_closing_tag_for_0: { code: 17002, category: DiagnosticCategory.Error, key: "Expected corresponding JSX closing tag for '{0}'." },
+        JSX_attribute_expected: { code: 17003, category: DiagnosticCategory.Error, key: "JSX attribute expected." },
+        JSX_factory_cannot_have_multiple_assignments: { code: 17004, category: DiagnosticCategory.Error, key: "JSX factory cannot have multiple assignments." },
+        JSX_elements_are_not_currently_supported: { code: 17005, category: DiagnosticCategory.Error, key: "JSX elements are not currently supported." },
     };
 }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2172,5 +2172,29 @@
     "'class' declarations are only supported directly inside a module or as a top level declaration.": {
         "category": "Error",
         "code": 9004
+    },
+    "JSX attributes must only be assigned a non-empty 'expression'.": {
+        "category": "Error",
+        "code": 17000
+    },
+    "JSX elements cannot have multiple attributes with the same name.": {
+        "category": "Error",
+        "code": 17001
+    },
+    "Expected corresponding JSX closing tag for '{0}'.": {
+        "category": "Error",
+        "code": 17002
+    },
+    "JSX attribute expected.": {
+        "category": "Error",
+        "code": 17003
+    },
+    "JSX factory cannot have multiple assignments.": {
+        "category": "Error",
+        "code": 17004
+    },
+     "JSX elements are not currently supported.": {
+        "category": "Error",
+        "code" : 17005
     }
 }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -40,6 +40,7 @@ module ts {
         SemicolonToken,
         CommaToken,
         LessThanToken,
+        LessThanSlashToken,
         GreaterThanToken,
         LessThanEqualsToken,
         GreaterThanEqualsToken,
@@ -251,6 +252,15 @@ module ts {
         NamedExports,
         ExportSpecifier,
         MissingDeclaration,
+
+        //JSX
+        JSXElement,
+        JSXOpeningElement,
+        JSXText,
+        JSXClosingElement,
+        JSXAttribute,
+        JSXSpreadAttribute,
+        JSXExpression,
 
         // Module references
         ExternalModuleReference,
@@ -895,6 +905,39 @@ module ts {
         token: SyntaxKind;
         types?: NodeArray<ExpressionWithTypeArguments>;
     }
+    
+    export interface JSXElement extends PrimaryExpression {
+        openingElement: JSXOpeningElement;
+        children?: NodeArray<JSXElement | JSXExpression | JSXText>;
+        closingElement?: JSXClosingElement;
+    }
+
+    export interface JSXOpeningElement extends Node {
+        tagName: EntityName;
+        attributes: NodeArray<JSXAttribute | JSXSpreadAttribute>;
+        isSelfClosing: boolean;
+    }
+
+    export interface JSXAttribute extends Node {
+        name: Identifier;
+        initializer?: Expression;
+    }
+
+    export interface JSXSpreadAttribute extends Node {
+        expression: Expression;
+    }
+
+    export interface JSXClosingElement extends Node {
+        tagName: EntityName;
+    }
+
+    export interface JSXExpression extends Expression {
+        expression?: Expression;
+    }
+
+    export interface JSXText extends Node {
+        _jsxTextBrand: any;
+    }
 
     export interface TypeAliasDeclaration extends Declaration, ModuleElement {
         name: Identifier;
@@ -1003,6 +1046,7 @@ module ts {
         amdDependencies: {path: string; name: string}[];
         amdModuleName: string;
         referencedFiles: FileReference[];
+        isTSXFile: boolean;
 
         hasNoDefaultLib: boolean;
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -733,6 +733,8 @@ module ts {
             case SyntaxKind.TemplateExpression:
             case SyntaxKind.NoSubstitutionTemplateLiteral:
             case SyntaxKind.OmittedExpression:
+            case SyntaxKind.JSXElement:
+            case SyntaxKind.JSXExpression:
                 return true;
             case SyntaxKind.QualifiedName:
                 while (node.parent.kind === SyntaxKind.QualifiedName) {
@@ -1652,6 +1654,7 @@ module ts {
                 case SyntaxKind.ElementAccessExpression:
                 case SyntaxKind.NewExpression:
                 case SyntaxKind.CallExpression:
+                case SyntaxKind.JSXElement:
                 case SyntaxKind.TaggedTemplateExpression:
                 case SyntaxKind.ArrayLiteralExpression:
                 case SyntaxKind.ParenthesizedExpression:

--- a/src/harness/compilerRunner.ts
+++ b/src/harness/compilerRunner.ts
@@ -150,7 +150,7 @@ class CompilerBaselineRunner extends RunnerBase {
             // check errors
             it('Correct errors for ' + fileName, () => {
                 if (this.errors) {
-                    Harness.Baseline.runBaseline('Correct errors for ' + fileName, justName.replace(/\.ts$/, '.errors.txt'), (): string => {
+                    Harness.Baseline.runBaseline('Correct errors for ' + fileName, justName.replace(/\.tsx?$/, '.errors.txt'), (): string => {
                         if (result.errors.length === 0) return null;
                         return getErrorBaseline(toBeCompiled, otherFiles, result);
                     });
@@ -160,7 +160,7 @@ class CompilerBaselineRunner extends RunnerBase {
             // Source maps?
             it('Correct sourcemap content for ' + fileName, () => {
                 if (options.sourceMap || options.inlineSourceMap) {
-                    Harness.Baseline.runBaseline('Correct sourcemap content for ' + fileName, justName.replace(/\.ts$/, '.sourcemap.txt'), () => {
+                    Harness.Baseline.runBaseline('Correct sourcemap content for ' + fileName, justName.replace(/\.tsx?$/, '.sourcemap.txt'), () => {
                         var record = result.getSourceMapRecord();
                         if (options.noEmitOnError && result.errors.length !== 0 && record === undefined) {
                             // Because of the noEmitOnError option no files are created. We need to return null because baselining isn't required.
@@ -179,7 +179,7 @@ class CompilerBaselineRunner extends RunnerBase {
                     }
 
                     // check js output
-                    Harness.Baseline.runBaseline('Correct JS output for ' + fileName, justName.replace(/\.ts/, '.js'), () => {
+                    Harness.Baseline.runBaseline('Correct JS output for ' + fileName, justName.replace(/\.tsx?/, '.js'), () => {
                         var tsCode = '';
                         var tsSources = otherFiles.concat(toBeCompiled);
                         if (tsSources.length > 1) {
@@ -239,7 +239,7 @@ class CompilerBaselineRunner extends RunnerBase {
                         throw new Error('Number of sourcemap files should be same as js files.');
                     }
 
-                    Harness.Baseline.runBaseline('Correct Sourcemap output for ' + fileName, justName.replace(/\.ts/, '.js.map'), () => {
+                    Harness.Baseline.runBaseline('Correct Sourcemap output for ' + fileName, justName.replace(/\.tsx?/, '.js.map'), () => {
                         if (options.noEmitOnError && result.errors.length !== 0 && result.sourceMaps.length === 0) {
                             // We need to return null here or the runBaseLine will actually create a empty file.
                             // Baselining isn't required here because there is no output.
@@ -324,11 +324,11 @@ class CompilerBaselineRunner extends RunnerBase {
                         let pullExtension = isSymbolBaseLine ? '.symbols.pull' : '.types.pull';
 
                         if (fullBaseLine !== pullBaseLine) {
-                            Harness.Baseline.runBaseline('Correct full information for ' + fileName, justName.replace(/\.ts/, fullExtension), () => fullBaseLine);
-                            Harness.Baseline.runBaseline('Correct pull information for ' + fileName, justName.replace(/\.ts/, pullExtension), () => pullBaseLine);
+                            Harness.Baseline.runBaseline('Correct full information for ' + fileName, justName.replace(/\.tsx?/, fullExtension), () => fullBaseLine);
+                            Harness.Baseline.runBaseline('Correct pull information for ' + fileName, justName.replace(/\.tsx?/, pullExtension), () => pullBaseLine);
                         }
                         else {
-                            Harness.Baseline.runBaseline('Correct information for ' + fileName, justName.replace(/\.ts/, fullExtension), () => fullBaseLine);
+                            Harness.Baseline.runBaseline('Correct information for ' + fileName, justName.replace(/\.tsx?/, fullExtension), () => fullBaseLine);
                         }
                     }
 
@@ -395,7 +395,7 @@ class CompilerBaselineRunner extends RunnerBase {
 
         // this will set up a series of describe/it blocks to run between the setup and cleanup phases
         if (this.tests.length === 0) {
-            var testFiles = this.enumerateFiles(this.basePath, /\.ts$/, { recursive: true });
+            var testFiles = this.enumerateFiles(this.basePath, /\.tsx?$/, { recursive: true });
             testFiles.forEach(fn => {
                 fn = fn.replace(/\\/g, "/");
                 this.checkTestCodeOutput(fn);

--- a/src/harness/runnerbase.ts
+++ b/src/harness/runnerbase.ts
@@ -27,7 +27,7 @@ class RunnerBase {
         var fixedPath = path;
 
         // full paths either start with a drive letter or / for *nix, shouldn't have \ in the path at this point
-        var fullPath = /(\w+:|\/)?([\w+\-\.]|\/)*\.ts/g; 
+        var fullPath = /(\w+:|\/)?([\w+\-\.]|\/)*\.tsx?/g; 
         var fullPathList = fixedPath.match(fullPath);
         if (fullPathList) {
             fullPathList.forEach((match: string) => fixedPath = fixedPath.replace(match, Harness.Path.getFileName(match)));

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -737,6 +737,7 @@ module ts {
         public amdDependencies: { name: string; path: string }[];
         public amdModuleName: string;
         public referencedFiles: FileReference[];
+        public isTSXFile: boolean;
 
         public syntacticDiagnostics: Diagnostic[];
         public referenceDiagnostics: Diagnostic[];

--- a/tests/baselines/reference/APISample_linter.js
+++ b/tests/baselines/reference/APISample_linter.js
@@ -75,28 +75,28 @@ function delint(sourceFile) {
     delintNode(sourceFile);
     function delintNode(node) {
         switch (node.kind) {
-            case 187 /* ForStatement */:
-            case 188 /* ForInStatement */:
-            case 186 /* WhileStatement */:
-            case 185 /* DoStatement */:
-                if (node.statement.kind !== 180 /* Block */) {
+            case 188 /* ForStatement */:
+            case 189 /* ForInStatement */:
+            case 187 /* WhileStatement */:
+            case 186 /* DoStatement */:
+                if (node.statement.kind !== 181 /* Block */) {
                     report(node, "A looping statement's contents should be wrapped in a block body.");
                 }
                 break;
-            case 184 /* IfStatement */:
+            case 185 /* IfStatement */:
                 var ifStatement = node;
-                if (ifStatement.thenStatement.kind !== 180 /* Block */) {
+                if (ifStatement.thenStatement.kind !== 181 /* Block */) {
                     report(ifStatement.thenStatement, "An if statement's contents should be wrapped in a block body.");
                 }
                 if (ifStatement.elseStatement &&
-                    ifStatement.elseStatement.kind !== 180 /* Block */ &&
-                    ifStatement.elseStatement.kind !== 184 /* IfStatement */) {
+                    ifStatement.elseStatement.kind !== 181 /* Block */ &&
+                    ifStatement.elseStatement.kind !== 185 /* IfStatement */) {
                     report(ifStatement.elseStatement, "An else statement's contents should be wrapped in a block body.");
                 }
                 break;
-            case 170 /* BinaryExpression */:
+            case 171 /* BinaryExpression */:
                 var op = node.operatorToken.kind;
-                if (op === 28 /* EqualsEqualsToken */ || op == 29 /* ExclamationEqualsToken */) {
+                if (op === 29 /* EqualsEqualsToken */ || op == 30 /* ExclamationEqualsToken */) {
                     report(node, "Use '===' and '!=='.");
                 }
                 break;

--- a/tests/baselines/reference/jsxAndTypeAssertion.errors.txt
+++ b/tests/baselines/reference/jsxAndTypeAssertion.errors.txt
@@ -1,0 +1,36 @@
+tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(2,15): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(4,6): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(6,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(8,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(10,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx(12,1): error TS17005: JSX elements are not currently supported.
+
+
+==== tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx (6 errors) ====
+    
+    <any> { test: <any></any> };
+                  ~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <any><any></any>;
+         ~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+     
+    <foo>hello {<foo>{}} </foo>;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <foo test={<foo>{}}>hello</foo>;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <foo test={<foo>{}}>hello{<foo>{}}</foo>;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <foo>{<foo><foo>{/foo/.test(x) ? <foo><foo></foo> : <foo><foo></foo>}</foo>}</foo>
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+        
+    

--- a/tests/baselines/reference/jsxAndTypeAssertion.js
+++ b/tests/baselines/reference/jsxAndTypeAssertion.js
@@ -1,0 +1,24 @@
+//// [jsxAndTypeAssertion.tsx]
+
+<any> { test: <any></any> };
+
+<any><any></any>;
+ 
+<foo>hello {<foo>{}} </foo>;
+
+<foo test={<foo>{}}>hello</foo>;
+
+<foo test={<foo>{}}>hello{<foo>{}}</foo>;
+
+<foo>{<foo><foo>{/foo/.test(x) ? <foo><foo></foo> : <foo><foo></foo>}</foo>}</foo>
+
+    
+
+
+//// [jsxAndTypeAssertion.js]
+{ test:  };
+;
+;
+;
+;
+;

--- a/tests/baselines/reference/jsxClosingTagMapsRelaxingRules.errors.txt
+++ b/tests/baselines/reference/jsxClosingTagMapsRelaxingRules.errors.txt
@@ -1,0 +1,19 @@
+tests/cases/conformance/jsx/jsxClosingTagMapsRelaxingRules.tsx(1,4): error TS17002: Expected corresponding JSX closing tag for 'a'.
+tests/cases/conformance/jsx/jsxClosingTagMapsRelaxingRules.tsx(2,11): error TS17002: Expected corresponding JSX closing tag for 'a'.
+tests/cases/conformance/jsx/jsxClosingTagMapsRelaxingRules.tsx(3,12): error TS17002: Expected corresponding JSX closing tag for 'a'.
+
+
+==== tests/cases/conformance/jsx/jsxClosingTagMapsRelaxingRules.tsx (3 errors) ====
+    <a></b>;
+       ~~~~
+!!! error TS17002: Expected corresponding JSX closing tag for 'a'.
+    <a> foo {}</b>;
+              ~~~~
+!!! error TS17002: Expected corresponding JSX closing tag for 'a'.
+    <a> foo bar</b>;
+               ~~~~
+!!! error TS17002: Expected corresponding JSX closing tag for 'a'.
+    <MyElement.myProperty> Hello </
+    MyElement.
+       myProperty
+    >

--- a/tests/baselines/reference/jsxClosingTagMapsRelaxingRules.js
+++ b/tests/baselines/reference/jsxClosingTagMapsRelaxingRules.js
@@ -1,0 +1,14 @@
+//// [jsxClosingTagMapsRelaxingRules.tsx]
+<a></b>;
+<a> foo {}</b>;
+<a> foo bar</b>;
+<MyElement.myProperty> Hello </
+MyElement.
+   myProperty
+>
+
+//// [jsxClosingTagMapsRelaxingRules.js]
+;
+;
+;
+;

--- a/tests/baselines/reference/jsxEsprimaFbTestSuite.errors.txt
+++ b/tests/baselines/reference/jsxEsprimaFbTestSuite.errors.txt
@@ -1,0 +1,115 @@
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(2,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(8,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(10,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(11,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(14,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(16,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(22,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(24,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(26,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(28,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(30,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(32,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(34,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(36,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(38,2): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(38,13): error TS2304: Cannot find name 'x'.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(40,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(42,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(44,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx(46,1): error TS17005: JSX elements are not currently supported.
+
+
+==== tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx (20 errors) ====
+    
+    <a />;
+    ~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    //<n:a n:v />; Namespace unsuported
+    
+    //<a n:foo="bar"> {value} <b><c /></b></a>;  Namespace unsuported
+    
+    <a b={" "} c=" " d="&amp;" e="id=1&group=2" f="&#123456789" g="&#123*;" h="&#x;" />;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <a b="&notanentity;" />;
+    ~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    <a
+    ~~
+    />;
+    ~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <日本語></日本語>;
+    ~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <AbC_def
+    ~~~~~~~~
+      test="&#x0026;&#38;">
+    ~~~~~~~~~~~~~~~~~~~~~~~
+    bar
+    ~~~
+    baz
+    ~~~
+    </AbC_def>;
+    ~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <a b={x ? <c /> : <d />} />;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <a>{}</a>;
+    ~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <a>{/* this is a comment */}</a>;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <div>@test content</div>;
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <div><br />7x invalid-js-identifier</div>;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <LeftRight left=<a /> right=<b>monkeys /> gorillas</b> />;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <a.b></a.b>;
+    ~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <a.b.c></a.b.c>;
+    ~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    (<div />) < x;
+     ~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+                ~
+!!! error TS2304: Cannot find name 'x'.
+    
+    <div {...props} />;
+    ~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <div {...props} post="attribute" />;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <div pre="leading" pre2="attribute" {...props}></div>;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <a>    </a>;
+    ~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    

--- a/tests/baselines/reference/jsxEsprimaFbTestSuite.js
+++ b/tests/baselines/reference/jsxEsprimaFbTestSuite.js
@@ -1,0 +1,71 @@
+//// [jsxEsprimaFbTestSuite.tsx]
+
+<a />;
+
+//<n:a n:v />; Namespace unsuported
+
+//<a n:foo="bar"> {value} <b><c /></b></a>;  Namespace unsuported
+
+<a b={" "} c=" " d="&amp;" e="id=1&group=2" f="&#123456789" g="&#123*;" h="&#x;" />;
+
+<a b="&notanentity;" />;
+<a
+/>;
+
+<日本語></日本語>;
+
+<AbC_def
+  test="&#x0026;&#38;">
+bar
+baz
+</AbC_def>;
+
+<a b={x ? <c /> : <d />} />;
+
+<a>{}</a>;
+
+<a>{/* this is a comment */}</a>;
+
+<div>@test content</div>;
+
+<div><br />7x invalid-js-identifier</div>;
+
+<LeftRight left=<a /> right=<b>monkeys /> gorillas</b> />;
+
+<a.b></a.b>;
+
+<a.b.c></a.b.c>;
+
+(<div />) < x;
+
+<div {...props} />;
+
+<div {...props} post="attribute" />;
+
+<div pre="leading" pre2="attribute" {...props}></div>;
+
+<a>    </a>;
+
+
+//// [jsxEsprimaFbTestSuite.js]
+;
+//<n:a n:v />; Namespace unsuported
+//<a n:foo="bar"> {value} <b><c /></b></a>;  Namespace unsuported
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+() < x;
+;
+;
+;
+;

--- a/tests/baselines/reference/jsxInvalidEsprimaTestSuite.errors.txt
+++ b/tests/baselines/reference/jsxInvalidEsprimaTestSuite.errors.txt
@@ -1,0 +1,205 @@
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(2,2): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(3,3): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(4,2): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(5,6): error TS1005: '{' expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(5,9): error TS1109: Expression expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(5,10): error TS1109: Expression expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(6,1): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(7,4): error TS17002: Expected corresponding JSX closing tag for 'a'.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(8,13): error TS1002: Unterminated string literal.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(9,1): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(9,3): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(9,6): error TS17002: Expected corresponding JSX closing tag for 'a'.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(10,3): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(10,5): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(10,11): error TS1005: '>' expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(11,5): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(11,13): error TS1005: '>' expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(12,8): error TS17002: Expected corresponding JSX closing tag for 'a.b.c'.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(13,2): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(13,7): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(14,4): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(14,9): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(15,3): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(15,12): error TS1005: '>' expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(16,3): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(16,14): error TS1005: '>' expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(21,10): error TS1005: '}' expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(21,11): error TS1012: Unexpected token.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(21,13): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(21,14): error TS1005: '>' expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(21,14): error TS2304: Cannot find name 'a'.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(21,16): error TS1109: Expression expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(22,20): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(23,15): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(24,7): error TS1005: '...' expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(26,17): error TS1005: '>' expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(26,18): error TS1109: Expression expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(26,26): error TS1012: Unexpected token.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(26,27): error TS1109: Expression expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(26,28): error TS1109: Expression expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(27,28): error TS1005: '>' expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(27,29): error TS1129: Statement expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(27,32): error TS2304: Cannot find name 'props'.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(27,38): error TS1109: Expression expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(27,39): error TS1109: Expression expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(31,6): error TS1005: '{' expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(32,7): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(32,8): error TS1109: Expression expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(32,9): error TS1109: Expression expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(33,2): error TS2304: Cannot find name 'a'.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(33,4): error TS1109: Expression expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(33,6): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(33,7): error TS1005: '>' expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(33,7): error TS2304: Cannot find name 'a'.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(33,9): error TS1109: Expression expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(34,4): error TS1003: Identifier expected.
+
+
+==== tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx (56 errors) ====
+    
+    </>;
+     ~
+!!! error TS1003: Identifier expected.
+    <a: />;
+      ~
+!!! error TS1003: Identifier expected.
+    <:a />;
+     ~
+!!! error TS1003: Identifier expected.
+    <a b=d />;
+         ~
+!!! error TS1005: '{' expected.
+            ~
+!!! error TS1109: Expression expected.
+             ~
+!!! error TS1109: Expression expected.
+    <a>;
+    ~
+!!! error TS1003: Identifier expected.
+    <a></b>;
+       ~~~~
+!!! error TS17002: Expected corresponding JSX closing tag for 'a'.
+    <a foo="bar;
+                
+!!! error TS1002: Unterminated string literal.
+    <a:b></b>;
+    ~
+!!! error TS1003: Identifier expected.
+      ~
+!!! error TS1003: Identifier expected.
+         ~~~~
+!!! error TS17002: Expected corresponding JSX closing tag for 'a'.
+    <a:b.c></a:b.c>;
+      ~
+!!! error TS1003: Identifier expected.
+        ~
+!!! error TS1003: Identifier expected.
+              ~
+!!! error TS1005: '>' expected.
+    <a.b:c></a.b:c>;
+        ~
+!!! error TS1003: Identifier expected.
+                ~
+!!! error TS1005: '>' expected.
+    <a.b.c></a>;
+           ~~~~
+!!! error TS17002: Expected corresponding JSX closing tag for 'a.b.c'.
+    <.a></.a>;
+     ~
+!!! error TS1003: Identifier expected.
+          ~
+!!! error TS1003: Identifier expected.
+    <a.></a.>;
+       ~
+!!! error TS1003: Identifier expected.
+            ~
+!!! error TS1003: Identifier expected.
+    <a[foo]></a[foo]>;
+      ~
+!!! error TS1003: Identifier expected.
+               ~
+!!! error TS1005: '>' expected.
+    <a['foo']></a['foo']>;
+      ~
+!!! error TS1003: Identifier expected.
+                 ~
+!!! error TS1005: '>' expected.
+    <a><a />;
+    <a b={}>;
+    var x = <div>one</div><div>two</div>;;
+    var x = <div>one</div> /* intervening comment */ <div>two</div>;;
+    <a>{"str";}</a>;
+             ~
+!!! error TS1005: '}' expected.
+              ~
+!!! error TS1012: Unexpected token.
+                ~
+!!! error TS1003: Identifier expected.
+                 ~
+!!! error TS1005: '>' expected.
+                 ~
+!!! error TS2304: Cannot find name 'a'.
+                   ~
+!!! error TS1109: Expression expected.
+    <span className="a", id="b" />;
+                       ~
+!!! error TS1003: Identifier expected.
+    <div className"app">;
+                  ~~~~~
+!!! error TS1003: Identifier expected.
+    <div {props} />;
+          ~~~~~
+!!! error TS1005: '...' expected.
+    
+    <div>stuff</div {...props}>;
+                    ~
+!!! error TS1005: '>' expected.
+                     ~~~
+!!! error TS1109: Expression expected.
+                             ~
+!!! error TS1012: Unexpected token.
+                              ~
+!!! error TS1109: Expression expected.
+                               ~
+!!! error TS1109: Expression expected.
+    <div {...props}>stuff</div {...props}>;
+                               ~
+!!! error TS1005: '>' expected.
+                                ~~~
+!!! error TS1129: Statement expected.
+                                   ~~~~~
+!!! error TS2304: Cannot find name 'props'.
+                                         ~
+!!! error TS1109: Expression expected.
+                                          ~
+!!! error TS1109: Expression expected.
+    
+    <a>></a>;
+    <a> ></a>;
+    <a b=}>;
+         ~
+!!! error TS1005: '{' expected.
+    <a b=<}>;
+          ~
+!!! error TS1003: Identifier expected.
+           ~
+!!! error TS1109: Expression expected.
+            ~
+!!! error TS1109: Expression expected.
+    <a>}</a>;
+     ~
+!!! error TS2304: Cannot find name 'a'.
+       ~
+!!! error TS1109: Expression expected.
+         ~
+!!! error TS1003: Identifier expected.
+          ~
+!!! error TS1005: '>' expected.
+          ~
+!!! error TS2304: Cannot find name 'a'.
+            ~
+!!! error TS1109: Expression expected.
+    <a .../*hai*/asdf/>;
+       ~~~
+!!! error TS1003: Identifier expected.

--- a/tests/baselines/reference/jsxInvalidEsprimaTestSuite.js
+++ b/tests/baselines/reference/jsxInvalidEsprimaTestSuite.js
@@ -1,0 +1,59 @@
+//// [jsxInvalidEsprimaTestSuite.tsx]
+
+</>;
+<a: />;
+<:a />;
+<a b=d />;
+<a>;
+<a></b>;
+<a foo="bar;
+<a:b></b>;
+<a:b.c></a:b.c>;
+<a.b:c></a.b:c>;
+<a.b.c></a>;
+<.a></.a>;
+<a.></a.>;
+<a[foo]></a[foo]>;
+<a['foo']></a['foo']>;
+<a><a />;
+<a b={}>;
+var x = <div>one</div><div>two</div>;;
+var x = <div>one</div> /* intervening comment */ <div>two</div>;;
+<a>{"str";}</a>;
+<span className="a", id="b" />;
+<div className"app">;
+<div {props} />;
+
+<div>stuff</div {...props}>;
+<div {...props}>stuff</div {...props}>;
+
+<a>></a>;
+<a> ></a>;
+<a b=}>;
+<a b=<}>;
+<a>}</a>;
+<a .../*hai*/asdf/>;
+
+//// [jsxInvalidEsprimaTestSuite.js]
+;
+;
+;
+;
+;
+a > ;
+;
+;
+ > ;
+;
+{
+    props;
+}
+ > ;
+;
+;
+;
+ > ;
+;
+;
+a > ;
+;

--- a/tests/baselines/reference/jsxReactApp.errors.txt
+++ b/tests/baselines/reference/jsxReactApp.errors.txt
@@ -1,0 +1,212 @@
+tests/cases/compiler/jsxReactApp.tsx(163,17): error TS17005: JSX elements are not currently supported.
+tests/cases/compiler/jsxReactApp.tsx(185,13): error TS17005: JSX elements are not currently supported.
+
+
+==== tests/cases/compiler/jsxReactApp.tsx (2 errors) ====
+    declare module React {
+        
+        interface ComponentClass<P> { 
+            new(props: any): Component<any, any>; 
+            prototype: { props: P };
+        }
+            
+        interface ReactCompositeElement<P extends ReactAttributes> {
+            type: ComponentClass<P>;
+            props?: P;
+            key?: number | string;
+            ref?: string;
+        }
+        
+        interface ReactHtmlElement {
+            type: string;
+            props?: ReactAttributes;
+            key?: number | string;
+            ref?: string;
+        }
+        
+        type ReactElement = ReactCompositeElement<any> | ReactHtmlElement;
+        
+        interface ReactElementArray extends Array<string | ReactElement | ReactElementArray> {
+        
+        }
+        
+        class Component<P extends ReactAttributes, S> {
+            constructor(props: P, childen?: any[]);
+    
+            props: P;
+            state: S;
+    
+            setState(state: S, callback?: () => void): void
+            render(): ReactElement;
+        }
+        
+        interface ReactAttributes {
+            children?: ReactElementArray;
+            key?: number | string;
+            ref?: string;
+    
+            // Event Attributes
+    
+            dangerouslySetInnerHTML?: {
+                __html: string;
+            };
+        }
+        
+        interface HTMLAttributes extends ReactAttributes {
+            accept?: string;
+            acceptCharset?: string;
+            accessKey?: string;
+            action?: string;
+            allowFullScreen?: boolean;
+            allowTransparency?: boolean;
+            alt?: string;
+            async?: boolean;
+            autoComplete?: boolean;
+            autoFocus?: boolean;
+            autoPlay?: boolean;
+            cellPadding?: number | string;
+            cellSpacing?: number | string;
+            charSet?: string;
+            checked?: boolean;
+            classID?: string;
+            className?: string;
+            cols?: number;
+            colSpan?: number;
+            content?: string;
+            contentEditable?: boolean;
+            contextMenu?: string;
+            controls?: any;
+            coords?: string;
+            crossOrigin?: string;
+            data?: string;
+            dateTime?: string;
+            defer?: boolean;
+            dir?: string;
+            disabled?: boolean;
+            download?: any;
+            draggable?: boolean;
+            encType?: string;
+            form?: string;
+            formNoValidate?: boolean;
+            frameBorder?: number | string;
+            height?: number | string;
+            hidden?: boolean;
+            href?: string;
+            hrefLang?: string;
+            htmlFor?: string;
+            httpEquiv?: string;
+            icon?: string;
+            id?: string;
+            label?: string;
+            lang?: string;
+            list?: string;
+            loop?: boolean;
+            manifest?: string;
+            max?: number | string;
+            maxLength?: number;
+            media?: string;
+            mediaGroup?: string;
+            method?: string;
+            min?: number | string;
+            multiple?: boolean;
+            muted?: boolean;
+            name?: string;
+            noValidate?: boolean;
+            open?: boolean;
+            pattern?: string;
+            placeholder?: string;
+            poster?: string;
+            preload?: string;
+            radioGroup?: string;
+            readOnly?: boolean;
+            rel?: string;
+            required?: boolean;
+            role?: string;
+            rows?: number;
+            rowSpan?: number;
+            sandbox?: string;
+            scope?: string;
+            scrollLeft?: number;
+            scrolling?: string;
+            scrollTop?: number;
+            seamless?: boolean;
+            selected?: boolean;
+            shape?: string;
+            size?: number;
+            sizes?: string;
+            span?: number;
+            spellCheck?: boolean;
+            src?: string;
+            srcDoc?: string;
+            srcSet?: string;
+            start?: number;
+            step?: number | string;
+            tabIndex?: number;
+            target?: string;
+            title?: string;
+            type?: string;
+            useMap?: string;
+            value?: string;
+            width?: number | string;
+            wmode?: string;
+    
+            // Non-standard Attributes
+            autoCapitalize?: boolean;
+            autoCorrect?: boolean;
+            property?: string;
+            itemProp?: string;
+            itemScope?: boolean;
+            itemType?: string;
+        }
+        
+        function createElement(type: string, props?: HTMLAttributes, ...rest: any[]): ReactHtmlElement;
+        function createElement<P>(type: ComponentClass<P>, props?: P, ...rest: any[]): ReactCompositeElement<P>;
+    }
+    
+    class TodoList extends React.Component<{ items: string[] },{}> {
+        render(): React.ReactElement {
+            return  <ul>{this.props.items.map(itemText => <li>{itemText}</li>)}</ul>;
+                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+        }
+    }
+    
+    class TodoApp extends React.Component<{},{items?: string[]; text?: string}> {
+        state = {items: [], text: ''};
+        
+        onChange = (e: any) => {
+            this.setState({
+                text: <string>e.target.value
+            });
+        }
+        
+        handleSubmit = (e: any) => {
+            e.preventDefault();
+            var nextItems = this.state.items.concat([this.state.text]);
+            var nextText = '';
+            this.setState({items: nextItems, text: nextText});
+        }
+        
+        render(): React.ReactElement  {
+            return (
+                <div>
+                ~~~~~
+                    <h3>TODO</h3>
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    <TodoList items={this.state.items} />
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    <form onSubmit={this.handleSubmit}>
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        <input onChange={this.onChange} value={this.state.text} />
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        <button>{'Add #' + (this.state.items.length + 1)}</button>
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                    </form>
+    ~~~~~~~~~~~~~~~~~~~~~~~
+                </div>
+    ~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+            );
+        }
+    }
+    

--- a/tests/baselines/reference/jsxReactApp.js
+++ b/tests/baselines/reference/jsxReactApp.js
@@ -1,0 +1,238 @@
+//// [jsxReactApp.tsx]
+declare module React {
+    
+    interface ComponentClass<P> { 
+        new(props: any): Component<any, any>; 
+        prototype: { props: P };
+    }
+        
+    interface ReactCompositeElement<P extends ReactAttributes> {
+        type: ComponentClass<P>;
+        props?: P;
+        key?: number | string;
+        ref?: string;
+    }
+    
+    interface ReactHtmlElement {
+        type: string;
+        props?: ReactAttributes;
+        key?: number | string;
+        ref?: string;
+    }
+    
+    type ReactElement = ReactCompositeElement<any> | ReactHtmlElement;
+    
+    interface ReactElementArray extends Array<string | ReactElement | ReactElementArray> {
+    
+    }
+    
+    class Component<P extends ReactAttributes, S> {
+        constructor(props: P, childen?: any[]);
+
+        props: P;
+        state: S;
+
+        setState(state: S, callback?: () => void): void
+        render(): ReactElement;
+    }
+    
+    interface ReactAttributes {
+        children?: ReactElementArray;
+        key?: number | string;
+        ref?: string;
+
+        // Event Attributes
+
+        dangerouslySetInnerHTML?: {
+            __html: string;
+        };
+    }
+    
+    interface HTMLAttributes extends ReactAttributes {
+        accept?: string;
+        acceptCharset?: string;
+        accessKey?: string;
+        action?: string;
+        allowFullScreen?: boolean;
+        allowTransparency?: boolean;
+        alt?: string;
+        async?: boolean;
+        autoComplete?: boolean;
+        autoFocus?: boolean;
+        autoPlay?: boolean;
+        cellPadding?: number | string;
+        cellSpacing?: number | string;
+        charSet?: string;
+        checked?: boolean;
+        classID?: string;
+        className?: string;
+        cols?: number;
+        colSpan?: number;
+        content?: string;
+        contentEditable?: boolean;
+        contextMenu?: string;
+        controls?: any;
+        coords?: string;
+        crossOrigin?: string;
+        data?: string;
+        dateTime?: string;
+        defer?: boolean;
+        dir?: string;
+        disabled?: boolean;
+        download?: any;
+        draggable?: boolean;
+        encType?: string;
+        form?: string;
+        formNoValidate?: boolean;
+        frameBorder?: number | string;
+        height?: number | string;
+        hidden?: boolean;
+        href?: string;
+        hrefLang?: string;
+        htmlFor?: string;
+        httpEquiv?: string;
+        icon?: string;
+        id?: string;
+        label?: string;
+        lang?: string;
+        list?: string;
+        loop?: boolean;
+        manifest?: string;
+        max?: number | string;
+        maxLength?: number;
+        media?: string;
+        mediaGroup?: string;
+        method?: string;
+        min?: number | string;
+        multiple?: boolean;
+        muted?: boolean;
+        name?: string;
+        noValidate?: boolean;
+        open?: boolean;
+        pattern?: string;
+        placeholder?: string;
+        poster?: string;
+        preload?: string;
+        radioGroup?: string;
+        readOnly?: boolean;
+        rel?: string;
+        required?: boolean;
+        role?: string;
+        rows?: number;
+        rowSpan?: number;
+        sandbox?: string;
+        scope?: string;
+        scrollLeft?: number;
+        scrolling?: string;
+        scrollTop?: number;
+        seamless?: boolean;
+        selected?: boolean;
+        shape?: string;
+        size?: number;
+        sizes?: string;
+        span?: number;
+        spellCheck?: boolean;
+        src?: string;
+        srcDoc?: string;
+        srcSet?: string;
+        start?: number;
+        step?: number | string;
+        tabIndex?: number;
+        target?: string;
+        title?: string;
+        type?: string;
+        useMap?: string;
+        value?: string;
+        width?: number | string;
+        wmode?: string;
+
+        // Non-standard Attributes
+        autoCapitalize?: boolean;
+        autoCorrect?: boolean;
+        property?: string;
+        itemProp?: string;
+        itemScope?: boolean;
+        itemType?: string;
+    }
+    
+    function createElement(type: string, props?: HTMLAttributes, ...rest: any[]): ReactHtmlElement;
+    function createElement<P>(type: ComponentClass<P>, props?: P, ...rest: any[]): ReactCompositeElement<P>;
+}
+
+class TodoList extends React.Component<{ items: string[] },{}> {
+    render(): React.ReactElement {
+        return  <ul>{this.props.items.map(itemText => <li>{itemText}</li>)}</ul>;
+    }
+}
+
+class TodoApp extends React.Component<{},{items?: string[]; text?: string}> {
+    state = {items: [], text: ''};
+    
+    onChange = (e: any) => {
+        this.setState({
+            text: <string>e.target.value
+        });
+    }
+    
+    handleSubmit = (e: any) => {
+        e.preventDefault();
+        var nextItems = this.state.items.concat([this.state.text]);
+        var nextText = '';
+        this.setState({items: nextItems, text: nextText});
+    }
+    
+    render(): React.ReactElement  {
+        return (
+            <div>
+                <h3>TODO</h3>
+                <TodoList items={this.state.items} />
+                <form onSubmit={this.handleSubmit}>
+                    <input onChange={this.onChange} value={this.state.text} />
+                    <button>{'Add #' + (this.state.items.length + 1)}</button>
+                </form>
+            </div>
+        );
+    }
+}
+
+
+//// [jsxReactApp.js]
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    __.prototype = b.prototype;
+    d.prototype = new __();
+};
+var TodoList = (function (_super) {
+    __extends(TodoList, _super);
+    function TodoList() {
+        _super.apply(this, arguments);
+    }
+    TodoList.prototype.render = function () {
+        return ;
+    };
+    return TodoList;
+})(React.Component);
+var TodoApp = (function (_super) {
+    __extends(TodoApp, _super);
+    function TodoApp() {
+        var _this = this;
+        _super.apply(this, arguments);
+        this.state = { items: [], text: '' };
+        this.onChange = function (e) {
+            _this.setState({
+                text: e.target.value
+            });
+        };
+        this.handleSubmit = function (e) {
+            e.preventDefault();
+            var nextItems = _this.state.items.concat([_this.state.text]);
+            var nextText = '';
+            _this.setState({ items: nextItems, text: nextText });
+        };
+    }
+    TodoApp.prototype.render = function () {
+        return ();
+    };
+    return TodoApp;
+})(React.Component);

--- a/tests/baselines/reference/jsxReactTestSuite.errors.txt
+++ b/tests/baselines/reference/jsxReactTestSuite.errors.txt
@@ -1,0 +1,225 @@
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(1,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(3,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(7,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(14,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(18,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(23,3): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(41,3): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(55,3): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(65,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(67,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(69,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(71,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(73,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(75,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(77,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(80,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(83,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(85,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(87,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(89,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(91,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(93,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(95,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(98,1): error TS17005: JSX elements are not currently supported.
+tests/cases/conformance/jsx/jsxReactTestSuite.tsx(100,1): error TS17005: JSX elements are not currently supported.
+
+
+==== tests/cases/conformance/jsx/jsxReactTestSuite.tsx (25 errors) ====
+    <div>text</div>;
+    ~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <div>
+    ~~~~~
+      {this.props.children}
+    ~~~~~~~~~~~~~~~~~~~~~~~
+    </div>;
+    ~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <div>
+    ~~~~~
+      <div><br /></div>
+    ~~~~~~~~~~~~~~~~~~~
+      <Component>{foo}<br />{bar}</Component>
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      <br />
+    ~~~~~~~~
+    </div>;
+    ~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    
+    <Composite>
+    ~~~~~~~~~~~
+        {this.props.children}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
+    </Composite>;
+    ~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <Composite>
+    ~~~~~~~~~~~
+        <Composite2 />
+    ~~~~~~~~~~~~~~~~~~
+    </Composite>;
+    ~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    var x =
+      <div
+      ~~~~
+        attr1={
+    ~~~~~~~~~~~
+          "foo" + "bar"
+    ~~~~~~~~~~~~~~~~~~~
+        }
+    ~~~~~
+        attr2={
+    ~~~~~~~~~~~
+          "foo" + "bar" +
+    ~~~~~~~~~~~~~~~~~~~~~
+          
+    ~~~~~~
+          "baz" + "bug"
+    ~~~~~~~~~~~~~~~~~~~
+        }
+    ~~~~~
+        attr3={
+    ~~~~~~~~~~~
+          "foo" + "bar" +
+    ~~~~~~~~~~~~~~~~~~~~~
+          "baz" + "bug"
+    ~~~~~~~~~~~~~~~~~~~
+          // Extra line here.
+    ~~~~~~~~~~~~~~~~~~~~~~~~~
+        }
+    ~~~~~
+        attr4="baz">
+    ~~~~~~~~~~~~~~~~
+      </div>;
+    ~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    (
+      <div>
+      ~~~~~
+        {/* A comment at the beginning */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        {/* A second comment at the beginning */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        <span>
+    ~~~~~~~~~~
+          {/* A nested comment */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        </span>
+    ~~~~~~~~~~~
+        {/* A sandwiched comment */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        <br />
+    ~~~~~~~~~~
+        {/* A comment at the end */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+        {/* A second comment at the end */}
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+      </div>
+    ~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    );
+    
+    (
+      <div
+      ~~~~
+        /* a multi-line
+    ~~~~~~~~~~~~~~~~~~~
+           comment */
+    ~~~~~~~~~~~~~~~~~
+        attr1="foo">
+    ~~~~~~~~~~~~~~~~
+        <span // a double-slash comment
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+          attr2="bar"
+    ~~~~~~~~~~~~~~~~~
+        />
+    ~~~~~~
+      </div>
+    ~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    );
+    
+    <div>&nbsp;</div>;
+    ~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <div>&nbsp; </div>;
+    ~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <hasOwnProperty>testing</hasOwnProperty>;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <Component constructor="foo" />;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <Namespace.Component />;
+    ~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <Namespace.DeepNamespace.Component />;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <Component { ... x } y
+    ~~~~~~~~~~~~~~~~~~~~~~
+    ={2 } z />;
+    ~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <Component
+    ~~~~~~~~~~
+        {...this.props} sound="moo" />;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <font-face />;
+    ~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <Component x={y} />;
+    ~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <x-component />;
+    ~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <Component {...x} />;
+    ~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <Component { ...x } y={2} />;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <Component { ... x } y={2} z />;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <Component x={1} {...y} />;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    
+    <Component x={1} y="2" {...z} {...z}><Child /></Component>;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    <Component x="1" {...(z = { y: 2 }, z)} z={3}>Text</Component>;
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17005: JSX elements are not currently supported.
+    
+    
+    

--- a/tests/baselines/reference/jsxReactTestSuite.js
+++ b/tests/baselines/reference/jsxReactTestSuite.js
@@ -1,0 +1,131 @@
+//// [jsxReactTestSuite.tsx]
+<div>text</div>;
+
+<div>
+  {this.props.children}
+</div>;
+
+<div>
+  <div><br /></div>
+  <Component>{foo}<br />{bar}</Component>
+  <br />
+</div>;
+
+
+<Composite>
+    {this.props.children}
+</Composite>;
+
+<Composite>
+    <Composite2 />
+</Composite>;
+
+var x =
+  <div
+    attr1={
+      "foo" + "bar"
+    }
+    attr2={
+      "foo" + "bar" +
+      
+      "baz" + "bug"
+    }
+    attr3={
+      "foo" + "bar" +
+      "baz" + "bug"
+      // Extra line here.
+    }
+    attr4="baz">
+  </div>;
+
+(
+  <div>
+    {/* A comment at the beginning */}
+    {/* A second comment at the beginning */}
+    <span>
+      {/* A nested comment */}
+    </span>
+    {/* A sandwiched comment */}
+    <br />
+    {/* A comment at the end */}
+    {/* A second comment at the end */}
+  </div>
+);
+
+(
+  <div
+    /* a multi-line
+       comment */
+    attr1="foo">
+    <span // a double-slash comment
+      attr2="bar"
+    />
+  </div>
+);
+
+<div>&nbsp;</div>;
+
+<div>&nbsp; </div>;
+
+<hasOwnProperty>testing</hasOwnProperty>;
+
+<Component constructor="foo" />;
+
+<Namespace.Component />;
+
+<Namespace.DeepNamespace.Component />;
+
+<Component { ... x } y
+={2 } z />;
+
+<Component
+    {...this.props} sound="moo" />;
+
+<font-face />;
+
+<Component x={y} />;
+
+<x-component />;
+
+<Component {...x} />;
+
+<Component { ...x } y={2} />;
+
+<Component { ... x } y={2} z />;
+
+<Component x={1} {...y} />;
+
+
+<Component x={1} y="2" {...z} {...z}><Child /></Component>;
+
+<Component x="1" {...(z = { y: 2 }, z)} z={3}>Text</Component>;
+
+
+
+
+//// [jsxReactTestSuite.js]
+;
+;
+;
+;
+;
+var x = ;
+();
+();
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;
+;

--- a/tests/baselines/reference/project/invalidRootFile/amd/invalidRootFile.errors.txt
+++ b/tests/baselines/reference/project/invalidRootFile/amd/invalidRootFile.errors.txt
@@ -1,6 +1,6 @@
-error TS6054: File 'a.t' has unsupported extension. The only supported extensions are '.ts', '.d.ts'.
+error TS6054: File 'a.t' has unsupported extension. The only supported extensions are '.tsx', '.ts', '.d.ts'.
 error TS6053: File 'a.ts' not found.
 
 
-!!! error TS6054: File 'a.t' has unsupported extension. The only supported extensions are '.ts', '.d.ts'.
+!!! error TS6054: File 'a.t' has unsupported extension. The only supported extensions are '.tsx', '.ts', '.d.ts'.
 !!! error TS6053: File 'a.ts' not found.

--- a/tests/baselines/reference/project/invalidRootFile/node/invalidRootFile.errors.txt
+++ b/tests/baselines/reference/project/invalidRootFile/node/invalidRootFile.errors.txt
@@ -1,6 +1,6 @@
-error TS6054: File 'a.t' has unsupported extension. The only supported extensions are '.ts', '.d.ts'.
+error TS6054: File 'a.t' has unsupported extension. The only supported extensions are '.tsx', '.ts', '.d.ts'.
 error TS6053: File 'a.ts' not found.
 
 
-!!! error TS6054: File 'a.t' has unsupported extension. The only supported extensions are '.ts', '.d.ts'.
+!!! error TS6054: File 'a.t' has unsupported extension. The only supported extensions are '.tsx', '.ts', '.d.ts'.
 !!! error TS6053: File 'a.ts' not found.

--- a/tests/cases/compiler/jsxReactApp.tsx
+++ b/tests/cases/compiler/jsxReactApp.tsx
@@ -1,0 +1,195 @@
+declare module React {
+    
+    interface ComponentClass<P> { 
+        new(props: any): Component<any, any>; 
+        prototype: { props: P };
+    }
+        
+    interface ReactCompositeElement<P extends ReactAttributes> {
+        type: ComponentClass<P>;
+        props?: P;
+        key?: number | string;
+        ref?: string;
+    }
+    
+    interface ReactHtmlElement {
+        type: string;
+        props?: ReactAttributes;
+        key?: number | string;
+        ref?: string;
+    }
+    
+    type ReactElement = ReactCompositeElement<any> | ReactHtmlElement;
+    
+    interface ReactElementArray extends Array<string | ReactElement | ReactElementArray> {
+    
+    }
+    
+    class Component<P extends ReactAttributes, S> {
+        constructor(props: P, childen?: any[]);
+
+        props: P;
+        state: S;
+
+        setState(state: S, callback?: () => void): void
+        render(): ReactElement;
+    }
+    
+    interface ReactAttributes {
+        children?: ReactElementArray;
+        key?: number | string;
+        ref?: string;
+
+        // Event Attributes
+
+        dangerouslySetInnerHTML?: {
+            __html: string;
+        };
+    }
+    
+    interface HTMLAttributes extends ReactAttributes {
+        accept?: string;
+        acceptCharset?: string;
+        accessKey?: string;
+        action?: string;
+        allowFullScreen?: boolean;
+        allowTransparency?: boolean;
+        alt?: string;
+        async?: boolean;
+        autoComplete?: boolean;
+        autoFocus?: boolean;
+        autoPlay?: boolean;
+        cellPadding?: number | string;
+        cellSpacing?: number | string;
+        charSet?: string;
+        checked?: boolean;
+        classID?: string;
+        className?: string;
+        cols?: number;
+        colSpan?: number;
+        content?: string;
+        contentEditable?: boolean;
+        contextMenu?: string;
+        controls?: any;
+        coords?: string;
+        crossOrigin?: string;
+        data?: string;
+        dateTime?: string;
+        defer?: boolean;
+        dir?: string;
+        disabled?: boolean;
+        download?: any;
+        draggable?: boolean;
+        encType?: string;
+        form?: string;
+        formNoValidate?: boolean;
+        frameBorder?: number | string;
+        height?: number | string;
+        hidden?: boolean;
+        href?: string;
+        hrefLang?: string;
+        htmlFor?: string;
+        httpEquiv?: string;
+        icon?: string;
+        id?: string;
+        label?: string;
+        lang?: string;
+        list?: string;
+        loop?: boolean;
+        manifest?: string;
+        max?: number | string;
+        maxLength?: number;
+        media?: string;
+        mediaGroup?: string;
+        method?: string;
+        min?: number | string;
+        multiple?: boolean;
+        muted?: boolean;
+        name?: string;
+        noValidate?: boolean;
+        open?: boolean;
+        pattern?: string;
+        placeholder?: string;
+        poster?: string;
+        preload?: string;
+        radioGroup?: string;
+        readOnly?: boolean;
+        rel?: string;
+        required?: boolean;
+        role?: string;
+        rows?: number;
+        rowSpan?: number;
+        sandbox?: string;
+        scope?: string;
+        scrollLeft?: number;
+        scrolling?: string;
+        scrollTop?: number;
+        seamless?: boolean;
+        selected?: boolean;
+        shape?: string;
+        size?: number;
+        sizes?: string;
+        span?: number;
+        spellCheck?: boolean;
+        src?: string;
+        srcDoc?: string;
+        srcSet?: string;
+        start?: number;
+        step?: number | string;
+        tabIndex?: number;
+        target?: string;
+        title?: string;
+        type?: string;
+        useMap?: string;
+        value?: string;
+        width?: number | string;
+        wmode?: string;
+
+        // Non-standard Attributes
+        autoCapitalize?: boolean;
+        autoCorrect?: boolean;
+        property?: string;
+        itemProp?: string;
+        itemScope?: boolean;
+        itemType?: string;
+    }
+    
+    function createElement(type: string, props?: HTMLAttributes, ...rest: any[]): ReactHtmlElement;
+    function createElement<P>(type: ComponentClass<P>, props?: P, ...rest: any[]): ReactCompositeElement<P>;
+}
+
+class TodoList extends React.Component<{ items: string[] },{}> {
+    render(): React.ReactElement {
+        return  <ul>{this.props.items.map(itemText => <li>{itemText}</li>)}</ul>;
+    }
+}
+
+class TodoApp extends React.Component<{},{items?: string[]; text?: string}> {
+    state = {items: [], text: ''};
+    
+    onChange = (e: any) => {
+        this.setState({
+            text: <string>e.target.value
+        });
+    }
+    
+    handleSubmit = (e: any) => {
+        e.preventDefault();
+        var nextItems = this.state.items.concat([this.state.text]);
+        var nextText = '';
+        this.setState({items: nextItems, text: nextText});
+    }
+    
+    render(): React.ReactElement  {
+        return (
+            <div>
+                <h3>TODO</h3>
+                <TodoList items={this.state.items} />
+                <form onSubmit={this.handleSubmit}>
+                    <input onChange={this.onChange} value={this.state.text} />
+                    <button>{'Add #' + (this.state.items.length + 1)}</button>
+                </form>
+            </div>
+        );
+    }
+}

--- a/tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx
+++ b/tests/cases/conformance/jsx/jsxAndTypeAssertion.tsx
@@ -1,0 +1,14 @@
+
+<any> { test: <any></any> };
+
+<any><any></any>;
+ 
+<foo>hello {<foo>{}} </foo>;
+
+<foo test={<foo>{}}>hello</foo>;
+
+<foo test={<foo>{}}>hello{<foo>{}}</foo>;
+
+<foo>{<foo><foo>{/foo/.test(x) ? <foo><foo></foo> : <foo><foo></foo>}</foo>}</foo>
+
+    

--- a/tests/cases/conformance/jsx/jsxClosingTagMapsRelaxingRules.tsx
+++ b/tests/cases/conformance/jsx/jsxClosingTagMapsRelaxingRules.tsx
@@ -1,0 +1,7 @@
+<a></b>;
+<a> foo {}</b>;
+<a> foo bar</b>;
+<MyElement.myProperty> Hello </
+MyElement.
+   myProperty
+>

--- a/tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx
+++ b/tests/cases/conformance/jsx/jsxEsprimaFbTestSuite.tsx
@@ -1,0 +1,46 @@
+
+<a />;
+
+//<n:a n:v />; Namespace unsuported
+
+//<a n:foo="bar"> {value} <b><c /></b></a>;  Namespace unsuported
+
+<a b={" "} c=" " d="&amp;" e="id=1&group=2" f="&#123456789" g="&#123*;" h="&#x;" />;
+
+<a b="&notanentity;" />;
+<a
+/>;
+
+<日本語></日本語>;
+
+<AbC_def
+  test="&#x0026;&#38;">
+bar
+baz
+</AbC_def>;
+
+<a b={x ? <c /> : <d />} />;
+
+<a>{}</a>;
+
+<a>{/* this is a comment */}</a>;
+
+<div>@test content</div>;
+
+<div><br />7x invalid-js-identifier</div>;
+
+<LeftRight left=<a /> right=<b>monkeys /> gorillas</b> />;
+
+<a.b></a.b>;
+
+<a.b.c></a.b.c>;
+
+(<div />) < x;
+
+<div {...props} />;
+
+<div {...props} post="attribute" />;
+
+<div pre="leading" pre2="attribute" {...props}></div>;
+
+<a>    </a>;

--- a/tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx
+++ b/tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx
@@ -1,0 +1,34 @@
+
+</>;
+<a: />;
+<:a />;
+<a b=d />;
+<a>;
+<a></b>;
+<a foo="bar;
+<a:b></b>;
+<a:b.c></a:b.c>;
+<a.b:c></a.b:c>;
+<a.b.c></a>;
+<.a></.a>;
+<a.></a.>;
+<a[foo]></a[foo]>;
+<a['foo']></a['foo']>;
+<a><a />;
+<a b={}>;
+var x = <div>one</div><div>two</div>;;
+var x = <div>one</div> /* intervening comment */ <div>two</div>;;
+<a>{"str";}</a>;
+<span className="a", id="b" />;
+<div className"app">;
+<div {props} />;
+
+<div>stuff</div {...props}>;
+<div {...props}>stuff</div {...props}>;
+
+<a>></a>;
+<a> ></a>;
+<a b=}>;
+<a b=<}>;
+<a>}</a>;
+<a .../*hai*/asdf/>;

--- a/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
+++ b/tests/cases/conformance/jsx/jsxReactTestSuite.tsx
@@ -1,0 +1,102 @@
+<div>text</div>;
+
+<div>
+  {this.props.children}
+</div>;
+
+<div>
+  <div><br /></div>
+  <Component>{foo}<br />{bar}</Component>
+  <br />
+</div>;
+
+
+<Composite>
+    {this.props.children}
+</Composite>;
+
+<Composite>
+    <Composite2 />
+</Composite>;
+
+var x =
+  <div
+    attr1={
+      "foo" + "bar"
+    }
+    attr2={
+      "foo" + "bar" +
+      
+      "baz" + "bug"
+    }
+    attr3={
+      "foo" + "bar" +
+      "baz" + "bug"
+      // Extra line here.
+    }
+    attr4="baz">
+  </div>;
+
+(
+  <div>
+    {/* A comment at the beginning */}
+    {/* A second comment at the beginning */}
+    <span>
+      {/* A nested comment */}
+    </span>
+    {/* A sandwiched comment */}
+    <br />
+    {/* A comment at the end */}
+    {/* A second comment at the end */}
+  </div>
+);
+
+(
+  <div
+    /* a multi-line
+       comment */
+    attr1="foo">
+    <span // a double-slash comment
+      attr2="bar"
+    />
+  </div>
+);
+
+<div>&nbsp;</div>;
+
+<div>&nbsp; </div>;
+
+<hasOwnProperty>testing</hasOwnProperty>;
+
+<Component constructor="foo" />;
+
+<Namespace.Component />;
+
+<Namespace.DeepNamespace.Component />;
+
+<Component { ... x } y
+={2 } z />;
+
+<Component
+    {...this.props} sound="moo" />;
+
+<font-face />;
+
+<Component x={y} />;
+
+<x-component />;
+
+<Component {...x} />;
+
+<Component { ...x } y={2} />;
+
+<Component { ... x } y={2} z />;
+
+<Component x={1} {...y} />;
+
+
+<Component x={1} y="2" {...z} {...z}><Child /></Component>;
+
+<Component x="1" {...(z = { y: 2 }, z)} z={3}>Text</Component>;
+
+


### PR DESCRIPTION
Following the discussion in #296, here is a PR that adds support for JSX constructs.

And some details about the implementation/spec :

* JSX elements are only parsed if a triple slash directive is present : 
```typescript
///<jsx factory="myFactory" />
```
* JSX elements are type checked as a call of the factory function : 
```typescript
///<jsx factory="myFactory" />
<MyComp attr={something}> Something </MyComp>;
// typechecked as : 
myFactory(MyComp, { attr: something}, " Something ");
```
* JSX elements are emitted unchanged (only formatted).

* To reproduce React's behavior, depending of the case of the tag, the first argument of the function call might be treated as a string:
```typescript
///<jsx factory="myFactory" />
<div />
// typechecked as : 
myFactory("div", {});

<MyComp />
// typechecked as : 
myFactory(MyComp, {});
```
* JSX directive factory attribute value might contain any property access level: 
```typescript
///<jsx factory="myNameSpace.myNameSpace1.myFunc" />
///<jsx factory="React.createElement" />
```
* In General JSX elements describe how a component should be instantiated (at least in React). In this context the way of how attributes should be checked is generally dictated by the *tag*.  
For this purpose, types for *JSXElement call* are only inferred from the first argument (the *tag*).
```typescript
///<jsx factory="test" />

declare function test<P>(p1: P, p2: P): void;

var Comp = { items: "foo" };
test(Comp, {}); // no error P is inferred as `{}` 
<Comp />; // error Argument of type '{}' is not assignable to parameter of type '{ items: string; }'.
```
The service integration is minimal and ported from my old version of jsx-typescript, so not well tested. 
