### PR TITLE
Ensure that getOccurrences not return items not in the file asked for.

### DIFF
--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -336,6 +336,9 @@ module Harness.LanguageService {
         getOccurrencesAtPosition(fileName: string, position: number): ts.ReferenceEntry[] {
             return unwrapJSONCallResult(this.shim.getOccurrencesAtPosition(fileName, position));
         }
+        getDocumentHighlights(fileName: string, position: number): ts.DocumentHighlights[] {
+            return unwrapJSONCallResult(this.shim.getDocumentHighlights(fileName, position));
+        }
         getNavigateToItems(searchValue: string): ts.NavigateToItem[] {
             return unwrapJSONCallResult(this.shim.getNavigateToItems(searchValue));
         }

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -336,8 +336,8 @@ module Harness.LanguageService {
         getOccurrencesAtPosition(fileName: string, position: number): ts.ReferenceEntry[] {
             return unwrapJSONCallResult(this.shim.getOccurrencesAtPosition(fileName, position));
         }
-        getDocumentHighlights(fileName: string, position: number): ts.DocumentHighlights[] {
-            return unwrapJSONCallResult(this.shim.getDocumentHighlights(fileName, position));
+        getDocumentHighlights(fileName: string, position: number, filesToSearch: string[]): ts.DocumentHighlights[] {
+            return unwrapJSONCallResult(this.shim.getDocumentHighlights(fileName, position, JSON.stringify(filesToSearch)));
         }
         getNavigateToItems(searchValue: string): ts.NavigateToItem[] {
             return unwrapJSONCallResult(this.shim.getNavigateToItems(searchValue));

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -468,6 +468,10 @@ module ts.server {
             throw new Error("Not Implemented Yet.");
         }
 
+        getDocumentHighlights(fileName: string, position: number): DocumentHighlights[] {
+            throw new Error("Not Implemented Yet.");
+        }
+
         getOutliningSpans(fileName: string): OutliningSpan[] {
             throw new Error("Not Implemented Yet.");
         }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1022,6 +1022,7 @@ module ts {
     export interface HighlightSpan {
         textSpan: TextSpan;
         isDefinition: boolean;
+        isWriteAccess: boolean;
     }
 
     export interface NavigateToItem {
@@ -3992,546 +3993,606 @@ module ts {
                 return undefined;
             }
 
-            return getSyntacticDocumentHighlights(node);
-        }
+            return getSemanticDocumentHighlights(node) || getSyntacticDocumentHighlights(node);
 
-        // returns true if 'node' is defined and has a matching 'kind'.
-        function hasKind(node: Node, kind: SyntaxKind) {
-            return node !== undefined && node.kind === kind;
-        }
+            function getHighlightSpanForNode(node: Node): HighlightSpan {
+                let start = node.getStart();
+                let end = node.getEnd();
 
-        // Null-propagating 'parent' function.
-        function parent(node: Node): Node {
-            return node && node.parent;
-        }
-
-        function getSyntacticDocumentHighlights(node: Node): DocumentHighlights[] {
-            let sourceFile = node.getSourceFile();
-            let fileName = sourceFile.fileName;
-
-            var highlightSpans = getHighlightSpans(node);
-            if (!highlightSpans || highlightSpans.length === 0) {
-                return undefined;
-            }
-
-            return [{ fileName, highlightSpans }];
-
-            function getHighlightSpans(node: Node): HighlightSpan[] {
-                if (node) {
-                    switch (node.kind) {
-                        case SyntaxKind.IfKeyword:
-                        case SyntaxKind.ElseKeyword:
-                            if (hasKind(node.parent, SyntaxKind.IfStatement)) {
-                                return getIfElseOccurrences(<IfStatement>node.parent);
-                            }
-                            break;
-                        case SyntaxKind.ReturnKeyword:
-                            if (hasKind(node.parent, SyntaxKind.ReturnStatement)) {
-                                return getReturnOccurrences(<ReturnStatement>node.parent);
-                            }
-                            break;
-                        case SyntaxKind.ThrowKeyword:
-                            if (hasKind(node.parent, SyntaxKind.ThrowStatement)) {
-                                return getThrowOccurrences(<ThrowStatement>node.parent);
-                            }
-                            break;
-                        case SyntaxKind.CatchKeyword:
-                            if (hasKind(parent(parent(node)), SyntaxKind.TryStatement)) {
-                                return getTryCatchFinallyOccurrences(<TryStatement>node.parent.parent);
-                            }
-                            break;
-                        case SyntaxKind.TryKeyword:
-                        case SyntaxKind.FinallyKeyword:
-                            if (hasKind(parent(node), SyntaxKind.TryStatement)) {
-                                return getTryCatchFinallyOccurrences(<TryStatement>node.parent);
-                            }
-                            break;
-                        case SyntaxKind.SwitchKeyword:
-                            if (hasKind(node.parent, SyntaxKind.SwitchStatement)) {
-                                return getSwitchCaseDefaultOccurrences(<SwitchStatement>node.parent);
-                            }
-                            break;
-                        case SyntaxKind.CaseKeyword:
-                        case SyntaxKind.DefaultKeyword:
-                            if (hasKind(parent(parent(parent(node))), SyntaxKind.SwitchStatement)) {
-                                return getSwitchCaseDefaultOccurrences(<SwitchStatement>node.parent.parent.parent);
-                            }
-                            break;
-                        case SyntaxKind.BreakKeyword:
-                        case SyntaxKind.ContinueKeyword:
-                            if (hasKind(node.parent, SyntaxKind.BreakStatement) || hasKind(node.parent, SyntaxKind.ContinueStatement)) {
-                                return getBreakOrContinueStatementOccurences(<BreakOrContinueStatement>node.parent);
-                            }
-                            break;
-                        case SyntaxKind.ForKeyword:
-                            if (hasKind(node.parent, SyntaxKind.ForStatement) ||
-                                hasKind(node.parent, SyntaxKind.ForInStatement) ||
-                                hasKind(node.parent, SyntaxKind.ForOfStatement)) {
-                                return getLoopBreakContinueOccurrences(<IterationStatement>node.parent);
-                            }
-                            break;
-                        case SyntaxKind.WhileKeyword:
-                        case SyntaxKind.DoKeyword:
-                            if (hasKind(node.parent, SyntaxKind.WhileStatement) || hasKind(node.parent, SyntaxKind.DoStatement)) {
-                                return getLoopBreakContinueOccurrences(<IterationStatement>node.parent);
-                            }
-                            break;
-                        case SyntaxKind.ConstructorKeyword:
-                            if (hasKind(node.parent, SyntaxKind.Constructor)) {
-                                return getConstructorOccurrences(<ConstructorDeclaration>node.parent);
-                            }
-                            break;
-                        case SyntaxKind.GetKeyword:
-                        case SyntaxKind.SetKeyword:
-                            if (hasKind(node.parent, SyntaxKind.GetAccessor) || hasKind(node.parent, SyntaxKind.SetAccessor)) {
-                                return getGetAndSetOccurrences(<AccessorDeclaration>node.parent);
-                            }
-                        default:
-                            if (isModifier(node.kind) && node.parent &&
-                                (isDeclaration(node.parent) || node.parent.kind === SyntaxKind.VariableStatement)) {
-                                return getModifierOccurrences(node.kind, node.parent);
-                            }
-                    }
+                if (node.kind === SyntaxKind.StringLiteral) {
+                    start += 1;
+                    end -= 1;
                 }
 
-                return undefined;
-            }
-
-            /**
- * Aggregates all throw-statements within this node *without* crossing
- * into function boundaries and try-blocks with catch-clauses.
- */
-            function aggregateOwnedThrowStatements(node: Node): ThrowStatement[] {
-                let statementAccumulator: ThrowStatement[] = []
-                aggregate(node);
-                return statementAccumulator;
-
-                function aggregate(node: Node): void {
-                    if (node.kind === SyntaxKind.ThrowStatement) {
-                        statementAccumulator.push(<ThrowStatement>node);
-                    }
-                    else if (node.kind === SyntaxKind.TryStatement) {
-                        let tryStatement = <TryStatement>node;
-
-                        if (tryStatement.catchClause) {
-                            aggregate(tryStatement.catchClause);
-                        }
-                        else {
-                            // Exceptions thrown within a try block lacking a catch clause
-                            // are "owned" in the current context.
-                            aggregate(tryStatement.tryBlock);
-                        }
-
-                        if (tryStatement.finallyBlock) {
-                            aggregate(tryStatement.finallyBlock);
-                        }
-                    }
-                    // Do not cross function boundaries.
-                    else if (!isFunctionLike(node)) {
-                        forEachChild(node, aggregate);
-                    }
+                return {
+                    fileName: node.getSourceFile().fileName,
+                    textSpan: createTextSpanFromBounds(start, end),
+                    isDefinition: false,
+                    isWriteAccess: false,
                 };
             }
 
-            /**
-             * For lack of a better name, this function takes a throw statement and returns the
-             * nearest ancestor that is a try-block (whose try statement has a catch clause),
-             * function-block, or source file.
-             */
-            function getThrowStatementOwner(throwStatement: ThrowStatement): Node {
-                let child: Node = throwStatement;
+            function getSemanticDocumentHighlights(node: Node): DocumentHighlights[] {
+                if (node.kind === SyntaxKind.Identifier ||
+                    node.kind === SyntaxKind.ThisKeyword ||
+                    node.kind === SyntaxKind.SuperKeyword ||
+                    isLiteralNameOfPropertyDeclarationOrIndexAccess(node) ||
+                    isNameOfExternalModuleImportOrDeclaration(node)) {
 
-                while (child.parent) {
-                    let parent = child.parent;
+                    let referencedSymbols = getReferencedSymbolsForNodes(node, [node.getSourceFile()], /*searchOnlyInCurrentFile*/ true, /*findInStrings:*/ false, /*findInComments:*/ false);
+                    return convertReferencedSymbols(referencedSymbols);
+                }
 
-                    if (isFunctionBlock(parent) || parent.kind === SyntaxKind.SourceFile) {
-                        return parent;
+                return undefined;
+
+                function convertReferencedSymbols(referencedSymbols: ReferencedSymbol[]): DocumentHighlights[] {
+                    if (!referencedSymbols) {
+                        return undefined;
                     }
-                    
-                    // A throw-statement is only owned by a try-statement if the try-statement has
-                    // a catch clause, and if the throw-statement occurs within the try block.
-                    if (parent.kind === SyntaxKind.TryStatement) {
-                        let tryStatement = <TryStatement>parent;
 
-                        if (tryStatement.tryBlock === child && tryStatement.catchClause) {
-                            return child;
+                    let fileNameToDocumentHighlights: Map<DocumentHighlights> = {};
+                    let result: DocumentHighlights[] = [];
+                    for (let referencedSymbol of referencedSymbols) {
+                        for (let referenceEntry of referencedSymbol.references) {
+                            let fileName = referenceEntry.fileName;
+                            let documentHighlights = getProperty(fileNameToDocumentHighlights, fileName);
+                            if (!documentHighlights) {
+                                documentHighlights = { fileName, highlightSpans: [] };
+
+                                fileNameToDocumentHighlights[fileName] = documentHighlights;
+                                result.push(documentHighlights);
+                            }
+
+                            documentHighlights.highlightSpans.push({
+                                textSpan: referenceEntry.textSpan,
+                                isDefinition: false,
+                                isWriteAccess: referenceEntry.isWriteAccess
+                            });
                         }
                     }
 
-                    child = parent;
+                    return result;
                 }
-
-                return undefined;
             }
 
-            function aggregateAllBreakAndContinueStatements(node: Node): BreakOrContinueStatement[] {
-                let statementAccumulator: BreakOrContinueStatement[] = []
-                aggregate(node);
-                return statementAccumulator;
+            function getSyntacticDocumentHighlights(node: Node): DocumentHighlights[] {
+                let fileName = sourceFile.fileName;
 
-                function aggregate(node: Node): void {
-                    if (node.kind === SyntaxKind.BreakStatement || node.kind === SyntaxKind.ContinueStatement) {
-                        statementAccumulator.push(<BreakOrContinueStatement>node);
-                    }
-                    // Do not cross function boundaries.
-                    else if (!isFunctionLike(node)) {
-                        forEachChild(node, aggregate);
-                    }
-                };
-            }
-
-            function ownsBreakOrContinueStatement(owner: Node, statement: BreakOrContinueStatement): boolean {
-                let actualOwner = getBreakOrContinueOwner(statement);
-
-                return actualOwner && actualOwner === owner;
-            }
-
-            function getBreakOrContinueOwner(statement: BreakOrContinueStatement): Node {
-                for (let node = statement.parent; node; node = node.parent) {
-                    switch (node.kind) {
-                        case SyntaxKind.SwitchStatement:
-                            if (statement.kind === SyntaxKind.ContinueStatement) {
-                                continue;
-                            }
-                        // Fall through.
-                        case SyntaxKind.ForStatement:
-                        case SyntaxKind.ForInStatement:
-                        case SyntaxKind.ForOfStatement:
-                        case SyntaxKind.WhileStatement:
-                        case SyntaxKind.DoStatement:
-                            if (!statement.label || isLabeledBy(node, statement.label.text)) {
-                                return node;
-                            }
-                            break;
-                        default:
-                            // Don't cross function boundaries.
-                            if (isFunctionLike(node)) {
-                                return undefined;
-                            }
-                            break;
-                    }
-                }
-
-                return undefined;
-            }
-
-            function getModifierOccurrences(modifier: SyntaxKind, declaration: Node): HighlightSpan[] {
-                let container = declaration.parent;
-
-                // Make sure we only highlight the keyword when it makes sense to do so.
-                if (isAccessibilityModifier(modifier)) {
-                    if (!(container.kind === SyntaxKind.ClassDeclaration ||
-                        (declaration.kind === SyntaxKind.Parameter && hasKind(container, SyntaxKind.Constructor)))) {
-                        return undefined;
-                    }
-                }
-                else if (modifier === SyntaxKind.StaticKeyword) {
-                    if (container.kind !== SyntaxKind.ClassDeclaration) {
-                        return undefined;
-                    }
-                }
-                else if (modifier === SyntaxKind.ExportKeyword || modifier === SyntaxKind.DeclareKeyword) {
-                    if (!(container.kind === SyntaxKind.ModuleBlock || container.kind === SyntaxKind.SourceFile)) {
-                        return undefined;
-                    }
-                }
-                else { 
-                    // unsupported modifier
+                var highlightSpans = getHighlightSpans(node);
+                if (!highlightSpans || highlightSpans.length === 0) {
                     return undefined;
                 }
 
-                let keywords: Node[] = [];
-                let modifierFlag: NodeFlags = getFlagFromModifier(modifier);
+                return [{ fileName, highlightSpans }];
 
-                let nodes: Node[];
-                switch (container.kind) {
-                    case SyntaxKind.ModuleBlock:
-                    case SyntaxKind.SourceFile:
-                        nodes = (<Block>container).statements;
-                        break;
-                    case SyntaxKind.Constructor:
-                        nodes = (<Node[]>(<ConstructorDeclaration>container).parameters).concat(
-                            (<ClassDeclaration>container.parent).members);
-                        break;
-                    case SyntaxKind.ClassDeclaration:
-                        nodes = (<ClassDeclaration>container).members;
-
-                        // If we're an accessibility modifier, we're in an instance member and should search
-                        // the constructor's parameter list for instance members as well.
-                        if (modifierFlag & NodeFlags.AccessibilityModifier) {
-                            let constructor = forEach((<ClassDeclaration>container).members, member => {
-                                return member.kind === SyntaxKind.Constructor && <ConstructorDeclaration>member;
-                            });
-
-                            if (constructor) {
-                                nodes = nodes.concat(constructor.parameters);
-                            }
-                        }
-                        break;
-                    default:
-                        Debug.fail("Invalid container kind.")
+                // returns true if 'node' is defined and has a matching 'kind'.
+                function hasKind(node: Node, kind: SyntaxKind) {
+                    return node !== undefined && node.kind === kind;
                 }
 
-                forEach(nodes, node => {
-                    if (node.modifiers && node.flags & modifierFlag) {
-                        forEach(node.modifiers, child => pushKeywordIf(keywords, child, modifier));
-                    }
-                });
-
-                return map(keywords, getHighlightSpanForNode);
-
-                function getFlagFromModifier(modifier: SyntaxKind) {
-                    switch (modifier) {
-                        case SyntaxKind.PublicKeyword:
-                            return NodeFlags.Public;
-                        case SyntaxKind.PrivateKeyword:
-                            return NodeFlags.Private;
-                        case SyntaxKind.ProtectedKeyword:
-                            return NodeFlags.Protected;
-                        case SyntaxKind.StaticKeyword:
-                            return NodeFlags.Static;
-                        case SyntaxKind.ExportKeyword:
-                            return NodeFlags.Export;
-                        case SyntaxKind.DeclareKeyword:
-                            return NodeFlags.Ambient;
-                        default:
-                            Debug.fail();
-                    }
-                }
-            }
-
-            function pushKeywordIf(keywordList: Node[], token: Node, ...expected: SyntaxKind[]): boolean {
-                if (token && contains(expected, token.kind)) {
-                    keywordList.push(token);
-                    return true;
+                // Null-propagating 'parent' function.
+                function parent(node: Node): Node {
+                    return node && node.parent;
                 }
 
-                return false;
-            }
-        
-            function getGetAndSetOccurrences(accessorDeclaration: AccessorDeclaration): HighlightSpan[] {
-                let keywords: Node[] = [];
-
-                tryPushAccessorKeyword(accessorDeclaration.symbol, SyntaxKind.GetAccessor);
-                tryPushAccessorKeyword(accessorDeclaration.symbol, SyntaxKind.SetAccessor);
-
-                return map(keywords, getHighlightSpanForNode);
-
-                function tryPushAccessorKeyword(accessorSymbol: Symbol, accessorKind: SyntaxKind): void {
-                    let accessor = getDeclarationOfKind(accessorSymbol, accessorKind);
-
-                    if (accessor) {
-                        forEach(accessor.getChildren(), child => pushKeywordIf(keywords, child, SyntaxKind.GetKeyword, SyntaxKind.SetKeyword));
-                    }
-                }
-            }
-
-            function getConstructorOccurrences(constructorDeclaration: ConstructorDeclaration): HighlightSpan[] {
-                let declarations = constructorDeclaration.symbol.getDeclarations()
-
-                let keywords: Node[] = [];
-
-                forEach(declarations, declaration => {
-                    forEach(declaration.getChildren(), token => {
-                        return pushKeywordIf(keywords, token, SyntaxKind.ConstructorKeyword);
-                    });
-                });
-
-                return map(keywords, getHighlightSpanForNode);
-            }
-
-            function getLoopBreakContinueOccurrences(loopNode: IterationStatement): HighlightSpan[] {
-                let keywords: Node[] = [];
-
-                if (pushKeywordIf(keywords, loopNode.getFirstToken(), SyntaxKind.ForKeyword, SyntaxKind.WhileKeyword, SyntaxKind.DoKeyword)) {
-                    // If we succeeded and got a do-while loop, then start looking for a 'while' keyword.
-                    if (loopNode.kind === SyntaxKind.DoStatement) {
-                        let loopTokens = loopNode.getChildren();
-
-                        for (let i = loopTokens.length - 1; i >= 0; i--) {
-                            if (pushKeywordIf(keywords, loopTokens[i], SyntaxKind.WhileKeyword)) {
+                function getHighlightSpans(node: Node): HighlightSpan[] {
+                    if (node) {
+                        switch (node.kind) {
+                            case SyntaxKind.IfKeyword:
+                            case SyntaxKind.ElseKeyword:
+                                if (hasKind(node.parent, SyntaxKind.IfStatement)) {
+                                    return getIfElseOccurrences(<IfStatement>node.parent);
+                                }
                                 break;
+                            case SyntaxKind.ReturnKeyword:
+                                if (hasKind(node.parent, SyntaxKind.ReturnStatement)) {
+                                    return getReturnOccurrences(<ReturnStatement>node.parent);
+                                }
+                                break;
+                            case SyntaxKind.ThrowKeyword:
+                                if (hasKind(node.parent, SyntaxKind.ThrowStatement)) {
+                                    return getThrowOccurrences(<ThrowStatement>node.parent);
+                                }
+                                break;
+                            case SyntaxKind.CatchKeyword:
+                                if (hasKind(parent(parent(node)), SyntaxKind.TryStatement)) {
+                                    return getTryCatchFinallyOccurrences(<TryStatement>node.parent.parent);
+                                }
+                                break;
+                            case SyntaxKind.TryKeyword:
+                            case SyntaxKind.FinallyKeyword:
+                                if (hasKind(parent(node), SyntaxKind.TryStatement)) {
+                                    return getTryCatchFinallyOccurrences(<TryStatement>node.parent);
+                                }
+                                break;
+                            case SyntaxKind.SwitchKeyword:
+                                if (hasKind(node.parent, SyntaxKind.SwitchStatement)) {
+                                    return getSwitchCaseDefaultOccurrences(<SwitchStatement>node.parent);
+                                }
+                                break;
+                            case SyntaxKind.CaseKeyword:
+                            case SyntaxKind.DefaultKeyword:
+                                if (hasKind(parent(parent(parent(node))), SyntaxKind.SwitchStatement)) {
+                                    return getSwitchCaseDefaultOccurrences(<SwitchStatement>node.parent.parent.parent);
+                                }
+                                break;
+                            case SyntaxKind.BreakKeyword:
+                            case SyntaxKind.ContinueKeyword:
+                                if (hasKind(node.parent, SyntaxKind.BreakStatement) || hasKind(node.parent, SyntaxKind.ContinueStatement)) {
+                                    return getBreakOrContinueStatementOccurences(<BreakOrContinueStatement>node.parent);
+                                }
+                                break;
+                            case SyntaxKind.ForKeyword:
+                                if (hasKind(node.parent, SyntaxKind.ForStatement) ||
+                                    hasKind(node.parent, SyntaxKind.ForInStatement) ||
+                                    hasKind(node.parent, SyntaxKind.ForOfStatement)) {
+                                    return getLoopBreakContinueOccurrences(<IterationStatement>node.parent);
+                                }
+                                break;
+                            case SyntaxKind.WhileKeyword:
+                            case SyntaxKind.DoKeyword:
+                                if (hasKind(node.parent, SyntaxKind.WhileStatement) || hasKind(node.parent, SyntaxKind.DoStatement)) {
+                                    return getLoopBreakContinueOccurrences(<IterationStatement>node.parent);
+                                }
+                                break;
+                            case SyntaxKind.ConstructorKeyword:
+                                if (hasKind(node.parent, SyntaxKind.Constructor)) {
+                                    return getConstructorOccurrences(<ConstructorDeclaration>node.parent);
+                                }
+                                break;
+                            case SyntaxKind.GetKeyword:
+                            case SyntaxKind.SetKeyword:
+                                if (hasKind(node.parent, SyntaxKind.GetAccessor) || hasKind(node.parent, SyntaxKind.SetAccessor)) {
+                                    return getGetAndSetOccurrences(<AccessorDeclaration>node.parent);
+                                }
+                            default:
+                                if (isModifier(node.kind) && node.parent &&
+                                    (isDeclaration(node.parent) || node.parent.kind === SyntaxKind.VariableStatement)) {
+                                    return getModifierOccurrences(node.kind, node.parent);
+                                }
+                        }
+                    }
+
+                    return undefined;
+                }
+
+                /**
+     * Aggregates all throw-statements within this node *without* crossing
+     * into function boundaries and try-blocks with catch-clauses.
+     */
+                function aggregateOwnedThrowStatements(node: Node): ThrowStatement[] {
+                    let statementAccumulator: ThrowStatement[] = []
+                    aggregate(node);
+                    return statementAccumulator;
+
+                    function aggregate(node: Node): void {
+                        if (node.kind === SyntaxKind.ThrowStatement) {
+                            statementAccumulator.push(<ThrowStatement>node);
+                        }
+                        else if (node.kind === SyntaxKind.TryStatement) {
+                            let tryStatement = <TryStatement>node;
+
+                            if (tryStatement.catchClause) {
+                                aggregate(tryStatement.catchClause);
                             }
+                            else {
+                                // Exceptions thrown within a try block lacking a catch clause
+                                // are "owned" in the current context.
+                                aggregate(tryStatement.tryBlock);
+                            }
+
+                            if (tryStatement.finallyBlock) {
+                                aggregate(tryStatement.finallyBlock);
+                            }
+                        }
+                        // Do not cross function boundaries.
+                        else if (!isFunctionLike(node)) {
+                            forEachChild(node, aggregate);
+                        }
+                    };
+                }
+
+                /**
+                 * For lack of a better name, this function takes a throw statement and returns the
+                 * nearest ancestor that is a try-block (whose try statement has a catch clause),
+                 * function-block, or source file.
+                 */
+                function getThrowStatementOwner(throwStatement: ThrowStatement): Node {
+                    let child: Node = throwStatement;
+
+                    while (child.parent) {
+                        let parent = child.parent;
+
+                        if (isFunctionBlock(parent) || parent.kind === SyntaxKind.SourceFile) {
+                            return parent;
+                        }
+                    
+                        // A throw-statement is only owned by a try-statement if the try-statement has
+                        // a catch clause, and if the throw-statement occurs within the try block.
+                        if (parent.kind === SyntaxKind.TryStatement) {
+                            let tryStatement = <TryStatement>parent;
+
+                            if (tryStatement.tryBlock === child && tryStatement.catchClause) {
+                                return child;
+                            }
+                        }
+
+                        child = parent;
+                    }
+
+                    return undefined;
+                }
+
+                function aggregateAllBreakAndContinueStatements(node: Node): BreakOrContinueStatement[] {
+                    let statementAccumulator: BreakOrContinueStatement[] = []
+                    aggregate(node);
+                    return statementAccumulator;
+
+                    function aggregate(node: Node): void {
+                        if (node.kind === SyntaxKind.BreakStatement || node.kind === SyntaxKind.ContinueStatement) {
+                            statementAccumulator.push(<BreakOrContinueStatement>node);
+                        }
+                        // Do not cross function boundaries.
+                        else if (!isFunctionLike(node)) {
+                            forEachChild(node, aggregate);
+                        }
+                    };
+                }
+
+                function ownsBreakOrContinueStatement(owner: Node, statement: BreakOrContinueStatement): boolean {
+                    let actualOwner = getBreakOrContinueOwner(statement);
+
+                    return actualOwner && actualOwner === owner;
+                }
+
+                function getBreakOrContinueOwner(statement: BreakOrContinueStatement): Node {
+                    for (let node = statement.parent; node; node = node.parent) {
+                        switch (node.kind) {
+                            case SyntaxKind.SwitchStatement:
+                                if (statement.kind === SyntaxKind.ContinueStatement) {
+                                    continue;
+                                }
+                            // Fall through.
+                            case SyntaxKind.ForStatement:
+                            case SyntaxKind.ForInStatement:
+                            case SyntaxKind.ForOfStatement:
+                            case SyntaxKind.WhileStatement:
+                            case SyntaxKind.DoStatement:
+                                if (!statement.label || isLabeledBy(node, statement.label.text)) {
+                                    return node;
+                                }
+                                break;
+                            default:
+                                // Don't cross function boundaries.
+                                if (isFunctionLike(node)) {
+                                    return undefined;
+                                }
+                                break;
+                        }
+                    }
+
+                    return undefined;
+                }
+
+                function getModifierOccurrences(modifier: SyntaxKind, declaration: Node): HighlightSpan[] {
+                    let container = declaration.parent;
+
+                    // Make sure we only highlight the keyword when it makes sense to do so.
+                    if (isAccessibilityModifier(modifier)) {
+                        if (!(container.kind === SyntaxKind.ClassDeclaration ||
+                            (declaration.kind === SyntaxKind.Parameter && hasKind(container, SyntaxKind.Constructor)))) {
+                            return undefined;
+                        }
+                    }
+                    else if (modifier === SyntaxKind.StaticKeyword) {
+                        if (container.kind !== SyntaxKind.ClassDeclaration) {
+                            return undefined;
+                        }
+                    }
+                    else if (modifier === SyntaxKind.ExportKeyword || modifier === SyntaxKind.DeclareKeyword) {
+                        if (!(container.kind === SyntaxKind.ModuleBlock || container.kind === SyntaxKind.SourceFile)) {
+                            return undefined;
+                        }
+                    }
+                    else { 
+                        // unsupported modifier
+                        return undefined;
+                    }
+
+                    let keywords: Node[] = [];
+                    let modifierFlag: NodeFlags = getFlagFromModifier(modifier);
+
+                    let nodes: Node[];
+                    switch (container.kind) {
+                        case SyntaxKind.ModuleBlock:
+                        case SyntaxKind.SourceFile:
+                            nodes = (<Block>container).statements;
+                            break;
+                        case SyntaxKind.Constructor:
+                            nodes = (<Node[]>(<ConstructorDeclaration>container).parameters).concat(
+                                (<ClassDeclaration>container.parent).members);
+                            break;
+                        case SyntaxKind.ClassDeclaration:
+                            nodes = (<ClassDeclaration>container).members;
+
+                            // If we're an accessibility modifier, we're in an instance member and should search
+                            // the constructor's parameter list for instance members as well.
+                            if (modifierFlag & NodeFlags.AccessibilityModifier) {
+                                let constructor = forEach((<ClassDeclaration>container).members, member => {
+                                    return member.kind === SyntaxKind.Constructor && <ConstructorDeclaration>member;
+                                });
+
+                                if (constructor) {
+                                    nodes = nodes.concat(constructor.parameters);
+                                }
+                            }
+                            break;
+                        default:
+                            Debug.fail("Invalid container kind.")
+                    }
+
+                    forEach(nodes, node => {
+                        if (node.modifiers && node.flags & modifierFlag) {
+                            forEach(node.modifiers, child => pushKeywordIf(keywords, child, modifier));
+                        }
+                    });
+
+                    return map(keywords, getHighlightSpanForNode);
+
+                    function getFlagFromModifier(modifier: SyntaxKind) {
+                        switch (modifier) {
+                            case SyntaxKind.PublicKeyword:
+                                return NodeFlags.Public;
+                            case SyntaxKind.PrivateKeyword:
+                                return NodeFlags.Private;
+                            case SyntaxKind.ProtectedKeyword:
+                                return NodeFlags.Protected;
+                            case SyntaxKind.StaticKeyword:
+                                return NodeFlags.Static;
+                            case SyntaxKind.ExportKeyword:
+                                return NodeFlags.Export;
+                            case SyntaxKind.DeclareKeyword:
+                                return NodeFlags.Ambient;
+                            default:
+                                Debug.fail();
                         }
                     }
                 }
 
-                let breaksAndContinues = aggregateAllBreakAndContinueStatements(loopNode.statement);
-
-                forEach(breaksAndContinues, statement => {
-                    if (ownsBreakOrContinueStatement(loopNode, statement)) {
-                        pushKeywordIf(keywords, statement.getFirstToken(), SyntaxKind.BreakKeyword, SyntaxKind.ContinueKeyword);
+                function pushKeywordIf(keywordList: Node[], token: Node, ...expected: SyntaxKind[]): boolean {
+                    if (token && contains(expected, token.kind)) {
+                        keywordList.push(token);
+                        return true;
                     }
-                });
 
-                return map(keywords, getHighlightSpanForNode);
-            }
+                    return false;
+                }
 
-            function getBreakOrContinueStatementOccurences(breakOrContinueStatement: BreakOrContinueStatement): HighlightSpan[] {
-                let owner = getBreakOrContinueOwner(breakOrContinueStatement);
+                function getGetAndSetOccurrences(accessorDeclaration: AccessorDeclaration): HighlightSpan[] {
+                    let keywords: Node[] = [];
 
-                if (owner) {
-                    switch (owner.kind) {
-                        case SyntaxKind.ForStatement:
-                        case SyntaxKind.ForInStatement:
-                        case SyntaxKind.ForOfStatement:
-                        case SyntaxKind.DoStatement:
-                        case SyntaxKind.WhileStatement:
-                            return getLoopBreakContinueOccurrences(<IterationStatement>owner)
-                        case SyntaxKind.SwitchStatement:
-                            return getSwitchCaseDefaultOccurrences(<SwitchStatement>owner);
+                    tryPushAccessorKeyword(accessorDeclaration.symbol, SyntaxKind.GetAccessor);
+                    tryPushAccessorKeyword(accessorDeclaration.symbol, SyntaxKind.SetAccessor);
 
+                    return map(keywords, getHighlightSpanForNode);
+
+                    function tryPushAccessorKeyword(accessorSymbol: Symbol, accessorKind: SyntaxKind): void {
+                        let accessor = getDeclarationOfKind(accessorSymbol, accessorKind);
+
+                        if (accessor) {
+                            forEach(accessor.getChildren(), child => pushKeywordIf(keywords, child, SyntaxKind.GetKeyword, SyntaxKind.SetKeyword));
+                        }
                     }
                 }
 
-                return undefined;
-            }
+                function getConstructorOccurrences(constructorDeclaration: ConstructorDeclaration): HighlightSpan[] {
+                    let declarations = constructorDeclaration.symbol.getDeclarations()
 
-            function getSwitchCaseDefaultOccurrences(switchStatement: SwitchStatement): HighlightSpan[] {
-                let keywords: Node[] = [];
+                    let keywords: Node[] = [];
 
-                pushKeywordIf(keywords, switchStatement.getFirstToken(), SyntaxKind.SwitchKeyword);
+                    forEach(declarations, declaration => {
+                        forEach(declaration.getChildren(), token => {
+                            return pushKeywordIf(keywords, token, SyntaxKind.ConstructorKeyword);
+                        });
+                    });
 
-                // Go through each clause in the switch statement, collecting the 'case'/'default' keywords.
-                forEach(switchStatement.caseBlock.clauses, clause => {
-                    pushKeywordIf(keywords, clause.getFirstToken(), SyntaxKind.CaseKeyword, SyntaxKind.DefaultKeyword);
+                    return map(keywords, getHighlightSpanForNode);
+                }
 
-                    let breaksAndContinues = aggregateAllBreakAndContinueStatements(clause);
+                function getLoopBreakContinueOccurrences(loopNode: IterationStatement): HighlightSpan[] {
+                    let keywords: Node[] = [];
+
+                    if (pushKeywordIf(keywords, loopNode.getFirstToken(), SyntaxKind.ForKeyword, SyntaxKind.WhileKeyword, SyntaxKind.DoKeyword)) {
+                        // If we succeeded and got a do-while loop, then start looking for a 'while' keyword.
+                        if (loopNode.kind === SyntaxKind.DoStatement) {
+                            let loopTokens = loopNode.getChildren();
+
+                            for (let i = loopTokens.length - 1; i >= 0; i--) {
+                                if (pushKeywordIf(keywords, loopTokens[i], SyntaxKind.WhileKeyword)) {
+                                    break;
+                                }
+                            }
+                        }
+                    }
+
+                    let breaksAndContinues = aggregateAllBreakAndContinueStatements(loopNode.statement);
 
                     forEach(breaksAndContinues, statement => {
-                        if (ownsBreakOrContinueStatement(switchStatement, statement)) {
-                            pushKeywordIf(keywords, statement.getFirstToken(), SyntaxKind.BreakKeyword);
+                        if (ownsBreakOrContinueStatement(loopNode, statement)) {
+                            pushKeywordIf(keywords, statement.getFirstToken(), SyntaxKind.BreakKeyword, SyntaxKind.ContinueKeyword);
                         }
                     });
-                });
 
-                return map(keywords, getHighlightSpanForNode);
-            }
-
-            function getTryCatchFinallyOccurrences(tryStatement: TryStatement): HighlightSpan[] {
-                let keywords: Node[] = [];
-
-                pushKeywordIf(keywords, tryStatement.getFirstToken(), SyntaxKind.TryKeyword);
-
-                if (tryStatement.catchClause) {
-                    pushKeywordIf(keywords, tryStatement.catchClause.getFirstToken(), SyntaxKind.CatchKeyword);
+                    return map(keywords, getHighlightSpanForNode);
                 }
 
-                if (tryStatement.finallyBlock) {
-                    let finallyKeyword = findChildOfKind(tryStatement, SyntaxKind.FinallyKeyword, sourceFile);
-                    pushKeywordIf(keywords, finallyKeyword, SyntaxKind.FinallyKeyword);
-                }
+                function getBreakOrContinueStatementOccurences(breakOrContinueStatement: BreakOrContinueStatement): HighlightSpan[] {
+                    let owner = getBreakOrContinueOwner(breakOrContinueStatement);
 
-                return map(keywords, getHighlightSpanForNode);
-            }
+                    if (owner) {
+                        switch (owner.kind) {
+                            case SyntaxKind.ForStatement:
+                            case SyntaxKind.ForInStatement:
+                            case SyntaxKind.ForOfStatement:
+                            case SyntaxKind.DoStatement:
+                            case SyntaxKind.WhileStatement:
+                                return getLoopBreakContinueOccurrences(<IterationStatement>owner)
+                            case SyntaxKind.SwitchStatement:
+                                return getSwitchCaseDefaultOccurrences(<SwitchStatement>owner);
 
-            function getThrowOccurrences(throwStatement: ThrowStatement): HighlightSpan[] {
-                let owner = getThrowStatementOwner(throwStatement);
+                        }
+                    }
 
-                if (!owner) {
                     return undefined;
                 }
 
-                let keywords: Node[] = [];
+                function getSwitchCaseDefaultOccurrences(switchStatement: SwitchStatement): HighlightSpan[] {
+                    let keywords: Node[] = [];
 
-                forEach(aggregateOwnedThrowStatements(owner), throwStatement => {
-                    pushKeywordIf(keywords, throwStatement.getFirstToken(), SyntaxKind.ThrowKeyword);
-                });
+                    pushKeywordIf(keywords, switchStatement.getFirstToken(), SyntaxKind.SwitchKeyword);
 
-                // If the "owner" is a function, then we equate 'return' and 'throw' statements in their
-                // ability to "jump out" of the function, and include occurrences for both.
-                if (isFunctionBlock(owner)) {
-                    forEachReturnStatement(<Block>owner, returnStatement => {
+                    // Go through each clause in the switch statement, collecting the 'case'/'default' keywords.
+                    forEach(switchStatement.caseBlock.clauses, clause => {
+                        pushKeywordIf(keywords, clause.getFirstToken(), SyntaxKind.CaseKeyword, SyntaxKind.DefaultKeyword);
+
+                        let breaksAndContinues = aggregateAllBreakAndContinueStatements(clause);
+
+                        forEach(breaksAndContinues, statement => {
+                            if (ownsBreakOrContinueStatement(switchStatement, statement)) {
+                                pushKeywordIf(keywords, statement.getFirstToken(), SyntaxKind.BreakKeyword);
+                            }
+                        });
+                    });
+
+                    return map(keywords, getHighlightSpanForNode);
+                }
+
+                function getTryCatchFinallyOccurrences(tryStatement: TryStatement): HighlightSpan[] {
+                    let keywords: Node[] = [];
+
+                    pushKeywordIf(keywords, tryStatement.getFirstToken(), SyntaxKind.TryKeyword);
+
+                    if (tryStatement.catchClause) {
+                        pushKeywordIf(keywords, tryStatement.catchClause.getFirstToken(), SyntaxKind.CatchKeyword);
+                    }
+
+                    if (tryStatement.finallyBlock) {
+                        let finallyKeyword = findChildOfKind(tryStatement, SyntaxKind.FinallyKeyword, sourceFile);
+                        pushKeywordIf(keywords, finallyKeyword, SyntaxKind.FinallyKeyword);
+                    }
+
+                    return map(keywords, getHighlightSpanForNode);
+                }
+
+                function getThrowOccurrences(throwStatement: ThrowStatement): HighlightSpan[] {
+                    let owner = getThrowStatementOwner(throwStatement);
+
+                    if (!owner) {
+                        return undefined;
+                    }
+
+                    let keywords: Node[] = [];
+
+                    forEach(aggregateOwnedThrowStatements(owner), throwStatement => {
+                        pushKeywordIf(keywords, throwStatement.getFirstToken(), SyntaxKind.ThrowKeyword);
+                    });
+
+                    // If the "owner" is a function, then we equate 'return' and 'throw' statements in their
+                    // ability to "jump out" of the function, and include occurrences for both.
+                    if (isFunctionBlock(owner)) {
+                        forEachReturnStatement(<Block>owner, returnStatement => {
+                            pushKeywordIf(keywords, returnStatement.getFirstToken(), SyntaxKind.ReturnKeyword);
+                        });
+                    }
+
+                    return map(keywords, getHighlightSpanForNode);
+                }
+
+                function getReturnOccurrences(returnStatement: ReturnStatement): HighlightSpan[] {
+                    let func = <FunctionLikeDeclaration>getContainingFunction(returnStatement);
+
+                    // If we didn't find a containing function with a block body, bail out.
+                    if (!(func && hasKind(func.body, SyntaxKind.Block))) {
+                        return undefined;
+                    }
+
+                    let keywords: Node[] = []
+                    forEachReturnStatement(<Block>func.body, returnStatement => {
                         pushKeywordIf(keywords, returnStatement.getFirstToken(), SyntaxKind.ReturnKeyword);
                     });
+
+                    // Include 'throw' statements that do not occur within a try block.
+                    forEach(aggregateOwnedThrowStatements(func.body), throwStatement => {
+                        pushKeywordIf(keywords, throwStatement.getFirstToken(), SyntaxKind.ThrowKeyword);
+                    });
+
+                    return map(keywords, getHighlightSpanForNode);
                 }
 
-                return map(keywords, getHighlightSpanForNode);
-            }
+                function getIfElseOccurrences(ifStatement: IfStatement): HighlightSpan[] {
+                    let keywords: Node[] = [];
 
-            function getReturnOccurrences(returnStatement: ReturnStatement): HighlightSpan[] {
-                let func = <FunctionLikeDeclaration>getContainingFunction(returnStatement);
-
-                // If we didn't find a containing function with a block body, bail out.
-                if (!(func && hasKind(func.body, SyntaxKind.Block))) {
-                    return undefined;
-                }
-
-                let keywords: Node[] = []
-                forEachReturnStatement(<Block>func.body, returnStatement => {
-                    pushKeywordIf(keywords, returnStatement.getFirstToken(), SyntaxKind.ReturnKeyword);
-                });
-
-                // Include 'throw' statements that do not occur within a try block.
-                forEach(aggregateOwnedThrowStatements(func.body), throwStatement => {
-                    pushKeywordIf(keywords, throwStatement.getFirstToken(), SyntaxKind.ThrowKeyword);
-                });
-
-                return map(keywords, getHighlightSpanForNode);
-            }
-
-            function getIfElseOccurrences(ifStatement: IfStatement): HighlightSpan[] {
-                let keywords: Node[] = [];
-
-                // Traverse upwards through all parent if-statements linked by their else-branches.
-                while (hasKind(ifStatement.parent, SyntaxKind.IfStatement) && (<IfStatement>ifStatement.parent).elseStatement === ifStatement) {
-                    ifStatement = <IfStatement>ifStatement.parent;
-                }
-
-                // Now traverse back down through the else branches, aggregating if/else keywords of if-statements.
-                while (ifStatement) {
-                    let children = ifStatement.getChildren();
-                    pushKeywordIf(keywords, children[0], SyntaxKind.IfKeyword);
-
-                    // Generally the 'else' keyword is second-to-last, so we traverse backwards.
-                    for (let i = children.length - 1; i >= 0; i--) {
-                        if (pushKeywordIf(keywords, children[i], SyntaxKind.ElseKeyword)) {
-                            break;
-                        }
+                    // Traverse upwards through all parent if-statements linked by their else-branches.
+                    while (hasKind(ifStatement.parent, SyntaxKind.IfStatement) && (<IfStatement>ifStatement.parent).elseStatement === ifStatement) {
+                        ifStatement = <IfStatement>ifStatement.parent;
                     }
 
-                    if (!hasKind(ifStatement.elseStatement, SyntaxKind.IfStatement)) {
-                        break
-                    }
+                    // Now traverse back down through the else branches, aggregating if/else keywords of if-statements.
+                    while (ifStatement) {
+                        let children = ifStatement.getChildren();
+                        pushKeywordIf(keywords, children[0], SyntaxKind.IfKeyword);
 
-                    ifStatement = <IfStatement>ifStatement.elseStatement;
-                }
-
-                let result: HighlightSpan[] = [];
-
-                // We'd like to highlight else/ifs together if they are only separated by whitespace
-                // (i.e. the keywords are separated by no comments, no newlines).
-                for (let i = 0; i < keywords.length; i++) {
-                    if (keywords[i].kind === SyntaxKind.ElseKeyword && i < keywords.length - 1) {
-                        let elseKeyword = keywords[i];
-                        let ifKeyword = keywords[i + 1]; // this *should* always be an 'if' keyword.
-
-                        let shouldHighlightNextKeyword = true;
-
-                        // Avoid recalculating getStart() by iterating backwards.
-                        for (let j = ifKeyword.getStart() - 1; j >= elseKeyword.end; j--) {
-                            if (!isWhiteSpace(sourceFile.text.charCodeAt(j))) {
-                                shouldHighlightNextKeyword = false;
+                        // Generally the 'else' keyword is second-to-last, so we traverse backwards.
+                        for (let i = children.length - 1; i >= 0; i--) {
+                            if (pushKeywordIf(keywords, children[i], SyntaxKind.ElseKeyword)) {
                                 break;
                             }
                         }
 
-                        if (shouldHighlightNextKeyword) {
-                            result.push({
-                                fileName: fileName,
-                                textSpan: createTextSpanFromBounds(elseKeyword.getStart(), ifKeyword.end),
-                                isDefinition: false
-                            });
-                            i++; // skip the next keyword
-                            continue;
+                        if (!hasKind(ifStatement.elseStatement, SyntaxKind.IfStatement)) {
+                            break
                         }
+
+                        ifStatement = <IfStatement>ifStatement.elseStatement;
                     }
 
-                    // Ordinary case: just highlight the keyword.
-                    result.push(getHighlightSpanForNode(keywords[i]));
-                }
+                    let result: HighlightSpan[] = [];
 
-                return result;
+                    // We'd like to highlight else/ifs together if they are only separated by whitespace
+                    // (i.e. the keywords are separated by no comments, no newlines).
+                    for (let i = 0; i < keywords.length; i++) {
+                        if (keywords[i].kind === SyntaxKind.ElseKeyword && i < keywords.length - 1) {
+                            let elseKeyword = keywords[i];
+                            let ifKeyword = keywords[i + 1]; // this *should* always be an 'if' keyword.
+
+                            let shouldHighlightNextKeyword = true;
+
+                            // Avoid recalculating getStart() by iterating backwards.
+                            for (let j = ifKeyword.getStart() - 1; j >= elseKeyword.end; j--) {
+                                if (!isWhiteSpace(sourceFile.text.charCodeAt(j))) {
+                                    shouldHighlightNextKeyword = false;
+                                    break;
+                                }
+                            }
+
+                            if (shouldHighlightNextKeyword) {
+                                result.push({
+                                    fileName: fileName,
+                                    textSpan: createTextSpanFromBounds(elseKeyword.getStart(), ifKeyword.end),
+                                    isDefinition: false,
+                                    isWriteAccess: false,
+                                });
+                                i++; // skip the next keyword
+                                continue;
+                            }
+                        }
+
+                        // Ordinary case: just highlight the keyword.
+                        result.push(getHighlightSpanForNode(keywords[i]));
+                    }
+
+                    return result;
+                }
             }
         }
 
@@ -4539,38 +4600,26 @@ module ts {
         function getOccurrencesAtPositionCore(fileName: string, position: number): ReferenceEntry[] {
             synchronizeHostData();
 
-            let sourceFile = getValidSourceFile(fileName);
+            return convertDocumentHighlights(getDocumentHighlights(fileName, position));
 
-            let node = getTouchingWord(sourceFile, position);
-            if (!node) {
-                return undefined;
-            }
-
-            if (node.kind === SyntaxKind.Identifier || node.kind === SyntaxKind.ThisKeyword || node.kind === SyntaxKind.SuperKeyword ||
-                isLiteralNameOfPropertyDeclarationOrIndexAccess(node) || isNameOfExternalModuleImportOrDeclaration(node)) {
-                return convertReferences(getReferencesForNode(node, [sourceFile], /*searchOnlyInCurrentFile*/ true, /*findInStrings:*/ false, /*findInComments:*/ false));
-            }
-
-            return convertDocumentHighlights(getSyntacticDocumentHighlights(node));
-        }
-
-        function convertDocumentHighlights(documentHighlights: DocumentHighlights[]): ReferenceEntry[] {
-            if (!documentHighlights) {
-                return undefined;
-            }
-
-            let result: ReferenceEntry[] = [];
-            for (let entry of documentHighlights) {
-                for (let highlightSpan of entry.highlightSpans) {
-                    result.push({
-                        fileName: entry.fileName,
-                        textSpan: highlightSpan.textSpan,
-                        isWriteAccess: false
-                    });
+            function convertDocumentHighlights(documentHighlights: DocumentHighlights[]): ReferenceEntry[] {
+                if (!documentHighlights) {
+                    return undefined;
                 }
-            }
 
-            return result;
+                let result: ReferenceEntry[] = [];
+                for (let entry of documentHighlights) {
+                    for (let highlightSpan of entry.highlightSpans) {
+                        result.push({
+                            fileName: entry.fileName,
+                            textSpan: highlightSpan.textSpan,
+                            isWriteAccess: highlightSpan.isWriteAccess
+                        });
+                    }
+                }
+
+                return result;
+            }
         }
 
         function convertReferences(referenceSymbols: ReferencedSymbol[]): ReferenceEntry[] {
@@ -4624,10 +4673,10 @@ module ts {
             }
 
             Debug.assert(node.kind === SyntaxKind.Identifier || node.kind === SyntaxKind.NumericLiteral || node.kind === SyntaxKind.StringLiteral);
-            return getReferencesForNode(node, program.getSourceFiles(), /*searchOnlyInCurrentFile*/ false, findInStrings, findInComments);
+            return getReferencedSymbolsForNodes(node, program.getSourceFiles(), /*searchOnlyInCurrentFile*/ false, findInStrings, findInComments);
         }
 
-        function getReferencesForNode(node: Node, sourceFiles: SourceFile[], searchOnlyInCurrentFile: boolean, findInStrings: boolean, findInComments: boolean): ReferencedSymbol[]{
+        function getReferencedSymbolsForNodes(node: Node, sourceFiles: SourceFile[], searchOnlyInCurrentFile: boolean, findInStrings: boolean, findInComments: boolean): ReferencedSymbol[]{
             // Labels
             if (isLabelName(node)) {
                 if (isJumpStatementTarget(node)) {
@@ -5405,23 +5454,6 @@ module ts {
                 }
                 return meaning;
             }
-        }
-
-        function getHighlightSpanForNode(node: Node): HighlightSpan {
-            let start = node.getStart();
-            let end = node.getEnd();
-
-            if (node.kind === SyntaxKind.StringLiteral) {
-                start += 1;
-                end -= 1;
-            }
-
-            return {
-                fileName: node.getSourceFile().fileName,
-                textSpan: createTextSpanFromBounds(start, end),
-                isDefinition: false
-            };
-
         }
 
         function getReferenceEntryFromNode(node: Node): ReferenceEntry {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1020,6 +1020,7 @@ module ts {
     }
 
     export class DocumentHighlightKind {
+        public static none = "none";
         public static definition = "definition";
         public static reference = "reference";
         public static writtenReference = "writtenReference";
@@ -4009,7 +4010,7 @@ module ts {
                 return {
                     fileName: sourceFile.fileName,
                     textSpan: createTextSpanFromBounds(start, end),
-                    kind: DocumentHighlightKind.reference
+                    kind: DocumentHighlightKind.none
                 };
             }
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -4154,9 +4154,9 @@ module ts {
                 }
 
                 /**
-     * Aggregates all throw-statements within this node *without* crossing
-     * into function boundaries and try-blocks with catch-clauses.
-     */
+                 * Aggregates all throw-statements within this node *without* crossing
+                 * into function boundaries and try-blocks with catch-clauses.
+                 */
                 function aggregateOwnedThrowStatements(node: Node): ThrowStatement[] {
                     let statementAccumulator: ThrowStatement[] = []
                     aggregate(node);
@@ -4562,17 +4562,17 @@ module ts {
                             let elseKeyword = keywords[i];
                             let ifKeyword = keywords[i + 1]; // this *should* always be an 'if' keyword.
 
-                            let shouldHighlightNextKeyword = true;
+                            let shouldCombindElseAndIf = true;
 
                             // Avoid recalculating getStart() by iterating backwards.
                             for (let j = ifKeyword.getStart() - 1; j >= elseKeyword.end; j--) {
                                 if (!isWhiteSpace(sourceFile.text.charCodeAt(j))) {
-                                    shouldHighlightNextKeyword = false;
+                                    shouldCombindElseAndIf = false;
                                     break;
                                 }
                             }
 
-                            if (shouldHighlightNextKeyword) {
+                            if (shouldCombindElseAndIf) {
                                 result.push({
                                     fileName: fileName,
                                     textSpan: createTextSpanFromBounds(elseKeyword.getStart(), ifKeyword.end),

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1019,10 +1019,15 @@ module ts {
         highlightSpans: HighlightSpan[];
     }
 
+    export class DocumentHighlightKind {
+        public static definition = "definition";
+        public static reference = "reference";
+        public static writtenReference = "writtenReference";
+    } 
+
     export interface HighlightSpan {
         textSpan: TextSpan;
-        isDefinition: boolean;
-        isWriteAccess: boolean;
+        kind: string;
     }
 
     export interface NavigateToItem {
@@ -4004,8 +4009,7 @@ module ts {
                 return {
                     fileName: sourceFile.fileName,
                     textSpan: createTextSpanFromBounds(start, end),
-                    isDefinition: false,
-                    isWriteAccess: false,
+                    kind: DocumentHighlightKind.reference
                 };
             }
 
@@ -4042,8 +4046,7 @@ module ts {
 
                             documentHighlights.highlightSpans.push({
                                 textSpan: referenceEntry.textSpan,
-                                isDefinition: false,
-                                isWriteAccess: referenceEntry.isWriteAccess
+                                kind: referenceEntry.isWriteAccess ? DocumentHighlightKind.writtenReference : DocumentHighlightKind.reference
                             });
                         }
                     }
@@ -4576,8 +4579,7 @@ module ts {
                                 result.push({
                                     fileName: fileName,
                                     textSpan: createTextSpanFromBounds(elseKeyword.getStart(), ifKeyword.end),
-                                    isDefinition: false,
-                                    isWriteAccess: false,
+                                    kind: DocumentHighlightKind.reference
                                 });
                                 i++; // skip the next keyword
                                 continue;
@@ -4610,7 +4612,7 @@ module ts {
                         result.push({
                             fileName: entry.fileName,
                             textSpan: highlightSpan.textSpan,
-                            isWriteAccess: highlightSpan.isWriteAccess
+                            isWriteAccess: highlightSpan.kind === DocumentHighlightKind.writtenReference
                         });
                     }
                 }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -3999,11 +3999,6 @@ module ts {
                 let start = node.getStart();
                 let end = node.getEnd();
 
-                if (node.kind === SyntaxKind.StringLiteral) {
-                    start += 1;
-                    end -= 1;
-                }
-
                 return {
                     fileName: node.getSourceFile().fileName,
                     textSpan: createTextSpanFromBounds(start, end),

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1019,11 +1019,11 @@ module ts {
         highlightSpans: HighlightSpan[];
     }
 
-    export class DocumentHighlightKind {
-        public static none = "none";
-        public static definition = "definition";
-        public static reference = "reference";
-        public static writtenReference = "writtenReference";
+    export module DocumentHighlightKind {
+        export const none = "none";
+        export const definition = "definition";
+        export const reference = "reference";
+        export const writtenReference = "writtenReference";
     } 
 
     export interface HighlightSpan {
@@ -1335,92 +1335,92 @@ module ts {
     }
 
     // TODO: move these to enums
-    export class ScriptElementKind {
-        static unknown = "";
-        static warning = "warning";
+    export module ScriptElementKind {
+        export const unknown = "";
+        export const warning = "warning";
 
         // predefined type (void) or keyword (class)
-        static keyword = "keyword";
+        export const keyword = "keyword";
 
         // top level script node
-        static scriptElement = "script";
+        export const scriptElement = "script";
 
         // module foo {}
-        static moduleElement = "module";
+        export const moduleElement = "module";
 
         // class X {}
-        static classElement = "class";
+        export const classElement = "class";
 
         // interface Y {}
-        static interfaceElement = "interface";
+        export const interfaceElement = "interface";
 
         // type T = ...
-        static typeElement = "type";
+        export const typeElement = "type";
 
         // enum E
-        static enumElement = "enum";
+        export const enumElement = "enum";
 
         // Inside module and script only
         // let v = ..
-        static variableElement = "var";
+        export const variableElement = "var";
 
         // Inside function
-        static localVariableElement = "local var";
+        export const localVariableElement = "local var";
 
         // Inside module and script only
         // function f() { }
-        static functionElement = "function";
+        export const functionElement = "function";
 
         // Inside function
-        static localFunctionElement = "local function";
+        export const localFunctionElement = "local function";
 
         // class X { [public|private]* foo() {} }
-        static memberFunctionElement = "method";
+        export const memberFunctionElement = "method";
 
         // class X { [public|private]* [get|set] foo:number; }
-        static memberGetAccessorElement = "getter";
-        static memberSetAccessorElement = "setter";
+        export const memberGetAccessorElement = "getter";
+        export const memberSetAccessorElement = "setter";
 
         // class X { [public|private]* foo:number; }
         // interface Y { foo:number; }
-        static memberVariableElement = "property";
+        export const memberVariableElement = "property";
 
         // class X { constructor() { } }
-        static constructorImplementationElement = "constructor";
+        export const constructorImplementationElement = "constructor";
 
         // interface Y { ():number; }
-        static callSignatureElement = "call";
+        export const callSignatureElement = "call";
 
         // interface Y { []:number; }
-        static indexSignatureElement = "index";
+        export const indexSignatureElement = "index";
 
         // interface Y { new():Y; }
-        static constructSignatureElement = "construct";
+        export const constructSignatureElement = "construct";
 
         // function foo(*Y*: string)
-        static parameterElement = "parameter";
+        export const parameterElement = "parameter";
 
-        static typeParameterElement = "type parameter";
+        export const typeParameterElement = "type parameter";
 
-        static primitiveType = "primitive type";
+        export const primitiveType = "primitive type";
 
-        static label = "label";
+        export const label = "label";
 
-        static alias = "alias";
+        export const alias = "alias";
 
-        static constElement = "const";
+        export const constElement = "const";
 
-        static letElement = "let";
+        export const letElement = "let";
     }
 
-    export class ScriptElementKindModifier {
-        static none = "";
-        static publicMemberModifier = "public";
-        static privateMemberModifier = "private";
-        static protectedMemberModifier = "protected";
-        static exportedModifier = "export";
-        static ambientModifier = "declare";
-        static staticModifier = "static";
+    export module ScriptElementKindModifier {
+        export const none = "";
+        export const publicMemberModifier = "public";
+        export const privateMemberModifier = "private";
+        export const protectedMemberModifier = "protected";
+        export const exportedModifier = "export";
+        export const ambientModifier = "declare";
+        export const staticModifier = "static";
     }
 
     export class ClassificationTypeNames {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -4000,7 +4000,7 @@ module ts {
                 let end = node.getEnd();
 
                 return {
-                    fileName: node.getSourceFile().fileName,
+                    fileName: sourceFile.fileName,
                     textSpan: createTextSpanFromBounds(start, end),
                     isDefinition: false,
                     isWriteAccess: false,

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -144,8 +144,11 @@ module ts {
         /**
          * Returns a JSON-encoded value of the type:
          * { fileName: string; highlights: { start: number; length: number, isDefinition: boolean }[] }[]
+         * 
+         * @param fileToSearch A JSON encoded string[] containing the file names that should be 
+         *  considered when searching.
          */
-        getDocumentHighlights(fileName: string, position: number): string;
+        getDocumentHighlights(fileName: string, position: number, filesToSearch: string): string;
 
         /**
          * Returns a JSON-encoded value of the type:
@@ -597,11 +600,11 @@ module ts {
                 });
         }
 
-        public getDocumentHighlights(fileName: string, position: number): string {
+        public getDocumentHighlights(fileName: string, position: number, filesToSearch: string): string {
             return this.forwardJSONCall(
                 "getDocumentHighlights('" + fileName + "', " + position + ")",
                 () => {
-                    return this.languageService.getDocumentHighlights(fileName, position);
+                    return this.languageService.getDocumentHighlights(fileName, position, JSON.parse(filesToSearch));
                 });
         }
 

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -135,10 +135,17 @@ module ts {
         findReferences(fileName: string, position: number): string;
 
         /**
+         * @deprecated
          * Returns a JSON-encoded value of the type:
          * { fileName: string; textSpan: { start: number; length: number}; isWriteAccess: boolean }[]
          */
         getOccurrencesAtPosition(fileName: string, position: number): string;
+
+        /**
+         * Returns a JSON-encoded value of the type:
+         * { fileName: string; highlights: { start: number; length: number, isDefinition: boolean }[] }[]
+         */
+        getDocumentHighlights(fileName: string, position: number): string;
 
         /**
          * Returns a JSON-encoded value of the type:
@@ -587,6 +594,14 @@ module ts {
                 "getOccurrencesAtPosition('" + fileName + "', " + position + ")",
                 () => {
                     return this.languageService.getOccurrencesAtPosition(fileName, position);
+                });
+        }
+
+        public getDocumentHighlights(fileName: string, position: number): string {
+            return this.forwardJSONCall(
+                "getDocumentHighlights('" + fileName + "', " + position + ")",
+                () => {
+                    return this.languageService.getDocumentHighlights(fileName, position);
                 });
         }
 


### PR DESCRIPTION
Also, deprecate getOccurrences and replace it with an appropriate getDocumentHighlights API that matches the Roslyn API and properly handles highlights across multiple files.