### PR TITLE
Emit generator functions and yield expressions in ES6.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7340,7 +7340,7 @@ module ts {
 
         function checkFunctionExpressionOrObjectLiteralMethodBody(node: FunctionExpression | MethodDeclaration) {
             Debug.assert(node.kind !== SyntaxKind.MethodDeclaration || isObjectLiteralMethod(node));
-            if (node.type) {
+            if (node.type && !node.asteriskToken) {
                 checkIfNonVoidFunctionHasReturnExpressionsOrSingleThrowStatment(node, getTypeFromTypeNodeOrHeritageClauseElement(node.type));
             }
 
@@ -8906,7 +8906,7 @@ module ts {
             }
 
             checkSourceElement(node.body);
-            if (node.type && !isAccessor(node.kind)) {
+            if (node.type && !isAccessor(node.kind) && !node.asteriskToken) {
                 checkIfNonVoidFunctionHasReturnExpressionsOrSingleThrowStatment(node, getTypeFromTypeNodeOrHeritageClauseElement(node.type));
             }
 

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1097,6 +1097,7 @@ var __param = this.__param || function(index, decorator) { return function (targ
                                 default:
                                     return Comparison.LessThan;
                             }
+                        case SyntaxKind.YieldExpression:
                         case SyntaxKind.ConditionalExpression:
                             return Comparison.LessThan;
                         default:
@@ -1303,6 +1304,17 @@ var __param = this.__param || function(index, decorator) { return function (targ
             function emitSpreadElementExpression(node: SpreadElementExpression) {
                 write("...");
                 emit((<SpreadElementExpression>node).expression);
+            }
+
+            function emitYieldExpression(node: YieldExpression) {
+                write(tokenToString(SyntaxKind.YieldKeyword));
+                if (node.asteriskToken) {
+                    write("*");
+                }
+                if (node.expression) {
+                    write(" ");
+                    emit(node.expression);
+                }
             }
 
             function needsParenthesisForPropertyAccessOrInvocation(node: Expression) {
@@ -1601,6 +1613,10 @@ var __param = this.__param || function(index, decorator) { return function (targ
             }
 
             function emitMethod(node: MethodDeclaration) {
+                if (languageVersion >= ScriptTarget.ES6 && node.asteriskToken) {
+                    write("*");
+                }
+
                 emit(node.name, /*allowGeneratedIdentifiers*/ false);
                 if (languageVersion < ScriptTarget.ES6) {
                     write(": function ");
@@ -2960,7 +2976,12 @@ var __param = this.__param || function(index, decorator) { return function (targ
                             write("default ");
                         }
                     }
-                    write("function ");
+
+                    write("function");
+                    if (languageVersion >= ScriptTarget.ES6 && node.asteriskToken) {
+                        write("*");
+                    }
+                    write(" ");
                 }
 
                 if (shouldEmitFunctionName(node)) {
@@ -3343,6 +3364,9 @@ var __param = this.__param || function(index, decorator) { return function (targ
                         }
                         else if (member.kind === SyntaxKind.SetAccessor) {
                             write("set ");
+                        }
+                        if ((<MethodDeclaration>member).asteriskToken) {
+                            write("*");
                         }
                         emit((<MethodDeclaration>member).name);
                         emitSignatureAndBody(<MethodDeclaration>member);
@@ -4922,6 +4946,8 @@ var __param = this.__param || function(index, decorator) { return function (targ
                         return emitConditionalExpression(<ConditionalExpression>node);
                     case SyntaxKind.SpreadElementExpression:
                         return emitSpreadElementExpression(<SpreadElementExpression>node);
+                    case SyntaxKind.YieldExpression:
+                        return emitYieldExpression(<YieldExpression>node);
                     case SyntaxKind.OmittedExpression:
                         return;
                     case SyntaxKind.Block:

--- a/tests/baselines/reference/FunctionDeclaration9_es6.js
+++ b/tests/baselines/reference/FunctionDeclaration9_es6.js
@@ -5,6 +5,6 @@ function * foo() {
 
 //// [FunctionDeclaration9_es6.js]
 function foo() {
-    var v = (_a = {}, _a[] = foo, _a);
+    var v = (_a = {}, _a[yield] = foo, _a);
     var _a;
 }

--- a/tests/baselines/reference/YieldExpression10_es6.js
+++ b/tests/baselines/reference/YieldExpression10_es6.js
@@ -7,6 +7,6 @@ var v = { * foo() {
 
 //// [YieldExpression10_es6.js]
 var v = { foo: function () {
-        ;
+        yield (foo);
     }
 };

--- a/tests/baselines/reference/YieldExpression11_es6.js
+++ b/tests/baselines/reference/YieldExpression11_es6.js
@@ -10,7 +10,7 @@ var C = (function () {
     function C() {
     }
     C.prototype.foo = function () {
-        ;
+        yield (foo);
     };
     return C;
 })();

--- a/tests/baselines/reference/YieldExpression12_es6.js
+++ b/tests/baselines/reference/YieldExpression12_es6.js
@@ -8,7 +8,7 @@ class C {
 //// [YieldExpression12_es6.js]
 var C = (function () {
     function C() {
-        ;
+        yield foo;
     }
     return C;
 })();

--- a/tests/baselines/reference/YieldExpression13_es6.js
+++ b/tests/baselines/reference/YieldExpression13_es6.js
@@ -2,4 +2,4 @@
 function* foo() { yield }
 
 //// [YieldExpression13_es6.js]
-function foo() { ; }
+function foo() { yield; }

--- a/tests/baselines/reference/YieldExpression14_es6.js
+++ b/tests/baselines/reference/YieldExpression14_es6.js
@@ -10,7 +10,7 @@ var C = (function () {
     function C() {
     }
     C.prototype.foo = function () {
-        ;
+        yield foo;
     };
     return C;
 })();

--- a/tests/baselines/reference/YieldExpression15_es6.js
+++ b/tests/baselines/reference/YieldExpression15_es6.js
@@ -5,5 +5,5 @@ var v = () => {
 
 //// [YieldExpression15_es6.js]
 var v = function () {
-    ;
+    yield foo;
 };

--- a/tests/baselines/reference/YieldExpression16_es6.js
+++ b/tests/baselines/reference/YieldExpression16_es6.js
@@ -8,6 +8,6 @@ function* foo() {
 //// [YieldExpression16_es6.js]
 function foo() {
     function bar() {
-        ;
+        yield foo;
     }
 }

--- a/tests/baselines/reference/YieldExpression17_es6.js
+++ b/tests/baselines/reference/YieldExpression17_es6.js
@@ -2,4 +2,4 @@
 var v = { get foo() { yield foo; } }
 
 //// [YieldExpression17_es6.js]
-var v = { get foo() { ; } };
+var v = { get foo() { yield foo; } };

--- a/tests/baselines/reference/YieldExpression18_es6.js
+++ b/tests/baselines/reference/YieldExpression18_es6.js
@@ -4,4 +4,4 @@ yield(foo);
 
 //// [YieldExpression18_es6.js]
 "use strict";
-;
+yield (foo);

--- a/tests/baselines/reference/YieldExpression19_es6.js
+++ b/tests/baselines/reference/YieldExpression19_es6.js
@@ -11,7 +11,7 @@ function*foo() {
 function foo() {
     function bar() {
         function quux() {
-            ;
+            yield (foo);
         }
     }
 }

--- a/tests/baselines/reference/YieldExpression2_es6.js
+++ b/tests/baselines/reference/YieldExpression2_es6.js
@@ -2,4 +2,4 @@
 yield foo;
 
 //// [YieldExpression2_es6.js]
-;
+yield foo;

--- a/tests/baselines/reference/YieldExpression3_es6.js
+++ b/tests/baselines/reference/YieldExpression3_es6.js
@@ -6,6 +6,6 @@ function* foo() {
 
 //// [YieldExpression3_es6.js]
 function foo() {
-    ;
-    ;
+    yield;
+    yield;
 }

--- a/tests/baselines/reference/YieldExpression4_es6.js
+++ b/tests/baselines/reference/YieldExpression4_es6.js
@@ -6,6 +6,6 @@ function* foo() {
 
 //// [YieldExpression4_es6.js]
 function foo() {
-    ;
-    ;
+    yield;
+    yield;
 }

--- a/tests/baselines/reference/YieldExpression5_es6.js
+++ b/tests/baselines/reference/YieldExpression5_es6.js
@@ -5,5 +5,5 @@ function* foo() {
 
 //// [YieldExpression5_es6.js]
 function foo() {
-    ;
+    yield* ;
 }

--- a/tests/baselines/reference/YieldExpression6_es6.js
+++ b/tests/baselines/reference/YieldExpression6_es6.js
@@ -5,5 +5,5 @@ function* foo() {
 
 //// [YieldExpression6_es6.js]
 function foo() {
-    ;
+    yield* foo;
 }

--- a/tests/baselines/reference/YieldExpression7_es6.js
+++ b/tests/baselines/reference/YieldExpression7_es6.js
@@ -5,5 +5,5 @@ function* foo() {
 
 //// [YieldExpression7_es6.js]
 function foo() {
-    ;
+    yield foo;
 }

--- a/tests/baselines/reference/YieldExpression8_es6.js
+++ b/tests/baselines/reference/YieldExpression8_es6.js
@@ -7,5 +7,5 @@ function* foo() {
 //// [YieldExpression8_es6.js]
 yield(foo);
 function foo() {
-    ;
+    yield (foo);
 }

--- a/tests/baselines/reference/YieldExpression9_es6.js
+++ b/tests/baselines/reference/YieldExpression9_es6.js
@@ -5,5 +5,5 @@ var v = function*() {
 
 //// [YieldExpression9_es6.js]
 var v = function () {
-    ;
+    yield (foo);
 };

--- a/tests/baselines/reference/constructorWithIncompleteTypeAnnotation.js
+++ b/tests/baselines/reference/constructorWithIncompleteTypeAnnotation.js
@@ -486,7 +486,7 @@ number;
 }
 var CLASS = (function () {
     function CLASS() {
-        this.d = function () { ; };
+        this.d = function () { yield 0; };
     }
     Object.defineProperty(CLASS.prototype, "Property", {
         get: function () { return 0; },

--- a/tests/baselines/reference/generatorES6_1.errors.txt
+++ b/tests/baselines/reference/generatorES6_1.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/generatorES6_1.ts(1,9): error TS9001: Generators are not currently supported.
+tests/cases/compiler/generatorES6_1.ts(2,5): error TS9000: 'yield' expressions are not currently supported.
+
+
+==== tests/cases/compiler/generatorES6_1.ts (2 errors) ====
+    function* foo() {
+            ~
+!!! error TS9001: Generators are not currently supported.
+        yield
+        ~~~~~
+!!! error TS9000: 'yield' expressions are not currently supported.
+    }

--- a/tests/baselines/reference/generatorES6_1.js
+++ b/tests/baselines/reference/generatorES6_1.js
@@ -1,0 +1,9 @@
+//// [generatorES6_1.ts]
+function* foo() {
+    yield
+}
+
+//// [generatorES6_1.js]
+function* foo() {
+    yield;
+}

--- a/tests/baselines/reference/generatorES6_2.errors.txt
+++ b/tests/baselines/reference/generatorES6_2.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/generatorES6_2.ts(2,12): error TS9001: Generators are not currently supported.
+tests/cases/compiler/generatorES6_2.ts(3,9): error TS9000: 'yield' expressions are not currently supported.
+
+
+==== tests/cases/compiler/generatorES6_2.ts (2 errors) ====
+    class C {
+        public * foo() {
+               ~
+!!! error TS9001: Generators are not currently supported.
+            yield 1
+            ~~~~~
+!!! error TS9000: 'yield' expressions are not currently supported.
+        }
+    }

--- a/tests/baselines/reference/generatorES6_2.js
+++ b/tests/baselines/reference/generatorES6_2.js
@@ -1,0 +1,13 @@
+//// [generatorES6_2.ts]
+class C {
+    public * foo() {
+        yield 1
+    }
+}
+
+//// [generatorES6_2.js]
+class C {
+    *foo() {
+        yield 1;
+    }
+}

--- a/tests/baselines/reference/generatorES6_3.errors.txt
+++ b/tests/baselines/reference/generatorES6_3.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/generatorES6_3.ts(1,17): error TS9001: Generators are not currently supported.
+tests/cases/compiler/generatorES6_3.ts(2,5): error TS9000: 'yield' expressions are not currently supported.
+
+
+==== tests/cases/compiler/generatorES6_3.ts (2 errors) ====
+    var v = function*() {
+                    ~
+!!! error TS9001: Generators are not currently supported.
+        yield 0
+        ~~~~~
+!!! error TS9000: 'yield' expressions are not currently supported.
+    }

--- a/tests/baselines/reference/generatorES6_3.js
+++ b/tests/baselines/reference/generatorES6_3.js
@@ -1,0 +1,9 @@
+//// [generatorES6_3.ts]
+var v = function*() {
+    yield 0
+}
+
+//// [generatorES6_3.js]
+var v = function* () {
+    yield 0;
+};

--- a/tests/baselines/reference/generatorES6_4.errors.txt
+++ b/tests/baselines/reference/generatorES6_4.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/generatorES6_4.ts(2,4): error TS9001: Generators are not currently supported.
+tests/cases/compiler/generatorES6_4.ts(3,8): error TS9000: 'yield' expressions are not currently supported.
+
+
+==== tests/cases/compiler/generatorES6_4.ts (2 errors) ====
+    var v = { 
+       *foo() {
+       ~
+!!! error TS9001: Generators are not currently supported.
+           yield 0
+           ~~~~~
+!!! error TS9000: 'yield' expressions are not currently supported.
+       }
+    }

--- a/tests/baselines/reference/generatorES6_4.js
+++ b/tests/baselines/reference/generatorES6_4.js
@@ -1,0 +1,13 @@
+//// [generatorES6_4.ts]
+var v = { 
+   *foo() {
+       yield 0
+   }
+}
+
+//// [generatorES6_4.js]
+var v = {
+    *foo() {
+        yield 0;
+    }
+};

--- a/tests/baselines/reference/generatorES6_5.errors.txt
+++ b/tests/baselines/reference/generatorES6_5.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/generatorES6_5.ts(1,9): error TS9001: Generators are not currently supported.
+tests/cases/compiler/generatorES6_5.ts(2,5): error TS9000: 'yield' expressions are not currently supported.
+
+
+==== tests/cases/compiler/generatorES6_5.ts (2 errors) ====
+    function* foo() {
+            ~
+!!! error TS9001: Generators are not currently supported.
+        yield a ? b : c;
+        ~~~~~
+!!! error TS9000: 'yield' expressions are not currently supported.
+    }

--- a/tests/baselines/reference/generatorES6_5.js
+++ b/tests/baselines/reference/generatorES6_5.js
@@ -1,0 +1,9 @@
+//// [generatorES6_5.ts]
+function* foo() {
+    yield a ? b : c;
+}
+
+//// [generatorES6_5.js]
+function* foo() {
+    yield a ? b : c;
+}

--- a/tests/baselines/reference/generatorES6_6.errors.txt
+++ b/tests/baselines/reference/generatorES6_6.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/generatorES6_6.ts(2,3): error TS9001: Generators are not currently supported.
+tests/cases/compiler/generatorES6_6.ts(3,13): error TS9000: 'yield' expressions are not currently supported.
+
+
+==== tests/cases/compiler/generatorES6_6.ts (2 errors) ====
+    class C {
+      *[Symbol.iterator]() {
+      ~
+!!! error TS9001: Generators are not currently supported.
+        let a = yield 1;
+                ~~~~~
+!!! error TS9000: 'yield' expressions are not currently supported.
+      }
+    }

--- a/tests/baselines/reference/generatorES6_6.js
+++ b/tests/baselines/reference/generatorES6_6.js
@@ -1,0 +1,13 @@
+//// [generatorES6_6.ts]
+class C {
+  *[Symbol.iterator]() {
+    let a = yield 1;
+  }
+}
+
+//// [generatorES6_6.js]
+class C {
+    *[Symbol.iterator]() {
+        let a = yield 1;
+    }
+}

--- a/tests/baselines/reference/templateStringInYieldKeyword.js
+++ b/tests/baselines/reference/templateStringInYieldKeyword.js
@@ -8,5 +8,5 @@ function* gen() {
 //// [templateStringInYieldKeyword.js]
 function gen() {
     // Once this is supported, the inner expression does not need to be parenthesized.
-    var x = ;
+    var x = yield "abc" + x + "def";
 }

--- a/tests/baselines/reference/templateStringWithEmbeddedYieldKeyword.js
+++ b/tests/baselines/reference/templateStringWithEmbeddedYieldKeyword.js
@@ -8,5 +8,5 @@ function* gen {
 //// [templateStringWithEmbeddedYieldKeyword.js]
 function gen() {
     // Once this is supported, yield *must* be parenthesized.
-    var x = "abc" +  + "def";
+    var x = "abc" + (yield 10) + "def";
 }

--- a/tests/baselines/reference/templateStringWithEmbeddedYieldKeywordES6.js
+++ b/tests/baselines/reference/templateStringWithEmbeddedYieldKeywordES6.js
@@ -6,7 +6,7 @@ function* gen() {
 
 
 //// [templateStringWithEmbeddedYieldKeywordES6.js]
-function gen() {
+function* gen() {
     // Once this is supported, yield *must* be parenthesized.
-    var x = `abc${}def`;
+    var x = `abc${yield 10}def`;
 }

--- a/tests/baselines/reference/yieldExpression1.js
+++ b/tests/baselines/reference/yieldExpression1.js
@@ -5,5 +5,5 @@ function* foo() {
 
 //// [yieldExpression1.js]
 function foo() {
-    ;
+    yield;
 }

--- a/tests/cases/compiler/generatorES6_1.ts
+++ b/tests/cases/compiler/generatorES6_1.ts
@@ -1,0 +1,4 @@
+// @target: es6
+function* foo() {
+    yield
+}

--- a/tests/cases/compiler/generatorES6_2.ts
+++ b/tests/cases/compiler/generatorES6_2.ts
@@ -1,0 +1,6 @@
+// @target: es6
+class C {
+    public * foo() {
+        yield 1
+    }
+}

--- a/tests/cases/compiler/generatorES6_3.ts
+++ b/tests/cases/compiler/generatorES6_3.ts
@@ -1,0 +1,4 @@
+// @target: es6
+var v = function*() {
+    yield 0
+}

--- a/tests/cases/compiler/generatorES6_4.ts
+++ b/tests/cases/compiler/generatorES6_4.ts
@@ -1,0 +1,6 @@
+// @target: es6
+var v = { 
+   *foo() {
+       yield 0
+   }
+}

--- a/tests/cases/compiler/generatorES6_5.ts
+++ b/tests/cases/compiler/generatorES6_5.ts
@@ -1,0 +1,4 @@
+// @target: es6
+function* foo() {
+    yield a ? b : c;
+}

--- a/tests/cases/compiler/generatorES6_6.ts
+++ b/tests/cases/compiler/generatorES6_6.ts
@@ -1,0 +1,6 @@
+// @target: es6
+class C {
+  *[Symbol.iterator]() {
+    let a = yield 1;
+  }
+}


### PR DESCRIPTION
This is not the downlevel emit.  This simply emits the AST as-is for ES6 and above.  Fixes https://github.com/Microsoft/TypeScript/issues/2703