### PR TITLE
`exports.default` in ES5 vs `exports["default"]` in ES3

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11412,7 +11412,14 @@ module ts {
             let node = getDeclarationOfAliasSymbol(symbol);
             if (node) {
                 if (node.kind === SyntaxKind.ImportClause) {
-                    return getGeneratedNameForNode(<ImportDeclaration>node.parent) + ".default";
+                    let defaultKeyword: string;
+
+                    if (languageVersion === ScriptTarget.ES3) {
+                        defaultKeyword = "[\"default\"]";
+                    } else {
+                        defaultKeyword = ".default";
+                    }
+                    return getGeneratedNameForNode(<ImportDeclaration>node.parent) + defaultKeyword;
                 }
                 if (node.kind === SyntaxKind.ImportSpecifier) {
                     let moduleName = getGeneratedNameForNode(<ImportDeclaration>node.parent.parent.parent);

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2452,7 +2452,11 @@ var __param = this.__param || function(index, decorator) { return function (targ
                     writeLine();
                     emitStart(node);
                     if (node.flags & NodeFlags.Default) {
-                        write("exports.default");
+                        if (languageVersion === ScriptTarget.ES3) {
+                            write("exports[\"default\"]");
+                        } else {
+                            write("exports.default");
+                        }
                     }
                     else {
                         emitModuleMemberName(node);
@@ -4548,7 +4552,11 @@ var __param = this.__param || function(index, decorator) { return function (targ
                         writeLine();
                         emitStart(node);
                         emitContainingModuleName(node);
-                        write(".default = ");
+                        if (languageVersion === ScriptTarget.ES3) {
+                            write("[\"default\"] = ");
+                        } else {
+                            write(".default = ");
+                        }
                         emit(node.expression);
                         write(";");
                         emitEnd(node);

--- a/tests/baselines/reference/exportAndImport-es3-amd.js
+++ b/tests/baselines/reference/exportAndImport-es3-amd.js
@@ -1,0 +1,27 @@
+//// [tests/cases/conformance/es6/modules/exportAndImport-es3-amd.ts] ////
+
+//// [m1.ts]
+
+export default function f1() {
+}
+
+//// [m2.ts]
+import f1 from "./m1";
+export default function f2() {
+    f1();
+}
+
+
+//// [m1.js]
+define(["require", "exports"], function (require, exports) {
+    function f1() {
+    }
+    exports["default"] = f1;
+});
+//// [m2.js]
+define(["require", "exports", "./m1"], function (require, exports, m1_1) {
+    function f2() {
+        m1_1["default"]();
+    }
+    exports["default"] = f2;
+});

--- a/tests/baselines/reference/exportAndImport-es3-amd.types
+++ b/tests/baselines/reference/exportAndImport-es3-amd.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/es6/modules/m1.ts ===
+
+export default function f1() {
+>f1 : () => void, Symbol(f1, Decl(m1.ts, 0, 0))
+}
+
+=== tests/cases/conformance/es6/modules/m2.ts ===
+import f1 from "./m1";
+>f1 : () => void, Symbol(f1, Decl(m2.ts, 0, 6))
+
+export default function f2() {
+>f2 : () => void, Symbol(f2, Decl(m2.ts, 0, 22))
+
+    f1();
+>f1() : void
+>f1 : () => void, Symbol(f1, Decl(m2.ts, 0, 6))
+}
+

--- a/tests/baselines/reference/exportAndImport-es3.js
+++ b/tests/baselines/reference/exportAndImport-es3.js
@@ -1,0 +1,24 @@
+//// [tests/cases/conformance/es6/modules/exportAndImport-es3.ts] ////
+
+//// [m1.ts]
+
+export default function f1() {
+}
+
+//// [m2.ts]
+import f1 from "./m1";
+export default function f2() {
+  f1();
+}
+
+
+//// [m1.js]
+function f1() {
+}
+exports["default"] = f1;
+//// [m2.js]
+var m1_1 = require("./m1");
+function f2() {
+    m1_1["default"]();
+}
+exports["default"] = f2;

--- a/tests/baselines/reference/exportAndImport-es3.types
+++ b/tests/baselines/reference/exportAndImport-es3.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/es6/modules/m1.ts ===
+
+export default function f1() {
+>f1 : () => void, Symbol(f1, Decl(m1.ts, 0, 0))
+}
+
+=== tests/cases/conformance/es6/modules/m2.ts ===
+import f1 from "./m1";
+>f1 : () => void, Symbol(f1, Decl(m2.ts, 0, 6))
+
+export default function f2() {
+>f2 : () => void, Symbol(f2, Decl(m2.ts, 0, 22))
+
+  f1();
+>f1() : void
+>f1 : () => void, Symbol(f1, Decl(m2.ts, 0, 6))
+}
+

--- a/tests/baselines/reference/exportAndImport-es5-amd.js
+++ b/tests/baselines/reference/exportAndImport-es5-amd.js
@@ -1,0 +1,27 @@
+//// [tests/cases/conformance/es6/modules/exportAndImport-es5-amd.ts] ////
+
+//// [m1.ts]
+
+export default function f1() {
+}
+
+//// [m2.ts]
+import f1 from "./m1";
+export default function f2() {
+    f1();
+}
+
+
+//// [m1.js]
+define(["require", "exports"], function (require, exports) {
+    function f1() {
+    }
+    exports.default = f1;
+});
+//// [m2.js]
+define(["require", "exports", "./m1"], function (require, exports, m1_1) {
+    function f2() {
+        m1_1.default();
+    }
+    exports.default = f2;
+});

--- a/tests/baselines/reference/exportAndImport-es5-amd.types
+++ b/tests/baselines/reference/exportAndImport-es5-amd.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/es6/modules/m1.ts ===
+
+export default function f1() {
+>f1 : () => void, Symbol(f1, Decl(m1.ts, 0, 0))
+}
+
+=== tests/cases/conformance/es6/modules/m2.ts ===
+import f1 from "./m1";
+>f1 : () => void, Symbol(f1, Decl(m2.ts, 0, 6))
+
+export default function f2() {
+>f2 : () => void, Symbol(f2, Decl(m2.ts, 0, 22))
+
+    f1();
+>f1() : void
+>f1 : () => void, Symbol(f1, Decl(m2.ts, 0, 6))
+}
+

--- a/tests/baselines/reference/exportAndImport-es5.js
+++ b/tests/baselines/reference/exportAndImport-es5.js
@@ -1,0 +1,24 @@
+//// [tests/cases/conformance/es6/modules/exportAndImport-es5.ts] ////
+
+//// [m1.ts]
+
+export default function f1() {
+}
+
+//// [m2.ts]
+import f1 from "./m1";
+export default function f2() {
+    f1();
+}
+
+
+//// [m1.js]
+function f1() {
+}
+exports.default = f1;
+//// [m2.js]
+var m1_1 = require("./m1");
+function f2() {
+    m1_1.default();
+}
+exports.default = f2;

--- a/tests/baselines/reference/exportAndImport-es5.types
+++ b/tests/baselines/reference/exportAndImport-es5.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/es6/modules/m1.ts ===
+
+export default function f1() {
+>f1 : () => void, Symbol(f1, Decl(m1.ts, 0, 0))
+}
+
+=== tests/cases/conformance/es6/modules/m2.ts ===
+import f1 from "./m1";
+>f1 : () => void, Symbol(f1, Decl(m2.ts, 0, 6))
+
+export default function f2() {
+>f2 : () => void, Symbol(f2, Decl(m2.ts, 0, 22))
+
+    f1();
+>f1() : void
+>f1 : () => void, Symbol(f1, Decl(m2.ts, 0, 6))
+}
+

--- a/tests/cases/compiler/es6ImportDefaultBindingAmd.ts
+++ b/tests/cases/compiler/es6ImportDefaultBindingAmd.ts
@@ -1,5 +1,6 @@
 // @module: amd
 // @declaration: true
+// @target: ES5
 
 // @filename: es6ImportDefaultBindingAmd_0.ts
 var a = 10;

--- a/tests/cases/compiler/es6ImportDefaultBindingDts.ts
+++ b/tests/cases/compiler/es6ImportDefaultBindingDts.ts
@@ -1,5 +1,6 @@
 // @module: commonjs
 // @declaration: true
+// @target: ES5
 
 // @filename: server.ts
 class c { }

--- a/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport1WithExport.ts
+++ b/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImport1WithExport.ts
@@ -1,5 +1,6 @@
 // @module: commonjs
 // @declaration: true
+// @target: ES5
 
 // @filename: server.ts
 var a = 10;

--- a/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportDts1.ts
+++ b/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportDts1.ts
@@ -1,5 +1,6 @@
 // @module: commonjs
 // @declaration: true
+// @target: ES5
 
 // @filename: server.ts
 class a { }

--- a/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportWithExport.ts
+++ b/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamedImportWithExport.ts
@@ -1,5 +1,6 @@
 // @module: amd
 // @declaration: true
+// @target: ES5
 
 // @filename: server.ts
 export var a = 10;

--- a/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding1WithExport.ts
+++ b/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBinding1WithExport.ts
@@ -1,5 +1,6 @@
 // @module: amd
 // @declaration: true
+// @target: ES5
 
 // @filename: server.ts
 var a = 10;

--- a/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingDts1.ts
+++ b/tests/cases/compiler/es6ImportDefaultBindingFollowedWithNamespaceBindingDts1.ts
@@ -1,5 +1,6 @@
 // @module: amd
 // @declaration: true
+// @target: ES5
 
 // @filename: server.ts
 class a { }

--- a/tests/cases/compiler/es6ImportDefaultBindingMergeErrors.ts
+++ b/tests/cases/compiler/es6ImportDefaultBindingMergeErrors.ts
@@ -1,4 +1,5 @@
 // @module: commonjs
+// @target: ES5
 
 // @filename: es6ImportDefaultBindingMergeErrors_0.ts
 var a = 10;

--- a/tests/cases/compiler/es6ImportDefaultBindingWithExport.ts
+++ b/tests/cases/compiler/es6ImportDefaultBindingWithExport.ts
@@ -1,5 +1,6 @@
 // @module: amd
 // @declaration: true
+// @target: ES5
 
 // @filename: server.ts
 var a = 10;

--- a/tests/cases/conformance/es6/modules/exportAndImport-es3-amd.ts
+++ b/tests/cases/conformance/es6/modules/exportAndImport-es3-amd.ts
@@ -1,0 +1,12 @@
+//@module: amd
+//@target: ES3
+
+// @filename: m1.ts
+export default function f1() {
+}
+
+// @filename: m2.ts
+import f1 from "./m1";
+export default function f2() {
+    f1();
+}

--- a/tests/cases/conformance/es6/modules/exportAndImport-es3.ts
+++ b/tests/cases/conformance/es6/modules/exportAndImport-es3.ts
@@ -1,0 +1,12 @@
+//@module: commonjs
+//@target: ES3
+
+// @filename: m1.ts
+export default function f1() {
+}
+
+// @filename: m2.ts
+import f1 from "./m1";
+export default function f2() {
+  f1();
+}

--- a/tests/cases/conformance/es6/modules/exportAndImport-es5-amd.ts
+++ b/tests/cases/conformance/es6/modules/exportAndImport-es5-amd.ts
@@ -1,0 +1,12 @@
+//@module: amd
+//@target: ES5
+
+// @filename: m1.ts
+export default function f1() {
+}
+
+// @filename: m2.ts
+import f1 from "./m1";
+export default function f2() {
+    f1();
+}

--- a/tests/cases/conformance/es6/modules/exportAndImport-es5.ts
+++ b/tests/cases/conformance/es6/modules/exportAndImport-es5.ts
@@ -1,0 +1,12 @@
+//@module: commonjs
+//@target: ES5
+
+// @filename: m1.ts
+export default function f1() {
+}
+
+// @filename: m2.ts
+import f1 from "./m1";
+export default function f2() {
+    f1();
+}

--- a/tests/cases/conformance/es6/modules/exportStar-amd.ts
+++ b/tests/cases/conformance/es6/modules/exportStar-amd.ts
@@ -1,4 +1,5 @@
 // @module: amd
+// @target: ES5
 
 // @filename: t1.ts
 export var x = 1;

--- a/tests/cases/conformance/es6/modules/exportStar.ts
+++ b/tests/cases/conformance/es6/modules/exportStar.ts
@@ -1,4 +1,5 @@
 // @module: commonjs
+// @target: ES5
 
 // @filename: t1.ts
 export var x = 1;

--- a/tests/cases/conformance/es6/modules/exportsAndImports1-amd.ts
+++ b/tests/cases/conformance/es6/modules/exportsAndImports1-amd.ts
@@ -1,4 +1,5 @@
 // @module: amd
+// @target: ES5
 
 // @filename: t1.ts
 var v = 1;

--- a/tests/cases/conformance/es6/modules/exportsAndImports2-amd.ts
+++ b/tests/cases/conformance/es6/modules/exportsAndImports2-amd.ts
@@ -1,4 +1,5 @@
 // @module: amd
+// @target: ES5
 
 // @filename: t1.ts
 export var x = "x";

--- a/tests/cases/conformance/es6/modules/exportsAndImports3-amd.ts
+++ b/tests/cases/conformance/es6/modules/exportsAndImports3-amd.ts
@@ -1,4 +1,5 @@
 // @module: amd
+// @target: ES5
 
 // @filename: t1.ts
 export var v = 1;

--- a/tests/cases/conformance/es6/modules/exportsAndImports4-amd.ts
+++ b/tests/cases/conformance/es6/modules/exportsAndImports4-amd.ts
@@ -1,4 +1,5 @@
 // @module: amd
+// @target: ES5
 
 // @filename: t1.ts
 export default "hello";

--- a/tests/cases/conformance/es6/modules/exportsAndImports4.ts
+++ b/tests/cases/conformance/es6/modules/exportsAndImports4.ts
@@ -1,4 +1,5 @@
 // @module: commonjs
+// @target: ES5
 
 // @filename: t1.ts
 export default "hello";


### PR DESCRIPTION
I am not sure if I am supposed to run `jake LKG`, but I did it anyway, so I can immediately use this `tsc` in my project.

There are 4 new test cases to cover this scenario; some other test cases are just updated to have `target: ES5`, as I believed that was author's original idea.