### PR TITLE
Fix combineTypeMappers to use instantiateType

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3788,7 +3788,7 @@ module ts {
         }
 
         function combineTypeMappers(mapper1: TypeMapper, mapper2: TypeMapper): TypeMapper {
-            return t => mapper2(mapper1(t));
+            return t => instantiateType(mapper1(t), mapper2);
         }
 
         function instantiateTypeParameter(typeParameter: TypeParameter, mapper: TypeMapper): TypeParameter {
@@ -3859,7 +3859,7 @@ module ts {
         function instantiateType(type: Type, mapper: TypeMapper): Type {
             if (mapper !== identityMapper) {
                 if (type.flags & TypeFlags.TypeParameter) {
-                    return mapper(type);
+                    return mapper(<TypeParameter>type);
                 }
                 if (type.flags & TypeFlags.Anonymous) {
                     return type.symbol && type.symbol.flags & (SymbolFlags.Function | SymbolFlags.Method | SymbolFlags.TypeLiteral | SymbolFlags.ObjectLiteral) ?

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1577,7 +1577,7 @@ module ts {
 
     /* @internal */
     export interface TypeMapper {
-        (t: Type): Type;
+        (t: TypeParameter): Type;
     }
 
     /* @internal */

--- a/tests/baselines/reference/baseTypeWrappingInstantiationChain.js
+++ b/tests/baselines/reference/baseTypeWrappingInstantiationChain.js
@@ -1,0 +1,72 @@
+//// [baseTypeWrappingInstantiationChain.ts]
+class C<T1> extends CBase<T1> {
+    public works() {
+        new CBaseBase<Wrapper<T1>>(this);
+    }
+    public alsoWorks() {
+        new CBase<T1>(this); // Should not error, parameter is of type Parameter<Wrapper<T1>>
+    }
+
+    public method(t: Wrapper<T1>) { }
+}
+
+class CBase<T2> extends CBaseBase<Wrapper<T2>> {
+
+}
+
+class CBaseBase<T3> {
+    constructor(x: Parameter<T3>) { }
+}
+
+class Parameter<T4> {
+    method(t: T4) { }
+}
+
+class Wrapper<T5> {
+    property: T5;
+}
+
+//// [baseTypeWrappingInstantiationChain.js]
+var __extends = this.__extends || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    __.prototype = b.prototype;
+    d.prototype = new __();
+};
+var C = (function (_super) {
+    __extends(C, _super);
+    function C() {
+        _super.apply(this, arguments);
+    }
+    C.prototype.works = function () {
+        new CBaseBase(this);
+    };
+    C.prototype.alsoWorks = function () {
+        new CBase(this); // Should not error, parameter is of type Parameter<Wrapper<T1>>
+    };
+    C.prototype.method = function (t) { };
+    return C;
+})(CBase);
+var CBase = (function (_super) {
+    __extends(CBase, _super);
+    function CBase() {
+        _super.apply(this, arguments);
+    }
+    return CBase;
+})(CBaseBase);
+var CBaseBase = (function () {
+    function CBaseBase(x) {
+    }
+    return CBaseBase;
+})();
+var Parameter = (function () {
+    function Parameter() {
+    }
+    Parameter.prototype.method = function (t) { };
+    return Parameter;
+})();
+var Wrapper = (function () {
+    function Wrapper() {
+    }
+    return Wrapper;
+})();

--- a/tests/baselines/reference/baseTypeWrappingInstantiationChain.symbols
+++ b/tests/baselines/reference/baseTypeWrappingInstantiationChain.symbols
@@ -1,0 +1,69 @@
+=== tests/cases/compiler/baseTypeWrappingInstantiationChain.ts ===
+class C<T1> extends CBase<T1> {
+>C : Symbol(C, Decl(baseTypeWrappingInstantiationChain.ts, 0, 0))
+>T1 : Symbol(T1, Decl(baseTypeWrappingInstantiationChain.ts, 0, 8))
+>CBase : Symbol(CBase, Decl(baseTypeWrappingInstantiationChain.ts, 9, 1))
+>T1 : Symbol(T1, Decl(baseTypeWrappingInstantiationChain.ts, 0, 8))
+
+    public works() {
+>works : Symbol(works, Decl(baseTypeWrappingInstantiationChain.ts, 0, 31))
+
+        new CBaseBase<Wrapper<T1>>(this);
+>CBaseBase : Symbol(CBaseBase, Decl(baseTypeWrappingInstantiationChain.ts, 13, 1))
+>Wrapper : Symbol(Wrapper, Decl(baseTypeWrappingInstantiationChain.ts, 21, 1))
+>T1 : Symbol(T1, Decl(baseTypeWrappingInstantiationChain.ts, 0, 8))
+>this : Symbol(C, Decl(baseTypeWrappingInstantiationChain.ts, 0, 0))
+    }
+    public alsoWorks() {
+>alsoWorks : Symbol(alsoWorks, Decl(baseTypeWrappingInstantiationChain.ts, 3, 5))
+
+        new CBase<T1>(this); // Should not error, parameter is of type Parameter<Wrapper<T1>>
+>CBase : Symbol(CBase, Decl(baseTypeWrappingInstantiationChain.ts, 9, 1))
+>T1 : Symbol(T1, Decl(baseTypeWrappingInstantiationChain.ts, 0, 8))
+>this : Symbol(C, Decl(baseTypeWrappingInstantiationChain.ts, 0, 0))
+    }
+
+    public method(t: Wrapper<T1>) { }
+>method : Symbol(method, Decl(baseTypeWrappingInstantiationChain.ts, 6, 5))
+>t : Symbol(t, Decl(baseTypeWrappingInstantiationChain.ts, 8, 18))
+>Wrapper : Symbol(Wrapper, Decl(baseTypeWrappingInstantiationChain.ts, 21, 1))
+>T1 : Symbol(T1, Decl(baseTypeWrappingInstantiationChain.ts, 0, 8))
+}
+
+class CBase<T2> extends CBaseBase<Wrapper<T2>> {
+>CBase : Symbol(CBase, Decl(baseTypeWrappingInstantiationChain.ts, 9, 1))
+>T2 : Symbol(T2, Decl(baseTypeWrappingInstantiationChain.ts, 11, 12))
+>CBaseBase : Symbol(CBaseBase, Decl(baseTypeWrappingInstantiationChain.ts, 13, 1))
+>Wrapper : Symbol(Wrapper, Decl(baseTypeWrappingInstantiationChain.ts, 21, 1))
+>T2 : Symbol(T2, Decl(baseTypeWrappingInstantiationChain.ts, 11, 12))
+
+}
+
+class CBaseBase<T3> {
+>CBaseBase : Symbol(CBaseBase, Decl(baseTypeWrappingInstantiationChain.ts, 13, 1))
+>T3 : Symbol(T3, Decl(baseTypeWrappingInstantiationChain.ts, 15, 16))
+
+    constructor(x: Parameter<T3>) { }
+>x : Symbol(x, Decl(baseTypeWrappingInstantiationChain.ts, 16, 16))
+>Parameter : Symbol(Parameter, Decl(baseTypeWrappingInstantiationChain.ts, 17, 1))
+>T3 : Symbol(T3, Decl(baseTypeWrappingInstantiationChain.ts, 15, 16))
+}
+
+class Parameter<T4> {
+>Parameter : Symbol(Parameter, Decl(baseTypeWrappingInstantiationChain.ts, 17, 1))
+>T4 : Symbol(T4, Decl(baseTypeWrappingInstantiationChain.ts, 19, 16))
+
+    method(t: T4) { }
+>method : Symbol(method, Decl(baseTypeWrappingInstantiationChain.ts, 19, 21))
+>t : Symbol(t, Decl(baseTypeWrappingInstantiationChain.ts, 20, 11))
+>T4 : Symbol(T4, Decl(baseTypeWrappingInstantiationChain.ts, 19, 16))
+}
+
+class Wrapper<T5> {
+>Wrapper : Symbol(Wrapper, Decl(baseTypeWrappingInstantiationChain.ts, 21, 1))
+>T5 : Symbol(T5, Decl(baseTypeWrappingInstantiationChain.ts, 23, 14))
+
+    property: T5;
+>property : Symbol(property, Decl(baseTypeWrappingInstantiationChain.ts, 23, 19))
+>T5 : Symbol(T5, Decl(baseTypeWrappingInstantiationChain.ts, 23, 14))
+}

--- a/tests/baselines/reference/baseTypeWrappingInstantiationChain.types
+++ b/tests/baselines/reference/baseTypeWrappingInstantiationChain.types
@@ -1,0 +1,71 @@
+=== tests/cases/compiler/baseTypeWrappingInstantiationChain.ts ===
+class C<T1> extends CBase<T1> {
+>C : C<T1>
+>T1 : T1
+>CBase : CBase<T2>
+>T1 : T1
+
+    public works() {
+>works : () => void
+
+        new CBaseBase<Wrapper<T1>>(this);
+>new CBaseBase<Wrapper<T1>>(this) : CBaseBase<Wrapper<T1>>
+>CBaseBase : typeof CBaseBase
+>Wrapper : Wrapper<T5>
+>T1 : T1
+>this : C<T1>
+    }
+    public alsoWorks() {
+>alsoWorks : () => void
+
+        new CBase<T1>(this); // Should not error, parameter is of type Parameter<Wrapper<T1>>
+>new CBase<T1>(this) : CBase<T1>
+>CBase : typeof CBase
+>T1 : T1
+>this : C<T1>
+    }
+
+    public method(t: Wrapper<T1>) { }
+>method : (t: Wrapper<T1>) => void
+>t : Wrapper<T1>
+>Wrapper : Wrapper<T5>
+>T1 : T1
+}
+
+class CBase<T2> extends CBaseBase<Wrapper<T2>> {
+>CBase : CBase<T2>
+>T2 : T2
+>CBaseBase : CBaseBase<T3>
+>Wrapper : Wrapper<T5>
+>T2 : T2
+
+}
+
+class CBaseBase<T3> {
+>CBaseBase : CBaseBase<T3>
+>T3 : T3
+
+    constructor(x: Parameter<T3>) { }
+>x : Parameter<T3>
+>Parameter : Parameter<T4>
+>T3 : T3
+}
+
+class Parameter<T4> {
+>Parameter : Parameter<T4>
+>T4 : T4
+
+    method(t: T4) { }
+>method : (t: T4) => void
+>t : T4
+>T4 : T4
+}
+
+class Wrapper<T5> {
+>Wrapper : Wrapper<T5>
+>T5 : T5
+
+    property: T5;
+>property : T5
+>T5 : T5
+}

--- a/tests/cases/compiler/baseTypeWrappingInstantiationChain.ts
+++ b/tests/cases/compiler/baseTypeWrappingInstantiationChain.ts
@@ -1,0 +1,26 @@
+class C<T1> extends CBase<T1> {
+    public works() {
+        new CBaseBase<Wrapper<T1>>(this);
+    }
+    public alsoWorks() {
+        new CBase<T1>(this); // Should not error, parameter is of type Parameter<Wrapper<T1>>
+    }
+
+    public method(t: Wrapper<T1>) { }
+}
+
+class CBase<T2> extends CBaseBase<Wrapper<T2>> {
+
+}
+
+class CBaseBase<T3> {
+    constructor(x: Parameter<T3>) { }
+}
+
+class Parameter<T4> {
+    method(t: T4) { }
+}
+
+class Wrapper<T5> {
+    property: T5;
+}


### PR DESCRIPTION
Fixes #1424.

When you have a chain of instantiated generics, like this:
```ts
interface Type<T1> {
    x: T1;
}
interface Type2<T2> {
    y: Type<T2>; // Replace T1 with T2 in Type
}
var v: Type2<string>; // Replace T2 with string in Type2
```
Eventually T1 has to be replaced with string in Type1. So to do that we combine / compose the two type mappers that we already have. The result is a type mapper that replaces T1 with T2, and then immediately replaces the resulting T2 with string.

This worked when the output of the first mapper was a type parameter (in the above example T2). However, the first mapper can output an arbitrary type, and it might not be appropriate to immediately apply the second mapper (this was the problem in #1424). In general, it is necessary to treat the application of the second mapper as an instantiation, and not simply apply the second mapper.

Another way of saying this is that a mapper must take a TypeParameter as a parameter, even though it can output any Type.
