### PR TITLE
Simplify binder flow.

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -409,17 +409,9 @@ module ts {
                     return declareSymbolAndAddToSymbolTable(node, SymbolFlags.NamespaceModule, SymbolFlags.NamespaceModuleExcludes);
                 }
                 else {
-                    return declareSymbolAndAddToSymbolTable(node, SymbolFlags.ValueModule, SymbolFlags.ValueModuleExcludes);
-                }
-            }
-        }
+                    let result = declareSymbolAndAddToSymbolTable(node, SymbolFlags.ValueModule, SymbolFlags.ValueModuleExcludes);
 
-        function postBindModuleDeclarationChildren(node: ModuleDeclaration) {
-            if (node.name.kind !== SyntaxKind.StringLiteral) {
-                let state = getModuleInstanceState(node);
-                if (state !== ModuleInstanceState.NonInstantiated) {
                     let currentModuleIsConstEnumOnly = state === ModuleInstanceState.ConstEnumOnly;
-
                     if (node.symbol.constEnumOnlyModule === undefined) {
                         // non-merged case - use the current state
                         node.symbol.constEnumOnlyModule = currentModuleIsConstEnumOnly;
@@ -428,6 +420,8 @@ module ts {
                         // merged case: module is const enum only if all its pieces are non-instantiated or const enum
                         node.symbol.constEnumOnlyModule = node.symbol.constEnumOnlyModule && currentModuleIsConstEnumOnly;
                     }
+
+                    return result;
                 }
             }
         }
@@ -600,8 +594,6 @@ module ts {
 
         function postBindChildren(node: Node) {
             switch (node.kind) {
-                case SyntaxKind.ModuleDeclaration:
-                    return postBindModuleDeclarationChildren(<ModuleDeclaration>node);
                 case SyntaxKind.FunctionType:
                 case SyntaxKind.ConstructorType:
                     return postBindFunctionOrConstructorTypeChildren(<SignatureDeclaration>node);

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -68,8 +68,7 @@ module ts {
 
         if (!file.locals) {
             file.locals = {};
-            container = file;
-            setBlockScopeContainer(file, /*cleanLocals*/ false);
+            container = blockScopeContainer = file;
             bind(file);
             file.symbolCount = symbolCount;
         }
@@ -77,13 +76,6 @@ module ts {
         function createSymbol(flags: SymbolFlags, name: string): Symbol {
             symbolCount++;
             return new Symbol(flags, name);
-        }
-
-        function setBlockScopeContainer(node: Node, cleanLocals: boolean) {
-            blockScopeContainer = node;
-            if (cleanLocals) {
-                blockScopeContainer.locals = undefined;
-            }
         }
 
         function addDeclarationToSymbol(symbol: Symbol, node: Declaration, symbolFlags: SymbolFlags) {
@@ -266,7 +258,10 @@ module ts {
                 // these cases are:
                 // - node has locals (symbolKind & HasLocals) !== 0
                 // - node is a source file
-                setBlockScopeContainer(node, /*cleanLocals*/  (symbolFlags & SymbolFlags.HasLocals) === 0 && node.kind !== SyntaxKind.SourceFile);
+                blockScopeContainer = node;
+                if ((symbolFlags & SymbolFlags.HasLocals) === 0 && node.kind !== SyntaxKind.SourceFile) {
+                    blockScopeContainer.locals = undefined;
+                }
             }
 
             forEachChild(node, bind);

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -143,7 +143,7 @@ module ts {
             return node.name ? declarationNameToString(node.name) : getDeclarationName(node);
         }
 
-        function declareSymbol(symbols: SymbolTable, parent: Symbol, node: Declaration, includes: SymbolFlags, excludes: SymbolFlags): Symbol {
+        function declareSymbol(symbolTable: SymbolTable, parent: Symbol, node: Declaration, includes: SymbolFlags, excludes: SymbolFlags): Symbol {
             Debug.assert(!hasDynamicName(node));
 
             // The exported symbol for an export default function/class node is always named "default"
@@ -151,7 +151,27 @@ module ts {
 
             let symbol: Symbol;
             if (name !== undefined) {
-                symbol = hasProperty(symbols, name) ? symbols[name] : (symbols[name] = createSymbol(SymbolFlags.None, name));
+                // Check and see if the symbol table already has a symbol with this name.  If not,
+                // create a new symbol with this name and add it to the table.  Note that we don't
+                // give the new symbol any flags *yet*.  This ensures that it will not conflict 
+                // witht he 'excludes' flags we pass in.
+                //
+                // If we do get an existing symbol, see if it conflicts with the new symbol we're
+                // creating.  For example, a 'var' symbol and a 'class' symbol will conflict within
+                // the same symbol table.  If we have a conflict, report the issue on each 
+                // declaration we have for this symbol, and then create a new symbol for this 
+                // declaration.
+                //
+                // If we created a new symbol, either because we didn't have a symbol with this name
+                // in the symbol table, or we conflicted with an existing symbol, then just add this
+                // node as the sole declaration of the new symbol.
+                //
+                // Otherwise, we'll be merging into a compatible existing symbol (for example when
+                // you have multiple 'vars' with the same name in the same container).  In this case
+                // just add this node into the declarations list of the symbol.
+                symbol = hasProperty(symbolTable, name)
+                    ? symbolTable[name]
+                    : (symbolTable[name] = createSymbol(SymbolFlags.None, name));
                 if (symbol.flags & excludes) {
                     if (node.name) {
                         node.name.parent = node;
@@ -160,9 +180,8 @@ module ts {
                     // Report errors every position with duplicate declaration
                     // Report errors on previous encountered declarations
                     let message = symbol.flags & SymbolFlags.BlockScopedVariable
-                        ? Diagnostics.Cannot_redeclare_block_scoped_variable_0 
+                        ? Diagnostics.Cannot_redeclare_block_scoped_variable_0
                         : Diagnostics.Duplicate_identifier_0;
-
                     forEach(symbol.declarations, declaration => {
                         file.bindDiagnostics.push(createDiagnosticForNode(declaration.name || declaration, message, getDisplayName(declaration)));
                     });
@@ -204,7 +223,8 @@ module ts {
                 //      but return the export symbol (by calling getExportSymbolOfValueSymbolIfExported). That way
                 //      when the emitter comes back to it, it knows not to qualify the name if it was found in a containing scope.
                 if (hasExportModifier || container.flags & NodeFlags.ExportContext) {
-                    let exportKind = (symbolFlags & SymbolFlags.Value ? SymbolFlags.ExportValue : 0) |
+                    let exportKind =
+                        (symbolFlags & SymbolFlags.Value ? SymbolFlags.ExportValue : 0) |
                         (symbolFlags & SymbolFlags.Type ? SymbolFlags.ExportType : 0) |
                         (symbolFlags & SymbolFlags.Namespace ? SymbolFlags.ExportNamespace : 0);
                     let local = declareSymbol(container.locals, undefined, node, exportKind, symbolExcludes);
@@ -541,11 +561,10 @@ module ts {
                     // do not treat function block a block-scope container
                     // all block-scope locals that reside in this block should go to the function locals.
                     // Otherwise this won't be considered as redeclaration of a block scoped local:
-                    // function foo() {
-                    //  let x;
+                    // function foo(x) {
                     //  let x;
                     // }
-                    // 'let x' will be placed into the function locals and 'let x' - into the locals of the block
+                    // 'x' will be placed into the function locals and 'let x' - into the locals of the block
                     return isFunctionLike(node.parent) ? SymbolFlags.None : SymbolFlags.BlockScopedContainer;
                 case SyntaxKind.CatchClause:
                 case SyntaxKind.ForStatement:

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -293,8 +293,8 @@ module ts {
                     return declareClassMember(node, symbolFlags, symbolExcludes);
 
                 case SyntaxKind.EnumDeclaration:
-                    // Enum members are always put int the 'exports' of the containing enum.
-                    // They are only accessibly through their container, and are never in 
+                    // Enum members are always put in the 'exports' of the containing enum.
+                    // They are only accessible through their container, and are never in 
                     // scope otherwise (even inside the body of the enum declaring them.).
                     return declareSymbol(container.symbol.exports, container.symbol, node, symbolFlags, symbolExcludes);
 
@@ -462,7 +462,7 @@ module ts {
             node.parent = parent;
 
             // First we bind declaration nodes to a symbol if possible.  We'll both create a symbol
-            // and add the symbol to an appropriate symbol table (if appropriate).  The symbolFlags 
+            // and then potentially add the symbol to an appropriate symbol table.  The symbolFlags 
             // that are returned from this help inform how we recurse into the children of this node.
             //
             // Possible destination symbol tables are:

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -480,7 +480,6 @@ module ts {
 
         function bind(node: Node): void {
             node.parent = parent;
-            
             switch (node.kind) {
                 case SyntaxKind.TypeParameter:
                     declareSymbolForDeclarationAndBindChildren(<Declaration>node, SymbolFlags.TypeParameter, SymbolFlags.TypeParameterExcludes);

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -151,7 +151,7 @@ module ts {
 
             let symbol: Symbol;
             if (name !== undefined) {
-                symbol = hasProperty(symbols, name) ? symbols[name] : (symbols[name] = createSymbol(0, name));
+                symbol = hasProperty(symbols, name) ? symbols[name] : (symbols[name] = createSymbol(SymbolFlags.None, name));
                 if (symbol.flags & excludes) {
                     if (node.name) {
                         node.name.parent = node;
@@ -168,11 +168,11 @@ module ts {
                     });
                     file.bindDiagnostics.push(createDiagnosticForNode(node.name || node, message, getDisplayName(node)));
 
-                    symbol = createSymbol(0, name);
+                    symbol = createSymbol(SymbolFlags.None, name);
                 }
             }
             else {
-                symbol = createSymbol(0, "__missing");
+                symbol = createSymbol(SymbolFlags.None, "__missing");
             }
             addDeclarationToSymbol(symbol, node, includes);
             symbol.parent = parent;
@@ -493,7 +493,7 @@ module ts {
                     return bindVariableDeclarationOrBindingElement(<VariableDeclaration | BindingElement>node);
                 case SyntaxKind.PropertyDeclaration:
                 case SyntaxKind.PropertySignature:
-                    return bindPropertyOrMethodOrAccessor(<Declaration>node, SymbolFlags.Property | ((<PropertyDeclaration>node).questionToken ? SymbolFlags.Optional : 0), SymbolFlags.PropertyExcludes);
+                    return bindPropertyOrMethodOrAccessor(<Declaration>node, SymbolFlags.Property | ((<PropertyDeclaration>node).questionToken ? SymbolFlags.Optional : SymbolFlags.None), SymbolFlags.PropertyExcludes);
                 case SyntaxKind.PropertyAssignment:
                 case SyntaxKind.ShorthandPropertyAssignment:
                     return bindPropertyOrMethodOrAccessor(<Declaration>node, SymbolFlags.Property, SymbolFlags.PropertyExcludes);
@@ -502,19 +502,19 @@ module ts {
                 case SyntaxKind.CallSignature:
                 case SyntaxKind.ConstructSignature:
                 case SyntaxKind.IndexSignature:
-                    return declareSymbolAndAddToSymbolTable(<Declaration>node, SymbolFlags.Signature, 0);
+                    return declareSymbolAndAddToSymbolTable(<Declaration>node, SymbolFlags.Signature, SymbolFlags.None);
                 case SyntaxKind.MethodDeclaration:
                 case SyntaxKind.MethodSignature:
                     // If this is an ObjectLiteralExpression method, then it sits in the same space
                     // as other properties in the object literal.  So we use SymbolFlags.PropertyExcludes
                     // so that it will conflict with any other object literal members with the same
                     // name.
-                    return bindPropertyOrMethodOrAccessor(<Declaration>node, SymbolFlags.Method | ((<MethodDeclaration>node).questionToken ? SymbolFlags.Optional : 0),
+                    return bindPropertyOrMethodOrAccessor(<Declaration>node, SymbolFlags.Method | ((<MethodDeclaration>node).questionToken ? SymbolFlags.Optional : SymbolFlags.None),
                         isObjectLiteralMethod(node) ? SymbolFlags.PropertyExcludes : SymbolFlags.MethodExcludes);
                 case SyntaxKind.FunctionDeclaration:
                     return declareSymbolAndAddToSymbolTable(<Declaration>node, SymbolFlags.Function, SymbolFlags.FunctionExcludes);
                 case SyntaxKind.Constructor:
-                    return declareSymbolAndAddToSymbolTable(<Declaration>node, SymbolFlags.Constructor, /*symbolExcludes:*/ 0);
+                    return declareSymbolAndAddToSymbolTable(<Declaration>node, SymbolFlags.Constructor, /*symbolExcludes:*/ SymbolFlags.None);
                 case SyntaxKind.GetAccessor:
                     return bindPropertyOrMethodOrAccessor(<Declaration>node, SymbolFlags.GetAccessor, SymbolFlags.GetAccessorExcludes);
                 case SyntaxKind.SetAccessor:
@@ -563,7 +563,7 @@ module ts {
                     //  let x;
                     // }
                     // 'let x' will be placed into the function locals and 'let x' - into the locals of the block
-                    return isFunctionLike(node.parent) ? 0 : SymbolFlags.BlockScopedContainer;
+                    return isFunctionLike(node.parent) ? SymbolFlags.None : SymbolFlags.BlockScopedContainer;
                 case SyntaxKind.CatchClause:
                 case SyntaxKind.ForStatement:
                 case SyntaxKind.ForInStatement:
@@ -598,7 +598,7 @@ module ts {
         function bindExportDeclaration(node: ExportDeclaration) {
             if (!node.exportClause) {
                 // All export * declarations are collected in an __export symbol
-                declareSymbol(container.symbol.exports, container.symbol, node, SymbolFlags.ExportStar, 0);
+                declareSymbol(container.symbol.exports, container.symbol, node, SymbolFlags.ExportStar, SymbolFlags.None);
             }
             return SymbolFlags.None;
         }

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -90,6 +90,9 @@ module ts {
             symbol.flags |= symbolFlags;
 
             node.symbol = symbol;
+            if (symbolFlags & SymbolFlags.HasLocals) {
+                node.locals = {};
+            }
 
             if (!symbol.declarations) {
                 symbol.declarations = [];
@@ -242,10 +245,6 @@ module ts {
         // All container nodes are kept on a linked list in declaration order. This list is used by the getLocalNameOfContainer function
         // in the type checker to validate that the local name used for a container is unique.
         function bindChildren(node: Node, symbolFlags: SymbolFlags) {
-            if (symbolFlags & SymbolFlags.HasLocals) {
-                node.locals = {};
-            }
-
             let saveParent = parent;
             let saveContainer = container;
             let savedBlockScopeContainer = blockScopeContainer;
@@ -271,6 +270,7 @@ module ts {
             }
 
             forEachChild(node, bind);
+
             container = saveContainer;
             parent = saveParent;
             blockScopeContainer = savedBlockScopeContainer;

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -478,7 +478,7 @@ module ts {
             return "__" + indexOf((<SignatureDeclaration>node.parent).parameters, node);
         }
 
-        function bind(node: Node) {
+        function bind(node: Node): void {
             node.parent = parent;
             
             switch (node.kind) {

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -600,8 +600,6 @@ module ts {
 
         function postBindChildren(node: Node) {
             switch (node.kind) {
-                case SyntaxKind.Parameter:
-                    return postParameterChildren(<ParameterDeclaration>node);
                 case SyntaxKind.ModuleDeclaration:
                     return postBindModuleDeclarationChildren(<ModuleDeclaration>node);
                 case SyntaxKind.FunctionType:
@@ -667,14 +665,12 @@ module ts {
 
         function bindParameter(node: ParameterDeclaration): SymbolFlags {
             if (isBindingPattern(node.name)) {
-                return bindAnonymousDeclaration(node, SymbolFlags.FunctionScopedVariable, getDestructuringParameterName(node));
+                bindAnonymousDeclaration(node, SymbolFlags.FunctionScopedVariable, getDestructuringParameterName(node));
             }
             else {
-                return declareSymbolAndAddToSymbolTable(node, SymbolFlags.FunctionScopedVariable, SymbolFlags.ParameterExcludes);
+                declareSymbolAndAddToSymbolTable(node, SymbolFlags.FunctionScopedVariable, SymbolFlags.ParameterExcludes);
             }
-        }
 
-        function postParameterChildren(node: ParameterDeclaration): void {
             // If this is a property-parameter, then also declare the property symbol into the 
             // containing class.
             if (node.flags & NodeFlags.AccessibilityModifier &&
@@ -684,6 +680,8 @@ module ts {
                 let classDeclaration = <ClassLikeDeclaration>node.parent.parent;
                 declareSymbol(classDeclaration.symbol.members, classDeclaration.symbol, node, SymbolFlags.Property, SymbolFlags.PropertyExcludes);
             }
+
+            return SymbolFlags.FunctionScopedVariable;
         }
 
         function bindPropertyOrMethodOrAccessor(node: Declaration, symbolFlags: SymbolFlags, symbolExcludes: SymbolFlags): SymbolFlags {

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -277,16 +277,6 @@ module ts {
         }
 
         function declareSymbolAndAddToSymbolTable(node: Declaration, symbolFlags: SymbolFlags, symbolExcludes: SymbolFlags): SymbolFlags {
-            // First we declare a symbol for the provided node.  The symbol will be added to an 
-            // appropriate symbol table.  Possible symbol tables include:
-            // 
-            //  1) The 'exports' table of the current container's symbol.
-            //  2) The 'members' table of the current container's symbol.
-            //  3) The 'locals' table of the current container.
-            //
-            // Then, we recurse down the children of this declaration, seeking more declarations
-            // to bind.
-
             declareSymbolAndAddToSymbolTableWorker(node, symbolFlags, symbolExcludes);
             return symbolFlags;
         }
@@ -477,8 +467,17 @@ module ts {
             node.parent = parent;
 
             // First we bind declaration nodes to a symbol if possible.  We'll both create a symbol
-            // and add the symbol to an appropriate symbol table.  The symbolFlags that are retuerned
-            // from this help inform how we recurse into the children of this node.
+            // and add the symbol to an appropriate symbol table (if appropriate).  The symbolFlags 
+            // that are returned from this help inform how we recurse into the children of this node.
+            //
+            // Possible destination symbol tables are:
+            // 
+            //  1) The 'exports' table of the current container's symbol.
+            //  2) The 'members' table of the current container's symbol.
+            //  3) The 'locals' table of the current container.
+            //
+            // However, not all symbols will end up in any of these tables.  'Anonymous' symbols 
+            // (like TypeLiterals for example) will not be put in any table.
             var symbolFlags = bindWorker(node);
 
             // Then we recurse into the children of the node to bind them as well.  For certain 

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -601,22 +601,21 @@ module ts {
             }
 
             let symbol = node.symbol;
-            if (symbol.exports) {
-                // TypeScript 1.0 spec (April 2014): 8.4
-                // Every class automatically contains a static property member named 'prototype', 
-                // the type of which is an instantiation of the class type with type Any supplied as a type argument for each type parameter.
-                // It is an error to explicitly declare a static property member with the name 'prototype'.
-                let prototypeSymbol = createSymbol(SymbolFlags.Property | SymbolFlags.Prototype, "prototype");
-                if (hasProperty(symbol.exports, prototypeSymbol.name)) {
-                    if (node.name) {
-                        node.name.parent = node;
-                    }
-                    file.bindDiagnostics.push(createDiagnosticForNode(symbol.exports[prototypeSymbol.name].declarations[0],
-                        Diagnostics.Duplicate_identifier_0, prototypeSymbol.name));
+
+            // TypeScript 1.0 spec (April 2014): 8.4
+            // Every class automatically contains a static property member named 'prototype', 
+            // the type of which is an instantiation of the class type with type Any supplied as a type argument for each type parameter.
+            // It is an error to explicitly declare a static property member with the name 'prototype'.
+            let prototypeSymbol = createSymbol(SymbolFlags.Property | SymbolFlags.Prototype, "prototype");
+            if (hasProperty(symbol.exports, prototypeSymbol.name)) {
+                if (node.name) {
+                    node.name.parent = node;
                 }
-                symbol.exports[prototypeSymbol.name] = prototypeSymbol;
-                prototypeSymbol.parent = symbol;
+                file.bindDiagnostics.push(createDiagnosticForNode(symbol.exports[prototypeSymbol.name].declarations[0],
+                    Diagnostics.Duplicate_identifier_0, prototypeSymbol.name));
             }
+            symbol.exports[prototypeSymbol.name] = prototypeSymbol;
+            prototypeSymbol.parent = symbol;
 
             return SymbolFlags.Class;
         }

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -347,21 +347,15 @@ module ts {
         }
 
         function declareClassMember(node: Declaration, symbolFlags: SymbolFlags, symbolExcludes: SymbolFlags) {
-            if (node.flags & NodeFlags.Static) {
-                return declareSymbol(container.symbol.exports, container.symbol, node, symbolFlags, symbolExcludes);
-            }
-            else {
-                return declareSymbol(container.symbol.members, container.symbol, node, symbolFlags, symbolExcludes);
-            }
+            return node.flags & NodeFlags.Static
+                ? declareSymbol(container.symbol.exports, container.symbol, node, symbolFlags, symbolExcludes)
+                : declareSymbol(container.symbol.members, container.symbol, node, symbolFlags, symbolExcludes);
         }
 
         function declareSourceFileMember(node: Declaration, symbolFlags: SymbolFlags, symbolExcludes: SymbolFlags) {
-            if (isExternalModule(file)) {
-                return declareModuleMember(node, symbolFlags, symbolExcludes);
-            }
-            else {
-                return declareSymbol(file.locals, undefined, node, symbolFlags, symbolExcludes);
-            }
+            return isExternalModule(file)
+                ? declareModuleMember(node, symbolFlags, symbolExcludes)
+                : declareSymbol(file.locals, undefined, node, symbolFlags, symbolExcludes);
         }
 
         function isAmbientContext(node: Node): boolean {
@@ -616,12 +610,9 @@ module ts {
         }
 
         function bindImportClause(node: ImportClause) {
-            if (node.name) {
-                return declareSymbolAndAddToSymbolTable(node, SymbolFlags.Alias, SymbolFlags.AliasExcludes);
-            }
-            else {
-                return SymbolFlags.None;
-            }
+            return node.name
+                ? declareSymbolAndAddToSymbolTable(node, SymbolFlags.Alias, SymbolFlags.AliasExcludes)
+                : SymbolFlags.None;
         }
 
         function bindEnumDeclaration(node: EnumDeclaration) {
@@ -664,12 +655,9 @@ module ts {
         }
 
         function bindPropertyOrMethodOrAccessor(node: Declaration, symbolFlags: SymbolFlags, symbolExcludes: SymbolFlags): SymbolFlags {
-            if (hasDynamicName(node)) {
-                return bindAnonymousDeclaration(node, symbolFlags, "__computed");
-            }
-            else {
-                return declareSymbolAndAddToSymbolTable(node, symbolFlags, symbolExcludes);
-            }
+            return hasDynamicName(node)
+                ? bindAnonymousDeclaration(node, symbolFlags, "__computed")
+                : declareSymbolAndAddToSymbolTable(node, symbolFlags, symbolExcludes);
         }
     }
 }

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -111,12 +111,12 @@ module ts {
                 return (<Identifier | LiteralExpression>node.name).text;
             }
             switch (node.kind) {
-                case SyntaxKind.ConstructorType:
                 case SyntaxKind.Constructor:
                     return "__constructor";
                 case SyntaxKind.FunctionType:
                 case SyntaxKind.CallSignature:
                     return "__call";
+                case SyntaxKind.ConstructorType:
                 case SyntaxKind.ConstructSignature:
                     return "__new";
                 case SyntaxKind.IndexSignature:
@@ -368,15 +368,14 @@ module ts {
             // We do that by making an anonymous type literal symbol, and then setting the function 
             // symbol as its sole member. To the rest of the system, this symbol will be  indistinguishable 
             // from an actual type literal symbol you would have gotten had you used the long form.
-
-            let symbol = createSymbol(SymbolFlags.Signature, getDeclarationName(node));
+            let name = getDeclarationName(node);
+            let symbol = createSymbol(SymbolFlags.Signature, name);
             addDeclarationToSymbol(symbol, node, SymbolFlags.Signature);
             bindChildren(node, SymbolFlags.Signature, /*isBlockScopeContainer:*/ false);
 
             let typeLiteralSymbol = createSymbol(SymbolFlags.TypeLiteral, "__type");
             addDeclarationToSymbol(typeLiteralSymbol, node, SymbolFlags.TypeLiteral);
-            typeLiteralSymbol.members = {};
-            typeLiteralSymbol.members[node.kind === SyntaxKind.FunctionType ? "__call" : "__new"] = symbol
+            typeLiteralSymbol.members = { [name]: symbol };
         }
 
         function bindAnonymousDeclaration(node: Declaration, symbolKind: SymbolFlags, name: string, isBlockScopeContainer: boolean) {

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -575,10 +575,8 @@ module ts {
                     bindChildren(node, 0, /*isBlockScopeContainer*/ true);
                     break;
                 default:
-                    let saveParent = parent;
-                    parent = node;
-                    forEachChild(node, bind);
-                    parent = saveParent;
+                    bindChildren(node, 0, /*isBlockScopeContainer*/ false);
+                    break;
             }
         }
 

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -603,9 +603,14 @@ module ts {
             let symbol = node.symbol;
 
             // TypeScript 1.0 spec (April 2014): 8.4
-            // Every class automatically contains a static property member named 'prototype', 
-            // the type of which is an instantiation of the class type with type Any supplied as a type argument for each type parameter.
-            // It is an error to explicitly declare a static property member with the name 'prototype'.
+            // Every class automatically contains a static property member named 'prototype', the 
+            // type of which is an instantiation of the class type with type Any supplied as a type
+            // argument for each type parameter. It is an error to explicitly declare a static 
+            // property member with the name 'prototype'.
+            //
+            // Note: we check for this here because this class may be merging into a module.  The
+            // module might have an exported variable called 'prototype'.  We can't allow that as
+            // that would clash with the built-in 'prototype' for the class.
             let prototypeSymbol = createSymbol(SymbolFlags.Property | SymbolFlags.Prototype, "prototype");
             if (hasProperty(symbol.exports, prototypeSymbol.name)) {
                 if (node.name) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1310,6 +1310,7 @@ module ts {
         UnionProperty           = 0x10000000,  // Property in union type
         Optional                = 0x20000000,  // Optional property
         ExportStar              = 0x40000000,  // Export * declaration
+        BlockScopedContainer    = 0x80000000,
 
         Enum = RegularEnum | ConstEnum,
         Variable = FunctionScopedVariable | BlockScopedVariable,
@@ -1352,6 +1353,7 @@ module ts {
         HasExports = Class | Enum | Module,
         HasMembers = Class | Interface | TypeLiteral | ObjectLiteral,
 
+        IsBlockScopedContainer = BlockScopedContainer | Module | Function | Accessor | Method | Constructor,
         IsContainer = HasLocals | HasExports | HasMembers,
         PropertyOrAccessor = Property | Accessor,
         Export = ExportNamespace | ExportType | ExportValue,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1360,14 +1360,15 @@ module ts {
     export interface Symbol {
         flags: SymbolFlags;                     // Symbol flags
         name: string;                           // Name of symbol
-        /* @internal */ id?: number;            // Unique id (used to look up SymbolLinks)
-        /* @internal */ mergeId?: number;       // Merge id (used to look up merged symbol)
         declarations?: Declaration[];           // Declarations associated with this symbol
-        /* @internal */ parent?: Symbol;        // Parent symbol
+        valueDeclaration?: Declaration;         // First value declaration of the symbol
+
         members?: SymbolTable;                  // Class, interface or literal instance members
         exports?: SymbolTable;                  // Module exports
+        /* @internal */ id?: number;            // Unique id (used to look up SymbolLinks)
+        /* @internal */ mergeId?: number;       // Merge id (used to look up merged symbol)
+        /* @internal */ parent?: Symbol;        // Parent symbol
         /* @internal */ exportSymbol?: Symbol;  // Exported symbol associated with this symbol
-        valueDeclaration?: Declaration;         // First value declaration of the symbol
         /* @internal */ constEnumOnlyModule?: boolean; // True if module contains only const enums or other modules with only const enums
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1279,6 +1279,7 @@ module ts {
     }
 
     export const enum SymbolFlags {
+        None                    = 0,
         FunctionScopedVariable  = 0x00000001,  // Variable (var) or parameter
         BlockScopedVariable     = 0x00000002,  // A block-scoped variable (let or const)
         Property                = 0x00000004,  // Property or enum member


### PR DESCRIPTION
CR notes: I recommend reading this CR one commit at a time to better understand what's going on.

---

Previously, it was very difficult to reason about the flow of the binder.  Different parts of the binder recursed in different ways.  For example, some codepaths called ```bindChildren```.  Others called ```forEachChild(node, bind)```.  Some codepaths did not recurse, but were called from paths that woudl then later ```break``` out and recurse.  This made it very easy to end up doing something wrong if you accidentally ```return```ed early.  It was also very difficult to know if you should should recurse if you were in ```bind``` or ```bindDeclaration``` or ```bindAnonymousDeclaration```.  The answer was always "it depends".

I've gone in and completely unified the recursion logic in the binder.  The top level logic looks like this now:

```ts
bind(node: Node) {
    // dispatch and bind this node only
    // recurse and bind children
}
```

That's it.  Individual binding functions never need to worry about recursing.  Instead, they just deal with the node they have, and they top level bind driver will always be responsible for recursing.  This makes things much easier to reason about and provides a consistent framework for future binding code to follow.