### PR TITLE
Blocks with locals should be added to the container chain.

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -239,11 +239,7 @@ module ts {
             if (symbolKind & SymbolFlags.IsContainer) {
                 container = node;
 
-                if (lastContainer) {
-                    lastContainer.nextContainer = container;
-                }
-
-                lastContainer = container;
+                addToContainerChain(container);
             }
 
             if (isBlockScopeContainer) {
@@ -260,6 +256,14 @@ module ts {
             container = saveContainer;
             parent = saveParent;
             blockScopeContainer = savedBlockScopeContainer;
+        }
+
+        function addToContainerChain(node: Node) {
+            if (lastContainer) {
+                lastContainer.nextContainer = node;
+            }
+
+            lastContainer = node;
         }
 
         function bindDeclaration(node: Declaration, symbolKind: SymbolFlags, symbolExcludes: SymbolFlags, isBlockScopeContainer: boolean) {
@@ -403,6 +407,7 @@ module ts {
                 default:
                     if (!blockScopeContainer.locals) {
                         blockScopeContainer.locals = {};
+                        addToContainerChain(blockScopeContainer);
                     }
                     declareSymbol(blockScopeContainer.locals, undefined, node, symbolKind, symbolExcludes);
             }

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -352,7 +352,7 @@ module ts {
     export function isLineBreak(ch: number): boolean {
         // ES5 7.3:
         // The ECMAScript line terminator characters are listed in Table 3.
-        //     Table 3 — Line Terminator Characters
+        //     Table 3: Line Terminator Characters
         //     Code Unit Value     Name                    Formal Name
         //     \u000A              Line Feed               <LF>
         //     \u000D              Carriage Return         <CR>

--- a/tests/baselines/reference/nameCollisionWithBlockScopedVariable1.js
+++ b/tests/baselines/reference/nameCollisionWithBlockScopedVariable1.js
@@ -1,0 +1,25 @@
+//// [nameCollisionWithBlockScopedVariable1.ts]
+module M {
+    export class C { }
+}
+module M {
+    {
+        let M = 0;
+        new C();
+    }
+}
+
+//// [nameCollisionWithBlockScopedVariable1.js]
+var M;
+(function (M) {
+    class C {
+    }
+    M.C = C;
+})(M || (M = {}));
+var M;
+(function (M_1) {
+    {
+        let M = 0;
+        new M_1.C();
+    }
+})(M || (M = {}));

--- a/tests/baselines/reference/nameCollisionWithBlockScopedVariable1.symbols
+++ b/tests/baselines/reference/nameCollisionWithBlockScopedVariable1.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/nameCollisionWithBlockScopedVariable1.ts ===
+module M {
+>M : Symbol(M, Decl(nameCollisionWithBlockScopedVariable1.ts, 0, 0), Decl(nameCollisionWithBlockScopedVariable1.ts, 2, 1))
+
+    export class C { }
+>C : Symbol(C, Decl(nameCollisionWithBlockScopedVariable1.ts, 0, 10))
+}
+module M {
+>M : Symbol(M, Decl(nameCollisionWithBlockScopedVariable1.ts, 0, 0), Decl(nameCollisionWithBlockScopedVariable1.ts, 2, 1))
+    {
+        let M = 0;
+>M : Symbol(M, Decl(nameCollisionWithBlockScopedVariable1.ts, 5, 11))
+
+        new C();
+>C : Symbol(C, Decl(nameCollisionWithBlockScopedVariable1.ts, 0, 10))
+    }
+}

--- a/tests/baselines/reference/nameCollisionWithBlockScopedVariable1.types
+++ b/tests/baselines/reference/nameCollisionWithBlockScopedVariable1.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/nameCollisionWithBlockScopedVariable1.ts ===
+module M {
+>M : typeof M
+
+    export class C { }
+>C : C
+}
+module M {
+>M : typeof M
+    {
+        let M = 0;
+>M : number
+>0 : number
+
+        new C();
+>new C() : C
+>C : typeof C
+    }
+}

--- a/tests/cases/compiler/nameCollisionWithBlockScopedVariable1.ts
+++ b/tests/cases/compiler/nameCollisionWithBlockScopedVariable1.ts
@@ -1,0 +1,10 @@
+// @target: es6
+module M {
+    export class C { }
+}
+module M {
+    {
+        let M = 0;
+        new C();
+    }
+}


### PR DESCRIPTION
By doing this we can accurately handle name collisions with block scoped locals.

Fixes https://github.com/Microsoft/TypeScript/issues/2852