### PR TITLE
Produce type and symbol baselines when running tests.

### DIFF
--- a/src/harness/compilerRunner.ts
+++ b/src/harness/compilerRunner.ts
@@ -97,7 +97,7 @@ class CompilerBaselineRunner extends RunnerBase {
                     program = _program;
                 }, function (settings) {
                         harnessCompiler.setCompilerSettings(tcSettings);
-                });
+                    });
             });
 
             beforeEach(() => {
@@ -252,7 +252,7 @@ class CompilerBaselineRunner extends RunnerBase {
                 }
             });
 
-            it('Correct type baselines for ' + fileName, () => {
+            it('Correct type/symbol baselines for ' + fileName, () => {
                 if (fileName.indexOf("APISample") >= 0) {
                     return;
                 }
@@ -289,8 +289,26 @@ class CompilerBaselineRunner extends RunnerBase {
 
                     // Produce baselines.  The first gives the types for all expressions.
                     // The second gives symbols for all identifiers.
-                    checkBaseLines(/*isSymbolBaseLine:*/ false);
-                    checkBaseLines(/*isSymbolBaseLine:*/ true);
+                    var e1: Error, e2: Error;
+                    try {
+                        checkBaseLines(/*isSymbolBaseLine:*/ false);
+                    }
+                    catch (e) {
+                        e1 = e;
+                    }
+
+                    try {
+                        checkBaseLines(/*isSymbolBaseLine:*/ true);
+                    }
+                    catch (e) {
+                        e2 = e;
+                    }
+
+                    if (e1 || e2) {
+                        throw e1 || e2;
+                    }
+
+                    return;
 
                     function checkBaseLines(isSymbolBaseLine: boolean) {
                         let fullBaseLine = generateBaseLine(fullResults, isSymbolBaseLine);


### PR DESCRIPTION
*Edit from DanielRosenwasser: this fixes #2822.*