### PR TITLE
Add support for --noEmitHelpers flag

### DIFF
--- a/bin/typescript.d.ts
+++ b/bin/typescript.d.ts
@@ -1087,6 +1087,7 @@ declare module "typescript" {
         mapRoot?: string;
         module?: ModuleKind;
         noEmit?: boolean;
+        noEmitHelpers?: boolean;
         noEmitOnError?: boolean;
         noErrorTruncation?: boolean;
         noImplicitAny?: boolean;

--- a/bin/typescriptServices.d.ts
+++ b/bin/typescriptServices.d.ts
@@ -1087,6 +1087,7 @@ declare module ts {
         mapRoot?: string;
         module?: ModuleKind;
         noEmit?: boolean;
+        noEmitHelpers?: boolean;
         noEmitOnError?: boolean;
         noErrorTruncation?: boolean;
         noImplicitAny?: boolean;

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -72,6 +72,10 @@ module ts {
             description: Diagnostics.Do_not_emit_outputs,
         },
         {
+            name: "noEmitHelpers",
+            type: "boolean"
+        },
+        {
             name: "noEmitOnError",
             type: "boolean",
             description: Diagnostics.Do_not_emit_outputs_if_any_type_checking_errors_were_reported,

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -5487,6 +5487,9 @@ if (typeof __param !== "function") __param = function (paramIndex, decorator) {
                 }
 
                 write("[\"require\", \"exports\"");
+                if (compilerOptions.noEmitHelpers) {
+                    write(", \"__extends\"");
+                }
                 if (aliasedModuleNames.length) {
                     write(", ");
                     write(aliasedModuleNames.join(", "));
@@ -5496,6 +5499,9 @@ if (typeof __param !== "function") __param = function (paramIndex, decorator) {
                     write(unaliasedModuleNames.join(", "));
                 }
                 write("], function (require, exports");
+                if (compilerOptions.noEmitHelpers) {
+                    write(", __extends");
+                }
                 if (importAliasNames.length) {
                     write(", ");
                     write(importAliasNames.join(", "));
@@ -5614,24 +5620,30 @@ if (typeof __param !== "function") __param = function (paramIndex, decorator) {
 
                 // emit prologue directives prior to __extends
                 var startIndex = emitDirectivePrologues(node.statements, /*startWithNewLine*/ false);
-                // Only Emit __extends function when target ES5.
-                // For target ES6 and above, we can emit classDeclaration as is.
-                if ((languageVersion < ScriptTarget.ES6) && (!extendsEmitted && resolver.getNodeCheckFlags(node) & NodeCheckFlags.EmitExtends)) {
-                    writeLines(extendsHelper);
-                    extendsEmitted = true;
-                }
 
-                if (!decorateEmitted && resolver.getNodeCheckFlags(node) & NodeCheckFlags.EmitDecorate) {
-                    writeLines(decorateHelper);
-                    if (compilerOptions.emitDecoratorMetadata) {
-                        writeLines(metadataHelper);
+                // Only emit helpers if the user did not say otherwise.
+                if (!compilerOptions.noEmitHelpers) {
+
+                    // Only Emit __extends function when target ES5.
+                    // For target ES6 and above, we can emit classDeclaration as is.
+                    if ((languageVersion < ScriptTarget.ES6) && (!extendsEmitted && resolver.getNodeCheckFlags(node) & NodeCheckFlags.EmitExtends)) {
+                        writeLines(extendsHelper);
+                        extendsEmitted = true;
                     }
-                    decorateEmitted = true;
-                }
 
-                if (!paramEmitted && resolver.getNodeCheckFlags(node) & NodeCheckFlags.EmitParam) {
-                    writeLines(paramHelper);
-                    paramEmitted = true;
+                    if (!decorateEmitted && resolver.getNodeCheckFlags(node) & NodeCheckFlags.EmitDecorate) {
+                        writeLines(decorateHelper);
+                        if (compilerOptions.emitDecoratorMetadata) {
+                            writeLines(metadataHelper);
+                        }
+                        decorateEmitted = true;
+                    }
+
+                    if (!paramEmitted && resolver.getNodeCheckFlags(node) & NodeCheckFlags.EmitParam) {
+                        writeLines(paramHelper);
+                        paramEmitted = true;
+                    }
+
                 }
 
                 if (isExternalModule(node) || compilerOptions.separateCompilation) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1657,6 +1657,7 @@ module ts {
         mapRoot?: string;
         module?: ModuleKind;
         noEmit?: boolean;
+        noEmitHelpers?: boolean;
         noEmitOnError?: boolean;
         noErrorTruncation?: boolean;
         noImplicitAny?: boolean;

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -990,6 +990,10 @@ module Harness {
                             }
                             break;
 
+                        case 'noemithelpers':
+                            options.noEmitHelpers = !!setting.value;
+                            break;
+
                         case 'noemitonerror':
                             options.noEmitOnError = !!setting.value;
                             break;
@@ -1477,7 +1481,7 @@ module Harness {
 
         // List of allowed metadata names
         var fileMetadataNames = ["filename", "comments", "declaration", "module",
-            "nolib", "sourcemap", "target", "out", "outdir", "noemitonerror",
+            "nolib", "sourcemap", "target", "out", "outdir", "noemithelpers", "noemitonerror",
             "noimplicitany", "noresolve", "newline", "newlines", "emitbom",
             "errortruncation", "usecasesensitivefilenames", "preserveconstenums",
             "includebuiltfile", "suppressimplicitanyindexerrors", "stripinternal",

--- a/tests/baselines/reference/noEmitHelpers.js
+++ b/tests/baselines/reference/noEmitHelpers.js
@@ -1,0 +1,19 @@
+//// [noEmitHelpers.ts]
+
+class A { }
+class B extends A { }
+
+
+//// [noEmitHelpers.js]
+var A = (function () {
+    function A() {
+    }
+    return A;
+})();
+var B = (function (_super) {
+    __extends(B, _super);
+    function B() {
+        _super.apply(this, arguments);
+    }
+    return B;
+})(A);

--- a/tests/baselines/reference/noEmitHelpers.symbols
+++ b/tests/baselines/reference/noEmitHelpers.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/noEmitHelpers.ts ===
+
+class A { }
+>A : Symbol(A, Decl(noEmitHelpers.ts, 0, 0))
+
+class B extends A { }
+>B : Symbol(B, Decl(noEmitHelpers.ts, 1, 11))
+>A : Symbol(A, Decl(noEmitHelpers.ts, 0, 0))
+

--- a/tests/baselines/reference/noEmitHelpers.types
+++ b/tests/baselines/reference/noEmitHelpers.types
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/noEmitHelpers.ts ===
+
+class A { }
+>A : A
+
+class B extends A { }
+>B : B
+>A : A
+

--- a/tests/cases/compiler/noEmitHelpers.ts
+++ b/tests/cases/compiler/noEmitHelpers.ts
@@ -1,0 +1,4 @@
+// @noemithelpers: true
+
+class A { }
+class B extends A { }


### PR DESCRIPTION
This PR is a Work In Progress that addresses multiple `__extends`
being output as described in #1350: Multiple `__extends` being output
when `--module amd` is set.

The issue still exists as of `v1.5.0 - f53e6a8`.

Apparently a fix was created for this in #1356 but according to #2009, a
[comment](https://github.com/Microsoft/TypeScript/issues/2009#issuecomment-74136291) later indicated that this was never merged in.

Further conversation continued in #2487 but did not yield any result. I
refer to my earlier recommendation in #1350.

> My question is this, would the TypeScript team be open to a flag that
> can be passed to tsc that will generate something like the following
> ```js
> define(["require", "exports", "__extends", './mammal'], function (require, exports, __extends, Mammal) {
>     var Human = (function (_super) {
>         __extends(Human, _super);
>         function Human() {
>             _super.apply(this, arguments);
>         }
>         return Human;
>     })(Mammal);
>     return Human;
> });
> ```

To continue with the naming convention I have chosen the flag
`--noEmitHelpers`.

Edit: renamed `noEmitExtends` to `noEmitHelpers`