### PR TITLE
Fix #2929: relax the check for export= in ES6 if it is resulting from an ambient declaration

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10689,7 +10689,7 @@ module ts {
             }
             checkExternalModuleExports(container);
 
-            if (node.isExportEquals) {
+            if (node.isExportEquals && !isInAmbientContext(node)) {
                 if (languageVersion >= ScriptTarget.ES6) {
                     // export assignment is deprecated in es6 or above
                     grammarErrorOnNode(node, Diagnostics.Export_assignment_cannot_be_used_when_targeting_ECMAScript_6_or_higher_Consider_using_export_default_instead);

--- a/tests/baselines/reference/es6ExportAssignment2.errors.txt
+++ b/tests/baselines/reference/es6ExportAssignment2.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/compiler/a.ts(3,1): error TS1203: Export assignment cannot be used when targeting ECMAScript 6 or higher. Consider using 'export default' instead.
+
+
+==== tests/cases/compiler/a.ts (1 errors) ====
+    
+    var a = 10;
+    export = a;  // Error: export = not allowed in ES6
+    ~~~~~~~~~~~
+!!! error TS1203: Export assignment cannot be used when targeting ECMAScript 6 or higher. Consider using 'export default' instead.
+    
+==== tests/cases/compiler/b.ts (0 errors) ====
+    import * as a from "a";
+    

--- a/tests/baselines/reference/es6ExportAssignment2.js
+++ b/tests/baselines/reference/es6ExportAssignment2.js
@@ -1,0 +1,14 @@
+//// [tests/cases/compiler/es6ExportAssignment2.ts] ////
+
+//// [a.ts]
+
+var a = 10;
+export = a;  // Error: export = not allowed in ES6
+
+//// [b.ts]
+import * as a from "a";
+
+
+//// [a.js]
+var a = 10;
+//// [b.js]

--- a/tests/baselines/reference/es6ExportAssignment3.js
+++ b/tests/baselines/reference/es6ExportAssignment3.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/es6ExportAssignment3.ts] ////
+
+//// [a.d.ts]
+
+declare var a: number;
+export = a;  // OK, in ambient context
+
+//// [b.ts]
+import * as a from "a";
+
+
+//// [b.js]

--- a/tests/baselines/reference/es6ExportAssignment3.symbols
+++ b/tests/baselines/reference/es6ExportAssignment3.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/a.d.ts ===
+
+declare var a: number;
+>a : Symbol(a, Decl(a.d.ts, 1, 11))
+
+export = a;  // OK, in ambient context
+>a : Symbol(a, Decl(a.d.ts, 1, 11))
+
+=== tests/cases/compiler/b.ts ===
+import * as a from "a";
+>a : Symbol(a, Decl(b.ts, 0, 6))
+

--- a/tests/baselines/reference/es6ExportAssignment3.types
+++ b/tests/baselines/reference/es6ExportAssignment3.types
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/a.d.ts ===
+
+declare var a: number;
+>a : number
+
+export = a;  // OK, in ambient context
+>a : number
+
+=== tests/cases/compiler/b.ts ===
+import * as a from "a";
+>a : number
+

--- a/tests/baselines/reference/es6ExportAssignment4.js
+++ b/tests/baselines/reference/es6ExportAssignment4.js
@@ -1,0 +1,14 @@
+//// [tests/cases/compiler/es6ExportAssignment4.ts] ////
+
+//// [modules.d.ts]
+
+declare module "a" {
+    var a: number;
+    export = a;  // OK, in ambient context
+}
+
+//// [b.ts]
+import * as a from "a";
+
+
+//// [b.js]

--- a/tests/baselines/reference/es6ExportAssignment4.symbols
+++ b/tests/baselines/reference/es6ExportAssignment4.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/modules.d.ts ===
+
+declare module "a" {
+    var a: number;
+>a : Symbol(a, Decl(modules.d.ts, 2, 7))
+
+    export = a;  // OK, in ambient context
+>a : Symbol(a, Decl(modules.d.ts, 2, 7))
+}
+
+=== tests/cases/compiler/b.ts ===
+import * as a from "a";
+>a : Symbol(a, Decl(b.ts, 0, 6))
+

--- a/tests/baselines/reference/es6ExportAssignment4.types
+++ b/tests/baselines/reference/es6ExportAssignment4.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/modules.d.ts ===
+
+declare module "a" {
+    var a: number;
+>a : number
+
+    export = a;  // OK, in ambient context
+>a : number
+}
+
+=== tests/cases/compiler/b.ts ===
+import * as a from "a";
+>a : number
+

--- a/tests/baselines/reference/systemExportAssignment.js
+++ b/tests/baselines/reference/systemExportAssignment.js
@@ -1,0 +1,19 @@
+//// [tests/cases/compiler/systemExportAssignment.ts] ////
+
+//// [a.d.ts]
+
+declare var a: number;
+export = a;  // OK, in ambient context
+
+//// [b.ts]
+import * as a from "a";
+
+
+//// [b.js]
+System.register([], function(exports_1) {
+    return {
+        setters:[],
+        execute: function() {
+        }
+    }
+});

--- a/tests/baselines/reference/systemExportAssignment.symbols
+++ b/tests/baselines/reference/systemExportAssignment.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/a.d.ts ===
+
+declare var a: number;
+>a : Symbol(a, Decl(a.d.ts, 1, 11))
+
+export = a;  // OK, in ambient context
+>a : Symbol(a, Decl(a.d.ts, 1, 11))
+
+=== tests/cases/compiler/b.ts ===
+import * as a from "a";
+>a : Symbol(a, Decl(b.ts, 0, 6))
+

--- a/tests/baselines/reference/systemExportAssignment.types
+++ b/tests/baselines/reference/systemExportAssignment.types
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/a.d.ts ===
+
+declare var a: number;
+>a : number
+
+export = a;  // OK, in ambient context
+>a : number
+
+=== tests/cases/compiler/b.ts ===
+import * as a from "a";
+>a : number
+

--- a/tests/baselines/reference/systemExportAssignment2.errors.txt
+++ b/tests/baselines/reference/systemExportAssignment2.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/compiler/a.ts(3,1): error TS1218: Export assignment is not supported when '--module' flag is 'system'.
+
+
+==== tests/cases/compiler/a.ts (1 errors) ====
+    
+    var a = 10;
+    export = a;  // Error: export = not allowed in ES6
+    ~~~~~~~~~~~
+!!! error TS1218: Export assignment is not supported when '--module' flag is 'system'.
+    
+==== tests/cases/compiler/b.ts (0 errors) ====
+    import * as a from "a";
+    

--- a/tests/baselines/reference/systemExportAssignment2.js
+++ b/tests/baselines/reference/systemExportAssignment2.js
@@ -1,0 +1,29 @@
+//// [tests/cases/compiler/systemExportAssignment2.ts] ////
+
+//// [a.ts]
+
+var a = 10;
+export = a;  // Error: export = not allowed in ES6
+
+//// [b.ts]
+import * as a from "a";
+
+
+//// [a.js]
+System.register([], function(exports_1) {
+    var a;
+    return {
+        setters:[],
+        execute: function() {
+            a = 10;
+        }
+    }
+});
+//// [b.js]
+System.register([], function(exports_1) {
+    return {
+        setters:[],
+        execute: function() {
+        }
+    }
+});

--- a/tests/baselines/reference/systemExportAssignment3.js
+++ b/tests/baselines/reference/systemExportAssignment3.js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/systemExportAssignment3.ts] ////
+
+//// [modules.d.ts]
+
+declare module "a" {
+    var a: number;
+    export = a;  // OK, in ambient context
+}
+
+//// [b.ts]
+import * as a from "a";
+
+
+//// [b.js]
+System.register([], function(exports_1) {
+    return {
+        setters:[],
+        execute: function() {
+        }
+    }
+});

--- a/tests/baselines/reference/systemExportAssignment3.symbols
+++ b/tests/baselines/reference/systemExportAssignment3.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/modules.d.ts ===
+
+declare module "a" {
+    var a: number;
+>a : Symbol(a, Decl(modules.d.ts, 2, 7))
+
+    export = a;  // OK, in ambient context
+>a : Symbol(a, Decl(modules.d.ts, 2, 7))
+}
+
+=== tests/cases/compiler/b.ts ===
+import * as a from "a";
+>a : Symbol(a, Decl(b.ts, 0, 6))
+

--- a/tests/baselines/reference/systemExportAssignment3.types
+++ b/tests/baselines/reference/systemExportAssignment3.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/modules.d.ts ===
+
+declare module "a" {
+    var a: number;
+>a : number
+
+    export = a;  // OK, in ambient context
+>a : number
+}
+
+=== tests/cases/compiler/b.ts ===
+import * as a from "a";
+>a : number
+

--- a/tests/cases/compiler/es6ExportAssignment2.ts
+++ b/tests/cases/compiler/es6ExportAssignment2.ts
@@ -1,0 +1,8 @@
+// @target: es6
+
+// @filename: a.ts
+var a = 10;
+export = a;  // Error: export = not allowed in ES6
+
+// @filename: b.ts
+import * as a from "a";

--- a/tests/cases/compiler/es6ExportAssignment3.ts
+++ b/tests/cases/compiler/es6ExportAssignment3.ts
@@ -1,0 +1,8 @@
+// @target: es6
+
+// @filename: a.d.ts
+declare var a: number;
+export = a;  // OK, in ambient context
+
+// @filename: b.ts
+import * as a from "a";

--- a/tests/cases/compiler/es6ExportAssignment4.ts
+++ b/tests/cases/compiler/es6ExportAssignment4.ts
@@ -1,0 +1,10 @@
+// @target: es6
+
+// @filename: modules.d.ts
+declare module "a" {
+    var a: number;
+    export = a;  // OK, in ambient context
+}
+
+// @filename: b.ts
+import * as a from "a";

--- a/tests/cases/compiler/systemExportAssignment.ts
+++ b/tests/cases/compiler/systemExportAssignment.ts
@@ -1,0 +1,9 @@
+// @target: es5
+// @module: system
+
+// @filename: a.d.ts
+declare var a: number;
+export = a;  // OK, in ambient context
+
+// @filename: b.ts
+import * as a from "a";

--- a/tests/cases/compiler/systemExportAssignment2.ts
+++ b/tests/cases/compiler/systemExportAssignment2.ts
@@ -1,0 +1,9 @@
+// @target: es5
+// @module: system
+
+// @filename: a.ts
+var a = 10;
+export = a;  // Error: export = not allowed in ES6
+
+// @filename: b.ts
+import * as a from "a";

--- a/tests/cases/compiler/systemExportAssignment3.ts
+++ b/tests/cases/compiler/systemExportAssignment3.ts
@@ -1,0 +1,11 @@
+// @target: es5
+// @module: system
+
+// @filename: modules.d.ts
+declare module "a" {
+    var a: number;
+    export = a;  // OK, in ambient context
+}
+
+// @filename: b.ts
+import * as a from "a";


### PR DESCRIPTION
`export =` is an error in ES6 and system module outputs as there is no way to emit it correctly. There is no reason why to make this an error for ambient declarations though. 
The change allows the use of export= in ambient declarations.