### PR TITLE
fix formatting for chained callbacks

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -323,6 +323,9 @@ module ts.formatting {
         let previousParent: Node;
         let previousRangeStartLine: number;
 
+        let lastIndentedLine: number;
+        let indentationOnLastIndentedLine: number;
+        
         let edits: TextChange[] = [];
 
         formattingScanner.advance();
@@ -416,7 +419,7 @@ module ts.formatting {
                 // if node is located on the same line with the parent
                 // - inherit indentation from the parent
                 // - push children if either parent of node itself has non-zero delta
-                indentation = parentDynamicIndentation.getIndentation();
+                indentation =  startLine === lastIndentedLine ? indentationOnLastIndentedLine : parentDynamicIndentation.getIndentation();
                 delta = Math.min(options.IndentSize, parentDynamicIndentation.getDelta() + delta);
             }
             return {
@@ -716,7 +719,6 @@ module ts.formatting {
                                 continue;
                             }
 
-                            let triviaStartLine = sourceFile.getLineAndCharacterOfPosition(triviaItem.pos).line;
                             switch (triviaItem.kind) {
                                 case SyntaxKind.MultiLineCommentTrivia:
                                     let commentIndentation = dynamicIndentation.getIndentationForComment(currentTokenInfo.token.kind);
@@ -741,6 +743,9 @@ module ts.formatting {
                     if (isTokenInRange && !rangeContainsError(currentTokenInfo.token)) {
                         let tokenIndentation = dynamicIndentation.getIndentationForToken(tokenStart.line, currentTokenInfo.token.kind);
                         insertIndentation(currentTokenInfo.token.pos, tokenIndentation, lineAdded);
+                        
+                        lastIndentedLine = tokenStart.line;
+                        indentationOnLastIndentedLine = tokenIndentation;
                     }
                 }
 

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -419,7 +419,9 @@ module ts.formatting {
                 // if node is located on the same line with the parent
                 // - inherit indentation from the parent
                 // - push children if either parent of node itself has non-zero delta
-                indentation =  startLine === lastIndentedLine ? indentationOnLastIndentedLine : parentDynamicIndentation.getIndentation();
+                indentation =  startLine === lastIndentedLine 
+                    ? indentationOnLastIndentedLine 
+                    : parentDynamicIndentation.getIndentation();
                 delta = Math.min(options.IndentSize, parentDynamicIndentation.getDelta() + delta);
             }
             return {

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -419,7 +419,7 @@ module ts.formatting {
                 // if node is located on the same line with the parent
                 // - inherit indentation from the parent
                 // - push children if either parent of node itself has non-zero delta
-                indentation =  startLine === lastIndentedLine 
+                indentation = startLine === lastIndentedLine 
                     ? indentationOnLastIndentedLine 
                     : parentDynamicIndentation.getIndentation();
                 delta = Math.min(options.IndentSize, parentDynamicIndentation.getDelta() + delta);

--- a/tests/cases/fourslash/formattingOnChainedCallbacks.ts
+++ b/tests/cases/fourslash/formattingOnChainedCallbacks.ts
@@ -4,7 +4,7 @@
 ////    .resolve()
 ////    .then(() => {/*1*/""/*2*/
 ////}).then(() => {/*3*//*4*/
-////})/*semi1*/ /*semi2*/
+////})/*semi1*//*semi2*/
 
 ////function foo() {
 ////    return Promise.resolve()
@@ -16,8 +16,7 @@
 goTo.marker('1');
 edit.insertLine('');
 goTo.marker('2');
-// Expected, with bug 1888: verify.currentLineContentIs('        ""');
-verify.currentLineContentIs('    ""'); 
+verify.currentLineContentIs('        ""');
 goTo.marker('4');
 edit.insertLine('');
 goTo.marker('3');
@@ -25,8 +24,7 @@ verify.currentLineContentIs('    }).then(() => {');
 
 goTo.marker("semi1");
 edit.insert(';');
-// Expected, with bug 1888: verify.currentLineContentIs('    });');
-verify.currentLineContentIs('}); ');
+verify.currentLineContentIs('    });');
 goTo.marker("semi2");
 edit.insert(';');
 verify.currentLineContentIs('    });;');
@@ -36,5 +34,4 @@ edit.insert(';');
 verify.currentLineContentIs('            "";');
 goTo.marker('b');
 edit.insert(';');
-// Expected, with bug 1888: verify.currentLineContentIs('        });');
-verify.currentLineContentIs('    });');
+verify.currentLineContentIs('        });');


### PR DESCRIPTION
fixes #1917, #1888

```typescript
foo
    .bar(() = {
     })
```
in cases like this nodes are processed in order: `CallExpresson` -> `PropertyAccess and its child nodes` -> `ParameterList and its child nodes`. Fact that indentation was inserted before the '.' during processing of `PropertyAccess` should be respected later when we return back to `CallExpression` and dive into `ParameterList` however this is something that was missed.

In this PR when token is indented we record line/indentation and later when computing indentation for the node check if current line was already indented and if yes - use actual indentation.