### PR TITLE
Fix host formatting configuration issues

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -424,7 +424,7 @@ module ts.server {
         
         getFormatCodeOptions(file?: string) {
             if (file) {
-                var info = this.filenameToScriptInfo[file];                
+                var info = this.filenameToScriptInfo[file];
                 if (info) {
                     return info.formatCodeOptions;
                 }
@@ -750,6 +750,7 @@ module ts.server {
                 if (content !== undefined) {
                     var indentSize: number;
                     info = new ScriptInfo(this.host, fileName, content, openedByClient);
+                    info.setFormatOptions(this.getFormatCodeOptions());
                     this.filenameToScriptInfo[fileName] = info;
                     if (!info.isOpen) {
                         info.fileWatcher = this.host.watchFile(fileName, _ => { this.watchedFileChanged(fileName); });

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -519,7 +519,7 @@ module ts.server {
                                 IndentSize: formatOptions.IndentSize,
                                 TabSize: formatOptions.TabSize,
                                 NewLineCharacter: "\n",
-                                ConvertTabsToSpaces: true,
+                                ConvertTabsToSpaces: formatOptions.ConvertTabsToSpaces,
                             };
                             var indentPosition =
                                 compilerService.languageService.getIndentationAtPosition(file, position, editorOptions);


### PR DESCRIPTION
Issue: when opening a new file on the server, the host loads "compiler default format options" instead of "host default format options"; and the "translate tabs to spaces option" is hard-coded to "true" on the server.

Related issue on typescript sublime repo: [link](https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/159)