### PR TITLE
emit input non .ts files as separate files when 'allowNonTsExtensions' a...

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1435,8 +1435,11 @@ module ts {
 
     export function shouldEmitToOwnFile(sourceFile: SourceFile, compilerOptions: CompilerOptions): boolean {
         if (!isDeclarationFile(sourceFile)) {
-            if ((isExternalModule(sourceFile) || !compilerOptions.out) && !fileExtensionIs(sourceFile.fileName, ".js")) {
-                return true;
+            if ((isExternalModule(sourceFile) || !compilerOptions.out)) {
+                // 1. in-browser single file compilation scenario
+                // 2. non .js file
+                return (compilerOptions.separateCompilation && compilerOptions.allowNonTsExtensions) ||
+                    !fileExtensionIs(sourceFile.fileName, ".js");
             }
             return false;
         }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1438,8 +1438,7 @@ module ts {
             if ((isExternalModule(sourceFile) || !compilerOptions.out)) {
                 // 1. in-browser single file compilation scenario
                 // 2. non .js file
-                return (compilerOptions.separateCompilation && compilerOptions.allowNonTsExtensions) ||
-                    !fileExtensionIs(sourceFile.fileName, ".js");
+                return compilerOptions.separateCompilation || !fileExtensionIs(sourceFile.fileName, ".js");
             }
             return false;
         }


### PR DESCRIPTION
...nd 'separateCompilation' flags are specified (used in 'transpile' related scenarios)

This PR forces emit for in-browser transpile scenarios when .js es6 file is converted to downlevel