### PR TITLE
unify file extension resolution logic

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -853,10 +853,11 @@ module ts {
                     return symbol;
                 }
             }
+            let fileName: string;
             let sourceFile: SourceFile;
             while (true) {
-                let fileName = normalizePath(combinePaths(searchPath, moduleName));
-                sourceFile = host.getSourceFile(fileName + ".ts") || host.getSourceFile(fileName + ".d.ts");
+                fileName = normalizePath(combinePaths(searchPath, moduleName));
+                sourceFile = forEach(supportedExtensions, extension => host.getSourceFile(fileName + extension));
                 if (sourceFile || isRelative) {
                     break;
                 }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -640,16 +640,18 @@ module ts {
         return pathLen > extLen && path.substr(pathLen - extLen, extLen) === extension;
     }
 
-    let supportedExtensions = [".d.ts", ".ts", ".js"];
+    /**
+     *  List of supported extensions in order of file resolution precedence.
+     */
+    export const supportedExtensions = [".ts", ".d.ts"];
 
+    const extensitionsToRemove = [".d.ts", ".ts", ".js"];
     export function removeFileExtension(path: string): string {
-        for (let ext of supportedExtensions) {
-
+        for (let ext of extensitionsToRemove) {
             if (fileExtensionIs(path, ext)) {
                 return path.substr(0, path.length - ext.length);
             }
         }
-
         return path;
     }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -313,7 +313,7 @@ module ts {
             }
             let diagnostic: DiagnosticMessage;
             if (hasExtension(fileName)) {
-                if (!options.allowNonTsExtensions && !fileExtensionIs(host.getCanonicalFileName(fileName), ".ts")) {
+                if (!options.allowNonTsExtensions && !forEach(supportedExtensions, extension => fileExtensionIs(host.getCanonicalFileName(fileName), extension))) {
                     diagnostic = Diagnostics.File_0_must_have_extension_ts_or_d_ts;
                 }
                 else if (!findSourceFile(fileName, isDefaultLib, refFile, refPos, refEnd)) {
@@ -327,7 +327,7 @@ module ts {
                 if (options.allowNonTsExtensions && !findSourceFile(fileName, isDefaultLib, refFile, refPos, refEnd)) {
                     diagnostic = Diagnostics.File_0_not_found;
                 }
-                else if (!findSourceFile(fileName + ".ts", isDefaultLib, refFile, refPos, refEnd) && !findSourceFile(fileName + ".d.ts", isDefaultLib, refFile, refPos, refEnd)) {
+                else if (!forEach(supportedExtensions, extension => findSourceFile(fileName + extension, isDefaultLib, refFile, refPos, refEnd))) {
                     diagnostic = Diagnostics.File_0_not_found;
                     fileName += ".ts";
                 }
@@ -417,9 +417,10 @@ module ts {
                         let moduleNameText = (<LiteralExpression>moduleNameExpr).text;
                         if (moduleNameText) {
                             let searchPath = basePath;
+                            let searchName: string; 
                             while (true) {
-                                let searchName = normalizePath(combinePaths(searchPath, moduleNameText));
-                                if (findModuleSourceFile(searchName + ".ts", moduleNameExpr) || findModuleSourceFile(searchName + ".d.ts", moduleNameExpr)) {
+                                searchName = normalizePath(combinePaths(searchPath, moduleNameText));
+                                if (forEach(supportedExtensions, extension => findModuleSourceFile(searchName + extension, moduleNameExpr))) {
                                     break;
                                 }
                                 let parentPath = getDirectoryPath(searchPath);
@@ -448,10 +449,7 @@ module ts {
                                 // An ExternalImportDeclaration in anAmbientExternalModuleDeclaration may reference other external modules 
                                 // only through top - level external module names. Relative external module names are not permitted.
                                 let searchName = normalizePath(combinePaths(basePath, moduleName));
-                                let tsFile = findModuleSourceFile(searchName + ".ts", nameLiteral);
-                                if (!tsFile) {
-                                    findModuleSourceFile(searchName + ".d.ts", nameLiteral);
-                                }
+                                forEach(supportedExtensions, extension => findModuleSourceFile(searchName + extension, nameLiteral));
                             }
                         }
                     });


### PR DESCRIPTION
We explicitly list ".ts" and ".d.ts" files every time we resolve files or modules. This change puts the two extensions in a list of supported extensions, and uses it everywhere. This allows for easy addition to supported extensions, e.g. the work @CyrusNajmabadi and @fdecampredon are doing.