### PR TITLE
Adds more travis test targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 
 node_js:
+  - iojs
+  - '0.12'
   - '0.10'
 
 sudo: false

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -45,10 +45,10 @@ module Utils {
     export function getExecutionEnvironment() {
         if (typeof WScript !== "undefined" && typeof ActiveXObject === "function") {
             return ExecutionEnvironment.CScript;
-        } else if (process && process.execPath && process.execPath.indexOf("node") !== -1) {
-            return ExecutionEnvironment.Node;
-        } else {
+        } else if (typeof window !== "undefined") {
             return ExecutionEnvironment.Browser;
+        } else {
+            return ExecutionEnvironment.Node;
         }
     }
 


### PR DESCRIPTION
This PR adds more Travis test targets. The `iojs` targets defaults to latest stable. There is also a fix issue with the node check environment `process.execPath` has the path `**/iojs` instead of `**/node` in iojs.