### PR TITLE
ProjectService passing incorrect object to parseConfigFile()

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -398,7 +398,7 @@ module ts.server {
 
     export class ProjectService {
         filenameToScriptInfo: ts.Map<ScriptInfo> = {};
-        // open, non-configured root files 
+        // open, non-configured root files
         openFileRoots: ScriptInfo[] = [];
         // projects built from openFileRoots
         inferredProjects: Project[] = [];
@@ -421,7 +421,7 @@ module ts.server {
                 hostInfo: "Unknown host"
             }
         }
-        
+
         getFormatCodeOptions(file?: string) {
             if (file) {
                 var info = this.filenameToScriptInfo[file];
@@ -448,7 +448,7 @@ module ts.server {
                 }
             }
         }
-        
+
         log(msg: string, type = "Err") {
             this.psLogger.msg(msg, type);
         }
@@ -457,17 +457,17 @@ module ts.server {
             if (args.file) {
                 var info = this.filenameToScriptInfo[args.file];
                 if (info) {
-                    info.setFormatOptions(args.formatOptions);  
+                    info.setFormatOptions(args.formatOptions);
                     this.log("Host configuration update for file " + args.file, "Info");
                 }
             }
             else {
                 if (args.hostInfo !== undefined) {
                     this.hostConfiguration.hostInfo = args.hostInfo;
-                    this.log("Host information " + args.hostInfo, "Info");                    
+                    this.log("Host information " + args.hostInfo, "Info");
                 }
                 if (args.formatOptions) {
-                    mergeFormatOptions(this.hostConfiguration.formatCodeOptions, args.formatOptions);                    
+                    mergeFormatOptions(this.hostConfiguration.formatCodeOptions, args.formatOptions);
                     this.log("Format host information updated", "Info");
                 }
             }
@@ -487,7 +487,7 @@ module ts.server {
 
         fileDeletedInFilesystem(info: ScriptInfo) {
             this.psLogger.info(info.fileName + " deleted");
-            
+
             if (info.fileWatcher) {
                 info.fileWatcher.close();
                 info.fileWatcher = undefined;
@@ -537,7 +537,7 @@ module ts.server {
              }
              return false;
         }
-            
+
         addOpenFile(info: ScriptInfo) {
             if (this.setConfiguredProjectRoot(info)) {
                 this.openFileRootsConfigured.push(info);
@@ -561,7 +561,7 @@ module ts.server {
                             copyListRemovingItem(r.defaultProject, this.inferredProjects);
                             // put r in referenced open file list
                             this.openFilesReferenced.push(r);
-                            // set default project of r to the new project 
+                            // set default project of r to the new project
                             r.defaultProject = info.defaultProject;
                         }
                         else {
@@ -694,7 +694,7 @@ module ts.server {
             this.openFilesReferenced = openFilesReferenced;
 
             // Then, loop through all of the open files that are project roots.
-            // For each root file, note the project that it roots.  Then see if 
+            // For each root file, note the project that it roots.  Then see if
             // any other projects newly reference the file.  If zero projects
             // newly reference the file, keep it as a root.  If one or more
             // projects newly references the file, remove its project from the
@@ -719,7 +719,7 @@ module ts.server {
 
             // Finally, if we found any open, referenced files that are no longer
             // referenced by their default project, treat them as newly opened
-            // by the editor. 
+            // by the editor.
             for (var i = 0, len = unattachedOpenFiles.length; i < len; i++) {
                 this.addOpenFile(unattachedOpenFiles[i]);
             }
@@ -809,7 +809,7 @@ module ts.server {
                 }
                 else {
                     this.log("Opened configuration file " + configFileName,"Info");
-                    this.configuredProjects.push(configResult.project);                    
+                    this.configuredProjects.push(configResult.project);
                 }
             }
             var info = this.openFile(fileName, true);
@@ -901,22 +901,22 @@ module ts.server {
             }
             return false;
         }
-        
+
         openConfigFile(configFilename: string, clientFileName?: string): ProjectOpenResult {
             configFilename = ts.normalizePath(configFilename);
             // file references will be relative to dirPath (or absolute)
             var dirPath = ts.getDirectoryPath(configFilename);
-            var rawConfig = <ProjectOptions>ts.readConfigFile(configFilename);
-            if (!rawConfig) {
-                return { errorMsg: "tsconfig syntax error" };
+            var rawConfig: { config?: ProjectOptions; error?: Diagnostic; } = ts.readConfigFile(configFilename);
+            if (rawConfig.error) {
+                return rawConfig.error;
             }
             else {
-                var parsedCommandLine = ts.parseConfigFile(rawConfig, ts.sys, dirPath);
+                var parsedCommandLine = ts.parseConfigFile(rawConfig.config, ts.sys, dirPath);
                 if (parsedCommandLine.errors && (parsedCommandLine.errors.length > 0)) {
                     return { errorMsg: "tsconfig option errors" };
                 }
                 else if (parsedCommandLine.fileNames) {
-                    var projectOptions: ProjectOptions = { 
+                    var projectOptions: ProjectOptions = {
                         files: parsedCommandLine.fileNames,
                         compilerOptions: parsedCommandLine.options
                     };
@@ -1040,7 +1040,7 @@ module ts.server {
         startPath: LineCollection[];
         endBranch: LineCollection[] = [];
         branchNode: LineNode;
-        // path to current node 
+        // path to current node
         stack: LineNode[];
         state = CharRangeSection.Entire;
         lineCollectionAtBranch: LineCollection;
@@ -1242,7 +1242,7 @@ module ts.server {
         }
     }
 
-    // text change information 
+    // text change information
     class TextChange {
         constructor(public pos: number, public deleteLen: number, public insertedText?: string) {
         }
@@ -1290,7 +1290,7 @@ module ts.server {
             if (cb)
                 cb();
         }
-    
+
         // reload whole script, leaving no change history behind reload
         reload(script: string) {
             this.currentVersion++;
@@ -1300,7 +1300,7 @@ module ts.server {
             snap.index = new LineIndex();
             var lm = LineIndex.linesFromText(script);
             snap.index.load(lm.lines);
-            // REVIEW: could use linked list 
+            // REVIEW: could use linked list
             for (var i = this.minVersion; i < this.currentVersion; i++) {
                 this.versions[i] = undefined;
             }
@@ -1381,7 +1381,7 @@ module ts.server {
             return this.index.root.charCount();
         }
 
-        // this requires linear space so don't hold on to these 
+        // this requires linear space so don't hold on to these
         getLineStartPositions(): number[] {
             var starts: number[] = [-1];
             var count = 1;
@@ -1643,7 +1643,7 @@ module ts.server {
         }
 
         walk(rangeStart: number, rangeLength: number, walkFns: ILineIndexWalker) {
-            // assume (rangeStart < this.totalChars) && (rangeLength <= this.totalChars) 
+            // assume (rangeStart < this.totalChars) && (rangeLength <= this.totalChars)
             var childIndex = 0;
             var child = this.children[0];
             var childCharCount = child.charCount();
@@ -1729,7 +1729,7 @@ module ts.server {
                     line: lineNumber,
                     offset: charOffset
                 }
-            } 
+            }
             else if (childInfo.child.isLeaf()) {
                 return {
                     line: lineNumber,

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -83,7 +83,7 @@ module ts {
     export interface Shim {
         dispose(dummy: any): void;
     }
-    
+
     export interface LanguageServiceShim extends Shim {
         languageService: LanguageService;
 
@@ -145,7 +145,7 @@ module ts {
          * { fileName: string; textSpan: { start: number; length: number}; isWriteAccess: boolean }[]
          */
         getReferencesAtPosition(fileName: string, position: number): string;
-        
+
         /**
          * Returns a JSON-encoded value of the type:
          * { definition: <encoded>; references: <encoded>[] }[]
@@ -162,8 +162,8 @@ module ts {
         /**
          * Returns a JSON-encoded value of the type:
          * { fileName: string; highlights: { start: number; length: number, isDefinition: boolean }[] }[]
-         * 
-         * @param fileToSearch A JSON encoded string[] containing the file names that should be 
+         *
+         * @param fileToSearch A JSON encoded string[] containing the file names that should be
          *  considered when searching.
          */
         getDocumentHighlights(fileName: string, position: number, filesToSearch: string): string;
@@ -244,7 +244,7 @@ module ts {
 
     export class LanguageServiceShimHostAdapter implements LanguageServiceHost {
         private files: string[];
-        
+
         constructor(private shimHost: LanguageServiceShimHost) {
         }
 
@@ -255,7 +255,7 @@ module ts {
         public trace(s: string): void {
             this.shimHost.trace(s);
         }
-        
+
         public error(s: string): void {
             this.shimHost.error(s);
         }
@@ -322,7 +322,7 @@ module ts {
             }
         }
     }
-    
+
     export class CoreServicesShimHostAdapter implements ParseConfigHost {
 
         constructor(private shimHost: CoreServicesShimHost) {
@@ -587,7 +587,7 @@ module ts {
 
         /**
          * Computes the definition location and file for the symbol
-         * at the requested position. 
+         * at the requested position.
          */
         public getDefinitionAtPosition(fileName: string, position: number): string {
             return this.forwardJSONCall(
@@ -601,7 +601,7 @@ module ts {
 
         /**
          * Computes the definition location of the type of the symbol
-         * at the requested position. 
+         * at the requested position.
          */
         public getTypeDefinitionAtPosition(fileName: string, position: number): string {
             return this.forwardJSONCall(
@@ -684,8 +684,8 @@ module ts {
         /// COMPLETION LISTS
 
         /**
-         * Get a string based representation of the completions 
-         * to provide at the given source position and providing a member completion 
+         * Get a string based representation of the completions
+         * to provide at the given source position and providing a member completion
          * list if requested.
          */
         public getCompletionsAtPosition(fileName: string, position: number) {
@@ -883,7 +883,7 @@ module ts {
                     return {
                         options: configFile.options,
                         files: configFile.fileNames,
-                        errors: realizeDiagnostics(configFile.errors, '\r\n')
+                        errors: [realizeDiagnostics(configFile.errors, '\r\n')]
                     };
                 });
         }


### PR DESCRIPTION
The return signature of `readConfigFile()` changed in f8424d0b0c91a487a2c8cc226c89ffb359816b7b and the code using it in `ProjectService` was never updated to match. This lead to the language services attempting to parse an object that doesn't match what is expected and using the default compiler options instead of what is defined in `tsconfig.json`. Similarly, the return value of the closure in `getTSConfigFileInfo()` was never updated to match in both places it returns.

This contribution should be covered by SitePen's corporate CLA.