### PR TITLE
Fixes iojs environment check issue

### DIFF
--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -45,10 +45,10 @@ module Utils {
     export function getExecutionEnvironment() {
         if (typeof WScript !== "undefined" && typeof ActiveXObject === "function") {
             return ExecutionEnvironment.CScript;
-        } else if (process && process.execPath && process.execPath.indexOf("node") !== -1) {
-            return ExecutionEnvironment.Node;
-        } else {
+        } else if (typeof window !== "undefined") {
             return ExecutionEnvironment.Browser;
+        } else {
+            return ExecutionEnvironment.Node;
         }
     }
 


### PR DESCRIPTION
process.execPath could have any name, but defaults on `iojs` for iojs and `node` on node. The current node check is not doable i iojs. This PR fixes it.