### PR TITLE
Refactor narrow type by instance of

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5404,6 +5404,7 @@ module ts {
                     else if (rightType.flags & TypeFlags.Anonymous) {
                         constructSignatures = getSignaturesOfType(rightType, SignatureKind.Construct);
                     }
+
                     if (constructSignatures && constructSignatures.length) {
                         targetType = getUnionType(map(constructSignatures, signature => getReturnTypeOfSignature(getErasedSignature(signature))));
                     }

--- a/tests/baselines/reference/narrowTypeByInstanceof.js
+++ b/tests/baselines/reference/narrowTypeByInstanceof.js
@@ -1,0 +1,53 @@
+//// [narrowTypeByInstanceof.ts]
+    class Match {
+        public range(): any {
+            return undefined;
+        }
+    }
+
+    class FileMatch {
+        public resource(): any {
+            return undefined;
+        }
+    }
+
+type FileMatchOrMatch = FileMatch | Match;
+
+
+let elementA: FileMatchOrMatch, elementB: FileMatchOrMatch;
+
+if (elementA instanceof FileMatch && elementB instanceof FileMatch) {
+    let a = elementA.resource().path;
+    let b = elementB.resource().path;
+} else if (elementA instanceof Match && elementB instanceof Match) {
+    let a = elementA.range();
+    let b = elementB.range();
+}
+
+
+//// [narrowTypeByInstanceof.js]
+var Match = (function () {
+    function Match() {
+    }
+    Match.prototype.range = function () {
+        return undefined;
+    };
+    return Match;
+})();
+var FileMatch = (function () {
+    function FileMatch() {
+    }
+    FileMatch.prototype.resource = function () {
+        return undefined;
+    };
+    return FileMatch;
+})();
+var elementA, elementB;
+if (elementA instanceof FileMatch && elementB instanceof FileMatch) {
+    var a = elementA.resource().path;
+    var b = elementB.resource().path;
+}
+else if (elementA instanceof Match && elementB instanceof Match) {
+    var a = elementA.range();
+    var b = elementB.range();
+}

--- a/tests/baselines/reference/narrowTypeByInstanceof.symbols
+++ b/tests/baselines/reference/narrowTypeByInstanceof.symbols
@@ -1,0 +1,72 @@
+=== tests/cases/compiler/narrowTypeByInstanceof.ts ===
+    class Match {
+>Match : Symbol(Match, Decl(narrowTypeByInstanceof.ts, 0, 0))
+
+        public range(): any {
+>range : Symbol(range, Decl(narrowTypeByInstanceof.ts, 0, 17))
+
+            return undefined;
+>undefined : Symbol(undefined)
+        }
+    }
+
+    class FileMatch {
+>FileMatch : Symbol(FileMatch, Decl(narrowTypeByInstanceof.ts, 4, 5))
+
+        public resource(): any {
+>resource : Symbol(resource, Decl(narrowTypeByInstanceof.ts, 6, 21))
+
+            return undefined;
+>undefined : Symbol(undefined)
+        }
+    }
+
+type FileMatchOrMatch = FileMatch | Match;
+>FileMatchOrMatch : Symbol(FileMatchOrMatch, Decl(narrowTypeByInstanceof.ts, 10, 5))
+>FileMatch : Symbol(FileMatch, Decl(narrowTypeByInstanceof.ts, 4, 5))
+>Match : Symbol(Match, Decl(narrowTypeByInstanceof.ts, 0, 0))
+
+
+let elementA: FileMatchOrMatch, elementB: FileMatchOrMatch;
+>elementA : Symbol(elementA, Decl(narrowTypeByInstanceof.ts, 15, 3))
+>FileMatchOrMatch : Symbol(FileMatchOrMatch, Decl(narrowTypeByInstanceof.ts, 10, 5))
+>elementB : Symbol(elementB, Decl(narrowTypeByInstanceof.ts, 15, 31))
+>FileMatchOrMatch : Symbol(FileMatchOrMatch, Decl(narrowTypeByInstanceof.ts, 10, 5))
+
+if (elementA instanceof FileMatch && elementB instanceof FileMatch) {
+>elementA : Symbol(elementA, Decl(narrowTypeByInstanceof.ts, 15, 3))
+>FileMatch : Symbol(FileMatch, Decl(narrowTypeByInstanceof.ts, 4, 5))
+>elementB : Symbol(elementB, Decl(narrowTypeByInstanceof.ts, 15, 31))
+>FileMatch : Symbol(FileMatch, Decl(narrowTypeByInstanceof.ts, 4, 5))
+
+    let a = elementA.resource().path;
+>a : Symbol(a, Decl(narrowTypeByInstanceof.ts, 18, 7))
+>elementA.resource : Symbol(FileMatch.resource, Decl(narrowTypeByInstanceof.ts, 6, 21))
+>elementA : Symbol(elementA, Decl(narrowTypeByInstanceof.ts, 15, 3))
+>resource : Symbol(FileMatch.resource, Decl(narrowTypeByInstanceof.ts, 6, 21))
+
+    let b = elementB.resource().path;
+>b : Symbol(b, Decl(narrowTypeByInstanceof.ts, 19, 7))
+>elementB.resource : Symbol(FileMatch.resource, Decl(narrowTypeByInstanceof.ts, 6, 21))
+>elementB : Symbol(elementB, Decl(narrowTypeByInstanceof.ts, 15, 31))
+>resource : Symbol(FileMatch.resource, Decl(narrowTypeByInstanceof.ts, 6, 21))
+
+} else if (elementA instanceof Match && elementB instanceof Match) {
+>elementA : Symbol(elementA, Decl(narrowTypeByInstanceof.ts, 15, 3))
+>Match : Symbol(Match, Decl(narrowTypeByInstanceof.ts, 0, 0))
+>elementB : Symbol(elementB, Decl(narrowTypeByInstanceof.ts, 15, 31))
+>Match : Symbol(Match, Decl(narrowTypeByInstanceof.ts, 0, 0))
+
+    let a = elementA.range();
+>a : Symbol(a, Decl(narrowTypeByInstanceof.ts, 21, 7))
+>elementA.range : Symbol(Match.range, Decl(narrowTypeByInstanceof.ts, 0, 17))
+>elementA : Symbol(elementA, Decl(narrowTypeByInstanceof.ts, 15, 3))
+>range : Symbol(Match.range, Decl(narrowTypeByInstanceof.ts, 0, 17))
+
+    let b = elementB.range();
+>b : Symbol(b, Decl(narrowTypeByInstanceof.ts, 22, 7))
+>elementB.range : Symbol(Match.range, Decl(narrowTypeByInstanceof.ts, 0, 17))
+>elementB : Symbol(elementB, Decl(narrowTypeByInstanceof.ts, 15, 31))
+>range : Symbol(Match.range, Decl(narrowTypeByInstanceof.ts, 0, 17))
+}
+

--- a/tests/baselines/reference/narrowTypeByInstanceof.types
+++ b/tests/baselines/reference/narrowTypeByInstanceof.types
@@ -1,0 +1,86 @@
+=== tests/cases/compiler/narrowTypeByInstanceof.ts ===
+    class Match {
+>Match : Match
+
+        public range(): any {
+>range : () => any
+
+            return undefined;
+>undefined : undefined
+        }
+    }
+
+    class FileMatch {
+>FileMatch : FileMatch
+
+        public resource(): any {
+>resource : () => any
+
+            return undefined;
+>undefined : undefined
+        }
+    }
+
+type FileMatchOrMatch = FileMatch | Match;
+>FileMatchOrMatch : Match | FileMatch
+>FileMatch : FileMatch
+>Match : Match
+
+
+let elementA: FileMatchOrMatch, elementB: FileMatchOrMatch;
+>elementA : Match | FileMatch
+>FileMatchOrMatch : Match | FileMatch
+>elementB : Match | FileMatch
+>FileMatchOrMatch : Match | FileMatch
+
+if (elementA instanceof FileMatch && elementB instanceof FileMatch) {
+>elementA instanceof FileMatch && elementB instanceof FileMatch : boolean
+>elementA instanceof FileMatch : boolean
+>elementA : Match | FileMatch
+>FileMatch : typeof FileMatch
+>elementB instanceof FileMatch : boolean
+>elementB : Match | FileMatch
+>FileMatch : typeof FileMatch
+
+    let a = elementA.resource().path;
+>a : any
+>elementA.resource().path : any
+>elementA.resource() : any
+>elementA.resource : () => any
+>elementA : FileMatch
+>resource : () => any
+>path : any
+
+    let b = elementB.resource().path;
+>b : any
+>elementB.resource().path : any
+>elementB.resource() : any
+>elementB.resource : () => any
+>elementB : FileMatch
+>resource : () => any
+>path : any
+
+} else if (elementA instanceof Match && elementB instanceof Match) {
+>elementA instanceof Match && elementB instanceof Match : boolean
+>elementA instanceof Match : boolean
+>elementA : Match | FileMatch
+>Match : typeof Match
+>elementB instanceof Match : boolean
+>elementB : Match | FileMatch
+>Match : typeof Match
+
+    let a = elementA.range();
+>a : any
+>elementA.range() : any
+>elementA.range : () => any
+>elementA : Match
+>range : () => any
+
+    let b = elementB.range();
+>b : any
+>elementB.range() : any
+>elementB.range : () => any
+>elementB : Match
+>range : () => any
+}
+

--- a/tests/baselines/reference/typeGuardsWithInstanceOfByConstructorSignature.errors.txt
+++ b/tests/baselines/reference/typeGuardsWithInstanceOfByConstructorSignature.errors.txt
@@ -1,15 +1,15 @@
 tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(12,10): error TS2339: Property 'bar' does not exist on type 'A'.
 tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(33,5): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(34,10): error TS2339: Property 'bar' does not exist on type 'B<number>'.
-tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(62,10): error TS2339: Property 'bar1' does not exist on type 'C1 | C2'.
-tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(63,10): error TS2339: Property 'bar2' does not exist on type 'C1 | C2'.
-tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(82,10): error TS2339: Property 'bar' does not exist on type 'D'.
-tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(108,10): error TS2339: Property 'bar1' does not exist on type 'E1 | E2'.
-tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(109,10): error TS2339: Property 'bar2' does not exist on type 'E1 | E2'.
-tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(131,11): error TS2339: Property 'foo' does not exist on type 'string | F'.
-tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(132,11): error TS2339: Property 'bar' does not exist on type 'string | F'.
-tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(157,11): error TS2339: Property 'foo2' does not exist on type 'G1'.
-tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(179,11): error TS2339: Property 'bar' does not exist on type 'H'.
+tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(65,10): error TS2339: Property 'bar1' does not exist on type 'C1 | C2'.
+tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(66,10): error TS2339: Property 'bar2' does not exist on type 'C1 | C2'.
+tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(85,10): error TS2339: Property 'bar' does not exist on type 'D'.
+tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(111,10): error TS2339: Property 'bar1' does not exist on type 'E1 | E2'.
+tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(112,10): error TS2339: Property 'bar2' does not exist on type 'E1 | E2'.
+tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(134,11): error TS2339: Property 'foo' does not exist on type 'string | F'.
+tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(135,11): error TS2339: Property 'bar' does not exist on type 'string | F'.
+tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(160,11): error TS2339: Property 'foo2' does not exist on type 'G1'.
+tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(182,11): error TS2339: Property 'bar' does not exist on type 'H'.
 
 
 ==== tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts (12 errors) ====
@@ -69,17 +69,20 @@ tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstru
     }
     interface C1 {
         foo: string;
+        c: string;
         bar1: number;
     }
     interface C2 {
         foo: string;
+        c: string;
         bar2: number;
     }
     declare var C: CConstructor;
     
     var obj5: C1 | A;
-    if (obj5 instanceof C) { // narrowed to C1.
+    if (obj5 instanceof C) { // narrowed to C1|C2.
         obj5.foo;
+        obj5.c;
         obj5.bar1;
              ~~~~
 !!! error TS2339: Property 'bar1' does not exist on type 'C1 | C2'.
@@ -130,7 +133,7 @@ tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstru
     declare var E: EConstructor;
     
     var obj9: E1 | A;
-    if (obj9 instanceof E) { // narrowed to E1.
+    if (obj9 instanceof E) { // narrowed to E1 | E2
         obj9.foo;
         obj9.bar1;
              ~~~~

--- a/tests/baselines/reference/typeGuardsWithInstanceOfByConstructorSignature.errors.txt
+++ b/tests/baselines/reference/typeGuardsWithInstanceOfByConstructorSignature.errors.txt
@@ -1,16 +1,18 @@
 tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(12,10): error TS2339: Property 'bar' does not exist on type 'A'.
 tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(33,5): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(34,10): error TS2339: Property 'bar' does not exist on type 'B<number>'.
-tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(63,10): error TS2339: Property 'bar2' does not exist on type 'C1'.
+tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(62,10): error TS2339: Property 'bar1' does not exist on type 'C1 | C2'.
+tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(63,10): error TS2339: Property 'bar2' does not exist on type 'C1 | C2'.
 tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(82,10): error TS2339: Property 'bar' does not exist on type 'D'.
-tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(109,10): error TS2339: Property 'bar2' does not exist on type 'E1'.
+tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(108,10): error TS2339: Property 'bar1' does not exist on type 'E1 | E2'.
+tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(109,10): error TS2339: Property 'bar2' does not exist on type 'E1 | E2'.
 tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(131,11): error TS2339: Property 'foo' does not exist on type 'string | F'.
 tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(132,11): error TS2339: Property 'bar' does not exist on type 'string | F'.
 tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(157,11): error TS2339: Property 'foo2' does not exist on type 'G1'.
 tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts(179,11): error TS2339: Property 'bar' does not exist on type 'H'.
 
 
-==== tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts (10 errors) ====
+==== tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts (12 errors) ====
     interface AConstructor {
         new (): A;
     }
@@ -79,9 +81,11 @@ tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstru
     if (obj5 instanceof C) { // narrowed to C1.
         obj5.foo;
         obj5.bar1;
+             ~~~~
+!!! error TS2339: Property 'bar1' does not exist on type 'C1 | C2'.
         obj5.bar2;
              ~~~~
-!!! error TS2339: Property 'bar2' does not exist on type 'C1'.
+!!! error TS2339: Property 'bar2' does not exist on type 'C1 | C2'.
     }
     
     var obj6: any;
@@ -129,9 +133,11 @@ tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstru
     if (obj9 instanceof E) { // narrowed to E1.
         obj9.foo;
         obj9.bar1;
+             ~~~~
+!!! error TS2339: Property 'bar1' does not exist on type 'E1 | E2'.
         obj9.bar2;
              ~~~~
-!!! error TS2339: Property 'bar2' does not exist on type 'E1'.
+!!! error TS2339: Property 'bar2' does not exist on type 'E1 | E2'.
     }
     
     var obj10: any;

--- a/tests/baselines/reference/typeGuardsWithInstanceOfByConstructorSignature.js
+++ b/tests/baselines/reference/typeGuardsWithInstanceOfByConstructorSignature.js
@@ -49,17 +49,20 @@ interface CConstructor {
 }
 interface C1 {
     foo: string;
+    c: string;
     bar1: number;
 }
 interface C2 {
     foo: string;
+    c: string;
     bar2: number;
 }
 declare var C: CConstructor;
 
 var obj5: C1 | A;
-if (obj5 instanceof C) { // narrowed to C1.
+if (obj5 instanceof C) { // narrowed to C1|C2.
     obj5.foo;
+    obj5.c;
     obj5.bar1;
     obj5.bar2;
 }
@@ -104,7 +107,7 @@ interface E2 {
 declare var E: EConstructor;
 
 var obj9: E1 | A;
-if (obj9 instanceof E) { // narrowed to E1.
+if (obj9 instanceof E) { // narrowed to E1 | E2
     obj9.foo;
     obj9.bar1;
     obj9.bar2;
@@ -213,6 +216,7 @@ if (obj4 instanceof B) {
 var obj5;
 if (obj5 instanceof C) {
     obj5.foo;
+    obj5.c;
     obj5.bar1;
     obj5.bar2;
 }

--- a/tests/cases/compiler/narrowTypeByInstanceof.ts
+++ b/tests/cases/compiler/narrowTypeByInstanceof.ts
@@ -1,0 +1,24 @@
+﻿    class Match {
+        public range(): any {
+            return undefined;
+        }
+    }
+
+    class FileMatch {
+        public resource(): any {
+            return undefined;
+        }
+    }
+
+type FileMatchOrMatch = FileMatch | Match;
+
+
+let elementA: FileMatchOrMatch, elementB: FileMatchOrMatch;
+
+if (elementA instanceof FileMatch && elementB instanceof FileMatch) {
+    let a = elementA.resource().path;
+    let b = elementB.resource().path;
+} else if (elementA instanceof Match && elementB instanceof Match) {
+    let a = elementA.range();
+    let b = elementB.range();
+}

--- a/tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts
+++ b/tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOfByConstructorSignature.ts
@@ -48,17 +48,20 @@ interface CConstructor {
 }
 interface C1 {
     foo: string;
+    c: string;
     bar1: number;
 }
 interface C2 {
     foo: string;
+    c: string;
     bar2: number;
 }
 declare var C: CConstructor;
 
 var obj5: C1 | A;
-if (obj5 instanceof C) { // narrowed to C1.
+if (obj5 instanceof C) { // narrowed to C1|C2.
     obj5.foo;
+    obj5.c;
     obj5.bar1;
     obj5.bar2;
 }
@@ -103,7 +106,7 @@ interface E2 {
 declare var E: EConstructor;
 
 var obj9: E1 | A;
-if (obj9 instanceof E) { // narrowed to E1.
+if (obj9 instanceof E) { // narrowed to E1 | E2
     obj9.foo;
     obj9.bar1;
     obj9.bar2;


### PR DESCRIPTION
Refactor narrowTypeByInstanceof to be more uniform for its two branches (prototype and construct signature return types), also fixed an issue we ran into in real world code. Added a regression test for it.