### PR TITLE
Format on type deletes valid range

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -29,6 +29,9 @@ module ts {
     declare var process: any;
     declare var global: any;
     declare var __filename: string;
+    declare var Buffer: {
+         new (str: string, encoding ?: string): any;
+    }
 
     declare class Enumerator {
         public atEnd(): boolean;
@@ -252,8 +255,15 @@ module ts {
                 newLine: _os.EOL,
                 useCaseSensitiveFileNames: useCaseSensitiveFileNames,
                 write(s: string): void {
+                    var buffer = new Buffer(s, 'utf8');
+                    var offset: number = 0;
+                    var toWrite: number = buffer.length
+                    var written = 0;
                     // 1 is a standard descriptor for stdout
-                    _fs.writeSync(1, s);
+                   while ((written = _fs.writeSync(1, buffer, offset, toWrite)) < toWrite) {
+                       offset += written;
+                       toWrite -= written; 
+                   }
                 },
                 readFile,
                 writeFile,

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -21,6 +21,21 @@ module ts.server {
         }  
         return spaceCache[n];
     }
+    
+    export function generateIndentString(n: number, editorOptions: EditorOptions): string {
+        if (editorOptions.ConvertTabsToSpaces) {
+            return generateSpaces(n);
+        } else {
+            var result = "";
+            for (var i = 0; i < Math.floor(n / editorOptions.TabSize); i++) {
+                result += "\t";
+            }
+            for (var i = 0; i < n % editorOptions.TabSize; i++) {
+                result += " ";
+            }
+            return result;
+        }
+    }
 
     interface FileStart {
         file: string;
@@ -541,31 +556,29 @@ module ts.server {
                             var editorOptions: ts.EditorOptions = {
                                 IndentSize: formatOptions.IndentSize,
                                 TabSize: formatOptions.TabSize,
-                                NewLineCharacter: "\n",
+                                NewLineCharacter: formatOptions.NewLineCharacter,
                                 ConvertTabsToSpaces: formatOptions.ConvertTabsToSpaces,
                             };
-                            var indentPosition =
-                                compilerService.languageService.getIndentationAtPosition(file, position, editorOptions);
+                            var preferredIndent = compilerService.languageService.getIndentationAtPosition(file, position, editorOptions);
+                            var hasIndent = 0;
                             for (var i = 0, len = lineText.length; i < len; i++) {
                                 if (lineText.charAt(i) == " ") {
-                                    indentPosition--;
+                                    hasIndent++;
                                 }
                                 else if (lineText.charAt(i) == "\t") {
-                                    indentPosition -= editorOptions.IndentSize;
+                                    hasIndent += editorOptions.TabSize;
                                 }
                                 else {
                                     break;
                                 }
                             }
-                            if (indentPosition > 0) {
-                                var spaces = generateSpaces(indentPosition);
-                                edits.push({ span: ts.createTextSpanFromBounds(position, position), newText: spaces });
-                            }
-                            else if (indentPosition < 0) {
-                                edits.push({
-                                    span: ts.createTextSpanFromBounds(position, position - indentPosition),
-                                    newText: ""
-                                });
+                            // i points to the first non whitespace character
+                            if (preferredIndent !== hasIndent) {
+                                var firstNoWhiteSpacePosition = lineInfo.offset + i;
+                                edits.push({ 
+                                    span: ts.createTextSpanFromBounds(lineInfo.offset, firstNoWhiteSpacePosition), 
+                                    newText: generateIndentString(preferredIndent, editorOptions)
+                                });                                
                             }
                         }
                     }


### PR DESCRIPTION
Type enter on a line and the result is totally unexpected. 
File (Game.ts):
/// <reference path="lib/Base.ts"/>
/// <reference path="Position.ts"/>
/// <reference path="Features.ts" />
module Mankala {
    export var NoSpace = -1;
    export var homeSpaces = [[0,1,2, 3, 4, 5],
                         [7,8,9,10,11,12]];
    export var firstHomeSpace = [0,7];
    export var lastHomeSpace = [5,12];
    export var capturedSpaces = [12,11,10,9,8,7,NoSpace,5,4,3,2,1,0,NoSpace];
    export var NoScore = 31;
    export var NoMove = -1;
}
Press enter after "  [7,8,9,10,11,12]];"

The result is super weird, see screenshot:
![capture](https://cloud.githubusercontent.com/assets/1931590/7534118/c529491a-f577-11e4-953d-03f1f7c936bd.png)

The problem is in 

                            else if (indentPosition < 0) {
                                edits.push({
                                    span: ts.createTextSpanFromBounds(position, position - indentPosition),
                                    newText: ""
                                });

IndentPosition is negative so we delete characters form the current position on forward.

The pull request fixes this plus handles the fact that existing indent uses tabs. The problem here is that indentPosition counts the column. But on removal one column doesn't equal one character to remove since \t counts for n columns.

