### PR TITLE
Don't wrap an array of errors in an additional array.

### DIFF
--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -883,7 +883,7 @@ module ts {
                     return {
                         options: configFile.options,
                         files: configFile.fileNames,
-                        errors: [realizeDiagnostics(configFile.errors, '\r\n')]
+                        errors: realizeDiagnostics(configFile.errors, '\r\n')
                     };
                 });
         }


### PR DESCRIPTION
This completely breaks the managed LS as the data shape no longer matches our established API.