### PR TITLE
Type check all files when emitting a file under -out

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -219,7 +219,12 @@ module ts {
             // Create the emit resolver outside of the "emitTime" tracking code below.  That way
             // any cost associated with it (like type checking) are appropriate associated with
             // the type-checking counter.
-            let emitResolver = getDiagnosticsProducingTypeChecker().getEmitResolver(sourceFile);
+            //
+            // If the -out option is specified, we should not pass the source file to getEmitResolver.
+            // This is because in the -out scenario all files need to be emitted, and therefore all
+            // files need to be type checked. And the way to specify that all files need to be type
+            // checked is to not pass the file to getEmitResolver.
+            let emitResolver = getDiagnosticsProducingTypeChecker().getEmitResolver(options.out ? undefined : sourceFile);
 
             let start = new Date().getTime();
 

--- a/tests/baselines/reference/getEmitOutputOut.baseline
+++ b/tests/baselines/reference/getEmitOutputOut.baseline
@@ -1,0 +1,12 @@
+EmitSkipped: false
+FileName : out.js
+/// <reference path='my.d.ts' />
+var foo;
+(function (foo) {
+    var bar;
+    (function (bar) {
+        var baz1 = bar.Baz.prototype; // Should emit as bar.Baz.prototype
+    })(bar = foo.bar || (foo.bar = {}));
+})(foo || (foo = {}));
+var x;
+

--- a/tests/cases/fourslash/getEmitOutputOut.ts
+++ b/tests/cases/fourslash/getEmitOutputOut.ts
@@ -1,0 +1,23 @@
+/// <reference path="fourslash.ts" />
+
+// @BaselineFile: getEmitOutputOut.baseline
+// @out: out.js
+
+// @Filename: my.d.ts
+// @emitThisFile: false
+////declare module foo.bar {
+////    class Baz { }
+////}
+
+// @Filename: input0.ts
+// @emitThisFile: false
+/////// <reference path='my.d.ts' />
+////module foo.bar {
+////    var baz1 = <any>Baz.prototype; // Should emit as bar.Baz.prototype
+////}
+
+// @Filename: input1.ts
+// @emitThisFile: true
+////var x;
+
+verify.baselineGetEmitOutput();


### PR DESCRIPTION
Since it is necessary to type check a source file before you emit it, it is necessary to type check all files before emitting -out.

Thanks @vladima for your help on this fix. It fixes #2061.