### PR TITLE
Remove nextTokenCanFollowContextualModifier

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -957,15 +957,6 @@ module ts {
         }
 
         function nextTokenCanFollowModifier() {
-            nextToken();
-            return canFollowModifier();
-        }
-
-        function parseAnyContextualModifier(): boolean {
-            return isModifier(token) && tryParse(nextTokenCanFollowContextualModifier);
-        }
-
-        function nextTokenCanFollowContextualModifier() {
             if (token === SyntaxKind.ConstKeyword) {
                 // 'const' is only a modifier if followed by 'enum'.
                 return nextToken() === SyntaxKind.EnumKeyword;
@@ -982,6 +973,10 @@ module ts {
             }
             nextToken();
             return canFollowModifier();
+        }
+
+        function parseAnyContextualModifier(): boolean {
+            return isModifier(token) && tryParse(nextTokenCanFollowModifier);
         }
 
         function canFollowModifier(): boolean {


### PR DESCRIPTION
The parser has a function called nextTokenCanFollowModifier and another one called nextTokenCanFollowContextualModifier. There is no reason for these to be two different functions. I used the following reasoning:

* A contextual modifier is a token that might be a modifier, depending on what token follows it.
* To test if a contextual modifier is playing the role of a modifier, we check if the next token can follow a modifier.
* Checking if the next token can follow a *contextual* modifier doesn't tell us whether the contextual modifier is in fact a modifier.

Basically the function nextTokenCanFollowContextualModifier was just named wrong. If we named it correctly, it would be nextTokenCanFollowModifier, which is exactly the same name as that other function! Hence they can be merged.