### PR TITLE
Add resolveAliasAsValue to fix a stack overflow

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1382,6 +1382,10 @@ module ts {
     /* @internal */ 
     export interface SymbolLinks {
         target?: Symbol;                    // Resolved (non-alias) target of an alias
+        aliasValueTarget?: Symbol;          // The result of resolving an alias as a value, which may be the target,
+                                            //     or something even farther down the chain of alias references.
+                                            //     This is needed when the target is simultaneously an alias and a non-value,
+                                            //     but we are looking for a value.
         type?: Type;                        // Type of value symbol
         declaredType?: Type;                // Type of class, interface, enum, or type parameter
         mapper?: TypeMapper;                // Type mapper for instantiation alias

--- a/tests/cases/fourslash/aliasMergingWithNamespace.ts
+++ b/tests/cases/fourslash/aliasMergingWithNamespace.ts
@@ -1,0 +1,7 @@
+///<reference path="fourslash.ts"/>
+
+////namespace bar { }
+////import bar = bar/**/;
+
+goTo.marker();
+verify.quickInfoExists();


### PR DESCRIPTION
Fixes #2933. The issue is that getTypeOfAlias needs to resolve the alias as a value, which would cause resolveAlias to detect a cycle. However, resolveAlias has no idea that it's looking for a value, so it stops early. This causes getTypeOfAlias to infinitely recurse, and each time it calls resolveAlias, it gets back an alias that is its own target.

The fix is to make a more aggressive resolveAliasAsValue, which will detect the cycle properly. And getTypeOfAlias should call that.

For a more complete explanation, see #3140.