### PR TITLE
external modules resolve by node_modules and package.json-main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+!tests/**/node_modules/
 built/*
 tests/cases/*.js
 tests/cases/*/*.js

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -859,17 +859,9 @@ module ts {
             }
             let fileName: string;
             let sourceFile: SourceFile;
-            while (true) {
-                fileName = normalizePath(combinePaths(searchPath, moduleName));
-                sourceFile = forEach(supportedExtensions, extension => host.getSourceFile(fileName + extension));
-                if (sourceFile || isRelative) {
-                    break;
-                }
-                let parentPath = getDirectoryPath(searchPath);
-                if (parentPath === searchPath) {
-                    break;
-                }
-                searchPath = parentPath;
+            let resolvedName: string = host.resolveExternalModule(moduleName, searchPath);
+            if (resolvedName) {
+               sourceFile = host.getSourceFile(resolvedName);
             }
             if (sourceFile) {
                 if (sourceFile.symbol) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -859,7 +859,7 @@ module ts {
             }
             let fileName: string;
             let sourceFile: SourceFile;
-            let resolvedName: string = host.resolveExternalModule(moduleName, searchPath);
+            let resolvedName = host.resolveExternalModule(moduleName, searchPath);
             if (resolvedName) {
                sourceFile = host.getSourceFile(resolvedName);
             }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -248,7 +248,10 @@ module ts {
                 return undefined;
             }
             function getNameIfExists(fileName: string): string {
-                if (sys.fileExists(fileName)) {
+                // To detect if file exists. 
+                // Using this is to demonstrate that sys.fileExists is what is causing module resolution to fail in test driver
+                // This is just for code review
+                if (host.getSourceFile(fileName, ScriptTarget.Latest)) {
                     return fileName;
                 }
             }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -484,7 +484,7 @@ module ts {
                     if (moduleNameExpr && moduleNameExpr.kind === SyntaxKind.StringLiteral) {
                         let moduleNameText = (<LiteralExpression>moduleNameExpr).text;
                         if (moduleNameText) {
-                            let resolvedName: string = resolveExternalModule(moduleNameText, getDirectoryPath(file.fileName));
+                            let resolvedName = resolveExternalModule(moduleNameText, getDirectoryPath(file.fileName));
                             if (resolvedName) {
                                 findModuleSourceFile(resolvedName, moduleNameExpr);
                             }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1881,6 +1881,8 @@ module ts {
         getCanonicalFileName(fileName: string): string;
         useCaseSensitiveFileNames(): boolean;
         getNewLine(): string;
+        readFile(path: string): string;
+        fileExists(path: string): boolean;
     }
 
     export interface TextSpan {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1069,6 +1069,8 @@ module ts {
          * Gets a type checker that can be used to semantically analyze source fils in the program.
          */
         getTypeChecker(): TypeChecker;
+        
+        resolveExternalModule(moduleName: string, basePath: string): string;
 
         /* @internal */ getCommonSourceDirectory(): string;
 
@@ -1133,6 +1135,7 @@ module ts {
     export interface TypeCheckerHost {
         getCompilerOptions(): CompilerOptions;
 
+        resolveExternalModule(moduleName: string, basePath: string): string;
         getSourceFiles(): SourceFile[];
         getSourceFile(fileName: string): SourceFile;
     }

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2230,6 +2230,8 @@ module FourSlash {
     {
         let host = Harness.Compiler.createCompilerHost([{ unitName: Harness.Compiler.fourslashFileName, content: undefined }],
             (fn, contents) => fourslashJsOutput = contents,
+            (fn) => undefined,
+            (fn) => true,
             ts.ScriptTarget.Latest,
             ts.sys.useCaseSensitiveFileNames);
 
@@ -2252,6 +2254,8 @@ module FourSlash {
                 { unitName: fileName, content: content }
             ],
             (fn, contents) => result = contents,
+            (fn) => result,
+            (fn) => true,
             ts.ScriptTarget.Latest,
             ts.sys.useCaseSensitiveFileNames);
 

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -822,6 +822,8 @@ module Harness {
 
         export function createCompilerHost(inputFiles: { unitName: string; content: string; }[],
             writeFile: (fn: string, contents: string, writeByteOrderMark: boolean) => void,
+            readFile: (fn: string) => string,
+            fileExists: (fn: string) => boolean,
             scriptTarget: ts.ScriptTarget,
             useCaseSensitiveFileNames: boolean,
             // the currentDirectory is needed for rwcRunner to passed in specified current directory to compiler host
@@ -876,6 +878,8 @@ module Harness {
                 },
                 getDefaultLibFileName: options => defaultLibFileName,
                 writeFile,
+                readFile,
+                fileExists,
                 getCanonicalFileName,
                 useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
                 getNewLine: () => newLine
@@ -1121,8 +1125,16 @@ module Harness {
                 var fileOutputs: GeneratedFile[] = [];
                 
                 var programFiles = inputFiles.concat(includeBuiltFiles).map(file => file.unitName);
-                var program = ts.createProgram(programFiles, options, createCompilerHost(inputFiles.concat(includeBuiltFiles).concat(otherFiles),
+                var compilerHostInputFiles = inputFiles.concat(includeBuiltFiles).concat(otherFiles);
+                var program = ts.createProgram(programFiles, options, createCompilerHost(compilerHostInputFiles,
                     (fn, contents, writeByteOrderMark) => fileOutputs.push({ fileName: fn, code: contents, writeByteOrderMark: writeByteOrderMark }),
+                    (fn) => {
+                        var found = compilerHostInputFiles.filter(f=>f.unitName === fn)[0];
+                        return found ? found.content : undefined;
+                    },
+                    (fn) => {
+                        return !!compilerHostInputFiles.some(f=> f.unitName === fn)
+                    },
                     options.target, useCaseSensitiveFileNames, currentDirectory, options.newLine));
 
                 var emitResult = program.emit();

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -190,6 +190,7 @@ module Harness.LanguageService {
         log(s: string): void { }
         trace(s: string): void { }
         error(s: string): void { }
+        fileExists = (fn: string) => this.getFilenames().some(serviceAdaptorFileName=> serviceAdaptorFileName === fn);
     }
 
     export class NativeLanugageServiceAdapter implements LanguageServiceAdapter {
@@ -236,6 +237,7 @@ module Harness.LanguageService {
         log(s: string): void { this.nativeHost.log(s); }
         trace(s: string): void { this.nativeHost.trace(s); }
         error(s: string): void { this.nativeHost.error(s); }
+        fileExists(fn: string) { return this.nativeHost.fileExists(fn); }
     }
 
     class ClassifierShimProxy implements ts.Classifier { 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1795,7 +1795,9 @@ module ts {
             useCaseSensitiveFileNames: () => false,
             getCanonicalFileName: fileName => fileName,
             getCurrentDirectory: () => "",
-            getNewLine: () => (sys && sys.newLine) || "\r\n"
+            getNewLine: () => (sys && sys.newLine) || "\r\n",
+            readFile: sys.readFile,
+            fileExists: sys.fileExists
         };
 
         var program = createProgram([inputFileName], options, compilerHost);
@@ -2433,7 +2435,9 @@ module ts {
                 getNewLine: () => host.getNewLine ? host.getNewLine() : "\r\n",
                 getDefaultLibFileName: (options) => host.getDefaultLibFileName(options),
                 writeFile: (fileName, data, writeByteOrderMark) => { },
-                getCurrentDirectory: () => host.getCurrentDirectory()
+                readFile: (fileName) => sys.readFile(fileName),
+                fileExists: (fileName) => !!hostCache.getOrCreateEntry(fileName),
+                getCurrentDirectory: () => host.getCurrentDirectory(),
             });
 
             // Release any files we have acquired in the old program but are 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -960,6 +960,9 @@ module ts {
         log? (s: string): void;
         trace? (s: string): void;
         error? (s: string): void;
+        
+        // Needed for mocking support
+        fileExists? (s: string): boolean;
     }
 
     //
@@ -2436,7 +2439,7 @@ module ts {
                 getDefaultLibFileName: (options) => host.getDefaultLibFileName(options),
                 writeFile: (fileName, data, writeByteOrderMark) => { },
                 readFile: (fileName) => sys.readFile(fileName),
-                fileExists: (fileName) => !!hostCache.getOrCreateEntry(fileName),
+                fileExists: host.fileExists ? (fn) => host.fileExists(fn) : sys.fileExists,
                 getCurrentDirectory: () => host.getCurrentDirectory(),
             });
 

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -56,6 +56,7 @@ module ts {
         getDefaultLibFileName(options: string): string;
         getNewLine?(): string;
         getProjectVersion?(): string;
+        fileExists(fileName: string): boolean;
     }
 
     /** Public interface of the the of a config service shim instance.*/
@@ -259,6 +260,10 @@ module ts {
 
         public error(s: string): void {
             this.shimHost.error(s);
+        }
+        
+        public fileExists(fn: string): boolean {
+            return this.shimHost.fileExists(fn);
         }
 
         public getProjectVersion(): string {

--- a/tests/baselines/reference/project/nodeModules/amd/consumeNodeModules.js
+++ b/tests/baselines/reference/project/nodeModules/amd/consumeNodeModules.js
@@ -1,0 +1,10 @@
+define(["require", "exports", "file-at-root", "somemodule/nested-file", "find-by-index", "find-by-package-main"], function (require, exports, file_at_root_1, nested_file_1, find_by_index_1, find_by_package_main_1) {
+    var fileAtRoot = new file_at_root_1.FileAtRoot();
+    fileAtRoot.fileAtRoot = '123';
+    var nestedFile = new nested_file_1.NestedFile();
+    nestedFile.nestedFile = '123';
+    var findByIndex = new find_by_index_1.FindByIndex();
+    findByIndex.findByIndex = '123';
+    var findByPackageMain = new find_by_package_main_1.FindByPackageMain();
+    findByPackageMain.findByPackageMain = '123';
+});

--- a/tests/baselines/reference/project/nodeModules/amd/nodeModules.json
+++ b/tests/baselines/reference/project/nodeModules/amd/nodeModules.json
@@ -1,0 +1,20 @@
+{
+    "scenario": "nodeModules",
+    "projectRoot": "tests/cases/projects/nodeModules",
+    "inputFiles": [
+        "consumeNodeModules.ts"
+    ],
+    "baselineCheck": true,
+    "runTest": true,
+    "resolvedInputFiles": [
+        "lib.d.ts",
+        "node_modules/file-at-root.d.ts",
+        "node_modules/somemodule/nested-file.d.ts",
+        "node_modules/find-by-index/index.d.ts",
+        "node_modules/find-by-package-main/dist/findByPackageMain.d.ts",
+        "consumeNodeModules.ts"
+    ],
+    "emittedFiles": [
+        "consumeNodeModules.js"
+    ]
+}

--- a/tests/baselines/reference/project/nodeModules/node/consumeNodeModules.js
+++ b/tests/baselines/reference/project/nodeModules/node/consumeNodeModules.js
@@ -1,0 +1,12 @@
+var file_at_root_1 = require("file-at-root");
+var fileAtRoot = new file_at_root_1.FileAtRoot();
+fileAtRoot.fileAtRoot = '123';
+var nested_file_1 = require("somemodule/nested-file");
+var nestedFile = new nested_file_1.NestedFile();
+nestedFile.nestedFile = '123';
+var find_by_index_1 = require("find-by-index");
+var findByIndex = new find_by_index_1.FindByIndex();
+findByIndex.findByIndex = '123';
+var find_by_package_main_1 = require("find-by-package-main");
+var findByPackageMain = new find_by_package_main_1.FindByPackageMain();
+findByPackageMain.findByPackageMain = '123';

--- a/tests/baselines/reference/project/nodeModules/node/nodeModules.json
+++ b/tests/baselines/reference/project/nodeModules/node/nodeModules.json
@@ -1,0 +1,20 @@
+{
+    "scenario": "nodeModules",
+    "projectRoot": "tests/cases/projects/nodeModules",
+    "inputFiles": [
+        "consumeNodeModules.ts"
+    ],
+    "baselineCheck": true,
+    "runTest": true,
+    "resolvedInputFiles": [
+        "lib.d.ts",
+        "node_modules/file-at-root.d.ts",
+        "node_modules/somemodule/nested-file.d.ts",
+        "node_modules/find-by-index/index.d.ts",
+        "node_modules/find-by-package-main/dist/findByPackageMain.d.ts",
+        "consumeNodeModules.ts"
+    ],
+    "emittedFiles": [
+        "consumeNodeModules.js"
+    ]
+}

--- a/tests/cases/project/nodeModules.json
+++ b/tests/cases/project/nodeModules.json
@@ -1,0 +1,9 @@
+{
+    "scenario": "nodeModules",
+    "projectRoot": "tests/cases/projects/nodeModules",
+    "inputFiles": [
+        "consumeNodeModules.ts"
+    ],
+    "baselineCheck": true,
+    "runTest": true
+}

--- a/tests/cases/projects/nodeModules/consumeNodeModules.ts
+++ b/tests/cases/projects/nodeModules/consumeNodeModules.ts
@@ -1,0 +1,15 @@
+import {FileAtRoot} from "file-at-root";
+var fileAtRoot = new FileAtRoot();
+fileAtRoot.fileAtRoot = '123';
+
+import {NestedFile} from "somemodule/nested-file";
+var nestedFile = new NestedFile();
+nestedFile.nestedFile = '123';
+
+import {FindByIndex} from "find-by-index";
+var findByIndex = new FindByIndex();
+findByIndex.findByIndex = '123';
+
+import {FindByPackageMain} from "find-by-package-main";
+var findByPackageMain = new FindByPackageMain();
+findByPackageMain.findByPackageMain = '123';

--- a/tests/cases/projects/nodeModules/node_modules/file-at-root.d.ts
+++ b/tests/cases/projects/nodeModules/node_modules/file-at-root.d.ts
@@ -1,0 +1,3 @@
+export declare class FileAtRoot{
+    fileAtRoot: string;
+}

--- a/tests/cases/projects/nodeModules/node_modules/find-by-index/index.d.ts
+++ b/tests/cases/projects/nodeModules/node_modules/find-by-index/index.d.ts
@@ -1,0 +1,3 @@
+export declare class FindByIndex {
+    findByIndex: string;
+}

--- a/tests/cases/projects/nodeModules/node_modules/find-by-package-main/dist/findByPackageMain.d.ts
+++ b/tests/cases/projects/nodeModules/node_modules/find-by-package-main/dist/findByPackageMain.d.ts
@@ -1,0 +1,3 @@
+export declare class FindByPackageMain {
+    findByPackageMain: string;
+}

--- a/tests/cases/projects/nodeModules/node_modules/find-by-package-main/package.json
+++ b/tests/cases/projects/nodeModules/node_modules/find-by-package-main/package.json
@@ -1,0 +1,3 @@
+{
+    "main": "dist/findByPackageMain"
+}

--- a/tests/cases/projects/nodeModules/node_modules/somemodule/nested-file.d.ts
+++ b/tests/cases/projects/nodeModules/node_modules/somemodule/nested-file.d.ts
@@ -1,0 +1,3 @@
+export declare class NestedFile {
+    nestedFile: string;
+}


### PR DESCRIPTION
Code for #2338. This is just for the node_modules resolution. Does everything for `node_modules` except for the `typings` stuff as I don't see the rational for that considering there is no way to have tsc send `.js` to one location and `.d.ts` to another location.

[](No longer relevant : 
using `ts.sys.fileExists` doesn't work under the test harness because it doesn't give actual file system paths. So tests are broken by this commit. What is the best way to overcome this. I have reviewed [previous work](https://github.com/Microsoft/TypeScript/compare/master...Nemo157:node_modules) that uses `program.getSourceFile` (which resolves to [this code](https://github.com/Microsoft/TypeScript/blob/e76439b2ff39e1e8afd926450e7cebba2149fe28/src/harness/projectsRunner.ts#L212-L222)) to do exists checks and read `package.json` and that feels *very ugly*. How would you guys recommend authoring the `resolveExternalModule` function.)