### PR TITLE
Only call getTypeOfSymbol recursively if it's a value

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2415,6 +2415,12 @@ module ts {
             let links = getSymbolLinks(symbol);
             if (!links.type) {
                 let targetSymbol = resolveAlias(symbol);
+
+                // It only makes sense to get the type of a value symbol. If the result of resolving
+                // the alias is not a value, then it has no type. To get the type associated with a
+                // type symbol, call getDeclaredTypeOfSymbol.
+                // This check is important because without it, a call to getTypeOfSymbol could end
+                // up recursively calling getTypeOfAlias, causing a stack overflow.
                 links.type = targetSymbol.flags & SymbolFlags.Value
                     ? getTypeOfSymbol(targetSymbol)
                     : unknownType;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2414,7 +2414,10 @@ module ts {
         function getTypeOfAlias(symbol: Symbol): Type {
             let links = getSymbolLinks(symbol);
             if (!links.type) {
-                links.type = getTypeOfSymbol(resolveAlias(symbol));
+                let targetSymbol = resolveAlias(symbol);
+                links.type = targetSymbol.flags & SymbolFlags.Value
+                    ? getTypeOfSymbol(targetSymbol)
+                    : unknownType;
             }
             return links.type;
         }

--- a/src/harness/fourslashRunner.ts
+++ b/src/harness/fourslashRunner.ts
@@ -35,9 +35,9 @@ class FourSlashRunner extends RunnerBase {
             this.tests = this.enumerateFiles(this.basePath, /\.ts/i, { recursive: false });
         }
 
-        describe(this.testSuiteName, () => {
             this.tests.forEach((fn: string) => {
-                fn = ts.normalizeSlashes(fn);
+         describe(fn, () => {
+               fn = ts.normalizeSlashes(fn);
                 var justName = fn.replace(/^.*[\\\/]/, '');
 
                 // Convert to relative path

--- a/tests/cases/fourslash/aliasMergingWithNamespace.ts
+++ b/tests/cases/fourslash/aliasMergingWithNamespace.ts
@@ -1,0 +1,9 @@
+///<reference path="fourslash.ts"/>
+
+////namespace bar { }
+////import bar = bar/**/;
+
+goTo.marker();
+verify.quickInfoIs(
+`namespace bar
+import bar = bar`);


### PR DESCRIPTION
This PR is intended to replace #3141, to fix #2933. Essentially, we have a design for aliases (#3158) that only continues to follow aliases if the symbol it hits is a pure alias. If it has any other meanings, it stops. This way, an alias can only refer to one symbol, and not multiple symbols depending on the meaning.