### PR TITLE
Adds glob-style pattern matching for file specifications using new "include" property in tsconfig.json

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -128,7 +128,8 @@ var harnessSources = [
     "services/preProcessFile.ts",
     "services/patternMatcher.ts",
     "versionCache.ts",
-    "convertToBase64.ts"
+    "convertToBase64.ts",
+    "expandFiles.ts"
 ].map(function (f) {
     return path.join(unittestsDirectory, f);
 })).concat([
@@ -505,7 +506,9 @@ function cleanTestDirs() {
 // used to pass data from jake command line directly to run.js
 function writeTestConfigFile(tests, testConfigFile) {
     console.log('Running test(s): ' + tests);
-    var testConfigContents = '{\n' + '\ttest: [\'' + tests + '\']\n}';
+    var testConfigContents = JSON.stringify({
+        "test": [tests]
+    });
     fs.writeFileSync('test.config', testConfigContents);
 }
 

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -804,7 +804,7 @@ module ts {
                 for (let i = start; i < len; ++i) {
                     let charCode = fileSpec.charCodeAt(i);
                     if (charCode === CharacterCodes.asterisk ||
-                        charCode === CharacterCodes.question /*question*/ ||
+                        charCode === CharacterCodes.question ||
                         charCode === CharacterCodes.openBracket) {
                         return i;
                     }

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -693,7 +693,7 @@ module ts {
                             pattern += "|";
                         }
                         
-                        pattern += "(" + combinePaths(basePath, excludePattern) + ")";
+                        pattern += "(" + combinePaths(basePath, excludePattern) + "($|/.*))";
                     }
                 }
                 

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -455,7 +455,6 @@ module ts {
             //                              - At the end of the wildcard, preceeded by `/`.
             //                              - Anywhere in the pattern if preceeded and followed by `/`.
             //                            These tokens, if matched, will be stored in capture group $1. 
-            //                            the pattern and followed by a directory separator
             //  `*`                     - Matches zero or more characters. This token, if matched, will be 
             //                            stored in capture group $2.
             //  `?`                     - Matches zero or one character. This token, if matched, will be

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -791,7 +791,8 @@ module ts {
               * @param offset The offset into the file specification. 
               */
             function isDirectorySeparatorOrEndOfLine(fileSpec: string, offset: number) {
-                return offset === fileSpec.length || (offset < fileSpec.length && fileSpec.charCodeAt(offset) === CharacterCodes.slash);
+                return offset === fileSpec.length || 
+                    (offset < fileSpec.length && fileSpec.charCodeAt(offset) === CharacterCodes.slash);
             }
             
             /**

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -506,7 +506,8 @@ module ts {
                 
                 // match the entries in the directory against the wildcard pattern.
                 let entries = host.readDirectoryFlat(basePath);
-                let pattern = createRegularExpressionFromWildcard(fileSpec, start, isEndOfLine ? fileSpec.length : offset);
+                let end = isEndOfLine ? fileSpec.length : offset;
+                let pattern = createRegularExpressionFromWildcard(fileSpec, start, end);
                 for (let entry of entries) {
                     // skip the entry if it does not match the pattern.
                     if (!pattern.test(entry)) {

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -380,6 +380,19 @@ module ts {
         if (b === undefined) return Comparison.GreaterThan;
         return a < b ? Comparison.LessThan : Comparison.GreaterThan;
     }
+    
+    export function compareStrings(a: string, b: string, ignoreCase?: boolean) {
+        if (a === b) return Comparison.EqualTo;
+        if (a === undefined) return Comparison.LessThan;
+        if (b === undefined) return Comparison.GreaterThan;
+        if (ignoreCase) {
+            a = a.toLowerCase();
+            b = b.toLowerCase();
+            if (a === b) return Comparison.EqualTo;
+        }
+        
+        return a < b ? Comparison.LessThan : Comparison.GreaterThan;
+    }
 
     function getDiagnosticFileName(diagnostic: Diagnostic): string {
         return diagnostic.file ? diagnostic.file.fileName : undefined;
@@ -643,7 +656,46 @@ module ts {
         if (path1.charAt(path1.length - 1) === directorySeparator) return path1 + path2;
         return path1 + directorySeparator + path2;
     }
+    
+    /**
+      * Removes a trailing directory separator from a path.
+      * @param path The path.
+      */
+    export function removeTrailingDirectorySeparator(path: string) {
+        if (path.charAt(path.length - 1) === directorySeparator) {
+            return path.substr(0, path.length - 1);
+        }
+        
+        return path;
+    }
+    
+    /**
+      * Adds a trailing directory separator to a path, if it does not already have one.
+      * @param path The path.
+      */
+    export function ensureTrailingDirectorySeparator(path: string) {
+        if (path.charAt(path.length - 1) !== directorySeparator) {
+            return path + directorySeparator;
+        }
+        
+        return path;
+    }
 
+    export function compareNormalizedPaths(a: string, b: string, currentDirectory: string, ignoreCase?: boolean) {
+        if (a === b) return Comparison.EqualTo;
+        if (a === undefined) return Comparison.LessThan;
+        if (b === undefined) return Comparison.GreaterThan;
+        let aComponents = getNormalizedPathComponents(a, currentDirectory);
+        let bComponents = getNormalizedPathComponents(b, currentDirectory);
+        let sharedLength = Math.min(aComponents.length, bComponents.length);
+        for (let i = 0; i < sharedLength; ++i) {
+            let result = compareStrings(aComponents[i], bComponents[i], ignoreCase);
+            if (result) return result;
+        }
+        
+        return compareValues(aComponents.length, bComponents.length);
+    }
+    
     export function fileExtensionIs(path: string, extension: string): boolean {
         let pathLen = path.length;
         let extLen = extension.length;
@@ -654,6 +706,10 @@ module ts {
      *  List of supported extensions in order of file resolution precedence.
      */
     export const supportedExtensions = [".ts", ".d.ts"];
+    
+    export function hasSupportedFileExtension(file: string) {
+        return forEach(supportedExtensions, extension => fileExtensionIs(file, extension));
+    }
 
     const extensionsToRemove = [".d.ts", ".ts", ".js"];
     export function removeFileExtension(path: string): string {

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -681,10 +681,12 @@ module ts {
         return path;
     }
 
-    export function compareNormalizedPaths(a: string, b: string, currentDirectory: string, ignoreCase?: boolean) {
+    export function comparePaths(a: string, b: string, currentDirectory: string, ignoreCase?: boolean) {
         if (a === b) return Comparison.EqualTo;
         if (a === undefined) return Comparison.LessThan;
         if (b === undefined) return Comparison.GreaterThan;
+        a = removeTrailingDirectorySeparator(a);
+        b = removeTrailingDirectorySeparator(b);
         let aComponents = getNormalizedPathComponents(a, currentDirectory);
         let bComponents = getNormalizedPathComponents(b, currentDirectory);
         let sharedLength = Math.min(aComponents.length, bComponents.length);
@@ -692,7 +694,7 @@ module ts {
             let result = compareStrings(aComponents[i], bComponents[i], ignoreCase);
             if (result) return result;
         }
-        
+
         return compareValues(aComponents.length, bComponents.length);
     }
     

--- a/src/compiler/diagnosticInformationMap.generated.ts
+++ b/src/compiler/diagnosticInformationMap.generated.ts
@@ -438,6 +438,7 @@ module ts {
         Loop_contains_block_scoped_variable_0_referenced_by_a_function_in_the_loop_This_is_only_supported_in_ECMAScript_6_or_higher: { code: 4091, category: DiagnosticCategory.Error, key: "Loop contains block-scoped variable '{0}' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher." },
         The_current_host_does_not_support_the_0_option: { code: 5001, category: DiagnosticCategory.Error, key: "The current host does not support the '{0}' option." },
         Cannot_find_the_common_subdirectory_path_for_the_input_files: { code: 5009, category: DiagnosticCategory.Error, key: "Cannot find the common subdirectory path for the input files." },
+        File_specification_cannot_contain_multiple_recursive_directory_wildcards_Asterisk_Asterisk_Colon_0: { code: 5011, category: DiagnosticCategory.Error, key: "File specification cannot contain multiple recursive directory wildcards ('**'): '{0}'." },
         Cannot_read_file_0_Colon_1: { code: 5012, category: DiagnosticCategory.Error, key: "Cannot read file '{0}': {1}" },
         Unsupported_file_encoding: { code: 5013, category: DiagnosticCategory.Error, key: "Unsupported file encoding." },
         Failed_to_parse_file_0_Colon_1: { code: 5014, category: DiagnosticCategory.Error, key: "Failed to parse file '{0}': {1}." },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1741,6 +1741,10 @@
         "category": "Error",
         "code": 5009
     },
+    "File specification cannot contain multiple recursive directory wildcards ('**'): '{0}'.": {
+      "category": "Error",
+      "code": 5011
+    },
     "Cannot read file '{0}': {1}": {
         "category": "Error",
         "code": 5012

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -288,7 +288,7 @@ module ts {
                     return _path.resolve(path);
                 },
                 fileExists(path: string): boolean {
-                    return _fs.existsSync(path);
+                    return _fs.existsSync(path) && _fs.statSync(path).isFile();
                 },
                 directoryExists(path: string) {
                     return _fs.existsSync(path) && _fs.statSync(path).isDirectory();

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -16,6 +16,7 @@ module ts {
         getExecutingFilePath(): string;
         getCurrentDirectory(): string;
         readDirectory(path: string, extension?: string): string[];
+        readDirectoryFlat(path: string): string[];
         getMemoryUsage?(): number;
         exit(exitCode?: number): void;
     }
@@ -135,6 +136,11 @@ module ts {
                     }
                 }
             }
+            
+            function readDirectoryFlat(path: string): string[] {
+                var folder = fso.GetFolder(path || ".");
+                return [...getNames(folder.files), ...getNames(folder.subfolders)];
+            }
 
             return {
                 args,
@@ -166,6 +172,7 @@ module ts {
                     return new ActiveXObject("WScript.Shell").CurrentDirectory;
                 },
                 readDirectory,
+                readDirectoryFlat,
                 exit(exitCode?: number): void {
                     try {
                         WScript.Quit(exitCode);
@@ -246,6 +253,10 @@ module ts {
                     }
                 }
             }
+            
+            function readDirectoryFlat(path: string): string[] {
+                return _fs.readdirSync(path || ".").sort();
+            }
 
             return {
                 args: process.argv.slice(2),
@@ -294,6 +305,7 @@ module ts {
                     return process.cwd();
                 },
                 readDirectory,
+                readDirectoryFlat,
                 getMemoryUsage() {
                     if (global.gc) {
                         global.gc();

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -242,7 +242,7 @@ module ts {
             setCachedProgram(compileResult.program);
             reportDiagnostic(createCompilerDiagnostic(Diagnostics.Compilation_complete_Watching_for_file_changes));
         }
-
+        
         function getSourceFile(fileName: string, languageVersion: ScriptTarget, onError ?: (message: string) => void) {
             // Return existing SourceFile object if one is available
             if (cachedProgram) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1027,7 +1027,7 @@ module ts {
         // This field should never be used directly to obtain line map, use getLineMap function instead.
         /* @internal */ lineMap: number[];
     }
-
+    
     export interface ScriptReferenceHost {
         getCompilerOptions(): CompilerOptions;
         getSourceFile(fileName: string): SourceFile;
@@ -1035,7 +1035,27 @@ module ts {
     }
 
     export interface ParseConfigHost {
+        useCaseSensitiveFileNames: boolean;
+
         readDirectory(rootDir: string, extension: string): string[];
+        
+        /**
+          * Gets a value indicating whether the specified path exists.
+          * @param path The path to test.
+          */
+        fileExists(path: string): boolean;
+    
+        /**
+          * Gets a value indicating whether the specified path exists and is a directory.
+          * @param path The path to test.
+          */
+        directoryExists(path: string): boolean;
+    
+        /**
+         * Reads the files in the directory.
+         * @param path The directory path.
+         */
+        readDirectoryFlat(path: string): string[];
     }
 
     export interface WriteFileCallback {

--- a/src/harness/external/chai.d.ts
+++ b/src/harness/external/chai.d.ts
@@ -171,5 +171,8 @@ declare module chai {
         function isFalse(value: any, message?: string): void;
         function isNull(value: any, message?: string): void;
         function isNotNull(value: any, message?: string): void;
+        function deepEqual(actual: any, expected: any, message?: string): void;
+        function notDeepEqual(actual: any, expected: any, message?: string): void;
+        function lengthOf(object: any[], length: number, message?: string): void;
     }
 }

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -232,6 +232,10 @@ module Harness.LanguageService {
         readDirectory(rootDir: string, extension: string): string {
             throw new Error("NYI");
         }
+        
+        readDirectoryFlat(path: string): string {
+            throw new Error("NYI");
+        }
 
         log(s: string): void { this.nativeHost.log(s); }
         trace(s: string): void { this.nativeHost.trace(s); }
@@ -534,6 +538,10 @@ module Harness.LanguageService {
         }
 
         readDirectory(path: string, extension?: string): string[] {
+            throw new Error("Not implemented Yet.");
+        }
+        
+        readDirectoryFlat(path: string): string[] {
             throw new Error("Not implemented Yet.");
         }
         

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -37,11 +37,19 @@ var testConfigFile =
     Harness.IO.fileExists(mytestconfig) ? Harness.IO.readFile(mytestconfig) :
     (Harness.IO.fileExists(testconfig) ? Harness.IO.readFile(testconfig) : '');
 
+var unitTestsRequested = false;
+
 if (testConfigFile !== '') {
-    // TODO: not sure why this is crashing mocha
-    //var testConfig = JSON.parse(testConfigRaw);
-    var testConfig = testConfigFile.match(/test:\s\['(.*)'\]/);
-    var options = testConfig ? [testConfig[1]] : [];
+    var options: string[];
+    try {
+        let testConfigJson = JSON.parse(testConfigFile);
+        options = testConfigJson.test instanceof Array ? testConfigJson.test : [];
+    }
+    catch (e) {
+        let testConfig = testConfigFile.match(/test:\s\['(.*)'\]/);
+        options = testConfig ? [testConfig[1]] : [];
+    }
+    
     for (var i = 0; i < options.length; i++) {
         switch (options[i]) {
             case 'compiler':
@@ -73,11 +81,14 @@ if (testConfigFile !== '') {
             case 'test262':
                 runners.push(new Test262BaselineRunner());
                 break;
+            case 'unit':
+                unitTestsRequested = true;
+                break;
         }
     }
 }
 
-if (runners.length === 0) {
+if (runners.length === 0 && !unitTestsRequested) {
     // compiler
     runners.push(new CompilerBaselineRunner(CompilerTestType.Conformance));
     runners.push(new CompilerBaselineRunner(CompilerTestType.Regressions));

--- a/tests/cases/unittests/expandFiles.ts
+++ b/tests/cases/unittests/expandFiles.ts
@@ -1,0 +1,236 @@
+/// <reference path="..\..\..\src\harness\external\mocha.d.ts" />
+/// <reference path="..\..\..\src\harness\harness.ts" />
+
+describe("expandFiles", () => {
+    const basePath = "c:/dev/";
+    const caseInsensitiveHost = createMockParseConfigHost(
+        basePath,
+        /*files*/ [
+            "c:/dev/a.ts",
+            "c:/dev/a.d.ts",
+            "c:/dev/a.js",
+            "c:/dev/b.ts",
+            "c:/dev/b.js",
+            "c:/dev/c.d.ts",
+            "c:/dev/z/a.ts",
+            "c:/dev/z/abz.ts",
+            "c:/dev/z/aba.ts",
+            "c:/dev/z/b.ts",
+            "c:/dev/z/bbz.ts",
+            "c:/dev/z/bba.ts",
+            "c:/dev/x/a.ts",
+            "c:/dev/x/aa.ts",
+            "c:/dev/x/b.ts",
+            "c:/dev/x/y/a.ts",
+            "c:/dev/x/y/b.ts"
+        ],
+        /*ignoreCase*/ true);
+
+    const caseSensitiveHost = createMockParseConfigHost(
+        basePath,
+        /*files*/ [
+            "c:/dev/a.ts",
+            "c:/dev/a.d.ts",
+            "c:/dev/a.js",
+            "c:/dev/b.ts",
+            "c:/dev/b.js",
+            "c:/dev/A.ts",
+            "c:/dev/B.ts",
+            "c:/dev/c.d.ts",
+            "c:/dev/z/a.ts",
+            "c:/dev/z/abz.ts",
+            "c:/dev/z/aba.ts",
+            "c:/dev/z/b.ts",
+            "c:/dev/z/bbz.ts",
+            "c:/dev/z/bba.ts",
+            "c:/dev/x/a.ts",
+            "c:/dev/x/b.ts",
+            "c:/dev/x/y/a.ts",
+            "c:/dev/x/y/b.ts",
+        ],
+        /*ignoreCase*/ false);
+    
+    let expect = _chai.expect;
+    describe("with literal file list", () => {
+        it("without exclusions", () => {
+            let fileNames = ["a.ts", "b.ts"];
+            let results = ts.expandFiles(basePath, fileNames, /*includeSpecs*/ undefined, /*excludeSpecs*/ undefined, {}, caseInsensitiveHost);
+            assert.deepEqual(results, ["c:/dev/a.ts", "c:/dev/b.ts"]);
+        });
+        it("missing files are still present", () => {
+            let fileNames = ["z.ts", "x.ts"];
+            let results = ts.expandFiles(basePath, fileNames, /*includeSpecs*/ undefined, /*excludeSpecs*/ undefined, {}, caseInsensitiveHost);
+            assert.deepEqual(results, ["c:/dev/z.ts", "c:/dev/x.ts"]);
+        });
+        it("are not removed due to excludes", () => {
+            let fileNames = ["a.ts", "b.ts"];
+            let excludeSpecs = ["b.ts"];
+            let results = ts.expandFiles(basePath, fileNames, /*includeSpecs*/ undefined, excludeSpecs, {}, caseInsensitiveHost);
+            assert.deepEqual(results, ["c:/dev/a.ts", "c:/dev/b.ts"]);
+        });
+    });
+    
+    describe("with literal include list", () => {
+        it("without exclusions", () => {
+            let includeSpecs = ["a.ts", "b.ts"];
+            let results = ts.expandFiles(basePath, /*fileNames*/ undefined, includeSpecs, /*excludeSpecs*/ undefined, {}, caseInsensitiveHost);
+            assert.deepEqual(results, ["c:/dev/a.ts", "c:/dev/b.ts"]);
+        });
+        it("with non .ts file extensions are excluded", () => {
+            let includeSpecs = ["a.js", "b.js"];
+            let results = ts.expandFiles(basePath, /*fileNames*/ undefined, includeSpecs, /*excludeSpecs*/ undefined, {}, caseInsensitiveHost);
+            assert.deepEqual(results, []);
+        });
+        it("with missing files are excluded", () => {
+            let includeSpecs = ["z.ts", "x.ts"];
+            let results = ts.expandFiles(basePath, /*fileNames*/ undefined, includeSpecs, /*excludeSpecs*/ undefined, {}, caseInsensitiveHost);
+            assert.deepEqual(results, []);
+        });
+        it("with literal excludes", () => {
+            let includeSpecs = ["a.ts", "b.ts"];
+            let excludeSpecs = ["b.ts"];
+            let results = ts.expandFiles(basePath, /*fileNames*/ undefined, includeSpecs, excludeSpecs, {}, caseInsensitiveHost);
+            assert.deepEqual(results, ["c:/dev/a.ts"]);
+        });
+        it("with wildcard excludes", () => {
+            let includeSpecs = ["a.ts", "b.ts", "z/a.ts", "z/abz.ts", "z/aba.ts", "x/b.ts"];
+            let excludeSpecs = ["*.ts", "z/??[b-z].ts", "*/b.ts"];
+            let results = ts.expandFiles(basePath, /*fileNames*/ undefined, includeSpecs, excludeSpecs, {}, caseInsensitiveHost);
+            assert.deepEqual(results, ["c:/dev/z/a.ts", "c:/dev/z/aba.ts"]);
+        });
+        it("with recursive excludes", () => {
+            let includeSpecs = ["a.ts", "b.ts", "x/a.ts", "x/b.ts", "x/y/a.ts", "x/y/b.ts"];
+            let excludeSpecs = ["**/b.ts"];
+            let results = ts.expandFiles(basePath, /*fileNames*/ undefined, includeSpecs, excludeSpecs, {}, caseInsensitiveHost);
+            assert.deepEqual(results, ["c:/dev/a.ts", "c:/dev/x/a.ts", "c:/dev/x/y/a.ts"]);
+        });
+        it("with case sensitive exclude", () => {
+            let includeSpecs = ["B.ts"];
+            let excludeSpecs = ["**/b.ts"];
+            let results = ts.expandFiles(basePath, /*fileNames*/ undefined, includeSpecs, excludeSpecs, {}, caseSensitiveHost);
+            assert.deepEqual(results, ["c:/dev/B.ts"]);
+        });
+    });
+
+    describe("with wildcard include list", () => {
+        it("same named declarations are excluded", () => {
+            let includeSpecs = ["*.ts"];
+            let results = ts.expandFiles(basePath, /*fileNames*/ undefined, includeSpecs, /*excludeSpecs*/ undefined, {}, caseInsensitiveHost);
+            assert.deepEqual(results, ["c:/dev/a.ts", "c:/dev/b.ts", "c:/dev/c.d.ts"]);
+        });
+        it("`*` matches only ts files", () => {
+            let includeSpecs = ["*"];
+            let results = ts.expandFiles(basePath, /*fileNames*/ undefined, includeSpecs, /*excludeSpecs*/ undefined, {}, caseInsensitiveHost);
+            assert.deepEqual(results, ["c:/dev/a.ts", "c:/dev/b.ts", "c:/dev/c.d.ts"]);
+        });
+        it("`?` matches only a single character", () => {
+            let includeSpecs = ["x/?.ts"];
+            let results = ts.expandFiles(basePath, /*fileNames*/ undefined, includeSpecs, /*excludeSpecs*/ undefined, {}, caseInsensitiveHost);
+            assert.deepEqual(results, ["c:/dev/x/a.ts", "c:/dev/x/b.ts"]);
+        });
+        it("`[]` matches only a single character", () => {
+            let includeSpecs = ["x/[b-z].ts"];
+            let results = ts.expandFiles(basePath, /*fileNames*/ undefined, includeSpecs, /*excludeSpecs*/ undefined, {}, caseInsensitiveHost);
+            assert.deepEqual(results, ["c:/dev/x/b.ts"]);
+        });
+        it("with recursive directory", () => {
+            let includeSpecs = ["**/a.ts"];
+            let results = ts.expandFiles(basePath, /*fileNames*/ undefined, includeSpecs, /*excludeSpecs*/ undefined, {}, caseInsensitiveHost);
+            assert.deepEqual(results, ["c:/dev/a.ts", "c:/dev/x/a.ts", "c:/dev/x/y/a.ts", "c:/dev/z/a.ts"]);
+        });
+        it("case sensitive", () => {
+            let includeSpecs = ["**/A.ts"];
+            let results = ts.expandFiles(basePath, /*fileNames*/ undefined, includeSpecs, /*excludeSpecs*/ undefined, {}, caseSensitiveHost);
+            assert.deepEqual(results, ["c:/dev/A.ts"]);
+        });
+        it("with missing files are excluded", () => {
+            let includeSpecs = ["*/z.ts"];
+            let results = ts.expandFiles(basePath, /*fileNames*/ undefined, includeSpecs, /*excludeSpecs*/ undefined, {}, caseInsensitiveHost);
+            assert.deepEqual(results, []);
+        });
+        it("always include literal files", () => {
+            let fileNames = ["a.ts"];
+            let includeSpecs = ["*/z.ts"];
+            let excludeSpecs = ["**/a.ts"];
+            let results = ts.expandFiles(basePath, fileNames, includeSpecs, excludeSpecs, {}, caseInsensitiveHost);
+            assert.deepEqual(results, ["c:/dev/a.ts"]);
+        });
+    });
+
+    function createMockParseConfigHost(basePath: string, files: string[], ignoreCase: boolean): ts.ParseConfigHost {
+        let fileSet: ts.Map<string> = {};
+        let directorySet: ts.Map<ts.Map<string>> = {};
+    
+        files.sort((a, b) => ts.comparePaths(a, b, basePath, ignoreCase));
+        for (let file of files) {
+            addFile(ts.getNormalizedAbsolutePath(file, basePath));
+        }
+    
+        return {
+            useCaseSensitiveFileNames: !ignoreCase,
+            fileExists,
+            directoryExists,
+            readDirectory,
+            readDirectoryFlat
+        };
+    
+        function fileExists(path: string): boolean {
+            let fileKey = ignoreCase ? path.toLowerCase() : path;
+            return ts.hasProperty(fileSet, fileKey);
+        }
+    
+        function directoryExists(path: string): boolean {
+            let directoryKey = ignoreCase ? path.toLowerCase() : path;
+            return ts.hasProperty(directorySet, directoryKey);
+        }
+    
+        function readDirectory(rootDir: string, extension: string): string[] {
+            throw new Error("Not implemented");
+        }
+    
+        function readDirectoryFlat(path: string): string[] {
+            path = ts.getNormalizedAbsolutePath(path, basePath);
+            path = ts.removeTrailingDirectorySeparator(path);
+            let directoryKey = ignoreCase ? path.toLowerCase() : path;
+            let entries = ts.getProperty(directorySet, directoryKey);
+            let result: string[] = [];
+            ts.forEachKey(entries, key => { result.push(key); });
+            result.sort((a, b) => ts.compareStrings(a, b, ignoreCase));
+            return result;
+        }
+    
+        function addFile(file: string) {
+            let fileKey = ignoreCase ? file.toLowerCase() : file;
+            if (!ts.hasProperty(fileSet, fileKey)) {
+                fileSet[fileKey] = file;
+                let name = ts.getBaseFileName(file);
+                let parent = ts.getDirectoryPath(file);
+                addToDirectory(parent, name);
+            }
+        }
+    
+        function addDirectory(directory: string) {
+            directory = ts.removeTrailingDirectorySeparator(directory);
+            let directoryKey = ignoreCase ? directory.toLowerCase() : directory;
+            if (!ts.hasProperty(directorySet, directoryKey)) {
+                directorySet[directoryKey] = {};
+                let name = ts.getBaseFileName(directory);
+                let parent = ts.getDirectoryPath(directory);
+                if (parent !== directory) {
+                    addToDirectory(parent, name);
+                }
+            }
+        }
+    
+        function addToDirectory(directory: string, entry: string) {
+            addDirectory(directory);
+            directory = ts.removeTrailingDirectorySeparator(directory);
+            let directoryKey = ignoreCase ? directory.toLowerCase() : directory;
+            let entryKey = ignoreCase ? entry.toLowerCase() : entry;
+            let entries = directorySet[directoryKey];
+            if (!ts.hasProperty(entries, entryKey)) {
+                entries[entryKey] = entry;
+            }
+        }
+    }
+});


### PR DESCRIPTION
Adds support for expanding [glob](http://en.wikipedia.org/wiki/Glob_(programming))-like patterns in "include" and "exclude" properties of tsconfig.json. The following patterns are supported:

* `*` - Matches zero or more characters, excluding directory separators.
* `?` - Matches any one character, excluding directory separators.
* `[abc]` - Matches any one character in the set `{ "a", "b", "c" }`.
* `[a-z]` - Matches any one character in between `"a"` and `"z"`.
* `[!abc]` - Matches any one character **not** in the set `{ "a", "b", "c" }`.
* `**/` - Recursively matches any subdirectory.

At this time, character escape sequences are not supported, as there is no standard cross-platform convention. The standard escape sequence in a Unix shell is prefixed with `\`, which is reserved as a directory separator on Windows, and is normalized to `/` by TypeScript.

This does not use the [glob](http://npmjs.org/glob) module, as TypeScript runs in more host environments than just NodeJS, and this would need interoperate with the language service host.

```json
{
    "compilerOptions": {
        "out": "test.js"
    },
    "files": [
      "literal.ts"
    ],
    "include": [
        "**/*.ts"
    ],
    "exclude": [
        "node_modules",
        "tests/**/*.spec.ts",
        "utils/t2.ts"
    ]
}
```

* Files in the `"files"` list are always added to the list of files.
* The `"exclude"` list only applies to files matched via `"include"`.
* If neither `"files"` nor `"include"` are present, `"include"` defaults to `"**/*.ts"`. This preserves the existing behavior.