### PR TITLE
Fix issue in the parsing of tsConfig file

### DIFF
--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -893,7 +893,7 @@ module ts {
                     return {
                         options: configFile.options,
                         files: configFile.fileNames,
-                        errors: [realizeDiagnostics(configFile.errors, '\r\n')]
+                        errors: realizeDiagnostics(configFile.errors, '\r\n')
                     };
                 });
         }

--- a/tests/cases/compiler/systemModuleAmbientDeclarations.ts
+++ b/tests/cases/compiler/systemModuleAmbientDeclarations.ts
@@ -1,5 +1,5 @@
 // @module: system
-// @separateCompilation: true
+// @isolatedModules: true
 
 // @filename: file1.ts
 declare class Promise { }

--- a/tests/cases/compiler/systemModuleConstEnumsSeparateCompilation.ts
+++ b/tests/cases/compiler/systemModuleConstEnumsSeparateCompilation.ts
@@ -1,5 +1,5 @@
 // @module: system
-// @separateCompilation: true
+// @isolatedModules: true
 
 declare function use(a: any);
 const enum TopLevelConstEnum { X }

--- a/tests/cases/compiler/systemModuleDeclarationMerging.ts
+++ b/tests/cases/compiler/systemModuleDeclarationMerging.ts
@@ -1,5 +1,5 @@
 // @module: system
-// @separateCompilation: true
+// @isolatedModules: true
 
 export function F() {}
 export module F { var x; }

--- a/tests/cases/compiler/systemModuleNonTopLevelModuleMembers.ts
+++ b/tests/cases/compiler/systemModuleNonTopLevelModuleMembers.ts
@@ -1,5 +1,5 @@
 // @module: system
-// @separateCompilation: true
+// @isolatedModules: true
 
 export class TopLevelClass {}
 export module TopLevelModule {var v;}


### PR DESCRIPTION
Fix issue in the parsing of tsConfig file, this was fixed in master before, but never ported.

The realizeDiagnosticS function already returns an array, no need to wrap again. The realizeDiagnostic (no S) function returns a single diagnostic.