### PR TITLE
Downlevel emit for let/const inside loops

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -599,6 +599,7 @@ module ts {
                 case SyntaxKind.ForInStatement:
                 case SyntaxKind.ForOfStatement:
                 case SyntaxKind.WhileStatement:
+                case SyntaxKind.DoStatement:
                     bindChildren(node, 0, /*isBlockScopeContainer*/ true, /*isIteration*/ true);
                     break;
                 case SyntaxKind.CatchClause:

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -62,6 +62,7 @@ module ts {
         let parent: Node;
         let container: Node;
         let blockScopeContainer: Node;
+        let iteration: IterationStatement;
         let lastContainer: Node;
         let symbolCount = 0;
         let Symbol = objectAllocator.getSymbolConstructor();
@@ -227,7 +228,7 @@ module ts {
 
         // All container nodes are kept on a linked list in declaration order. This list is used by the getLocalNameOfContainer function
         // in the type checker to validate that the local name used for a container is unique.
-        function bindChildren(node: Node, symbolKind: SymbolFlags, isBlockScopeContainer: boolean) {
+        function bindChildren(node: Node, symbolKind: SymbolFlags, isBlockScopeContainer: boolean, isIteration: boolean = false) {
             if (symbolKind & SymbolFlags.HasLocals) {
                 node.locals = {};
             }
@@ -235,6 +236,7 @@ module ts {
             let saveParent = parent;
             let saveContainer = container;
             let savedBlockScopeContainer = blockScopeContainer;
+            let savedIteration = iteration;
             parent = node;
             if (symbolKind & SymbolFlags.IsContainer) {
                 container = node;
@@ -251,11 +253,17 @@ module ts {
                 // - node is a source file
                 setBlockScopeContainer(node, /*cleanLocals*/  (symbolKind & SymbolFlags.HasLocals) === 0 && node.kind !== SyntaxKind.SourceFile);
             }
+            
+            if (isIteration) {
+                iteration = <IterationStatement> node;
+                iteration.iterationScopedDeclarations = [];
+            }
 
             forEachChild(node, bind);
             container = saveContainer;
             parent = saveParent;
             blockScopeContainer = savedBlockScopeContainer;
+            iteration = savedIteration;
         }
 
         function addToContainerChain(node: Node) {
@@ -266,7 +274,7 @@ module ts {
             lastContainer = node;
         }
 
-        function bindDeclaration(node: Declaration, symbolKind: SymbolFlags, symbolExcludes: SymbolFlags, isBlockScopeContainer: boolean) {
+        function bindDeclaration(node: Declaration, symbolKind: SymbolFlags, symbolExcludes: SymbolFlags, isBlockScopeContainer: boolean, isIteration: boolean = false) {
             switch (container.kind) {
                 case SyntaxKind.ModuleDeclaration:
                     declareModuleMember(node, symbolKind, symbolExcludes);
@@ -306,7 +314,7 @@ module ts {
                     declareSymbol(container.symbol.exports, container.symbol, node, symbolKind, symbolExcludes);
                     break;
             }
-            bindChildren(node, symbolKind, isBlockScopeContainer);
+            bindChildren(node, symbolKind, isBlockScopeContainer, isIteration);
         }
 
         function isAmbientContext(node: Node): boolean {
@@ -410,6 +418,9 @@ module ts {
                         addToContainerChain(blockScopeContainer);
                     }
                     declareSymbol(blockScopeContainer.locals, undefined, node, symbolKind, symbolExcludes);
+            }
+            if (iteration) {
+                iteration.iterationScopedDeclarations.push(node);
             }
             bindChildren(node, symbolKind, /*isBlockScopeContainer*/ false);
         }
@@ -584,10 +595,13 @@ module ts {
                     // 'let x' will be placed into the function locals and 'let x' - into the locals of the block
                     bindChildren(node, 0, /*isBlockScopeContainer*/ !isFunctionLike(node.parent));
                     break;
-                case SyntaxKind.CatchClause:
                 case SyntaxKind.ForStatement:
                 case SyntaxKind.ForInStatement:
                 case SyntaxKind.ForOfStatement:
+                case SyntaxKind.WhileStatement:
+                    bindChildren(node, 0, /*isBlockScopeContainer*/ true, /*isIteration*/ true);
+                    break;
+                case SyntaxKind.CatchClause:
                 case SyntaxKind.CaseBlock:
                     bindChildren(node, 0, /*isBlockScopeContainer*/ true);
                     break;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5536,7 +5536,6 @@ module ts {
                 if (isIterationStatement(current, /*lookInLabeledStatements*/ false)) {
                     if (inFunction) {
                         symbol.valueDeclaration.blockScopedBindingInLoop = true;
-                        grammarErrorOnFirstToken(current, Diagnostics.Loop_contains_block_scoped_variable_0_referenced_by_a_function_in_the_loop_This_is_only_supported_in_ECMAScript_6_or_higher, declarationNameToString(node));
                     }
                     // mark value declaration so during emit they can have a special handling
                     getNodeLinks(<VariableDeclaration>symbol.valueDeclaration).flags |= NodeCheckFlags.BlockScopedBindingInLoop;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5535,10 +5535,10 @@ module ts {
             while (current && !nodeStartsNewLexicalEnvironment(current)) {
                 if (isIterationStatement(current, /*lookInLabeledStatements*/ false)) {
                     if (inFunction) {
+                        symbol.valueDeclaration.blockScopedBindingInLoop = true;
                         grammarErrorOnFirstToken(current, Diagnostics.Loop_contains_block_scoped_variable_0_referenced_by_a_function_in_the_loop_This_is_only_supported_in_ECMAScript_6_or_higher, declarationNameToString(node));
                     }
                     // mark value declaration so during emit they can have a special handling
-                    symbol.valueDeclaration.blockScopedBindingInLoop = true;
                     getNodeLinks(<VariableDeclaration>symbol.valueDeclaration).flags |= NodeCheckFlags.BlockScopedBindingInLoop;
                     break;
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5538,6 +5538,7 @@ module ts {
                         grammarErrorOnFirstToken(current, Diagnostics.Loop_contains_block_scoped_variable_0_referenced_by_a_function_in_the_loop_This_is_only_supported_in_ECMAScript_6_or_higher, declarationNameToString(node));
                     }
                     // mark value declaration so during emit they can have a special handling
+                    symbol.valueDeclaration.blockScopedBindingInLoop = true;
                     getNodeLinks(<VariableDeclaration>symbol.valueDeclaration).flags |= NodeCheckFlags.BlockScopedBindingInLoop;
                     break;
                 }

--- a/src/compiler/diagnosticInformationMap.generated.ts
+++ b/src/compiler/diagnosticInformationMap.generated.ts
@@ -435,7 +435,6 @@ module ts {
         Parameter_0_of_exported_function_has_or_is_using_private_name_1: { code: 4078, category: DiagnosticCategory.Error, key: "Parameter '{0}' of exported function has or is using private name '{1}'." },
         Exported_type_alias_0_has_or_is_using_private_name_1: { code: 4081, category: DiagnosticCategory.Error, key: "Exported type alias '{0}' has or is using private name '{1}'." },
         Default_export_of_the_module_has_or_is_using_private_name_0: { code: 4082, category: DiagnosticCategory.Error, key: "Default export of the module has or is using private name '{0}'." },
-        Loop_contains_block_scoped_variable_0_referenced_by_a_function_in_the_loop_This_is_only_supported_in_ECMAScript_6_or_higher: { code: 4091, category: DiagnosticCategory.Error, key: "Loop contains block-scoped variable '{0}' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher." },
         The_current_host_does_not_support_the_0_option: { code: 5001, category: DiagnosticCategory.Error, key: "The current host does not support the '{0}' option." },
         Cannot_find_the_common_subdirectory_path_for_the_input_files: { code: 5009, category: DiagnosticCategory.Error, key: "Cannot find the common subdirectory path for the input files." },
         Cannot_read_file_0_Colon_1: { code: 5012, category: DiagnosticCategory.Error, key: "Cannot read file '{0}': {1}" },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1729,10 +1729,6 @@
         "category": "Error",
         "code": 4082
     },
-    "Loop contains block-scoped variable '{0}' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher.": {
-        "category": "Error",
-        "code": 4091
-    },
     "The current host does not support the '{0}' option.": {
         "category": "Error",
         "code": 5001

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2217,6 +2217,43 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
                     decreaseIndent();
                 }
             }
+            function emitDownlevelIterationEmbeddedStatement(node: Node) {
+                write(" (function() ");
+                if (node.kind === SyntaxKind.Block) {
+                    emit(<Block>node);
+                }
+                else {
+                    write("{");
+                    increaseIndent();
+                    writeLine();
+                    emit(node);
+                    decreaseIndent();
+                    writeLine();
+                    write("}");
+                }
+            }
+            function emitIterationEmbeddedStatement(node: IterationStatement) {
+                if (languageVersion >= ScriptTarget.ES6) {
+                    emitEmbeddedStatement(node.statement);
+                    return;
+                }
+                
+                let needsDownlevelEmit = false;
+                
+                for (const declaration of node.iterationScopedDeclarations) {
+                    if (declaration.blockScopedBindingInLoop) {
+                        needsDownlevelEmit = true;
+                        break;
+                    }
+                }
+                
+                if (!needsDownlevelEmit) {
+                    emitEmbeddedStatement(node.statement);
+                }
+                else {
+                    emitDownlevelIterationEmbeddedStatement(node.statement);
+                }
+            }
 
             function emitExpressionStatement(node: ExpressionStatement) {
                 emitParenthesizedIf(node.expression, /*parenthesized*/ node.expression.kind === SyntaxKind.ArrowFunction);

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2223,7 +2223,7 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
                 }
             }
             
-            function emitIteration<T extends IterationStatement>(node: T, headDeclarations: Declaration[], emitHead: (node: T) => void, emitBody?: (node: T) => void, emitFooter?: (node: T) => void) {
+            function emitIteration<T extends IterationStatement>(node: T, headDeclarations: Declaration[], emitHead: (node: T) => void, emitBody?: (node: T) => void, emitFooter?: (node: T, downlevel: boolean) => void) {
                 let needsDownlevelEmit = false;
                 const closureVariables: Identifier[] = [];
                 
@@ -2264,8 +2264,7 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
                     write(");");
                     
                     if (emitFooter) {
-                        writeLine();
-                        emitFooter(node);
+                        emitFooter(node, true);
                     }
                 } else {
                     emitHead(node);
@@ -2277,7 +2276,7 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
                     }
                     
                     if (emitFooter) {
-                        emitFooter(node);
+                        emitFooter(node, false);
                     }
                     return;
                 }
@@ -2311,8 +2310,8 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
             function emitDoStatementHead(node: DoStatement) {
                 write("do");
             }
-            function emitDoStatementFooter(node: DoStatement) {
-                if (node.statement.kind === SyntaxKind.Block) {
+            function emitDoStatementFooter(node: DoStatement, downlevel: boolean) {
+                if (node.statement.kind === SyntaxKind.Block || downlevel) {
                     write(" ");
                 }
                 else {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2282,7 +2282,7 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
 
             function emitDoStatement(node: DoStatement) {
                 write("do");
-                emitEmbeddedStatement(node.statement);
+                emitIterationEmbeddedStatement(node);
                 if (node.statement.kind === SyntaxKind.Block) {
                     write(" ");
                 }
@@ -2298,7 +2298,7 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
                 write("while (");
                 emit(node.expression);
                 write(")");
-                emitEmbeddedStatement(node.statement);
+                emitIterationEmbeddedStatement(node);
             }
 
             /**
@@ -2385,7 +2385,7 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
                 write(";");
                 emitOptional(" ", node.incrementor);
                 write(")");
-                emitEmbeddedStatement(node.statement);
+                emitIterationEmbeddedStatement(node);
             }
 
             function emitForInOrForOfStatement(node: ForInStatement | ForOfStatement) {
@@ -2415,7 +2415,7 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
                 }
                 emit(node.expression);
                 emitToken(SyntaxKind.CloseParenToken, node.expression.end);
-                emitEmbeddedStatement(node.statement);
+                emitIterationEmbeddedStatement(node);
             }
 
             function emitDownLevelForOfStatement(node: ForOfStatement) {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2212,7 +2212,7 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
                 }
                 else {
                     increaseIndent();
-                    if (block) write("{");
+                    if (block) write(" {");
                     writeLine();
                     emit(node);
                     decreaseIndent();
@@ -2245,7 +2245,7 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
                     write(" = ");
                     write("function(");
                     emitList(closureVariables, 0, closureVariables.length, false, false);
-                    write(") ");
+                    write(")");
                     
                     if (emitBody) {
                         emitBody(node, true);

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2231,6 +2231,7 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
                     writeLine();
                     write("}");
                 }
+                write("})();");
             }
             function emitIterationEmbeddedStatement(node: IterationStatement) {
                 if (languageVersion >= ScriptTarget.ES6) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -407,6 +407,7 @@ module ts {
     export interface Declaration extends Node {
         _declarationBrand: any;
         name?: DeclarationName;
+        blockScopedBindingInLoop?: boolean;
     }
 
     export interface ComputedPropertyName extends Node {
@@ -784,6 +785,8 @@ module ts {
 
     export interface IterationStatement extends Statement {
         statement: Statement;
+        // Block scoped declarations that are declared in this loop, but not in a subloop.
+        iterationScopedDeclarations: Declaration[];
     }
 
     export interface DoStatement extends IterationStatement {

--- a/tests/baselines/reference/downlevelLetConst18.errors.txt
+++ b/tests/baselines/reference/downlevelLetConst18.errors.txt
@@ -1,60 +1,39 @@
-tests/cases/compiler/downlevelLetConst18.ts(3,1): error TS4091: Loop contains block-scoped variable 'x' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher.
 tests/cases/compiler/downlevelLetConst18.ts(4,14): error TS2393: Duplicate function implementation.
-tests/cases/compiler/downlevelLetConst18.ts(7,1): error TS4091: Loop contains block-scoped variable 'x' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher.
 tests/cases/compiler/downlevelLetConst18.ts(8,14): error TS2393: Duplicate function implementation.
-tests/cases/compiler/downlevelLetConst18.ts(11,1): error TS4091: Loop contains block-scoped variable 'x' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher.
-tests/cases/compiler/downlevelLetConst18.ts(15,1): error TS4091: Loop contains block-scoped variable 'x' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher.
-tests/cases/compiler/downlevelLetConst18.ts(19,1): error TS4091: Loop contains block-scoped variable 'x' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher.
-tests/cases/compiler/downlevelLetConst18.ts(23,1): error TS4091: Loop contains block-scoped variable 'x' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher.
-tests/cases/compiler/downlevelLetConst18.ts(27,1): error TS4091: Loop contains block-scoped variable 'x' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher.
 
 
-==== tests/cases/compiler/downlevelLetConst18.ts (9 errors) ====
+==== tests/cases/compiler/downlevelLetConst18.ts (2 errors) ====
     'use strict'
     
     for (let x; ;) {
-    ~~~
-!!! error TS4091: Loop contains block-scoped variable 'x' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher.
         function foo() { x };
                  ~~~
 !!! error TS2393: Duplicate function implementation.
     }
     
     for (let x; ;) {
-    ~~~
-!!! error TS4091: Loop contains block-scoped variable 'x' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher.
         function foo() { x };
                  ~~~
 !!! error TS2393: Duplicate function implementation.
     }
     
     for (let x; ;) {
-    ~~~
-!!! error TS4091: Loop contains block-scoped variable 'x' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher.
         (() => { x })();
     }
     
     for (const x = 1; ;) {
-    ~~~
-!!! error TS4091: Loop contains block-scoped variable 'x' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher.
         (() => { x })();
     }
     
     for (let x; ;) {
-    ~~~
-!!! error TS4091: Loop contains block-scoped variable 'x' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher.
         ({ foo() { x }})
     }
     
     for (let x; ;) {
-    ~~~
-!!! error TS4091: Loop contains block-scoped variable 'x' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher.
         ({ get foo() { return x } })
     }
     
     for (let x; ;) {
-    ~~~
-!!! error TS4091: Loop contains block-scoped variable 'x' referenced by a function in the loop. This is only supported in ECMAScript 6 or higher.
         ({ set foo(v) { x } })
     }
     

--- a/tests/baselines/reference/downlevelLetConst18.js
+++ b/tests/baselines/reference/downlevelLetConst18.js
@@ -32,33 +32,33 @@ for (let x; ;) {
 
 //// [downlevelLetConst18.js]
 'use strict';
-var _a = function(x)  {
+var _a = function(x) {
     function foo() { x; }
     ;
 };
 for (var x = void 0;;) _a(x);
-var _b = function(x)  {
+var _b = function(x) {
     function foo() { x; }
     ;
 };
 for (var x = void 0;;) _b(x);
-var _c = function(x)  {
+var _c = function(x) {
     (function () { x; })();
 };
 for (var x = void 0;;) _c(x);
-var _d = function(x)  {
+var _d = function(x) {
     (function () { x; })();
 };
 for (var x = 1;;) _d(x);
-var _e = function(x)  {
+var _e = function(x) {
     ({ foo: function () { x; } });
 };
 for (var x = void 0;;) _e(x);
-var _f = function(x)  {
+var _f = function(x) {
     ({ get foo() { return x; } });
 };
 for (var x = void 0;;) _f(x);
-var _g = function(x)  {
+var _g = function(x) {
     ({ set foo(v) { x; } });
 };
 for (var x = void 0;;) _g(x);

--- a/tests/baselines/reference/downlevelLetConst18.js
+++ b/tests/baselines/reference/downlevelLetConst18.js
@@ -32,26 +32,33 @@ for (let x; ;) {
 
 //// [downlevelLetConst18.js]
 'use strict';
-for (var x = void 0;;) {
+var _a = function(x)  {
     function foo() { x; }
     ;
-}
-for (var x = void 0;;) {
+};
+for (var x = void 0;;) _a(x);
+var _b = function(x)  {
     function foo() { x; }
     ;
-}
-for (var x = void 0;;) {
+};
+for (var x = void 0;;) _b(x);
+var _c = function(x)  {
     (function () { x; })();
-}
-for (var x = 1;;) {
+};
+for (var x = void 0;;) _c(x);
+var _d = function(x)  {
     (function () { x; })();
-}
-for (var x = void 0;;) {
+};
+for (var x = 1;;) _d(x);
+var _e = function(x)  {
     ({ foo: function () { x; } });
-}
-for (var x = void 0;;) {
+};
+for (var x = void 0;;) _e(x);
+var _f = function(x)  {
     ({ get foo() { return x; } });
-}
-for (var x = void 0;;) {
+};
+for (var x = void 0;;) _f(x);
+var _g = function(x)  {
     ({ set foo(v) { x; } });
-}
+};
+for (var x = void 0;;) _g(x);


### PR DESCRIPTION
I've implemented a downlevel emit for block scoped variables that are used inside callbacks in a loop.
Example:
```typescript
for (let i = 0; i < 9; i++) {
  setTimeout(i, () => console.log(i));
}
```
Is emitted as
```javascript
var _a = function(i)  {
    setTimeout(i, function () { return console.log(i); });
};
for (var i = 0; i < 9; i++) _a(i);
```

Todo:
- [x] Formatting, a `do ... while()` loop is emitted ugly at the moment.
- [x] Downlevel emit of a `for of` loop.
- [ ] Variables declared using destructuring in the head of a for loop aren't added to the closure yet.
- [ ] Tests
- [ ] Comments

I'm not sure whether the code in `checker.ts` is ok, should the variable `blockScopedBindingInLoop` be turned into a `NodeFlag`?