### PR TITLE
Fix resolution of named function & class expressions as well as 'arguments'

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -422,27 +422,33 @@ module ts {
                     case SyntaxKind.SetAccessor:
                     case SyntaxKind.FunctionDeclaration:
                     case SyntaxKind.ArrowFunction:
-                        if (name === "arguments") {
-                            result = argumentsSymbol;
-                            break loop;
+                        if (meaning & SymbolFlags.Value) {
+                            if (name === "arguments") {
+                                result = argumentsSymbol;
+                                break loop;
+                            }
                         }
                         break;
                     case SyntaxKind.FunctionExpression:
-                        if (name === "arguments") {
-                            result = argumentsSymbol;
-                            break loop;
-                        }
-                        let functionName = (<FunctionExpression>location).name;
-                        if (functionName && name === functionName.text) {
-                            result = location.symbol;
-                            break loop;
+                        if (meaning & SymbolFlags.Value) {
+                            if (name === "arguments") {
+                                result = argumentsSymbol;
+                                break loop;
+                            }
+                            let functionName = (<FunctionExpression>location).name;
+                            if (functionName && name === functionName.text) {
+                                result = location.symbol;
+                                break loop;
+                            }
                         }
                         break;
                     case SyntaxKind.ClassExpression:
-                        let className = (<ClassExpression>location).name;
-                        if (className && name === className.text) {
-                            result = location.symbol;
-                            break loop;
+                        if (meaning & (SymbolFlags.Value | SymbolFlags.Type)) {
+                            let className = (<ClassExpression>location).name;
+                            if (className && name === className.text) {
+                                result = location.symbol;
+                                break loop;
+                            }
                         }
                         break;
                     case SyntaxKind.Decorator:

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -422,19 +422,18 @@ module ts {
                     case SyntaxKind.SetAccessor:
                     case SyntaxKind.FunctionDeclaration:
                     case SyntaxKind.ArrowFunction:
-                        if (meaning & SymbolFlags.Value) {
-                            if (name === "arguments") {
-                                result = argumentsSymbol;
-                                break loop;
-                            }
+                        if (meaning & SymbolFlags.Variable && name === "arguments") {
+                            result = argumentsSymbol;
+                            break loop;
                         }
                         break;
                     case SyntaxKind.FunctionExpression:
-                        if (meaning & SymbolFlags.Value) {
-                            if (name === "arguments") {
-                                result = argumentsSymbol;
-                                break loop;
-                            }
+                        if (meaning & SymbolFlags.Variable && name === "arguments") {
+                            result = argumentsSymbol;
+                            break loop;
+                        }
+
+                        if (meaning & SymbolFlags.Function) {
                             let functionName = (<FunctionExpression>location).name;
                             if (functionName && name === functionName.text) {
                                 result = location.symbol;
@@ -443,7 +442,7 @@ module ts {
                         }
                         break;
                     case SyntaxKind.ClassExpression:
-                        if (meaning & (SymbolFlags.Value | SymbolFlags.Type)) {
+                        if (meaning & SymbolFlags.Class) {
                             let className = (<ClassExpression>location).name;
                             if (className && name === className.text) {
                                 result = location.symbol;

--- a/tests/baselines/reference/classExpressionWithResolutionOfNamespaceOfSameName01.errors.txt
+++ b/tests/baselines/reference/classExpressionWithResolutionOfNamespaceOfSameName01.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/classExpressionWithResolutionOfNamespaceOfSameName01.ts(6,15): error TS9003: 'class' expressions are not currently supported.
+
+
+==== tests/cases/compiler/classExpressionWithResolutionOfNamespaceOfSameName01.ts (1 errors) ====
+    namespace C {
+        export interface type {
+        }
+    }
+    
+    var x = class C {
+                  ~
+!!! error TS9003: 'class' expressions are not currently supported.
+        prop: C.type;
+    }

--- a/tests/baselines/reference/classExpressionWithResolutionOfNamespaceOfSameName01.js
+++ b/tests/baselines/reference/classExpressionWithResolutionOfNamespaceOfSameName01.js
@@ -1,0 +1,16 @@
+//// [classExpressionWithResolutionOfNamespaceOfSameName01.ts]
+namespace C {
+    export interface type {
+    }
+}
+
+var x = class C {
+    prop: C.type;
+}
+
+//// [classExpressionWithResolutionOfNamespaceOfSameName01.js]
+var x = (function () {
+    function C() {
+    }
+    return C;
+})();

--- a/tests/baselines/reference/functionDeclarationWithResolutionOfTypeNamedArguments01.js
+++ b/tests/baselines/reference/functionDeclarationWithResolutionOfTypeNamedArguments01.js
@@ -1,0 +1,12 @@
+//// [functionDeclarationWithResolutionOfTypeNamedArguments01.ts]
+interface arguments {
+}
+
+function f() {
+    <arguments>arguments;
+}
+
+//// [functionDeclarationWithResolutionOfTypeNamedArguments01.js]
+function f() {
+    arguments;
+}

--- a/tests/baselines/reference/functionDeclarationWithResolutionOfTypeNamedArguments01.symbols
+++ b/tests/baselines/reference/functionDeclarationWithResolutionOfTypeNamedArguments01.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/functionDeclarationWithResolutionOfTypeNamedArguments01.ts ===
+interface arguments {
+>arguments : Symbol(arguments, Decl(functionDeclarationWithResolutionOfTypeNamedArguments01.ts, 0, 0))
+}
+
+function f() {
+>f : Symbol(f, Decl(functionDeclarationWithResolutionOfTypeNamedArguments01.ts, 1, 1))
+
+    <arguments>arguments;
+>arguments : Symbol(arguments, Decl(functionDeclarationWithResolutionOfTypeNamedArguments01.ts, 0, 0))
+>arguments : Symbol(arguments)
+}

--- a/tests/baselines/reference/functionDeclarationWithResolutionOfTypeNamedArguments01.types
+++ b/tests/baselines/reference/functionDeclarationWithResolutionOfTypeNamedArguments01.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/functionDeclarationWithResolutionOfTypeNamedArguments01.ts ===
+interface arguments {
+>arguments : arguments
+}
+
+function f() {
+>f : () => void
+
+    <arguments>arguments;
+><arguments>arguments : arguments
+>arguments : arguments
+>arguments : IArguments
+}

--- a/tests/baselines/reference/functionDeclarationWithResolutionOfTypeOfSameName01.js
+++ b/tests/baselines/reference/functionDeclarationWithResolutionOfTypeOfSameName01.js
@@ -1,0 +1,12 @@
+//// [functionDeclarationWithResolutionOfTypeOfSameName01.ts]
+interface f {
+}
+
+function f() {
+    <f>f;
+}
+
+//// [functionDeclarationWithResolutionOfTypeOfSameName01.js]
+function f() {
+    f;
+}

--- a/tests/baselines/reference/functionDeclarationWithResolutionOfTypeOfSameName01.symbols
+++ b/tests/baselines/reference/functionDeclarationWithResolutionOfTypeOfSameName01.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/functionDeclarationWithResolutionOfTypeOfSameName01.ts ===
+interface f {
+>f : Symbol(f, Decl(functionDeclarationWithResolutionOfTypeOfSameName01.ts, 0, 0), Decl(functionDeclarationWithResolutionOfTypeOfSameName01.ts, 1, 1))
+}
+
+function f() {
+>f : Symbol(f, Decl(functionDeclarationWithResolutionOfTypeOfSameName01.ts, 0, 0), Decl(functionDeclarationWithResolutionOfTypeOfSameName01.ts, 1, 1))
+
+    <f>f;
+>f : Symbol(f, Decl(functionDeclarationWithResolutionOfTypeOfSameName01.ts, 0, 0), Decl(functionDeclarationWithResolutionOfTypeOfSameName01.ts, 1, 1))
+>f : Symbol(f, Decl(functionDeclarationWithResolutionOfTypeOfSameName01.ts, 0, 0), Decl(functionDeclarationWithResolutionOfTypeOfSameName01.ts, 1, 1))
+}

--- a/tests/baselines/reference/functionDeclarationWithResolutionOfTypeOfSameName01.types
+++ b/tests/baselines/reference/functionDeclarationWithResolutionOfTypeOfSameName01.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/functionDeclarationWithResolutionOfTypeOfSameName01.ts ===
+interface f {
+>f : f
+}
+
+function f() {
+>f : () => void
+
+    <f>f;
+><f>f : f
+>f : f
+>f : () => void
+}

--- a/tests/baselines/reference/functionExpressionWithResolutionOfTypeNamedArguments01.js
+++ b/tests/baselines/reference/functionExpressionWithResolutionOfTypeNamedArguments01.js
@@ -1,0 +1,12 @@
+//// [functionExpressionWithResolutionOfTypeNamedArguments01.ts]
+interface arguments {
+}
+
+var x = function f() {
+    <arguments>arguments;
+}
+
+//// [functionExpressionWithResolutionOfTypeNamedArguments01.js]
+var x = function f() {
+    arguments;
+};

--- a/tests/baselines/reference/functionExpressionWithResolutionOfTypeNamedArguments01.symbols
+++ b/tests/baselines/reference/functionExpressionWithResolutionOfTypeNamedArguments01.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/functionExpressionWithResolutionOfTypeNamedArguments01.ts ===
+interface arguments {
+>arguments : Symbol(arguments, Decl(functionExpressionWithResolutionOfTypeNamedArguments01.ts, 0, 0))
+}
+
+var x = function f() {
+>x : Symbol(x, Decl(functionExpressionWithResolutionOfTypeNamedArguments01.ts, 3, 3))
+>f : Symbol(f, Decl(functionExpressionWithResolutionOfTypeNamedArguments01.ts, 3, 7))
+
+    <arguments>arguments;
+>arguments : Symbol(arguments, Decl(functionExpressionWithResolutionOfTypeNamedArguments01.ts, 0, 0))
+>arguments : Symbol(arguments)
+}

--- a/tests/baselines/reference/functionExpressionWithResolutionOfTypeNamedArguments01.types
+++ b/tests/baselines/reference/functionExpressionWithResolutionOfTypeNamedArguments01.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/functionExpressionWithResolutionOfTypeNamedArguments01.ts ===
+interface arguments {
+>arguments : arguments
+}
+
+var x = function f() {
+>x : () => void
+>function f() {    <arguments>arguments;} : () => void
+>f : () => void
+
+    <arguments>arguments;
+><arguments>arguments : arguments
+>arguments : arguments
+>arguments : IArguments
+}

--- a/tests/baselines/reference/functionExpressionWithResolutionOfTypeOfSameName01.js
+++ b/tests/baselines/reference/functionExpressionWithResolutionOfTypeOfSameName01.js
@@ -1,0 +1,12 @@
+//// [functionExpressionWithResolutionOfTypeOfSameName01.ts]
+interface f {
+}
+
+var x = function f() {
+    <f>f;
+}
+
+//// [functionExpressionWithResolutionOfTypeOfSameName01.js]
+var x = function f() {
+    f;
+};

--- a/tests/baselines/reference/functionExpressionWithResolutionOfTypeOfSameName01.symbols
+++ b/tests/baselines/reference/functionExpressionWithResolutionOfTypeOfSameName01.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/functionExpressionWithResolutionOfTypeOfSameName01.ts ===
+interface f {
+>f : Symbol(f, Decl(functionExpressionWithResolutionOfTypeOfSameName01.ts, 0, 0))
+}
+
+var x = function f() {
+>x : Symbol(x, Decl(functionExpressionWithResolutionOfTypeOfSameName01.ts, 3, 3))
+>f : Symbol(f, Decl(functionExpressionWithResolutionOfTypeOfSameName01.ts, 3, 7))
+
+    <f>f;
+>f : Symbol(f, Decl(functionExpressionWithResolutionOfTypeOfSameName01.ts, 0, 0))
+>f : Symbol(f, Decl(functionExpressionWithResolutionOfTypeOfSameName01.ts, 3, 7))
+}

--- a/tests/baselines/reference/functionExpressionWithResolutionOfTypeOfSameName01.types
+++ b/tests/baselines/reference/functionExpressionWithResolutionOfTypeOfSameName01.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/functionExpressionWithResolutionOfTypeOfSameName01.ts ===
+interface f {
+>f : f
+}
+
+var x = function f() {
+>x : () => void
+>function f() {    <f>f;} : () => void
+>f : () => void
+
+    <f>f;
+><f>f : f
+>f : f
+>f : () => void
+}

--- a/tests/baselines/reference/functionExpressionWithResolutionOfTypeOfSameName02.js
+++ b/tests/baselines/reference/functionExpressionWithResolutionOfTypeOfSameName02.js
@@ -1,0 +1,12 @@
+//// [functionExpressionWithResolutionOfTypeOfSameName02.ts]
+interface Foo {
+}
+
+var x = function Foo() {
+    var x: Foo;
+}
+
+//// [functionExpressionWithResolutionOfTypeOfSameName02.js]
+var x = function Foo() {
+    var x;
+};

--- a/tests/baselines/reference/functionExpressionWithResolutionOfTypeOfSameName02.symbols
+++ b/tests/baselines/reference/functionExpressionWithResolutionOfTypeOfSameName02.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/functionExpressionWithResolutionOfTypeOfSameName02.ts ===
+interface Foo {
+>Foo : Symbol(Foo, Decl(functionExpressionWithResolutionOfTypeOfSameName02.ts, 0, 0))
+}
+
+var x = function Foo() {
+>x : Symbol(x, Decl(functionExpressionWithResolutionOfTypeOfSameName02.ts, 3, 3))
+>Foo : Symbol(Foo, Decl(functionExpressionWithResolutionOfTypeOfSameName02.ts, 3, 7))
+
+    var x: Foo;
+>x : Symbol(x, Decl(functionExpressionWithResolutionOfTypeOfSameName02.ts, 4, 7))
+>Foo : Symbol(Foo, Decl(functionExpressionWithResolutionOfTypeOfSameName02.ts, 0, 0))
+}

--- a/tests/baselines/reference/functionExpressionWithResolutionOfTypeOfSameName02.types
+++ b/tests/baselines/reference/functionExpressionWithResolutionOfTypeOfSameName02.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/functionExpressionWithResolutionOfTypeOfSameName02.ts ===
+interface Foo {
+>Foo : Foo
+}
+
+var x = function Foo() {
+>x : () => void
+>function Foo() {    var x: Foo;} : () => void
+>Foo : () => void
+
+    var x: Foo;
+>x : Foo
+>Foo : Foo
+}

--- a/tests/cases/compiler/classExpressionWithResolutionOfNamespaceOfSameName01.ts
+++ b/tests/cases/compiler/classExpressionWithResolutionOfNamespaceOfSameName01.ts
@@ -1,0 +1,8 @@
+﻿namespace C {
+    export interface type {
+    }
+}
+
+var x = class C {
+    prop: C.type;
+}

--- a/tests/cases/compiler/functionDeclarationWithResolutionOfTypeNamedArguments01.ts
+++ b/tests/cases/compiler/functionDeclarationWithResolutionOfTypeNamedArguments01.ts
@@ -1,0 +1,6 @@
+﻿interface arguments {
+}
+
+function f() {
+    <arguments>arguments;
+}

--- a/tests/cases/compiler/functionDeclarationWithResolutionOfTypeOfSameName01.ts
+++ b/tests/cases/compiler/functionDeclarationWithResolutionOfTypeOfSameName01.ts
@@ -1,0 +1,6 @@
+﻿interface f {
+}
+
+function f() {
+    <f>f;
+}

--- a/tests/cases/compiler/functionExpressionWithResolutionOfTypeNamedArguments01.ts
+++ b/tests/cases/compiler/functionExpressionWithResolutionOfTypeNamedArguments01.ts
@@ -1,0 +1,6 @@
+﻿interface arguments {
+}
+
+var x = function f() {
+    <arguments>arguments;
+}

--- a/tests/cases/compiler/functionExpressionWithResolutionOfTypeOfSameName01.ts
+++ b/tests/cases/compiler/functionExpressionWithResolutionOfTypeOfSameName01.ts
@@ -1,0 +1,6 @@
+﻿interface f {
+}
+
+var x = function f() {
+    <f>f;
+}

--- a/tests/cases/compiler/functionExpressionWithResolutionOfTypeOfSameName02.ts
+++ b/tests/cases/compiler/functionExpressionWithResolutionOfTypeOfSameName02.ts
@@ -1,0 +1,6 @@
+﻿interface Foo {
+}
+
+var x = function Foo() {
+    var x: Foo;
+}


### PR DESCRIPTION
In resolution, we special case the `arguments` object as well as names of function and class expressions.

However, when resolving, we ignore the resolution meaning and special case these unconditionally. That means in the following case, we will always resolve `Foo` as the function rather than the type.

```TypeScript
interface Foo {
}

var x = function Foo() {
    var x: Foo;
}
```

Fixes #3285.