### PR TITLE
Follow symlinks when enumerating files in a directory

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -231,7 +231,7 @@ module ts {
                     var directories: string[] = [];
                     for (let current of files) {
                         var name = combinePaths(path, current);
-                        var stat = _fs.lstatSync(name);
+                        var stat = _fs.statSync(name);
                         if (stat.isFile()) {
                             if (!extension || fileExtensionIs(name, extension)) {
                                 result.push(name);


### PR DESCRIPTION
This resolves issue #3301.

As it seems from discussion here https://github.com/Microsoft/TypeScript/commit/25e52a3975bfb7774323931bc1b5b7b438622dfa, the main concern with symlinks was a possibility of circular links. Instead of ignoring symlinks entirely, we can just catch the error that will occur when trying to read a recursive symlink.

Simple example that didn't work before the fix, but works now: https://github.com/OleksandrChekhovskyi/ts-symlinks

To test circular symlinks see: https://github.com/OleksandrChekhovskyi/ts-circular-symlinks

CLA has been signed and mailed to cla@microsoft.com
