### PR TITLE
Never normalize end-of-lines on clone/commit.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.js linguist-language=TypeScript
+* -text


### PR DESCRIPTION
This change should remove the requirement that people have to set a global git config flag in order for the tests to pass on clean clone.

Verification steps:

1. delete local repo
1. clone repo
1. build
1. run tests
1. make code change
1. verify git diff doesn't see file as binary (you should see an actual diff)