### PR TITLE
External module resolution

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.js linguist-language=TypeScript
+* -text

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
         "istanbul": "latest"
     },
     "scripts": {
-        "test": "jake runtests"
+        "test": "jake runtests",
+        "clean": "jake clean",
+        "build": "jake local",
+        "build-tests": "jake tests"
     }
 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -862,7 +862,9 @@ module ts {
             // Escape the name in the "require(...)" clause to ensure we find the right symbol.
             let moduleName = escapeIdentifier(moduleReferenceLiteral.text);
 
-            if (!moduleName) return;
+            if (!moduleName) {
+                return;
+            }
             let isRelative = isExternalModuleNameRelative(moduleName);
             if (!isRelative) {
                 let symbol = getSymbol(globals, '"' + moduleName + '"', SymbolFlags.ValueModule);
@@ -870,20 +872,9 @@ module ts {
                     return symbol;
                 }
             }
-            let fileName: string;
-            let sourceFile: SourceFile;
-            while (true) {
-                fileName = normalizePath(combinePaths(searchPath, moduleName));
-                sourceFile = forEach(supportedExtensions, extension => host.getSourceFile(fileName + extension));
-                if (sourceFile || isRelative) {
-                    break;
-                }
-                let parentPath = getDirectoryPath(searchPath);
-                if (parentPath === searchPath) {
-                    break;
-                }
-                searchPath = parentPath;
-            }
+
+            let fileName = getResolvedModuleFileName(getSourceFile(location), moduleReferenceLiteral);
+            let sourceFile = fileName && host.getSourceFile(fileName);
             if (sourceFile) {
                 if (sourceFile.symbol) {
                     return sourceFile.symbol;

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5678,7 +5678,8 @@ module ts {
             // will immediately bail out of walking any subtrees when we can see that their parents
             // are already correct.
             let result = Parser.parseSourceFile(sourceFile.fileName, newText, sourceFile.languageVersion, syntaxCursor, /* setParentNode */ true)
-
+            // pass set of modules that were resolved before so 'createProgram' can reuse previous resolution results
+            result.resolvedModules = sourceFile.resolvedModules;
             return result;
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1159,6 +1159,10 @@ module ts {
         // Stores a line map for the file.
         // This field should never be used directly to obtain line map, use getLineMap function instead.
         /* @internal */ lineMap: number[];
+        
+        // Stores a mapping 'external module reference text' -> 'resolved file name' | undefined
+        // Content of this fiels should never be used directly - use getResolvedModuleFileName/setResolvedModuleFileName functions instead
+        /* @internal */ resolvedModules: Map<string>;
     }
 
     export interface ScriptReferenceHost {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -78,6 +78,30 @@ module ts {
         return node.end - node.pos;
     }
 
+    export function ensureResolvedModuleNamesAreUptoDate(sourceFile: SourceFile, imports: LiteralExpression[]): void {
+        if (!sourceFile.resolvedModules) {
+            return;
+        }
+        // TOOD: check that imports are consistent
+    }
+
+    export function hasResolvedModuleName(sourceFile: SourceFile, moduleReferenceLiteral: LiteralExpression): boolean {
+        return sourceFile.resolvedModules && hasProperty(sourceFile.resolvedModules, moduleReferenceLiteral.text);
+    }
+
+    export function getResolvedModuleFileName(sourceFile: SourceFile, moduleReferenceLiteral: LiteralExpression): string {
+        return sourceFile.resolvedModules && sourceFile.resolvedModules[moduleReferenceLiteral.text];
+    }
+
+    export function setResolvedModuleName(sourceFile: SourceFile, moduleReferenceLiteral: LiteralExpression, resolvedFileName: string): void {
+        if (!sourceFile.resolvedModules) {
+            sourceFile.resolvedModules = {};
+        }
+
+        // TODO: check if value for the given key already exists and if yes - that it is the same as new value
+        sourceFile.resolvedModules[moduleReferenceLiteral.text] = resolvedFileName;
+    }
+
     // Returns true if this node contains a parse error anywhere underneath it.
     export function containsParseError(node: Node): boolean {
         aggregateChildData(node);

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -752,6 +752,7 @@ module ts {
         public languageVersion: ScriptTarget;
         public identifiers: Map<string>;
         public nameTable: Map<string>;
+        public resolvedModules: Map<string>;
 
         private namedDeclarations: Map<Declaration[]>;
 

--- a/tests/baselines/reference/project/import_via_mapping_file/amd/app/main.js
+++ b/tests/baselines/reference/project/import_via_mapping_file/amd/app/main.js
@@ -1,0 +1,3 @@
+define(["require", "exports", 'foo'], function (require, exports, foo_1) {
+    var foo = new foo_1.Foo();
+});

--- a/tests/baselines/reference/project/import_via_mapping_file/amd/import_via_mapping_file.json
+++ b/tests/baselines/reference/project/import_via_mapping_file/amd/import_via_mapping_file.json
@@ -1,0 +1,18 @@
+{
+    "scenario": "Import a module found in a mapping file",
+    "projectRoot": "tests/cases/projects/import_via_mapping_file",
+    "inputFiles": [
+        "app/main.ts"
+    ],
+    "resolvedInputFiles": [
+        "lib.d.ts",
+        "libs/library.ts",
+        "libs/library2.ts",
+        "app/main.ts"
+    ],
+    "emittedFiles": [
+        "libs/library.js",
+        "libs/library2.js",
+        "app/main.js"
+    ]
+}

--- a/tests/baselines/reference/project/import_via_mapping_file/amd/libs/library.js
+++ b/tests/baselines/reference/project/import_via_mapping_file/amd/libs/library.js
@@ -1,0 +1,8 @@
+define(["require", "exports"], function (require, exports) {
+    var Foo = (function () {
+        function Foo() {
+        }
+        return Foo;
+    })();
+    exports.Foo = Foo;
+});

--- a/tests/baselines/reference/project/import_via_mapping_file/node/app/main.js
+++ b/tests/baselines/reference/project/import_via_mapping_file/node/app/main.js
@@ -1,0 +1,2 @@
+var foo_1 = require('foo');
+var foo = new foo_1.Foo();

--- a/tests/baselines/reference/project/import_via_mapping_file/node/import_via_mapping_file.json
+++ b/tests/baselines/reference/project/import_via_mapping_file/node/import_via_mapping_file.json
@@ -1,0 +1,18 @@
+{
+    "scenario": "Import a module found in a mapping file",
+    "projectRoot": "tests/cases/projects/import_via_mapping_file",
+    "inputFiles": [
+        "app/main.ts"
+    ],
+    "resolvedInputFiles": [
+        "lib.d.ts",
+        "libs/library.ts",
+        "libs/library2.ts",
+        "app/main.ts"
+    ],
+    "emittedFiles": [
+        "libs/library.js",
+        "libs/library2.js",
+        "app/main.js"
+    ]
+}

--- a/tests/baselines/reference/project/import_via_mapping_file/node/libs/library.js
+++ b/tests/baselines/reference/project/import_via_mapping_file/node/libs/library.js
@@ -1,0 +1,6 @@
+var Foo = (function () {
+    function Foo() {
+    }
+    return Foo;
+})();
+exports.Foo = Foo;

--- a/tests/cases/project/import_via_mapping_file.json
+++ b/tests/cases/project/import_via_mapping_file.json
@@ -1,0 +1,7 @@
+{
+    "scenario": "Import a module found in a mapping file",
+    "projectRoot": "tests/cases/projects/import_via_mapping_file",
+    "inputFiles": [
+        "app/main.ts"
+    ]
+}

--- a/tests/cases/projects/import_via_mapping_file/app/main.ts
+++ b/tests/cases/projects/import_via_mapping_file/app/main.ts
@@ -1,0 +1,5 @@
+import { Foo } from 'foo';
+import { Bar } from 'bar';
+
+let foo = new Foo();
+let bar = new Bar();

--- a/tests/cases/projects/import_via_mapping_file/app/typescript-definition-map.json
+++ b/tests/cases/projects/import_via_mapping_file/app/typescript-definition-map.json
@@ -1,0 +1,3 @@
+{
+	"bar": "../libs/library2.ts"
+}

--- a/tests/cases/projects/import_via_mapping_file/libs/library.ts
+++ b/tests/cases/projects/import_via_mapping_file/libs/library.ts
@@ -1,0 +1,2 @@
+export class Foo {
+}

--- a/tests/cases/projects/import_via_mapping_file/libs/library2.ts
+++ b/tests/cases/projects/import_via_mapping_file/libs/library2.ts
@@ -1,0 +1,2 @@
+export class Bar {
+}

--- a/tests/cases/projects/import_via_mapping_file/typescript-definition-map.json
+++ b/tests/cases/projects/import_via_mapping_file/typescript-definition-map.json
@@ -1,0 +1,3 @@
+{
+	"foo": "libs/library.ts"
+}


### PR DESCRIPTION
Fixes #2338 ... at least half of it.

*TL;DR*: See last commit, ignore others.

Note: This is branched off of https://github.com/Microsoft/TypeScript/pull/3324 and has Microsoft/TypeScript#externalModuleResolution rebased on master underneath it since that seemed to be relevant for this change.  It also has some jake commands added for ease of testing.  If this PR nears approval, I will clean it up as desired by maintainers.  In the meantime, check the last commit for the meat of the PR.

Summary
----
Adds support for module resolution via a mapping file.

This is a proof of concept for module resolution via mapping file(s).  Includes limited test coverage, no caching and poor factorization.  If the spec for this feature lands on something near this PR I don't mind fixing it up, though I don't know how to write idiomatic TSC code so the PR will still likely need some maintainer love.

CAVEAT
----
Currently only supports references within the project root directory tree.  Since dependencies managed by a package manager are likely to sit *outside* of the project root directory tree this solution falls short of achieving full desired results.  Unfortunately, I am not sure how to find a mapping file that is shipped with third party modules (outside the project root tree) since I can't walk up the directory tree indefinitely, and it is undefined how far up is a reasonable distance to walk.

This is particularly important for dependencies that have dependencies since one can reference a dependency outside of the tree with a mapping file but that dependency can't have a mapping file of its own up its directory tree.  This means that dependencies would have to either have relative file paths (no mappings) or they would need to use whatever you have defined in your project's mapping file(s).  In the first case, this hurts library distribution because dependency managers have to do the terrible NPM thing of having every dependency have its own node_modules folder.  In the second case, this just leads to broken apps when you cause a dependency to use a mis-matched version of one of its dependencies.