### PR TITLE
Fix WebGL / texImage2D base definition

### DIFF
--- a/bin/lib.d.ts
+++ b/bin/lib.d.ts
@@ -14748,6 +14748,7 @@ interface WebGLRenderingContext {
     stencilMaskSeparate(face: number, mask: number): void;
     stencilOp(fail: number, zfail: number, zpass: number): void;
     stencilOpSeparate(face: number, fail: number, zfail: number, zpass: number): void;
+    texImage2D(target: number, level: number, internalformat: number, width: number, height: number, border: number, format: number, type: number, pixels: ArrayBufferView): void;
     texImage2D(target: number, level: number, internalformat: number, format: number, type: number, pixels: ImageData): void;
     texParameterf(target: number, pname: number, param: number): void;
     texParameteri(target: number, pname: number, param: number): void;


### PR DESCRIPTION
Added 'ArrayBufferView' variant of texImage2D function.

Issue: https://github.com/Microsoft/TypeScript/issues/3344