### PR TITLE
Simplify handling of the 'any' type inside the checker.

### DIFF
--- a/tests/baselines/reference/ArrowFunction3.errors.txt
+++ b/tests/baselines/reference/ArrowFunction3.errors.txt
@@ -1,11 +1,8 @@
-tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrowFunctions/ArrowFunction3.ts(1,13): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrowFunctions/ArrowFunction3.ts(1,14): error TS1110: Type expected.
 
 
-==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrowFunctions/ArrowFunction3.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrowFunctions/ArrowFunction3.ts (1 errors) ====
     var v = (a): => {
-                
-!!! error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
                  ~~
 !!! error TS1110: Type expected.
        

--- a/tests/baselines/reference/genericRecursiveImplicitConstructorErrors3.errors.txt
+++ b/tests/baselines/reference/genericRecursiveImplicitConstructorErrors3.errors.txt
@@ -1,5 +1,4 @@
 tests/cases/compiler/genericRecursiveImplicitConstructorErrors3.ts(3,66): error TS2314: Generic type 'MemberName<A, B, C>' requires 3 type argument(s).
-tests/cases/compiler/genericRecursiveImplicitConstructorErrors3.ts(3,66): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
 tests/cases/compiler/genericRecursiveImplicitConstructorErrors3.ts(10,22): error TS2314: Generic type 'PullTypeSymbol<A, B, C>' requires 3 type argument(s).
 tests/cases/compiler/genericRecursiveImplicitConstructorErrors3.ts(12,48): error TS2314: Generic type 'PullSymbol<A, B, C>' requires 3 type argument(s).
 tests/cases/compiler/genericRecursiveImplicitConstructorErrors3.ts(13,31): error TS2314: Generic type 'PullTypeSymbol<A, B, C>' requires 3 type argument(s).
@@ -8,14 +7,12 @@ tests/cases/compiler/genericRecursiveImplicitConstructorErrors3.ts(18,53): error
 tests/cases/compiler/genericRecursiveImplicitConstructorErrors3.ts(19,22): error TS2339: Property 'isArray' does not exist on type 'PullTypeSymbol<A, B, C>'.
 
 
-==== tests/cases/compiler/genericRecursiveImplicitConstructorErrors3.ts (8 errors) ====
+==== tests/cases/compiler/genericRecursiveImplicitConstructorErrors3.ts (7 errors) ====
     module TypeScript {
         export class MemberName <A,B,C>{
             static create<A,B,C>(arg1: any, arg2?: any, arg3?: any): MemberName {
                                                                      ~~~~~~~~~~
 !!! error TS2314: Generic type 'MemberName<A, B, C>' requires 3 type argument(s).
-                                                                     ~~~~~~~~~~
-!!! error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
             }
         }
     }

--- a/tests/baselines/reference/parserGenericsInTypeContexts1.errors.txt
+++ b/tests/baselines/reference/parserGenericsInTypeContexts1.errors.txt
@@ -7,10 +7,9 @@ tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(8,9): error TS2304: Cannot find name 'K'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(11,16): error TS2304: Cannot find name 'E'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(14,16): error TS2304: Cannot find name 'F'.
-tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(14,16): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
 
 
-==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts (10 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts (9 errors) ====
     class C extends A<T> implements B<T> {
                     ~
 !!! error TS2304: Cannot find name 'A'.
@@ -43,8 +42,6 @@ tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts
     function f2(): F<T> {
                    ~
 !!! error TS2304: Cannot find name 'F'.
-                   ~~~~
-!!! error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
     }
     
     

--- a/tests/baselines/reference/parserGenericsInTypeContexts2.errors.txt
+++ b/tests/baselines/reference/parserGenericsInTypeContexts2.errors.txt
@@ -7,10 +7,9 @@ tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(8,9): error TS2304: Cannot find name 'K'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(11,16): error TS2304: Cannot find name 'E'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(14,16): error TS2304: Cannot find name 'F'.
-tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(14,16): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
 
 
-==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts (10 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts (9 errors) ====
     class C extends A<X<T>, Y<Z<T>>> implements B<X<T>, Y<Z<T>>> {
                     ~
 !!! error TS2304: Cannot find name 'A'.
@@ -43,8 +42,6 @@ tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts
     function f2(): F<X<T>, Y<Z<T>>> {
                    ~
 !!! error TS2304: Cannot find name 'F'.
-                   ~~~~~~~~~~~~~~~~
-!!! error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
     }
     
     

--- a/tests/baselines/reference/parserX_ArrowFunction3.errors.txt
+++ b/tests/baselines/reference/parserX_ArrowFunction3.errors.txt
@@ -1,11 +1,8 @@
-tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrowFunctions/parserX_ArrowFunction3.ts(1,13): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrowFunctions/parserX_ArrowFunction3.ts(1,14): error TS1110: Type expected.
 
 
-==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrowFunctions/parserX_ArrowFunction3.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/ArrowFunctions/parserX_ArrowFunction3.ts (1 errors) ====
     var v = (a): => {
-                
-!!! error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
                  ~~
 !!! error TS1110: Type expected.
        

--- a/tests/baselines/reference/typeParameterUsedAsTypeParameterConstraint4.errors.txt
+++ b/tests/baselines/reference/typeParameterUsedAsTypeParameterConstraint4.errors.txt
@@ -7,16 +7,12 @@ tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsed
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(15,8): error TS2304: Cannot find name 'W'.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(19,17): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(19,43): error TS2304: Cannot find name 'V'.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(19,43): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(20,47): error TS2304: Cannot find name 'X'.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(20,47): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(22,13): error TS2322: Type 'U' is not assignable to type 'T'.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(23,20): error TS2322: Type 'U' is not assignable to type 'T'.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(28,15): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(28,44): error TS2304: Cannot find name 'W'.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(28,44): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(29,47): error TS2304: Cannot find name 'Y'.
-tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(29,47): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(31,13): error TS2322: Type 'U' is not assignable to type 'T'.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(32,20): error TS2322: Type 'U' is not assignable to type 'T'.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(37,14): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
@@ -29,7 +25,7 @@ tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsed
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(46,36): error TS2304: Cannot find name 'X'.
 
 
-==== tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts (29 errors) ====
+==== tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts (25 errors) ====
     // Type parameters are in scope in their own and other type parameter lists
     // Some negative cases
     
@@ -67,13 +63,9 @@ tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsed
 !!! error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
                                               ~
 !!! error TS2304: Cannot find name 'V'.
-                                              ~
-!!! error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
         function bar<V extends T, W extends U>(): X { // error
                                                   ~
 !!! error TS2304: Cannot find name 'X'.
-                                                  ~
-!!! error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
             function baz<X extends W, Y extends V>(a: X, b: Y): T {
                 x = y;
                 ~
@@ -90,13 +82,9 @@ tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsed
 !!! error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
                                                ~
 !!! error TS2304: Cannot find name 'W'.
-                                               ~
-!!! error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
         function bar<V extends T, W extends U>(): Y { // error
                                                   ~
 !!! error TS2304: Cannot find name 'Y'.
-                                                  ~
-!!! error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
             function baz<X extends W, Y extends V>(a: X, b: Y): T {
                 x = y;
                 ~

--- a/tests/baselines/reference/unknownSymbols1.errors.txt
+++ b/tests/baselines/reference/unknownSymbols1.errors.txt
@@ -2,7 +2,6 @@ tests/cases/compiler/unknownSymbols1.ts(1,9): error TS2304: Cannot find name 'as
 tests/cases/compiler/unknownSymbols1.ts(2,8): error TS2304: Cannot find name 'asdf'.
 tests/cases/compiler/unknownSymbols1.ts(4,17): error TS2304: Cannot find name 'asdf'.
 tests/cases/compiler/unknownSymbols1.ts(4,35): error TS2304: Cannot find name 'asdf'.
-tests/cases/compiler/unknownSymbols1.ts(4,35): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
 tests/cases/compiler/unknownSymbols1.ts(6,12): error TS2304: Cannot find name 'asdf'.
 tests/cases/compiler/unknownSymbols1.ts(9,10): error TS2304: Cannot find name 'asdf'.
 tests/cases/compiler/unknownSymbols1.ts(12,10): error TS2304: Cannot find name 'asdf'.
@@ -14,7 +13,7 @@ tests/cases/compiler/unknownSymbols1.ts(30,14): error TS2339: Property 'asdf' do
 tests/cases/compiler/unknownSymbols1.ts(30,21): error TS2304: Cannot find name 'asdf'.
 
 
-==== tests/cases/compiler/unknownSymbols1.ts (14 errors) ====
+==== tests/cases/compiler/unknownSymbols1.ts (13 errors) ====
     var x = asdf;
             ~~~~
 !!! error TS2304: Cannot find name 'asdf'.
@@ -27,8 +26,6 @@ tests/cases/compiler/unknownSymbols1.ts(30,21): error TS2304: Cannot find name '
 !!! error TS2304: Cannot find name 'asdf'.
                                       ~~~~
 !!! error TS2304: Cannot find name 'asdf'.
-                                      ~~~~
-!!! error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value or consist of a single 'throw' statement.
     function foo2() {
         return asdf;
                ~~~~


### PR DESCRIPTION
1. Never reference 'anyType' directly, unless it is the result of some operation.  i.e. do not use it when checking if some type is the 'any' type or not.
2. Always use the TypeFlags.Any flag to see if a type is the 'any' type.
3. When possible, propagate the 'unknown' type along to help suppress cascading errors.

I recommend looking at this commit-wise, and appending "?w=1" to make it easier to read.