### PR TITLE
Emit parenthesized type assertion

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1644,6 +1644,13 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
             }
 
             function parenthesizeForAccess(expr: Expression): LeftHandSideExpression {
+                // When diagnosing whether the expression needs parentheses, the decision should be based
+                // on the innermost expression in a chain of nested type assertions.
+                let innerExpression = expr;
+                while (innerExpression.kind === SyntaxKind.TypeAssertionExpression) {
+                    innerExpression = (<TypeAssertion>innerExpression).expression;
+                }
+
                 // isLeftHandSideExpression is almost the correct criterion for when it is not necessary
                 // to parenthesize the expression before a dot. The known exceptions are:
                 //
@@ -1652,7 +1659,10 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
                 //    NumberLiteral
                 //       1.x            -> not the same as (1).x
                 //
-                if (isLeftHandSideExpression(expr) && expr.kind !== SyntaxKind.NewExpression && expr.kind !== SyntaxKind.NumericLiteral) {
+                if (isLeftHandSideExpression(innerExpression) &&
+                    innerExpression.kind !== SyntaxKind.NewExpression &&
+                    innerExpression.kind !== SyntaxKind.NumericLiteral) {
+
                     return <LeftHandSideExpression>expr;
                 }
                 let node = <ParenthesizedExpression>createSynthesizedNode(SyntaxKind.ParenthesizedExpression);
@@ -1906,7 +1916,10 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
             }
 
             function emitParenExpression(node: ParenthesizedExpression) {
-                if (!node.parent || node.parent.kind !== SyntaxKind.ArrowFunction) {
+                // If the node is synthesized, it means the emitter put the parentheses there,
+                // not the user. If we didn't want them, the emitter would not have put them
+                // there.
+                if (!nodeIsSynthesized(node) && node.parent.kind !== SyntaxKind.ArrowFunction) {
                     if (node.expression.kind === SyntaxKind.TypeAssertionExpression) {
                         let operand = (<TypeAssertion>node.expression).expression;
 

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1646,9 +1646,8 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
             function parenthesizeForAccess(expr: Expression): LeftHandSideExpression {
                 // When diagnosing whether the expression needs parentheses, the decision should be based
                 // on the innermost expression in a chain of nested type assertions.
-                let innerExpression = expr;
-                while (innerExpression.kind === SyntaxKind.TypeAssertionExpression) {
-                    innerExpression = (<TypeAssertion>innerExpression).expression;
+                while (expr.kind === SyntaxKind.TypeAssertionExpression) {
+                    expr = (<TypeAssertion>expr).expression;
                 }
 
                 // isLeftHandSideExpression is almost the correct criterion for when it is not necessary
@@ -1659,9 +1658,9 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
                 //    NumberLiteral
                 //       1.x            -> not the same as (1).x
                 //
-                if (isLeftHandSideExpression(innerExpression) &&
-                    innerExpression.kind !== SyntaxKind.NewExpression &&
-                    innerExpression.kind !== SyntaxKind.NumericLiteral) {
+                if (isLeftHandSideExpression(expr) &&
+                    expr.kind !== SyntaxKind.NewExpression &&
+                    expr.kind !== SyntaxKind.NumericLiteral) {
 
                     return <LeftHandSideExpression>expr;
                 }

--- a/tests/baselines/reference/destructuringTypeAssertionsES5_1.errors.txt
+++ b/tests/baselines/reference/destructuringTypeAssertionsES5_1.errors.txt
@@ -1,0 +1,7 @@
+tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_1.ts(1,18): error TS2304: Cannot find name 'foo'.
+
+
+==== tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_1.ts (1 errors) ====
+    var { x } = <any>foo();
+                     ~~~
+!!! error TS2304: Cannot find name 'foo'.

--- a/tests/baselines/reference/destructuringTypeAssertionsES5_1.js
+++ b/tests/baselines/reference/destructuringTypeAssertionsES5_1.js
@@ -1,0 +1,5 @@
+//// [destructuringTypeAssertionsES5_1.ts]
+var { x } = <any>foo();
+
+//// [destructuringTypeAssertionsES5_1.js]
+var x = foo().x;

--- a/tests/baselines/reference/destructuringTypeAssertionsES5_2.errors.txt
+++ b/tests/baselines/reference/destructuringTypeAssertionsES5_2.errors.txt
@@ -1,0 +1,7 @@
+tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_2.ts(1,19): error TS2304: Cannot find name 'foo'.
+
+
+==== tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_2.ts (1 errors) ====
+    var { x } = (<any>foo());
+                      ~~~
+!!! error TS2304: Cannot find name 'foo'.

--- a/tests/baselines/reference/destructuringTypeAssertionsES5_2.js
+++ b/tests/baselines/reference/destructuringTypeAssertionsES5_2.js
@@ -1,0 +1,5 @@
+//// [destructuringTypeAssertionsES5_2.ts]
+var { x } = (<any>foo());
+
+//// [destructuringTypeAssertionsES5_2.js]
+var x = foo().x;

--- a/tests/baselines/reference/destructuringTypeAssertionsES5_3.errors.txt
+++ b/tests/baselines/reference/destructuringTypeAssertionsES5_3.errors.txt
@@ -1,0 +1,7 @@
+tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_3.ts(1,19): error TS2304: Cannot find name 'foo'.
+
+
+==== tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_3.ts (1 errors) ====
+    var { x } = <any>(foo());
+                      ~~~
+!!! error TS2304: Cannot find name 'foo'.

--- a/tests/baselines/reference/destructuringTypeAssertionsES5_3.js
+++ b/tests/baselines/reference/destructuringTypeAssertionsES5_3.js
@@ -1,0 +1,5 @@
+//// [destructuringTypeAssertionsES5_3.ts]
+var { x } = <any>(foo());
+
+//// [destructuringTypeAssertionsES5_3.js]
+var x = (foo()).x;

--- a/tests/baselines/reference/destructuringTypeAssertionsES5_4.errors.txt
+++ b/tests/baselines/reference/destructuringTypeAssertionsES5_4.errors.txt
@@ -1,0 +1,7 @@
+tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_4.ts(1,23): error TS2304: Cannot find name 'foo'.
+
+
+==== tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_4.ts (1 errors) ====
+    var { x } = <any><any>foo();
+                          ~~~
+!!! error TS2304: Cannot find name 'foo'.

--- a/tests/baselines/reference/destructuringTypeAssertionsES5_4.js
+++ b/tests/baselines/reference/destructuringTypeAssertionsES5_4.js
@@ -1,0 +1,5 @@
+//// [destructuringTypeAssertionsES5_4.ts]
+var { x } = <any><any>foo();
+
+//// [destructuringTypeAssertionsES5_4.js]
+var x = foo().x;

--- a/tests/baselines/reference/destructuringTypeAssertionsES5_5.js
+++ b/tests/baselines/reference/destructuringTypeAssertionsES5_5.js
@@ -1,0 +1,5 @@
+//// [destructuringTypeAssertionsES5_5.ts]
+var { x } = <any>0;
+
+//// [destructuringTypeAssertionsES5_5.js]
+var x = (0).x;

--- a/tests/baselines/reference/destructuringTypeAssertionsES5_5.symbols
+++ b/tests/baselines/reference/destructuringTypeAssertionsES5_5.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_5.ts ===
+var { x } = <any>0;
+>x : Symbol(x, Decl(destructuringTypeAssertionsES5_5.ts, 0, 5))
+

--- a/tests/baselines/reference/destructuringTypeAssertionsES5_5.types
+++ b/tests/baselines/reference/destructuringTypeAssertionsES5_5.types
@@ -1,0 +1,6 @@
+=== tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_5.ts ===
+var { x } = <any>0;
+>x : any
+><any>0 : any
+>0 : number
+

--- a/tests/baselines/reference/destructuringTypeAssertionsES5_6.errors.txt
+++ b/tests/baselines/reference/destructuringTypeAssertionsES5_6.errors.txt
@@ -1,0 +1,7 @@
+tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_6.ts(1,22): error TS2304: Cannot find name 'Foo'.
+
+
+==== tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_6.ts (1 errors) ====
+    var { x } = <any>new Foo;
+                         ~~~
+!!! error TS2304: Cannot find name 'Foo'.

--- a/tests/baselines/reference/destructuringTypeAssertionsES5_6.js
+++ b/tests/baselines/reference/destructuringTypeAssertionsES5_6.js
@@ -1,0 +1,5 @@
+//// [destructuringTypeAssertionsES5_6.ts]
+var { x } = <any>new Foo;
+
+//// [destructuringTypeAssertionsES5_6.js]
+var x = (new Foo).x;

--- a/tests/baselines/reference/destructuringTypeAssertionsES5_7.errors.txt
+++ b/tests/baselines/reference/destructuringTypeAssertionsES5_7.errors.txt
@@ -1,0 +1,7 @@
+tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_7.ts(1,27): error TS2304: Cannot find name 'Foo'.
+
+
+==== tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_7.ts (1 errors) ====
+    var { x } = <any><any>new Foo;
+                              ~~~
+!!! error TS2304: Cannot find name 'Foo'.

--- a/tests/baselines/reference/destructuringTypeAssertionsES5_7.js
+++ b/tests/baselines/reference/destructuringTypeAssertionsES5_7.js
@@ -1,0 +1,5 @@
+//// [destructuringTypeAssertionsES5_7.ts]
+var { x } = <any><any>new Foo;
+
+//// [destructuringTypeAssertionsES5_7.js]
+var x = (new Foo).x;

--- a/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_1.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_1.ts
@@ -1,0 +1,2 @@
+//@target: ES5
+var { x } = <any>foo();

--- a/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_2.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_2.ts
@@ -1,0 +1,2 @@
+//@target: ES5
+var { x } = (<any>foo());

--- a/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_3.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_3.ts
@@ -1,0 +1,2 @@
+//@target: ES5
+var { x } = <any>(foo());

--- a/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_4.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_4.ts
@@ -1,0 +1,2 @@
+//@target: ES5
+var { x } = <any><any>foo();

--- a/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_5.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_5.ts
@@ -1,0 +1,2 @@
+//@target: ES5
+var { x } = <any>0;

--- a/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_6.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_6.ts
@@ -1,0 +1,2 @@
+//@target: ES5
+var { x } = <any>new Foo;

--- a/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_7.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringTypeAssertionsES5_7.ts
@@ -1,0 +1,2 @@
+//@target: ES5
+var { x } = <any><any>new Foo;


### PR DESCRIPTION
The emitter should not fight itself. If it synthesized a node with parentheses, then it should not try to strip away those parentheses on emit. If parentheses are not needed, they should not be added in the first place.

This PR retains the parentheses if the parenthesized expression was synthesized. It also steps through type assertions when deciding whether to synthesized parentheses.

Fixes https://github.com/Microsoft/TypeScript/issues/3366