### PR TITLE
Adds a failing test for System JS compilation.

### DIFF
--- a/tests/baselines/reference/systemModuleEnum.js
+++ b/tests/baselines/reference/systemModuleEnum.js
@@ -1,0 +1,25 @@
+//// [systemModuleEnum.ts]
+
+export enum Foo {}
+
+export module Bar {
+	export var baz = (): any => {}
+}
+
+
+//// [systemModuleEnum.js]
+System.register([], function(exports_1) {
+    var Foo, Bar;
+    return {
+        setters:[],
+        execute: function() {
+            (function (Foo) {
+            })(Foo || (Foo = {}));
+            exports_1("Foo", Foo);
+            (function (Bar) {
+                Bar.baz = function () { };
+            })(Bar = Bar || (Bar = {}));
+            exports_1("Bar", Bar);
+        }
+    }
+});

--- a/tests/baselines/reference/systemModuleEnum.symbols
+++ b/tests/baselines/reference/systemModuleEnum.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/systemModuleEnum.ts ===
+
+export enum Foo {}
+>Foo : Symbol(Foo, Decl(systemModuleEnum.ts, 0, 0))
+
+export module Bar {
+>Bar : Symbol(Bar, Decl(systemModuleEnum.ts, 1, 18))
+
+	export var baz = (): any => {}
+>baz : Symbol(baz, Decl(systemModuleEnum.ts, 4, 11))
+}
+

--- a/tests/baselines/reference/systemModuleEnum.types
+++ b/tests/baselines/reference/systemModuleEnum.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/systemModuleEnum.ts ===
+
+export enum Foo {}
+>Foo : Foo
+
+export module Bar {
+>Bar : typeof Bar
+
+	export var baz = (): any => {}
+>baz : () => any
+>(): any => {} : () => any
+}
+

--- a/tests/cases/compiler/systemModuleEnum.ts
+++ b/tests/cases/compiler/systemModuleEnum.ts
@@ -1,0 +1,7 @@
+// @module: system
+
+export enum Foo {}
+
+export module Bar {
+	export var baz = (): any => {}
+}


### PR DESCRIPTION
I do not know nearly enough about JavaScript or SystemJS to understand why the semicolon is necessary, but without it the module fails to load in chrome (unsure about other browsers).  A semicolon does not appear to be necessary on the second `exports_1(...)` call, though perhaps it would be easiest to just apply the semicolon more liberally in general to avoid dealing with JavaScript semicolon weirdness?

Note: It is possible this test could be whittled down some more and the bug would still reproduce but I don't have an environment setup to get chrome to throw an error (outside of the application I am working on where I first saw the bug) so I didn't want to over-reduce it.  I believe that fundamentally this is the issue I am seeing, hopefully a JavaScript expert can chime in and indicate what the minimum necessary repro case actually is.