### PR TITLE
Adding iterators to DOM interfaces

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -145,7 +145,6 @@ var harnessSources = [
 var librarySourceMap = [
         { target: "lib.core.d.ts", sources: ["core.d.ts"] },
         { target: "lib.dom.d.ts", sources: ["importcore.d.ts", "extensions.d.ts", "intl.d.ts", "dom.generated.d.ts"], },
-        { target: "lib.dom.es6.d.ts", sources: ["importcore.d.ts", "es6.d.ts", "intl.d.ts", "dom.generated.d.ts", "dom.es6.d.ts"] },
         { target: "lib.webworker.d.ts", sources: ["importcore.d.ts", "extensions.d.ts", "intl.d.ts", "webworker.generated.d.ts"], },
         { target: "lib.scriptHost.d.ts", sources: ["importcore.d.ts", "scriptHost.d.ts"], },
         { target: "lib.d.ts", sources: ["core.d.ts", "extensions.d.ts", "intl.d.ts", "dom.generated.d.ts", "webworker.importscripts.d.ts", "scriptHost.d.ts"], },

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -145,11 +145,12 @@ var harnessSources = [
 var librarySourceMap = [
         { target: "lib.core.d.ts", sources: ["core.d.ts"] },
         { target: "lib.dom.d.ts", sources: ["importcore.d.ts", "extensions.d.ts", "intl.d.ts", "dom.generated.d.ts"], },
+        { target: "lib.dom.es6.d.ts", sources: ["importcore.d.ts", "es6.d.ts", "intl.d.ts", "dom.generated.d.ts", "dom.es6.d.ts"] },
         { target: "lib.webworker.d.ts", sources: ["importcore.d.ts", "extensions.d.ts", "intl.d.ts", "webworker.generated.d.ts"], },
         { target: "lib.scriptHost.d.ts", sources: ["importcore.d.ts", "scriptHost.d.ts"], },
         { target: "lib.d.ts", sources: ["core.d.ts", "extensions.d.ts", "intl.d.ts", "dom.generated.d.ts", "webworker.importscripts.d.ts", "scriptHost.d.ts"], },
         { target: "lib.core.es6.d.ts", sources: ["core.d.ts", "es6.d.ts"]},
-        { target: "lib.es6.d.ts", sources: ["core.d.ts", "es6.d.ts", "intl.d.ts", "dom.generated.d.ts", "webworker.importscripts.d.ts", "scriptHost.d.ts"]},
+        { target: "lib.es6.d.ts", sources: ["core.d.ts", "es6.d.ts", "intl.d.ts", "dom.generated.d.ts", "dom.es6.d.ts", "webworker.importscripts.d.ts", "scriptHost.d.ts"] },
 ];
 
 var libraryTargets = librarySourceMap.map(function (f) {

--- a/src/lib/dom.es6.d.ts
+++ b/src/lib/dom.es6.d.ts
@@ -1,0 +1,11 @@
+interface DOMTokenList {
+    [Symbol.iterator](): IterableIterator<string>;
+}
+
+interface NodeList {
+    [Symbol.iterator](): IterableIterator<Node>
+}
+
+interface NodeListOf<TNode extends Node> {
+    [Symbol.iterator](): IterableIterator<TNode>
+}


### PR DESCRIPTION
Fixing #2695, or at least #3381.

I added dom.es6.d.ts to do this. Not all interfaces listed in #2695 are covered because I couldn't find specs for them. I need some help for this. Spec list: https://github.com/SaschaNaz/TypeScript/issues/1

I thought I have to add some tests as #3306 did but two things blocked me:

1. There is no other tests for DOM interfaces in `tests/cases/compiler`. Is a test set only required for language features?
2. I couldn't understand how a `.symbols` file can be written. How can I get the numbers to write something like `>result.push : Symbol(Array.push, Decl(lib.d.ts, 1016, 29))`?

Pinging @mhegazy to get some help.

<del>- [ ] Add tests.</del>