### PR TITLE
Don't consume 'is' keyword if there is a preceding line terminator

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1903,7 +1903,7 @@ module ts {
 
         function parseTypeReferenceOrTypePredicate(): TypeReferenceNode | TypePredicateNode {
             let typeName = parseEntityName(/*allowReservedWords*/ false, Diagnostics.Type_expected);
-            if (typeName.kind === SyntaxKind.Identifier && token === SyntaxKind.IsKeyword) {
+            if (typeName.kind === SyntaxKind.Identifier && token === SyntaxKind.IsKeyword && !scanner.hasPrecedingLineBreak()) {
                 nextToken();
                 let node = <TypePredicateNode>createNode(SyntaxKind.TypePredicate, typeName.pos);
                 node.parameterName = <Identifier>typeName;

--- a/tests/baselines/reference/typePredicateASI.js
+++ b/tests/baselines/reference/typePredicateASI.js
@@ -1,0 +1,7 @@
+//// [typePredicateASI.ts]
+interface I {
+    foo(callback: (a: any, b: any) => void): I
+    is(): boolean;
+}
+
+//// [typePredicateASI.js]

--- a/tests/baselines/reference/typePredicateASI.symbols
+++ b/tests/baselines/reference/typePredicateASI.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/expressions/typeGuards/typePredicateASI.ts ===
+interface I {
+>I : Symbol(I, Decl(typePredicateASI.ts, 0, 0))
+
+    foo(callback: (a: any, b: any) => void): I
+>foo : Symbol(foo, Decl(typePredicateASI.ts, 0, 13))
+>callback : Symbol(callback, Decl(typePredicateASI.ts, 1, 8))
+>a : Symbol(a, Decl(typePredicateASI.ts, 1, 19))
+>b : Symbol(b, Decl(typePredicateASI.ts, 1, 26))
+>I : Symbol(I, Decl(typePredicateASI.ts, 0, 0))
+
+    is(): boolean;
+>is : Symbol(is, Decl(typePredicateASI.ts, 1, 46))
+}

--- a/tests/baselines/reference/typePredicateASI.types
+++ b/tests/baselines/reference/typePredicateASI.types
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/expressions/typeGuards/typePredicateASI.ts ===
+interface I {
+>I : I
+
+    foo(callback: (a: any, b: any) => void): I
+>foo : (callback: (a: any, b: any) => void) => I
+>callback : (a: any, b: any) => void
+>a : any
+>b : any
+>I : I
+
+    is(): boolean;
+>is : () => boolean
+}

--- a/tests/cases/conformance/expressions/typeGuards/typePredicateASI.ts
+++ b/tests/cases/conformance/expressions/typeGuards/typePredicateASI.ts
@@ -1,0 +1,4 @@
+interface I {
+    foo(callback: (a: any, b: any) => void): I
+    is(): boolean;
+}


### PR DESCRIPTION
ASI should kick in when we parse a type predicate, in a case like this:
```ts
interface I {
    foo(callback: (a: any, b: any) => void): I
    is(): boolean;
}
```
This should not be parsed as a type predicate. The grammar production should look something like
```
Type:
     Identifier [No line terminator here] is Type
```