### PR TITLE
Emit awaiter arguments on new line

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -3476,7 +3476,9 @@ var __awaiter = (this && this.__awaiter) || function (generator, thisArg, args, 
                 emitFunctionBody(node);
                 
                 // Emit the current `this` binding.
-                write(", this");
+                write(",");
+                writeLine();
+                write("this");
                 
                 // Optionally emit the lexical arguments.
                 if (hasLexicalArguments) {

--- a/tests/baselines/reference/asyncArrowFunction1_es6.js
+++ b/tests/baselines/reference/asyncArrowFunction1_es6.js
@@ -5,4 +5,5 @@ var foo = async (): Promise<void> => {
 
 //// [asyncArrowFunction1_es6.js]
 var foo = () => __awaiter(function* () {
-}, this, void 0, Promise);
+},
+this, void 0, Promise);

--- a/tests/baselines/reference/asyncArrowFunction6_es6.js
+++ b/tests/baselines/reference/asyncArrowFunction6_es6.js
@@ -5,4 +5,5 @@ var foo = async (a = await): Promise<void> => {
 
 //// [asyncArrowFunction6_es6.js]
 var foo = (a = await) => __awaiter(function* () {
-}, this, void 0, Promise);
+},
+this, void 0, Promise);

--- a/tests/baselines/reference/asyncArrowFunction7_es6.js
+++ b/tests/baselines/reference/asyncArrowFunction7_es6.js
@@ -10,5 +10,7 @@ var bar = async (): Promise<void> => {
 var bar = () => __awaiter(function* () {
     // 'await' here is an identifier, and not an await expression.
     var foo = (a = await) => __awaiter(function* () {
-    }, this, void 0, Promise);
-}, this, void 0, Promise);
+    },
+    this, void 0, Promise);
+},
+this, void 0, Promise);

--- a/tests/baselines/reference/asyncArrowFunction8_es6.js
+++ b/tests/baselines/reference/asyncArrowFunction8_es6.js
@@ -7,4 +7,5 @@ var foo = async (): Promise<void> => {
 //// [asyncArrowFunction8_es6.js]
 var foo = () => __awaiter(function* () {
     var v = { [yield ]: foo };
-}, this, void 0, Promise);
+},
+this, void 0, Promise);

--- a/tests/baselines/reference/asyncArrowFunction9_es6.js
+++ b/tests/baselines/reference/asyncArrowFunction9_es6.js
@@ -4,4 +4,5 @@ var foo = async (a = await => await): Promise<void> => {
 
 //// [asyncArrowFunction9_es6.js]
 var foo = (a = await => await) => __awaiter(function* () {
-}, this, void 0, Promise);
+},
+this, void 0, Promise);

--- a/tests/baselines/reference/asyncArrowFunctionCapturesArguments_es6.js
+++ b/tests/baselines/reference/asyncArrowFunctionCapturesArguments_es6.js
@@ -11,6 +11,7 @@ class C {
 class C {
     method() {
         function other() { }
-        var fn = () => __awaiter(function* (arguments) { return yield other.apply(this, arguments); }, this, arguments);
+        var fn = () => __awaiter(function* (arguments) { return yield other.apply(this, arguments); },
+        this, arguments);
     }
 }

--- a/tests/baselines/reference/asyncArrowFunctionCapturesThis_es6.js
+++ b/tests/baselines/reference/asyncArrowFunctionCapturesThis_es6.js
@@ -9,6 +9,7 @@ class C {
 //// [asyncArrowFunctionCapturesThis_es6.js]
 class C {
     method() {
-        var fn = () => __awaiter(function* () { return yield this; }, this);
+        var fn = () => __awaiter(function* () { return yield this; },
+        this);
     }
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es6.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es6.js
@@ -5,5 +5,6 @@ async function foo(a = await => await): Promise<void> {
 //// [asyncFunctionDeclaration10_es6.js]
 function foo(a = await => await) {
     return __awaiter(function* () {
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration11_es6.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration11_es6.js
@@ -5,5 +5,6 @@ async function await(): Promise<void> {
 //// [asyncFunctionDeclaration11_es6.js]
 function await() {
     return __awaiter(function* () {
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration13_es6.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration13_es6.js
@@ -10,5 +10,6 @@ function foo() {
     return __awaiter(function* () {
         // Legal to use 'await' in a type context.
         var v;
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration14_es6.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration14_es6.js
@@ -7,5 +7,6 @@ async function foo(): Promise<void> {
 function foo() {
     return __awaiter(function* () {
         return;
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration1_es6.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration1_es6.js
@@ -5,5 +5,6 @@ async function foo(): Promise<void> {
 //// [asyncFunctionDeclaration1_es6.js]
 function foo() {
     return __awaiter(function* () {
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration6_es6.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration6_es6.js
@@ -5,5 +5,6 @@ async function foo(a = await): Promise<void> {
 //// [asyncFunctionDeclaration6_es6.js]
 function foo(a = await) {
     return __awaiter(function* () {
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration7_es6.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration7_es6.js
@@ -11,7 +11,9 @@ function bar() {
         // 'await' here is an identifier, and not a yield expression.
         function foo(a = await) {
             return __awaiter(function* () {
-            }, this, void 0, Promise);
+            },
+            this, void 0, Promise);
         }
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/asyncFunctionDeclaration9_es6.js
+++ b/tests/baselines/reference/asyncFunctionDeclaration9_es6.js
@@ -7,5 +7,6 @@ async function foo(): Promise<void> {
 function foo() {
     return __awaiter(function* () {
         var v = { [yield ]: foo };
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/awaitBinaryExpression1_es6.js
+++ b/tests/baselines/reference/awaitBinaryExpression1_es6.js
@@ -13,5 +13,6 @@ function func() {
         "before";
         var b = (yield p) || a;
         "after";
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/awaitBinaryExpression2_es6.js
+++ b/tests/baselines/reference/awaitBinaryExpression2_es6.js
@@ -13,5 +13,6 @@ function func() {
         "before";
         var b = (yield p) && a;
         "after";
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/awaitBinaryExpression3_es6.js
+++ b/tests/baselines/reference/awaitBinaryExpression3_es6.js
@@ -13,5 +13,6 @@ function func() {
         "before";
         var b = (yield p) + a;
         "after";
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/awaitBinaryExpression4_es6.js
+++ b/tests/baselines/reference/awaitBinaryExpression4_es6.js
@@ -13,5 +13,6 @@ function func() {
         "before";
         var b = yield p, a;
         "after";
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/awaitBinaryExpression5_es6.js
+++ b/tests/baselines/reference/awaitBinaryExpression5_es6.js
@@ -15,5 +15,6 @@ function func() {
         var o;
         o.a = yield p;
         "after";
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/awaitCallExpression1_es6.js
+++ b/tests/baselines/reference/awaitCallExpression1_es6.js
@@ -17,5 +17,6 @@ function func() {
         "before";
         var b = fn(a, a, a);
         "after";
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/awaitCallExpression2_es6.js
+++ b/tests/baselines/reference/awaitCallExpression2_es6.js
@@ -17,5 +17,6 @@ function func() {
         "before";
         var b = fn(yield p, a, a);
         "after";
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/awaitCallExpression3_es6.js
+++ b/tests/baselines/reference/awaitCallExpression3_es6.js
@@ -17,5 +17,6 @@ function func() {
         "before";
         var b = fn(a, yield p, a);
         "after";
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/awaitCallExpression4_es6.js
+++ b/tests/baselines/reference/awaitCallExpression4_es6.js
@@ -17,5 +17,6 @@ function func() {
         "before";
         var b = (yield pfn)(a, a, a);
         "after";
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/awaitCallExpression5_es6.js
+++ b/tests/baselines/reference/awaitCallExpression5_es6.js
@@ -17,5 +17,6 @@ function func() {
         "before";
         var b = o.fn(a, a, a);
         "after";
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/awaitCallExpression6_es6.js
+++ b/tests/baselines/reference/awaitCallExpression6_es6.js
@@ -17,5 +17,6 @@ function func() {
         "before";
         var b = o.fn(yield p, a, a);
         "after";
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/awaitCallExpression7_es6.js
+++ b/tests/baselines/reference/awaitCallExpression7_es6.js
@@ -17,5 +17,6 @@ function func() {
         "before";
         var b = o.fn(a, yield p, a);
         "after";
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }

--- a/tests/baselines/reference/awaitCallExpression8_es6.js
+++ b/tests/baselines/reference/awaitCallExpression8_es6.js
@@ -17,5 +17,6 @@ function func() {
         "before";
         var b = (yield po).fn(a, a, a);
         "after";
-    }, this, void 0, Promise);
+    },
+    this, void 0, Promise);
 }


### PR DESCRIPTION
This is required because of an issue with the sourcemaps generated by the __awaiter wrapping - specifically, the arguments to it are accidentally included in the sourcemap.

The awaiter has a null sourcecode mapping, however the generator passed as the first argument does not. Having the remaining awaiter arguments on the same line as the last bracket for the generator resulted in the arguments being interpreted as non-null mappings. Changing the emit to emit the remaining arguments on the following line corrects this issue. As far as I know, there is no way to emit a null mapping on part of a line, so this is the solution.