### PR TITLE
Fix HTMLSelectElement property type "options"

### DIFF
--- a/bin/lib.d.ts
+++ b/bin/lib.d.ts
@@ -9739,7 +9739,7 @@ interface HTMLSelectElement extends HTMLElement {
       * Sets or retrieves the name of the object.
       */
     name: string;
-    options: HTMLSelectElement;
+    options: NodeListOf<HTMLOptionElement>;
     /**
       * When present, marks an element that can't be submitted without a value.
       */

--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -6081,7 +6081,7 @@ interface HTMLSelectElement extends HTMLElement {
       * Sets or retrieves the name of the object.
       */
     name: string;
-    options: HTMLSelectElement;
+    options: NodeListOf<HTMLOptionElement>;
     /**
       * When present, marks an element that can't be submitted without a value.
       */


### PR DESCRIPTION
I found this bug. The property "options" is of the same type of its parent, not making sense.