### PR TITLE
Define Array.isArray using a type predicate

### DIFF
--- a/src/lib/core.d.ts
+++ b/src/lib/core.d.ts
@@ -1150,7 +1150,7 @@ interface ArrayConstructor {
     (arrayLength?: number): any[];
     <T>(arrayLength: number): T[];
     <T>(...items: T[]): T[];
-    isArray(arg: any): boolean;
+    isArray(arg: any): arg is Array<any>;
     prototype: Array<any>;
 }
 

--- a/tests/baselines/reference/isArray.js
+++ b/tests/baselines/reference/isArray.js
@@ -1,0 +1,19 @@
+//// [isArray.ts]
+var maybeArray: number | number[];
+
+
+if (Array.isArray(maybeArray)) {
+    maybeArray.length; // OK
+}
+else {
+    maybeArray.toFixed(); // OK
+}
+
+//// [isArray.js]
+var maybeArray;
+if (Array.isArray(maybeArray)) {
+    maybeArray.length; // OK
+}
+else {
+    maybeArray.toFixed(); // OK
+}

--- a/tests/baselines/reference/isArray.symbols
+++ b/tests/baselines/reference/isArray.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/isArray.ts ===
+var maybeArray: number | number[];
+>maybeArray : Symbol(maybeArray, Decl(isArray.ts, 0, 3))
+
+
+if (Array.isArray(maybeArray)) {
+>Array.isArray : Symbol(ArrayConstructor.isArray, Decl(lib.d.ts, 1166, 28))
+>Array : Symbol(Array, Decl(lib.d.ts, 1000, 23), Decl(lib.d.ts, 1171, 11))
+>isArray : Symbol(ArrayConstructor.isArray, Decl(lib.d.ts, 1166, 28))
+>maybeArray : Symbol(maybeArray, Decl(isArray.ts, 0, 3))
+
+    maybeArray.length; // OK
+>maybeArray.length : Symbol(Array.length, Decl(lib.d.ts, 1007, 20))
+>maybeArray : Symbol(maybeArray, Decl(isArray.ts, 0, 3))
+>length : Symbol(Array.length, Decl(lib.d.ts, 1007, 20))
+}
+else {
+    maybeArray.toFixed(); // OK
+>maybeArray.toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, 463, 37))
+>maybeArray : Symbol(maybeArray, Decl(isArray.ts, 0, 3))
+>toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, 463, 37))
+}

--- a/tests/baselines/reference/isArray.types
+++ b/tests/baselines/reference/isArray.types
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/isArray.ts ===
+var maybeArray: number | number[];
+>maybeArray : number | number[]
+
+
+if (Array.isArray(maybeArray)) {
+>Array.isArray(maybeArray) : boolean
+>Array.isArray : (arg: any) => boolean
+>Array : ArrayConstructor
+>isArray : (arg: any) => boolean
+>maybeArray : number | number[]
+
+    maybeArray.length; // OK
+>maybeArray.length : number
+>maybeArray : number[]
+>length : number
+}
+else {
+    maybeArray.toFixed(); // OK
+>maybeArray.toFixed() : string
+>maybeArray.toFixed : (fractionDigits?: number) => string
+>maybeArray : number
+>toFixed : (fractionDigits?: number) => string
+}

--- a/tests/baselines/reference/library_ArraySlice.symbols
+++ b/tests/baselines/reference/library_ArraySlice.symbols
@@ -2,22 +2,22 @@
 // Array.prototype.slice can have zero, one, or two arguments
 Array.prototype.slice();
 >Array.prototype.slice : Symbol(Array.slice, Decl(lib.d.ts, 1048, 15))
->Array.prototype : Symbol(ArrayConstructor.prototype, Decl(lib.d.ts, 1167, 31))
+>Array.prototype : Symbol(ArrayConstructor.prototype, Decl(lib.d.ts, 1167, 41))
 >Array : Symbol(Array, Decl(lib.d.ts, 1000, 23), Decl(lib.d.ts, 1171, 11))
->prototype : Symbol(ArrayConstructor.prototype, Decl(lib.d.ts, 1167, 31))
+>prototype : Symbol(ArrayConstructor.prototype, Decl(lib.d.ts, 1167, 41))
 >slice : Symbol(Array.slice, Decl(lib.d.ts, 1048, 15))
 
 Array.prototype.slice(0);
 >Array.prototype.slice : Symbol(Array.slice, Decl(lib.d.ts, 1048, 15))
->Array.prototype : Symbol(ArrayConstructor.prototype, Decl(lib.d.ts, 1167, 31))
+>Array.prototype : Symbol(ArrayConstructor.prototype, Decl(lib.d.ts, 1167, 41))
 >Array : Symbol(Array, Decl(lib.d.ts, 1000, 23), Decl(lib.d.ts, 1171, 11))
->prototype : Symbol(ArrayConstructor.prototype, Decl(lib.d.ts, 1167, 31))
+>prototype : Symbol(ArrayConstructor.prototype, Decl(lib.d.ts, 1167, 41))
 >slice : Symbol(Array.slice, Decl(lib.d.ts, 1048, 15))
 
 Array.prototype.slice(0, 1);
 >Array.prototype.slice : Symbol(Array.slice, Decl(lib.d.ts, 1048, 15))
->Array.prototype : Symbol(ArrayConstructor.prototype, Decl(lib.d.ts, 1167, 31))
+>Array.prototype : Symbol(ArrayConstructor.prototype, Decl(lib.d.ts, 1167, 41))
 >Array : Symbol(Array, Decl(lib.d.ts, 1000, 23), Decl(lib.d.ts, 1171, 11))
->prototype : Symbol(ArrayConstructor.prototype, Decl(lib.d.ts, 1167, 31))
+>prototype : Symbol(ArrayConstructor.prototype, Decl(lib.d.ts, 1167, 41))
 >slice : Symbol(Array.slice, Decl(lib.d.ts, 1048, 15))
 

--- a/tests/baselines/reference/returnTypeParameterWithModules.symbols
+++ b/tests/baselines/reference/returnTypeParameterWithModules.symbols
@@ -14,9 +14,9 @@ module M1 {
         return Array.prototype.reduce.apply(ar, e ? [f, e] : [f]);
 >Array.prototype.reduce.apply : Symbol(Function.apply, Decl(lib.d.ts, 228, 20))
 >Array.prototype.reduce : Symbol(Array.reduce, Decl(lib.d.ts, 1129, 93), Decl(lib.d.ts, 1136, 120))
->Array.prototype : Symbol(ArrayConstructor.prototype, Decl(lib.d.ts, 1167, 31))
+>Array.prototype : Symbol(ArrayConstructor.prototype, Decl(lib.d.ts, 1167, 41))
 >Array : Symbol(Array, Decl(lib.d.ts, 1000, 23), Decl(lib.d.ts, 1171, 11))
->prototype : Symbol(ArrayConstructor.prototype, Decl(lib.d.ts, 1167, 31))
+>prototype : Symbol(ArrayConstructor.prototype, Decl(lib.d.ts, 1167, 41))
 >reduce : Symbol(Array.reduce, Decl(lib.d.ts, 1129, 93), Decl(lib.d.ts, 1136, 120))
 >apply : Symbol(Function.apply, Decl(lib.d.ts, 228, 20))
 >ar : Symbol(ar, Decl(returnTypeParameterWithModules.ts, 1, 30))

--- a/tests/cases/compiler/isArray.ts
+++ b/tests/cases/compiler/isArray.ts
@@ -1,0 +1,9 @@
+var maybeArray: number | number[];
+
+
+if (Array.isArray(maybeArray)) {
+    maybeArray.length; // OK
+}
+else {
+    maybeArray.toFixed(); // OK
+}


### PR DESCRIPTION
With type predicates in, here is a change to the lib to make it use that in isArray definition.