### PR TITLE
Don't log by default.

### DIFF
--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -246,16 +246,22 @@ namespace ts {
 
     export class LanguageServiceShimHostAdapter implements LanguageServiceHost {
         private files: string[];
+        private loggingEnabled = false;
+        private tracingEnabled = false;
 
         constructor(private shimHost: LanguageServiceShimHost) {
         }
 
         public log(s: string): void {
-            this.shimHost.log(s);
+            if (this.loggingEnabled) {
+                this.shimHost.log(s);
+            }
         }
 
         public trace(s: string): void {
-            this.shimHost.trace(s);
+            if (this.tracingEnabled) {
+                this.shimHost.trace(s);
+            }
         }
 
         public error(s: string): void {
@@ -349,15 +355,15 @@ namespace ts {
         }
     }
 
-    function simpleForwardCall(logger: Logger, actionDescription: string, action: () => any, noPerfLogging: boolean): any {
-        if (!noPerfLogging) {
+    function simpleForwardCall(logger: Logger, actionDescription: string, action: () => any, logPerformance: boolean): any {
+        if (logPerformance) {
             logger.log(actionDescription);
             var start = Date.now();
         }
 
         var result = action();
 
-        if (!noPerfLogging) {
+        if (logPerformance) {
             var end = Date.now();
             logger.log(actionDescription + " completed in " + (end - start) + " msec");
             if (typeof (result) === "string") {
@@ -372,9 +378,9 @@ namespace ts {
         return result;
     }
 
-    function forwardJSONCall(logger: Logger, actionDescription: string, action: () => any, noPerfLogging: boolean): string {
+    function forwardJSONCall(logger: Logger, actionDescription: string, action: () => any, logPerformance: boolean): string {
         try {
-            var result = simpleForwardCall(logger, actionDescription, action, noPerfLogging);
+            var result = simpleForwardCall(logger, actionDescription, action, logPerformance);
             return JSON.stringify({ result: result });
         }
         catch (err) {
@@ -413,6 +419,7 @@ namespace ts {
 
     class LanguageServiceShimObject extends ShimBase implements LanguageServiceShim {
         private logger: Logger;
+        private logPerformance = false;
 
         constructor(factory: ShimFactory,
             private host: LanguageServiceShimHost,
@@ -422,7 +429,7 @@ namespace ts {
         }
 
         public forwardJSONCall(actionDescription: string, action: () => any): string {
-            return forwardJSONCall(this.logger, actionDescription, action, /*noPerfLogging:*/ false);
+            return forwardJSONCall(this.logger, actionDescription, action, this.logPerformance);
         }
 
         /// DISPOSE
@@ -811,6 +818,7 @@ namespace ts {
 
     class ClassifierShimObject extends ShimBase implements ClassifierShim {
         public classifier: Classifier;
+        private logPerformance = false;
 
         constructor(factory: ShimFactory, private logger: Logger) {
             super(factory);
@@ -820,7 +828,7 @@ namespace ts {
         public getEncodedLexicalClassifications(text: string, lexState: EndOfLineState, syntacticClassifierAbsent?: boolean): string {
             return forwardJSONCall(this.logger, "getEncodedLexicalClassifications",
                 () => convertClassifications(this.classifier.getEncodedLexicalClassifications(text, lexState, syntacticClassifierAbsent)),
-                /*noPerfLogging:*/ true);
+                this.logPerformance);
         }
 
         /// COLORIZATION
@@ -838,13 +846,14 @@ namespace ts {
     }
 
     class CoreServicesShimObject extends ShimBase implements CoreServicesShim {
+        private logPerformance = false;
 
         constructor(factory: ShimFactory, public logger: Logger, private host: CoreServicesShimHostAdapter) {
             super(factory);
         }
 
         private forwardJSONCall(actionDescription: string, action: () => any): any {
-            return forwardJSONCall(this.logger, actionDescription, action, /*noPerfLogging:*/ false);
+            return forwardJSONCall(this.logger, actionDescription, action, this.logPerformance);
         }
 
         public getPreProcessedFileInfo(fileName: string, sourceTextSnapshot: IScriptSnapshot): string {


### PR DESCRIPTION
On the managed side tracing is disabled by default anyways.  By logging we still
cause tons of allocations of strings on the managed side.  These then cause
expensive GCs which can pause editing.

Logging can always be enabled manually (either by hand editing typescriptServices.js, or by debugging and enabling logging) by someone if they need this data.