### PR TITLE
A few perf fixes we'd like to take for release 1.5

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -65,6 +65,7 @@ module ts {
         let lastContainer: Node;
         let symbolCount = 0;
         let Symbol = objectAllocator.getSymbolConstructor();
+        let classifiableNames: Map<string> = {}; 
 
         if (!file.locals) {
             file.locals = {};
@@ -72,6 +73,7 @@ module ts {
             setBlockScopeContainer(file, /*cleanLocals*/ false);
             bind(file);
             file.symbolCount = symbolCount;
+            file.classifiableNames = classifiableNames;
         }
 
         function createSymbol(flags: SymbolFlags, name: string): Symbol {
@@ -144,6 +146,11 @@ module ts {
             let symbol: Symbol;
             if (name !== undefined) {
                 symbol = hasProperty(symbols, name) ? symbols[name] : (symbols[name] = createSymbol(0, name));
+
+                if (name && (includes & SymbolFlags.Classifiable)) {
+                    classifiableNames[name] = name;   
+                } 
+
                 if (symbol.flags & excludes) {
                     if (node.name) {
                         node.name.parent = node;

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -149,6 +149,7 @@ module ts {
         let commonSourceDirectory: string;
         let diagnosticsProducingTypeChecker: TypeChecker;
         let noDiagnosticsTypeChecker: TypeChecker;
+        let classifiableNames: Map<string>;
 
         let start = new Date().getTime();
 
@@ -171,6 +172,7 @@ module ts {
             getDeclarationDiagnostics,
             getCompilerOptionsDiagnostics,
             getTypeChecker,
+            getClassifiableNames,
             getDiagnosticsProducingTypeChecker,
             getCommonSourceDirectory: () => commonSourceDirectory,
             emit,
@@ -181,6 +183,20 @@ module ts {
             getTypeCount: () => getDiagnosticsProducingTypeChecker().getTypeCount(),
         };
         return program;
+
+        function getClassifiableNames() {
+            if (!classifiableNames) {
+                // Initialize a checker so that all our files are bound.
+                getTypeChecker();
+                classifiableNames = {};
+
+                for (let sourceFile of files) {
+                    copyMap(sourceFile.classifiableNames, classifiableNames);
+                }
+            }
+
+            return classifiableNames;
+        }
 
         function getEmitHost(writeFileCallback?: WriteFileCallback): EmitHost {
             return {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1026,6 +1026,8 @@ module ts {
         // Stores a line map for the file.
         // This field should never be used directly to obtain line map, use getLineMap function instead.
         /* @internal */ lineMap: number[];
+
+        /* @internal */ classifiableNames?: Map<string>;
     }
 
     export interface ScriptReferenceHost {
@@ -1076,6 +1078,8 @@ module ts {
         // For testing purposes only.  Should not be used by any other consumers (including the
         // language service).
         /* @internal */ getDiagnosticsProducingTypeChecker(): TypeChecker;
+
+        /* @internal */ getClassifiableNames(): Map<string>;
 
         /* @internal */ getNodeCount(): number;
         /* @internal */ getIdentifierCount(): number;
@@ -1364,6 +1368,11 @@ module ts {
         IsContainer = HasLocals | HasExports | HasMembers,
         PropertyOrAccessor = Property | Accessor,
         Export = ExportNamespace | ExportType | ExportValue,
+
+        /* @internal */
+        // The set of things we consider semantically classifiable.  Used to speed up the LS during 
+        // classification.
+        Classifiable = Class | Enum | TypeAlias | Interface | TypeParameter | Module,
     }
 
     export interface Symbol {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -6012,8 +6012,8 @@ module ts {
 
             function processNode(node: Node) {
                 // Only walk into nodes that intersect the requested span.
-                if (node && textSpanIntersectsWith(span, node.getStart(), node.getWidth())) {
-                    if (node.kind === SyntaxKind.Identifier && node.getWidth() > 0) {
+                if (node && textSpanIntersectsWith(span, node.getFullStart(), node.getFullWidth())) {
+                    if (node.kind === SyntaxKind.Identifier && !nodeIsMissing(node)) {
                         let symbol = typeChecker.getSymbolAtLocation(node);
                         if (symbol) {
                             let type = classifySymbol(symbol, getMeaningFromLocation(node));

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -5958,6 +5958,7 @@ module ts {
             let typeChecker = program.getTypeChecker();
 
             let result: number[] = [];
+            let classifiableNames = program.getClassifiableNames();
             processNode(sourceFile);
 
             return { spans: result, endOfLineState: EndOfLineState.None };
@@ -5970,6 +5971,9 @@ module ts {
 
             function classifySymbol(symbol: Symbol, meaningAtPosition: SemanticMeaning): ClassificationType {
                 let flags = symbol.getFlags();
+                if ((flags & SymbolFlags.Classifiable) === 0) {
+                    return;
+                }
 
                 if (flags & SymbolFlags.Class) {
                     return ClassificationType.className;
@@ -6014,11 +6018,18 @@ module ts {
                 // Only walk into nodes that intersect the requested span.
                 if (node && textSpanIntersectsWith(span, node.getFullStart(), node.getFullWidth())) {
                     if (node.kind === SyntaxKind.Identifier && !nodeIsMissing(node)) {
-                        let symbol = typeChecker.getSymbolAtLocation(node);
-                        if (symbol) {
-                            let type = classifySymbol(symbol, getMeaningFromLocation(node));
-                            if (type) {
-                                pushClassification(node.getStart(), node.getWidth(), type);
+                        let identifier = <Identifier>node;
+
+                        // Only bother calling into the typechecker if this is an identifier that
+                        // could possibly resolve to a type name.  This makes classification run
+                        // in a third of the time it would normally take.
+                        if (classifiableNames[identifier.text]) {
+                            let symbol = typeChecker.getSymbolAtLocation(node);
+                            if (symbol) {
+                                let type = classifySymbol(symbol, getMeaningFromLocation(node));
+                                if (type) {
+                                    pushClassification(node.getStart(), node.getWidth(), type);
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
These are:

https://github.com/Microsoft/TypeScript/commit/05b8609f04f3f10513ecc2059c868b2aeea49012 Reduce GC pressure by not logging by default.  This prevents GCs that were causing hiccups during typeing.
https://github.com/Microsoft/TypeScript/commit/29fcd4aa905f4d51fcaca92a0ff85425a5315306 Make semantic classification cheaper by avoiding scanning calls to get start/width.  fullStart/fullWidth is much cheaper and and speeds things up significantly.
https://github.com/Microsoft/TypeScript/commit/a3916ffb50f4297b76dbb91cd1210cb23c2c10b6 Make semantic classification cheaper by avoiding resolution of identifiers that couldn't possibly be classified.  