### PR TITLE
Add support to emit a dependency file listing compile and runtime dependencies of a module

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -202,6 +202,12 @@ namespace ts {
             type: "boolean",
             experimental: true,
             description: Diagnostics.Enables_experimental_support_for_emitting_type_metadata_for_decorators
+        },
+        {
+            name: "emitModuleDepedencies",
+            type: "boolean",
+            experimental: true,
+            description: Diagnostics.Enables_experimental_support_for_emitting_moduleDependencies
         }
     ];
 

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -204,7 +204,7 @@ namespace ts {
             description: Diagnostics.Enables_experimental_support_for_emitting_type_metadata_for_decorators
         },
         {
-            name: "emitModuleDepedencies",
+            name: "emitModuleDependencies",
             type: "boolean",
             experimental: true,
             description: Diagnostics.Enables_experimental_support_for_emitting_moduleDependencies

--- a/src/compiler/diagnosticInformationMap.generated.ts
+++ b/src/compiler/diagnosticInformationMap.generated.ts
@@ -529,6 +529,7 @@ namespace ts {
         Option_experimentalDecorators_must_also_be_specified_when_option_emitDecoratorMetadata_is_specified: { code: 6064, category: DiagnosticCategory.Error, key: "Option 'experimentalDecorators' must also be specified when option 'emitDecoratorMetadata' is specified." },
         Enables_experimental_support_for_ES7_decorators: { code: 6065, category: DiagnosticCategory.Message, key: "Enables experimental support for ES7 decorators." },
         Enables_experimental_support_for_emitting_type_metadata_for_decorators: { code: 6066, category: DiagnosticCategory.Message, key: "Enables experimental support for emitting type metadata for decorators." },
+        Enables_experimental_support_for_emitting_moduleDependencies: { code: 6067, category: DiagnosticCategory.Message, key: "Enables experimental support for emitting module dependency data." },
         Variable_0_implicitly_has_an_1_type: { code: 7005, category: DiagnosticCategory.Error, key: "Variable '{0}' implicitly has an '{1}' type." },
         Parameter_0_implicitly_has_an_1_type: { code: 7006, category: DiagnosticCategory.Error, key: "Parameter '{0}' implicitly has an '{1}' type." },
         Member_0_implicitly_has_an_1_type: { code: 7008, category: DiagnosticCategory.Error, key: "Member '{0}' implicitly has an '{1}' type." },

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -192,7 +192,7 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
             writeLine();
             writeEmittedFiles(writer.getText(), /*writeByteOrderMark*/ compilerOptions.emitBOM);
             
-            if (compilerOptions.dependency && root && compilerOptions.module) {
+            if (compilerOptions.emitModuleDependencies && root && compilerOptions.module) {
                 emitDependencyFile(root);                
             }
             

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1835,7 +1835,6 @@ namespace ts {
         allowNonTsExtensions?: boolean;
         charset?: string;
         declaration?: boolean;
-        dependency?: boolean;
         diagnostics?: boolean;
         emitBOM?: boolean;
         help?: boolean;
@@ -1868,6 +1867,7 @@ namespace ts {
         isolatedModules?: boolean;
         experimentalDecorators?: boolean;
         emitDecoratorMetadata?: boolean;
+        emitModuleDependencies?: boolean;
         /* @internal */ stripInternal?: boolean;
 
         // Skip checking lib.d.ts to help speed up tests.

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1835,6 +1835,7 @@ namespace ts {
         allowNonTsExtensions?: boolean;
         charset?: string;
         declaration?: boolean;
+        dependency?: boolean;
         diagnostics?: boolean;
         emitBOM?: boolean;
         help?: boolean;


### PR DESCRIPTION
Packaging JS files into larger modules currently requires to understand the used module system. In addition code has to be written to reparse the runtime dependencies out of the JS file (e.g. for AMD by understanding the define call). The PR adds support to emit this information directly form the TS compiler. The generated *.dep.json files can then be used as a input to a packager. In addition the dependency files can be used by an incremental compiler to only compile upstream dependencies. 

The PR is still missing test cases. I first wanted to get the view of the TS team on this to see if such a PR makes sense at all.