### PR TITLE
Add build target for packaging tsserver as a library

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -100,7 +100,16 @@ var serverSources = [
     "editorServices.ts",
     "protocol.d.ts",
     "session.ts",
+    "nodeimpl.ts",
     "server.ts"
+].map(function (f) {
+    return path.join(serverDirectory, f);
+});
+
+var languageServiceLibrarySources = [
+    "editorServices.ts",
+    "protocol.d.ts",
+    "session.ts"
 ].map(function (f) {
     return path.join(serverDirectory, f);
 });
@@ -137,6 +146,7 @@ var harnessSources = [
     "protocol.d.ts",
     "session.ts",
     "client.ts",
+    "nodeimpl.ts",
     "editorServices.ts",
 ].map(function (f) {
     return path.join(serverDirectory, f);
@@ -368,6 +378,20 @@ compileFile(servicesFile, servicesSources,[builtLocalDirectory, copyright].conca
 
 var serverFile = path.join(builtLocalDirectory, "tsserver.js");
 compileFile(serverFile, serverSources,[builtLocalDirectory, copyright].concat(serverSources), /*prefixes*/ [copyright], /*useBuiltCompiler*/ true);
+
+var lsslFile = path.join(builtLocalDirectory, "tslssl.js");
+compileFile(
+    lsslFile, 
+    languageServiceLibrarySources, 
+    [builtLocalDirectory, copyright].concat(serverSources).concat(languageServiceLibrarySources),
+    /*prefixes*/ [copyright], 
+    /*useBuiltCompiler*/ true, 
+    /*noOutFile*/ false, 
+    /*generateDeclarations*/ true);
+
+// Local target to build the language service server library
+desc("Builds language service server library");
+task("lssl", [lsslFile]);
 
 // Local target to build the compiler and services
 desc("Builds the full compiler and services");

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -583,7 +583,7 @@ module Harness.LanguageService {
             // This host is just a proxy for the clientHost, it uses the client
             // host to answer server queries about files on disk
             var serverHost = new SessionServerHost(clientHost);
-            var server = new ts.server.Session(serverHost, serverHost);
+            var server = new ts.server.Session(serverHost, new ts.server.NodeEnvironment(), serverHost);
 
             // Fake the connection between the client and the server
             serverHost.writeMessage = client.onMessage.bind(client);

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2,7 +2,6 @@
 /// <reference path="..\services\services.ts" />
 /// <reference path="protocol.d.ts" />
 /// <reference path="session.ts" />
-/// <reference path="node.d.ts" />
 
 module ts.server {
     export interface Logger {
@@ -28,7 +27,7 @@ module ts.server {
         });
     }
 
-    class ScriptInfo {
+    export class ScriptInfo {
         svc: ScriptVersionCache;
         children: ScriptInfo[] = [];     // files referenced by this file
         defaultProject: Project;      // project to use by default for file
@@ -80,7 +79,7 @@ module ts.server {
         }
     }
 
-    class LSHost implements ts.LanguageServiceHost {
+    export class LSHost implements ts.LanguageServiceHost {
         ls: ts.LanguageService = null;
         compilationSettings: ts.CompilerOptions;
         filenameToScript: ts.Map<ScriptInfo> = {};
@@ -273,7 +272,7 @@ module ts.server {
         }
     }
 
-    interface ProjectOptions {
+    export interface ProjectOptions {
         // these fields can be present in the project file
         files?: string[];
         compilerOptions?: ts.CompilerOptions;
@@ -376,7 +375,7 @@ module ts.server {
         }
     }
 
-    interface ProjectOpenResult {
+    export interface ProjectOpenResult {
         success?: boolean;
         errorMsg?: string;
         project?: Project;
@@ -392,11 +391,11 @@ module ts.server {
         return copiedList;
     }
 
-    interface ProjectServiceEventHandler {
+    export interface ProjectServiceEventHandler {
         (eventName: string, project: Project, fileName: string): void;
     }
 
-    interface HostConfiguration {
+    export interface HostConfiguration {
         formatCodeOptions: ts.FormatCodeOptions;
         hostInfo: string;
     }
@@ -953,7 +952,7 @@ module ts.server {
 
     }
 
-    class CompilerService {
+    export class CompilerService {
         host: LSHost;
         languageService: ts.LanguageService;
         classifier: ts.Classifier;
@@ -999,7 +998,7 @@ module ts.server {
 
     }
 
-    interface LineCollection {
+    export interface LineCollection {
         charCount(): number;
         lineCount(): number;
         isLeaf(): boolean;
@@ -1013,7 +1012,7 @@ module ts.server {
         leaf?: LineLeaf;
     }
 
-    enum CharRangeSection {
+    export enum CharRangeSection {
         PreStart,
         Start,
         Entire,
@@ -1022,7 +1021,7 @@ module ts.server {
         PostEnd
     }
 
-    interface ILineIndexWalker {
+    export interface ILineIndexWalker {
         goSubtree: boolean;
         done: boolean;
         leaf(relativeStart: number, relativeLength: number, lineCollection: LineLeaf): void;
@@ -1248,7 +1247,7 @@ module ts.server {
     }
 
     // text change information
-    class TextChange {
+    export class TextChange {
         constructor(public pos: number, public deleteLen: number, public insertedText?: string) {
         }
 
@@ -1371,7 +1370,7 @@ module ts.server {
         }
     }
 
-    class LineIndexSnapshot implements ts.IScriptSnapshot {
+    export class LineIndexSnapshot implements ts.IScriptSnapshot {
         index: LineIndex;
         changesSincePreviousVersion: TextChange[] = [];
 
@@ -1605,7 +1604,7 @@ module ts.server {
         }
     }
 
-    class LineNode implements LineCollection {
+    export class LineNode implements LineCollection {
         totalChars = 0;
         totalLines = 0;
         children: LineCollection[] = [];
@@ -1891,7 +1890,7 @@ module ts.server {
         }
     }
 
-    class LineLeaf implements LineCollection {
+    export class LineLeaf implements LineCollection {
         udata: any;
 
         constructor(public text: string) {

--- a/src/server/nodeimpl.ts
+++ b/src/server/nodeimpl.ts
@@ -1,0 +1,7 @@
+/// <reference path="node.d.ts" />
+module ts.server {
+    export class NodeEnvironment implements Environment {
+        byteLength = Buffer.byteLength;
+        hrtime = process.hrtime;
+    }  
+}

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -11,7 +11,7 @@ module ts.server {
         input: process.stdin,
         output: process.stdout,
         terminal: false,
-    });
+    });  
 
     class Logger implements ts.server.Logger {
         fd = -1;
@@ -170,11 +170,11 @@ module ts.server {
         removeFile(file: WatchedFile) {
             this.watchedFiles = WatchedFileSet.copyListRemovingItem(file, this.watchedFiles);
         }
-    }
+    } 
 
     class IOSession extends Session {
-        constructor(host: ServerHost, logger: ts.server.Logger) {
-            super(host, logger);
+        constructor(host: ServerHost, env: NodeEnvironment, logger: ts.server.Logger) {
+            super(host, env, logger);
         }
 
         exit() {
@@ -265,7 +265,7 @@ module ts.server {
         }
 
     };
-    var ioSession = new IOSession(ts.sys, logger);
+    var ioSession = new IOSession(ts.sys, new NodeEnvironment(), logger);
     process.on('uncaughtException', function(err: Error) {
         ioSession.logError(err, "unknown");
     });

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -12,6 +12,7 @@
         "editorServices.ts",
         "protocol.d.ts",
         "server.ts",
+        "nodeimpl.ts",
         "session.ts"
     ]
 }

--- a/tests/cases/unittests/versionCache.ts
+++ b/tests/cases/unittests/versionCache.ts
@@ -231,7 +231,7 @@ and grew 1cm per day`;
         });
 
         it("Edit ScriptVersionCache ", () => {
-            let svc = server.ScriptVersionCache.fromString(testContent);
+            let svc = server.ScriptVersionCache.fromString(ts.sys, testContent);
             let checkText = testContent;
 
             for (let i = 0; i < iterationCount; i++) {


### PR DESCRIPTION
Specifically, adds `jake lssl` (language service server library). The goal was to export the `Session` type which, in turn, has necessitated exporting most of the types in `editorServices.ts` by extension. 

Additionally, I've made some changes to enable this library to function outside node - (`node.d.ts` is no longer compiled into the `lssl` target by any of the files included in it). Specifically, the two features of Node which Session used - `Buffer.byteLength` and `process.hrtime`, I've offloaded to a new `Environment` interface, and created a node implementation of it for `tsserver` - `server\nodeimpl.ts`. I was considering that they may be better provided by the `System` interface, and would like feedback on this - changing the `System` interface seemed like a farther reaching change than was desired.

On top of this, to make `Session` (or trivial subclasses) actually instantiate at runtime in non-node environments, I removed `Session`'s meager dependency on `ts.sys` - which only gets set in node or in windows script host. For the most part, this simply meant calling the host which `Session` was constructed with, but in one instance this meant that the `host` had to be passed along to a static function - `ScriptVersionCache.fromString`. Additionally, the static `CompilerService.defaultFormatCodeOptions` had to be made aware that `ts.sys` may not be set at static initialization time if not running in either node or windows script host.

The remaining changes, b8f6ada and 9a3fead, are less critical to exporting the `Session` type as a library, but do provide quality improvements in the exported interface. 
* b8f6ada allows consumers of the `Session` class to subclass and override `onMessage` and still call the `onMessageParsed` implementation - or just call `onMessageParsed` directly. This is useful in situations where the service is capable of receiving message objects as objects directly, rather than as json strings, thereby allowing consumers to remove (de)serialization overhead.
* 9a3fead adds support into the new `onMessageParsed` function to handle arbitrary messages, rather than throwing immediately if the massive switch statement falls all the way through. (IMO, it may be nicer to register all message handlers this way and remove the switch entirely.) This is incredibly useful in situations when the session communication channel is intended to the the primary communication channel between a client and a server, and allows a server to provide extended functionality (or, in the case of running in a browser worker thread, allows a client to send the server content with which to build a virtual filesystem and external edits to the files therein). This is the least required of the changes herein, so if too much issue is taken with it, it is not necessarily required if the prior commit is still accepted.

