### PR TITLE
Parse class member with a missing identifier in the presence of a modifier

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4207,7 +4207,7 @@ module ts {
                 return parsePropertyOrMethodDeclaration(fullStart, decorators, modifiers);
             }
 
-            if (decorators) {
+            if (decorators || modifiers) {
                 // treat this as a property declaration with a missing name.
                 let name = <Identifier>createMissingNode(SyntaxKind.Identifier, /*reportAtCurrentPosition*/ true, Diagnostics.Declaration_expected);
                 return parsePropertyDeclaration(fullStart, decorators, modifiers, name, /*questionToken*/ undefined);
@@ -4729,7 +4729,7 @@ module ts {
                 case SyntaxKind.ImportKeyword:
                     return parseImportDeclarationOrImportEqualsDeclaration(fullStart, decorators, modifiers);
                 default:
-                    if (decorators) {
+                    if (decorators || modifiers) {
                         // We reached this point because we encountered an AtToken and assumed a declaration would
                         // follow. For recovery and error reporting purposes, return an incomplete declaration.                        
                         let node = <ModuleElement>createMissingNode(SyntaxKind.MissingDeclaration, /*reportAtCurrentPosition*/ true, Diagnostics.Declaration_expected);

--- a/tests/baselines/reference/classMemberWithMissingIdentifier.errors.txt
+++ b/tests/baselines/reference/classMemberWithMissingIdentifier.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/classMemberWithMissingIdentifier.ts(2,11): error TS1146: Declaration expected.
+tests/cases/compiler/classMemberWithMissingIdentifier.ts(2,12): error TS1005: '=' expected.
+
+
+==== tests/cases/compiler/classMemberWithMissingIdentifier.ts (2 errors) ====
+    class C { 
+        public {};
+              
+!!! error TS1146: Declaration expected.
+               ~
+!!! error TS1005: '=' expected.
+    }

--- a/tests/baselines/reference/classMemberWithMissingIdentifier.js
+++ b/tests/baselines/reference/classMemberWithMissingIdentifier.js
@@ -1,0 +1,12 @@
+//// [classMemberWithMissingIdentifier.ts]
+class C { 
+    public {};
+}
+
+//// [classMemberWithMissingIdentifier.js]
+var C = (function () {
+    function C() {
+        this. = {};
+    }
+    return C;
+})();

--- a/tests/baselines/reference/classMemberWithMissingIdentifier2.errors.txt
+++ b/tests/baselines/reference/classMemberWithMissingIdentifier2.errors.txt
@@ -1,0 +1,30 @@
+tests/cases/compiler/classMemberWithMissingIdentifier2.ts(2,11): error TS1146: Declaration expected.
+tests/cases/compiler/classMemberWithMissingIdentifier2.ts(2,12): error TS1005: '=' expected.
+tests/cases/compiler/classMemberWithMissingIdentifier2.ts(2,14): error TS2304: Cannot find name 'name'.
+tests/cases/compiler/classMemberWithMissingIdentifier2.ts(2,18): error TS1005: ']' expected.
+tests/cases/compiler/classMemberWithMissingIdentifier2.ts(2,19): error TS2304: Cannot find name 'string'.
+tests/cases/compiler/classMemberWithMissingIdentifier2.ts(2,25): error TS1005: ',' expected.
+tests/cases/compiler/classMemberWithMissingIdentifier2.ts(2,26): error TS1136: Property assignment expected.
+tests/cases/compiler/classMemberWithMissingIdentifier2.ts(2,27): error TS2304: Cannot find name 'VariableDeclaration'.
+
+
+==== tests/cases/compiler/classMemberWithMissingIdentifier2.ts (8 errors) ====
+    class C { 
+        public {[name:string]:VariableDeclaration};
+              
+!!! error TS1146: Declaration expected.
+               ~
+!!! error TS1005: '=' expected.
+                 ~~~~
+!!! error TS2304: Cannot find name 'name'.
+                     ~
+!!! error TS1005: ']' expected.
+                      ~~~~~~
+!!! error TS2304: Cannot find name 'string'.
+                            ~
+!!! error TS1005: ',' expected.
+                             ~
+!!! error TS1136: Property assignment expected.
+                              ~~~~~~~~~~~~~~~~~~~
+!!! error TS2304: Cannot find name 'VariableDeclaration'.
+    }

--- a/tests/baselines/reference/classMemberWithMissingIdentifier2.js
+++ b/tests/baselines/reference/classMemberWithMissingIdentifier2.js
@@ -1,0 +1,13 @@
+//// [classMemberWithMissingIdentifier2.ts]
+class C { 
+    public {[name:string]:VariableDeclaration};
+}
+
+//// [classMemberWithMissingIdentifier2.js]
+var C = (function () {
+    function C() {
+        this. = (_a = {}, _a[name] = string, _a.VariableDeclaration = VariableDeclaration, _a);
+        var _a;
+    }
+    return C;
+})();

--- a/tests/cases/compiler/classMemberWithMissingIdentifier.ts
+++ b/tests/cases/compiler/classMemberWithMissingIdentifier.ts
@@ -1,0 +1,3 @@
+class C { 
+    public {};
+}

--- a/tests/cases/compiler/classMemberWithMissingIdentifier2.ts
+++ b/tests/cases/compiler/classMemberWithMissingIdentifier2.ts
@@ -1,0 +1,3 @@
+class C { 
+    public {[name:string]:VariableDeclaration};
+}


### PR DESCRIPTION
Fixes #3504.
```ts
class C { 
    public {};
}
```
Our parser function isClassMemberStart treats `public {}` as a class member because it starts with the word "public". Starting with a modifier is enough evidence to consider it a class member. However, parseClassElement is not so forgiving. It expects to see an identifier after the word "public". It does have a special case for a decorator with no identifier after it, so I'm piggy backing on this fallback logic for modifiers as well.