### PR TITLE
Cleanup double equals

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11920,7 +11920,7 @@ namespace ts {
                 // Intentional fall-through
                 case SyntaxKind.NumericLiteral:
                     // index access
-                    if (node.parent.kind == SyntaxKind.ElementAccessExpression && (<ElementAccessExpression>node.parent).argumentExpression === node) {
+                    if (node.parent.kind === SyntaxKind.ElementAccessExpression && (<ElementAccessExpression>node.parent).argumentExpression === node) {
                         let objectType = checkExpression((<ElementAccessExpression>node.parent).expression);
                         if (objectType === unknownType) return undefined;
                         let apparentType = getApparentType(objectType);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3523,7 +3523,7 @@ namespace ts {
                             // -> typeParameter and symbol.declaration originate from the same type parameter list
                             // -> illegal for all declarations in symbol
                             // forEach === exists
-                            links.isIllegalTypeReferenceInConstraint = forEach(symbol.declarations, d => d.parent == typeParameter.parent);
+                            links.isIllegalTypeReferenceInConstraint = forEach(symbol.declarations, d => d.parent === typeParameter.parent);
                         }
                     }
                     if (links.isIllegalTypeReferenceInConstraint) {
@@ -8432,7 +8432,7 @@ namespace ts {
         // contextually typed function and arrow expressions in the initial phase.
         function checkExpression(node: Expression | QualifiedName, contextualMapper?: TypeMapper): Type {
             let type: Type;
-            if (node.kind == SyntaxKind.QualifiedName) {
+            if (node.kind === SyntaxKind.QualifiedName) {
                 type = checkQualifiedName(<QualifiedName>node);
             }
             else {
@@ -9871,7 +9871,7 @@ namespace ts {
         function checkForStatement(node: ForStatement) {
             // Grammar checking
             if (!checkGrammarStatementInAmbientContext(node)) {
-                if (node.initializer && node.initializer.kind == SyntaxKind.VariableDeclarationList) {
+                if (node.initializer && node.initializer.kind === SyntaxKind.VariableDeclarationList) {
                     checkGrammarVariableDeclarationList(<VariableDeclarationList>node.initializer);
                 }
             }
@@ -11751,7 +11751,7 @@ namespace ts {
         }
 
         function isTypeDeclarationName(name: Node): boolean {
-            return name.kind == SyntaxKind.Identifier &&
+            return name.kind === SyntaxKind.Identifier &&
                 isTypeDeclaration(name.parent) &&
                 (<Declaration>name.parent).name === name;
         }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -572,7 +572,7 @@ namespace ts {
     export function getNormalizedPathComponents(path: string, currentDirectory: string) {
         path = normalizeSlashes(path);
         let rootLength = getRootLength(path);
-        if (rootLength == 0) {
+        if (rootLength === 0) {
             // If the path is not rooted it is relative to current directory
             path = combinePaths(normalizeSlashes(currentDirectory), path);
             rootLength = getRootLength(path);

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -320,7 +320,7 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
 
                     let prevEncodedEmittedColumn = lastEncodedSourceMapSpan.emittedColumn;
                     // Line/Comma delimiters
-                    if (lastEncodedSourceMapSpan.emittedLine == lastRecordedSourceMapSpan.emittedLine) {
+                    if (lastEncodedSourceMapSpan.emittedLine === lastRecordedSourceMapSpan.emittedLine) {
                         // Emit comma to separate the entry
                         if (sourceMapData.sourceMapMappings) {
                             sourceMapData.sourceMapMappings += ",";
@@ -403,8 +403,8 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
 
                     // If this location wasn't recorded or the location in source is going backwards, record the span
                     if (!lastRecordedSourceMapSpan ||
-                        lastRecordedSourceMapSpan.emittedLine != emittedLine ||
-                        lastRecordedSourceMapSpan.emittedColumn != emittedColumn ||
+                        lastRecordedSourceMapSpan.emittedLine !== emittedLine ||
+                        lastRecordedSourceMapSpan.emittedColumn !== emittedColumn ||
                         (lastRecordedSourceMapSpan.sourceIndex === sourceMapSourceIndex &&
                             (lastRecordedSourceMapSpan.sourceLine > sourceLinePos.line ||
                                 (lastRecordedSourceMapSpan.sourceLine === sourceLinePos.line && lastRecordedSourceMapSpan.sourceColumn > sourceLinePos.character)))) {
@@ -654,7 +654,7 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
                         if (nodeIsSynthesized(node)) {
                             return emitNodeWithoutSourceMap(node);
                         }
-                        if (node.kind != SyntaxKind.SourceFile) {
+                        if (node.kind !== SyntaxKind.SourceFile) {
                             recordEmitNodeStartSpan(node);
                             emitNodeWithoutSourceMap(node);
                             recordEmitNodeEndSpan(node);
@@ -1962,7 +1962,7 @@ var __param = (this && this.__param) || function (paramIndex, decorator) {
 
                         // Make sure we consider all nested cast expressions, e.g.:
                         // (<any><number><any>-A).x;
-                        while (operand.kind == SyntaxKind.TypeAssertionExpression) {
+                        while (operand.kind === SyntaxKind.TypeAssertionExpression) {
                             operand = (<TypeAssertion>operand).expression;
                         }
 

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -934,7 +934,7 @@ namespace ts {
                 error(Diagnostics.Unexpected_end_of_text);
                 isInvalidExtendedEscape = true;
             }
-            else if (text.charCodeAt(pos) == CharacterCodes.closeBrace) {
+            else if (text.charCodeAt(pos) === CharacterCodes.closeBrace) {
                 // Only swallow the following character up if it's a '}'.
                 pos++;
             }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -42,7 +42,7 @@ namespace ts {
     // Pool writers to avoid needing to allocate them for every symbol we write.
     let stringWriters: StringSymbolWriter[] = [];
     export function getSingleLineStringWriter(): StringSymbolWriter {
-        if (stringWriters.length == 0) {
+        if (stringWriters.length === 0) {
             let str = "";
 
             let writeText: (text: string) => void = text => str += text;

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -831,6 +831,7 @@ module FourSlash {
                 if (expectedText !== undefined) {
                     assert.notEqual(actualQuickInfoText, expectedText, this.messageAtLastKnownMarker("quick info text"));
                 }
+                // TODO: should be '==='?
                 if (expectedDocumentation != undefined) {
                     assert.notEqual(actualQuickInfoDocumentation, expectedDocumentation, this.messageAtLastKnownMarker("quick info doc comment"));
                 }
@@ -838,6 +839,7 @@ module FourSlash {
                 if (expectedText !== undefined) {
                     assert.equal(actualQuickInfoText, expectedText, this.messageAtLastKnownMarker("quick info text"));
                 }
+                // TODO: should be '==='?
                 if (expectedDocumentation != undefined) {
                     assert.equal(actualQuickInfoDocumentation, expectedDocumentation, assertionMessage("quick info doc"));
                 }
@@ -1820,7 +1822,7 @@ module FourSlash {
         }
 
         private verifyProjectInfo(expected: string[]) {
-            if (this.testType == FourSlashTestType.Server) {
+            if (this.testType === FourSlashTestType.Server) {
                 let actual = (<ts.server.SessionClient>this.languageService).getProjectInfo(
                     this.activeFile.fileName,
                     /* needFileNameList */ true
@@ -1937,7 +1939,7 @@ module FourSlash {
                 }
             }
 
-            if (expected != actual) {
+            if (expected !== actual) {
                 this.raiseError('verifyNavigationItemsCount failed - found: ' + actual + ' navigation items, expected: ' + expected + '.');
             }
         }
@@ -1984,7 +1986,7 @@ module FourSlash {
             var items = this.languageService.getNavigationBarItems(this.activeFile.fileName);
             var actual = this.getNavigationBarItemsCount(items);
 
-            if (expected != actual) {
+            if (expected !== actual) {
                 this.raiseError('verifyGetScriptLexicalStructureListCount failed - found: ' + actual + ' navigation items, expected: ' + expected + '.');
             }
         }
@@ -2402,6 +2404,7 @@ module FourSlash {
                         globalOptions[match[1]] = match[2];
                     }
                 }
+            // TODO: should be '==='?
             } else if (line == '' || lineLength === 0) {
                 // Previously blank lines between fourslash content caused it to be considered as 2 files,
                 // Remove this behavior since it just causes errors now

--- a/src/harness/projectsRunner.ts
+++ b/src/harness/projectsRunner.ts
@@ -241,7 +241,7 @@ class ProjectRunner extends RunnerBase {
                 if (Harness.Compiler.isJS(fileName)) {
                     // Make sure if there is URl we have it cleaned up
                     var indexOfSourceMapUrl = data.lastIndexOf("//# sourceMappingURL=");
-                    if (indexOfSourceMapUrl != -1) {
+                    if (indexOfSourceMapUrl !== -1) {
                         data = data.substring(0, indexOfSourceMapUrl + 21) + cleanProjectUrl(data.substring(indexOfSourceMapUrl + 21));
                     }
                 }

--- a/src/harness/projectsRunner.ts
+++ b/src/harness/projectsRunner.ts
@@ -110,6 +110,7 @@ class ProjectRunner extends RunnerBase {
                 else if (url.indexOf(diskProjectPath) === 0) {
                     // Replace the disk specific path into the project root path
                     url = url.substr(diskProjectPath.length);
+                    // TODO: should be '!=='?
                     if (url.charCodeAt(0) != ts.CharacterCodes.slash) {
                         url = "/" + url;
                     }

--- a/src/harness/sourceMapRecorder.ts
+++ b/src/harness/sourceMapRecorder.ts
@@ -46,7 +46,7 @@ module Harness.SourceMapRecoder {
         }
 
         function isSourceMappingSegmentEnd() {
-            if (decodingIndex == sourceMapMappings.length) {
+            if (decodingIndex === sourceMapMappings.length) {
                 return true;
             }
 
@@ -95,7 +95,7 @@ module Harness.SourceMapRecoder {
                     var currentByte = base64FormatDecode();
 
                     // If msb is set, we still have more bits to continue
-                    moreDigits = (currentByte & 32) != 0;
+                    moreDigits = (currentByte & 32) !== 0;
 
                     // least significant 5 bits are the next msbs in the final value.
                     value = value | ((currentByte & 31) << shiftCount);
@@ -103,7 +103,7 @@ module Harness.SourceMapRecoder {
                 }
 
                 // Least significant bit if 1 represents negative and rest of the msb is actual absolute value
-                if ((value & 1) == 0) {
+                if ((value & 1) === 0) {
                     // + number
                     value = value >> 1;
                 }
@@ -182,7 +182,7 @@ module Harness.SourceMapRecoder {
                     }
                 }
                 // Dont support reading mappings that dont have information about original source and its line numbers
-                if (createErrorIfCondition(!isSourceMappingSegmentEnd(), "Unsupported Error Format: There are more entries after " + (decodeOfEncodedMapping.nameIndex == -1 ? "sourceColumn" : "nameIndex"))) {
+                if (createErrorIfCondition(!isSourceMappingSegmentEnd(), "Unsupported Error Format: There are more entries after " + (decodeOfEncodedMapping.nameIndex === -1 ? "sourceColumn" : "nameIndex"))) {
                     return { error: errorDecodeOfEncodedMapping, sourceMapSpan: decodeOfEncodedMapping };
                 }
 
@@ -249,7 +249,7 @@ module Harness.SourceMapRecoder {
                 mapString += " name (" + sourceMapNames[mapEntry.nameIndex] + ")";
             }
             else {
-                if (mapEntry.nameIndex != -1 || getAbsentNameIndex) {
+                if (mapEntry.nameIndex !== -1 || getAbsentNameIndex) {
                     mapString += " nameIndex (" + mapEntry.nameIndex + ")";
                 }
             }
@@ -262,12 +262,12 @@ module Harness.SourceMapRecoder {
             var decodeResult = SourceMapDecoder.decodeNextEncodedSourceMapSpan();
             var decodedErrors: string[];
             if (decodeResult.error
-                || decodeResult.sourceMapSpan.emittedLine != sourceMapSpan.emittedLine
-                || decodeResult.sourceMapSpan.emittedColumn != sourceMapSpan.emittedColumn
-                || decodeResult.sourceMapSpan.sourceLine != sourceMapSpan.sourceLine
-                || decodeResult.sourceMapSpan.sourceColumn != sourceMapSpan.sourceColumn
-                || decodeResult.sourceMapSpan.sourceIndex != sourceMapSpan.sourceIndex
-                || decodeResult.sourceMapSpan.nameIndex != sourceMapSpan.nameIndex) {
+                || decodeResult.sourceMapSpan.emittedLine   !== sourceMapSpan.emittedLine
+                || decodeResult.sourceMapSpan.emittedColumn !== sourceMapSpan.emittedColumn
+                || decodeResult.sourceMapSpan.sourceLine    !== sourceMapSpan.sourceLine
+                || decodeResult.sourceMapSpan.sourceColumn  !== sourceMapSpan.sourceColumn
+                || decodeResult.sourceMapSpan.sourceIndex   !== sourceMapSpan.sourceIndex
+                || decodeResult.sourceMapSpan.nameIndex     !== sourceMapSpan.nameIndex) {
                 if (decodeResult.error) {
                     decodedErrors = ["!!^^ !!^^ There was decoding error in the sourcemap at this location: " + decodeResult.error];
                 }
@@ -288,7 +288,7 @@ module Harness.SourceMapRecoder {
         }
 
         export function recordNewSourceFileSpan(sourceMapSpan: ts.SourceMapSpan, newSourceFileCode: string) {
-            assert.isTrue(spansOnSingleLine.length == 0 || spansOnSingleLine[0].sourceMapSpan.emittedLine !== sourceMapSpan.emittedLine, "new file source map span should be on new line. We currently handle only that scenario");
+            assert.isTrue(spansOnSingleLine.length === 0 || spansOnSingleLine[0].sourceMapSpan.emittedLine !== sourceMapSpan.emittedLine, "new file source map span should be on new line. We currently handle only that scenario");
             recordSourceMapSpan(sourceMapSpan);
 
             assert.isTrue(spansOnSingleLine.length === 1);
@@ -395,9 +395,9 @@ module Harness.SourceMapRecoder {
 
                 var tsCodeLineMap = ts.computeLineStarts(sourceText);
                 for (var i = 0; i < tsCodeLineMap.length; i++) {
-                    writeSourceMapIndent(prevEmittedCol, i == 0 ? markerIds[index] : "  >");
+                    writeSourceMapIndent(prevEmittedCol, i === 0 ? markerIds[index] : "  >");
                     sourceMapRecoder.Write(getTextOfLine(i, tsCodeLineMap, sourceText));
-                    if (i == tsCodeLineMap.length - 1) {
+                    if (i === tsCodeLineMap.length - 1) {
                         sourceMapRecoder.WriteLine("");
                     }
                 }
@@ -447,7 +447,7 @@ module Harness.SourceMapRecoder {
             for (var j = 0; j < sourceMapData.sourceMapDecodedMappings.length; j++) {
                 var decodedSourceMapping = sourceMapData.sourceMapDecodedMappings[j];
                 var currentSourceFile = program.getSourceFile(sourceMapData.inputSourceFileNames[decodedSourceMapping.sourceIndex]);
-                if (currentSourceFile != prevSourceFile) {
+                if (currentSourceFile !== prevSourceFile) {
                     SourceMapSpanWriter.recordNewSourceFileSpan(decodedSourceMapping, currentSourceFile.text);
                     prevSourceFile = currentSourceFile;
                 }

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -219,7 +219,7 @@ namespace ts.server {
 
             var request = this.processRequest<protocol.CompletionDetailsRequest>(CommandNames.CompletionDetails, args);
             var response = this.processResponse<protocol.CompletionDetailsResponse>(request);
-            Debug.assert(response.body.length == 1, "Unexpected length of completion details response body.");
+            Debug.assert(response.body.length === 1, "Unexpected length of completion details response body.");
             return response.body[0];
         }
 
@@ -429,8 +429,8 @@ namespace ts.server {
             if (!this.lastRenameEntry ||
                 this.lastRenameEntry.fileName !== fileName ||
                 this.lastRenameEntry.position !== position ||
-                this.lastRenameEntry.findInStrings != findInStrings ||
-                this.lastRenameEntry.findInComments != findInComments) {
+                this.lastRenameEntry.findInStrings !== findInStrings ||
+                this.lastRenameEntry.findInComments !== findInComments) {
                 this.getRenameInfo(fileName, position, findInStrings, findInComments);
             }
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -629,7 +629,7 @@ namespace ts.server {
                 for (var i = 0, len = this.openFilesReferenced.length; i < len; i++) {
                     var f = this.openFilesReferenced[i];
                     // if f was referenced by the removed project, remember it
-                    if (f.defaultProject == removedProject) {
+                    if (f.defaultProject === removedProject) {
                         f.defaultProject = undefined;
                         orphanFiles.push(f);
                     }
@@ -656,7 +656,7 @@ namespace ts.server {
             for (var i = 0, len = this.inferredProjects.length; i < len; i++) {
                 var inferredProject = this.inferredProjects[i];
                 inferredProject.updateGraph();
-                if (inferredProject != excludedProject) {
+                if (inferredProject !== excludedProject) {
                     if (inferredProject.getSourceFile(info)) {
                         info.defaultProject = inferredProject;
                         referencingProjects.push(inferredProject);
@@ -710,7 +710,7 @@ namespace ts.server {
                 var rootFile = this.openFileRoots[i];
                 var rootedProject = rootFile.defaultProject;
                 var referencingProjects = this.findReferencingProjects(rootFile, rootedProject);
-                if (referencingProjects.length == 0) {
+                if (referencingProjects.length === 0) {
                     rootFile.defaultProject = rootedProject;
                     openFileRoots.push(rootFile);
                 }
@@ -1082,7 +1082,7 @@ namespace ts.server {
 
             for (var k = this.endBranch.length - 1; k >= 0; k--) {
                 (<LineNode>this.endBranch[k]).updateCounts();
-                if (this.endBranch[k].charCount() == 0) {
+                if (this.endBranch[k].charCount() === 0) {
                     lastZeroCount = this.endBranch[k];
                     if (k > 0) {
                         branchParent = <LineNode>this.endBranch[k - 1];
@@ -1147,7 +1147,7 @@ namespace ts.server {
         post(relativeStart: number, relativeLength: number, lineCollection: LineCollection, parent: LineCollection, nodeType: CharRangeSection): LineCollection {
             // have visited the path for start of range, now looking for end
             // if range is on single line, we will never make this state transition
-            if (lineCollection == this.lineCollectionAtBranch) {
+            if (lineCollection === this.lineCollectionAtBranch) {
                 this.state = CharRangeSection.End;
             }
             // always pop stack because post only called when child has been visited
@@ -1159,7 +1159,7 @@ namespace ts.server {
             // currentNode corresponds to parent, but in the new tree
             var currentNode = this.stack[this.stack.length - 1];
 
-            if ((this.state == CharRangeSection.Entire) && (nodeType == CharRangeSection.Start)) {
+            if ((this.state === CharRangeSection.Entire) && (nodeType === CharRangeSection.Start)) {
                 // if range is on single line, we will never make this state transition
                 this.state = CharRangeSection.Start;
                 this.branchNode = currentNode;
@@ -1176,12 +1176,12 @@ namespace ts.server {
             switch (nodeType) {
                 case CharRangeSection.PreStart:
                     this.goSubtree = false;
-                    if (this.state != CharRangeSection.End) {
+                    if (this.state !== CharRangeSection.End) {
                         currentNode.add(lineCollection);
                     }
                     break;
                 case CharRangeSection.Start:
-                    if (this.state == CharRangeSection.End) {
+                    if (this.state === CharRangeSection.End) {
                         this.goSubtree = false;
                     }
                     else {
@@ -1191,7 +1191,7 @@ namespace ts.server {
                     }
                     break;
                 case CharRangeSection.Entire:
-                    if (this.state != CharRangeSection.End) {
+                    if (this.state !== CharRangeSection.End) {
                         child = fresh(lineCollection);
                         currentNode.add(child);
                         this.startPath[this.startPath.length] = child;
@@ -1208,7 +1208,7 @@ namespace ts.server {
                     this.goSubtree = false;
                     break;
                 case CharRangeSection.End:
-                    if (this.state != CharRangeSection.End) {
+                    if (this.state !== CharRangeSection.End) {
                         this.goSubtree = false;
                     }
                     else {
@@ -1221,7 +1221,7 @@ namespace ts.server {
                     break;
                 case CharRangeSection.PostEnd:
                     this.goSubtree = false;
-                    if (this.state != CharRangeSection.Start) {
+                    if (this.state !== CharRangeSection.Start) {
                         currentNode.add(lineCollection);
                     }
                     break;
@@ -1233,10 +1233,10 @@ namespace ts.server {
         }
         // just gather text from the leaves
         leaf(relativeStart: number, relativeLength: number, ll: LineLeaf) {
-            if (this.state == CharRangeSection.Start) {
+            if (this.state === CharRangeSection.Start) {
                 this.initialText = ll.text.substring(0, relativeStart);
             }
-            else if (this.state == CharRangeSection.Entire) {
+            else if (this.state === CharRangeSection.Entire) {
                 this.initialText = ll.text.substring(0, relativeStart);
                 this.trailingText = ll.text.substring(relativeStart + relativeLength);
             }
@@ -1499,8 +1499,8 @@ namespace ts.server {
             function editFlat(source: string, s: number, dl: number, nt = "") {
                 return source.substring(0, s) + nt + source.substring(s + dl, source.length);
             }
-            if (this.root.charCount() == 0) {
-                // TODO: assert deleteLength == 0
+            if (this.root.charCount() === 0) {
+                // TODO: assert deleteLength === 0
                 if (newText) {
                     this.load(LineIndex.linesFromText(newText).lines);
                     return this;
@@ -1528,7 +1528,7 @@ namespace ts.server {
                     // check whether last characters deleted are line break
                     var e = pos + deleteLength;
                     var lineInfo = this.charOffsetToLineNumberAndPos(e);
-                    if ((lineInfo && (lineInfo.offset == 0))) {
+                    if ((lineInfo && (lineInfo.offset === 0))) {
                         // move range end just past line that will merge with previous line
                         deleteLength += lineInfo.text.length;
                         // store text by appending to end of insertedText
@@ -1574,7 +1574,7 @@ namespace ts.server {
                 interiorNodes[i].totalChars = charCount;
                 interiorNodes[i].totalLines = lineCount;
             }
-            if (interiorNodes.length == 1) {
+            if (interiorNodes.length === 1) {
                 return interiorNodes[0];
             }
             else {
@@ -1585,7 +1585,7 @@ namespace ts.server {
         static linesFromText(text: string) {
             var lineStarts = ts.computeLineStarts(text);
 
-            if (lineStarts.length == 0) {
+            if (lineStarts.length === 0) {
                 return { lines: <string[]>[], lineMap: lineStarts };
             }
             var lines = <string[]>new Array(lineStarts.length);
@@ -1821,7 +1821,7 @@ namespace ts.server {
         findChildIndex(child: LineCollection) {
             var childIndex = 0;
             var clen = this.children.length;
-            while ((this.children[childIndex] != child) && (childIndex < clen)) childIndex++;
+            while ((this.children[childIndex] !== child) && (childIndex < clen)) childIndex++;
             return childIndex;
         }
 
@@ -1830,7 +1830,7 @@ namespace ts.server {
             var clen = this.children.length;
             var nodeCount = nodes.length;
             // if child is last and there is more room and only one node to place, place it
-            if ((clen < lineCollectionCapacity) && (childIndex == (clen - 1)) && (nodeCount == 1)) {
+            if ((clen < lineCollectionCapacity) && (childIndex === (clen - 1)) && (nodeCount === 1)) {
                 this.add(nodes[0]);
                 this.updateCounts();
                 return [];
@@ -1854,13 +1854,13 @@ namespace ts.server {
                     var splitNode = <LineNode>splitNodes[0];
                     while (nodeIndex < nodeCount) {
                         splitNode.add(nodes[nodeIndex++]);
-                        if (splitNode.children.length == lineCollectionCapacity) {
+                        if (splitNode.children.length === lineCollectionCapacity) {
                             splitNodeIndex++;
                             splitNode = <LineNode>splitNodes[splitNodeIndex];
                         }
                     }
                     for (i = splitNodes.length - 1; i >= 0; i--) {
-                        if (splitNodes[i].children.length == 0) {
+                        if (splitNodes[i].children.length === 0) {
                             splitNodes.length--;
                         }
                     }

--- a/src/server/node.d.ts
+++ b/src/server/node.d.ts
@@ -584,9 +584,9 @@ declare module NodeJS {
         export interface Response extends Message {
             request_seq: number;
             success: boolean;
-            /** Contains error message if success == false. */
+            /** Contains error message if success === false. */
             message?: string;
-            /** Contains message body if success == true. */
+            /** Contains message body if success === true. */
             body?: any;
         }
 

--- a/src/server/protocol.d.ts
+++ b/src/server/protocol.d.ts
@@ -67,12 +67,12 @@ declare namespace ts.server.protocol {
         command: string;
 
         /** 
-          * Contains error message if success == false. 
+          * Contains error message if success === false. 
           */
         message?: string;
 
         /**
-          * Contains message body if success == true.
+          * Contains message body if success === true.
           */
         body?: any;
     }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -123,7 +123,7 @@ namespace ts.server {
                 if (err) {
                     watchedFile.callback(watchedFile.fileName);
                 }
-                else if (watchedFile.mtime.getTime() != stats.mtime.getTime()) {
+                else if (watchedFile.mtime.getTime() !== stats.mtime.getTime()) {
                     watchedFile.mtime = WatchedFileSet.getModifiedTime(watchedFile.fileName);
                     watchedFile.callback(watchedFile.fileName);
                 }
@@ -138,7 +138,7 @@ namespace ts.server {
                 var count = 0;
                 var nextToCheck = this.nextFileToCheck;
                 var firstCheck = -1;
-                while ((count < this.chunkSize) && (nextToCheck != firstCheck)) {
+                while ((count < this.chunkSize) && (nextToCheck !== firstCheck)) {
                     this.poll(nextToCheck);
                     if (firstCheck < 0) {
                         firstCheck = nextToCheck;

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -31,7 +31,7 @@ namespace ts.server {
         if (a < b) {
             return -1;
         }
-        else if (a == b) {
+        else if (a === b) {
             return 0;
         }
         else return 1;
@@ -43,7 +43,7 @@ namespace ts.server {
         }
         else if (a.file == b.file) {
             var n = compareNumber(a.start.line, b.start.line);
-            if (n == 0) {
+            if (n === 0) {
                 return compareNumber(a.start.offset, b.start.offset);
             }
             else return n;
@@ -129,7 +129,7 @@ namespace ts.server {
             if (eventName == "context") {
                 this.projectService.log("got context event, updating diagnostics for" + fileName, "Info");
                 this.updateErrorCheck([{ fileName, project }], this.changeSeq,
-                    (n) => n == this.changeSeq, 100);
+                    (n) => n === this.changeSeq, 100);
             }
         }
 
@@ -546,7 +546,7 @@ namespace ts.server {
             // getFormattingEditsAfterKeytroke either empty or pertaining
             // only to the previous line.  If all this is true, then
             // add edits necessary to properly indent the current line.
-            if ((key == "\n") && ((!edits) || (edits.length == 0) || allEditsBeforePos(edits, position))) {
+            if ((key == "\n") && ((!edits) || (edits.length === 0) || allEditsBeforePos(edits, position))) {
                 var scriptInfo = compilerService.host.getScriptInfo(file);
                 if (scriptInfo) {
                     var lineInfo = scriptInfo.getLineInfo(line);
@@ -622,7 +622,7 @@ namespace ts.server {
             }
 
             return completions.entries.reduce((result: protocol.CompletionEntry[], entry: ts.CompletionEntry) => {
-                if (completions.isMemberCompletion || (entry.name.toLowerCase().indexOf(prefix.toLowerCase()) == 0)) {
+                if (completions.isMemberCompletion || (entry.name.toLowerCase().indexOf(prefix.toLowerCase()) === 0)) {
                     result.push(entry);
                 }
                 return result;
@@ -689,7 +689,7 @@ namespace ts.server {
             }, []);
 
             if (checkList.length > 0) {
-                this.updateErrorCheck(checkList, this.changeSeq,(n) => n == this.changeSeq, delay)
+                this.updateErrorCheck(checkList, this.changeSeq,(n) => n === this.changeSeq, delay)
             }
         }
 
@@ -704,7 +704,7 @@ namespace ts.server {
                     compilerService.host.editScript(file, start, end, insertString);
                     this.changeSeq++;
                 }
-                this.updateProjectStructure(this.changeSeq, (n) => n == this.changeSeq);
+                this.updateProjectStructure(this.changeSeq, (n) => n === this.changeSeq);
             }
         }
 

--- a/src/services/breakpoints.ts
+++ b/src/services/breakpoints.ts
@@ -75,7 +75,7 @@ namespace ts.BreakpointResolver {
                         return textSpan(node);
                     }
 
-                    if (node.parent.kind == SyntaxKind.ArrowFunction && (<FunctionLikeDeclaration>node.parent).body == node) {
+                    if (node.parent.kind === SyntaxKind.ArrowFunction && (<FunctionLikeDeclaration>node.parent).body === node) {
                         // If this is body of arrow function, it is allowed to have the breakpoint
                         return textSpan(node);
                     }

--- a/src/services/formatting/formattingContext.ts
+++ b/src/services/formatting/formattingContext.ts
@@ -59,7 +59,7 @@ namespace ts.formatting {
             if (this.tokensAreOnSameLine === undefined) {
                 let startLine = this.sourceFile.getLineAndCharacterOfPosition(this.currentTokenSpan.pos).line;
                 let endLine = this.sourceFile.getLineAndCharacterOfPosition(this.nextTokenSpan.pos).line;
-                this.tokensAreOnSameLine = (startLine == endLine);
+                this.tokensAreOnSameLine = (startLine === endLine);
             }
 
             return this.tokensAreOnSameLine;
@@ -84,7 +84,7 @@ namespace ts.formatting {
         private NodeIsOnOneLine(node: Node): boolean {
             let startLine = this.sourceFile.getLineAndCharacterOfPosition(node.getStart(this.sourceFile)).line;
             let endLine = this.sourceFile.getLineAndCharacterOfPosition(node.getEnd()).line;
-            return startLine == endLine;
+            return startLine === endLine;
         }
 
         private BlockIsOnOneLine(node: Node): boolean {

--- a/src/services/formatting/ruleOperationContext.ts
+++ b/src/services/formatting/ruleOperationContext.ts
@@ -14,7 +14,7 @@ namespace ts.formatting {
 
 
         public IsAny(): boolean {
-            return this == RuleOperationContext.Any;
+            return this === RuleOperationContext.Any;
         }
 
         public  InContext(context: FormattingContext): boolean {

--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -692,7 +692,7 @@ namespace ts.formatting {
         }
 
         static IsNotFormatOnEnter(context: FormattingContext): boolean {
-            return context.formattingRequestKind != FormattingRequestKind.FormatOnEnter;
+            return context.formattingRequestKind !== FormattingRequestKind.FormatOnEnter;
         }
 
         static IsModuleDeclContext(context: FormattingContext): boolean {

--- a/src/services/formatting/rulesMap.ts
+++ b/src/services/formatting/rulesMap.ts
@@ -41,15 +41,15 @@ namespace ts.formatting {
         }
 
         private FillRule(rule: Rule, rulesBucketConstructionStateList: RulesBucketConstructionState[]): void {
-            let specificRule = rule.Descriptor.LeftTokenRange != Shared.TokenRange.Any &&
-                               rule.Descriptor.RightTokenRange != Shared.TokenRange.Any;
+            let specificRule = rule.Descriptor.LeftTokenRange !== Shared.TokenRange.Any &&
+                               rule.Descriptor.RightTokenRange !== Shared.TokenRange.Any;
 
             rule.Descriptor.LeftTokenRange.GetTokens().forEach((left) => {
                 rule.Descriptor.RightTokenRange.GetTokens().forEach((right) => {
                     let rulesBucketIndex = this.GetRuleBucketIndex(left, right);
 
                     let rulesBucket = this.map[rulesBucketIndex];
-                    if (rulesBucket == undefined) {
+                    if (rulesBucket === undefined) {
                         rulesBucket = this.map[rulesBucketIndex] = new RulesBucket();
                     }
 
@@ -124,7 +124,7 @@ namespace ts.formatting {
         public IncreaseInsertionIndex(maskPosition: RulesPosition): void {
             let value = (this.rulesInsertionIndexBitmap >> maskPosition) & Mask;
             value++;
-            Debug.assert((value & Mask) == value, "Adding more rules into the sub-bucket than allowed. Maximum allowed is 32 rules.");
+            Debug.assert((value & Mask) === value, "Adding more rules into the sub-bucket than allowed. Maximum allowed is 32 rules.");
 
             let temp = this.rulesInsertionIndexBitmap & ~(Mask << maskPosition);
             temp |= value << maskPosition;
@@ -147,7 +147,7 @@ namespace ts.formatting {
         public AddRule(rule: Rule, specificTokens: boolean, constructionState: RulesBucketConstructionState[], rulesBucketIndex: number): void {
             let position: RulesPosition;
 
-            if (rule.Operation.Action == RuleAction.Ignore) {
+            if (rule.Operation.Action === RuleAction.Ignore) {
                 position = specificTokens ?
                     RulesPosition.IgnoreRulesSpecific :
                     RulesPosition.IgnoreRulesAny;

--- a/src/services/formatting/rulesProvider.ts
+++ b/src/services/formatting/rulesProvider.ts
@@ -25,7 +25,7 @@ namespace ts.formatting {
         }
 
         public ensureUpToDate(options: ts.FormatCodeOptions) {
-            // TODO: should this be '==='?
+            // TODO: Should this be '==='?
             if (this.options == null || !ts.compareDataObjects(this.options, options)) {
                 let activeRules = this.createActiveRules(options);
                 let rulesMap = RulesMap.create(activeRules);

--- a/src/services/formatting/rulesProvider.ts
+++ b/src/services/formatting/rulesProvider.ts
@@ -25,6 +25,7 @@ namespace ts.formatting {
         }
 
         public ensureUpToDate(options: ts.FormatCodeOptions) {
+            // TODO: should this be '==='?
             if (this.options == null || !ts.compareDataObjects(this.options, options)) {
                 let activeRules = this.createActiveRules(options);
                 let rulesMap = RulesMap.create(activeRules);

--- a/src/services/formatting/tokenRange.ts
+++ b/src/services/formatting/tokenRange.ts
@@ -54,7 +54,7 @@ namespace ts.formatting {
             }
 
             public Contains(tokenValue: SyntaxKind): boolean {
-                return tokenValue == this.token;
+                return tokenValue === this.token;
             }
         }
 

--- a/src/services/patternMatcher.ts
+++ b/src/services/patternMatcher.ts
@@ -686,7 +686,7 @@ namespace ts {
 
             if (charIsPunctuation(identifier.charCodeAt(i - 1)) ||
                 charIsPunctuation(identifier.charCodeAt(i)) ||
-                lastIsDigit != currentIsDigit ||
+                lastIsDigit !== currentIsDigit ||
                 hasTransitionFromLowerToUpper ||
                 hasTransitionFromUpperToLower) {
 
@@ -757,7 +757,7 @@ namespace ts {
             // 3) HTMLDocument -> HTML, Document
             //
             // etc.
-            if (index != wordStart &&
+            if (index !== wordStart &&
                 index + 1 < identifier.length) {
                 let currentIsUpper = isUpperCaseLetter(identifier.charCodeAt(index));
                 let nextIsLower = isLowerCaseLetter(identifier.charCodeAt(index + 1));

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -6043,7 +6043,8 @@ namespace ts {
                  */
                 function hasValueSideModule(symbol: Symbol): boolean {
                     return forEach(symbol.declarations, declaration => {
-                        return declaration.kind === SyntaxKind.ModuleDeclaration && getModuleInstanceState(declaration) == ModuleInstanceState.Instantiated;
+                        return declaration.kind === SyntaxKind.ModuleDeclaration && 
+                            getModuleInstanceState(declaration) === ModuleInstanceState.Instantiated;
                     });
                 }
             }

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -234,6 +234,7 @@ namespace ts {
         public getChangeRange(oldSnapshot: IScriptSnapshot): TextChangeRange {
             var oldSnapshotShim = <ScriptSnapshotShimAdapter>oldSnapshot;
             var encoded = this.scriptSnapshotShim.getChangeRange(oldSnapshotShim.scriptSnapshotShim);
+            // TODO: should this be '==='?
             if (encoded == null) {
                 return null;
             }
@@ -283,6 +284,7 @@ namespace ts {
 
         public getCompilationSettings(): CompilerOptions {
             var settingsJson = this.shimHost.getCompilationSettings();
+            // TODO: should this be '==='?
             if (settingsJson == null || settingsJson == "") {
                 throw Error("LanguageServiceShimHostAdapter.getCompilationSettings: empty compilationSettings");
                 return null;


### PR DESCRIPTION
There are several places in the code that unnecessarily use `==` or `!=` instead of `===` or `!==`, respectively. This makes the easy change where possible.

Changes haven't been made in a couple places that do depend on type coercions, as this breaks the baselines.