### PR TITLE
Make resolveName ignore export specifiers without calling getSymbol

### DIFF
--- a/tests/baselines/reference/exportSpecifierAndExportedMemberDeclaration.js
+++ b/tests/baselines/reference/exportSpecifierAndExportedMemberDeclaration.js
@@ -1,0 +1,15 @@
+//// [exportSpecifierAndExportedMemberDeclaration.ts]
+declare module "m2" {
+    export module X {
+        interface I { }
+    }
+    function Y();
+    export { Y as X };
+    function Z(): X.I;
+}
+
+declare module "m2" {
+    function Z2(): X.I;
+}
+
+//// [exportSpecifierAndExportedMemberDeclaration.js]

--- a/tests/baselines/reference/exportSpecifierAndExportedMemberDeclaration.symbols
+++ b/tests/baselines/reference/exportSpecifierAndExportedMemberDeclaration.symbols
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/exportSpecifierAndExportedMemberDeclaration.ts ===
+declare module "m2" {
+    export module X {
+>X : Symbol(X, Decl(exportSpecifierAndExportedMemberDeclaration.ts, 0, 21), Decl(exportSpecifierAndExportedMemberDeclaration.ts, 5, 12))
+
+        interface I { }
+>I : Symbol(I, Decl(exportSpecifierAndExportedMemberDeclaration.ts, 1, 21))
+    }
+    function Y();
+>Y : Symbol(Y, Decl(exportSpecifierAndExportedMemberDeclaration.ts, 3, 5))
+
+    export { Y as X };
+>Y : Symbol(X, Decl(exportSpecifierAndExportedMemberDeclaration.ts, 0, 21), Decl(exportSpecifierAndExportedMemberDeclaration.ts, 5, 12))
+>X : Symbol(X, Decl(exportSpecifierAndExportedMemberDeclaration.ts, 0, 21), Decl(exportSpecifierAndExportedMemberDeclaration.ts, 5, 12))
+
+    function Z(): X.I;
+>Z : Symbol(Z, Decl(exportSpecifierAndExportedMemberDeclaration.ts, 5, 22))
+>X : Symbol(X, Decl(exportSpecifierAndExportedMemberDeclaration.ts, 0, 21), Decl(exportSpecifierAndExportedMemberDeclaration.ts, 5, 12))
+>I : Symbol(X.I, Decl(exportSpecifierAndExportedMemberDeclaration.ts, 1, 21))
+}
+
+declare module "m2" {
+    function Z2(): X.I;
+>Z2 : Symbol(Z2, Decl(exportSpecifierAndExportedMemberDeclaration.ts, 9, 21))
+>X : Symbol(X, Decl(exportSpecifierAndExportedMemberDeclaration.ts, 0, 21), Decl(exportSpecifierAndExportedMemberDeclaration.ts, 5, 12))
+>I : Symbol(X.I, Decl(exportSpecifierAndExportedMemberDeclaration.ts, 1, 21))
+}

--- a/tests/baselines/reference/exportSpecifierAndExportedMemberDeclaration.types
+++ b/tests/baselines/reference/exportSpecifierAndExportedMemberDeclaration.types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/exportSpecifierAndExportedMemberDeclaration.ts ===
+declare module "m2" {
+    export module X {
+>X : () => any
+
+        interface I { }
+>I : I
+    }
+    function Y();
+>Y : () => any
+
+    export { Y as X };
+>Y : () => any
+>X : () => any
+
+    function Z(): X.I;
+>Z : () => X.I
+>X : any
+>I : X.I
+}
+
+declare module "m2" {
+    function Z2(): X.I;
+>Z2 : () => X.I
+>X : any
+>I : X.I
+}

--- a/tests/baselines/reference/exportSpecifierAndLocalMemberDeclaration.errors.txt
+++ b/tests/baselines/reference/exportSpecifierAndLocalMemberDeclaration.errors.txt
@@ -1,0 +1,18 @@
+tests/cases/compiler/exportSpecifierAndLocalMemberDeclaration.ts(11,20): error TS2503: Cannot find namespace 'X'.
+
+
+==== tests/cases/compiler/exportSpecifierAndLocalMemberDeclaration.ts (1 errors) ====
+    declare module "m2" {
+        module X {
+            interface I { }
+        }
+        function Y();
+        export { Y as X };
+        function Z(): X.I;
+    }
+    
+    declare module "m2" {
+        function Z2(): X.I;
+                       ~
+!!! error TS2503: Cannot find namespace 'X'.
+    }

--- a/tests/baselines/reference/exportSpecifierAndLocalMemberDeclaration.js
+++ b/tests/baselines/reference/exportSpecifierAndLocalMemberDeclaration.js
@@ -1,0 +1,15 @@
+//// [exportSpecifierAndLocalMemberDeclaration.ts]
+declare module "m2" {
+    module X {
+        interface I { }
+    }
+    function Y();
+    export { Y as X };
+    function Z(): X.I;
+}
+
+declare module "m2" {
+    function Z2(): X.I;
+}
+
+//// [exportSpecifierAndLocalMemberDeclaration.js]

--- a/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration1.js
+++ b/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration1.js
@@ -1,0 +1,8 @@
+//// [exportSpecifierReferencingOuterDeclaration1.ts]
+declare module X { export interface bar { } }
+declare module "m" {
+    export { X };
+    export function foo(): X.bar;
+}
+
+//// [exportSpecifierReferencingOuterDeclaration1.js]

--- a/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration1.symbols
+++ b/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration1.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/exportSpecifierReferencingOuterDeclaration1.ts ===
+declare module X { export interface bar { } }
+>X : Symbol(X, Decl(exportSpecifierReferencingOuterDeclaration1.ts, 0, 0))
+>bar : Symbol(bar, Decl(exportSpecifierReferencingOuterDeclaration1.ts, 0, 18))
+
+declare module "m" {
+    export { X };
+>X : Symbol(X, Decl(exportSpecifierReferencingOuterDeclaration1.ts, 2, 12))
+
+    export function foo(): X.bar;
+>foo : Symbol(foo, Decl(exportSpecifierReferencingOuterDeclaration1.ts, 2, 17))
+>X : Symbol(X, Decl(exportSpecifierReferencingOuterDeclaration1.ts, 0, 0))
+>bar : Symbol(X.bar, Decl(exportSpecifierReferencingOuterDeclaration1.ts, 0, 18))
+}

--- a/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration1.types
+++ b/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration1.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/exportSpecifierReferencingOuterDeclaration1.ts ===
+declare module X { export interface bar { } }
+>X : any
+>bar : bar
+
+declare module "m" {
+    export { X };
+>X : any
+
+    export function foo(): X.bar;
+>foo : () => X.bar
+>X : any
+>bar : X.bar
+}

--- a/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration2.js
+++ b/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration2.js
@@ -1,0 +1,11 @@
+//// [tests/cases/compiler/exportSpecifierReferencingOuterDeclaration2.ts] ////
+
+//// [exportSpecifierReferencingOuterDeclaration2_A.ts]
+declare module X { export interface bar { } }
+
+//// [exportSpecifierReferencingOuterDeclaration2_B.ts]
+export { X };
+export declare function foo(): X.bar;
+
+//// [exportSpecifierReferencingOuterDeclaration2_A.js]
+//// [exportSpecifierReferencingOuterDeclaration2_B.js]

--- a/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration2.symbols
+++ b/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration2.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/exportSpecifierReferencingOuterDeclaration2_A.ts ===
+declare module X { export interface bar { } }
+>X : Symbol(X, Decl(exportSpecifierReferencingOuterDeclaration2_A.ts, 0, 0))
+>bar : Symbol(bar, Decl(exportSpecifierReferencingOuterDeclaration2_A.ts, 0, 18))
+
+=== tests/cases/compiler/exportSpecifierReferencingOuterDeclaration2_B.ts ===
+export { X };
+>X : Symbol(X, Decl(exportSpecifierReferencingOuterDeclaration2_B.ts, 0, 8))
+
+export declare function foo(): X.bar;
+>foo : Symbol(foo, Decl(exportSpecifierReferencingOuterDeclaration2_B.ts, 0, 13))
+>X : Symbol(X, Decl(exportSpecifierReferencingOuterDeclaration2_A.ts, 0, 0))
+>bar : Symbol(X.bar, Decl(exportSpecifierReferencingOuterDeclaration2_A.ts, 0, 18))
+

--- a/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration2.types
+++ b/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration2.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/exportSpecifierReferencingOuterDeclaration2_A.ts ===
+declare module X { export interface bar { } }
+>X : any
+>bar : bar
+
+=== tests/cases/compiler/exportSpecifierReferencingOuterDeclaration2_B.ts ===
+export { X };
+>X : any
+
+export declare function foo(): X.bar;
+>foo : () => X.bar
+>X : any
+>bar : X.bar
+

--- a/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration3.errors.txt
+++ b/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration3.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/compiler/exportSpecifierReferencingOuterDeclaration3.ts(6,30): error TS2305: Module 'X' has no exported member 'bar'.
+
+
+==== tests/cases/compiler/exportSpecifierReferencingOuterDeclaration3.ts (1 errors) ====
+    declare module X { export interface bar { } }
+    declare module "m" {
+        module X { export interface foo { } }
+        export { X };
+        export function foo(): X.foo;
+        export function bar(): X.bar; // error
+                                 ~~~
+!!! error TS2305: Module 'X' has no exported member 'bar'.
+    }

--- a/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration3.js
+++ b/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration3.js
@@ -1,0 +1,10 @@
+//// [exportSpecifierReferencingOuterDeclaration3.ts]
+declare module X { export interface bar { } }
+declare module "m" {
+    module X { export interface foo { } }
+    export { X };
+    export function foo(): X.foo;
+    export function bar(): X.bar; // error
+}
+
+//// [exportSpecifierReferencingOuterDeclaration3.js]

--- a/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration4.errors.txt
+++ b/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration4.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/compiler/exportSpecifierReferencingOuterDeclaration2_B.ts(4,34): error TS2305: Module 'X' has no exported member 'bar'.
+
+
+==== tests/cases/compiler/exportSpecifierReferencingOuterDeclaration2_A.ts (0 errors) ====
+    declare module X { export interface bar { } }
+    
+==== tests/cases/compiler/exportSpecifierReferencingOuterDeclaration2_B.ts (1 errors) ====
+    declare module X { export interface foo { } }
+    export { X };
+    export declare function foo(): X.foo;
+    export declare function bar(): X.bar; // error
+                                     ~~~
+!!! error TS2305: Module 'X' has no exported member 'bar'.

--- a/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration4.js
+++ b/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration4.js
@@ -1,0 +1,13 @@
+//// [tests/cases/compiler/exportSpecifierReferencingOuterDeclaration4.ts] ////
+
+//// [exportSpecifierReferencingOuterDeclaration2_A.ts]
+declare module X { export interface bar { } }
+
+//// [exportSpecifierReferencingOuterDeclaration2_B.ts]
+declare module X { export interface foo { } }
+export { X };
+export declare function foo(): X.foo;
+export declare function bar(): X.bar; // error
+
+//// [exportSpecifierReferencingOuterDeclaration2_A.js]
+//// [exportSpecifierReferencingOuterDeclaration2_B.js]

--- a/tests/cases/compiler/exportSpecifierAndExportedMemberDeclaration.ts
+++ b/tests/cases/compiler/exportSpecifierAndExportedMemberDeclaration.ts
@@ -1,0 +1,12 @@
+declare module "m2" {
+    export module X {
+        interface I { }
+    }
+    function Y();
+    export { Y as X };
+    function Z(): X.I;
+}
+
+declare module "m2" {
+    function Z2(): X.I;
+}

--- a/tests/cases/compiler/exportSpecifierAndLocalMemberDeclaration.ts
+++ b/tests/cases/compiler/exportSpecifierAndLocalMemberDeclaration.ts
@@ -1,0 +1,12 @@
+declare module "m2" {
+    module X {
+        interface I { }
+    }
+    function Y();
+    export { Y as X };
+    function Z(): X.I;
+}
+
+declare module "m2" {
+    function Z2(): X.I;
+}

--- a/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration1.ts
+++ b/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration1.ts
@@ -1,0 +1,5 @@
+declare module X { export interface bar { } }
+declare module "m" {
+    export { X };
+    export function foo(): X.bar;
+}

--- a/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration2.ts
+++ b/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration2.ts
@@ -1,0 +1,7 @@
+// @module: commonjs
+// @Filename: exportSpecifierReferencingOuterDeclaration2_A.ts
+declare module X { export interface bar { } }
+
+// @Filename: exportSpecifierReferencingOuterDeclaration2_B.ts
+export { X };
+export declare function foo(): X.bar;

--- a/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration3.ts
+++ b/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration3.ts
@@ -1,0 +1,7 @@
+declare module X { export interface bar { } }
+declare module "m" {
+    module X { export interface foo { } }
+    export { X };
+    export function foo(): X.foo;
+    export function bar(): X.bar; // error
+}

--- a/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration4.ts
+++ b/tests/cases/compiler/exportSpecifierReferencingOuterDeclaration4.ts
@@ -1,0 +1,9 @@
+// @module: commonjs
+// @Filename: exportSpecifierReferencingOuterDeclaration2_A.ts
+declare module X { export interface bar { } }
+
+// @Filename: exportSpecifierReferencingOuterDeclaration2_B.ts
+declare module X { export interface foo { } }
+export { X };
+export declare function foo(): X.foo;
+export declare function bar(): X.bar; // error


### PR DESCRIPTION
Fixes #3514 in release-1.5.

Export specifiers never put a symbol in scope in a module. Right now, resolveName calls getSymbol on the exports of the module, and if it finds an export specifier, dismisses it and keeps going. The problem is that getSymbol may try to resolveAlias on the export specifier, which would indirectly detect a circular reference if the target of the export specifier is outside the module.

The fix in this PR is to detect if the symbol in resolveName is an export specifier *without* calling getSymbol. Other than that, this PR is intended to keep the behavior pretty much the same.

This highlights an interesting difference between export modifiers and export specifiers when it comes to declaration merging of ambient external modules. I will open an issue to track this behavior discussion (#3535).

Another potential fix is to create two different symbol tables for the exports of external modules, one for loose exports that are put into scope, and one for strict exports that do not. That is a much deeper and invasive change though, and is likely not appropriate for release-1.5.