### PR TITLE
Emit declarations of namespaces correctly

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -361,7 +361,7 @@ compileFile(servicesFile, servicesSources,[builtLocalDirectory, copyright].conca
                 // Create the node definition file by replacing 'ts' module with '"typescript"' as a module.
                 jake.cpR(standaloneDefinitionsFile, nodeDefinitionsFile, {silent: true});
                 var definitionFileContents = fs.readFileSync(nodeDefinitionsFile).toString();
-                definitionFileContents = definitionFileContents.replace(/declare namespace ts/g, 'declare module "typescript"');
+                definitionFileContents = definitionFileContents.replace(/declare (namespace|module) ts/g, 'declare module "typescript"');
                 fs.writeFileSync(nodeDefinitionsFile, definitionFileContents);
             });
 

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -361,7 +361,7 @@ compileFile(servicesFile, servicesSources,[builtLocalDirectory, copyright].conca
                 // Create the node definition file by replacing 'ts' module with '"typescript"' as a module.
                 jake.cpR(standaloneDefinitionsFile, nodeDefinitionsFile, {silent: true});
                 var definitionFileContents = fs.readFileSync(nodeDefinitionsFile).toString();
-                definitionFileContents = definitionFileContents.replace(/declare module ts/g, 'declare module "typescript"');
+                definitionFileContents = definitionFileContents.replace(/declare namespace ts/g, 'declare module "typescript"');
                 fs.writeFileSync(nodeDefinitionsFile, definitionFileContents);
             });
 

--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -709,7 +709,12 @@ namespace ts {
         function writeModuleDeclaration(node: ModuleDeclaration) {
             emitJsDocComments(node);
             emitModuleElementDeclarationFlags(node);
-            write("module ");
+            if (node.flags & NodeFlags.Namespace) {
+                write("namespace ");
+            }
+            else {
+                write("module ");
+            }
             writeTextOfNode(currentSourceFile, node.name);
             while (node.body.kind !== SyntaxKind.ModuleBlock) {
                 node = <ModuleDeclaration>node.body;

--- a/tests/baselines/reference/namespacesDeclaration.js
+++ b/tests/baselines/reference/namespacesDeclaration.js
@@ -1,0 +1,22 @@
+//// [namespacesDeclaration.ts]
+
+module M {
+   export namespace N {
+      export module M2 {
+         export interface I {}
+      }
+   }
+}
+
+//// [namespacesDeclaration.js]
+
+
+//// [namespacesDeclaration.d.ts]
+declare module M {
+    namespace N {
+        module M2 {
+            interface I {
+            }
+        }
+    }
+}

--- a/tests/baselines/reference/namespacesDeclaration.symbols
+++ b/tests/baselines/reference/namespacesDeclaration.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/namespacesDeclaration.ts ===
+
+module M {
+>M : Symbol(M, Decl(namespacesDeclaration.ts, 0, 0))
+
+   export namespace N {
+>N : Symbol(N, Decl(namespacesDeclaration.ts, 1, 10))
+
+      export module M2 {
+>M2 : Symbol(M2, Decl(namespacesDeclaration.ts, 2, 23))
+
+         export interface I {}
+>I : Symbol(I, Decl(namespacesDeclaration.ts, 3, 24))
+      }
+   }
+}

--- a/tests/baselines/reference/namespacesDeclaration.types
+++ b/tests/baselines/reference/namespacesDeclaration.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/namespacesDeclaration.ts ===
+
+module M {
+>M : any
+
+   export namespace N {
+>N : any
+
+      export module M2 {
+>M2 : any
+
+         export interface I {}
+>I : I
+      }
+   }
+}

--- a/tests/cases/compiler/namespacesDeclaration.ts
+++ b/tests/cases/compiler/namespacesDeclaration.ts
@@ -1,0 +1,9 @@
+// @declaration: true
+
+module M {
+   export namespace N {
+      export module M2 {
+         export interface I {}
+      }
+   }
+}


### PR DESCRIPTION
Fixes #3544. This is a follow up to #3491, emits `namespace` declarations as `namespaces` instead of `module`s. 