### PR TITLE
tsconfig.json exclude LS support

### DIFF
--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -64,8 +64,12 @@ namespace ts {
 
     /** Public interface of the the of a config service shim instance.*/
     export interface CoreServicesShimHost extends Logger {
-        /** Returns a JSON-encoded value of the type: string[] */
-        readDirectory(rootDir: string, extension: string): string;
+        /** Returns a JSON-encoded value of the type: string[] 
+         *
+         * @param exclude A JSON encoded string[] containing the paths to exclude
+         *  when enumerating the directory.
+         */
+        readDirectory(rootDir: string, extension: string, exclude?: string): string;
     }
 
     ///
@@ -386,8 +390,18 @@ namespace ts {
         constructor(private shimHost: CoreServicesShimHost) {
         }
 
-        public readDirectory(rootDir: string, extension: string): string[] {
-            var encoded = this.shimHost.readDirectory(rootDir, extension);
+        public readDirectory(rootDir: string, extension: string, exclude: string[]): string[] {
+            // Wrap the API changes for 1.5 release. This try/catch
+            // should be removed once TypeScript 1.5 has shipped.
+            // Also consider removing the optional designation for
+            // the exclude param at this time.
+            var encoded: string;
+            try {
+                encoded = this.shimHost.readDirectory(rootDir, extension, JSON.stringify(exclude));
+            }
+            catch (e) {
+                encoded = this.shimHost.readDirectory(rootDir, extension);
+            }
             return JSON.parse(encoded);
         }
     }

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -64,7 +64,8 @@ namespace ts {
 
     /** Public interface of the the of a config service shim instance.*/
     export interface CoreServicesShimHost extends Logger {
-        /** Returns a JSON-encoded value of the type: string[] 
+        /**
+         * Returns a JSON-encoded value of the type: string[]
          *
          * @param exclude A JSON encoded string[] containing the paths to exclude
          *  when enumerating the directory.


### PR DESCRIPTION
@CyrusNajmabadi, @vladima,  @billti : CoreServicesShimHost and CoreServicesShimHostAdapter changes to support tsconfig.json exclude from the language service.

