### PR TITLE
Add a non-generic construct signature to Map, Set, and WeakMap

### DIFF
--- a/src/lib/es6.d.ts
+++ b/src/lib/es6.d.ts
@@ -694,6 +694,7 @@ interface Map<K, V> {
 }
 
 interface MapConstructor {
+    new (): Map<any, any>;
     new <K, V>(): Map<K, V>;
     new <K, V>(iterable: Iterable<[K, V]>): Map<K, V>;
     prototype: Map<any, any>;
@@ -710,6 +711,7 @@ interface WeakMap<K, V> {
 }
 
 interface WeakMapConstructor {
+    new (): WeakMap<any, any>;
     new <K, V>(): WeakMap<K, V>;
     new <K, V>(iterable: Iterable<[K, V]>): WeakMap<K, V>;
     prototype: WeakMap<any, any>;
@@ -731,6 +733,7 @@ interface Set<T> {
 }
 
 interface SetConstructor {
+    new (): Set<any>;
     new <T>(): Set<T>;
     new <T>(iterable: Iterable<T>): Set<T>;
     prototype: Set<any>;
@@ -746,6 +749,7 @@ interface WeakSet<T> {
 }
 
 interface WeakSetConstructor {
+    new (): WeakSet<any>;
     new <T>(): WeakSet<T>;
     new <T>(iterable: Iterable<T>): WeakSet<T>;
     prototype: WeakSet<any>;

--- a/tests/baselines/reference/for-of37.symbols
+++ b/tests/baselines/reference/for-of37.symbols
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/for-ofStatements/for-of37.ts ===
 var map = new Map([["", true]]);
 >map : Symbol(map, Decl(for-of37.ts, 0, 3))
->Map : Symbol(Map, Decl(lib.d.ts, 1864, 1), Decl(lib.d.ts, 1886, 11))
+>Map : Symbol(Map, Decl(lib.d.ts, 1864, 1), Decl(lib.d.ts, 1887, 11))
 
 for (var v of map) {
 >v : Symbol(v, Decl(for-of37.ts, 1, 8))

--- a/tests/baselines/reference/for-of38.symbols
+++ b/tests/baselines/reference/for-of38.symbols
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/for-ofStatements/for-of38.ts ===
 var map = new Map([["", true]]);
 >map : Symbol(map, Decl(for-of38.ts, 0, 3))
->Map : Symbol(Map, Decl(lib.d.ts, 1864, 1), Decl(lib.d.ts, 1886, 11))
+>Map : Symbol(Map, Decl(lib.d.ts, 1864, 1), Decl(lib.d.ts, 1887, 11))
 
 for (var [k, v] of map) {
 >k : Symbol(k, Decl(for-of38.ts, 1, 10))

--- a/tests/baselines/reference/for-of40.symbols
+++ b/tests/baselines/reference/for-of40.symbols
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/for-ofStatements/for-of40.ts ===
 var map = new Map([["", true]]);
 >map : Symbol(map, Decl(for-of40.ts, 0, 3))
->Map : Symbol(Map, Decl(lib.d.ts, 1864, 1), Decl(lib.d.ts, 1886, 11))
+>Map : Symbol(Map, Decl(lib.d.ts, 1864, 1), Decl(lib.d.ts, 1887, 11))
 
 for (var [k = "", v = false] of map) {
 >k : Symbol(k, Decl(for-of40.ts, 1, 10))

--- a/tests/baselines/reference/for-of45.symbols
+++ b/tests/baselines/reference/for-of45.symbols
@@ -5,7 +5,7 @@ var k: string, v: boolean;
 
 var map = new Map([["", true]]);
 >map : Symbol(map, Decl(for-of45.ts, 1, 3))
->Map : Symbol(Map, Decl(lib.d.ts, 1864, 1), Decl(lib.d.ts, 1886, 11))
+>Map : Symbol(Map, Decl(lib.d.ts, 1864, 1), Decl(lib.d.ts, 1887, 11))
 
 for ([k = "", v = false] of map) {
 >k : Symbol(k, Decl(for-of45.ts, 0, 3))

--- a/tests/baselines/reference/for-of50.symbols
+++ b/tests/baselines/reference/for-of50.symbols
@@ -1,7 +1,7 @@
 === tests/cases/conformance/es6/for-ofStatements/for-of50.ts ===
 var map = new Map([["", true]]);
 >map : Symbol(map, Decl(for-of50.ts, 0, 3))
->Map : Symbol(Map, Decl(lib.d.ts, 1864, 1), Decl(lib.d.ts, 1886, 11))
+>Map : Symbol(Map, Decl(lib.d.ts, 1864, 1), Decl(lib.d.ts, 1887, 11))
 
 for (const [k, v] of map) {
 >k : Symbol(k, Decl(for-of50.ts, 1, 12))

--- a/tests/baselines/reference/iterableArrayPattern30.symbols
+++ b/tests/baselines/reference/iterableArrayPattern30.symbols
@@ -4,5 +4,5 @@ const [[k1, v1], [k2, v2]] = new Map([["", true], ["hello", true]])
 >v1 : Symbol(v1, Decl(iterableArrayPattern30.ts, 0, 11))
 >k2 : Symbol(k2, Decl(iterableArrayPattern30.ts, 0, 18))
 >v2 : Symbol(v2, Decl(iterableArrayPattern30.ts, 0, 21))
->Map : Symbol(Map, Decl(lib.d.ts, 1864, 1), Decl(lib.d.ts, 1886, 11))
+>Map : Symbol(Map, Decl(lib.d.ts, 1864, 1), Decl(lib.d.ts, 1887, 11))
 

--- a/tests/baselines/reference/promiseVoidErrorCallback.symbols
+++ b/tests/baselines/reference/promiseVoidErrorCallback.symbols
@@ -22,13 +22,13 @@ interface T3 {
 
 function f1(): Promise<T1> {
 >f1 : Symbol(f1, Decl(promiseVoidErrorCallback.ts, 10, 1))
->Promise : Symbol(Promise, Decl(lib.d.ts, 4766, 1), Decl(lib.d.ts, 4851, 11))
+>Promise : Symbol(Promise, Decl(lib.d.ts, 4770, 1), Decl(lib.d.ts, 4855, 11))
 >T1 : Symbol(T1, Decl(promiseVoidErrorCallback.ts, 0, 0))
 
     return Promise.resolve({ __t1: "foo_t1" });
->Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.d.ts, 4833, 39), Decl(lib.d.ts, 4840, 54))
->Promise : Symbol(Promise, Decl(lib.d.ts, 4766, 1), Decl(lib.d.ts, 4851, 11))
->resolve : Symbol(PromiseConstructor.resolve, Decl(lib.d.ts, 4833, 39), Decl(lib.d.ts, 4840, 54))
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.d.ts, 4837, 39), Decl(lib.d.ts, 4844, 54))
+>Promise : Symbol(Promise, Decl(lib.d.ts, 4770, 1), Decl(lib.d.ts, 4855, 11))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.d.ts, 4837, 39), Decl(lib.d.ts, 4844, 54))
 >__t1 : Symbol(__t1, Decl(promiseVoidErrorCallback.ts, 13, 28))
 }
 
@@ -47,12 +47,12 @@ function f2(x: T1): T2 {
 
 var x3 = f1()
 >x3 : Symbol(x3, Decl(promiseVoidErrorCallback.ts, 20, 3))
->f1()    .then(f2, (e: Error) => {    throw e;})    .then : Symbol(Promise.then, Decl(lib.d.ts, 4771, 22), Decl(lib.d.ts, 4778, 158))
->f1()    .then : Symbol(Promise.then, Decl(lib.d.ts, 4771, 22), Decl(lib.d.ts, 4778, 158))
+>f1()    .then(f2, (e: Error) => {    throw e;})    .then : Symbol(Promise.then, Decl(lib.d.ts, 4775, 22), Decl(lib.d.ts, 4782, 158))
+>f1()    .then : Symbol(Promise.then, Decl(lib.d.ts, 4775, 22), Decl(lib.d.ts, 4782, 158))
 >f1 : Symbol(f1, Decl(promiseVoidErrorCallback.ts, 10, 1))
 
     .then(f2, (e: Error) => {
->then : Symbol(Promise.then, Decl(lib.d.ts, 4771, 22), Decl(lib.d.ts, 4778, 158))
+>then : Symbol(Promise.then, Decl(lib.d.ts, 4775, 22), Decl(lib.d.ts, 4782, 158))
 >f2 : Symbol(f2, Decl(promiseVoidErrorCallback.ts, 14, 1))
 >e : Symbol(e, Decl(promiseVoidErrorCallback.ts, 21, 15))
 >Error : Symbol(Error, Decl(lib.d.ts, 876, 38), Decl(lib.d.ts, 889, 11))
@@ -62,7 +62,7 @@ var x3 = f1()
 
 })
     .then((x: T2) => {
->then : Symbol(Promise.then, Decl(lib.d.ts, 4771, 22), Decl(lib.d.ts, 4778, 158))
+>then : Symbol(Promise.then, Decl(lib.d.ts, 4775, 22), Decl(lib.d.ts, 4782, 158))
 >x : Symbol(x, Decl(promiseVoidErrorCallback.ts, 24, 11))
 >T2 : Symbol(T2, Decl(promiseVoidErrorCallback.ts, 2, 1))
 

--- a/tests/baselines/reference/typedArrays.symbols
+++ b/tests/baselines/reference/typedArrays.symbols
@@ -8,39 +8,39 @@ function CreateTypedArrayTypes() {
 
     typedArrays[0] = Int8Array;
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 2, 7))
->Int8Array : Symbol(Int8Array, Decl(lib.d.ts, 2104, 42), Decl(lib.d.ts, 2394, 11))
+>Int8Array : Symbol(Int8Array, Decl(lib.d.ts, 2108, 42), Decl(lib.d.ts, 2398, 11))
 
     typedArrays[1] = Uint8Array;
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 2, 7))
->Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, 2394, 44), Decl(lib.d.ts, 2684, 11))
+>Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, 2398, 44), Decl(lib.d.ts, 2688, 11))
 
     typedArrays[2] = Int16Array;
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 2, 7))
->Int16Array : Symbol(Int16Array, Decl(lib.d.ts, 2974, 60), Decl(lib.d.ts, 3264, 11))
+>Int16Array : Symbol(Int16Array, Decl(lib.d.ts, 2978, 60), Decl(lib.d.ts, 3268, 11))
 
     typedArrays[3] = Uint16Array;
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 2, 7))
->Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, 3264, 46), Decl(lib.d.ts, 3554, 11))
+>Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, 3268, 46), Decl(lib.d.ts, 3558, 11))
 
     typedArrays[4] = Int32Array;
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 2, 7))
->Int32Array : Symbol(Int32Array, Decl(lib.d.ts, 3554, 48), Decl(lib.d.ts, 3844, 11))
+>Int32Array : Symbol(Int32Array, Decl(lib.d.ts, 3558, 48), Decl(lib.d.ts, 3848, 11))
 
     typedArrays[5] = Uint32Array;
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 2, 7))
->Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, 3844, 46), Decl(lib.d.ts, 4134, 11))
+>Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, 3848, 46), Decl(lib.d.ts, 4138, 11))
 
     typedArrays[6] = Float32Array;
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 2, 7))
->Float32Array : Symbol(Float32Array, Decl(lib.d.ts, 4134, 48), Decl(lib.d.ts, 4424, 11))
+>Float32Array : Symbol(Float32Array, Decl(lib.d.ts, 4138, 48), Decl(lib.d.ts, 4428, 11))
 
     typedArrays[7] = Float64Array;
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 2, 7))
->Float64Array : Symbol(Float64Array, Decl(lib.d.ts, 4424, 50), Decl(lib.d.ts, 4714, 11))
+>Float64Array : Symbol(Float64Array, Decl(lib.d.ts, 4428, 50), Decl(lib.d.ts, 4718, 11))
 
     typedArrays[8] = Uint8ClampedArray;
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 2, 7))
->Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, 2684, 46), Decl(lib.d.ts, 2974, 11))
+>Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, 2688, 46), Decl(lib.d.ts, 2978, 11))
 
     return typedArrays;
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 2, 7))
@@ -55,47 +55,47 @@ function CreateTypedArrayInstancesFromLength(obj: number) {
 
     typedArrays[0] = new Int8Array(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 17, 7))
->Int8Array : Symbol(Int8Array, Decl(lib.d.ts, 2104, 42), Decl(lib.d.ts, 2394, 11))
+>Int8Array : Symbol(Int8Array, Decl(lib.d.ts, 2108, 42), Decl(lib.d.ts, 2398, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 16, 45))
 
     typedArrays[1] = new Uint8Array(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 17, 7))
->Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, 2394, 44), Decl(lib.d.ts, 2684, 11))
+>Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, 2398, 44), Decl(lib.d.ts, 2688, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 16, 45))
 
     typedArrays[2] = new Int16Array(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 17, 7))
->Int16Array : Symbol(Int16Array, Decl(lib.d.ts, 2974, 60), Decl(lib.d.ts, 3264, 11))
+>Int16Array : Symbol(Int16Array, Decl(lib.d.ts, 2978, 60), Decl(lib.d.ts, 3268, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 16, 45))
 
     typedArrays[3] = new Uint16Array(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 17, 7))
->Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, 3264, 46), Decl(lib.d.ts, 3554, 11))
+>Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, 3268, 46), Decl(lib.d.ts, 3558, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 16, 45))
 
     typedArrays[4] = new Int32Array(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 17, 7))
->Int32Array : Symbol(Int32Array, Decl(lib.d.ts, 3554, 48), Decl(lib.d.ts, 3844, 11))
+>Int32Array : Symbol(Int32Array, Decl(lib.d.ts, 3558, 48), Decl(lib.d.ts, 3848, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 16, 45))
 
     typedArrays[5] = new Uint32Array(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 17, 7))
->Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, 3844, 46), Decl(lib.d.ts, 4134, 11))
+>Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, 3848, 46), Decl(lib.d.ts, 4138, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 16, 45))
 
     typedArrays[6] = new Float32Array(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 17, 7))
->Float32Array : Symbol(Float32Array, Decl(lib.d.ts, 4134, 48), Decl(lib.d.ts, 4424, 11))
+>Float32Array : Symbol(Float32Array, Decl(lib.d.ts, 4138, 48), Decl(lib.d.ts, 4428, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 16, 45))
 
     typedArrays[7] = new Float64Array(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 17, 7))
->Float64Array : Symbol(Float64Array, Decl(lib.d.ts, 4424, 50), Decl(lib.d.ts, 4714, 11))
+>Float64Array : Symbol(Float64Array, Decl(lib.d.ts, 4428, 50), Decl(lib.d.ts, 4718, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 16, 45))
 
     typedArrays[8] = new Uint8ClampedArray(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 17, 7))
->Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, 2684, 46), Decl(lib.d.ts, 2974, 11))
+>Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, 2688, 46), Decl(lib.d.ts, 2978, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 16, 45))
 
     return typedArrays;
@@ -111,47 +111,47 @@ function CreateTypedArrayInstancesFromArray(obj: number[]) {
 
     typedArrays[0] = new Int8Array(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 32, 7))
->Int8Array : Symbol(Int8Array, Decl(lib.d.ts, 2104, 42), Decl(lib.d.ts, 2394, 11))
+>Int8Array : Symbol(Int8Array, Decl(lib.d.ts, 2108, 42), Decl(lib.d.ts, 2398, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 31, 44))
 
     typedArrays[1] = new Uint8Array(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 32, 7))
->Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, 2394, 44), Decl(lib.d.ts, 2684, 11))
+>Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, 2398, 44), Decl(lib.d.ts, 2688, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 31, 44))
 
     typedArrays[2] = new Int16Array(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 32, 7))
->Int16Array : Symbol(Int16Array, Decl(lib.d.ts, 2974, 60), Decl(lib.d.ts, 3264, 11))
+>Int16Array : Symbol(Int16Array, Decl(lib.d.ts, 2978, 60), Decl(lib.d.ts, 3268, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 31, 44))
 
     typedArrays[3] = new Uint16Array(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 32, 7))
->Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, 3264, 46), Decl(lib.d.ts, 3554, 11))
+>Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, 3268, 46), Decl(lib.d.ts, 3558, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 31, 44))
 
     typedArrays[4] = new Int32Array(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 32, 7))
->Int32Array : Symbol(Int32Array, Decl(lib.d.ts, 3554, 48), Decl(lib.d.ts, 3844, 11))
+>Int32Array : Symbol(Int32Array, Decl(lib.d.ts, 3558, 48), Decl(lib.d.ts, 3848, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 31, 44))
 
     typedArrays[5] = new Uint32Array(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 32, 7))
->Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, 3844, 46), Decl(lib.d.ts, 4134, 11))
+>Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, 3848, 46), Decl(lib.d.ts, 4138, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 31, 44))
 
     typedArrays[6] = new Float32Array(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 32, 7))
->Float32Array : Symbol(Float32Array, Decl(lib.d.ts, 4134, 48), Decl(lib.d.ts, 4424, 11))
+>Float32Array : Symbol(Float32Array, Decl(lib.d.ts, 4138, 48), Decl(lib.d.ts, 4428, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 31, 44))
 
     typedArrays[7] = new Float64Array(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 32, 7))
->Float64Array : Symbol(Float64Array, Decl(lib.d.ts, 4424, 50), Decl(lib.d.ts, 4714, 11))
+>Float64Array : Symbol(Float64Array, Decl(lib.d.ts, 4428, 50), Decl(lib.d.ts, 4718, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 31, 44))
 
     typedArrays[8] = new Uint8ClampedArray(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 32, 7))
->Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, 2684, 46), Decl(lib.d.ts, 2974, 11))
+>Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, 2688, 46), Decl(lib.d.ts, 2978, 11))
 >obj : Symbol(obj, Decl(typedArrays.ts, 31, 44))
 
     return typedArrays;
@@ -167,65 +167,65 @@ function CreateIntegerTypedArraysFromArray2(obj:number[]) {
 
     typedArrays[0] = Int8Array.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 47, 7))
->Int8Array.from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, 2384, 38))
->Int8Array : Symbol(Int8Array, Decl(lib.d.ts, 2104, 42), Decl(lib.d.ts, 2394, 11))
->from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, 2384, 38))
+>Int8Array.from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, 2388, 38))
+>Int8Array : Symbol(Int8Array, Decl(lib.d.ts, 2108, 42), Decl(lib.d.ts, 2398, 11))
+>from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, 2388, 38))
 >obj : Symbol(obj, Decl(typedArrays.ts, 46, 44))
 
     typedArrays[1] = Uint8Array.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 47, 7))
->Uint8Array.from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, 2674, 39))
->Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, 2394, 44), Decl(lib.d.ts, 2684, 11))
->from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, 2674, 39))
+>Uint8Array.from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, 2678, 39))
+>Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, 2398, 44), Decl(lib.d.ts, 2688, 11))
+>from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, 2678, 39))
 >obj : Symbol(obj, Decl(typedArrays.ts, 46, 44))
 
     typedArrays[2] = Int16Array.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 47, 7))
->Int16Array.from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, 3254, 39))
->Int16Array : Symbol(Int16Array, Decl(lib.d.ts, 2974, 60), Decl(lib.d.ts, 3264, 11))
->from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, 3254, 39))
+>Int16Array.from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, 3258, 39))
+>Int16Array : Symbol(Int16Array, Decl(lib.d.ts, 2978, 60), Decl(lib.d.ts, 3268, 11))
+>from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, 3258, 39))
 >obj : Symbol(obj, Decl(typedArrays.ts, 46, 44))
 
     typedArrays[3] = Uint16Array.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 47, 7))
->Uint16Array.from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, 3544, 40))
->Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, 3264, 46), Decl(lib.d.ts, 3554, 11))
->from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, 3544, 40))
+>Uint16Array.from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, 3548, 40))
+>Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, 3268, 46), Decl(lib.d.ts, 3558, 11))
+>from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, 3548, 40))
 >obj : Symbol(obj, Decl(typedArrays.ts, 46, 44))
 
     typedArrays[4] = Int32Array.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 47, 7))
->Int32Array.from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, 3834, 39))
->Int32Array : Symbol(Int32Array, Decl(lib.d.ts, 3554, 48), Decl(lib.d.ts, 3844, 11))
->from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, 3834, 39))
+>Int32Array.from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, 3838, 39))
+>Int32Array : Symbol(Int32Array, Decl(lib.d.ts, 3558, 48), Decl(lib.d.ts, 3848, 11))
+>from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, 3838, 39))
 >obj : Symbol(obj, Decl(typedArrays.ts, 46, 44))
 
     typedArrays[5] = Uint32Array.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 47, 7))
->Uint32Array.from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, 4124, 40))
->Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, 3844, 46), Decl(lib.d.ts, 4134, 11))
->from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, 4124, 40))
+>Uint32Array.from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, 4128, 40))
+>Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, 3848, 46), Decl(lib.d.ts, 4138, 11))
+>from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, 4128, 40))
 >obj : Symbol(obj, Decl(typedArrays.ts, 46, 44))
 
     typedArrays[6] = Float32Array.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 47, 7))
->Float32Array.from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, 4414, 41))
->Float32Array : Symbol(Float32Array, Decl(lib.d.ts, 4134, 48), Decl(lib.d.ts, 4424, 11))
->from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, 4414, 41))
+>Float32Array.from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, 4418, 41))
+>Float32Array : Symbol(Float32Array, Decl(lib.d.ts, 4138, 48), Decl(lib.d.ts, 4428, 11))
+>from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, 4418, 41))
 >obj : Symbol(obj, Decl(typedArrays.ts, 46, 44))
 
     typedArrays[7] = Float64Array.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 47, 7))
->Float64Array.from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, 4704, 41))
->Float64Array : Symbol(Float64Array, Decl(lib.d.ts, 4424, 50), Decl(lib.d.ts, 4714, 11))
->from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, 4704, 41))
+>Float64Array.from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, 4708, 41))
+>Float64Array : Symbol(Float64Array, Decl(lib.d.ts, 4428, 50), Decl(lib.d.ts, 4718, 11))
+>from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, 4708, 41))
 >obj : Symbol(obj, Decl(typedArrays.ts, 46, 44))
 
     typedArrays[8] = Uint8ClampedArray.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 47, 7))
->Uint8ClampedArray.from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, 2964, 46))
->Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, 2684, 46), Decl(lib.d.ts, 2974, 11))
->from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, 2964, 46))
+>Uint8ClampedArray.from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, 2968, 46))
+>Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, 2688, 46), Decl(lib.d.ts, 2978, 11))
+>from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, 2968, 46))
 >obj : Symbol(obj, Decl(typedArrays.ts, 46, 44))
 
     return typedArrays;
@@ -242,65 +242,65 @@ function CreateIntegerTypedArraysFromArrayLike(obj:ArrayLike<number>) {
 
     typedArrays[0] = Int8Array.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 62, 7))
->Int8Array.from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, 2384, 38))
->Int8Array : Symbol(Int8Array, Decl(lib.d.ts, 2104, 42), Decl(lib.d.ts, 2394, 11))
->from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, 2384, 38))
+>Int8Array.from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, 2388, 38))
+>Int8Array : Symbol(Int8Array, Decl(lib.d.ts, 2108, 42), Decl(lib.d.ts, 2398, 11))
+>from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, 2388, 38))
 >obj : Symbol(obj, Decl(typedArrays.ts, 61, 47))
 
     typedArrays[1] = Uint8Array.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 62, 7))
->Uint8Array.from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, 2674, 39))
->Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, 2394, 44), Decl(lib.d.ts, 2684, 11))
->from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, 2674, 39))
+>Uint8Array.from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, 2678, 39))
+>Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, 2398, 44), Decl(lib.d.ts, 2688, 11))
+>from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, 2678, 39))
 >obj : Symbol(obj, Decl(typedArrays.ts, 61, 47))
 
     typedArrays[2] = Int16Array.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 62, 7))
->Int16Array.from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, 3254, 39))
->Int16Array : Symbol(Int16Array, Decl(lib.d.ts, 2974, 60), Decl(lib.d.ts, 3264, 11))
->from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, 3254, 39))
+>Int16Array.from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, 3258, 39))
+>Int16Array : Symbol(Int16Array, Decl(lib.d.ts, 2978, 60), Decl(lib.d.ts, 3268, 11))
+>from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, 3258, 39))
 >obj : Symbol(obj, Decl(typedArrays.ts, 61, 47))
 
     typedArrays[3] = Uint16Array.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 62, 7))
->Uint16Array.from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, 3544, 40))
->Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, 3264, 46), Decl(lib.d.ts, 3554, 11))
->from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, 3544, 40))
+>Uint16Array.from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, 3548, 40))
+>Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, 3268, 46), Decl(lib.d.ts, 3558, 11))
+>from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, 3548, 40))
 >obj : Symbol(obj, Decl(typedArrays.ts, 61, 47))
 
     typedArrays[4] = Int32Array.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 62, 7))
->Int32Array.from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, 3834, 39))
->Int32Array : Symbol(Int32Array, Decl(lib.d.ts, 3554, 48), Decl(lib.d.ts, 3844, 11))
->from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, 3834, 39))
+>Int32Array.from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, 3838, 39))
+>Int32Array : Symbol(Int32Array, Decl(lib.d.ts, 3558, 48), Decl(lib.d.ts, 3848, 11))
+>from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, 3838, 39))
 >obj : Symbol(obj, Decl(typedArrays.ts, 61, 47))
 
     typedArrays[5] = Uint32Array.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 62, 7))
->Uint32Array.from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, 4124, 40))
->Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, 3844, 46), Decl(lib.d.ts, 4134, 11))
->from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, 4124, 40))
+>Uint32Array.from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, 4128, 40))
+>Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, 3848, 46), Decl(lib.d.ts, 4138, 11))
+>from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, 4128, 40))
 >obj : Symbol(obj, Decl(typedArrays.ts, 61, 47))
 
     typedArrays[6] = Float32Array.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 62, 7))
->Float32Array.from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, 4414, 41))
->Float32Array : Symbol(Float32Array, Decl(lib.d.ts, 4134, 48), Decl(lib.d.ts, 4424, 11))
->from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, 4414, 41))
+>Float32Array.from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, 4418, 41))
+>Float32Array : Symbol(Float32Array, Decl(lib.d.ts, 4138, 48), Decl(lib.d.ts, 4428, 11))
+>from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, 4418, 41))
 >obj : Symbol(obj, Decl(typedArrays.ts, 61, 47))
 
     typedArrays[7] = Float64Array.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 62, 7))
->Float64Array.from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, 4704, 41))
->Float64Array : Symbol(Float64Array, Decl(lib.d.ts, 4424, 50), Decl(lib.d.ts, 4714, 11))
->from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, 4704, 41))
+>Float64Array.from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, 4708, 41))
+>Float64Array : Symbol(Float64Array, Decl(lib.d.ts, 4428, 50), Decl(lib.d.ts, 4718, 11))
+>from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, 4708, 41))
 >obj : Symbol(obj, Decl(typedArrays.ts, 61, 47))
 
     typedArrays[8] = Uint8ClampedArray.from(obj);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 62, 7))
->Uint8ClampedArray.from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, 2964, 46))
->Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, 2684, 46), Decl(lib.d.ts, 2974, 11))
->from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, 2964, 46))
+>Uint8ClampedArray.from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, 2968, 46))
+>Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, 2688, 46), Decl(lib.d.ts, 2978, 11))
+>from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, 2968, 46))
 >obj : Symbol(obj, Decl(typedArrays.ts, 61, 47))
 
     return typedArrays;
@@ -332,57 +332,57 @@ function CreateTypedArraysOf2() {
 
     typedArrays[0] = Int8Array.of(1,2,3,4);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
->Int8Array.of : Symbol(Int8ArrayConstructor.of, Decl(lib.d.ts, 2378, 30))
->Int8Array : Symbol(Int8Array, Decl(lib.d.ts, 2104, 42), Decl(lib.d.ts, 2394, 11))
->of : Symbol(Int8ArrayConstructor.of, Decl(lib.d.ts, 2378, 30))
+>Int8Array.of : Symbol(Int8ArrayConstructor.of, Decl(lib.d.ts, 2382, 30))
+>Int8Array : Symbol(Int8Array, Decl(lib.d.ts, 2108, 42), Decl(lib.d.ts, 2398, 11))
+>of : Symbol(Int8ArrayConstructor.of, Decl(lib.d.ts, 2382, 30))
 
     typedArrays[1] = Uint8Array.of(1,2,3,4);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
->Uint8Array.of : Symbol(Uint8ArrayConstructor.of, Decl(lib.d.ts, 2668, 30))
->Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, 2394, 44), Decl(lib.d.ts, 2684, 11))
->of : Symbol(Uint8ArrayConstructor.of, Decl(lib.d.ts, 2668, 30))
+>Uint8Array.of : Symbol(Uint8ArrayConstructor.of, Decl(lib.d.ts, 2672, 30))
+>Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, 2398, 44), Decl(lib.d.ts, 2688, 11))
+>of : Symbol(Uint8ArrayConstructor.of, Decl(lib.d.ts, 2672, 30))
 
     typedArrays[2] = Int16Array.of(1,2,3,4);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
->Int16Array.of : Symbol(Int16ArrayConstructor.of, Decl(lib.d.ts, 3248, 30))
->Int16Array : Symbol(Int16Array, Decl(lib.d.ts, 2974, 60), Decl(lib.d.ts, 3264, 11))
->of : Symbol(Int16ArrayConstructor.of, Decl(lib.d.ts, 3248, 30))
+>Int16Array.of : Symbol(Int16ArrayConstructor.of, Decl(lib.d.ts, 3252, 30))
+>Int16Array : Symbol(Int16Array, Decl(lib.d.ts, 2978, 60), Decl(lib.d.ts, 3268, 11))
+>of : Symbol(Int16ArrayConstructor.of, Decl(lib.d.ts, 3252, 30))
 
     typedArrays[3] = Uint16Array.of(1,2,3,4);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
->Uint16Array.of : Symbol(Uint16ArrayConstructor.of, Decl(lib.d.ts, 3538, 30))
->Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, 3264, 46), Decl(lib.d.ts, 3554, 11))
->of : Symbol(Uint16ArrayConstructor.of, Decl(lib.d.ts, 3538, 30))
+>Uint16Array.of : Symbol(Uint16ArrayConstructor.of, Decl(lib.d.ts, 3542, 30))
+>Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, 3268, 46), Decl(lib.d.ts, 3558, 11))
+>of : Symbol(Uint16ArrayConstructor.of, Decl(lib.d.ts, 3542, 30))
 
     typedArrays[4] = Int32Array.of(1,2,3,4);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
->Int32Array.of : Symbol(Int32ArrayConstructor.of, Decl(lib.d.ts, 3828, 30))
->Int32Array : Symbol(Int32Array, Decl(lib.d.ts, 3554, 48), Decl(lib.d.ts, 3844, 11))
->of : Symbol(Int32ArrayConstructor.of, Decl(lib.d.ts, 3828, 30))
+>Int32Array.of : Symbol(Int32ArrayConstructor.of, Decl(lib.d.ts, 3832, 30))
+>Int32Array : Symbol(Int32Array, Decl(lib.d.ts, 3558, 48), Decl(lib.d.ts, 3848, 11))
+>of : Symbol(Int32ArrayConstructor.of, Decl(lib.d.ts, 3832, 30))
 
     typedArrays[5] = Uint32Array.of(1,2,3,4);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
->Uint32Array.of : Symbol(Uint32ArrayConstructor.of, Decl(lib.d.ts, 4118, 30))
->Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, 3844, 46), Decl(lib.d.ts, 4134, 11))
->of : Symbol(Uint32ArrayConstructor.of, Decl(lib.d.ts, 4118, 30))
+>Uint32Array.of : Symbol(Uint32ArrayConstructor.of, Decl(lib.d.ts, 4122, 30))
+>Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, 3848, 46), Decl(lib.d.ts, 4138, 11))
+>of : Symbol(Uint32ArrayConstructor.of, Decl(lib.d.ts, 4122, 30))
 
     typedArrays[6] = Float32Array.of(1,2,3,4);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
->Float32Array.of : Symbol(Float32ArrayConstructor.of, Decl(lib.d.ts, 4408, 30))
->Float32Array : Symbol(Float32Array, Decl(lib.d.ts, 4134, 48), Decl(lib.d.ts, 4424, 11))
->of : Symbol(Float32ArrayConstructor.of, Decl(lib.d.ts, 4408, 30))
+>Float32Array.of : Symbol(Float32ArrayConstructor.of, Decl(lib.d.ts, 4412, 30))
+>Float32Array : Symbol(Float32Array, Decl(lib.d.ts, 4138, 48), Decl(lib.d.ts, 4428, 11))
+>of : Symbol(Float32ArrayConstructor.of, Decl(lib.d.ts, 4412, 30))
 
     typedArrays[7] = Float64Array.of(1,2,3,4);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
->Float64Array.of : Symbol(Float64ArrayConstructor.of, Decl(lib.d.ts, 4698, 30))
->Float64Array : Symbol(Float64Array, Decl(lib.d.ts, 4424, 50), Decl(lib.d.ts, 4714, 11))
->of : Symbol(Float64ArrayConstructor.of, Decl(lib.d.ts, 4698, 30))
+>Float64Array.of : Symbol(Float64ArrayConstructor.of, Decl(lib.d.ts, 4702, 30))
+>Float64Array : Symbol(Float64Array, Decl(lib.d.ts, 4428, 50), Decl(lib.d.ts, 4718, 11))
+>of : Symbol(Float64ArrayConstructor.of, Decl(lib.d.ts, 4702, 30))
 
     typedArrays[8] = Uint8ClampedArray.of(1,2,3,4);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
->Uint8ClampedArray.of : Symbol(Uint8ClampedArrayConstructor.of, Decl(lib.d.ts, 2958, 30))
->Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, 2684, 46), Decl(lib.d.ts, 2974, 11))
->of : Symbol(Uint8ClampedArrayConstructor.of, Decl(lib.d.ts, 2958, 30))
+>Uint8ClampedArray.of : Symbol(Uint8ClampedArrayConstructor.of, Decl(lib.d.ts, 2962, 30))
+>Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, 2688, 46), Decl(lib.d.ts, 2978, 11))
+>of : Symbol(Uint8ClampedArrayConstructor.of, Decl(lib.d.ts, 2962, 30))
 
     return typedArrays;
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
@@ -401,73 +401,73 @@ function CreateTypedArraysFromMapFn(obj:ArrayLike<number>, mapFn: (n:number, v:n
 
     typedArrays[0] = Int8Array.from(obj, mapFn);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
->Int8Array.from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, 2384, 38))
->Int8Array : Symbol(Int8Array, Decl(lib.d.ts, 2104, 42), Decl(lib.d.ts, 2394, 11))
->from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, 2384, 38))
+>Int8Array.from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, 2388, 38))
+>Int8Array : Symbol(Int8Array, Decl(lib.d.ts, 2108, 42), Decl(lib.d.ts, 2398, 11))
+>from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, 2388, 38))
 >obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
 
     typedArrays[1] = Uint8Array.from(obj, mapFn);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
->Uint8Array.from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, 2674, 39))
->Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, 2394, 44), Decl(lib.d.ts, 2684, 11))
->from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, 2674, 39))
+>Uint8Array.from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, 2678, 39))
+>Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, 2398, 44), Decl(lib.d.ts, 2688, 11))
+>from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, 2678, 39))
 >obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
 
     typedArrays[2] = Int16Array.from(obj, mapFn);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
->Int16Array.from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, 3254, 39))
->Int16Array : Symbol(Int16Array, Decl(lib.d.ts, 2974, 60), Decl(lib.d.ts, 3264, 11))
->from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, 3254, 39))
+>Int16Array.from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, 3258, 39))
+>Int16Array : Symbol(Int16Array, Decl(lib.d.ts, 2978, 60), Decl(lib.d.ts, 3268, 11))
+>from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, 3258, 39))
 >obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
 
     typedArrays[3] = Uint16Array.from(obj, mapFn);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
->Uint16Array.from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, 3544, 40))
->Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, 3264, 46), Decl(lib.d.ts, 3554, 11))
->from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, 3544, 40))
+>Uint16Array.from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, 3548, 40))
+>Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, 3268, 46), Decl(lib.d.ts, 3558, 11))
+>from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, 3548, 40))
 >obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
 
     typedArrays[4] = Int32Array.from(obj, mapFn);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
->Int32Array.from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, 3834, 39))
->Int32Array : Symbol(Int32Array, Decl(lib.d.ts, 3554, 48), Decl(lib.d.ts, 3844, 11))
->from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, 3834, 39))
+>Int32Array.from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, 3838, 39))
+>Int32Array : Symbol(Int32Array, Decl(lib.d.ts, 3558, 48), Decl(lib.d.ts, 3848, 11))
+>from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, 3838, 39))
 >obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
 
     typedArrays[5] = Uint32Array.from(obj, mapFn);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
->Uint32Array.from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, 4124, 40))
->Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, 3844, 46), Decl(lib.d.ts, 4134, 11))
->from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, 4124, 40))
+>Uint32Array.from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, 4128, 40))
+>Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, 3848, 46), Decl(lib.d.ts, 4138, 11))
+>from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, 4128, 40))
 >obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
 
     typedArrays[6] = Float32Array.from(obj, mapFn);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
->Float32Array.from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, 4414, 41))
->Float32Array : Symbol(Float32Array, Decl(lib.d.ts, 4134, 48), Decl(lib.d.ts, 4424, 11))
->from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, 4414, 41))
+>Float32Array.from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, 4418, 41))
+>Float32Array : Symbol(Float32Array, Decl(lib.d.ts, 4138, 48), Decl(lib.d.ts, 4428, 11))
+>from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, 4418, 41))
 >obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
 
     typedArrays[7] = Float64Array.from(obj, mapFn);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
->Float64Array.from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, 4704, 41))
->Float64Array : Symbol(Float64Array, Decl(lib.d.ts, 4424, 50), Decl(lib.d.ts, 4714, 11))
->from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, 4704, 41))
+>Float64Array.from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, 4708, 41))
+>Float64Array : Symbol(Float64Array, Decl(lib.d.ts, 4428, 50), Decl(lib.d.ts, 4718, 11))
+>from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, 4708, 41))
 >obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
 
     typedArrays[8] = Uint8ClampedArray.from(obj, mapFn);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
->Uint8ClampedArray.from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, 2964, 46))
->Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, 2684, 46), Decl(lib.d.ts, 2974, 11))
->from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, 2964, 46))
+>Uint8ClampedArray.from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, 2968, 46))
+>Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, 2688, 46), Decl(lib.d.ts, 2978, 11))
+>from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, 2968, 46))
 >obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
 
@@ -489,81 +489,81 @@ function CreateTypedArraysFromThisObj(obj:ArrayLike<number>, mapFn: (n:number, v
 
     typedArrays[0] = Int8Array.from(obj, mapFn, thisArg);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
->Int8Array.from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, 2384, 38))
->Int8Array : Symbol(Int8Array, Decl(lib.d.ts, 2104, 42), Decl(lib.d.ts, 2394, 11))
->from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, 2384, 38))
+>Int8Array.from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, 2388, 38))
+>Int8Array : Symbol(Int8Array, Decl(lib.d.ts, 2108, 42), Decl(lib.d.ts, 2398, 11))
+>from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, 2388, 38))
 >obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
 >thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
 
     typedArrays[1] = Uint8Array.from(obj, mapFn, thisArg);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
->Uint8Array.from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, 2674, 39))
->Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, 2394, 44), Decl(lib.d.ts, 2684, 11))
->from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, 2674, 39))
+>Uint8Array.from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, 2678, 39))
+>Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, 2398, 44), Decl(lib.d.ts, 2688, 11))
+>from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, 2678, 39))
 >obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
 >thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
 
     typedArrays[2] = Int16Array.from(obj, mapFn, thisArg);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
->Int16Array.from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, 3254, 39))
->Int16Array : Symbol(Int16Array, Decl(lib.d.ts, 2974, 60), Decl(lib.d.ts, 3264, 11))
->from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, 3254, 39))
+>Int16Array.from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, 3258, 39))
+>Int16Array : Symbol(Int16Array, Decl(lib.d.ts, 2978, 60), Decl(lib.d.ts, 3268, 11))
+>from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, 3258, 39))
 >obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
 >thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
 
     typedArrays[3] = Uint16Array.from(obj, mapFn, thisArg);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
->Uint16Array.from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, 3544, 40))
->Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, 3264, 46), Decl(lib.d.ts, 3554, 11))
->from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, 3544, 40))
+>Uint16Array.from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, 3548, 40))
+>Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, 3268, 46), Decl(lib.d.ts, 3558, 11))
+>from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, 3548, 40))
 >obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
 >thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
 
     typedArrays[4] = Int32Array.from(obj, mapFn, thisArg);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
->Int32Array.from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, 3834, 39))
->Int32Array : Symbol(Int32Array, Decl(lib.d.ts, 3554, 48), Decl(lib.d.ts, 3844, 11))
->from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, 3834, 39))
+>Int32Array.from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, 3838, 39))
+>Int32Array : Symbol(Int32Array, Decl(lib.d.ts, 3558, 48), Decl(lib.d.ts, 3848, 11))
+>from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, 3838, 39))
 >obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
 >thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
 
     typedArrays[5] = Uint32Array.from(obj, mapFn, thisArg);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
->Uint32Array.from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, 4124, 40))
->Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, 3844, 46), Decl(lib.d.ts, 4134, 11))
->from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, 4124, 40))
+>Uint32Array.from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, 4128, 40))
+>Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, 3848, 46), Decl(lib.d.ts, 4138, 11))
+>from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, 4128, 40))
 >obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
 >thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
 
     typedArrays[6] = Float32Array.from(obj, mapFn, thisArg);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
->Float32Array.from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, 4414, 41))
->Float32Array : Symbol(Float32Array, Decl(lib.d.ts, 4134, 48), Decl(lib.d.ts, 4424, 11))
->from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, 4414, 41))
+>Float32Array.from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, 4418, 41))
+>Float32Array : Symbol(Float32Array, Decl(lib.d.ts, 4138, 48), Decl(lib.d.ts, 4428, 11))
+>from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, 4418, 41))
 >obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
 >thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
 
     typedArrays[7] = Float64Array.from(obj, mapFn, thisArg);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
->Float64Array.from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, 4704, 41))
->Float64Array : Symbol(Float64Array, Decl(lib.d.ts, 4424, 50), Decl(lib.d.ts, 4714, 11))
->from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, 4704, 41))
+>Float64Array.from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, 4708, 41))
+>Float64Array : Symbol(Float64Array, Decl(lib.d.ts, 4428, 50), Decl(lib.d.ts, 4718, 11))
+>from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, 4708, 41))
 >obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
 >thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
 
     typedArrays[8] = Uint8ClampedArray.from(obj, mapFn, thisArg);
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
->Uint8ClampedArray.from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, 2964, 46))
->Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, 2684, 46), Decl(lib.d.ts, 2974, 11))
->from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, 2964, 46))
+>Uint8ClampedArray.from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, 2968, 46))
+>Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, 2688, 46), Decl(lib.d.ts, 2978, 11))
+>from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, 2968, 46))
 >obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
 >mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
 >thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))


### PR DESCRIPTION
This change adds a non-generic construct signature to Map, Set and WeakMap to allow for calling `new Map()` without having to specify the generic type arguments.

```ts
var m: Map<number, string> = new Map(); // results in error: Map<{}, {}> is not assignable to Map<number, string>
```
