### PR TITLE
Make it so all our diagnostics APIs return an independent set of diagnostics.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -159,6 +159,14 @@ namespace ts {
             }
         };
 
+        let subtypeRelation: Map<RelationComparisonResult> = {};
+        let assignableRelation: Map<RelationComparisonResult> = {};
+        let identityRelation: Map<RelationComparisonResult> = {};
+
+        initializeTypeChecker();
+
+        return checker;
+
         function getEmitResolver(sourceFile?: SourceFile) {
             // Ensure we have all the type information in place for this file so that all the
             // emitter questions of this resolver will return the right information.
@@ -4220,10 +4228,6 @@ namespace ts {
         }
 
         // TYPE CHECKING
-
-        let subtypeRelation: Map<RelationComparisonResult> = {};
-        let assignableRelation: Map<RelationComparisonResult> = {};
-        let identityRelation: Map<RelationComparisonResult> = {};
 
         function isTypeIdenticalTo(source: Type, target: Type): boolean {
             return checkTypeRelatedTo(source, target, identityRelation, /*errorNode*/ undefined);
@@ -13614,9 +13618,5 @@ namespace ts {
                 return true;
             }
         }
-
-        initializeTypeChecker();
-
-        return checker;
     }
 }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -105,7 +105,7 @@ namespace ts {
     }
 
     export function getPreEmitDiagnostics(program: Program, sourceFile?: SourceFile): Diagnostic[] {
-        let diagnostics = program.getSyntacticDiagnostics(sourceFile).concat(program.getGlobalDiagnostics()).concat(program.getSemanticDiagnostics(sourceFile));
+        let diagnostics = program.getOptionsDiagnostics().concat(program.getSyntacticDiagnostics(sourceFile)).concat(program.getGlobalDiagnostics()).concat(program.getSemanticDiagnostics(sourceFile));
 
         if (program.getCompilerOptions().declaration) {
             diagnostics.concat(program.getDeclarationDiagnostics(sourceFile));
@@ -177,10 +177,10 @@ namespace ts {
             getSourceFiles: () => files,
             getCompilerOptions: () => options,
             getSyntacticDiagnostics,
+            getOptionsDiagnostics,
             getGlobalDiagnostics,
             getSemanticDiagnostics,
             getDeclarationDiagnostics,
-            getCompilerOptionsDiagnostics,
             getTypeChecker,
             getClassifiableNames,
             getDiagnosticsProducingTypeChecker,
@@ -311,19 +311,15 @@ namespace ts {
             }
         }
 
-        function getCompilerOptionsDiagnostics(): Diagnostic[] {
+        function getOptionsDiagnostics(): Diagnostic[] {
             let allDiagnostics: Diagnostic[] = [];
             addRange(allDiagnostics, diagnostics.getGlobalDiagnostics());
             return sortAndDeduplicateDiagnostics(allDiagnostics);
         }
 
         function getGlobalDiagnostics(): Diagnostic[] {
-            let typeChecker = getDiagnosticsProducingTypeChecker();
-
             let allDiagnostics: Diagnostic[] = [];
-            addRange(allDiagnostics, typeChecker.getGlobalDiagnostics());
-            addRange(allDiagnostics, diagnostics.getGlobalDiagnostics());
-
+            addRange(allDiagnostics, getDiagnosticsProducingTypeChecker().getGlobalDiagnostics());
             return sortAndDeduplicateDiagnostics(allDiagnostics);
         }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -105,7 +105,10 @@ namespace ts {
     }
 
     export function getPreEmitDiagnostics(program: Program, sourceFile?: SourceFile): Diagnostic[] {
-        let diagnostics = program.getOptionsDiagnostics().concat(program.getSyntacticDiagnostics(sourceFile)).concat(program.getGlobalDiagnostics()).concat(program.getSemanticDiagnostics(sourceFile));
+        let diagnostics = program.getOptionsDiagnostics().concat(
+                          program.getSyntacticDiagnostics(sourceFile),
+                          program.getGlobalDiagnostics(),
+                          program.getSemanticDiagnostics(sourceFile));
 
         if (program.getCompilerOptions().declaration) {
             diagnostics.concat(program.getDeclarationDiagnostics(sourceFile));

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1212,11 +1212,11 @@ namespace ts {
          */
         emit(targetSourceFile?: SourceFile, writeFile?: WriteFileCallback): EmitResult;
 
-        getSyntacticDiagnostics(sourceFile?: SourceFile): Diagnostic[];
+        getOptionsDiagnostics(): Diagnostic[];
         getGlobalDiagnostics(): Diagnostic[];
+        getSyntacticDiagnostics(sourceFile?: SourceFile): Diagnostic[];
         getSemanticDiagnostics(sourceFile?: SourceFile): Diagnostic[];
         getDeclarationDiagnostics(sourceFile?: SourceFile): Diagnostic[];
-        /* @internal */ getCompilerOptionsDiagnostics(): Diagnostic[];
 
         /** 
          * Gets a type checker that can be used to semantically analyze source fils in the program.

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -973,6 +973,9 @@ namespace ts {
 
         getSyntacticDiagnostics(fileName: string): Diagnostic[];
         getSemanticDiagnostics(fileName: string): Diagnostic[];
+
+        // TODO: Rename this to getProgramDiagnostics to better indicate that these are any
+        // diagnostics present for the program level, and not just 'options' diagnostics.
         getCompilerOptionsDiagnostics(): Diagnostic[];
 
         /** 
@@ -1816,7 +1819,7 @@ namespace ts {
         var program = createProgram([inputFileName], options, compilerHost);
 
         if (diagnostics) {
-            diagnostics.push(...program.getCompilerOptionsDiagnostics());
+            diagnostics.push(...program.getOptionsDiagnostics());
         }
 
         // Emit
@@ -2796,7 +2799,7 @@ namespace ts {
 
         function getCompilerOptionsDiagnostics() {
             synchronizeHostData();
-            return program.getGlobalDiagnostics();
+            return program.getOptionsDiagnostics().concat(program.getGlobalDiagnostics());
         }
 
         /// Completion

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1813,7 +1813,7 @@ namespace ts {
 
         var program = createProgram([inputFileName], options, compilerHost);
 
-        addRange(/*to*/ diagnostics, /*from*/ sourceFile.parseDiagnostics);
+        addRange(/*to*/ diagnostics, /*from*/ program.getSyntacticDiagnostics(sourceFile));
         addRange(/*to*/ diagnostics, /*from*/ program.getOptionsDiagnostics());
 
         // Emit


### PR DESCRIPTION
In order to get all diagnostics, you must call all the APIs.  And no APIs return
diagnostics produced by other APIs.  This is how things were before the addition
of the getCompletionOptionsDiagnostics API, and i'm returning things to that state.