### PR TITLE
Fix incremental parsing issue.

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1491,12 +1491,20 @@ namespace ts {
                 switch (node.kind) {
                     case SyntaxKind.Constructor:
                     case SyntaxKind.IndexSignature:
-                    case SyntaxKind.MethodDeclaration:
                     case SyntaxKind.GetAccessor:
                     case SyntaxKind.SetAccessor:
                     case SyntaxKind.PropertyDeclaration:
                     case SyntaxKind.SemicolonClassElement:
                         return true;
+                    case SyntaxKind.MethodDeclaration:
+                        // Method declarations are not necessarily reusable.  An object-literal
+                        // may have a method calls "constructor(...)" and we must reparse that
+                        // into an actual .ConstructorDeclaration.
+                        let methodDeclaration = <MethodDeclaration>node;
+                        let nameIsConstructor = methodDeclaration.name.kind === SyntaxKind.Identifier &&
+                            (<Identifier>methodDeclaration.name).originalKeywordKind === SyntaxKind.ConstructorKeyword;
+
+                        return !nameIsConstructor;
                 }
             }
 

--- a/tests/cases/unittests/incrementalParser.ts
+++ b/tests/cases/unittests/incrementalParser.ts
@@ -713,6 +713,24 @@ module m3 { }\
             compareTrees(oldText, newTextAndChange.text, newTextAndChange.textChangeRange, 4);
         });
 
+        it('Do not move constructors from class to object-literal.', () => {
+            var source = "class C { public constructor() { } public constructor() { } public constructor() { } }"
+
+            var oldText = ScriptSnapshot.fromString(source);
+            var newTextAndChange = withChange(oldText, 0, "class C".length, "var v =");
+
+            compareTrees(oldText, newTextAndChange.text, newTextAndChange.textChangeRange, 0);
+        });
+
+        it('Do not move methods called "constructor" from object literal to class', () => {
+            var source = "var v = { public constructor() { } public constructor() { } public constructor() { } }"
+
+            var oldText = ScriptSnapshot.fromString(source);
+            var newTextAndChange = withChange(oldText, 0, "var v =".length, "class C");
+
+            compareTrees(oldText, newTextAndChange.text, newTextAndChange.textChangeRange, 0);
+        });
+
         it('Moving index signatures from class to interface',() => {
             var source = "class C { public [a: number]: string; public [a: number]: string; public [a: number]: string }"
 


### PR DESCRIPTION
We were moving a method-declaration called "constructor" into a class.  This is incorrect
as that same code should be parsed as a constructor-declaration now that it is in the
class context.