### PR TITLE
Fix the issue that the "out" path is not relative to the path of tsconfig.json

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -110,6 +110,7 @@ namespace ts {
         {
             name: "out",
             type: "string",
+            isFilePath: true,
             description: Diagnostics.Concatenate_and_emit_output_to_single_file,
             paramType: Diagnostics.FILE,
         },


### PR DESCRIPTION
This is to fix the bug mentioned in https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/244
For now the "out" path in tsconfig.json file is related to the path where tsc gets executed, instead of the path of tsconfig.json, which is not expected.