### PR TITLE
Add services sources as dependencies to tsserver.

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -103,7 +103,7 @@ var serverSources = [
     "server.ts"
 ].map(function (f) {
     return path.join(serverDirectory, f);
-});
+}).concat(servicesSources);
 
 var languageServiceLibrarySources = [
     "editorServices.ts",


### PR DESCRIPTION
Previously, modifying any part of the compiler/language service and then triggering a build would not update `tsserver.js`. This amends that behavior.