### PR TITLE
Conflict with Object.prototype.watch in FireFox/Gecko

### DIFF
--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -191,7 +191,7 @@ namespace ts {
             return sys.exit(ExitStatus.Success);
         }
 
-        if (commandLine.options.watch) {
+        if (commandLine.options.watch && commandLine.options.hasOwnProperty('watch')) { // FireFox has Object.prototype.watch
             if (!sys.watchFile) {
                 reportDiagnostic(createCompilerDiagnostic(Diagnostics.The_current_host_does_not_support_the_0_option, "--watch"));
                 return sys.exit(ExitStatus.DiagnosticsPresent_OutputsSkipped);

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -191,7 +191,8 @@ namespace ts {
             return sys.exit(ExitStatus.Success);
         }
 
-        if (commandLine.options.watch && commandLine.options.hasOwnProperty('watch')) { // FireFox has Object.prototype.watch
+        // Firefox has Object.prototype.watch
+        if (commandLine.options.watch && commandLine.options.hasOwnProperty('watch')) {
             if (!sys.watchFile) {
                 reportDiagnostic(createCompilerDiagnostic(Diagnostics.The_current_host_does_not_support_the_0_option, "--watch"));
                 return sys.exit(ExitStatus.DiagnosticsPresent_OutputsSkipped);


### PR DESCRIPTION
In Gecko engine `commandLine.options.watch` evaluates to a truthy value — [Object.prototype.watch](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/watch). That means running the compiler in Gecko (as opposed to V8/node) it effectively defaults --watch to true

Extra hasOwnProperty check makes sure we're discounting prototype's `watch` function.

As an alternative to the suggested changes we can check `typeof != 'function'` or rename [CompilerOptions.watch](https://github.com/Microsoft/TypeScript/blob/master/src/compiler/types.ts#L1860) to say `watchFiles` to avoid the conflict altogether. Neither of those looks preferable.

I've got a tool prototype that allows [running TypeScript compiler in a browser](https://cdn.rawgit.com/portabled/portabled/61ff51ead97882a7f8b202c0c5f4f06db180c0f4/mi-save.html). Surprisingly, **tsc.js** is able to compile a simple dummy file in virtually any old browser: Opera12, IE6, old Blackberry, iPhone 4. The only exception at the moment is FireFox/Gecko, because of 'watch'. When I delete Object.prototype.watch and run tsc.js, it succeeds in Gecko too.

Despite browser compatibility is not an official goal, it's a nice to have feature. And the cost is a one-line change.