### PR TITLE
Node System host write - need to loop since writeSync might not write all bytes in one request

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -29,6 +29,9 @@ namespace ts {
     declare var process: any;
     declare var global: any;
     declare var __filename: string;
+    declare var Buffer: {  
+        new (str: string, encoding ?: string): any;  
+    }
 
     declare class Enumerator {
         public atEnd(): boolean;
@@ -267,10 +270,17 @@ namespace ts {
                 args: process.argv.slice(2),
                 newLine: _os.EOL,
                 useCaseSensitiveFileNames: useCaseSensitiveFileNames,
-                write(s: string): void {
+                write(s: string): void {  
+                    var buffer = new Buffer(s, 'utf8');  
+                    var offset: number = 0;
+                    var toWrite: number = buffer.length;
+                    var written = 0;
                     // 1 is a standard descriptor for stdout
-                    _fs.writeSync(1, s);
-                },
+                    while ((written = _fs.writeSync(1, buffer, offset, toWrite)) < toWrite) {
+                        offset += written;
+                        toWrite -= written;
+                    }
+                },  
                 readFile,
                 writeFile,
                 watchFile: (fileName, callback) => {


### PR DESCRIPTION
fs.writeSync is speced in a way that it returns the byes written which is not handled correctly the the write function of the node system host. 

We say issues  with the tsserver when writing more than 64KB using fs.writeSync on the Mac running under electron (io.js)