### PR TITLE
Add language service API to get the compile and runtime dependencies of a source file

### DIFF
--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -384,6 +384,9 @@ module Harness.LanguageService {
         getFormattingEditsAfterKeystroke(fileName: string, position: number, key: string, options: ts.FormatCodeOptions): ts.TextChange[] {
             return unwrapJSONCallResult(this.shim.getFormattingEditsAfterKeystroke(fileName, position, key, JSON.stringify(options)));
         }
+        getDependencies(fileName: string): ts.DependencyInfo {
+            return unwrapJSONCallResult(this.shim.getDependencies(fileName));
+        }
         getEmitOutput(fileName: string): ts.EmitOutput {
             return unwrapJSONCallResult(this.shim.getEmitOutput(fileName));
         }

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -369,6 +369,10 @@ namespace ts.server {
             });
         }
 
+        getDependencies(fileName: string): DependencyInfo {
+            throw new Error("Not Implemented Yet.");            
+        }
+        
         getEmitOutput(fileName: string): EmitOutput {
             throw new Error("Not Implemented Yet.");
         }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -5806,10 +5806,12 @@ namespace ts {
                         break;  
                     case SyntaxKind.ImportEqualsDeclaration:
                         let importEqualsDeclaration = <ImportEqualsDeclaration>node;
-                        if (importEqualsDeclaration.moduleReference.kind === SyntaxKind.ExternalModuleReference && resolver.isReferencedAliasDeclaration(importEqualsDeclaration)) {
-                            runtime.push(getModuleNameText(importEqualsDeclaration));
-                        } else {
-                            compileTime.push(getModuleNameText(importEqualsDeclaration));
+                        if (importEqualsDeclaration.moduleReference.kind === SyntaxKind.ExternalModuleReference) {
+                            if (resolver.isReferencedAliasDeclaration(importEqualsDeclaration)) {
+                                runtime.push(getModuleNameText(importEqualsDeclaration));
+                            } else {
+                                compileTime.push(getModuleNameText(importEqualsDeclaration));
+                            }
                         }
                         break;  
                     case SyntaxKind.ExportDeclaration:  

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -197,6 +197,8 @@ namespace ts {
         getFormattingEditsForDocument(fileName: string, options: string/*Services.FormatCodeOptions*/): string;
         getFormattingEditsAfterKeystroke(fileName: string, position: number, key: string, options: string/*Services.FormatCodeOptions*/): string;
 
+        getDependencies(fileName: string): string;
+        
         getEmitOutput(fileName: string): string;
     }
 
@@ -798,6 +800,16 @@ namespace ts {
                     var items = this.languageService.getTodoComments(fileName, JSON.parse(descriptors));
                     return items;
                 });
+        }
+        
+        public getDependencies(fileName: string): string  {
+            return this.forwardJSONCall(
+                "getDependencies('" + fileName + "')",
+                () => {
+                    var dependencies = this.languageService.getDependencies(fileName);
+                    return dependencies;
+                }
+            )
         }
 
         /// Emit


### PR DESCRIPTION
This PR adds API to the language service to provide the compile and runtime dependencies of a TS file. This information is useful for a package that works independent of the module system and can be used for an incremental compiler that compiles upwards dependencies.
