### PR TITLE
Show builder at beginning of index signatures & computed properties

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -3062,7 +3062,7 @@ namespace ts {
                     }
                     return true;
                 }
-                else if(jsxContainer) {
+                else if (jsxContainer) {
                     let attrsType: Type;
                     if ((jsxContainer.kind === SyntaxKind.JsxSelfClosingElement) || (jsxContainer.kind === SyntaxKind.JsxOpeningElement)) {
                         // Cursor is inside a JSX self-closing element or opening element
@@ -3162,7 +3162,7 @@ namespace ts {
                     switch (previousToken.kind) {
                         case SyntaxKind.CommaToken:
                             return containingNodeKind === SyntaxKind.CallExpression               // func( a, |
-                                || containingNodeKind === SyntaxKind.Constructor                  // constructor( a, |   public, protected, private keywords are allowed here, so show completion
+                                || containingNodeKind === SyntaxKind.Constructor                  // constructor( a, |   /* public, protected, private keywords are allowed here, so show completion */
                                 || containingNodeKind === SyntaxKind.NewExpression                // new C(a, |
                                 || containingNodeKind === SyntaxKind.ArrayLiteralExpression       // [a, |
                                 || containingNodeKind === SyntaxKind.BinaryExpression             // let x = (a, |
@@ -3173,10 +3173,12 @@ namespace ts {
                                 || containingNodeKind === SyntaxKind.Constructor                  // constructor( |
                                 || containingNodeKind === SyntaxKind.NewExpression                // new C(a|
                                 || containingNodeKind === SyntaxKind.ParenthesizedExpression      // let x = (a|
-                                || containingNodeKind === SyntaxKind.ParenthesizedType;           // function F(pred: (a| this can become an arrow function, where 'a' is the argument
+                                || containingNodeKind === SyntaxKind.ParenthesizedType;           // function F(pred: (a| /* this can become an arrow function, where 'a' is the argument */
 
                         case SyntaxKind.OpenBracketToken:
-                            return containingNodeKind === SyntaxKind.ArrayLiteralExpression;      // [ |
+                            return containingNodeKind === SyntaxKind.ArrayLiteralExpression       // [ |
+                                || containingNodeKind === SyntaxKind.IndexSignature               // [ | : string ]
+                                || containingNodeKind === SyntaxKind.ComputedPropertyName         // [ |    /* this can become an index signature */
 
                         case SyntaxKind.ModuleKeyword:                                            // module |
                         case SyntaxKind.NamespaceKeyword:                                         // namespace |

--- a/tests/cases/fourslash/completionListInIndexSignature01.ts
+++ b/tests/cases/fourslash/completionListInIndexSignature01.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+////interface I<T> {
+////    [/*1*/]: T;
+////    [/*2*/]: T;
+////}
+////
+////class C {
+////    [/*3*/]: string;
+////    [str/*4*/: string]: number;
+////}
+////
+////type T = {
+////    [x/*5*/yz: number]: boolean;
+////    [/*6*/
+
+for (let marker of test.markers()) {
+    goTo.position(marker.position);
+    verify.completionListAllowsNewIdentifier();
+}

--- a/tests/cases/fourslash/completionListInIndexSignature02.ts
+++ b/tests/cases/fourslash/completionListInIndexSignature02.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts' />
+
+////interface I<T> {
+////    [x: /*1*/]: T;
+////    [: /*2*/]: T
+////}
+////
+////class C {
+////    [a: /*3*/]: string;
+////    [str: string/*4*/]: number;
+////}
+////
+////type T = {
+////    [xyz: /*5*/
+
+for (let marker of test.markers()) {
+    goTo.position(marker.position);
+    verify.not.completionListAllowsNewIdentifier();
+}


### PR DESCRIPTION
While computed property names shouldn't necessarily get a builder (or maybe they should since you can have `x => x` in a computed property - those pesky expressions just manage to show up anywhere, huh?), they can eventually become index signatures, so we always show one at the beginning as well.

Fixes #3378