### PR TITLE
Change default node pos/end to -1

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -764,8 +764,8 @@ namespace ts {
             }
             Node.prototype = {
                 kind: kind,
-                pos: 0,
-                end: 0,
+                pos: -1,
+                end: -1,
                 flags: 0,
                 parent: undefined,
             };

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -144,7 +144,7 @@ namespace ts {
             return true;
         }
 
-        return node.pos === node.end && node.kind !== SyntaxKind.EndOfFileToken;
+        return node.pos === node.end && node.pos >= 0 && node.kind !== SyntaxKind.EndOfFileToken;
     }
 
     export function nodeIsPresent(node: Node) {
@@ -1428,8 +1428,6 @@ namespace ts {
 
     export function createSynthesizedNode(kind: SyntaxKind, startsOnNewLine?: boolean): Node {
         let node = <SynthesizedNode>createNode(kind);
-        node.pos = -1;
-        node.end = -1;
         node.startsOnNewLine = startsOnNewLine;
         return node;
     }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -7387,8 +7387,8 @@ namespace ts {
                 }
                 let proto = kind === SyntaxKind.SourceFile ? new SourceFileObject() : new NodeObject();
                 proto.kind = kind;
-                proto.pos = 0;
-                proto.end = 0;
+                proto.pos = -1;
+                proto.end = -1;
                 proto.flags = 0;
                 proto.parent = undefined;
                 Node.prototype = proto;


### PR DESCRIPTION
There are two issues addressed here, meant to help support down-level emit for Async Functions (and optionally Generators) in ES5/3.

Currently, the `objectAllocator` for both **compiler** and **services** sets the default node `pos`/`end` to `0`. While generally this seems a valid default, we always set the `pos` and `end` of every node created by the parser to a non-negative value when we call `createNode` and `finishNode`. Whenever we create a synthesized node in the emitter, we explicitly set the `pos`/`end` to `-1`. For the down-level rewrite, I will be generating many synthesized nodes and am looking to centralize node creation into a set of factory methods for creating each of our various types of nodes. I plan to have both parser and emitter rely on this to centralize node creation, and as such it seems reasonable to treat any new `Node` as synthesized by default (with a `pos`/`end` of `-1`) until such time as the parser explicitly sets the position.

In addition, the `nodeIsMissing` function currently tests whether the node exists, is not the `EndOfFileToken`, and that its `pos` and `end` are not the same value. This means that any any synthesized node would be considered "missing". As such, I have added a condition that the node's `pos` must be non-negative to be considered "missing".