### PR TITLE
Add property URL in Window interface

### DIFF
--- a/bin/lib.d.ts
+++ b/bin/lib.d.ts
@@ -15674,6 +15674,7 @@ interface Window extends EventTarget, WindowTimers, WindowSessionStorage, Window
     styleMedia: StyleMedia;
     toolbar: BarProp;
     top: Window;
+    URL: URL;
     window: Window;
     alert(message?: any): void;
     blur(): void;


### PR DESCRIPTION
Fix error TS2339: Property 'URL' does not exist on type 'Window'.