### PR TITLE
Correctly emit prologue directives in constructors

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4219,6 +4219,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 scopeEmitStart(node, "constructor");
                 increaseIndent();
                 if (ctor) {
+                    // Emit all the directive prologues (like "use strict").  These have to come before
+                    // any other preamble code we write (like parameter initializers).
                     var startIndex = emitDirectivePrologues(ctor.body.statements, /*startWithNewLine*/ true);                    
                     emitDetachedComments(ctor.body.statements);
                 }

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4219,6 +4219,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 scopeEmitStart(node, "constructor");
                 increaseIndent();
                 if (ctor) {
+                    var startIndex = emitDirectivePrologues(ctor.body.statements, /*startWithNewLine*/ true);                    
                     emitDetachedComments(ctor.body.statements);
                 }
                 emitCaptureThisForNodeIfNecessary(node);
@@ -4253,7 +4254,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     if (superCall) {
                         statements = statements.slice(1);
                     }
-                    emitLines(statements);
+                    emitLinesStartingAt(statements, startIndex);
                 }
                 emitTempDeclarations(/*newLine*/ true);
                 writeLine();

--- a/tests/baselines/reference/strictModeInConstructor.js
+++ b/tests/baselines/reference/strictModeInConstructor.js
@@ -74,8 +74,8 @@ var A = (function () {
 var B = (function (_super) {
     __extends(B, _super);
     function B() {
-        this.s = 9;
         "use strict"; // No error
+        this.s = 9;
         _super.call(this);
     }
     return B;


### PR DESCRIPTION
## Fixed "Directive prologues are not preserved"
Fixes issue #3454