### PR TITLE
Update harness code for TSLint rules

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -730,8 +730,9 @@ task("update-sublime", ["local", serverFile], function() {
 // run this task automatically
 desc("Runs tslint on the compiler sources");
 task("lint", [], function() {
-    for(var i in compilerSources) {
-        var f = compilerSources[i];
+    var lintTagets = compilerSources.concat(harnessSources);
+    for(var i in lintTagets) {
+        var f = lintTagets[i];
         var cmd = 'tslint -f ' + f;
         exec(cmd,
             function() { console.log('SUCCESS: No linter errors'); },

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -113,7 +113,7 @@ var languageServiceLibrarySources = [
     return path.join(serverDirectory, f);
 }).concat(servicesSources);
 
-var harnessSources = [
+var harnessCoreSources = [
     "harness.ts",
     "sourceMapRecorder.ts",
     "harnessLanguageService.ts",
@@ -129,7 +129,9 @@ var harnessSources = [
     "runner.ts"
 ].map(function (f) {
     return path.join(harnessDirectory, f);
-}).concat([
+});
+
+var harnessSources = harnessCoreSources.concat([
     "incrementalParser.ts",
     "jsDocParsing.ts",
     "services/colorization.ts",
@@ -730,13 +732,13 @@ task("update-sublime", ["local", serverFile], function() {
 // run this task automatically
 desc("Runs tslint on the compiler sources");
 task("lint", [], function() {
-    var lintTagets = compilerSources.concat(harnessSources);
-    for(var i in lintTagets) {
-        var f = lintTagets[i];
+    function success(f) { return function() { console.log('SUCCESS: No linter errors in ' + f + '\n'); }};
+    function failure(f) { return function() { console.log('FAILURE: Please fix linting errors in ' + f + '\n') }};
+
+    var lintTargets = compilerSources.concat(harnessCoreSources);
+    for(var i in lintTargets) {
+        var f = lintTargets[i];
         var cmd = 'tslint -f ' + f;
-        exec(cmd,
-            function() { console.log('SUCCESS: No linter errors'); },
-            function() { console.log('FAILURE: Please fix linting errors in ' + f + '\n');
-        });
+        exec(cmd, success(f), failure(f));
     }
 }, { async: true });

--- a/src/harness/compilerRunner.ts
+++ b/src/harness/compilerRunner.ts
@@ -44,7 +44,7 @@ class CompilerBaselineRunner extends RunnerBase {
             // Everything declared here should be cleared out in the "after" callback.
             var justName: string;
             var content: string;
-            var testCaseContent: { settings: Harness.TestCaseParser.CompilerSetting[]; testUnitData: Harness.TestCaseParser.TestUnitData[]; }
+            var testCaseContent: { settings: Harness.TestCaseParser.CompilerSetting[]; testUnitData: Harness.TestCaseParser.TestUnitData[]; };
 
             var units: Harness.TestCaseParser.TestUnitData[];
             var tcSettings: Harness.TestCaseParser.CompilerSetting[];

--- a/src/harness/compilerRunner.ts
+++ b/src/harness/compilerRunner.ts
@@ -42,27 +42,27 @@ class CompilerBaselineRunner extends RunnerBase {
         describe('compiler tests for ' + fileName, () => {
             // Mocha holds onto the closure environment of the describe callback even after the test is done.
             // Everything declared here should be cleared out in the "after" callback.
-            var justName: string;
-            var content: string;
-            var testCaseContent: { settings: Harness.TestCaseParser.CompilerSetting[]; testUnitData: Harness.TestCaseParser.TestUnitData[]; };
+            let justName: string;
+            let content: string;
+            let testCaseContent: { settings: Harness.TestCaseParser.CompilerSetting[]; testUnitData: Harness.TestCaseParser.TestUnitData[]; };
 
-            var units: Harness.TestCaseParser.TestUnitData[];
-            var tcSettings: Harness.TestCaseParser.CompilerSetting[];
-            var createNewInstance: boolean;
+            let units: Harness.TestCaseParser.TestUnitData[];
+            let tcSettings: Harness.TestCaseParser.CompilerSetting[];
+            let createNewInstance: boolean;
 
-            var lastUnit: Harness.TestCaseParser.TestUnitData;
-            var rootDir: string;
+            let lastUnit: Harness.TestCaseParser.TestUnitData;
+            let rootDir: string;
 
-            var result: Harness.Compiler.CompilerResult;
-            var program: ts.Program;
-            var options: ts.CompilerOptions;
+            let result: Harness.Compiler.CompilerResult;
+            let program: ts.Program;
+            let options: ts.CompilerOptions;
             // equivalent to the files that will be passed on the command line
-            var toBeCompiled: { unitName: string; content: string }[];
+            let toBeCompiled: { unitName: string; content: string }[];
             // equivalent to other files on the file system not directly passed to the compiler (ie things that are referenced by other files)
-            var otherFiles: { unitName: string; content: string }[];
-            var harnessCompiler: Harness.Compiler.HarnessCompiler;
+            let otherFiles: { unitName: string; content: string }[];
+            let harnessCompiler: Harness.Compiler.HarnessCompiler;
 
-            var createNewInstance = false;
+            let createNewInstance = false;
 
             before(() => {
                 justName = fileName.replace(/^.*[\\\/]/, ''); // strips the fileName from the path.
@@ -105,7 +105,7 @@ class CompilerBaselineRunner extends RunnerBase {
                 /* The compiler doesn't handle certain flags flipping during a single compilation setting. Tests on these flags will need
                    a fresh compiler instance for themselves and then create a fresh one for the next test. Would be nice to get dev fixes
                    eventually to remove this limitation. */
-                for (var i = 0; i < tcSettings.length; ++i) {
+                for (let i = 0; i < tcSettings.length; ++i) {
                     // noImplicitAny is passed to getCompiler, but target is just passed in the settings blob to setCompilerSettings
                     if (!createNewInstance && (tcSettings[i].flag == "noimplicitany" || tcSettings[i].flag === 'target')) {
                         harnessCompiler = Harness.Compiler.getCompiler();
@@ -162,7 +162,7 @@ class CompilerBaselineRunner extends RunnerBase {
             it('Correct sourcemap content for ' + fileName, () => {
                 if (options.sourceMap || options.inlineSourceMap) {
                     Harness.Baseline.runBaseline('Correct sourcemap content for ' + fileName, justName.replace(/\.tsx?$/, '.sourcemap.txt'), () => {
-                        var record = result.getSourceMapRecord();
+                        let record = result.getSourceMapRecord();
                         if (options.noEmitOnError && result.errors.length !== 0 && record === undefined) {
                             // Because of the noEmitOnError option no files are created. We need to return null because baselining isn't required.
                             return null;
@@ -180,18 +180,18 @@ class CompilerBaselineRunner extends RunnerBase {
 
                     // check js output
                     Harness.Baseline.runBaseline('Correct JS output for ' + fileName, justName.replace(/\.tsx?/, '.js'), () => {
-                        var tsCode = '';
-                        var tsSources = otherFiles.concat(toBeCompiled);
+                        let tsCode = '';
+                        let tsSources = otherFiles.concat(toBeCompiled);
                         if (tsSources.length > 1) {
                             tsCode += '//// [' + fileName + '] ////\r\n\r\n';
                         }
-                        for (var i = 0; i < tsSources.length; i++) {
+                        for (let i = 0; i < tsSources.length; i++) {
                             tsCode += '//// [' + Harness.Path.getFileName(tsSources[i].unitName) + ']\r\n';
                             tsCode += tsSources[i].content + (i < (tsSources.length - 1) ? '\r\n' : '');
                         }
 
-                        var jsCode = '';
-                        for (var i = 0; i < result.files.length; i++) {
+                        let jsCode = '';
+                        for (let i = 0; i < result.files.length; i++) {
                             jsCode += '//// [' + Harness.Path.getFileName(result.files[i].fileName) + ']\r\n';
                             jsCode += getByteOrderMarkText(result.files[i]);
                             jsCode += result.files[i].code;
@@ -199,14 +199,14 @@ class CompilerBaselineRunner extends RunnerBase {
 
                         if (result.declFilesCode.length > 0) {
                             jsCode += '\r\n\r\n';
-                            for (var i = 0; i < result.declFilesCode.length; i++) {
+                            for (let i = 0; i < result.declFilesCode.length; i++) {
                                 jsCode += '//// [' + Harness.Path.getFileName(result.declFilesCode[i].fileName) + ']\r\n';
                                 jsCode += getByteOrderMarkText(result.declFilesCode[i]);
                                 jsCode += result.declFilesCode[i].code;
                             }
                         }
 
-                        var declFileCompilationResult = harnessCompiler.compileDeclarationFiles(toBeCompiled, otherFiles, result, function (settings) {
+                        let declFileCompilationResult = harnessCompiler.compileDeclarationFiles(toBeCompiled, otherFiles, result, function (settings) {
                             harnessCompiler.setCompilerSettings(tcSettings);
                         }, options);
 
@@ -244,8 +244,8 @@ class CompilerBaselineRunner extends RunnerBase {
                             return null;
                         }
 
-                        var sourceMapCode = '';
-                        for (var i = 0; i < result.sourceMaps.length; i++) {
+                        let sourceMapCode = '';
+                        for (let i = 0; i < result.sourceMaps.length; i++) {
                             sourceMapCode += '//// [' + Harness.Path.getFileName(result.sourceMaps[i].fileName) + ']\r\n';
                             sourceMapCode += getByteOrderMarkText(result.sourceMaps[i]);
                             sourceMapCode += result.sourceMaps[i].code;
@@ -293,7 +293,7 @@ class CompilerBaselineRunner extends RunnerBase {
 
                     // Produce baselines.  The first gives the types for all expressions.
                     // The second gives symbols for all identifiers.
-                    var e1: Error, e2: Error;
+                    let e1: Error, e2: Error;
                     try {
                         checkBaseLines(/*isSymbolBaseLine:*/ false);
                     }
@@ -335,20 +335,20 @@ class CompilerBaselineRunner extends RunnerBase {
                         let typeMap: { [fileName: string]: { [lineNum: number]: string[]; } } = {};
 
                         allFiles.forEach(file => {
-                            var codeLines = file.content.split('\n');
+                            let codeLines = file.content.split('\n');
                             typeWriterResults[file.unitName].forEach(result => {
                                 if (isSymbolBaseline && !result.symbol) {
                                     return;
                                 }
 
-                                var typeOrSymbolString = isSymbolBaseline ? result.symbol : result.type;
-                                var formattedLine = result.sourceText.replace(/\r?\n/g, "") + " : " + typeOrSymbolString;
+                                let typeOrSymbolString = isSymbolBaseline ? result.symbol : result.type;
+                                let formattedLine = result.sourceText.replace(/\r?\n/g, "") + " : " + typeOrSymbolString;
                                 if (!typeMap[file.unitName]) {
                                     typeMap[file.unitName] = {};
                                 }
 
-                                var typeInfo = [formattedLine];
-                                var existingTypeInfo = typeMap[file.unitName][result.line];
+                                let typeInfo = [formattedLine];
+                                let existingTypeInfo = typeMap[file.unitName][result.line];
                                 if (existingTypeInfo) {
                                     typeInfo = existingTypeInfo.concat(typeInfo);
                                 }
@@ -356,11 +356,11 @@ class CompilerBaselineRunner extends RunnerBase {
                             });
 
                             typeLines.push('=== ' + file.unitName + ' ===\r\n');
-                            for (var i = 0; i < codeLines.length; i++) {
-                                var currentCodeLine = codeLines[i];
+                            for (let i = 0; i < codeLines.length; i++) {
+                                let currentCodeLine = codeLines[i];
                                 typeLines.push(currentCodeLine + '\r\n');
                                 if (typeMap[file.unitName]) {
-                                    var typeInfo = typeMap[file.unitName][i];
+                                    let typeInfo = typeMap[file.unitName][i];
                                     if (typeInfo) {
                                         typeInfo.forEach(ty => {
                                             typeLines.push('>' + ty + '\r\n');
@@ -388,13 +388,13 @@ class CompilerBaselineRunner extends RunnerBase {
     public initializeTests() {
         describe(this.testSuiteName + ' tests', () => {
             describe("Setup compiler for compiler baselines", () => {
-                var harnessCompiler = Harness.Compiler.getCompiler();
+                let harnessCompiler = Harness.Compiler.getCompiler();
                 this.parseOptions();
             });
 
             // this will set up a series of describe/it blocks to run between the setup and cleanup phases
             if (this.tests.length === 0) {
-                var testFiles = this.enumerateFiles(this.basePath, /\.tsx?$/, { recursive: true });
+                let testFiles = this.enumerateFiles(this.basePath, /\.tsx?$/, { recursive: true });
                 testFiles.forEach(fn => {
                     fn = fn.replace(/\\/g, "/");
                     this.checkTestCodeOutput(fn);
@@ -405,7 +405,7 @@ class CompilerBaselineRunner extends RunnerBase {
             }
 
             describe("Cleanup after compiler baselines", () => {
-                var harnessCompiler = Harness.Compiler.getCompiler();
+                let harnessCompiler = Harness.Compiler.getCompiler();
             });
         });
     }
@@ -417,8 +417,8 @@ class CompilerBaselineRunner extends RunnerBase {
             this.decl = false;
             this.output = false;
 
-            var opts = this.options.split(',');
-            for (var i = 0; i < opts.length; i++) {
+            let opts = this.options.split(',');
+            for (let i = 0; i < opts.length; i++) {
                 switch (opts[i]) {
                     case 'error':
                         this.errors = true;

--- a/src/harness/compilerRunner.ts
+++ b/src/harness/compilerRunner.ts
@@ -48,7 +48,6 @@ class CompilerBaselineRunner extends RunnerBase {
 
             let units: Harness.TestCaseParser.TestUnitData[];
             let tcSettings: Harness.TestCaseParser.CompilerSetting[];
-            let createNewInstance: boolean;
 
             let lastUnit: Harness.TestCaseParser.TestUnitData;
             let rootDir: string;

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -135,7 +135,7 @@ module FourSlash {
     var fileMetadataNames = [metadataOptionNames.fileName, metadataOptionNames.emitThisFile, metadataOptionNames.resolveReference];
     var globalMetadataNames = [metadataOptionNames.allowNonTsExtensions, metadataOptionNames.baselineFile, metadataOptionNames.declaration,
         metadataOptionNames.mapRoot, metadataOptionNames.module, metadataOptionNames.out,
-        metadataOptionNames.outDir, metadataOptionNames.sourceMap, metadataOptionNames.sourceRoot]
+        metadataOptionNames.outDir, metadataOptionNames.sourceMap, metadataOptionNames.sourceRoot];
 
     function convertGlobalOptionsToCompilerOptions(globalOptions: { [idx: string]: string }): ts.CompilerOptions {
         var settings: ts.CompilerOptions = { target: ts.ScriptTarget.ES5 };
@@ -192,7 +192,7 @@ module FourSlash {
 
     export class TestCancellationToken implements ts.HostCancellationToken {
         // 0 - cancelled
-        // >0 - not cancelled 
+        // >0 - not cancelled
         // <0 - not cancelled and value denotes number of isCancellationRequested after which token become cancelled
         private static NotCanceled: number = -1;
         private numberOfCallsBeforeCancellation: number = TestCancellationToken.NotCanceled;
@@ -271,7 +271,7 @@ module FourSlash {
         private taoInvalidReason: string = null;
 
         private inputFiles: ts.Map<string> = {};  // Map between inputFile's fileName and its content for easily looking up when resolving references
-        
+
         // Add input file which has matched file name with the given reference-file path.
         // This is necessary when resolveReference flag is specified
         private addMatchedInputFile(referenceFilePath: string) {
@@ -426,7 +426,7 @@ module FourSlash {
             this.activeFile = fileToOpen;
             var fileName = fileToOpen.fileName.replace(Harness.IO.directoryName(fileToOpen.fileName), '').substr(1);
             this.scenarioActions.push('<OpenFile FileName="" SrcFileId="' + fileName + '" FileId="' + fileName + '" />');
-            
+
             // Let the host know that this file is now open
             this.languageServiceAdapterHost.openFile(fileToOpen.fileName);
         }
@@ -755,7 +755,7 @@ module FourSlash {
                         error += "Expected documentation: " + expectedDocumentation + " to equal: " + ts.displayPartsToString(details.documentation) + ".";
                     }
                     if (expectedKind) {
-                        error += "Expected kind: " + expectedKind + " to equal: " + filterCompletions[0].kind + "."
+                        error += "Expected kind: " + expectedKind + " to equal: " + filterCompletions[0].kind + ".";
                     }
                     this.raiseError(error);
                 }
@@ -1151,6 +1151,7 @@ module FourSlash {
             var length: number;
             var prefixString = "    >";
 
+            var pos = 0;
             var addSpanInfoString = () => {
                 if (previousSpanInfo) {
                     resultString += currentLine;
@@ -1163,7 +1164,7 @@ module FourSlash {
                 }
             };
 
-            for (var pos = 0; pos < this.activeFile.content.length; pos++) {
+            for (pos < this.activeFile.content.length; pos++) {
                 if (pos === 0 || pos === fileLineMap[nextLine]) {
                     nextLine++;
                     addSpanInfoString();
@@ -1347,7 +1348,7 @@ module FourSlash {
             var offset = this.currentCaretPosition;
             var ch = "";
 
-            var checkCadence = (count >> 2) + 1
+            var checkCadence = (count >> 2) + 1;
 
             for (var i = 0; i < count; i++) {
                 // Make the edit
@@ -1363,7 +1364,7 @@ module FourSlash {
                     var edits = this.languageService.getFormattingEditsAfterKeystroke(this.activeFile.fileName, offset, ch, this.formatCodeOptions);
                     if (edits.length) {
                         offset += this.applyEdits(this.activeFile.fileName, edits, true);
-                        //this.checkPostEditInvariants();
+                        // this.checkPostEditInvariants();
                     }
                 }
             }
@@ -1388,7 +1389,7 @@ module FourSlash {
 
             var offset = this.currentCaretPosition;
             var ch = "";
-            var checkCadence = (count >> 2) + 1
+            var checkCadence = (count >> 2) + 1;
 
             for (var i = 0; i < count; i++) {
                 offset--;
@@ -1503,8 +1504,8 @@ module FourSlash {
         }
 
         private checkPostEditInvariants() {
-            if (this.testType !== FourSlashTestType.Native) { 
-                // getSourcefile() results can not be serialized. Only perform these verifications 
+            if (this.testType !== FourSlashTestType.Native) {
+                // getSourcefile() results can not be serialized. Only perform these verifications
                 // if running against a native LS object.
                 return;
             }
@@ -1883,7 +1884,7 @@ module FourSlash {
                 assert.equal(
                     expected.join(","),
                     actual.fileNameList.map( file => {
-                        return file.replace(this.basePath + "/", "")
+                        return file.replace(this.basePath + "/", "");
                         }).join(",")
                     );
             }
@@ -2156,7 +2157,7 @@ module FourSlash {
 
         // Get the text of the entire line the caret is currently at
         private getCurrentLineContent() {
-            var text = this.getFileContent(this.activeFile.fileName)
+            var text = this.getFileContent(this.activeFile.fileName);
 
             var pos = this.currentCaretPosition;
             var startPos = pos, endPos = pos;
@@ -2286,7 +2287,7 @@ module FourSlash {
         }
 
         public setCancelled(numberOfCalls: number): void {
-            this.cancellationToken.setCancelled(numberOfCalls)
+            this.cancellationToken.setCancelled(numberOfCalls);
         }
 
         public resetCancelled(): void {

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -100,7 +100,7 @@ module FourSlash {
         end: number;
     }
 
-    var entityMap: ts.Map<string> = {
+    let entityMap: ts.Map<string> = {
         '&': '&amp;',
         '"': '&quot;',
         "'": '&#39;',
@@ -116,7 +116,7 @@ module FourSlash {
     // Name of testcase metadata including ts.CompilerOptions properties that will be used by globalOptions
     // To add additional option, add property into the testOptMetadataNames, refer the property in either globalMetadataNames or fileMetadataNames
     // Add cases into convertGlobalOptionsToCompilationsSettings function for the compiler to acknowledge such option from meta data
-    var metadataOptionNames = {
+    let metadataOptionNames = {
         baselineFile: 'BaselineFile',
         declaration: 'declaration',
         emitThisFile: 'emitThisFile',  // This flag is used for testing getEmitOutput feature. It allows test-cases to indicate what file to be output in multiple files project
@@ -132,15 +132,15 @@ module FourSlash {
     };
 
     // List of allowed metadata names
-    var fileMetadataNames = [metadataOptionNames.fileName, metadataOptionNames.emitThisFile, metadataOptionNames.resolveReference];
-    var globalMetadataNames = [metadataOptionNames.allowNonTsExtensions, metadataOptionNames.baselineFile, metadataOptionNames.declaration,
+    let fileMetadataNames = [metadataOptionNames.fileName, metadataOptionNames.emitThisFile, metadataOptionNames.resolveReference];
+    let globalMetadataNames = [metadataOptionNames.allowNonTsExtensions, metadataOptionNames.baselineFile, metadataOptionNames.declaration,
         metadataOptionNames.mapRoot, metadataOptionNames.module, metadataOptionNames.out,
         metadataOptionNames.outDir, metadataOptionNames.sourceMap, metadataOptionNames.sourceRoot];
 
     function convertGlobalOptionsToCompilerOptions(globalOptions: { [idx: string]: string }): ts.CompilerOptions {
-        var settings: ts.CompilerOptions = { target: ts.ScriptTarget.ES5 };
+        let settings: ts.CompilerOptions = { target: ts.ScriptTarget.ES5 };
         // Convert all property in globalOptions into ts.CompilationSettings
-        for (var prop in globalOptions) {
+        for (let prop in globalOptions) {
             if (globalOptions.hasOwnProperty(prop)) {
                 switch (prop) {
                     case metadataOptionNames.allowNonTsExtensions:
@@ -185,7 +185,7 @@ module FourSlash {
         return settings;
     }
 
-    export var currentTestState: TestState = null;
+    export let currentTestState: TestState = null;
     function assertionMessage(msg: string) {
         return "\nMarker: " + currentTestState.lastKnownMarker + "\nChecking: " + msg + "\n\n";
     }
@@ -275,7 +275,7 @@ module FourSlash {
         // Add input file which has matched file name with the given reference-file path.
         // This is necessary when resolveReference flag is specified
         private addMatchedInputFile(referenceFilePath: string) {
-            var inputFile = this.inputFiles[referenceFilePath];
+            let inputFile = this.inputFiles[referenceFilePath];
             if (inputFile && !Harness.isLibraryFile(referenceFilePath)) {
                 this.languageServiceAdapterHost.addScript(referenceFilePath, inputFile);
             }
@@ -297,13 +297,13 @@ module FourSlash {
         constructor(private basePath: string, private testType: FourSlashTestType, public testData: FourSlashData) {
             // Create a new Services Adapter
             this.cancellationToken = new TestCancellationToken();
-            var compilationOptions = convertGlobalOptionsToCompilerOptions(this.testData.globalOptions);
-            var languageServiceAdapter = this.getLanguageServiceAdapter(testType, this.cancellationToken, compilationOptions);
+            let compilationOptions = convertGlobalOptionsToCompilerOptions(this.testData.globalOptions);
+            let languageServiceAdapter = this.getLanguageServiceAdapter(testType, this.cancellationToken, compilationOptions);
             this.languageServiceAdapterHost = languageServiceAdapter.getHost();
             this.languageService = languageServiceAdapter.getLanguageService();
 
             // Initialize the language service with all the scripts
-            var startResolveFileRef: FourSlashFile;
+            let startResolveFileRef: FourSlashFile;
 
             ts.forEach(testData.files, file => {
                 // Create map between fileName and its content for easily looking up when resolveReference flag is specified
@@ -320,14 +320,14 @@ module FourSlash {
                 // Add the entry-point file itself into the languageServiceShimHost
                 this.languageServiceAdapterHost.addScript(startResolveFileRef.fileName, startResolveFileRef.content);
 
-                var resolvedResult = languageServiceAdapter.getPreProcessedFileInfo(startResolveFileRef.fileName, startResolveFileRef.content);
-                var referencedFiles: ts.FileReference[] = resolvedResult.referencedFiles;
-                var importedFiles: ts.FileReference[] = resolvedResult.importedFiles;
+                let resolvedResult = languageServiceAdapter.getPreProcessedFileInfo(startResolveFileRef.fileName, startResolveFileRef.content);
+                let referencedFiles: ts.FileReference[] = resolvedResult.referencedFiles;
+                let importedFiles: ts.FileReference[] = resolvedResult.importedFiles;
 
                 // Add triple reference files into language-service host
                 ts.forEach(referencedFiles, referenceFile => {
                     // Fourslash insert tests/cases/fourslash into inputFile.unitName so we will properly append the same base directory to refFile path
-                    var referenceFilePath = this.basePath + '/' + referenceFile.fileName;
+                    let referenceFilePath = this.basePath + '/' + referenceFile.fileName;
                     this.addMatchedInputFile(referenceFilePath);
                 });
 
@@ -335,7 +335,7 @@ module FourSlash {
                 ts.forEach(importedFiles, importedFile => {
                     // Fourslash insert tests/cases/fourslash into inputFile.unitName and import statement doesn't require ".ts"
                     // so convert them before making appropriate comparison
-                    var importedFilePath = this.basePath + '/' + importedFile.fileName + ".ts";
+                    let importedFilePath = this.basePath + '/' + importedFile.fileName + ".ts";
                     this.addMatchedInputFile(importedFilePath);
                 });
 
@@ -370,8 +370,8 @@ module FourSlash {
             };
 
             this.testData.files.forEach(file => {
-                var fileName = file.fileName.replace(Harness.IO.directoryName(file.fileName), '').substr(1);
-                var fileNameWithoutExtension = fileName.substr(0, fileName.lastIndexOf("."));
+                let fileName = file.fileName.replace(Harness.IO.directoryName(file.fileName), '').substr(1);
+                let fileNameWithoutExtension = fileName.substr(0, fileName.lastIndexOf("."));
                 this.scenarioActions.push('<CreateFileOnDisk FileId="' + fileName + '" FileNameWithoutExtension="' + fileNameWithoutExtension + '" FileExtension=".ts"><![CDATA[' + file.content + ']]></CreateFileOnDisk>');
             });
 
@@ -380,18 +380,18 @@ module FourSlash {
         }
 
         private getFileContent(fileName: string): string {
-            var script = this.languageServiceAdapterHost.getScriptInfo(fileName);
+            let script = this.languageServiceAdapterHost.getScriptInfo(fileName);
             return script.content;
         }
 
         // Entry points from fourslash.ts
         public goToMarker(name = '') {
-            var marker = this.getMarkerByName(name);
+            let marker = this.getMarkerByName(name);
             if (this.activeFile.fileName !== marker.fileName) {
                 this.openFile(marker.fileName);
             }
 
-            var content = this.getFileContent(marker.fileName);
+            let content = this.getFileContent(marker.fileName);
             if (marker.position === -1 || marker.position > content.length) {
                 throw new Error('Marker "' + name + '" has been invalidated by unrecoverable edits to the file.');
             }
@@ -402,8 +402,8 @@ module FourSlash {
         public goToPosition(pos: number) {
             this.currentCaretPosition = pos;
 
-            var lineStarts = ts.computeLineStarts(this.getFileContent(this.activeFile.fileName));
-            var lineCharPos = ts.computeLineAndCharacterOfPosition(lineStarts, pos);
+            let lineStarts = ts.computeLineStarts(this.getFileContent(this.activeFile.fileName));
+            let lineCharPos = ts.computeLineAndCharacterOfPosition(lineStarts, pos);
             this.scenarioActions.push(`<MoveCaretToLineAndChar LineNumber=${ lineCharPos.line + 1 } CharNumber=${ lineCharPos.character + 1 } />`);
         }
 
@@ -421,10 +421,10 @@ module FourSlash {
         public openFile(index: number): void;
         public openFile(name: string): void;
         public openFile(indexOrName: any) {
-            var fileToOpen: FourSlashFile = this.findFile(indexOrName);
+            let fileToOpen: FourSlashFile = this.findFile(indexOrName);
             fileToOpen.fileName = ts.normalizeSlashes(fileToOpen.fileName);
             this.activeFile = fileToOpen;
-            var fileName = fileToOpen.fileName.replace(Harness.IO.directoryName(fileToOpen.fileName), '').substr(1);
+            let fileName = fileToOpen.fileName.replace(Harness.IO.directoryName(fileToOpen.fileName), '').substr(1);
             this.scenarioActions.push('<OpenFile FileName="" SrcFileId="' + fileName + '" FileId="' + fileName + '" />');
 
             // Let the host know that this file is now open
@@ -432,13 +432,13 @@ module FourSlash {
         }
 
         public verifyErrorExistsBetweenMarkers(startMarkerName: string, endMarkerName: string, negative: boolean) {
-            var startMarker = this.getMarkerByName(startMarkerName);
-            var endMarker = this.getMarkerByName(endMarkerName);
-            var predicate = function (errorMinChar: number, errorLimChar: number, startPos: number, endPos: number) {
+            let startMarker = this.getMarkerByName(startMarkerName);
+            let endMarker = this.getMarkerByName(endMarkerName);
+            let predicate = function (errorMinChar: number, errorLimChar: number, startPos: number, endPos: number) {
                 return ((errorMinChar === startPos) && (errorLimChar === endPos)) ? true : false;
             };
 
-            var exists = this.anyErrorInRange(predicate, startMarker, endMarker);
+            let exists = this.anyErrorInRange(predicate, startMarker, endMarker);
 
             this.taoInvalidReason = 'verifyErrorExistsBetweenMarkers NYI';
 
@@ -458,10 +458,10 @@ module FourSlash {
         }
 
         private getDiagnostics(fileName: string): ts.Diagnostic[] {
-            var syntacticErrors = this.languageService.getSyntacticDiagnostics(fileName);
-            var semanticErrors = this.languageService.getSemanticDiagnostics(fileName);
+            let syntacticErrors = this.languageService.getSyntacticDiagnostics(fileName);
+            let semanticErrors = this.languageService.getSemanticDiagnostics(fileName);
 
-            var diagnostics: ts.Diagnostic[] = [];
+            let diagnostics: ts.Diagnostic[] = [];
             diagnostics.push.apply(diagnostics, syntacticErrors);
             diagnostics.push.apply(diagnostics, semanticErrors);
 
@@ -469,10 +469,10 @@ module FourSlash {
         }
 
         private getAllDiagnostics(): ts.Diagnostic[] {
-            var diagnostics: ts.Diagnostic[] = [];
+            let diagnostics: ts.Diagnostic[] = [];
 
-            var fileNames = this.languageServiceAdapterHost.getFilenames();
-            for (var i = 0, n = fileNames.length; i < n; i++) {
+            let fileNames = this.languageServiceAdapterHost.getFilenames();
+            for (let i = 0, n = fileNames.length; i < n; i++) {
                 diagnostics.push.apply(this.getDiagnostics(fileNames[i]));
             }
 
@@ -480,8 +480,8 @@ module FourSlash {
         }
 
         public verifyErrorExistsAfterMarker(markerName: string, negative: boolean, after: boolean) {
-            var marker: Marker = this.getMarkerByName(markerName);
-            var predicate: (errorMinChar: number, errorLimChar: number, startPos: number, endPos: number) => boolean;
+            let marker: Marker = this.getMarkerByName(markerName);
+            let predicate: (errorMinChar: number, errorLimChar: number, startPos: number, endPos: number) => boolean;
 
             if (after) {
                 predicate = function (errorMinChar: number, errorLimChar: number, startPos: number, endPos: number) {
@@ -495,8 +495,8 @@ module FourSlash {
 
             this.taoInvalidReason = 'verifyErrorExistsAfterMarker NYI';
 
-            var exists = this.anyErrorInRange(predicate, marker);
-            var diagnostics = this.getAllDiagnostics();
+            let exists = this.anyErrorInRange(predicate, marker);
+            let diagnostics = this.getAllDiagnostics();
 
             if (exists !== negative) {
                 this.printErrorLog(negative, diagnostics);
@@ -506,12 +506,12 @@ module FourSlash {
 
         private anyErrorInRange(predicate: (errorMinChar: number, errorLimChar: number, startPos: number, endPos: number) => boolean, startMarker: Marker, endMarker?: Marker) {
 
-            var errors = this.getDiagnostics(startMarker.fileName);
-            var exists = false;
+            let errors = this.getDiagnostics(startMarker.fileName);
+            let exists = false;
 
-            var startPos = startMarker.position;
+            let startPos = startMarker.position;
             if (endMarker !== undefined) {
-                var endPos = endMarker.position;
+                let endPos = endMarker.position;
             }
 
             errors.forEach(function (error: ts.Diagnostic) {
@@ -538,40 +538,40 @@ module FourSlash {
         }
 
         public verifyNumberOfErrorsInCurrentFile(expected: number) {
-            var errors = this.getDiagnostics(this.activeFile.fileName);
-            var actual = errors.length;
+            let errors = this.getDiagnostics(this.activeFile.fileName);
+            let actual = errors.length;
 
             this.scenarioActions.push('<CheckErrorList ExpectedNumOfErrors="' + expected + '" />');
 
             if (actual !== expected) {
                 this.printErrorLog(false, errors);
-                var errorMsg = "Actual number of errors (" + actual + ") does not match expected number (" + expected + ")";
+                let errorMsg = "Actual number of errors (" + actual + ") does not match expected number (" + expected + ")";
                 Harness.IO.log(errorMsg);
                 this.raiseError(errorMsg);
             }
         }
 
         public verifyEval(expr: string, value: any) {
-            var emit = this.languageService.getEmitOutput(this.activeFile.fileName);
+            let emit = this.languageService.getEmitOutput(this.activeFile.fileName);
             if (emit.outputFiles.length !== 1) {
                 throw new Error("Expected exactly one output from emit of " + this.activeFile.fileName);
             }
 
             this.taoInvalidReason = 'verifyEval impossible';
 
-            var evaluation = new Function(emit.outputFiles[0].text + ';\r\nreturn (' + expr + ');')();
+            let evaluation = new Function(emit.outputFiles[0].text + ';\r\nreturn (' + expr + ');')();
             if (evaluation !== value) {
                 this.raiseError('Expected evaluation of expression "' + expr + '" to equal "' + value + '", but got "' + evaluation + '"');
             }
         }
 
         public verifyGetEmitOutputForCurrentFile(expected: string): void {
-            var emit = this.languageService.getEmitOutput(this.activeFile.fileName);
+            let emit = this.languageService.getEmitOutput(this.activeFile.fileName);
             if (emit.outputFiles.length !== 1) {
                 throw new Error("Expected exactly one output from emit of " + this.activeFile.fileName);
             }
             this.taoInvalidReason = 'verifyGetEmitOutputForCurrentFile impossible';
-            var actual = emit.outputFiles[0].text;
+            let actual = emit.outputFiles[0].text;
             if (actual !== expected) {
                 this.raiseError("Expected emit output to be '" + expected + "', but got '" + actual + "'");
             }
@@ -585,7 +585,7 @@ module FourSlash {
                 this.taoInvalidReason = 'verifyMemberListContains only supports the "symbol" parameter';
             }
 
-            var members = this.getMemberListAtCaret();
+            let members = this.getMemberListAtCaret();
             if (members) {
                 this.assertItemInCompletionList(members.entries, symbol, text, documentation, kind);
             }
@@ -607,10 +607,10 @@ module FourSlash {
                 this.scenarioActions.push('<VerifyCompletionItemsCount Count="' + expectedCount + '" ' + (negative ? 'ExpectsFailure="true"' : '') + ' />');
             }
 
-            var members = this.getMemberListAtCaret();
+            let members = this.getMemberListAtCaret();
 
             if (members) {
-                var match = members.entries.length === expectedCount;
+                let match = members.entries.length === expectedCount;
 
                 if ((!match && !negative) || (match && negative)) {
                     this.raiseError("Member list count was " + members.entries.length + ". Expected " + expectedCount);
@@ -625,7 +625,7 @@ module FourSlash {
             this.scenarioActions.push('<ShowCompletionList />');
             this.scenarioActions.push('<VerifyCompletionDoesNotContainItem ItemName="' + escapeXmlAttributeValue(symbol) + '" />');
 
-            var members = this.getMemberListAtCaret();
+            let members = this.getMemberListAtCaret();
             if (members && members.entries.filter(e => e.name === symbol).length !== 0) {
                 this.raiseError('Member list did contain ' + symbol);
             }
@@ -634,8 +634,8 @@ module FourSlash {
         public verifyCompletionListItemsCountIsGreaterThan(count: number) {
             this.taoInvalidReason = 'verifyCompletionListItemsCountIsGreaterThan NYI';
 
-            var completions = this.getCompletionListAtCaret();
-            var itemsCount = completions.entries.length;
+            let completions = this.getCompletionListAtCaret();
+            let itemsCount = completions.entries.length;
 
             if (itemsCount <= count) {
                 this.raiseError('Expected completion list items count to be greater than ' + count + ', but is actually ' + itemsCount);
@@ -649,13 +649,13 @@ module FourSlash {
                 this.scenarioActions.push('<ShowCompletionList ExpectsFailure="true" />');
             }
 
-            var members = this.getMemberListAtCaret();
+            let members = this.getMemberListAtCaret();
             if ((!members || members.entries.length === 0) && negative) {
                 this.raiseError("Member list is empty at Caret");
             } else if ((members && members.entries.length !== 0) && !negative) {
 
-                var errorMsg = "\n" + "Member List contains: [" + members.entries[0].name;
-                for (var i = 1; i < members.entries.length; i++) {
+                let errorMsg = "\n" + "Member List contains: [" + members.entries[0].name;
+                for (let i = 1; i < members.entries.length; i++) {
                     errorMsg += ", " + members.entries[i].name;
                 }
                 errorMsg += "]\n";
@@ -668,13 +668,13 @@ module FourSlash {
         public verifyCompletionListIsEmpty(negative: boolean) {
             this.scenarioActions.push('<ShowCompletionList ExpectsFailure="true" />');
 
-            var completions = this.getCompletionListAtCaret();
+            let completions = this.getCompletionListAtCaret();
             if ((!completions || completions.entries.length === 0) && negative) {
                 this.raiseError("Completion list is empty at Caret");
             } else if ((completions && completions.entries.length !== 0) && !negative) {
 
-                var errorMsg = "\n" + "Completion List contains: [" + completions.entries[0].name;
-                for (var i = 1; i < completions.entries.length; i++) {
+                let errorMsg = "\n" + "Completion List contains: [" + completions.entries[0].name;
+                for (let i = 1; i < completions.entries.length; i++) {
                     errorMsg += ", " + completions.entries[i].name;
                 }
                 errorMsg += "]\n";
@@ -685,7 +685,7 @@ module FourSlash {
         }
 
         public verifyCompletionListAllowsNewIdentifier(negative: boolean) {
-            var completions = this.getCompletionListAtCaret();
+            let completions = this.getCompletionListAtCaret();
 
             if ((completions && !completions.isNewIdentifierLocation) && !negative) {
                 this.raiseError("Expected builder completion entry");
@@ -695,7 +695,7 @@ module FourSlash {
         }
 
         public verifyCompletionListContains(symbol: string, text?: string, documentation?: string, kind?: string) {
-            var completions = this.getCompletionListAtCaret();
+            let completions = this.getCompletionListAtCaret();
             if (completions) {
                 this.assertItemInCompletionList(completions.entries, symbol, text, documentation, kind);
             }
@@ -737,7 +737,7 @@ module FourSlash {
             this.scenarioActions.push('<ShowCompletionList />');
             this.scenarioActions.push('<VerifyCompletionDoesNotContainItem ItemName="' + escapeXmlAttributeValue(symbol) + '" />');
 
-            var completions = this.getCompletionListAtCaret();
+            let completions = this.getCompletionListAtCaret();
             if (completions) {
                 let filterCompletions = completions.entries.filter(e => e.name === symbol);
                 filterCompletions = expectedKind ? filterCompletions.filter(e => e.kind === expectedKind) : filterCompletions;
@@ -765,7 +765,7 @@ module FourSlash {
         public verifyCompletionEntryDetails(entryName: string, expectedText: string, expectedDocumentation?: string, kind?: string) {
             this.taoInvalidReason = 'verifyCompletionEntryDetails NYI';
 
-            var details = this.getCompletionEntryDetails(entryName);
+            let details = this.getCompletionEntryDetails(entryName);
 
             assert.equal(ts.displayPartsToString(details.displayParts), expectedText, assertionMessage("completion entry details text"));
 
@@ -781,14 +781,14 @@ module FourSlash {
         public verifyReferencesAtPositionListContains(fileName: string, start: number, end: number, isWriteAccess?: boolean) {
             this.taoInvalidReason = 'verifyReferencesAtPositionListContains NYI';
 
-            var references = this.getReferencesAtCaret();
+            let references = this.getReferencesAtCaret();
 
             if (!references || references.length === 0) {
                 this.raiseError('verifyReferencesAtPositionListContains failed - found 0 references, expected at least one.');
             }
 
-            for (var i = 0; i < references.length; i++) {
-                var reference = references[i];
+            for (let i = 0; i < references.length; i++) {
+                let reference = references[i];
                 if (reference && reference.fileName === fileName && reference.textSpan.start === start && ts.textSpanEnd(reference.textSpan) === end) {
                     if (typeof isWriteAccess !== "undefined" && reference.isWriteAccess !== isWriteAccess) {
                         this.raiseError('verifyReferencesAtPositionListContains failed - item isWriteAccess value does not match, actual: ' + reference.isWriteAccess + ', expected: ' + isWriteAccess + '.');
@@ -797,18 +797,18 @@ module FourSlash {
                 }
             }
 
-            var missingItem = { fileName: fileName, start: start, end: end, isWriteAccess: isWriteAccess };
+            let missingItem = { fileName: fileName, start: start, end: end, isWriteAccess: isWriteAccess };
             this.raiseError('verifyReferencesAtPositionListContains failed - could not find the item: ' + JSON.stringify(missingItem) + ' in the returned list: (' + JSON.stringify(references) + ')');
         }
 
         public verifyReferencesCountIs(count: number, localFilesOnly: boolean = true) {
             this.taoInvalidReason = 'verifyReferences NYI';
 
-            var references = this.getReferencesAtCaret();
-            var referencesCount = 0;
+            let references = this.getReferencesAtCaret();
+            let referencesCount = 0;
 
             if (localFilesOnly) {
-                var localFiles = this.testData.files.map<string>(file => file.fileName);
+                let localFiles = this.testData.files.map<string>(file => file.fileName);
                 // Count only the references in local files. Filter the ones in lib and other files.
                 ts.forEach(references, entry => {
                     if (localFiles.some((fileName) => fileName === entry.fileName)) {
@@ -821,7 +821,7 @@ module FourSlash {
             }
 
             if (referencesCount !== count) {
-                var condition = localFilesOnly ? "excluding libs" : "including libs";
+                let condition = localFilesOnly ? "excluding libs" : "including libs";
                 this.raiseError("Expected references count (" + condition + ") to be " + count + ", but is actually " + referencesCount);
             }
         }
@@ -847,18 +847,18 @@ module FourSlash {
         }
 
         public getSyntacticDiagnostics(expected: string) {
-            var diagnostics = this.languageService.getSyntacticDiagnostics(this.activeFile.fileName);
+            let diagnostics = this.languageService.getSyntacticDiagnostics(this.activeFile.fileName);
             this.testDiagnostics(expected, diagnostics);
         }
 
         public getSemanticDiagnostics(expected: string) {
-            var diagnostics = this.languageService.getSemanticDiagnostics(this.activeFile.fileName);
+            let diagnostics = this.languageService.getSemanticDiagnostics(this.activeFile.fileName);
             this.testDiagnostics(expected, diagnostics);
         }
 
         private testDiagnostics(expected: string, diagnostics: ts.Diagnostic[]) {
-            var realized = ts.realizeDiagnostics(diagnostics, "\r\n");
-            var actual = JSON.stringify(realized, null, "  ");
+            let realized = ts.realizeDiagnostics(diagnostics, "\r\n");
+            let actual = JSON.stringify(realized, null, "  ");
             assert.equal(actual, expected);
         }
 
@@ -870,9 +870,9 @@ module FourSlash {
                 }
             });
 
-            var actualQuickInfo = this.languageService.getQuickInfoAtPosition(this.activeFile.fileName, this.currentCaretPosition);
-            var actualQuickInfoText = actualQuickInfo ? ts.displayPartsToString(actualQuickInfo.displayParts) : "";
-            var actualQuickInfoDocumentation = actualQuickInfo ? ts.displayPartsToString(actualQuickInfo.documentation) : "";
+            let actualQuickInfo = this.languageService.getQuickInfoAtPosition(this.activeFile.fileName, this.currentCaretPosition);
+            let actualQuickInfoText = actualQuickInfo ? ts.displayPartsToString(actualQuickInfo.displayParts) : "";
+            let actualQuickInfoDocumentation = actualQuickInfo ? ts.displayPartsToString(actualQuickInfo.documentation) : "";
 
             if (negative) {
                 if (expectedText !== undefined) {
@@ -900,7 +900,7 @@ module FourSlash {
             this.scenarioActions.push('<Verify return values of quickInfo="' + JSON.stringify(displayParts) + '"/>');
 
             function getDisplayPartsJson(displayParts: ts.SymbolDisplayPart[]) {
-                var result = "";
+                let result = "";
                 ts.forEach(displayParts, part => {
                     if (result) {
                         result += ",\n    ";
@@ -917,7 +917,7 @@ module FourSlash {
                 return result;
             }
 
-            var actualQuickInfo = this.languageService.getQuickInfoAtPosition(this.activeFile.fileName, this.currentCaretPosition);
+            let actualQuickInfo = this.languageService.getQuickInfoAtPosition(this.activeFile.fileName, this.currentCaretPosition);
             assert.equal(actualQuickInfo.kind, kind, this.messageAtLastKnownMarker("QuickInfo kind"));
             assert.equal(actualQuickInfo.kindModifiers, kindModifiers, this.messageAtLastKnownMarker("QuickInfo kindModifiers"));
             assert.equal(JSON.stringify(actualQuickInfo.textSpan), JSON.stringify(textSpan), this.messageAtLastKnownMarker("QuickInfo textSpan"));
@@ -926,12 +926,12 @@ module FourSlash {
         }
 
         public verifyRenameLocations(findInStrings: boolean, findInComments: boolean) {
-            var renameInfo = this.languageService.getRenameInfo(this.activeFile.fileName, this.currentCaretPosition);
+            let renameInfo = this.languageService.getRenameInfo(this.activeFile.fileName, this.currentCaretPosition);
             if (renameInfo.canRename) {
-                var references = this.languageService.findRenameLocations(
+                let references = this.languageService.findRenameLocations(
                     this.activeFile.fileName, this.currentCaretPosition, findInStrings, findInComments);
 
-                var ranges = this.getRanges();
+                let ranges = this.getRanges();
 
                 if (!references) {
                     if (ranges.length !== 0) {
@@ -947,9 +947,9 @@ module FourSlash {
                 ranges = ranges.sort((r1, r2) => r1.start - r2.start);
                 references = references.sort((r1, r2) => r1.textSpan.start - r2.textSpan.start);
 
-                for (var i = 0, n = ranges.length; i < n; i++) {
-                    var reference = references[i];
-                    var range = ranges[i];
+                for (let i = 0, n = ranges.length; i < n; i++) {
+                    let reference = references[i];
+                    let range = ranges[i];
 
                     if (reference.textSpan.start !== range.start ||
                         ts.textSpanEnd(reference.textSpan) !== range.end) {
@@ -966,7 +966,7 @@ module FourSlash {
         public verifyQuickInfoExists(negative: boolean) {
             this.taoInvalidReason = 'verifyQuickInfoExists NYI';
 
-            var actualQuickInfo = this.languageService.getQuickInfoAtPosition(this.activeFile.fileName, this.currentCaretPosition);
+            let actualQuickInfo = this.languageService.getQuickInfoAtPosition(this.activeFile.fileName, this.currentCaretPosition);
             if (negative) {
                 if (actualQuickInfo) {
                     this.raiseError('verifyQuickInfoExists failed. Expected quick info NOT to exist');
@@ -982,42 +982,42 @@ module FourSlash {
         public verifyCurrentSignatureHelpIs(expected: string) {
             this.taoInvalidReason = 'verifyCurrentSignatureHelpIs NYI';
 
-            var help = this.getActiveSignatureHelpItem();
+            let help = this.getActiveSignatureHelpItem();
             assert.equal(
                 ts.displayPartsToString(help.prefixDisplayParts) +
                 help.parameters.map(p => ts.displayPartsToString(p.displayParts)).join(ts.displayPartsToString(help.separatorDisplayParts)) +
                 ts.displayPartsToString(help.suffixDisplayParts), expected);
         }
 
-        public verifyCurrentParameterIsVariable(isVariable: boolean) {
-            this.taoInvalidReason = 'verifyCurrentParameterIsVariable NYI';
+        public verifyCurrentParameterIsletiable(isletiable: boolean) {
+            this.taoInvalidReason = 'verifyCurrentParameterIsletiable NYI';
 
-            var signature = this.getActiveSignatureHelpItem();
+            let signature = this.getActiveSignatureHelpItem();
             assert.isNotNull(signature);
-            assert.equal(isVariable, signature.isVariadic);
+            assert.equal(isletiable, signature.isletiadic);
         }
 
         public verifyCurrentParameterHelpName(name: string) {
             this.taoInvalidReason = 'verifyCurrentParameterHelpName NYI';
 
-            var activeParameter = this.getActiveParameter();
-            var activeParameterName = activeParameter.name;
+            let activeParameter = this.getActiveParameter();
+            let activeParameterName = activeParameter.name;
             assert.equal(activeParameterName, name);
         }
 
         public verifyCurrentParameterSpanIs(parameter: string) {
             this.taoInvalidReason = 'verifyCurrentParameterSpanIs NYI';
 
-            var activeSignature = this.getActiveSignatureHelpItem();
-            var activeParameter = this.getActiveParameter();
+            let activeSignature = this.getActiveSignatureHelpItem();
+            let activeParameter = this.getActiveParameter();
             assert.equal(ts.displayPartsToString(activeParameter.displayParts), parameter);
         }
 
         public verifyCurrentParameterHelpDocComment(docComment: string) {
             this.taoInvalidReason = 'verifyCurrentParameterHelpDocComment NYI';
 
-            var activeParameter = this.getActiveParameter();
-            var activeParameterDocComment = activeParameter.documentation;
+            let activeParameter = this.getActiveParameter();
+            let activeParameterDocComment = activeParameter.documentation;
             assert.equal(ts.displayPartsToString(activeParameterDocComment), docComment, assertionMessage("current parameter Help DocComment"));
         }
 
@@ -1036,7 +1036,7 @@ module FourSlash {
         public verifyCurrentSignatureHelpDocComment(docComment: string) {
             this.taoInvalidReason = 'verifyCurrentSignatureHelpDocComment NYI';
 
-            var actualDocComment = this.getActiveSignatureHelpItem().documentation;
+            let actualDocComment = this.getActiveSignatureHelpItem().documentation;
             assert.equal(ts.displayPartsToString(actualDocComment), docComment, assertionMessage("current signature help doc comment"));
         }
 
@@ -1044,22 +1044,22 @@ module FourSlash {
             this.scenarioActions.push('<InvokeSignatureHelp />');
             this.scenarioActions.push('<VerifySignatureHelpOverloadCountEquals Count="' + expected + '" />');
 
-            var help = this.languageService.getSignatureHelpItems(this.activeFile.fileName, this.currentCaretPosition);
-            var actual = help && help.items ? help.items.length : 0;
+            let help = this.languageService.getSignatureHelpItems(this.activeFile.fileName, this.currentCaretPosition);
+            let actual = help && help.items ? help.items.length : 0;
             assert.equal(actual, expected);
         }
 
         public verifySignatureHelpArgumentCount(expected: number) {
             this.taoInvalidReason = 'verifySignatureHelpArgumentCount NYI';
-            var signatureHelpItems = this.languageService.getSignatureHelpItems(this.activeFile.fileName, this.currentCaretPosition);
-            var actual = signatureHelpItems.argumentCount;
+            let signatureHelpItems = this.languageService.getSignatureHelpItems(this.activeFile.fileName, this.currentCaretPosition);
+            let actual = signatureHelpItems.argumentCount;
             assert.equal(actual, expected);
         }
 
         public verifySignatureHelpPresent(shouldBePresent = true) {
             this.taoInvalidReason = 'verifySignatureHelpPresent NYI';
 
-            var actual = this.languageService.getSignatureHelpItems(this.activeFile.fileName, this.currentCaretPosition);
+            let actual = this.languageService.getSignatureHelpItems(this.activeFile.fileName, this.currentCaretPosition);
             if (shouldBePresent) {
                 if (!actual) {
                     this.raiseError("Expected signature help to be present, but it wasn't");
@@ -1078,7 +1078,7 @@ module FourSlash {
         }
 
         public verifyRenameInfoSucceeded(displayName?: string, fullDisplayName?: string, kind?: string, kindModifiers?: string) {
-            var renameInfo = this.languageService.getRenameInfo(this.activeFile.fileName, this.currentCaretPosition);
+            let renameInfo = this.languageService.getRenameInfo(this.activeFile.fileName, this.currentCaretPosition);
             if (!renameInfo.canRename) {
                 this.raiseError("Rename did not succeed");
             }
@@ -1092,7 +1092,7 @@ module FourSlash {
                 this.raiseError("Expected a single range to be selected in the test file.");
             }
 
-            var expectedRange = this.getRanges()[0];
+            let expectedRange = this.getRanges()[0];
             if (renameInfo.triggerSpan.start !== expectedRange.start ||
                 ts.textSpanEnd(renameInfo.triggerSpan) !== expectedRange.end) {
                 this.raiseError("Expected triggerSpan [" + expectedRange.start + "," + expectedRange.end + ").  Got [" +
@@ -1101,7 +1101,7 @@ module FourSlash {
         }
 
         public verifyRenameInfoFailed(message?: string) {
-            var renameInfo = this.languageService.getRenameInfo(this.activeFile.fileName, this.currentCaretPosition);
+            let renameInfo = this.languageService.getRenameInfo(this.activeFile.fileName, this.currentCaretPosition);
             if (renameInfo.canRename) {
                 this.raiseError("Rename was expected to fail");
             }
@@ -1110,26 +1110,26 @@ module FourSlash {
         }
 
         private getActiveSignatureHelpItem() {
-            var help = this.languageService.getSignatureHelpItems(this.activeFile.fileName, this.currentCaretPosition);
-            var index = help.selectedItemIndex;
+            let help = this.languageService.getSignatureHelpItems(this.activeFile.fileName, this.currentCaretPosition);
+            let index = help.selectedItemIndex;
             return help.items[index];
         }
 
         private getActiveParameter(): ts.SignatureHelpParameter {
-            var help = this.languageService.getSignatureHelpItems(this.activeFile.fileName, this.currentCaretPosition);
-            var item = help.items[help.selectedItemIndex];
-            var currentParam = help.argumentIndex;
+            let help = this.languageService.getSignatureHelpItems(this.activeFile.fileName, this.currentCaretPosition);
+            let item = help.items[help.selectedItemIndex];
+            let currentParam = help.argumentIndex;
             return item.parameters[currentParam];
         }
 
         private alignmentForExtraInfo = 50;
 
         private spanInfoToString(pos: number, spanInfo: ts.TextSpan, prefixString: string) {
-            var resultString = "SpanInfo: " + JSON.stringify(spanInfo);
+            let resultString = "SpanInfo: " + JSON.stringify(spanInfo);
             if (spanInfo) {
-                var spanString = this.activeFile.content.substr(spanInfo.start, spanInfo.length);
-                var spanLineMap = ts.computeLineStarts(spanString);
-                for (var i = 0; i < spanLineMap.length; i++) {
+                let spanString = this.activeFile.content.substr(spanInfo.start, spanInfo.length);
+                let spanLineMap = ts.computeLineStarts(spanString);
+                for (let i = 0; i < spanLineMap.length; i++) {
                     if (!i) {
                         resultString += "\n";
                     }
@@ -1142,20 +1142,20 @@ module FourSlash {
         }
 
         private baselineCurrentFileLocations(getSpanAtPos: (pos: number) => ts.TextSpan): string {
-            var fileLineMap = ts.computeLineStarts(this.activeFile.content);
-            var nextLine = 0;
-            var resultString = "";
-            var currentLine: string;
-            var previousSpanInfo: string;
-            var startColumn: number;
-            var length: number;
-            var prefixString = "    >";
+            let fileLineMap = ts.computeLineStarts(this.activeFile.content);
+            let nextLine = 0;
+            let resultString = "";
+            let currentLine: string;
+            let previousSpanInfo: string;
+            let startColumn: number;
+            let length: number;
+            let prefixString = "    >";
 
-            var pos = 0;
-            var addSpanInfoString = () => {
+            let pos = 0;
+            let addSpanInfoString = () => {
                 if (previousSpanInfo) {
                     resultString += currentLine;
-                    var thisLineMarker = repeatString(startColumn, " ") + repeatString(length, "~");
+                    let thisLineMarker = repeatString(startColumn, " ") + repeatString(length, "~");
                     thisLineMarker += repeatString(this.alignmentForExtraInfo - thisLineMarker.length - prefixString.length + 1, " ");
                     resultString += thisLineMarker;
                     resultString += "=> Pos: (" + (pos - length) + " to " + (pos - 1) + ") ";
@@ -1175,7 +1175,7 @@ module FourSlash {
                     startColumn = 0;
                     length = 0;
                 }
-                var spanInfo = this.spanInfoToString(pos, getSpanAtPos(pos), prefixString);
+                let spanInfo = this.spanInfoToString(pos, getSpanAtPos(pos), prefixString);
                 if (previousSpanInfo && previousSpanInfo !== spanInfo) {
                     addSpanInfoString();
                     previousSpanInfo = spanInfo;
@@ -1191,8 +1191,8 @@ module FourSlash {
             return resultString;
 
             function repeatString(count: number, char: string) {
-                var result = "";
-                for (var i = 0; i < count; i++) {
+                let result = "";
+                for (let i = 0; i < count; i++) {
                     result += char;
                 }
                 return result;
@@ -1219,11 +1219,11 @@ module FourSlash {
         public baselineGetEmitOutput() {
             this.taoInvalidReason = 'baselineGetEmitOutput impossible';
             // Find file to be emitted
-            var emitFiles: FourSlashFile[] = [];  // List of FourSlashFile that has emitThisFile flag on
+            let emitFiles: FourSlashFile[] = [];  // List of FourSlashFile that has emitThisFile flag on
 
-            var allFourSlashFiles = this.testData.files;
-            for (var idx = 0; idx < allFourSlashFiles.length; ++idx) {
-                var file = allFourSlashFiles[idx];
+            let allFourSlashFiles = this.testData.files;
+            for (let idx = 0; idx < allFourSlashFiles.length; ++idx) {
+                let file = allFourSlashFiles[idx];
                 if (file.fileOptions[metadataOptionNames.emitThisFile] === "true") {
                     // Find a file with the flag emitThisFile turned on
                     emitFiles.push(file);
@@ -1239,23 +1239,23 @@ module FourSlash {
                 "Generate getEmitOutput baseline : " + emitFiles.join(" "),
                 this.testData.globalOptions[metadataOptionNames.baselineFile],
                 () => {
-                    var resultString = "";
+                    let resultString = "";
                     // Loop through all the emittedFiles and emit them one by one
                     emitFiles.forEach(emitFile => {
-                        var emitOutput = this.languageService.getEmitOutput(emitFile.fileName);
+                        let emitOutput = this.languageService.getEmitOutput(emitFile.fileName);
                         // Print emitOutputStatus in readable format
                         resultString += "EmitSkipped: " + emitOutput.emitSkipped + ts.sys.newLine;
 
                         if (emitOutput.emitSkipped) {
                             resultString += "Diagnostics:" + ts.sys.newLine;
-                            var diagnostics = ts.getPreEmitDiagnostics(this.languageService.getProgram());
-                            for (var i = 0, n = diagnostics.length; i < n; i++) {
+                            let diagnostics = ts.getPreEmitDiagnostics(this.languageService.getProgram());
+                            for (let i = 0, n = diagnostics.length; i < n; i++) {
                                 resultString += "  " + diagnostics[0].messageText + ts.sys.newLine;
                             }
                         }
 
                         emitOutput.outputFiles.forEach((outputFile, idx, array) => {
-                            var fileName = "FileName : " + outputFile.name + ts.sys.newLine;
+                            let fileName = "FileName : " + outputFile.name + ts.sys.newLine;
                             resultString = resultString + fileName + outputFile.text;
                         });
                         resultString += ts.sys.newLine;
@@ -1275,19 +1275,19 @@ module FourSlash {
         }
 
         public printCurrentParameterHelp() {
-            var help = this.languageService.getSignatureHelpItems(this.activeFile.fileName, this.currentCaretPosition);
+            let help = this.languageService.getSignatureHelpItems(this.activeFile.fileName, this.currentCaretPosition);
             Harness.IO.log(JSON.stringify(help));
         }
 
         public printCurrentQuickInfo() {
-            var quickInfo = this.languageService.getQuickInfoAtPosition(this.activeFile.fileName, this.currentCaretPosition);
+            let quickInfo = this.languageService.getQuickInfoAtPosition(this.activeFile.fileName, this.currentCaretPosition);
             Harness.IO.log(JSON.stringify(quickInfo));
         }
 
         public printErrorList() {
-            var syntacticErrors = this.languageService.getSyntacticDiagnostics(this.activeFile.fileName);
-            var semanticErrors = this.languageService.getSemanticDiagnostics(this.activeFile.fileName);
-            var errorList = syntacticErrors.concat(semanticErrors);
+            let syntacticErrors = this.languageService.getSyntacticDiagnostics(this.activeFile.fileName);
+            let semanticErrors = this.languageService.getSemanticDiagnostics(this.activeFile.fileName);
+            let errorList = syntacticErrors.concat(semanticErrors);
             Harness.IO.log('Error list (' + errorList.length + ' errors)');
 
             if (errorList.length) {
@@ -1301,11 +1301,11 @@ module FourSlash {
         }
 
         public printCurrentFileState(makeWhitespaceVisible = false, makeCaretVisible = true) {
-            for (var i = 0; i < this.testData.files.length; i++) {
-                var file = this.testData.files[i];
-                var active = (this.activeFile === file);
+            for (let i = 0; i < this.testData.files.length; i++) {
+                let file = this.testData.files[i];
+                let active = (this.activeFile === file);
                 Harness.IO.log('=== Script (' + file.fileName + ') ' + (active ? '(active, cursor at |)' : '') + ' ===');
-                var content = this.getFileContent(file.fileName);
+                let content = this.getFileContent(file.fileName);
                 if (active) {
                     content = content.substr(0, this.currentCaretPosition) + (makeCaretVisible ? '|' : "") + content.substr(this.currentCaretPosition);
                 }
@@ -1317,22 +1317,22 @@ module FourSlash {
         }
 
         public printCurrentSignatureHelp() {
-            var sigHelp = this.getActiveSignatureHelpItem();
+            let sigHelp = this.getActiveSignatureHelpItem();
             Harness.IO.log(JSON.stringify(sigHelp));
         }
 
         public printMemberListMembers() {
-            var members = this.getMemberListAtCaret();
+            let members = this.getMemberListAtCaret();
             Harness.IO.log(JSON.stringify(members));
         }
 
         public printCompletionListMembers() {
-            var completions = this.getCompletionListAtCaret();
+            let completions = this.getCompletionListAtCaret();
             Harness.IO.log(JSON.stringify(completions));
         }
 
         public printReferences() {
-            var references = this.getReferencesAtCaret();
+            let references = this.getReferencesAtCaret();
             ts.forEach(references, entry => {
                 Harness.IO.log(JSON.stringify(entry));
             });
@@ -1345,26 +1345,26 @@ module FourSlash {
         public deleteChar(count = 1) {
             this.scenarioActions.push('<DeleteCharNext Count="' + count + '" />');
 
-            var offset = this.currentCaretPosition;
-            var ch = "";
+            let offset = this.currentCaretPosition;
+            let ch = "";
 
-            var checkCadence = (count >> 2) + 1;
+            let checkCadence = (count >> 2) + 1;
 
-            for (var i = 0; i < count; i++) {
+            for (let i = 0; i < count; i++) {
                 // Make the edit
                 this.languageServiceAdapterHost.editScript(this.activeFile.fileName, offset, offset + 1, ch);
                 this.updateMarkersForEdit(this.activeFile.fileName, offset, offset + 1, ch);
 
                 if (i % checkCadence === 0) {
-                    this.checkPostEditInvariants();
+                    this.checkPostEditInletiants();
                 }
 
                 // Handle post-keystroke formatting
                 if (this.enableFormatting) {
-                    var edits = this.languageService.getFormattingEditsAfterKeystroke(this.activeFile.fileName, offset, ch, this.formatCodeOptions);
+                    let edits = this.languageService.getFormattingEditsAfterKeystroke(this.activeFile.fileName, offset, ch, this.formatCodeOptions);
                     if (edits.length) {
                         offset += this.applyEdits(this.activeFile.fileName, edits, true);
-                        // this.checkPostEditInvariants();
+                        // this.checkPostEditInletiants();
                     }
                 }
             }
@@ -1373,7 +1373,7 @@ module FourSlash {
             this.currentCaretPosition = offset;
 
             this.fixCaretPosition();
-            this.checkPostEditInvariants();
+            this.checkPostEditInletiants();
         }
 
         public replace(start: number, length: number, text: string) {
@@ -1381,29 +1381,29 @@ module FourSlash {
 
             this.languageServiceAdapterHost.editScript(this.activeFile.fileName, start, start + length, text);
             this.updateMarkersForEdit(this.activeFile.fileName, start, start + length, text);
-            this.checkPostEditInvariants();
+            this.checkPostEditInletiants();
         }
 
         public deleteCharBehindMarker(count = 1) {
             this.scenarioActions.push('<DeleteCharPrevious Count="' + count + '" />');
 
-            var offset = this.currentCaretPosition;
-            var ch = "";
-            var checkCadence = (count >> 2) + 1;
+            let offset = this.currentCaretPosition;
+            let ch = "";
+            let checkCadence = (count >> 2) + 1;
 
-            for (var i = 0; i < count; i++) {
+            for (let i = 0; i < count; i++) {
                 offset--;
                 // Make the edit
                 this.languageServiceAdapterHost.editScript(this.activeFile.fileName, offset, offset + 1, ch);
                 this.updateMarkersForEdit(this.activeFile.fileName, offset, offset + 1, ch);
 
                 if (i % checkCadence === 0) {
-                    this.checkPostEditInvariants();
+                    this.checkPostEditInletiants();
                 }
 
                 // Handle post-keystroke formatting
                 if (this.enableFormatting) {
-                    var edits = this.languageService.getFormattingEditsAfterKeystroke(this.activeFile.fileName, offset, ch, this.formatCodeOptions);
+                    let edits = this.languageService.getFormattingEditsAfterKeystroke(this.activeFile.fileName, offset, ch, this.formatCodeOptions);
                     if (edits.length) {
                         offset += this.applyEdits(this.activeFile.fileName, edits, true);
                     }
@@ -1414,7 +1414,7 @@ module FourSlash {
             this.currentCaretPosition = offset;
 
             this.fixCaretPosition();
-            this.checkPostEditInvariants();
+            this.checkPostEditInletiants();
         }
 
         // Enters lines of text at the current caret position
@@ -1432,13 +1432,13 @@ module FourSlash {
         // language service APIs to mimic Visual Studio's behavior
         // as much as possible
         private typeHighFidelity(text: string) {
-            var offset = this.currentCaretPosition;
-            var prevChar = ' ';
-            var checkCadence = (text.length >> 2) + 1;
+            let offset = this.currentCaretPosition;
+            let prevChar = ' ';
+            let checkCadence = (text.length >> 2) + 1;
 
-            for (var i = 0; i < text.length; i++) {
+            for (let i = 0; i < text.length; i++) {
                 // Make the edit
-                var ch = text.charAt(i);
+                let ch = text.charAt(i);
                 this.languageServiceAdapterHost.editScript(this.activeFile.fileName, offset, offset, ch);
                 this.languageService.getBraceMatchingAtPosition(this.activeFile.fileName, offset);
 
@@ -1454,17 +1454,17 @@ module FourSlash {
                 }
 
                 if (i % checkCadence === 0) {
-                    this.checkPostEditInvariants();
+                    this.checkPostEditInletiants();
                     // this.languageService.getSyntacticDiagnostics(this.activeFile.fileName);
                     // this.languageService.getSemanticDiagnostics(this.activeFile.fileName);
                 }
 
                 // Handle post-keystroke formatting
                 if (this.enableFormatting) {
-                    var edits = this.languageService.getFormattingEditsAfterKeystroke(this.activeFile.fileName, offset, ch, this.formatCodeOptions);
+                    let edits = this.languageService.getFormattingEditsAfterKeystroke(this.activeFile.fileName, offset, ch, this.formatCodeOptions);
                     if (edits.length) {
                         offset += this.applyEdits(this.activeFile.fileName, edits, true);
-                        // this.checkPostEditInvariants();
+                        // this.checkPostEditInletiants();
                     }
                 }
             }
@@ -1473,26 +1473,26 @@ module FourSlash {
             this.currentCaretPosition = offset;
 
             this.fixCaretPosition();
-            this.checkPostEditInvariants();
+            this.checkPostEditInletiants();
         }
 
         // Enters text as if the user had pasted it
         public paste(text: string) {
             this.scenarioActions.push('<InsertText><![CDATA[' + text + ']]></InsertText>');
 
-            var start = this.currentCaretPosition;
-            var offset = this.currentCaretPosition;
+            let start = this.currentCaretPosition;
+            let offset = this.currentCaretPosition;
             this.languageServiceAdapterHost.editScript(this.activeFile.fileName, offset, offset, text);
             this.updateMarkersForEdit(this.activeFile.fileName, offset, offset, text);
-            this.checkPostEditInvariants();
+            this.checkPostEditInletiants();
             offset += text.length;
 
             // Handle formatting
             if (this.enableFormatting) {
-                var edits = this.languageService.getFormattingEditsForRange(this.activeFile.fileName, start, offset, this.formatCodeOptions);
+                let edits = this.languageService.getFormattingEditsForRange(this.activeFile.fileName, start, offset, this.formatCodeOptions);
                 if (edits.length) {
                     offset += this.applyEdits(this.activeFile.fileName, edits, true);
-                    this.checkPostEditInvariants();
+                    this.checkPostEditInletiants();
                 }
             }
 
@@ -1500,27 +1500,27 @@ module FourSlash {
             this.currentCaretPosition = offset;
             this.fixCaretPosition();
 
-            this.checkPostEditInvariants();
+            this.checkPostEditInletiants();
         }
 
-        private checkPostEditInvariants() {
+        private checkPostEditInletiants() {
             if (this.testType !== FourSlashTestType.Native) {
                 // getSourcefile() results can not be serialized. Only perform these verifications
                 // if running against a native LS object.
                 return;
             }
 
-            var incrementalSourceFile = this.languageService.getSourceFile(this.activeFile.fileName);
-            Utils.assertInvariants(incrementalSourceFile, /*parent:*/ undefined);
+            let incrementalSourceFile = this.languageService.getSourceFile(this.activeFile.fileName);
+            Utils.assertInletiants(incrementalSourceFile, /*parent:*/ undefined);
 
-            var incrementalSyntaxDiagnostics = incrementalSourceFile.parseDiagnostics;
+            let incrementalSyntaxDiagnostics = incrementalSourceFile.parseDiagnostics;
 
             // Check syntactic structure
-            var content = this.getFileContent(this.activeFile.fileName);
+            let content = this.getFileContent(this.activeFile.fileName);
 
-            var referenceSourceFile = ts.createLanguageServiceSourceFile(
+            let referenceSourceFile = ts.createLanguageServiceSourceFile(
                 this.activeFile.fileName, createScriptSnapShot(content), ts.ScriptTarget.Latest, /*version:*/ "0", /*setNodeParents:*/ false);
-            var referenceSyntaxDiagnostics = referenceSourceFile.parseDiagnostics;
+            let referenceSyntaxDiagnostics = referenceSourceFile.parseDiagnostics;
 
             Utils.assertDiagnosticsEquals(incrementalSyntaxDiagnostics, referenceSyntaxDiagnostics);
             Utils.assertStructuralEquals(incrementalSourceFile, referenceSourceFile);
@@ -1530,7 +1530,7 @@ module FourSlash {
             // The caret can potentially end up between the \r and \n, which is confusing. If
             // that happens, move it back one character
             if (this.currentCaretPosition > 0) {
-                var ch = this.getFileContent(this.activeFile.fileName).substring(this.currentCaretPosition - 1, this.currentCaretPosition);
+                let ch = this.getFileContent(this.activeFile.fileName).substring(this.currentCaretPosition - 1, this.currentCaretPosition);
                 if (ch === '\r') {
                     this.currentCaretPosition--;
                 }
@@ -1540,21 +1540,21 @@ module FourSlash {
         private applyEdits(fileName: string, edits: ts.TextChange[], isFormattingEdit = false): number {
             // We get back a set of edits, but langSvc.editScript only accepts one at a time. Use this to keep track
             // of the incremental offset from each edit to the next. Assumption is that these edit ranges don't overlap
-            var runningOffset = 0;
+            let runningOffset = 0;
             edits = edits.sort((a, b) => a.span.start - b.span.start);
             // Get a snapshot of the content of the file so we can make sure any formatting edits didn't destroy non-whitespace characters
-            var oldContent = this.getFileContent(this.activeFile.fileName);
-            for (var j = 0; j < edits.length; j++) {
+            let oldContent = this.getFileContent(this.activeFile.fileName);
+            for (let j = 0; j < edits.length; j++) {
                 this.languageServiceAdapterHost.editScript(fileName, edits[j].span.start + runningOffset, ts.textSpanEnd(edits[j].span) + runningOffset, edits[j].newText);
                 this.updateMarkersForEdit(fileName, edits[j].span.start + runningOffset, ts.textSpanEnd(edits[j].span) + runningOffset, edits[j].newText);
-                var change = (edits[j].span.start - ts.textSpanEnd(edits[j].span)) + edits[j].newText.length;
+                let change = (edits[j].span.start - ts.textSpanEnd(edits[j].span)) + edits[j].newText.length;
                 runningOffset += change;
                 // TODO: Consider doing this at least some of the time for higher fidelity. Currently causes a failure (bug 707150)
                 // this.languageService.getScriptLexicalStructure(fileName);
             }
 
             if (isFormattingEdit) {
-                var newContent = this.getFileContent(fileName);
+                let newContent = this.getFileContent(fileName);
 
                 if (newContent.replace(/\s/g, '') !== oldContent.replace(/\s/g, '')) {
                     this.raiseError('Formatting operation destroyed non-whitespace content');
@@ -1568,7 +1568,7 @@ module FourSlash {
         }
 
         public setFormatOptions(formatCodeOptions: ts.FormatCodeOptions): ts.FormatCodeOptions {
-            var oldFormatCodeOptions = this.formatCodeOptions;
+            let oldFormatCodeOptions = this.formatCodeOptions;
             this.formatCodeOptions = formatCodeOptions;
             return oldFormatCodeOptions;
         }
@@ -1576,7 +1576,7 @@ module FourSlash {
         public formatDocument() {
             this.scenarioActions.push('<FormatDocument />');
 
-            var edits = this.languageService.getFormattingEditsForDocument(this.activeFile.fileName, this.formatCodeOptions);
+            let edits = this.languageService.getFormattingEditsForDocument(this.activeFile.fileName, this.formatCodeOptions);
             this.currentCaretPosition += this.applyEdits(this.activeFile.fileName, edits, true);
             this.fixCaretPosition();
         }
@@ -1584,14 +1584,14 @@ module FourSlash {
         public formatSelection(start: number, end: number) {
             this.taoInvalidReason = 'formatSelection NYI';
 
-            var edits = this.languageService.getFormattingEditsForRange(this.activeFile.fileName, start, end, this.formatCodeOptions);
+            let edits = this.languageService.getFormattingEditsForRange(this.activeFile.fileName, start, end, this.formatCodeOptions);
             this.currentCaretPosition += this.applyEdits(this.activeFile.fileName, edits, true);
             this.fixCaretPosition();
         }
 
         private updateMarkersForEdit(fileName: string, minChar: number, limChar: number, text: string) {
-            for (var i = 0; i < this.testData.markers.length; i++) {
-                var marker = this.testData.markers[i];
+            for (let i = 0; i < this.testData.markers.length; i++) {
+                let marker = this.testData.markers[i];
                 if (marker.fileName === fileName) {
                     if (marker.position > minChar) {
                         if (marker.position < limChar) {
@@ -1611,7 +1611,7 @@ module FourSlash {
         }
 
         public goToEOF() {
-            var len = this.getFileContent(this.activeFile.fileName).length;
+            let len = this.getFileContent(this.activeFile.fileName).length;
             this.goToPosition(len);
         }
 
@@ -1622,7 +1622,7 @@ module FourSlash {
                 this.taoInvalidReason = 'GoToDefinition not supported for non-zero definition indices';
             }
 
-            var definitions = this.languageService.getDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition);
+            let definitions = this.languageService.getDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition);
             if (!definitions || !definitions.length) {
                 this.raiseError('goToDefinition failed - expected to at least one definition location but got 0');
             }
@@ -1631,7 +1631,7 @@ module FourSlash {
                 this.raiseError('goToDefinition failed - definitionIndex value (' + definitionIndex + ') exceeds definition list size (' + definitions.length + ')');
             }
 
-            var definition = definitions[definitionIndex];
+            let definition = definitions[definitionIndex];
             this.openFile(definition.fileName);
             this.currentCaretPosition = definition.textSpan.start;
         }
@@ -1644,7 +1644,7 @@ module FourSlash {
                 this.taoInvalidReason = 'GoToTypeDefinition not supported for non-zero definition indices';
             }
 
-            var definitions = this.languageService.getTypeDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition);
+            let definitions = this.languageService.getTypeDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition);
             if (!definitions || !definitions.length) {
                 this.raiseError('goToTypeDefinition failed - expected to at least one definition location but got 0');
             }
@@ -1653,7 +1653,7 @@ module FourSlash {
                 this.raiseError('goToTypeDefinition failed - definitionIndex value (' + definitionIndex + ') exceeds definition list size (' + definitions.length + ')');
             }
 
-            var definition = definitions[definitionIndex];
+            let definition = definitions[definitionIndex];
             this.openFile(definition.fileName);
             this.currentCaretPosition = definition.textSpan.start;
         }
@@ -1661,9 +1661,9 @@ module FourSlash {
         public verifyDefinitionLocationExists(negative: boolean) {
             this.taoInvalidReason = 'verifyDefinitionLocationExists NYI';
 
-            var definitions = this.languageService.getDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition);
+            let definitions = this.languageService.getDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition);
 
-            var foundDefinitions = definitions && definitions.length;
+            let foundDefinitions = definitions && definitions.length;
 
             if (foundDefinitions && negative) {
                 this.raiseError('goToDefinition - expected to 0 definition locations but got ' + definitions.length);
@@ -1674,19 +1674,19 @@ module FourSlash {
         }
 
         public verifyDefinitionsCount(negative: boolean, expectedCount: number) {
-            var assertFn = negative ? assert.notEqual : assert.equal;
+            let assertFn = negative ? assert.notEqual : assert.equal;
 
-            var definitions = this.languageService.getDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition);
-            var actualCount = definitions && definitions.length || 0;
+            let definitions = this.languageService.getDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition);
+            let actualCount = definitions && definitions.length || 0;
 
             assertFn(actualCount, expectedCount, this.messageAtLastKnownMarker("Definitions Count"));
         }
 
         public verifyTypeDefinitionsCount(negative: boolean, expectedCount: number) {
-            var assertFn = negative ? assert.notEqual : assert.equal;
+            let assertFn = negative ? assert.notEqual : assert.equal;
 
-            var definitions = this.languageService.getTypeDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition);
-            var actualCount = definitions && definitions.length || 0;
+            let definitions = this.languageService.getTypeDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition);
+            let actualCount = definitions && definitions.length || 0;
 
             assertFn(actualCount, expectedCount, this.messageAtLastKnownMarker("Type definitions Count"));
         }
@@ -1694,9 +1694,9 @@ module FourSlash {
         public verifyDefinitionsName(negative: boolean, expectedName: string, expectedContainerName: string) {
             this.taoInvalidReason = 'verifyDefinititionsInfo NYI';
 
-            var definitions = this.languageService.getDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition);
-            var actualDefinitionName = definitions && definitions.length ? definitions[0].name : "";
-            var actualDefinitionContainerName = definitions && definitions.length ? definitions[0].containerName : "";
+            let definitions = this.languageService.getDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition);
+            let actualDefinitionName = definitions && definitions.length ? definitions[0].name : "";
+            let actualDefinitionContainerName = definitions && definitions.length ? definitions[0].containerName : "";
             if (negative) {
                 assert.notEqual(actualDefinitionName, expectedName, this.messageAtLastKnownMarker("Definition Info Name"));
                 assert.notEqual(actualDefinitionContainerName, expectedContainerName, this.messageAtLastKnownMarker("Definition Info Container Name"));
@@ -1719,7 +1719,7 @@ module FourSlash {
         public verifyCaretAtMarker(markerName = '') {
             this.taoInvalidReason = 'verifyCaretAtMarker NYI';
 
-            var pos = this.getMarkerByName(markerName);
+            let pos = this.getMarkerByName(markerName);
             if (pos.fileName !== this.activeFile.fileName) {
                 throw new Error('verifyCaretAtMarker failed - expected to be in file "' + pos.fileName + '", but was in file "' + this.activeFile.fileName + '"');
             }
@@ -1735,8 +1735,8 @@ module FourSlash {
         public verifyIndentationAtCurrentPosition(numberOfSpaces: number) {
             this.taoInvalidReason = 'verifyIndentationAtCurrentPosition NYI';
 
-            var actual = this.getIndentation(this.activeFile.fileName, this.currentCaretPosition);
-            var lineCol = this.getLineColStringAtPosition(this.currentCaretPosition);
+            let actual = this.getIndentation(this.activeFile.fileName, this.currentCaretPosition);
+            let lineCol = this.getLineColStringAtPosition(this.currentCaretPosition);
             if (actual !== numberOfSpaces) {
                 this.raiseError('verifyIndentationAtCurrentPosition failed at ' + lineCol + ' - expected: ' + numberOfSpaces + ', actual: ' + actual);
             }
@@ -1745,8 +1745,8 @@ module FourSlash {
         public verifyIndentationAtPosition(fileName: string, position: number, numberOfSpaces: number) {
             this.taoInvalidReason = 'verifyIndentationAtPosition NYI';
 
-            var actual = this.getIndentation(fileName, position);
-            var lineCol = this.getLineColStringAtPosition(position);
+            let actual = this.getIndentation(fileName, position);
+            let lineCol = this.getLineColStringAtPosition(position);
             if (actual !== numberOfSpaces) {
                 this.raiseError('verifyIndentationAtPosition failed at ' + lineCol + ' - expected: ' + numberOfSpaces + ', actual: ' + actual);
             }
@@ -1755,7 +1755,7 @@ module FourSlash {
         public verifyCurrentLineContent(text: string) {
             this.taoInvalidReason = 'verifyCurrentLineContent NYI';
 
-            var actual = this.getCurrentLineContent();
+            let actual = this.getCurrentLineContent();
             if (actual !== text) {
                 throw new Error('verifyCurrentLineContent\n' +
                     '\tExpected: "' + text + '"\n' +
@@ -1766,8 +1766,8 @@ module FourSlash {
         public verifyCurrentFileContent(text: string) {
             this.taoInvalidReason = 'verifyCurrentFileContent NYI';
 
-            var actual = this.getFileContent(this.activeFile.fileName);
-            var replaceNewlines = (str: string) => str.replace(/\r\n/g, "\n");
+            let actual = this.getFileContent(this.activeFile.fileName);
+            let replaceNewlines = (str: string) => str.replace(/\r\n/g, "\n");
             if (replaceNewlines(actual) !== replaceNewlines(text)) {
                 throw new Error('verifyCurrentFileContent\n' +
                     '\tExpected: "' + text + '"\n' +
@@ -1778,7 +1778,7 @@ module FourSlash {
         public verifyTextAtCaretIs(text: string) {
             this.taoInvalidReason = 'verifyCurrentFileContent NYI';
 
-            var actual = this.getFileContent(this.activeFile.fileName).substring(this.currentCaretPosition, this.currentCaretPosition + text.length);
+            let actual = this.getFileContent(this.activeFile.fileName).substring(this.currentCaretPosition, this.currentCaretPosition + text.length);
             if (actual !== text) {
                 throw new Error('verifyTextAtCaretIs\n' +
                     '\tExpected: "' + text + '"\n' +
@@ -1789,14 +1789,14 @@ module FourSlash {
         public verifyCurrentNameOrDottedNameSpanText(text: string) {
             this.taoInvalidReason = 'verifyCurrentNameOrDottedNameSpanText NYI';
 
-            var span = this.languageService.getNameOrDottedNameSpan(this.activeFile.fileName, this.currentCaretPosition, this.currentCaretPosition);
+            let span = this.languageService.getNameOrDottedNameSpan(this.activeFile.fileName, this.currentCaretPosition, this.currentCaretPosition);
             if (!span) {
                 this.raiseError('verifyCurrentNameOrDottedNameSpanText\n' +
                     '\tExpected: "' + text + '"\n' +
                     '\t  Actual: undefined');
             }
 
-            var actual = this.getFileContent(this.activeFile.fileName).substring(span.start, ts.textSpanEnd(span));
+            let actual = this.getFileContent(this.activeFile.fileName).substring(span.start, ts.textSpanEnd(span));
             if (actual !== text) {
                 this.raiseError('verifyCurrentNameOrDottedNameSpanText\n' +
                     '\tExpected: "' + text + '"\n' +
@@ -1833,11 +1833,11 @@ module FourSlash {
                     jsonMismatchString());
             }
 
-            for (var i = 0; i < expected.length; i++) {
-                var expectedClassification = expected[i];
-                var actualClassification = actual[i];
+            for (let i = 0; i < expected.length; i++) {
+                let expectedClassification = expected[i];
+                let actualClassification = actual[i];
 
-                var expectedType: string = (<any>ts.ClassificationTypeNames)[expectedClassification.classificationType];
+                let expectedType: string = (<any>ts.ClassificationTypeNames)[expectedClassification.classificationType];
                 if (expectedType !== actualClassification.classificationType) {
                     this.raiseError('verifyClassifications failed - expected classifications type to be ' +
                         expectedType + ', but was ' +
@@ -1845,11 +1845,11 @@ module FourSlash {
                         jsonMismatchString());
                 }
 
-                var expectedSpan = expectedClassification.textSpan;
-                var actualSpan = actualClassification.textSpan;
+                let expectedSpan = expectedClassification.textSpan;
+                let actualSpan = actualClassification.textSpan;
 
                 if (expectedSpan) {
-                    var expectedLength = expectedSpan.end - expectedSpan.start;
+                    let expectedLength = expectedSpan.end - expectedSpan.start;
 
                     if (expectedSpan.start !== actualSpan.start || expectedLength !== actualSpan.length) {
                         this.raiseError("verifyClassifications failed - expected span of text to be " +
@@ -1859,7 +1859,7 @@ module FourSlash {
                     }
                 }
 
-                var actualText = this.activeFile.content.substr(actualSpan.start, actualSpan.length);
+                let actualText = this.activeFile.content.substr(actualSpan.start, actualSpan.length);
                 if (expectedClassification.text !== actualText) {
                     this.raiseError('verifyClassifications failed - expected classified text to be ' +
                         expectedClassification.text + ', but was ' +
@@ -1891,14 +1891,14 @@ module FourSlash {
         }
 
         public verifySemanticClassifications(expected: { classificationType: string; text: string }[]) {
-            var actual = this.languageService.getSemanticClassifications(this.activeFile.fileName,
+            let actual = this.languageService.getSemanticClassifications(this.activeFile.fileName,
                 ts.createTextSpan(0, this.activeFile.content.length));
 
             this.verifyClassifications(expected, actual);
         }
 
         public verifySyntacticClassifications(expected: { classificationType: string; text: string }[]) {
-            var actual = this.languageService.getSyntacticClassifications(this.activeFile.fileName,
+            let actual = this.languageService.getSyntacticClassifications(this.activeFile.fileName,
                 ts.createTextSpan(0, this.activeFile.content.length));
 
             this.verifyClassifications(expected, actual);
@@ -1907,15 +1907,15 @@ module FourSlash {
         public verifyOutliningSpans(spans: TextSpan[]) {
             this.taoInvalidReason = 'verifyOutliningSpans NYI';
 
-            var actual = this.languageService.getOutliningSpans(this.activeFile.fileName);
+            let actual = this.languageService.getOutliningSpans(this.activeFile.fileName);
 
             if (actual.length !== spans.length) {
                 this.raiseError('verifyOutliningSpans failed - expected total spans to be ' + spans.length + ', but was ' + actual.length);
             }
 
-            for (var i = 0; i < spans.length; i++) {
-                var expectedSpan = spans[i];
-                var actualSpan = actual[i];
+            for (let i = 0; i < spans.length; i++) {
+                let expectedSpan = spans[i];
+                let actualSpan = actual[i];
                 if (expectedSpan.start !== actualSpan.textSpan.start || expectedSpan.end !== ts.textSpanEnd(actualSpan.textSpan)) {
                     this.raiseError('verifyOutliningSpans failed - span ' + (i + 1) + ' expected: (' + expectedSpan.start + ',' + expectedSpan.end + '),  actual: (' + actualSpan.textSpan.start + ',' + ts.textSpanEnd(actualSpan.textSpan) + ')');
                 }
@@ -1923,17 +1923,17 @@ module FourSlash {
         }
 
         public verifyTodoComments(descriptors: string[], spans: TextSpan[]) {
-            var actual = this.languageService.getTodoComments(this.activeFile.fileName,
+            let actual = this.languageService.getTodoComments(this.activeFile.fileName,
                 descriptors.map(d => { return { text: d, priority: 0 }; }));
 
             if (actual.length !== spans.length) {
                 this.raiseError('verifyTodoComments failed - expected total spans to be ' + spans.length + ', but was ' + actual.length);
             }
 
-            for (var i = 0; i < spans.length; i++) {
-                var expectedSpan = spans[i];
-                var actualComment = actual[i];
-                var actualCommentSpan = ts.createTextSpan(actualComment.position, actualComment.message.length);
+            for (let i = 0; i < spans.length; i++) {
+                let expectedSpan = spans[i];
+                let actualComment = actual[i];
+                let actualCommentSpan = ts.createTextSpan(actualComment.position, actualComment.message.length);
 
                 if (expectedSpan.start !== actualCommentSpan.start || expectedSpan.end !== ts.textSpanEnd(actualCommentSpan)) {
                     this.raiseError('verifyOutliningSpans failed - span ' + (i + 1) + ' expected: (' + expectedSpan.start + ',' + expectedSpan.end + '),  actual: (' + actualCommentSpan.start + ',' + ts.textSpanEnd(actualCommentSpan) + ')');
@@ -1944,13 +1944,13 @@ module FourSlash {
         public verifyMatchingBracePosition(bracePosition: number, expectedMatchPosition: number) {
             this.taoInvalidReason = 'verifyMatchingBracePosition NYI';
 
-            var actual = this.languageService.getBraceMatchingAtPosition(this.activeFile.fileName, bracePosition);
+            let actual = this.languageService.getBraceMatchingAtPosition(this.activeFile.fileName, bracePosition);
 
             if (actual.length !== 2) {
                 this.raiseError('verifyMatchingBracePosition failed - expected result to contain 2 spans, but it had ' + actual.length);
             }
 
-            var actualMatchPosition = -1;
+            let actualMatchPosition = -1;
             if (bracePosition === actual[0].start) {
                 actualMatchPosition = actual[1].start;
             } else if (bracePosition === actual[1].start) {
@@ -1967,7 +1967,7 @@ module FourSlash {
         public verifyNoMatchingBracePosition(bracePosition: number) {
             this.taoInvalidReason = 'verifyNoMatchingBracePosition NYI';
 
-            var actual = this.languageService.getBraceMatchingAtPosition(this.activeFile.fileName, bracePosition);
+            let actual = this.languageService.getBraceMatchingAtPosition(this.activeFile.fileName, bracePosition);
 
             if (actual.length !== 0) {
                 this.raiseError('verifyNoMatchingBracePosition failed - expected: 0 spans, actual: ' + actual.length);
@@ -1981,12 +1981,12 @@ module FourSlash {
         public verifyNavigationItemsCount(expected: number, searchValue: string, matchKind?: string) {
             this.taoInvalidReason = 'verifyNavigationItemsCount NYI';
 
-            var items = this.languageService.getNavigateToItems(searchValue);
-            var actual = 0;
-            var item: ts.NavigateToItem = null;
+            let items = this.languageService.getNavigateToItems(searchValue);
+            let actual = 0;
+            let item: ts.NavigateToItem = null;
 
             // Count only the match that match the same MatchKind
-            for (var i = 0; i < items.length; ++i) {
+            for (let i = 0; i < items.length; ++i) {
                 item = items[i];
                 if (!matchKind || item.matchKind === matchKind) {
                     actual++;
@@ -2011,14 +2011,14 @@ module FourSlash {
             parentName?: string) {
             this.taoInvalidReason = 'verifyNavigationItemsListContains NYI';
 
-            var items = this.languageService.getNavigateToItems(searchValue);
+            let items = this.languageService.getNavigateToItems(searchValue);
 
             if (!items || items.length === 0) {
                 this.raiseError('verifyNavigationItemsListContains failed - found 0 navigation items, expected at least one.');
             }
 
-            for (var i = 0; i < items.length; i++) {
-                var item = items[i];
+            for (let i = 0; i < items.length; i++) {
+                let item = items[i];
                 if (item && item.name === name && item.kind === kind &&
                     (matchKind === undefined || item.matchKind === matchKind) &&
                     (fileName === undefined || item.fileName === fileName) &&
@@ -2029,7 +2029,7 @@ module FourSlash {
 
             // if there was an explicit match kind specified, then it should be validated.
             if (matchKind !== undefined) {
-                var missingItem = { name: name, kind: kind, searchValue: searchValue, matchKind: matchKind, fileName: fileName, parentName: parentName };
+                let missingItem = { name: name, kind: kind, searchValue: searchValue, matchKind: matchKind, fileName: fileName, parentName: parentName };
                 this.raiseError('verifyNavigationItemsListContains failed - could not find the item: ' + JSON.stringify(missingItem) + ' in the returned list: (' + JSON.stringify(items) + ')');
             }
         }
@@ -2037,8 +2037,8 @@ module FourSlash {
         public verifyGetScriptLexicalStructureListCount(expected: number) {
             this.taoInvalidReason = 'verifyNavigationItemsListContains impossible';
 
-            var items = this.languageService.getNavigationBarItems(this.activeFile.fileName);
-            var actual = this.getNavigationBarItemsCount(items);
+            let items = this.languageService.getNavigationBarItems(this.activeFile.fileName);
+            let actual = this.getNavigationBarItemsCount(items);
 
             if (expected !== actual) {
                 this.raiseError('verifyGetScriptLexicalStructureListCount failed - found: ' + actual + ' navigation items, expected: ' + expected + '.');
@@ -2046,9 +2046,9 @@ module FourSlash {
         }
 
         private getNavigationBarItemsCount(items: ts.NavigationBarItem[]) {
-            var result = 0;
+            let result = 0;
             if (items) {
-                for (var i = 0, n = items.length; i < n; i++) {
+                for (let i = 0, n = items.length; i < n; i++) {
                     result++;
                     result += this.getNavigationBarItemsCount(items[i].childItems);
                 }
@@ -2063,7 +2063,7 @@ module FourSlash {
             markerPosition?: number) {
             this.taoInvalidReason = 'verifGetScriptLexicalStructureListContains impossible';
 
-            var items = this.languageService.getNavigationBarItems(this.activeFile.fileName);
+            let items = this.languageService.getNavigationBarItems(this.activeFile.fileName);
 
             if (!items || items.length === 0) {
                 this.raiseError('verifyGetScriptLexicalStructureListContains failed - found 0 navigation items, expected at least one.');
@@ -2073,14 +2073,14 @@ module FourSlash {
                 return;
             }
 
-            var missingItem = { name: name, kind: kind };
+            let missingItem = { name: name, kind: kind };
             this.raiseError('verifyGetScriptLexicalStructureListContains failed - could not find the item: ' + JSON.stringify(missingItem) + ' in the returned list: (' + JSON.stringify(items, null, " ") + ')');
         }
 
         private navigationBarItemsContains(items: ts.NavigationBarItem[], name: string, kind: string) {
             if (items) {
-                for (var i = 0; i < items.length; i++) {
-                    var item = items[i];
+                for (let i = 0; i < items.length; i++) {
+                    let item = items[i];
                     if (item && item.text === name && item.kind === kind) {
                         return true;
                     }
@@ -2095,25 +2095,25 @@ module FourSlash {
         }
 
         public printNavigationItems(searchValue: string) {
-            var items = this.languageService.getNavigateToItems(searchValue);
-            var length = items && items.length;
+            let items = this.languageService.getNavigateToItems(searchValue);
+            let length = items && items.length;
 
             Harness.IO.log('NavigationItems list (' + length + ' items)');
 
-            for (var i = 0; i < length; i++) {
-                var item = items[i];
+            for (let i = 0; i < length; i++) {
+                let item = items[i];
                 Harness.IO.log('name: ' + item.name + ', kind: ' + item.kind + ', parentName: ' + item.containerName + ', fileName: ' + item.fileName);
             }
         }
 
         public printScriptLexicalStructureItems() {
-            var items = this.languageService.getNavigationBarItems(this.activeFile.fileName);
-            var length = items && items.length;
+            let items = this.languageService.getNavigationBarItems(this.activeFile.fileName);
+            let length = items && items.length;
 
             Harness.IO.log('NavigationItems list (' + length + ' items)');
 
-            for (var i = 0; i < length; i++) {
-                var item = items[i];
+            for (let i = 0; i < length; i++) {
+                let item = items[i];
                 Harness.IO.log('name: ' + item.text + ', kind: ' + item.kind);
             }
         }
@@ -2125,14 +2125,14 @@ module FourSlash {
         public verifyOccurrencesAtPositionListContains(fileName: string, start: number, end: number, isWriteAccess?: boolean) {
             this.taoInvalidReason = 'verifyOccurrencesAtPositionListContains NYI';
 
-            var occurances = this.getOccurancesAtCurrentPosition();
+            let occurances = this.getOccurancesAtCurrentPosition();
 
             if (!occurances || occurances.length === 0) {
                 this.raiseError('verifyOccurancesAtPositionListContains failed - found 0 references, expected at least one.');
             }
 
-            for (var i = 0; i < occurances.length; i++) {
-                var occurance = occurances[i];
+            for (let i = 0; i < occurances.length; i++) {
+                let occurance = occurances[i];
                 if (occurance && occurance.fileName === fileName && occurance.textSpan.start === start && ts.textSpanEnd(occurance.textSpan) === end) {
                     if (typeof isWriteAccess !== "undefined" && occurance.isWriteAccess !== isWriteAccess) {
                         this.raiseError('verifyOccurancesAtPositionListContains failed - item isWriteAccess value doe not match, actual: ' + occurance.isWriteAccess + ', expected: ' + isWriteAccess + '.');
@@ -2141,15 +2141,15 @@ module FourSlash {
                 }
             }
 
-            var missingItem = { fileName: fileName, start: start, end: end, isWriteAccess: isWriteAccess };
+            let missingItem = { fileName: fileName, start: start, end: end, isWriteAccess: isWriteAccess };
             this.raiseError('verifyOccurancesAtPositionListContains failed - could not find the item: ' + JSON.stringify(missingItem) + ' in the returned list: (' + JSON.stringify(occurances) + ')');
         }
 
         public verifyOccurrencesAtPositionListCount(expectedCount: number) {
             this.taoInvalidReason = 'verifyOccurrencesAtPositionListCount NYI';
 
-            var occurances = this.getOccurancesAtCurrentPosition();
-            var actualCount = occurances ? occurances.length : 0;
+            let occurances = this.getOccurancesAtCurrentPosition();
+            let actualCount = occurances ? occurances.length : 0;
             if (expectedCount !== actualCount) {
                 this.raiseError('verifyOccurrencesAtPositionListCount failed - actual: ' + actualCount + ', expected:' + expectedCount);
             }
@@ -2157,13 +2157,13 @@ module FourSlash {
 
         // Get the text of the entire line the caret is currently at
         private getCurrentLineContent() {
-            var text = this.getFileContent(this.activeFile.fileName);
+            let text = this.getFileContent(this.activeFile.fileName);
 
-            var pos = this.currentCaretPosition;
-            var startPos = pos, endPos = pos;
+            let pos = this.currentCaretPosition;
+            let startPos = pos, endPos = pos;
 
             while (startPos > 0) {
-                var ch = text.charCodeAt(startPos - 1);
+                let ch = text.charCodeAt(startPos - 1);
                 if (ch === ts.CharacterCodes.carriageReturn || ch === ts.CharacterCodes.lineFeed) {
                     break;
                 }
@@ -2172,7 +2172,7 @@ module FourSlash {
             }
 
             while (endPos < text.length) {
-                var ch = text.charCodeAt(endPos);
+                let ch = text.charCodeAt(endPos);
 
                 if (ch === ts.CharacterCodes.carriageReturn || ch === ts.CharacterCodes.lineFeed) {
                     break;
@@ -2192,11 +2192,11 @@ module FourSlash {
                 this.taoInvalidReason = 'assertItemInCompletionList only supports the "name" parameter';
             }
 
-            for (var i = 0; i < items.length; i++) {
-                var item = items[i];
+            for (let i = 0; i < items.length; i++) {
+                let item = items[i];
                 if (item.name === name) {
                     if (documentation != undefined || text !== undefined) {
-                        var details = this.getCompletionEntryDetails(item.name);
+                        let details = this.getCompletionEntryDetails(item.name);
 
                         if (documentation !== undefined) {
                             assert.equal(ts.displayPartsToString(details.documentation), documentation, assertionMessage("completion item documentation"));
@@ -2214,30 +2214,30 @@ module FourSlash {
                 }
             }
 
-            var itemsString = items.map((item) => JSON.stringify({ name: item.name, kind: item.kind })).join(",\n");
+            let itemsString = items.map((item) => JSON.stringify({ name: item.name, kind: item.kind })).join(",\n");
 
             this.raiseError('Expected "' + JSON.stringify({ name, text, documentation, kind }) + '" to be in list [' + itemsString + ']');
         }
 
         private findFile(indexOrName: any) {
-            var result: FourSlashFile = null;
+            let result: FourSlashFile = null;
             if (typeof indexOrName === 'number') {
-                var index = <number>indexOrName;
+                let index = <number>indexOrName;
                 if (index >= this.testData.files.length) {
                     throw new Error('File index (' + index + ') in openFile was out of range. There are only ' + this.testData.files.length + ' files in this test.');
                 } else {
                     result = this.testData.files[index];
                 }
             } else if (typeof indexOrName === 'string') {
-                var name = <string>indexOrName;
+                let name = <string>indexOrName;
 
                 // names are stored in the compiler with this relative path, this allows people to use goTo.file on just the fileName
                 name = name.indexOf('/') === -1 ? (this.basePath + '/' + name) : name;
 
-                var availableNames: string[] = [];
-                var foundIt = false;
-                for (var i = 0; i < this.testData.files.length; i++) {
-                    var fn = this.testData.files[i].fileName;
+                let availableNames: string[] = [];
+                let foundIt = false;
+                for (let i = 0; i < this.testData.files.length; i++) {
+                    let fn = this.testData.files[i].fileName;
                     if (fn) {
                         if (fn === name) {
                             result = this.testData.files[i];
@@ -2259,15 +2259,15 @@ module FourSlash {
         }
 
         private getLineColStringAtPosition(position: number) {
-            var pos = this.languageServiceAdapterHost.positionToLineAndCharacter(this.activeFile.fileName, position);
+            let pos = this.languageServiceAdapterHost.positionToLineAndCharacter(this.activeFile.fileName, position);
             return 'line ' + (pos.line + 1) + ', col ' + pos.character;
         }
 
         private getMarkerByName(markerName: string) {
-            var markerPos = this.testData.markerPositions[markerName];
+            let markerPos = this.testData.markerPositions[markerName];
             if (markerPos === undefined) {
-                var markerNames: string[] = [];
-                for (var m in this.testData.markerPositions) markerNames.push(m);
+                let markerNames: string[] = [];
+                for (let m in this.testData.markerPositions) markerNames.push(m);
                 throw new Error('Unknown marker "' + markerName + '" Available markers: ' + markerNames.map(m => '"' + m + '"').join(', '));
             } else {
                 return markerPos;
@@ -2296,12 +2296,12 @@ module FourSlash {
     }
 
     // TOOD: should these just use the Harness's stdout/stderr?
-    var fsOutput = new Harness.Compiler.WriterAggregator();
-    var fsErrors = new Harness.Compiler.WriterAggregator();
-    export var xmlData: TestXmlData[] = [];
+    let fsOutput = new Harness.Compiler.WriterAggregator();
+    let fsErrors = new Harness.Compiler.WriterAggregator();
+    export let xmlData: TestXmlData[] = [];
     export function runFourSlashTest(basePath: string, testType: FourSlashTestType, fileName: string) {
-        var content = Harness.IO.readFile(fileName);
-        var xml = runFourSlashTestContent(basePath, testType, content, fileName);
+        let content = Harness.IO.readFile(fileName);
+        let xml = runFourSlashTestContent(basePath, testType, content, fileName);
         xmlData.push(xml);
     }
 
@@ -2366,8 +2366,8 @@ module FourSlash {
     }
 
     function chompLeadingSpace(content: string) {
-        var lines = content.split("\n");
-        for (var i = 0; i < lines.length; i++) {
+        let lines = content.split("\n");
+        for (let i = 0; i < lines.length; i++) {
             if ((lines[i].length !== 0) && (lines[i].charAt(0) !== ' ')) {
                 return content;
             }
@@ -2378,31 +2378,31 @@ module FourSlash {
 
     function parseTestData(basePath: string, contents: string, fileName: string): FourSlashData {
         // Regex for parsing options in the format "@Alpha: Value of any sort"
-        var optionRegex = /^\s*@(\w+): (.*)\s*/;
+        let optionRegex = /^\s*@(\w+): (.*)\s*/;
 
         // List of all the subfiles we've parsed out
-        var files: FourSlashFile[] = [];
+        let files: FourSlashFile[] = [];
         // Global options
-        var globalOptions: { [s: string]: string; } = {};
+        let globalOptions: { [s: string]: string; } = {};
         // Marker positions
 
         // Split up the input file by line
         // Note: IE JS engine incorrectly handles consecutive delimiters here when using RegExp split, so
         // we have to string-based splitting instead and try to figure out the delimiting chars
-        var lines = contents.split('\n');
+        let lines = contents.split('\n');
 
-        var markerPositions: MarkerMap = {};
-        var markers: Marker[] = [];
-        var ranges: Range[] = [];
+        let markerPositions: MarkerMap = {};
+        let markers: Marker[] = [];
+        let ranges: Range[] = [];
 
         // Stuff related to the subfile we're parsing
-        var currentFileContent: string = null;
-        var currentFileName = fileName;
-        var currentFileOptions: { [s: string]: string } = {};
+        let currentFileContent: string = null;
+        let currentFileName = fileName;
+        let currentFileOptions: { [s: string]: string } = {};
 
-        for (var i = 0; i < lines.length; i++) {
-            var line = lines[i];
-            var lineLength = line.length;
+        for (let i = 0; i < lines.length; i++) {
+            let line = lines[i];
+            let lineLength = line.length;
 
             if (lineLength > 0 && line.charAt(lineLength - 1) === '\r') {
                 line = line.substr(0, lineLength - 1);
@@ -2422,17 +2422,17 @@ module FourSlash {
                 currentFileContent = currentFileContent + line.substr(4);
             } else if (line.substr(0, 2) === '//') {
                 // Comment line, check for global/file @options and record them
-                var match = optionRegex.exec(line.substr(2));
+                let match = optionRegex.exec(line.substr(2));
                 if (match) {
-                    var globalMetadataNamesIndex = globalMetadataNames.indexOf(match[1]);
-                    var fileMetadataNamesIndex = fileMetadataNames.indexOf(match[1]);
+                    let globalMetadataNamesIndex = globalMetadataNames.indexOf(match[1]);
+                    let fileMetadataNamesIndex = fileMetadataNames.indexOf(match[1]);
                     if (globalMetadataNamesIndex === -1) {
                         if (fileMetadataNamesIndex === -1) {
                             throw new Error('Unrecognized metadata name "' + match[1] + '". Available global metadata names are: ' + globalMetadataNames.join(', ') + '; file metadata names are: ' + fileMetadataNames.join(', '));
                         } else if (fileMetadataNamesIndex === fileMetadataNames.indexOf(metadataOptionNames.fileName)) {
                             // Found an @FileName directive, if this is not the first then create a new subfile
                             if (currentFileContent) {
-                                var file = parseFileContent(currentFileContent, currentFileName, markerPositions, markers, ranges);
+                                let file = parseFileContent(currentFileContent, currentFileName, markerPositions, markers, ranges);
                                 file.fileOptions = currentFileOptions;
 
                                 // Store result file
@@ -2465,7 +2465,7 @@ module FourSlash {
             } else {
                 // Empty line or code line, terminate current subfile if there is one
                 if (currentFileContent) {
-                    var file = parseFileContent(currentFileContent, currentFileName, markerPositions, markers, ranges);
+                    let file = parseFileContent(currentFileContent, currentFileName, markerPositions, markers, ranges);
                     file.fileOptions = currentFileOptions;
 
                     // Store result file
@@ -2495,12 +2495,12 @@ module FourSlash {
     }
 
     function reportError(fileName: string, line: number, col: number, message: string) {
-        var errorMessage = fileName + "(" + line + "," + col + "): " + message;
+        let errorMessage = fileName + "(" + line + "," + col + "): " + message;
         throw new Error(errorMessage);
     }
 
     function recordObjectMarker(fileName: string, location: ILocationInformation, text: string, markerMap: MarkerMap, markers: Marker[]): Marker {
-        var markerValue: any = undefined;
+        let markerValue: any = undefined;
         try {
             // Attempt to parse the marker value as JSON
             markerValue = JSON.parse("{ " + text + " }");
@@ -2513,7 +2513,7 @@ module FourSlash {
             return null;
         }
 
-        var marker: Marker = {
+        let marker: Marker = {
             fileName: fileName,
             position: location.position,
             data: markerValue
@@ -2530,14 +2530,14 @@ module FourSlash {
     }
 
     function recordMarker(fileName: string, location: ILocationInformation, name: string, markerMap: MarkerMap, markers: Marker[]): Marker {
-        var marker: Marker = {
+        let marker: Marker = {
             fileName: fileName,
             position: location.position
         };
 
         // Verify markers for uniqueness
         if (markerMap[name] !== undefined) {
-            var message = "Marker '" + name + "' is duplicated in the source file contents.";
+            let message = "Marker '" + name + "' is duplicated in the source file contents.";
             reportError(marker.fileName, location.sourceLine, location.sourceColumn, message);
             return null;
         } else {
@@ -2551,34 +2551,34 @@ module FourSlash {
         content = chompLeadingSpace(content);
 
         // Any slash-star comment with a character not in this string is not a marker.
-        var validMarkerChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz$1234567890_';
+        let validMarkerChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz$1234567890_';
 
         /// The file content (minus metacharacters) so far
-        var output: string = "";
+        let output: string = "";
 
         /// The current marker (or maybe multi-line comment?) we're parsing, possibly
-        var openMarker: ILocationInformation = null;
+        let openMarker: ILocationInformation = null;
 
         /// A stack of the open range markers that are still unclosed
-        var openRanges: IRangeLocationInformation[] = [];
+        let openRanges: IRangeLocationInformation[] = [];
 
         /// A list of ranges we've collected so far */
-        var localRanges: Range[] = [];
+        let localRanges: Range[] = [];
 
         /// The latest position of the start of an unflushed plain text area
-        var lastNormalCharPosition: number = 0;
+        let lastNormalCharPosition: number = 0;
 
         /// The total number of metacharacters removed from the file (so far)
-        var difference: number = 0;
+        let difference: number = 0;
 
         /// The fourslash file state object we are generating
-        var state: State = State.none;
+        let state: State = State.none;
 
         /// Current position data
-        var line: number = 1;
-        var column: number = 1;
+        let line: number = 1;
+        let column: number = 1;
 
-        var flush = (lastSafeCharIndex: number) => {
+        let flush = (lastSafeCharIndex: number) => {
             if (lastSafeCharIndex === undefined) {
                 output = output + content.substr(lastNormalCharPosition);
             } else {
@@ -2587,9 +2587,9 @@ module FourSlash {
         };
 
         if (content.length > 0) {
-            var previousChar = content.charAt(0);
-            for (var i = 1; i < content.length; i++) {
-                var currentChar = content.charAt(i);
+            let previousChar = content.charAt(0);
+            for (let i = 1; i < content.length; i++) {
+                let currentChar = content.charAt(i);
                 switch (state) {
                     case State.none:
                         if (previousChar === "[" && currentChar === "|") {
@@ -2606,12 +2606,12 @@ module FourSlash {
                             difference += 2;
                         } else if (previousChar === "|" && currentChar === "]") {
                             // found a range end
-                            var rangeStart = openRanges.pop();
+                            let rangeStart = openRanges.pop();
                             if (!rangeStart) {
                                 reportError(fileName, line, column, "Found range end with no matching start.");
                             }
 
-                            var range: Range = {
+                            let range: Range = {
                                 fileName: fileName,
                                 start: rangeStart.position,
                                 end: (i - 1) - difference,
@@ -2649,8 +2649,8 @@ module FourSlash {
                         // Object markers are only ever terminated by |} and have no content restrictions
                         if (previousChar === "|" && currentChar === "}") {
                             // Record the marker
-                            var objectMarkerNameText = content.substring(openMarker.sourcePosition + 2, i - 1).trim();
-                            var marker = recordObjectMarker(fileName, openMarker, objectMarkerNameText, markerMap, markers);
+                            let objectMarkerNameText = content.substring(openMarker.sourcePosition + 2, i - 1).trim();
+                            let marker = recordObjectMarker(fileName, openMarker, objectMarkerNameText, markerMap, markers);
 
                             if (openRanges.length > 0) {
                                 openRanges[openRanges.length - 1].marker = marker;
@@ -2670,8 +2670,8 @@ module FourSlash {
                         if (previousChar === "*" && currentChar === "/") {
                             // Record the marker
                             // start + 2 to ignore the */, -1 on the end to ignore the * (/ is next)
-                            var markerNameText = content.substring(openMarker.sourcePosition + 2, i - 1).trim();
-                            var marker = recordMarker(fileName, openMarker, markerNameText, markerMap, markers);
+                            let markerNameText = content.substring(openMarker.sourcePosition + 2, i - 1).trim();
+                            let marker = recordMarker(fileName, openMarker, markerNameText, markerMap, markers);
 
                             if (openRanges.length > 0) {
                                 openRanges[openRanges.length - 1].marker = marker;
@@ -2719,7 +2719,7 @@ module FourSlash {
         flush(undefined);
 
         if (openRanges.length > 0) {
-            var openRange = openRanges[0];
+            let openRange = openRanges[0];
             reportError(fileName, openRange.sourceLine, openRange.sourceColumn, "Unterminated range.");
         }
 

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1164,7 +1164,7 @@ module FourSlash {
                 }
             };
 
-            for (pos < this.activeFile.content.length; pos++) {
+            for (; pos < this.activeFile.content.length; pos++) {
                 if (pos === 0 || pos === fileLineMap[nextLine]) {
                     nextLine++;
                     addSpanInfoString();

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -510,8 +510,9 @@ module FourSlash {
             let exists = false;
 
             let startPos = startMarker.position;
+            let endPos: number = undefined;
             if (endMarker !== undefined) {
-                let endPos = endMarker.position;
+                endPos = endMarker.position;
             }
 
             errors.forEach(function (error: ts.Diagnostic) {
@@ -989,12 +990,12 @@ module FourSlash {
                 ts.displayPartsToString(help.suffixDisplayParts), expected);
         }
 
-        public verifyCurrentParameterIsletiable(isletiable: boolean) {
+        public verifyCurrentParameterIsletiable(isVariable: boolean) {
             this.taoInvalidReason = 'verifyCurrentParameterIsletiable NYI';
 
             let signature = this.getActiveSignatureHelpItem();
             assert.isNotNull(signature);
-            assert.equal(isletiable, signature.isletiadic);
+            assert.equal(isVariable, signature.isVariadic);
         }
 
         public verifyCurrentParameterHelpName(name: string) {
@@ -1511,7 +1512,7 @@ module FourSlash {
             }
 
             let incrementalSourceFile = this.languageService.getSourceFile(this.activeFile.fileName);
-            Utils.assertInletiants(incrementalSourceFile, /*parent:*/ undefined);
+            Utils.assertInvariants(incrementalSourceFile, /*parent:*/ undefined);
 
             let incrementalSyntaxDiagnostics = incrementalSourceFile.parseDiagnostics;
 

--- a/src/harness/fourslashRunner.ts
+++ b/src/harness/fourslashRunner.ts
@@ -46,7 +46,7 @@ class FourSlashRunner extends RunnerBase {
                         if (testIndex >= 0) fn = fn.substr(testIndex);
 
                         if (justName && !justName.match(/fourslash\.ts$/i) && !justName.match(/\.d\.ts$/i)) {
-                            it(this.testSuiteName + ' test ' + justName + ' runs correctly',() => {
+                            it(this.testSuiteName + ' test ' + justName + ' runs correctly', () => {
                                 FourSlash.runFourSlashTest(this.basePath, this.testType, fn);
                         });
                     }

--- a/src/harness/fourslashRunner.ts
+++ b/src/harness/fourslashRunner.ts
@@ -39,10 +39,10 @@ class FourSlashRunner extends RunnerBase {
             this.tests.forEach((fn: string) => {
                  describe(fn, () => {
                        fn = ts.normalizeSlashes(fn);
-                        var justName = fn.replace(/^.*[\\\/]/, '');
+                        let justName = fn.replace(/^.*[\\\/]/, '');
 
                         // Convert to relative path
-                        var testIndex = fn.indexOf('tests/');
+                        let testIndex = fn.indexOf('tests/');
                         if (testIndex >= 0) fn = fn.substr(testIndex);
 
                         if (justName && !justName.match(/fourslash\.ts$/i) && !justName.match(/\.d\.ts$/i)) {
@@ -54,21 +54,21 @@ class FourSlashRunner extends RunnerBase {
             });
 
             describe('Generate Tao XML', () => {
-                var invalidReasons: any = {};
+                let invalidReasons: any = {};
                 FourSlash.xmlData.forEach(xml => {
                     if (xml.invalidReason !== null) {
                         invalidReasons[xml.invalidReason] = (invalidReasons[xml.invalidReason] || 0) + 1;
                     }
                 });
-                var invalidReport: { reason: string; count: number }[] = [];
-                for (var reason in invalidReasons) {
+                let invalidReport: { reason: string; count: number }[] = [];
+                for (let reason in invalidReasons) {
                     if (invalidReasons.hasOwnProperty(reason)) {
                         invalidReport.push({ reason: reason, count: invalidReasons[reason] });
                     }
                 }
                 invalidReport.sort((lhs, rhs) => lhs.count > rhs.count ? -1 : lhs.count === rhs.count ? 0 : 1);
 
-                var lines: string[] = [];
+                let lines: string[] = [];
                 lines.push('<!-- Blocked Test Report');
                 invalidReport.forEach((reasonAndCount) => {
                     lines.push(reasonAndCount.count + ' tests blocked by ' + reasonAndCount.reason);

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -24,16 +24,16 @@
 /// <reference path='sourceMapRecorder.ts'/>
 /// <reference path='runnerbase.ts'/>
 
-var Buffer: BufferConstructor = require('buffer').Buffer;
+let Buffer: BufferConstructor = require('buffer').Buffer;
 
 // this will work in the browser via browserify
-var _chai: typeof chai = require('chai');
-var assert: typeof _chai.assert = _chai.assert;
-declare var __dirname: string; // Node-specific
-var global = <any>Function("return this").call(null);
+let _chai: typeof chai = require('chai');
+let assert: typeof _chai.assert = _chai.assert;
+declare let __dirname: string; // Node-specific
+let global = <any>Function("return this").call(null);
 
 module Utils {
-    var global = <any>Function("return this").call(null);
+    let global = <any>Function("return this").call(null);
 
     // Setup some globals based on the current environment
     export const enum ExecutionEnvironment {
@@ -54,17 +54,17 @@ module Utils {
         }
     }
 
-    export var currentExecutionEnvironment = getExecutionEnvironment();
+    export let currentExecutionEnvironment = getExecutionEnvironment();
 
     export function evalFile(fileContents: string, fileName: string, nodeContext?: any) {
-        var environment = getExecutionEnvironment();
+        let environment = getExecutionEnvironment();
         switch (environment) {
             case ExecutionEnvironment.CScript:
             case ExecutionEnvironment.Browser:
                 eval(fileContents);
                 break;
             case ExecutionEnvironment.Node:
-                var vm = require('vm');
+                let vm = require('vm');
                 if (nodeContext) {
                     vm.runInNewContext(fileContents, nodeContext, fileName);
                 } else {
@@ -81,7 +81,7 @@ module Utils {
         // Split up the input file by line
         // Note: IE JS engine incorrectly handles consecutive delimiters here when using RegExp split, so
         // we have to use string-based splitting instead and try to figure out the delimiting chars
-        var lines = content.split('\r\n');
+        let lines = content.split('\r\n');
         if (lines.length === 1) {
             lines = content.split('\n');
 
@@ -99,7 +99,7 @@ module Utils {
         }
 
         try {
-            var content = ts.sys.readFile(Harness.userSpecifiedRoot + path);
+            let content = ts.sys.readFile(Harness.userSpecifiedRoot + path);
         }
         catch (err) {
             return undefined;
@@ -109,11 +109,11 @@ module Utils {
     }
 
     export function memoize<T extends Function>(f: T): T {
-        var cache: { [idx: string]: any } = {};
+        let cache: { [idx: string]: any } = {};
 
         return <any>(function () {
-            var key = Array.prototype.join.call(arguments);
-            var cachedResult = cache[key];
+            let key = Array.prototype.join.call(arguments);
+            let cachedResult = cache[key];
             if (cachedResult) {
                 return cachedResult;
             } else {
@@ -122,7 +122,7 @@ module Utils {
         });
     }
 
-    export function assertInvariants(node: ts.Node, parent: ts.Node): void {
+    export function assertInletiants(node: ts.Node, parent: ts.Node): void {
         if (node) {
             assert.isFalse(node.pos < 0, "node.pos < 0");
             assert.isFalse(node.end < 0, "node.end < 0");
@@ -136,11 +136,11 @@ module Utils {
             }
 
             ts.forEachChild(node, child => {
-                assertInvariants(child, node);
+                assertInletiants(child, node);
             });
 
             // Make sure each of the children is in order.
-            var currentPos = 0;
+            let currentPos = 0;
             ts.forEachChild(node,
                 child => {
                     assert.isFalse(child.pos < currentPos, "child.pos < currentPos");
@@ -151,22 +151,22 @@ module Utils {
                     assert.isFalse(array.end > node.end, "array.end > node.end");
                     assert.isFalse(array.pos < currentPos, "array.pos < currentPos");
 
-                    for (var i = 0, n = array.length; i < n; i++) {
+                    for (let i = 0, n = array.length; i < n; i++) {
                         assert.isFalse(array[i].pos < currentPos, "array[i].pos < currentPos");
-                        currentPos = array[i].end
+                        currentPos = array[i].end;
                     }
 
                     currentPos = array.end;
                 });
 
-            var childNodesAndArrays: any[] = [];
-            ts.forEachChild(node, child => { childNodesAndArrays.push(child) }, array => { childNodesAndArrays.push(array) });
+            let childNodesAndArrays: any[] = [];
+            ts.forEachChild(node, child => { childNodesAndArrays.push(child); }, array => { childNodesAndArrays.push(array); });
 
-            for (var childName in node) {
+            for (let childName in node) {
                 if (childName === "parent" || childName === "nextContainer" || childName === "modifiers" || childName === "externalModuleIndicator") {
                     continue;
                 }
-                var child = (<any>node)[childName];
+                let child = (<any>node)[childName];
                 if (isNodeOrArray(child)) {
                     assert.isFalse(childNodesAndArrays.indexOf(child) < 0,
                         "Missing child when forEach'ing over node: " + (<any>ts).SyntaxKind[node.kind] + "-" + childName);
@@ -194,7 +194,7 @@ module Utils {
     }
 
     export function sourceFileToJSON(file: ts.Node): string {
-        return JSON.stringify(file,(k, v) => {
+        return JSON.stringify(file, (k, v) => {
             return isNodeOrArray(v) ? serializeNode(v) : v;
         }, "    ");
 
@@ -203,7 +203,7 @@ module Utils {
                 return k;
             }
 
-            return (<any>ts).SyntaxKind[k]
+            return (<any>ts).SyntaxKind[k];
         }
 
         function getFlagName(flags: any, f: number): any {
@@ -211,7 +211,7 @@ module Utils {
                 return 0;
             }
 
-            var result = "";
+            let result = "";
             ts.forEach(Object.getOwnPropertyNames(flags), (v: any) => {
                 if (isFinite(v)) {
                     v = +v;
@@ -234,7 +234,7 @@ module Utils {
         function getParserContextFlagName(f: number) { return getFlagName((<any>ts).ParserContextFlags, f); }
 
         function serializeNode(n: ts.Node): any {
-            var o: any = { kind: getKindName(n.kind) };
+            let o: any = { kind: getKindName(n.kind) };
             if (ts.containsParseError(n)) {
                 o.containsParseError = true;
             }
@@ -268,7 +268,7 @@ module Utils {
                         // Clear the flag that are produced by aggregating child values..  That is ephemeral 
                         // data we don't care about in the dump.  We only care what the parser set directly
                         // on the ast.
-                        var value = n.parserContextFlags & ts.ParserContextFlags.ParserGeneratedFlags;
+                        let value = n.parserContextFlags & ts.ParserContextFlags.ParserGeneratedFlags;
                         if (value) {
                             o[propertyName] = getParserContextFlagName(value);
                         }
@@ -313,9 +313,9 @@ module Utils {
 
         assert.equal(array1.length, array2.length, "array1.length !== array2.length");
 
-        for (var i = 0, n = array1.length; i < n; i++) {
-            var d1 = array1[i];
-            var d2 = array2[i];
+        for (let i = 0, n = array1.length; i < n; i++) {
+            let d1 = array1[i];
+            let d2 = array2[i];
 
             assert.equal(d1.start, d2.start, "d1.start !== d2.start");
             assert.equal(d1.length, d2.length, "d1.length !== d2.length");
@@ -346,14 +346,14 @@ module Utils {
 
         ts.forEachChild(node1,
             child1 => {
-                var childName = findChildName(node1, child1);
-                var child2: ts.Node = (<any>node2)[childName];
+                let childName = findChildName(node1, child1);
+                let child2: ts.Node = (<any>node2)[childName];
 
                 assertStructuralEquals(child1, child2);
             },
             (array1: ts.NodeArray<ts.Node>) => {
-                var childName = findChildName(node1, array1);
-                var array2: ts.NodeArray<ts.Node> = (<any>node2)[childName];
+                let childName = findChildName(node1, array1);
+                let array2: ts.NodeArray<ts.Node> = (<any>node2)[childName];
 
                 assertArrayStructuralEquals(array1, array2);
             });
@@ -370,13 +370,13 @@ module Utils {
         assert.equal(array1.end, array2.end, "array1.end !== array2.end");
         assert.equal(array1.length, array2.length, "array1.length !== array2.length");
 
-        for (var i = 0, n = array1.length; i < n; i++) {
+        for (let i = 0, n = array1.length; i < n; i++) {
             assertStructuralEquals(array1[i], array2[i]);
         }
     }
 
     function findChildName(parent: any, child: any) {
-        for (var name in parent) {
+        for (let name in parent) {
             if (parent.hasOwnProperty(name) && parent[name] === child) {
                 return name;
             }
@@ -393,8 +393,8 @@ module Harness.Path {
 
     export function filePath(fullPath: string) {
         fullPath = ts.normalizeSlashes(fullPath);
-        var components = fullPath.split("/");
-        var path: string[] = components.slice(0, components.length - 1);
+        let components = fullPath.split("/");
+        let path: string[] = components.slice(0, components.length - 1);
         return path.join("/") + "/";
     }
 }
@@ -422,19 +422,19 @@ module Harness {
         }
 
         export module CScript {
-            var fso: any;
+            let fso: any;
             if (global.ActiveXObject) {
                 fso = new global.ActiveXObject("Scripting.FileSystemObject");
             } else {
                 fso = {};
             }
 
-            export var readFile: typeof IO.readFile = ts.sys.readFile;
-            export var writeFile: typeof IO.writeFile = ts.sys.writeFile;
-            export var directoryName: typeof IO.directoryName = fso.GetParentFolderName;
-            export var directoryExists: typeof IO.directoryExists = fso.FolderExists;
-            export var fileExists: typeof IO.fileExists = fso.FileExists;
-            export var log: typeof IO.log = global.WScript && global.WScript.StdOut.WriteLine;
+            export let readFile: typeof IO.readFile = ts.sys.readFile;
+            export let writeFile: typeof IO.writeFile = ts.sys.writeFile;
+            export let directoryName: typeof IO.directoryName = fso.GetParentFolderName;
+            export let directoryExists: typeof IO.directoryExists = fso.FolderExists;
+            export let fileExists: typeof IO.fileExists = fso.FileExists;
+            export let log: typeof IO.log = global.WScript && global.WScript.StdOut.WriteLine;
 
             export function createDirectory(path: string) {
                 if (directoryExists(path)) {
@@ -448,11 +448,11 @@ module Harness {
                 }
             }
 
-            export var listFiles: typeof IO.listFiles = (path, spec?, options?) => {
+            export let listFiles: typeof IO.listFiles = (path, spec?, options?) => {
                 options = options || <{ recursive?: boolean; }>{};
                 function filesInFolder(folder: any, root: string): string[] {
-                    var paths: string[] = [];
-                    var fc: any;
+                    let paths: string[] = [];
+                    let fc: any;
 
                     if (options.recursive) {
                         fc = new Enumerator(folder.subfolders);
@@ -473,17 +473,16 @@ module Harness {
                     return paths;
                 }
 
-                var folder: any = fso.GetFolder(path);
-                var paths: string[] = [];
+                let folder: any = fso.GetFolder(path);
+                let paths: string[] = [];
 
                 return filesInFolder(folder, path);
-
-            }
+            };
         }
 
         export module Node {
-            declare var require: any;
-            var fs: any, pathModule: any;
+            declare let require: any;
+            let fs: any, pathModule: any;
             if (require) {
                 fs = require('fs');
                 pathModule = require('path');
@@ -491,10 +490,10 @@ module Harness {
                 fs = pathModule = {};
             }
 
-            export var readFile: typeof IO.readFile = ts.sys.readFile;
-            export var writeFile: typeof IO.writeFile = ts.sys.writeFile;
-            export var fileExists: typeof IO.fileExists = fs.existsSync;
-            export var log: typeof IO.log = console.log;
+            export let readFile: typeof IO.readFile = ts.sys.readFile;
+            export let writeFile: typeof IO.writeFile = ts.sys.writeFile;
+            export let fileExists: typeof IO.fileExists = fs.existsSync;
+            export let log: typeof IO.log = console.log;
 
             export function createDirectory(path: string) {
                 if (!directoryExists(path)) {
@@ -514,7 +513,7 @@ module Harness {
             }
 
             export function directoryName(path: string) {
-                var dirPath = pathModule.dirname(path);
+                let dirPath = pathModule.dirname(path);
 
                 // Node will just continue to repeat the root path, rather than return null
                 if (dirPath === path) {
@@ -524,16 +523,16 @@ module Harness {
                 }
             }
 
-            export var listFiles: typeof IO.listFiles = (path, spec?, options?) => {
+            export let listFiles: typeof IO.listFiles = (path, spec?, options?) => {
                 options = options || <{ recursive?: boolean; }>{};
 
                 function filesInFolder(folder: string): string[] {
-                    var paths: string[] = [];
+                    let paths: string[] = [];
 
-                    var files = fs.readdirSync(folder);
-                    for (var i = 0; i < files.length; i++) {
-                        var pathToFile = pathModule.join(folder, files[i]);
-                        var stat = fs.statSync(pathToFile);
+                    let files = fs.readdirSync(folder);
+                    for (let i = 0; i < files.length; i++) {
+                        let pathToFile = pathModule.join(folder, files[i]);
+                        let stat = fs.statSync(pathToFile);
                         if (options.recursive && stat.isDirectory()) {
                             paths = paths.concat(filesInFolder(pathToFile));
                         }
@@ -546,23 +545,23 @@ module Harness {
                 }
 
                 return filesInFolder(path);
-            }
+            };
 
-            export var getMemoryUsage: typeof IO.getMemoryUsage = () => {
+            export let getMemoryUsage: typeof IO.getMemoryUsage = () => {
                 if (global.gc) {
                     global.gc();
                 }
                 return process.memoryUsage().heapUsed;
-            }
+            };
         }
 
         export module Network {
-            var serverRoot = "http://localhost:8888/";
+            let serverRoot = "http://localhost:8888/";
 
             // Unused?
-            var newLine = '\r\n';
-            var currentDirectory = () => '';
-            var supportsCodePage = () => false;
+            let newLine = '\r\n';
+            let currentDirectory = () => '';
+            let supportsCodePage = () => false;
 
             module Http {
                 function waitForXHR(xhr: XMLHttpRequest) {
@@ -572,7 +571,7 @@ module Harness {
 
                 /// Ask the server to use node's path.resolve to resolve the given path
                 function getResolvedPathFromServer(path: string) {
-                    var xhr = new XMLHttpRequest();
+                    let xhr = new XMLHttpRequest();
                     try {
                         xhr.open("GET", path + "?resolve", false);
                         xhr.send();
@@ -591,7 +590,7 @@ module Harness {
 
                 /// Ask the server for the contents of the file at the given URL via a simple GET request
                 export function getFileFromServerSync(url: string): XHRResponse {
-                    var xhr = new XMLHttpRequest();
+                    let xhr = new XMLHttpRequest();
                     try {
                         xhr.open("GET", url, false);
                         xhr.send();
@@ -605,9 +604,9 @@ module Harness {
 
                 /// Submit a POST request to the server to do the given action (ex WRITE, DELETE) on the provided URL
                 export function writeToServerSync(url: string, action: string, contents?: string): XHRResponse {
-                    var xhr = new XMLHttpRequest();
+                    let xhr = new XMLHttpRequest();
                     try {
-                        var action = '?action=' + action;
+                        let action = '?action=' + action;
                         xhr.open('POST', url + action, false);
                         xhr.setRequestHeader('Access-Control-Allow-Origin', '*');
                         xhr.send(contents);
@@ -633,7 +632,7 @@ module Harness {
             }
 
             function directoryNameImpl(path: string) {
-                var dirPath = path;
+                let dirPath = path;
                 // root of the server
                 if (dirPath.match(/localhost:\d+$/) || dirPath.match(/localhost:\d+\/$/)) {
                     dirPath = null;
@@ -646,22 +645,22 @@ module Harness {
                     if (dirPath.match(/.*\/$/)) {
                         dirPath = dirPath.substring(0, dirPath.length - 2);
                     }
-                    var dirPath = dirPath.substring(0, dirPath.lastIndexOf('/'));
+                    let dirPath = dirPath.substring(0, dirPath.lastIndexOf('/'));
                 }
 
                 return dirPath;
             }
-            export var directoryName: typeof IO.directoryName = Utils.memoize(directoryNameImpl);
+            export let directoryName: typeof IO.directoryName = Utils.memoize(directoryNameImpl);
 
             export function fileExists(path: string): boolean {
-                var response = Http.getFileFromServerSync(serverRoot + path);
+                let response = Http.getFileFromServerSync(serverRoot + path);
                 return response.status === 200;
             }
 
             export function _listFilesImpl(path: string, spec?: RegExp, options?: any) {
-                var response = Http.getFileFromServerSync(serverRoot + path);
+                let response = Http.getFileFromServerSync(serverRoot + path);
                 if (response.status === 200) {
-                    var results = response.responseText.split(',');
+                    let results = response.responseText.split(',');
                     if (spec) {
                         return results.filter(file => spec.test(file));
                     } else {
@@ -672,12 +671,12 @@ module Harness {
                     return [''];
                 }
             };
-            export var listFiles = Utils.memoize(_listFilesImpl);
+            export let listFiles = Utils.memoize(_listFilesImpl);
 
-            export var log = console.log;
+            export let log = console.log;
 
             export function readFile(file: string) {
-                var response = Http.getFileFromServerSync(serverRoot + file);
+                let response = Http.getFileFromServerSync(serverRoot + file);
                 if (response.status === 200) {
                     return response.responseText;
                 } else {
@@ -691,7 +690,7 @@ module Harness {
         }
     }
 
-    export var IO: IO;
+    export let IO: IO;
     switch (Utils.getExecutionEnvironment()) {
         case Utils.ExecutionEnvironment.CScript:
             IO = IOImpl.CScript;
@@ -706,9 +705,9 @@ module Harness {
 }
 
 module Harness {
-    var tcServicesFileName = "typescriptServices.js";
+    let tcServicesFileName = "typescriptServices.js";
 
-    export var libFolder: string;
+    export let libFolder: string;
     switch (Utils.getExecutionEnvironment()) {
         case Utils.ExecutionEnvironment.CScript:
             libFolder = "built/local/";
@@ -725,7 +724,7 @@ module Harness {
         default:
             throw new Error('Unknown context');
     }
-    export var tcServicesFile = IO.readFile(tcServicesFileName);
+    export let tcServicesFile = IO.readFile(tcServicesFileName);
 
     export interface SourceMapEmitterCallback {
         (emittedFile: string, emittedLine: number, emittedColumn: number, sourceFile: string, sourceLine: number, sourceColumn: number, sourceName: string): void;
@@ -737,7 +736,7 @@ module Harness {
 
     /** Functionality for compiling TypeScript code */
     export module Compiler {
-        /** Aggregate various writes into a single array of lines. Useful for passing to the
+        /** Aggregate letious writes into a single array of lines. Useful for passing to the
          *  TypeScript compiler to fill with source code or errors.
          */
         export class WriterAggregator implements ITextWriter {
@@ -777,7 +776,7 @@ module Harness {
 
             /** create file gets the whole path to create, so this works as expected with the --out parameter */
             public writeFile(s: string, contents: string, writeByteOrderMark: boolean): void {
-                var writer: ITextWriter;
+                let writer: ITextWriter;
                 if (this.fileCollection[s]) {
                     writer = <ITextWriter>this.fileCollection[s];
                 }
@@ -795,10 +794,10 @@ module Harness {
             public reset() { this.fileCollection = {}; }
 
             public toArray(): { fileName: string; file: WriterAggregator; }[] {
-                var result: { fileName: string; file: WriterAggregator; }[] = [];
-                for (var p in this.fileCollection) {
+                let result: { fileName: string; file: WriterAggregator; }[] = [];
+                for (let p in this.fileCollection) {
                     if (this.fileCollection.hasOwnProperty(p)) {
-                        var current = <Harness.Compiler.WriterAggregator>this.fileCollection[p];
+                        let current = <Harness.Compiler.WriterAggregator>this.fileCollection[p];
                         if (current.lines.length > 0) {
                             if (p.indexOf('.d.ts') !== -1) { current.lines.unshift(['////[', Path.getFileName(p), ']'].join('')); }
                             result.push({ fileName: p, file: this.fileCollection[p] });
@@ -809,18 +808,18 @@ module Harness {
             }
         }
 
-        export function createSourceFileAndAssertInvariants(
+        export function createSourceFileAndAssertInletiants(
                 fileName: string,
                 sourceText: string,
                 languageVersion: ts.ScriptTarget) {
-            // We'll only assert invariants outside of light mode. 
-            const shouldAssertInvariants = !Harness.lightMode;
+            // We'll only assert inletiants outside of light mode. 
+            const shouldAssertInletiants = !Harness.lightMode;
             
-            // Only set the parent nodes if we're asserting invariants.  We don't need them otherwise.
-            var result = ts.createSourceFile(fileName, sourceText, languageVersion, /*setParentNodes:*/ shouldAssertInvariants);
+            // Only set the parent nodes if we're asserting inletiants.  We don't need them otherwise.
+            let result = ts.createSourceFile(fileName, sourceText, languageVersion, /*setParentNodes:*/ shouldAssertInletiants);
 
-            if (shouldAssertInvariants) {
-                Utils.assertInvariants(result, /*parent:*/ undefined);
+            if (shouldAssertInletiants) {
+                Utils.assertInletiants(result, /*parent:*/ undefined);
             }
 
             return result;
@@ -829,13 +828,13 @@ module Harness {
         const carriageReturnLineFeed = "\r\n";
         const lineFeed = "\n";
 
-        export var defaultLibFileName = 'lib.d.ts';
-        export var defaultLibSourceFile = createSourceFileAndAssertInvariants(defaultLibFileName, IO.readFile(libFolder + 'lib.core.d.ts'), /*languageVersion*/ ts.ScriptTarget.Latest);
-        export var defaultES6LibSourceFile = createSourceFileAndAssertInvariants(defaultLibFileName, IO.readFile(libFolder + 'lib.core.es6.d.ts'), /*languageVersion*/ ts.ScriptTarget.Latest);
+        export let defaultLibFileName = 'lib.d.ts';
+        export let defaultLibSourceFile = createSourceFileAndAssertInletiants(defaultLibFileName, IO.readFile(libFolder + 'lib.core.d.ts'), /*languageVersion*/ ts.ScriptTarget.Latest);
+        export let defaultES6LibSourceFile = createSourceFileAndAssertInletiants(defaultLibFileName, IO.readFile(libFolder + 'lib.core.es6.d.ts'), /*languageVersion*/ ts.ScriptTarget.Latest);
 
         // Cache these between executions so we don't have to re-parse them for every test
-        export var fourslashFileName = 'fourslash.ts';
-        export var fourslashSourceFile: ts.SourceFile;
+        export let fourslashFileName = 'fourslash.ts';
+        export let fourslashSourceFile: ts.SourceFile;
 
         export function getCanonicalFileName(fileName: string): string {
             return ts.sys.useCaseSensitiveFileNames ? fileName : fileName.toLowerCase();
@@ -855,14 +854,14 @@ module Harness {
                 return useCaseSensitiveFileNames ? fileName : fileName.toLowerCase();
             }
 
-            var filemap: { [fileName: string]: ts.SourceFile; } = {};
-            var getCurrentDirectory = currentDirectory === undefined ? ts.sys.getCurrentDirectory : () => currentDirectory;
+            let filemap: { [fileName: string]: ts.SourceFile; } = {};
+            let getCurrentDirectory = currentDirectory === undefined ? ts.sys.getCurrentDirectory : () => currentDirectory;
 
             // Register input files
             function register(file: { unitName: string; content: string; }) {
                 if (file.content !== undefined) {
-                    var fileName = ts.normalizePath(file.unitName);
-                    filemap[getCanonicalFileName(fileName)] = createSourceFileAndAssertInvariants(fileName, file.content, scriptTarget);
+                    let fileName = ts.normalizePath(file.unitName);
+                    filemap[getCanonicalFileName(fileName)] = createSourceFileAndAssertInletiants(fileName, file.content, scriptTarget);
                 }
             };
             inputFiles.forEach(register);
@@ -880,12 +879,12 @@ module Harness {
                         return filemap[getCanonicalFileName(fn)];
                     }
                     else if (currentDirectory) {
-                        var canonicalAbsolutePath = getCanonicalFileName(ts.getNormalizedAbsolutePath(fn, currentDirectory));
+                        let canonicalAbsolutePath = getCanonicalFileName(ts.getNormalizedAbsolutePath(fn, currentDirectory));
                         return Object.prototype.hasOwnProperty.call(filemap, getCanonicalFileName(canonicalAbsolutePath)) ? filemap[canonicalAbsolutePath] : undefined;
                     }
                     else if (fn === fourslashFileName) {
-                        var tsFn = 'tests/cases/fourslash/' + fourslashFileName;
-                        fourslashSourceFile = fourslashSourceFile || createSourceFileAndAssertInvariants(tsFn, Harness.IO.readFile(tsFn), scriptTarget);
+                        let tsFn = 'tests/cases/fourslash/' + fourslashFileName;
+                        fourslashSourceFile = fourslashSourceFile || createSourceFileAndAssertInletiants(tsFn, Harness.IO.readFile(tsFn), scriptTarget);
                         return fourslashSourceFile;
                     }
                     else {
@@ -980,27 +979,27 @@ module Harness {
 
                 // Files from built\local that are requested by test "@includeBuiltFiles" to be in the context.
                 // Treat them as library files, so include them in build, but not in baselines.
-                var includeBuiltFiles: { unitName: string; content: string }[] = [];
+                let includeBuiltFiles: { unitName: string; content: string }[] = [];
 
-                var useCaseSensitiveFileNames = ts.sys.useCaseSensitiveFileNames;
+                let useCaseSensitiveFileNames = ts.sys.useCaseSensitiveFileNames;
                 this.settings.forEach(setCompilerOptionForSetting);
 
-                var fileOutputs: GeneratedFile[] = [];
+                let fileOutputs: GeneratedFile[] = [];
 
-                var programFiles = inputFiles.concat(includeBuiltFiles).map(file => file.unitName);
+                let programFiles = inputFiles.concat(includeBuiltFiles).map(file => file.unitName);
 
-                var compilerHost = createCompilerHost(
+                let compilerHost = createCompilerHost(
                     inputFiles.concat(includeBuiltFiles).concat(otherFiles),
                     (fn, contents, writeByteOrderMark) => fileOutputs.push({ fileName: fn, code: contents, writeByteOrderMark: writeByteOrderMark }),
                     options.target, useCaseSensitiveFileNames, currentDirectory, options.newLine);
-                var program = ts.createProgram(programFiles, options, compilerHost);
+                let program = ts.createProgram(programFiles, options, compilerHost);
 
-                var emitResult = program.emit();
+                let emitResult = program.emit();
 
-                var errors = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
+                let errors = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
                 this.lastErrors = errors;
 
-                var result = new CompilerResult(fileOutputs, errors, program, ts.sys.getCurrentDirectory(), emitResult.sourceMaps);
+                let result = new CompilerResult(fileOutputs, errors, program, ts.sys.getCurrentDirectory(), emitResult.sourceMaps);
                 onComplete(result, program);
 
                 // reset what newline means in case the last test changed it
@@ -1195,9 +1194,9 @@ module Harness {
 
                 // if the .d.ts is non-empty, confirm it compiles correctly as well
                 if (options.declaration && result.errors.length === 0 && result.declFilesCode.length > 0) {
-                    var declInputFiles: { unitName: string; content: string }[] = [];
-                    var declOtherFiles: { unitName: string; content: string }[] = [];
-                    var declResult: Harness.Compiler.CompilerResult;
+                    let declInputFiles: { unitName: string; content: string }[] = [];
+                    let declOtherFiles: { unitName: string; content: string }[] = [];
+                    let declResult: Harness.Compiler.CompilerResult;
 
                     ts.forEach(inputFiles, file => addDtsFile(file, declInputFiles));
                     ts.forEach(otherFiles, file => addDtsFile(file, declOtherFiles));
@@ -1212,20 +1211,20 @@ module Harness {
                         dtsFiles.push(file);
                     }
                     else if (isTS(file.unitName)) {
-                        var declFile = findResultCodeFile(file.unitName);
+                        let declFile = findResultCodeFile(file.unitName);
                         if (!findUnit(declFile.fileName, declInputFiles) && !findUnit(declFile.fileName, declOtherFiles)) {
                             dtsFiles.push({ unitName: declFile.fileName, content: declFile.code });
                         }
                     }
 
                     function findResultCodeFile(fileName: string) {
-                        var sourceFile = result.program.getSourceFile(fileName);
+                        let sourceFile = result.program.getSourceFile(fileName);
                         assert(sourceFile, "Program has no source file with name '" + fileName + "'");
                         // Is this file going to be emitted separately
-                        var sourceFileName: string;
+                        let sourceFileName: string;
                         if (ts.isExternalModule(sourceFile) || !options.out) {
                             if (options.outDir) {
-                                var sourceFilePath = ts.getNormalizedAbsolutePath(sourceFile.fileName, result.currentDirectoryForProgram);
+                                let sourceFilePath = ts.getNormalizedAbsolutePath(sourceFile.fileName, result.currentDirectoryForProgram);
                                 sourceFilePath = sourceFilePath.replace(result.program.getCommonSourceDirectory(), "");
                                 sourceFileName = ts.combinePaths(options.outDir, sourceFilePath);
                             }
@@ -1238,7 +1237,7 @@ module Harness {
                             sourceFileName = options.out;
                         }
 
-                        var dTsFileName = ts.removeFileExtension(sourceFileName) + ".d.ts";
+                        let dTsFileName = ts.removeFileExtension(sourceFileName) + ".d.ts";
 
                         return ts.forEach(result.declFilesCode, declFile => declFile.fileName === dTsFileName ? declFile : undefined);
                     }
@@ -1251,7 +1250,7 @@ module Harness {
         }
 
         function normalizeLineEndings(text: string, lineEnding: string): string {
-            var normalized = text.replace(/\r\n?/g, '\n');
+            let normalized = text.replace(/\r\n?/g, '\n');
             if (lineEnding !== '\n') {
                 normalized = normalized.replace(/\n/g, lineEnding);
             }
@@ -1260,10 +1259,10 @@ module Harness {
 
         export function minimalDiagnosticsToString(diagnostics: ts.Diagnostic[]) {
             // This is basically copied from tsc.ts's reportError to replicate what tsc does
-            var errorOutput = "";
+            let errorOutput = "";
             ts.forEach(diagnostics, diagnostic => {
                 if (diagnostic.file) {
-                    var lineAndCharacter = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+                    let lineAndCharacter = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
                     errorOutput += diagnostic.file.fileName + "(" + (lineAndCharacter.line + 1) + "," + (lineAndCharacter.character + 1) + "): ";
                 }
 
@@ -1275,14 +1274,14 @@ module Harness {
 
         export function getErrorBaseline(inputFiles: { unitName: string; content: string }[], diagnostics: ts.Diagnostic[]) {
             diagnostics.sort(ts.compareDiagnostics);
-            var outputLines: string[] = [];
+            let outputLines: string[] = [];
             // Count up all the errors we find so we don't miss any
-            var totalErrorsReported = 0;
+            let totalErrorsReported = 0;
 
             function outputErrorText(error: ts.Diagnostic) {
-                var message = ts.flattenDiagnosticMessageText(error.messageText, ts.sys.newLine);
+                let message = ts.flattenDiagnosticMessageText(error.messageText, ts.sys.newLine);
 
-                var errLines = RunnerBase.removeFullPaths(message)
+                let errLines = RunnerBase.removeFullPaths(message)
                     .split('\n')
                     .map(s => s.length > 0 && s.charAt(s.length - 1) === '\r' ? s.substr(0, s.length - 1) : s)
                     .filter(s => s.length > 0)
@@ -1293,14 +1292,14 @@ module Harness {
             }
 
             // Report global errors
-            var globalErrors = diagnostics.filter(err => !err.file);
+            let globalErrors = diagnostics.filter(err => !err.file);
             globalErrors.forEach(outputErrorText);
 
             // 'merge' the lines of each input file with any errors associated with it
             inputFiles.filter(f => f.content !== undefined).forEach(inputFile => {
                 // Filter down to the errors in the file
-                var fileErrors = diagnostics.filter(e => {
-                    var errFn = e.file;
+                let fileErrors = diagnostics.filter(e => {
+                    let errFn = e.file;
                     return errFn && errFn.fileName === inputFile.unitName;
                 });
 
@@ -1309,13 +1308,13 @@ module Harness {
                 outputLines.push('==== ' + inputFile.unitName + ' (' + fileErrors.length + ' errors) ====');
 
                 // Make sure we emit something for every error
-                var markedErrorCount = 0;
+                let markedErrorCount = 0;
                 // For each line, emit the line followed by any error squiggles matching this line
                 // Note: IE JS engine incorrectly handles consecutive delimiters here when using RegExp split, so
                 // we have to string-based splitting instead and try to figure out the delimiting chars
 
-                var lineStarts = ts.computeLineStarts(inputFile.content);
-                var lines = inputFile.content.split('\n');
+                let lineStarts = ts.computeLineStarts(inputFile.content);
+                let lines = inputFile.content.split('\n');
                 if (lines.length === 1) {
                     lines = lines[0].split("\r");
                 }
@@ -1325,8 +1324,8 @@ module Harness {
                         line = line.substr(0, line.length - 1);
                     }
 
-                    var thisLineStart = lineStarts[lineIndex];
-                    var nextLineStart: number;
+                    let thisLineStart = lineStarts[lineIndex];
+                    let nextLineStart: number;
                     // On the last line of the file, fake the next line start number so that we handle errors on the last character of the file correctly
                     if (lineIndex === lines.length - 1) {
                         nextLineStart = inputFile.content.length;
@@ -1340,11 +1339,11 @@ module Harness {
                         let end = ts.textSpanEnd(err);
                         if ((end >= thisLineStart) && ((err.start < nextLineStart) || (lineIndex === lines.length - 1))) {
                             // How many characters from the start of this line the error starts at (could be positive or negative)
-                            var relativeOffset = err.start - thisLineStart;
+                            let relativeOffset = err.start - thisLineStart;
                             // How many characters of the error are on this line (might be longer than this line in reality)
-                            var length = (end - err.start) - Math.max(0, thisLineStart - err.start);
+                            let length = (end - err.start) - Math.max(0, thisLineStart - err.start);
                             // Calculate the start of the squiggle
-                            var squiggleStart = Math.max(0, relativeOffset);
+                            let squiggleStart = Math.max(0, relativeOffset);
                             // TODO/REVIEW: this doesn't work quite right in the browser if a multi file test has files whose names are just the right length relative to one another
                             outputLines.push('    ' + line.substr(0, squiggleStart).replace(/[^\s]/g, ' ') + new Array(Math.min(length, line.length - squiggleStart) + 1).join('~'));
 
@@ -1364,11 +1363,11 @@ module Harness {
                 assert.equal(markedErrorCount, fileErrors.length, 'count of errors in ' + inputFile.unitName);
             });
 
-            var numLibraryDiagnostics = ts.countWhere(diagnostics, diagnostic => {
+            let numLibraryDiagnostics = ts.countWhere(diagnostics, diagnostic => {
                 return diagnostic.file && (isLibraryFile(diagnostic.file.fileName) || isBuiltFile(diagnostic.file.fileName));
             });
 
-            var numTest262HarnessDiagnostics = ts.countWhere(diagnostics, diagnostic => {
+            let numTest262HarnessDiagnostics = ts.countWhere(diagnostics, diagnostic => {
                 // Count an error generated from tests262-harness folder.This should only apply for test262
                 return diagnostic.file && diagnostic.file.fileName.indexOf("test262-harness") >= 0;
             });
@@ -1385,7 +1384,7 @@ module Harness {
             outputFiles.sort((a, b) => cleanName(a.fileName).localeCompare(cleanName(b.fileName)));
 
             // Emit them
-            var result = '';
+            let result = '';
             for (let outputFile of outputFiles) {
                 // Some extra spacing if this isn't the first file
                 if (result.length) {
@@ -1401,13 +1400,13 @@ module Harness {
             return result;
 
             function cleanName(fn: string) {
-                var lastSlash = ts.normalizeSlashes(fn).lastIndexOf('/');
+                let lastSlash = ts.normalizeSlashes(fn).lastIndexOf('/');
                 return fn.substr(lastSlash + 1).toLowerCase();
             }
         }
 
         /** The harness' compiler instance used when tests are actually run. Reseting or changing settings of this compiler instance must be done within a test case (i.e., describe/it) */
-        var harnessCompiler: HarnessCompiler;
+        let harnessCompiler: HarnessCompiler;
 
         /** Returns the singleton harness compiler instance for generating and running tests.
             If required a fresh compiler instance will be created, otherwise the existing singleton will be re-used.
@@ -1420,8 +1419,6 @@ module Harness {
         export function compileString(code: string, unitName: string, callback: (result: CompilerResult) => void) {
             // NEWTODO: Re-implement 'compileString'
             throw new Error('compileString NYI');
-            //var harnessCompiler = Harness.Compiler.getCompiler(Harness.Compiler.CompilerInstance.RunTime);
-            //harnessCompiler.compileString(code, unitName, callback);
         }
 
         export interface GeneratedFile {
@@ -1513,10 +1510,10 @@ module Harness {
         }
 
         // Regex for parsing options in the format "@Alpha: Value of any sort"
-        var optionRegex = /^[\/]{2}\s*@(\w+)\s*:\s*(\S*)/gm;  // multiple matches on multiple lines
+        let optionRegex = /^[\/]{2}\s*@(\w+)\s*:\s*(\S*)/gm;  // multiple matches on multiple lines
 
         // List of allowed metadata names
-        var fileMetadataNames = ["filename", "comments", "declaration", "module",
+        let fileMetadataNames = ["filename", "comments", "declaration", "module",
             "nolib", "sourcemap", "target", "out", "outdir", "noemithelpers", "noemitonerror",
             "noimplicitany", "noresolve", "newline", "normalizenewline", "emitbom",
             "errortruncation", "usecasesensitivefilenames", "preserveconstenums",
@@ -1527,9 +1524,9 @@ module Harness {
 
         function extractCompilerSettings(content: string): CompilerSetting[] {
 
-            var opts: CompilerSetting[] = [];
+            let opts: CompilerSetting[] = [];
 
-            var match: RegExpExecArray;
+            let match: RegExpExecArray;
             while ((match = optionRegex.exec(content)) != null) {
                 opts.push({ flag: match[1], value: match[2] });
             }
@@ -1539,26 +1536,26 @@ module Harness {
 
         /** Given a test file containing // @FileName directives, return an array of named units of code to be added to an existing compiler instance */
         export function makeUnitsFromTest(code: string, fileName: string): { settings: CompilerSetting[]; testUnitData: TestUnitData[]; } {
-            var settings = extractCompilerSettings(code);
+            let settings = extractCompilerSettings(code);
 
             // List of all the subfiles we've parsed out
-            var testUnitData: TestUnitData[] = [];
+            let testUnitData: TestUnitData[] = [];
 
-            var lines = Utils.splitContentByNewlines(code);
+            let lines = Utils.splitContentByNewlines(code);
 
             // Stuff related to the subfile we're parsing
-            var currentFileContent: string = null;
-            var currentFileOptions: any = {};
-            var currentFileName: any = null;
-            var refs: string[] = [];
+            let currentFileContent: string = null;
+            let currentFileOptions: any = {};
+            let currentFileName: any = null;
+            let refs: string[] = [];
 
-            for (var i = 0; i < lines.length; i++) {
-                var line = lines[i];
-                var testMetaData = optionRegex.exec(line);
+            for (let i = 0; i < lines.length; i++) {
+                let line = lines[i];
+                let testMetaData = optionRegex.exec(line);
                 if (testMetaData) {
                     // Comment line, check for global/file @options and record them
                     optionRegex.lastIndex = 0;
-                    var metaDataName = testMetaData[1].toLowerCase();
+                    let metaDataName = testMetaData[1].toLowerCase();
                     if (metaDataName === "filename") {
                         currentFileOptions[testMetaData[1]] = testMetaData[2];
                     } else {
@@ -1568,8 +1565,7 @@ module Harness {
                     // New metadata statement after having collected some code to go with the previous metadata
                     if (currentFileName) {
                         // Store result file
-                        var newTestFile =
-                            {
+                        let newTestFile = {
                                 content: currentFileContent,
                                 name: currentFileName,
                                 fileOptions: currentFileOptions,
@@ -1604,7 +1600,7 @@ module Harness {
             currentFileName = testUnitData.length > 0 ? currentFileName : Path.getFileName(fileName);
 
             // EOF, push whatever remains
-            var newTestFile2 = {
+            let newTestFile2 = {
                 content: currentFileContent || '',
                 name: currentFileName,
                 fileOptions: currentFileOptions,
@@ -1651,7 +1647,7 @@ module Harness {
             }
         }
 
-        var fileCache: { [idx: string]: boolean } = {};
+        let fileCache: { [idx: string]: boolean } = {};
         function generateActual(actualFileName: string, generateContent: () => string): string {
             // For now this is written using TypeScript, because sys is not available when running old test cases.
             // But we need to move to sys once we have
@@ -1662,7 +1658,7 @@ module Harness {
                     return;
                 }
 
-                var parentDirectory = IO.directoryName(dirName);
+                let parentDirectory = IO.directoryName(dirName);
                 if (parentDirectory != "") {
                     createDirectoryStructure(parentDirectory);
                 }
@@ -1678,7 +1674,7 @@ module Harness {
                 IO.deleteFile(actualFileName);
             }
 
-            var actual = generateContent();
+            let actual = generateContent();
 
             if (actual === undefined) {
                 throw new Error('The generated content was "undefined". Return "null" if no baselining is required."');
@@ -1701,13 +1697,13 @@ module Harness {
                 return;
             }
 
-            var refFileName = referencePath(relativeFileName, opts && opts.Baselinefolder, opts && opts.Subfolder);
+            let refFileName = referencePath(relativeFileName, opts && opts.Baselinefolder, opts && opts.Subfolder);
 
             if (actual === null) {
                 actual = '<no content>';
             }
 
-            var expected = '<no content>';
+            let expected = '<no content>';
             if (IO.fileExists(refFileName)) {
                 expected = IO.readFile(refFileName);
             }
@@ -1716,10 +1712,10 @@ module Harness {
         }
 
         function writeComparison(expected: string, actual: string, relativeFileName: string, actualFileName: string, descriptionForDescribe: string) {
-            var encoded_actual = (new Buffer(actual)).toString('utf8')
+            let encoded_actual = (new Buffer(actual)).toString('utf8');
             if (expected != encoded_actual) {
                 // Overwrite & issue error
-                var errMsg = 'The baseline file ' + relativeFileName + ' has changed';
+                let errMsg = 'The baseline file ' + relativeFileName + ' has changed';
                 throw new Error(errMsg);
             }
         }
@@ -1731,17 +1727,17 @@ module Harness {
             runImmediately = false,
             opts?: BaselineOptions): void {
 
-            var actual = <string>undefined;
-            var actualFileName = localPath(relativeFileName, opts && opts.Baselinefolder, opts && opts.Subfolder);
+            let actual = <string>undefined;
+            let actualFileName = localPath(relativeFileName, opts && opts.Baselinefolder, opts && opts.Subfolder);
 
             if (runImmediately) {
                 actual = generateActual(actualFileName, generateContent);
-                var comparison = compareToBaseline(actual, relativeFileName, opts);
+                let comparison = compareToBaseline(actual, relativeFileName, opts);
                 writeComparison(comparison.expected, comparison.actual, relativeFileName, actualFileName, descriptionForDescribe);
             } else {
                 actual = generateActual(actualFileName, generateContent);
 
-                var comparison = compareToBaseline(actual, relativeFileName, opts);
+                let comparison = compareToBaseline(actual, relativeFileName, opts);
                 writeComparison(comparison.expected, comparison.actual, relativeFileName, actualFileName, descriptionForDescribe);
             }
         }
@@ -1756,11 +1752,11 @@ module Harness {
     }
 
     export function getDefaultLibraryFile(): { unitName: string, content: string } {
-        var libFile = Harness.userSpecifiedRoot + Harness.libFolder + "/" + "lib.d.ts";
+        let libFile = Harness.userSpecifiedRoot + Harness.libFolder + "/" + "lib.d.ts";
         return {
             unitName: libFile,
             content: IO.readFile(libFile)
-        }
+        };
     }
 
     if (Error) (<any>Error).stackTraceLimit = 1;

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -96,7 +96,7 @@ module Utils {
             path = "tests/" + path;
         }
 
-        let content = '';
+        let content: string = undefined;
         try {
             content = ts.sys.readFile(Harness.userSpecifiedRoot + path);
         }
@@ -812,12 +812,12 @@ module Harness {
                 sourceText: string,
                 languageVersion: ts.ScriptTarget) {
             // We'll only assert inletiants outside of light mode. 
-            const shouldassertInvariants = !Harness.lightMode;
+            const shouldAssertInvariants = !Harness.lightMode;
             
             // Only set the parent nodes if we're asserting inletiants.  We don't need them otherwise.
-            let result = ts.createSourceFile(fileName, sourceText, languageVersion, /*setParentNodes:*/ shouldassertInvariants);
+            let result = ts.createSourceFile(fileName, sourceText, languageVersion, /*setParentNodes:*/ shouldAssertInvariants);
 
-            if (shouldassertInvariants) {
+            if (shouldAssertInvariants) {
                 Utils.assertInvariants(result, /*parent:*/ undefined);
             }
 

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -735,7 +735,7 @@ module Harness {
 
     /** Functionality for compiling TypeScript code */
     export module Compiler {
-        /** Aggregate letious writes into a single array of lines. Useful for passing to the
+        /** Aggregate various writes into a single array of lines. Useful for passing to the
          *  TypeScript compiler to fill with source code or errors.
          */
         export class WriterAggregator implements ITextWriter {

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -26,9 +26,9 @@ module Harness.LanguageService {
 
         public editContent(start: number, end: number, newText: string): void {
             // Apply edits
-            var prefix = this.content.substring(0, start);
-            var middle = newText;
-            var suffix = this.content.substring(end);
+            let prefix = this.content.substring(0, start);
+            let middle = newText;
+            let suffix = this.content.substring(end);
             this.setContent(prefix + middle + suffix);
 
             // Store edit range + new length of script
@@ -48,10 +48,10 @@ module Harness.LanguageService {
                 return ts.unchangedTextChangeRange;
             }
 
-            var initialEditRangeIndex = this.editRanges.length - (this.version - startVersion);
-            var lastEditRangeIndex = this.editRanges.length - (this.version - endVersion);
+            let initialEditRangeIndex = this.editRanges.length - (this.version - startVersion);
+            let lastEditRangeIndex = this.editRanges.length - (this.version - endVersion);
 
-            var entries = this.editRanges.slice(initialEditRangeIndex, lastEditRangeIndex);
+            let entries = this.editRanges.slice(initialEditRangeIndex, lastEditRangeIndex);
             return ts.collapseTextChangeRangesAcrossMultipleVersions(entries.map(e => e.textChangeRange));
         }
     }
@@ -74,7 +74,7 @@ module Harness.LanguageService {
         }
 
         public getChangeRange(oldScript: ts.IScriptSnapshot): ts.TextChangeRange {
-            var oldShim = <ScriptSnapshot>oldScript;
+            let oldShim = <ScriptSnapshot>oldScript;
             return this.scriptInfo.getTextChangeRangeBetweenVersions(oldShim.version, this.version);
         }
     }
@@ -92,9 +92,9 @@ module Harness.LanguageService {
         }
 
         public getChangeRange(oldScript: ts.ScriptSnapshotShim): string {
-            var oldShim = <ScriptSnapshotProxy>oldScript;
+            let oldShim = <ScriptSnapshotProxy>oldScript;
 
-            var range = this.scriptSnapshot.getChangeRange(oldShim.scriptSnapshot);
+            let range = this.scriptSnapshot.getChangeRange(oldShim.scriptSnapshot);
             if (range === null) {
                 return null;
             }
@@ -130,8 +130,8 @@ module Harness.LanguageService {
         }
 
         public getFilenames(): string[] {
-            var fileNames: string[] = [];
-            ts.forEachKey(this.fileNameToScript,(fileName) => { fileNames.push(fileName); });
+            let fileNames: string[] = [];
+            ts.forEachKey(this.fileNameToScript, (fileName) => { fileNames.push(fileName); });
             return fileNames;
         }
 
@@ -144,7 +144,7 @@ module Harness.LanguageService {
         }
 
         public editScript(fileName: string, start: number, end: number, newText: string) {
-            var script = this.getScriptInfo(fileName);
+            let script = this.getScriptInfo(fileName);
             if (script !== null) {
                 script.editContent(start, end, newText);
                 return;
@@ -161,7 +161,7 @@ module Harness.LanguageService {
           * @param col 0 based index
           */
         public positionToLineAndCharacter(fileName: string, position: number): ts.LineAndCharacter {
-            var script: ScriptInfo = this.fileNameToScript[fileName];
+            let script: ScriptInfo = this.fileNameToScript[fileName];
             assert.isNotNull(script);
 
             return ts.computeLineAndCharacterOfPosition(script.lineMap, position);
@@ -176,11 +176,11 @@ module Harness.LanguageService {
         getDefaultLibFileName(): string { return ""; }
         getScriptFileNames(): string[] { return this.getFilenames(); }
         getScriptSnapshot(fileName: string): ts.IScriptSnapshot {
-            var script = this.getScriptInfo(fileName);
+            let script = this.getScriptInfo(fileName);
             return script ? new ScriptSnapshot(script) : undefined;
         }
         getScriptVersion(fileName: string): string {
-            var script = this.getScriptInfo(fileName);
+            let script = this.getScriptInfo(fileName);
             return script ? script.version.toString() : undefined;
         }
 
@@ -220,7 +220,7 @@ module Harness.LanguageService {
         getDefaultLibFileName(): string { return this.nativeHost.getDefaultLibFileName(); }
         getScriptFileNames(): string { return JSON.stringify(this.nativeHost.getScriptFileNames()); }
         getScriptSnapshot(fileName: string): ts.ScriptSnapshotShim {
-            var nativeScriptSnapshot = this.nativeHost.getScriptSnapshot(fileName);
+            let nativeScriptSnapshot = this.nativeHost.getScriptSnapshot(fileName);
             return nativeScriptSnapshot && new ScriptSnapshotProxy(nativeScriptSnapshot); 
         }
         getScriptVersion(fileName: string): string { return this.nativeHost.getScriptVersion(fileName); }
@@ -242,13 +242,13 @@ module Harness.LanguageService {
             throw new Error("NYI");
         }
         getClassificationsForLine(text: string, lexState: ts.EndOfLineState, classifyKeywordsInGenerics?: boolean): ts.ClassificationResult {
-            var result = this.shim.getClassificationsForLine(text, lexState, classifyKeywordsInGenerics).split('\n');
-            var entries: ts.ClassificationInfo[] = [];
-            var i = 0;
-            var position = 0;
+            let result = this.shim.getClassificationsForLine(text, lexState, classifyKeywordsInGenerics).split('\n');
+            let entries: ts.ClassificationInfo[] = [];
+            let i = 0;
+            let position = 0;
 
             for (; i < result.length - 1; i += 2) {
-                var t = entries[i / 2] = {
+                let t = entries[i / 2] = {
                     length: parseInt(result[i]),
                     classification: parseInt(result[i + 1])
                 };
@@ -256,7 +256,7 @@ module Harness.LanguageService {
                 assert.isTrue(t.length > 0, "Result length should be greater than 0, got :" + t.length);
                 position += t.length;
             }
-            var finalLexState = parseInt(result[result.length - 1]);
+            let finalLexState = parseInt(result[result.length - 1]);
 
             assert.equal(position, text.length, "Expected cumulative length of all entries to match the length of the source. expected: " + text.length + ", but got: " + position);
 
@@ -268,7 +268,7 @@ module Harness.LanguageService {
     }
 
     function unwrapJSONCallResult(result: string): any {
-        var parsedResult = JSON.parse(result);
+        let parsedResult = JSON.parse(result);
         if (parsedResult.error) {
             throw new Error("Language Service Shim Error: " + JSON.stringify(parsedResult.error));
         }
@@ -282,7 +282,7 @@ module Harness.LanguageService {
         constructor(private shim: ts.LanguageServiceShim) {
         }
         private unwrappJSONCallResult(result: string): any {
-            var parsedResult = JSON.parse(result);
+            let parsedResult = JSON.parse(result);
             if (parsedResult.error) {
                 throw new Error("Language Service Shim Error: " + JSON.stringify(parsedResult.error));
             }
@@ -404,16 +404,16 @@ module Harness.LanguageService {
         getLanguageService(): ts.LanguageService { return new LanguageServiceShimProxy(this.factory.createLanguageServiceShim(this.host)); }
         getClassifier(): ts.Classifier { return new ClassifierShimProxy(this.factory.createClassifierShim(this.host)); }
         getPreProcessedFileInfo(fileName: string, fileContents: string): ts.PreProcessedFileInfo {
-            var shimResult: {
+            let shimResult: {
                 referencedFiles: ts.IFileReference[];
                 importedFiles: ts.IFileReference[];
                 isLibFile: boolean;
             };
 
-            var coreServicesShim = this.factory.createCoreServicesShim(this.host);
+            let coreServicesShim = this.factory.createCoreServicesShim(this.host);
             shimResult = unwrapJSONCallResult(coreServicesShim.getPreProcessedFileInfo(fileName, ts.ScriptSnapshot.fromString(fileContents)));
 
-            var convertResult: ts.PreProcessedFileInfo = {
+            let convertResult: ts.PreProcessedFileInfo = {
                 referencedFiles: [],
                 importedFiles: [],
                 isLibFile: shimResult.isLibFile
@@ -496,7 +496,7 @@ module Harness.LanguageService {
                 fileName = Harness.Compiler.defaultLibFileName;
             }
              
-            var snapshot = this.host.getScriptSnapshot(fileName);
+            let snapshot = this.host.getScriptSnapshot(fileName);
             return snapshot && snapshot.getText(0, snapshot.getLength());
         }
 
@@ -574,13 +574,13 @@ module Harness.LanguageService {
         private client: ts.server.SessionClient;
         constructor(cancellationToken?: ts.HostCancellationToken, options?: ts.CompilerOptions) {
             // This is the main host that tests use to direct tests
-            var clientHost = new SessionClientHost(cancellationToken, options);
-            var client = new ts.server.SessionClient(clientHost);
+            let clientHost = new SessionClientHost(cancellationToken, options);
+            let client = new ts.server.SessionClient(clientHost);
 
             // This host is just a proxy for the clientHost, it uses the client
             // host to answer server queries about files on disk
-            var serverHost = new SessionServerHost(clientHost);
-            var server = new ts.server.Session(serverHost, Buffer.byteLength, process.hrtime, serverHost);
+            let serverHost = new SessionServerHost(clientHost);
+            let server = new ts.server.Session(serverHost, Buffer.byteLength, process.hrtime, serverHost);
 
             // Fake the connection between the client and the server
             serverHost.writeMessage = client.onMessage.bind(client);

--- a/src/harness/loggedIO.ts
+++ b/src/harness/loggedIO.ts
@@ -70,9 +70,9 @@ interface PlaybackControl {
 }
 
 module Playback {
-    var recordLog: IOLog = undefined;
-    var replayLog: IOLog = undefined;
-    var recordLogFileNameBase = '';
+    let recordLog: IOLog = undefined;
+    let replayLog: IOLog = undefined;
+    let recordLogFileNameBase = '';
 
     interface Memoized<T> {
         (s: string): T;
@@ -80,8 +80,8 @@ module Playback {
     }
 
     function memoize<T>(func: (s: string) => T): Memoized<T> {
-        var lookup: { [s: string]: T } = {};
-        var run: Memoized<T> = <Memoized<T>>((s: string) => {
+        let lookup: { [s: string]: T } = {};
+        let run: Memoized<T> = <Memoized<T>>((s: string) => {
             if (lookup.hasOwnProperty(s)) return lookup[s];
             return lookup[s] = func(s);
         });
@@ -161,10 +161,10 @@ module Playback {
     }
 
     function findResultByFields<T>(logArray: { result?: T }[], expectedFields: {}, defaultValue?: T): T {
-        var predicate = (entry: { result?: T }) => {
+        let predicate = (entry: { result?: T }) => {
             return Object.getOwnPropertyNames(expectedFields).every((name) => (<any>entry)[name] === (<any>expectedFields)[name]);
         };
-        var results = logArray.filter(entry => predicate(entry));
+        let results = logArray.filter(entry => predicate(entry));
         if (results.length === 0) {
             if (defaultValue !== undefined) {
                 return defaultValue;
@@ -176,17 +176,17 @@ module Playback {
     }
 
     function findResultByPath<T>(wrapper: { resolvePath(s: string): string }, logArray: { path: string; result?: T }[], expectedPath: string, defaultValue?: T): T {
-        var normalizedName = ts.normalizeSlashes(expectedPath).toLowerCase();
+        let normalizedName = ts.normalizeSlashes(expectedPath).toLowerCase();
         // Try to find the result through normal fileName
-        for (var i = 0; i < logArray.length; i++) {
+        for (let i = 0; i < logArray.length; i++) {
             if (ts.normalizeSlashes(logArray[i].path).toLowerCase() === normalizedName) {
                 return logArray[i].result;
             }
         }
         // Fallback, try to resolve the target paths as well
         if (replayLog.pathsResolved.length > 0) {
-            var normalizedResolvedName = wrapper.resolvePath(expectedPath).toLowerCase();
-            for (var i = 0; i < logArray.length; i++) {
+            let normalizedResolvedName = wrapper.resolvePath(expectedPath).toLowerCase();
+            for (let i = 0; i < logArray.length; i++) {
                 if (wrapper.resolvePath(logArray[i].path).toLowerCase() === normalizedResolvedName) {
                     return logArray[i].result;
                 }
@@ -200,9 +200,9 @@ module Playback {
         }
     }
 
-    var pathEquivCache: any = {};
+    let pathEquivCache: any = {};
     function pathsAreEquivalent(left: string, right: string, wrapper: { resolvePath(s: string): string }) {
-        var key = left + '-~~-' + right;
+        let key = left + '-~~-' + right;
         function areSame(a: string, b: string) {
             return ts.normalizeSlashes(a).toLowerCase() === ts.normalizeSlashes(b).toLowerCase();
         }
@@ -219,11 +219,11 @@ module Playback {
     }
 
     function noOpReplay(name: string) {
-        //console.log("Swallowed write operation during replay: " + name);
+        // console.log("Swallowed write operation during replay: " + name);
     }
 
     export function wrapSystem(underlying: ts.System): PlaybackSystem {
-        var wrapper: PlaybackSystem = <any>{};
+        let wrapper: PlaybackSystem = <any>{};
         initWrapper(wrapper, underlying);
 
         wrapper.startReplayFromFile = logFn => {
@@ -231,8 +231,8 @@ module Playback {
         };
         wrapper.endRecord = () => {
             if (recordLog !== undefined) {
-                var i = 0;
-                var fn = () => recordLogFileNameBase + i + '.json';
+                let i = 0;
+                let fn = () => recordLogFileNameBase + i + '.json';
                 while (underlying.fileExists(fn())) i++;
                 underlying.writeFile(fn(), JSON.stringify(recordLog));
                 recordLog = undefined;
@@ -289,8 +289,8 @@ module Playback {
 
         wrapper.readFile = recordReplay(wrapper.readFile, underlying)(
             (path) => {
-                var result = underlying.readFile(path);
-                var logEntry = { path: path, codepage: 0, result: { contents: result, codepage: 0 } };
+                let result = underlying.readFile(path);
+                let logEntry = { path: path, codepage: 0, result: { contents: result, codepage: 0 } };
                 recordLog.filesRead.push(logEntry);
                 return result;
             },

--- a/src/harness/projectsRunner.ts
+++ b/src/harness/projectsRunner.ts
@@ -46,7 +46,7 @@ interface BatchCompileProjectTestCaseResult extends CompileProjectFilesResult {
 class ProjectRunner extends RunnerBase {
     public initializeTests() {
         if (this.tests.length === 0) {
-            var testFiles = this.enumerateFiles("tests/cases/project", /\.json$/, { recursive: true });
+            let testFiles = this.enumerateFiles("tests/cases/project", /\.json$/, { recursive: true });
             testFiles.forEach(fn => {
                 fn = fn.replace(/\\/g, "/");
                 this.runProjectTestCase(fn);
@@ -58,10 +58,10 @@ class ProjectRunner extends RunnerBase {
     }
 
     private runProjectTestCase(testCaseFileName: string) {
-        var testCase: ProjectRunnerTestCase;
+        let testCase: ProjectRunnerTestCase;
 
         try {
-            var testFileText = ts.sys.readFile(testCaseFileName);
+            let testFileText = ts.sys.readFile(testCaseFileName);
         }
         catch (e) {
             assert(false, "Unable to open testcase file: " + testCaseFileName + ": " + e.message);
@@ -73,7 +73,7 @@ class ProjectRunner extends RunnerBase {
         catch (e) {
             assert(false, "Testcase: " + testCaseFileName + " does not contain valid json format: " + e.message);
         }
-        var testCaseJustName = testCaseFileName.replace(/^.*[\\\/]/, '').replace(/\.json/, "");
+        let testCaseJustName = testCaseFileName.replace(/^.*[\\\/]/, '').replace(/\.json/, "");
 
         function moduleNameToString(moduleKind: ts.ModuleKind) {
             return moduleKind === ts.ModuleKind.AMD
@@ -97,9 +97,9 @@ class ProjectRunner extends RunnerBase {
         }
 
         function cleanProjectUrl(url: string) {
-            var diskProjectPath = ts.normalizeSlashes(ts.sys.resolvePath(testCase.projectRoot));
-            var projectRootUrl = "file:///" + diskProjectPath;
-            var normalizedProjectRoot = ts.normalizeSlashes(testCase.projectRoot);
+            let diskProjectPath = ts.normalizeSlashes(ts.sys.resolvePath(testCase.projectRoot));
+            let projectRootUrl = "file:///" + diskProjectPath;
+            let normalizedProjectRoot = ts.normalizeSlashes(testCase.projectRoot);
             diskProjectPath = diskProjectPath.substr(0, diskProjectPath.lastIndexOf(normalizedProjectRoot));
             projectRootUrl = projectRootUrl.substr(0, projectRootUrl.lastIndexOf(normalizedProjectRoot));
             if (url && url.length) {
@@ -128,17 +128,17 @@ class ProjectRunner extends RunnerBase {
             getSourceFileText: (fileName: string) => string,
             writeFile: (fileName: string, data: string, writeByteOrderMark: boolean) => void): CompileProjectFilesResult {
 
-            var program = ts.createProgram(getInputFiles(), createCompilerOptions(), createCompilerHost());
-            var errors = ts.getPreEmitDiagnostics(program);
+            let program = ts.createProgram(getInputFiles(), createCompilerOptions(), createCompilerHost());
+            let errors = ts.getPreEmitDiagnostics(program);
 
-            var emitResult = program.emit();
+            let emitResult = program.emit();
             errors = ts.concatenate(errors, emitResult.diagnostics);
-            var sourceMapData = emitResult.sourceMaps;
+            let sourceMapData = emitResult.sourceMaps;
 
             // Clean up source map data that will be used in baselining
             if (sourceMapData) {
-                for (var i = 0; i < sourceMapData.length; i++) {
-                    for (var j = 0; j < sourceMapData[i].sourceMapSources.length; j++) {
+                for (let i = 0; i < sourceMapData.length; i++) {
+                    for (let j = 0; j < sourceMapData[i].sourceMapSources.length; j++) {
                         sourceMapData[i].sourceMapSources[j] = cleanProjectUrl(sourceMapData[i].sourceMapSources[j]);
                     }
                     sourceMapData[i].jsSourceMappingURL = cleanProjectUrl(sourceMapData[i].jsSourceMappingURL);
@@ -168,14 +168,14 @@ class ProjectRunner extends RunnerBase {
             }
 
             function getSourceFile(fileName: string, languageVersion: ts.ScriptTarget): ts.SourceFile {
-                var sourceFile: ts.SourceFile = undefined;
+                let sourceFile: ts.SourceFile = undefined;
                 if (fileName === Harness.Compiler.defaultLibFileName) {
                     sourceFile = languageVersion === ts.ScriptTarget.ES6 ? Harness.Compiler.defaultES6LibSourceFile : Harness.Compiler.defaultLibSourceFile;
                 }
                 else {
-                    var text = getSourceFileText(fileName);
+                    let text = getSourceFileText(fileName);
                     if (text !== undefined) {
-                        sourceFile = Harness.Compiler.createSourceFileAndAssertInvariants(fileName, text, languageVersion);
+                        sourceFile = Harness.Compiler.createSourceFileAndAssertInletiants(fileName, text, languageVersion);
                     }
                 }
 
@@ -196,11 +196,11 @@ class ProjectRunner extends RunnerBase {
         }
 
         function batchCompilerProjectTestCase(moduleKind: ts.ModuleKind): BatchCompileProjectTestCaseResult{
-            var nonSubfolderDiskFiles = 0;
+            let nonSubfolderDiskFiles = 0;
 
-            var outputFiles: BatchCompileProjectTestCaseEmittedFile[] = [];
+            let outputFiles: BatchCompileProjectTestCaseEmittedFile[] = [];
 
-            var projectCompilerResult = compileProjectFiles(moduleKind, () => testCase.inputFiles, getSourceFileText, writeFile);
+            let projectCompilerResult = compileProjectFiles(moduleKind, () => testCase.inputFiles, getSourceFileText, writeFile);
             return {
                 moduleKind,
                 program: projectCompilerResult.program,
@@ -212,7 +212,7 @@ class ProjectRunner extends RunnerBase {
 
             function getSourceFileText(fileName: string): string {
                 try {
-                    var text = ts.sys.readFile(ts.isRootedDiskPath(fileName)
+                    let text = ts.sys.readFile(ts.isRootedDiskPath(fileName)
                         ? fileName
                         : ts.normalizeSlashes(testCase.projectRoot) + "/" + ts.normalizeSlashes(fileName));
                 }
@@ -223,11 +223,11 @@ class ProjectRunner extends RunnerBase {
             }
 
             function writeFile(fileName: string, data: string, writeByteOrderMark: boolean) {
-                var diskFileName = ts.isRootedDiskPath(fileName)
+                let diskFileName = ts.isRootedDiskPath(fileName)
                     ? fileName
                     : ts.normalizeSlashes(testCase.projectRoot) + "/" + ts.normalizeSlashes(fileName);
 
-                var diskRelativeName = ts.getRelativePathToDirectoryOrUrl(testCase.projectRoot, diskFileName,
+                let diskRelativeName = ts.getRelativePathToDirectoryOrUrl(testCase.projectRoot, diskFileName,
                     getCurrentDirectory(), Harness.Compiler.getCanonicalFileName, /*isAbsolutePathAnUrl*/ false);
                 if (ts.isRootedDiskPath(diskRelativeName) || diskRelativeName.substr(0, 3) === "../") {
                     // If the generated output file resides in the parent folder or is rooted path,
@@ -240,22 +240,22 @@ class ProjectRunner extends RunnerBase {
 
                 if (Harness.Compiler.isJS(fileName)) {
                     // Make sure if there is URl we have it cleaned up
-                    var indexOfSourceMapUrl = data.lastIndexOf("//# sourceMappingURL=");
+                    let indexOfSourceMapUrl = data.lastIndexOf("//# sourceMappingURL=");
                     if (indexOfSourceMapUrl !== -1) {
                         data = data.substring(0, indexOfSourceMapUrl + 21) + cleanProjectUrl(data.substring(indexOfSourceMapUrl + 21));
                     }
                 }
                 else if (Harness.Compiler.isJSMap(fileName)) {
                     // Make sure sources list is cleaned
-                    var sourceMapData = JSON.parse(data);
-                    for (var i = 0; i < sourceMapData.sources.length; i++) {
+                    let sourceMapData = JSON.parse(data);
+                    for (let i = 0; i < sourceMapData.sources.length; i++) {
                         sourceMapData.sources[i] = cleanProjectUrl(sourceMapData.sources[i]);
                     }
                     sourceMapData.sourceRoot = cleanProjectUrl(sourceMapData.sourceRoot);
                     data = JSON.stringify(sourceMapData);
                 }
 
-                var outputFilePath = getProjectOutputFolder(diskRelativeName, moduleKind);
+                let outputFilePath = getProjectOutputFolder(diskRelativeName, moduleKind);
                 // Actual writing of file as in tc.ts
                 function ensureDirectoryStructure(directoryname: string) {
                     if (directoryname) {
@@ -273,8 +273,8 @@ class ProjectRunner extends RunnerBase {
         }
 
         function compileCompileDTsFiles(compilerResult: BatchCompileProjectTestCaseResult) {
-            var allInputFiles: { emittedFileName: string; code: string; }[] = [];
-            var compilerOptions = compilerResult.program.getCompilerOptions();
+            let allInputFiles: { emittedFileName: string; code: string; }[] = [];
+            let compilerOptions = compilerResult.program.getCompilerOptions();
 
             ts.forEach(compilerResult.program.getSourceFiles(), sourceFile => {
                 if (Harness.Compiler.isDTS(sourceFile.fileName)) {
@@ -282,20 +282,20 @@ class ProjectRunner extends RunnerBase {
                 }
                 else if (ts.shouldEmitToOwnFile(sourceFile, compilerResult.program.getCompilerOptions())) {
                     if (compilerOptions.outDir) {
-                        var sourceFilePath = ts.getNormalizedAbsolutePath(sourceFile.fileName, compilerResult.program.getCurrentDirectory());
+                        let sourceFilePath = ts.getNormalizedAbsolutePath(sourceFile.fileName, compilerResult.program.getCurrentDirectory());
                         sourceFilePath = sourceFilePath.replace(compilerResult.program.getCommonSourceDirectory(), "");
-                        var emitOutputFilePathWithoutExtension = ts.removeFileExtension(ts.combinePaths(compilerOptions.outDir, sourceFilePath));
+                        let emitOutputFilePathWithoutExtension = ts.removeFileExtension(ts.combinePaths(compilerOptions.outDir, sourceFilePath));
                     }
                     else {
-                        var emitOutputFilePathWithoutExtension = ts.removeFileExtension(sourceFile.fileName);
+                        let emitOutputFilePathWithoutExtension = ts.removeFileExtension(sourceFile.fileName);
                     }
 
-                    var outputDtsFileName = emitOutputFilePathWithoutExtension + ".d.ts";
+                    let outputDtsFileName = emitOutputFilePathWithoutExtension + ".d.ts";
                     allInputFiles.unshift(findOutpuDtsFile(outputDtsFileName));
                 }
                 else {
-                    var outputDtsFileName = ts.removeFileExtension(compilerOptions.out) + ".d.ts";
-                    var outputDtsFile = findOutpuDtsFile(outputDtsFileName);
+                    let outputDtsFileName = ts.removeFileExtension(compilerOptions.out) + ".d.ts";
+                    let outputDtsFile = findOutpuDtsFile(outputDtsFileName);
                     if (!ts.contains(allInputFiles, outputDtsFile)) {
                         allInputFiles.unshift(outputDtsFile);
                     }
@@ -319,7 +319,7 @@ class ProjectRunner extends RunnerBase {
         }
 
         function getErrorsBaseline(compilerResult: CompileProjectFilesResult) {
-            var inputFiles = ts.map(ts.filter(compilerResult.program.getSourceFiles(),
+            let inputFiles = ts.map(ts.filter(compilerResult.program.getSourceFiles(),
                 sourceFile => sourceFile.fileName !== "lib.d.ts"),
                 sourceFile => {
                     return { unitName: sourceFile.fileName, content: sourceFile.text };
@@ -328,15 +328,15 @@ class ProjectRunner extends RunnerBase {
             return Harness.Compiler.getErrorBaseline(inputFiles, compilerResult.errors);
         }
 
-        var name = 'Compiling project for ' + testCase.scenario + ': testcase ' + testCaseFileName;
+        let name = 'Compiling project for ' + testCase.scenario + ': testcase ' + testCaseFileName;
 
         describe('Projects tests', () => {
             describe(name, () => {
                 function verifyCompilerResults(moduleKind: ts.ModuleKind) {
-                    var compilerResult: BatchCompileProjectTestCaseResult;
+                    let compilerResult: BatchCompileProjectTestCaseResult;
 
                     function getCompilerResolutionInfo() {
-                        var resolutionInfo: ProjectRunnerTestCaseResolutionInfo = {
+                        let resolutionInfo: ProjectRunnerTestCaseResolutionInfo = {
                             scenario: testCase.scenario,
                             projectRoot: testCase.projectRoot,
                             inputFiles: testCase.inputFiles,
@@ -410,7 +410,7 @@ class ProjectRunner extends RunnerBase {
 
                     it('Errors in generated Dts files for (' + moduleNameToString(moduleKind) + '): ' + testCaseFileName, () => {
                         if (!compilerResult.errors.length && testCase.declaration) {
-                            var dTsCompileResult = compileCompileDTsFiles(compilerResult);
+                            let dTsCompileResult = compileCompileDTsFiles(compilerResult);
                             if (dTsCompileResult.errors.length) {
                                 Harness.Baseline.runBaseline('Errors in generated Dts files for (' + moduleNameToString(compilerResult.moduleKind) + '): ' + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + '.dts.errors.txt', () => {
                                     return getErrorsBaseline(dTsCompileResult);

--- a/src/harness/projectsRunner.ts
+++ b/src/harness/projectsRunner.ts
@@ -124,7 +124,7 @@ class ProjectRunner extends RunnerBase {
             return ts.sys.resolvePath(testCase.projectRoot);
         }
 
-        function compileProjectFiles(moduleKind: ts.ModuleKind, getInputFiles: ()=> string[],
+        function compileProjectFiles(moduleKind: ts.ModuleKind, getInputFiles: () => string[],
             getSourceFileText: (fileName: string) => string,
             writeFile: (fileName: string, data: string, writeByteOrderMark: boolean) => void): CompileProjectFilesResult {
 
@@ -302,7 +302,7 @@ class ProjectRunner extends RunnerBase {
                 }
             });
 
-            return compileProjectFiles(compilerResult.moduleKind,getInputFiles, getSourceFileText, writeFile);
+            return compileProjectFiles(compilerResult.moduleKind, getInputFiles, getSourceFileText, writeFile);
 
             function findOutpuDtsFile(fileName: string) {
                 return ts.forEach(compilerResult.outputFiles, outputFile => outputFile.emittedFileName === fileName ? outputFile : undefined);
@@ -333,6 +333,8 @@ class ProjectRunner extends RunnerBase {
         describe('Projects tests', () => {
             describe(name, () => {
                 function verifyCompilerResults(moduleKind: ts.ModuleKind) {
+                    var compilerResult: BatchCompileProjectTestCaseResult;
+
                     function getCompilerResolutionInfo() {
                         var resolutionInfo: ProjectRunnerTestCaseResolutionInfo = {
                             scenario: testCase.scenario,
@@ -356,8 +358,6 @@ class ProjectRunner extends RunnerBase {
 
                         return resolutionInfo;
                     }
-
-                    var compilerResult: BatchCompileProjectTestCaseResult;
 
                     it(name + ": " + moduleNameToString(moduleKind) , () => {
                         // Compile using node

--- a/src/harness/projectsRunner.ts
+++ b/src/harness/projectsRunner.ts
@@ -60,8 +60,9 @@ class ProjectRunner extends RunnerBase {
     private runProjectTestCase(testCaseFileName: string) {
         let testCase: ProjectRunnerTestCase;
 
+        let testFileText: string = null;
         try {
-            let testFileText = ts.sys.readFile(testCaseFileName);
+            testFileText = ts.sys.readFile(testCaseFileName);
         }
         catch (e) {
             assert(false, "Unable to open testcase file: " + testCaseFileName + ": " + e.message);
@@ -175,7 +176,7 @@ class ProjectRunner extends RunnerBase {
                 else {
                     let text = getSourceFileText(fileName);
                     if (text !== undefined) {
-                        sourceFile = Harness.Compiler.createSourceFileAndAssertInletiants(fileName, text, languageVersion);
+                        sourceFile = Harness.Compiler.createSourceFileAndAssertInvariants(fileName, text, languageVersion);
                     }
                 }
 
@@ -211,8 +212,9 @@ class ProjectRunner extends RunnerBase {
             };
 
             function getSourceFileText(fileName: string): string {
+                let text: string = undefined;
                 try {
-                    let text = ts.sys.readFile(ts.isRootedDiskPath(fileName)
+                    text = ts.sys.readFile(ts.isRootedDiskPath(fileName)
                         ? fileName
                         : ts.normalizeSlashes(testCase.projectRoot) + "/" + ts.normalizeSlashes(fileName));
                 }
@@ -281,13 +283,14 @@ class ProjectRunner extends RunnerBase {
                     allInputFiles.unshift({ emittedFileName: sourceFile.fileName, code: sourceFile.text });
                 }
                 else if (ts.shouldEmitToOwnFile(sourceFile, compilerResult.program.getCompilerOptions())) {
+                    let emitOutputFilePathWithoutExtension: string = undefined;
                     if (compilerOptions.outDir) {
                         let sourceFilePath = ts.getNormalizedAbsolutePath(sourceFile.fileName, compilerResult.program.getCurrentDirectory());
                         sourceFilePath = sourceFilePath.replace(compilerResult.program.getCommonSourceDirectory(), "");
-                        let emitOutputFilePathWithoutExtension = ts.removeFileExtension(ts.combinePaths(compilerOptions.outDir, sourceFilePath));
+                        emitOutputFilePathWithoutExtension = ts.removeFileExtension(ts.combinePaths(compilerOptions.outDir, sourceFilePath));
                     }
                     else {
-                        let emitOutputFilePathWithoutExtension = ts.removeFileExtension(sourceFile.fileName);
+                        emitOutputFilePathWithoutExtension = ts.removeFileExtension(sourceFile.fileName);
                     }
 
                     let outputDtsFileName = emitOutputFilePathWithoutExtension + ".d.ts";

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -20,26 +20,26 @@
 /// <reference path='rwcRunner.ts' />
 /// <reference path='harness.ts' />
 
-var runners: RunnerBase[] = [];
-var iterations: number = 1;
+let runners: RunnerBase[] = [];
+let iterations: number = 1;
 
 function runTests(runners: RunnerBase[]) {
-    for (var i = iterations; i > 0; i--) {
-        for (var j = 0; j < runners.length; j++) {
+    for (let i = iterations; i > 0; i--) {
+        for (let j = 0; j < runners.length; j++) {
             runners[j].initializeTests();
         }
     }
 }
 
 // users can define tests to run in mytest.config that will override cmd line args, otherwise use cmd line args (test.config), otherwise no options
-var mytestconfig = 'mytest.config';
-var testconfig = 'test.config';
-var testConfigFile =
+let mytestconfig = 'mytest.config';
+let testconfig = 'test.config';
+let testConfigFile =
     Harness.IO.fileExists(mytestconfig) ? Harness.IO.readFile(mytestconfig) :
     (Harness.IO.fileExists(testconfig) ? Harness.IO.readFile(testconfig) : '');
 
 if (testConfigFile !== '') {
-    var testConfig = JSON.parse(testConfigFile);
+    let testConfig = JSON.parse(testConfigFile);
     if (testConfig.light) {
         Harness.lightMode = true;
     }

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -20,6 +20,9 @@
 /// <reference path='rwcRunner.ts' />
 /// <reference path='harness.ts' />
 
+var runners: RunnerBase[] = [];
+var iterations: number = 1;
+
 function runTests(runners: RunnerBase[]) {
     for (var i = iterations; i > 0; i--) {
         for (var j = 0; j < runners.length; j++) {
@@ -27,9 +30,6 @@ function runTests(runners: RunnerBase[]) {
         }
     }
 }
-
-var runners: RunnerBase[] = [];
-var iterations: number = 1;
 
 // users can define tests to run in mytest.config that will override cmd line args, otherwise use cmd line args (test.config), otherwise no options
 var mytestconfig = 'mytest.config';
@@ -99,7 +99,7 @@ if (runners.length === 0) {
     runners.push(new FourSlashRunner(FourSlashTestType.Native));
     runners.push(new FourSlashRunner(FourSlashTestType.Shims));
     runners.push(new FourSlashRunner(FourSlashTestType.Server));
-    //runners.push(new GeneratedFourslashRunner());
+    // runners.push(new GeneratedFourslashRunner());
 }
 
 ts.sys.newLine = '\r\n';

--- a/src/harness/runnerbase.ts
+++ b/src/harness/runnerbase.ts
@@ -24,17 +24,17 @@ class RunnerBase {
 
     /** Replaces instances of full paths with fileNames only */
     static removeFullPaths(path: string) {
-        var fixedPath = path;
+        let fixedPath = path;
 
         // full paths either start with a drive letter or / for *nix, shouldn't have \ in the path at this point
-        var fullPath = /(\w+:|\/)?([\w+\-\.]|\/)*\.tsx?/g; 
-        var fullPathList = fixedPath.match(fullPath);
+        let fullPath = /(\w+:|\/)?([\w+\-\.]|\/)*\.tsx?/g; 
+        let fullPathList = fixedPath.match(fullPath);
         if (fullPathList) {
             fullPathList.forEach((match: string) => fixedPath = fixedPath.replace(match, Harness.Path.getFileName(match)));
         }
         
         // when running in the browser the 'full path' is the host name, shows up in error baselines
-        var localHost = /http:\/localhost:\d+/g;
+        let localHost = /http:\/localhost:\d+/g;
         fixedPath = fixedPath.replace(localHost, '');
         return fixedPath;
     }

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -76,7 +76,7 @@ module RWC {
                     // Add files to compilation
                     for (let fileRead of ioLog.filesRead) {
                         // Check if the file is already added into the set of input files.
-                        let resolvedPath = ts.normalizeSlashes(ts.sys.resolvePath(fileRead.path));
+                        var resolvedPath = ts.normalizeSlashes(ts.sys.resolvePath(fileRead.path));
                         let inInputList = ts.forEach(inputFiles, inputFile => inputFile.unitName === resolvedPath);
 
                         if (!Harness.isLibraryFile(fileRead.path)) {
@@ -118,8 +118,9 @@ module RWC {
 
                 function getHarnessCompilerInputUnit(fileName: string) {
                     let unitName = ts.normalizeSlashes(ts.sys.resolvePath(fileName));
+                    let content: string = null;
                     try {
-                        let content = ts.sys.readFile(unitName);
+                        content = ts.sys.readFile(unitName);
                     }
                     catch (e) {
                         // Leave content undefined.

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -5,9 +5,9 @@
 
 module RWC {
     function runWithIOLog(ioLog: IOLog, fn: () => void) {
-        var oldSys = ts.sys;
+        let oldSys = ts.sys;
 
-        var wrappedSys = Playback.wrapSystem(ts.sys);
+        let wrappedSys = Playback.wrapSystem(ts.sys);
         wrappedSys.startReplayFromData(ioLog);
         ts.sys = wrappedSys;
 
@@ -21,17 +21,17 @@ module RWC {
 
     export function runRWCTest(jsonPath: string) {
         describe("Testing a RWC project: " + jsonPath, () => {
-            var inputFiles: { unitName: string; content: string; }[] = [];
-            var otherFiles: { unitName: string; content: string; }[] = [];
-            var compilerResult: Harness.Compiler.CompilerResult;
-            var compilerOptions: ts.CompilerOptions;
-            var baselineOpts: Harness.Baseline.BaselineOptions = {
+            let inputFiles: { unitName: string; content: string; }[] = [];
+            let otherFiles: { unitName: string; content: string; }[] = [];
+            let compilerResult: Harness.Compiler.CompilerResult;
+            let compilerOptions: ts.CompilerOptions;
+            let baselineOpts: Harness.Baseline.BaselineOptions = {
                 Subfolder: 'rwc',
                 Baselinefolder: 'internal/baselines'
             };
-            var baseName = /(.*)\/(.*).json/.exec(ts.normalizeSlashes(jsonPath))[2];
-            var currentDirectory: string;
-            var useCustomLibraryFile: boolean;
+            let baseName = /(.*)\/(.*).json/.exec(ts.normalizeSlashes(jsonPath))[2];
+            let currentDirectory: string;
+            let useCustomLibraryFile: boolean;
 
             after(() => {
                 // Mocha holds onto the closure environment of the describe callback even after the test is done.
@@ -50,10 +50,10 @@ module RWC {
             });
 
             it('can compile', () => {
-                var harnessCompiler = Harness.Compiler.getCompiler();
-                var opts: ts.ParsedCommandLine;
+                let harnessCompiler = Harness.Compiler.getCompiler();
+                let opts: ts.ParsedCommandLine;
 
-                var ioLog: IOLog = JSON.parse(Harness.IO.readFile(jsonPath));
+                let ioLog: IOLog = JSON.parse(Harness.IO.readFile(jsonPath));
                 currentDirectory = ioLog.currentDirectory;
                 useCustomLibraryFile = ioLog.useCustomLibraryFile;
                 runWithIOLog(ioLog, () => {
@@ -76,8 +76,8 @@ module RWC {
                     // Add files to compilation
                     for (let fileRead of ioLog.filesRead) {
                         // Check if the file is already added into the set of input files.
-                        var resolvedPath = ts.normalizeSlashes(ts.sys.resolvePath(fileRead.path));
-                        var inInputList = ts.forEach(inputFiles, inputFile => inputFile.unitName === resolvedPath);
+                        let resolvedPath = ts.normalizeSlashes(ts.sys.resolvePath(fileRead.path));
+                        let inInputList = ts.forEach(inputFiles, inputFile => inputFile.unitName === resolvedPath);
 
                         if (!Harness.isLibraryFile(fileRead.path)) {
                             if (inInputList) {
@@ -117,9 +117,9 @@ module RWC {
                 });
 
                 function getHarnessCompilerInputUnit(fileName: string) {
-                    var unitName = ts.normalizeSlashes(ts.sys.resolvePath(fileName));
+                    let unitName = ts.normalizeSlashes(ts.sys.resolvePath(fileName));
                     try {
-                        var content = ts.sys.readFile(unitName);
+                        let content = ts.sys.readFile(unitName);
                     }
                     catch (e) {
                         // Leave content undefined.
@@ -155,13 +155,13 @@ module RWC {
                 }, false, baselineOpts);
             });
 
-            //it('has correct source map record', () => {
-            //    if (compilerOptions.sourceMap) {
-            //        Harness.Baseline.runBaseline('has correct source map record', baseName + '.sourcemap.txt', () => {
-            //            return compilerResult.getSourceMapRecord();
-            //        }, false, baselineOpts);
-            //    }
-            //});
+            /*it('has correct source map record', () => {
+                if (compilerOptions.sourceMap) {
+                    Harness.Baseline.runBaseline('has correct source map record', baseName + '.sourcemap.txt', () => {
+                        return compilerResult.getSourceMapRecord();
+                    }, false, baselineOpts);
+                }
+            });*/
 
             it('has the expected errors', () => {
                 Harness.Baseline.runBaseline('has the expected errors', baseName + '.errors.txt', () => {
@@ -178,7 +178,7 @@ module RWC {
             it('has the expected errors in generated declaration files', () => {
                 if (compilerOptions.declaration && !compilerResult.errors.length) {
                     Harness.Baseline.runBaseline('has the expected errors in generated declaration files', baseName + '.dts.errors.txt', () => {
-                        var declFileCompilationResult = Harness.Compiler.getCompiler().compileDeclarationFiles(inputFiles, otherFiles, compilerResult,
+                        let declFileCompilationResult = Harness.Compiler.getCompiler().compileDeclarationFiles(inputFiles, otherFiles, compilerResult,
                             /*settingscallback*/ undefined, compilerOptions, currentDirectory);
                         if (declFileCompilationResult.declResult.errors.length === 0) {
                             return null;
@@ -204,8 +204,8 @@ class RWCRunner extends RunnerBase {
      */
     public initializeTests(): void {
         // Read in and evaluate the test list
-        var testList = Harness.IO.listFiles(RWCRunner.sourcePath, /.+\.json$/);
-        for (var i = 0; i < testList.length; i++) {
+        let testList = Harness.IO.listFiles(RWCRunner.sourcePath, /.+\.json$/);
+        for (let i = 0; i < testList.length; i++) {
             this.runTest(testList[i]);
         }
     }

--- a/src/harness/sourceMapRecorder.ts
+++ b/src/harness/sourceMapRecorder.ts
@@ -329,8 +329,6 @@ module Harness.SourceMapRecoder {
         }
 
         function writeRecordedSpans() {
-            let markerIds: string[] = [];
-
             function getMarkerId(markerIndex: number) {
                 let markerId = "";
                 if (spanMarkerContinues) {
@@ -418,6 +416,7 @@ module Harness.SourceMapRecoder {
                 writeJsFileLines(currentJsLine);
 
                 // Emit markers
+                var markerIds: string[] = [];
                 iterateSpans(writeSourceMapMarker);
 
                 let jsFileText = getTextOfLine(currentJsLine, jsLineMap, jsFile.code);

--- a/src/harness/sourceMapRecorder.ts
+++ b/src/harness/sourceMapRecorder.ts
@@ -329,6 +329,8 @@ module Harness.SourceMapRecoder {
         }
 
         function writeRecordedSpans() {
+            let markerIds: string[] = [];
+
             function getMarkerId(markerIndex: number) {
                 let markerId = "";
                 if (spanMarkerContinues) {
@@ -336,7 +338,7 @@ module Harness.SourceMapRecoder {
                     markerId = "1->";
                 }
                 else {
-                    let markerId = "" + (markerIndex + 1);
+                    markerId = "" + (markerIndex + 1);
                     if (markerId.length < 2) {
                         markerId = markerId + " ";
                     }
@@ -416,7 +418,6 @@ module Harness.SourceMapRecoder {
                 writeJsFileLines(currentJsLine);
 
                 // Emit markers
-                var markerIds: string[] = [];
                 iterateSpans(writeSourceMapMarker);
 
                 let jsFileText = getTextOfLine(currentJsLine, jsLineMap, jsFile.code);

--- a/src/harness/sourceMapRecorder.ts
+++ b/src/harness/sourceMapRecorder.ts
@@ -23,12 +23,12 @@ module Harness.SourceMapRecoder {
     }
 
     module SourceMapDecoder {
-        var sourceMapMappings: string;
-        var sourceMapNames: string[];
-        var decodingIndex: number;
-        var prevNameIndex: number;
-        var decodeOfEncodedMapping: ts.SourceMapSpan;
-        var errorDecodeOfEncodedMapping: string;
+        let sourceMapMappings: string;
+        let sourceMapNames: string[];
+        let decodingIndex: number;
+        let prevNameIndex: number;
+        let decodeOfEncodedMapping: ts.SourceMapSpan;
+        let errorDecodeOfEncodedMapping: string;
 
         export function initializeSourceMapDecoding(sourceMapData: ts.SourceMapData) {
             sourceMapMappings = sourceMapData.sourceMapMappings;
@@ -82,9 +82,9 @@ module Harness.SourceMapRecoder {
                     return "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".indexOf(sourceMapMappings.charAt(decodingIndex));
                 }
 
-                var moreDigits = true;
-                var shiftCount = 0;
-                var value = 0;
+                let moreDigits = true;
+                let shiftCount = 0;
+                let value = 0;
 
                 for (; moreDigits; decodingIndex++) {
                     if (createErrorIfCondition(decodingIndex >= sourceMapMappings.length, "Error in decoding base64VLQFormatDecode, past the mapping string")) {
@@ -92,7 +92,7 @@ module Harness.SourceMapRecoder {
                     }
 
                     // 6 digit number
-                    var currentByte = base64FormatDecode();
+                    let currentByte = base64FormatDecode();
 
                     // If msb is set, we still have more bits to continue
                     moreDigits = (currentByte & 32) !== 0;
@@ -203,19 +203,19 @@ module Harness.SourceMapRecoder {
     }
 
     module SourceMapSpanWriter {
-        var sourceMapRecoder: Compiler.WriterAggregator;
-        var sourceMapSources: string[];
-        var sourceMapNames: string[];
+        let sourceMapRecoder: Compiler.WriterAggregator;
+        let sourceMapSources: string[];
+        let sourceMapNames: string[];
 
-        var jsFile: Compiler.GeneratedFile;
-        var jsLineMap: number[];
-        var tsCode: string;
-        var tsLineMap: number[];
+        let jsFile: Compiler.GeneratedFile;
+        let jsLineMap: number[];
+        let tsCode: string;
+        let tsLineMap: number[];
 
-        var spansOnSingleLine: SourceMapSpanWithDecodeErrors[];
-        var prevWrittenSourcePos: number;
-        var prevWrittenJsLine: number;
-        var spanMarkerContinues: boolean;
+        let spansOnSingleLine: SourceMapSpanWithDecodeErrors[];
+        let prevWrittenSourcePos: number;
+        let prevWrittenJsLine: number;
+        let spanMarkerContinues: boolean;
 
         export function intializeSourceMapSpanWriter(sourceMapRecordWriter: Compiler.WriterAggregator, sourceMapData: ts.SourceMapData, currentJsFile: Compiler.GeneratedFile) {
             sourceMapRecoder = sourceMapRecordWriter;
@@ -244,7 +244,7 @@ module Harness.SourceMapRecoder {
         }
 
         function getSourceMapSpanString(mapEntry: ts.SourceMapSpan, getAbsentNameIndex?: boolean) {
-            var mapString = "Emitted(" + mapEntry.emittedLine + ", " + mapEntry.emittedColumn + ") Source(" + mapEntry.sourceLine + ", " + mapEntry.sourceColumn + ") + SourceIndex(" + mapEntry.sourceIndex + ")";
+            let mapString = "Emitted(" + mapEntry.emittedLine + ", " + mapEntry.emittedColumn + ") Source(" + mapEntry.sourceLine + ", " + mapEntry.sourceColumn + ") + SourceIndex(" + mapEntry.sourceIndex + ")";
             if (mapEntry.nameIndex >= 0 && mapEntry.nameIndex < sourceMapNames.length) {
                 mapString += " name (" + sourceMapNames[mapEntry.nameIndex] + ")";
             }
@@ -259,8 +259,8 @@ module Harness.SourceMapRecoder {
 
         export function recordSourceMapSpan(sourceMapSpan: ts.SourceMapSpan) {
             // verify the decoded span is same as the new span
-            var decodeResult = SourceMapDecoder.decodeNextEncodedSourceMapSpan();
-            var decodedErrors: string[];
+            let decodeResult = SourceMapDecoder.decodeNextEncodedSourceMapSpan();
+            let decodedErrors: string[];
             if (decodeResult.error
                 || decodeResult.sourceMapSpan.emittedLine   !== sourceMapSpan.emittedLine
                 || decodeResult.sourceMapSpan.emittedColumn !== sourceMapSpan.emittedColumn
@@ -317,8 +317,8 @@ module Harness.SourceMapRecoder {
         }
 
         function getTextOfLine(line: number, lineMap: number[], code: string) {
-            var startPos = lineMap[line];
-            var endPos = lineMap[line + 1];
+            let startPos = lineMap[line];
+            let endPos = lineMap[line + 1];
             return code.substring(startPos, endPos);
         }
 
@@ -329,16 +329,16 @@ module Harness.SourceMapRecoder {
         }
 
         function writeRecordedSpans() {
-            var markerIds: string[] = [];
+            let markerIds: string[] = [];
 
             function getMarkerId(markerIndex: number) {
-                var markerId = "";
+                let markerId = "";
                 if (spanMarkerContinues) {
                     assert.isTrue(markerIndex === 0);
                     markerId = "1->";
                 }
                 else {
-                    var markerId = "" + (markerIndex + 1);
+                    let markerId = "" + (markerIndex + 1);
                     if (markerId.length < 2) {
                         markerId = markerId + " ";
                     }
@@ -347,10 +347,10 @@ module Harness.SourceMapRecoder {
                 return markerId;
             }
 
-            var prevEmittedCol: number;
+            let prevEmittedCol: number;
             function iterateSpans(fn: (currentSpan: SourceMapSpanWithDecodeErrors, index: number) => void) {
                 prevEmittedCol = 1;
-                for (var i = 0; i < spansOnSingleLine.length; i++) {
+                for (let i = 0; i < spansOnSingleLine.length; i++) {
                     fn(spansOnSingleLine[i], i);
                     prevEmittedCol = spansOnSingleLine[i].sourceMapSpan.emittedColumn;
                 }
@@ -358,18 +358,18 @@ module Harness.SourceMapRecoder {
 
             function writeSourceMapIndent(indentLength: number, indentPrefix: string) {
                 sourceMapRecoder.Write(indentPrefix);
-                for (var i = 1; i < indentLength; i++) {
+                for (let i = 1; i < indentLength; i++) {
                     sourceMapRecoder.Write(" ");
                 }
             }
 
             function writeSourceMapMarker(currentSpan: SourceMapSpanWithDecodeErrors, index: number, endColumn = currentSpan.sourceMapSpan.emittedColumn, endContinues?: boolean) {
-                var markerId = getMarkerId(index);
+                let markerId = getMarkerId(index);
                 markerIds.push(markerId);
 
                 writeSourceMapIndent(prevEmittedCol, markerId);
 
-                for (var i = prevEmittedCol; i < endColumn; i++) {
+                for (let i = prevEmittedCol; i < endColumn; i++) {
                     sourceMapRecoder.Write("^");
                 }
                 if (endContinues) {
@@ -380,8 +380,8 @@ module Harness.SourceMapRecoder {
             }
 
             function writeSourceMapSourceText(currentSpan: SourceMapSpanWithDecodeErrors, index: number) {
-                var sourcePos = tsLineMap[currentSpan.sourceMapSpan.sourceLine - 1] + (currentSpan.sourceMapSpan.sourceColumn - 1);
-                var sourceText = "";
+                let sourcePos = tsLineMap[currentSpan.sourceMapSpan.sourceLine - 1] + (currentSpan.sourceMapSpan.sourceColumn - 1);
+                let sourceText = "";
                 if (prevWrittenSourcePos < sourcePos) {
                     // Position that goes forward, get text
                     sourceText = tsCode.substring(prevWrittenSourcePos, sourcePos);
@@ -389,14 +389,14 @@ module Harness.SourceMapRecoder {
 
                 if (currentSpan.decodeErrors) {
                     // If there are decode errors, write
-                    for (var i = 0; i < currentSpan.decodeErrors.length; i++) {
+                    for (let i = 0; i < currentSpan.decodeErrors.length; i++) {
                         writeSourceMapIndent(prevEmittedCol, markerIds[index]);
                         sourceMapRecoder.WriteLine(currentSpan.decodeErrors[i]);
                     }
                 }
 
-                var tsCodeLineMap = ts.computeLineStarts(sourceText);
-                for (var i = 0; i < tsCodeLineMap.length; i++) {
+                let tsCodeLineMap = ts.computeLineStarts(sourceText);
+                for (let i = 0; i < tsCodeLineMap.length; i++) {
                     writeSourceMapIndent(prevEmittedCol, i === 0 ? markerIds[index] : "  >");
                     sourceMapRecoder.Write(getTextOfLine(i, tsCodeLineMap, sourceText));
                     if (i === tsCodeLineMap.length - 1) {
@@ -412,7 +412,7 @@ module Harness.SourceMapRecoder {
             }
 
             if (spansOnSingleLine.length) {
-                var currentJsLine = spansOnSingleLine[0].sourceMapSpan.emittedLine;
+                let currentJsLine = spansOnSingleLine[0].sourceMapSpan.emittedLine;
 
                 // Write js line
                 writeJsFileLines(currentJsLine);
@@ -420,7 +420,7 @@ module Harness.SourceMapRecoder {
                 // Emit markers
                 iterateSpans(writeSourceMapMarker);
 
-                var jsFileText = getTextOfLine(currentJsLine, jsLineMap, jsFile.code);
+                let jsFileText = getTextOfLine(currentJsLine, jsLineMap, jsFile.code);
                 if (prevEmittedCol < jsFileText.length) {
                     // There is remaining text on this line that will be part of next source span so write marker that continues
                     writeSourceMapMarker(undefined, spansOnSingleLine.length, /*endColumn*/ jsFileText.length, /*endContinues*/ true);
@@ -438,16 +438,16 @@ module Harness.SourceMapRecoder {
     }
 
     export function getSourceMapRecord(sourceMapDataList: ts.SourceMapData[], program: ts.Program, jsFiles: Compiler.GeneratedFile[]) {
-        var sourceMapRecoder = new Compiler.WriterAggregator();
+        let sourceMapRecoder = new Compiler.WriterAggregator();
 
-        for (var i = 0; i < sourceMapDataList.length; i++) {
-            var sourceMapData = sourceMapDataList[i];
-            var prevSourceFile: ts.SourceFile = null;
+        for (let i = 0; i < sourceMapDataList.length; i++) {
+            let sourceMapData = sourceMapDataList[i];
+            let prevSourceFile: ts.SourceFile = null;
 
             SourceMapSpanWriter.intializeSourceMapSpanWriter(sourceMapRecoder, sourceMapData, jsFiles[i]);
-            for (var j = 0; j < sourceMapData.sourceMapDecodedMappings.length; j++) {
-                var decodedSourceMapping = sourceMapData.sourceMapDecodedMappings[j];
-                var currentSourceFile = program.getSourceFile(sourceMapData.inputSourceFileNames[decodedSourceMapping.sourceIndex]);
+            for (let j = 0; j < sourceMapData.sourceMapDecodedMappings.length; j++) {
+                let decodedSourceMapping = sourceMapData.sourceMapDecodedMappings[j];
+                let currentSourceFile = program.getSourceFile(sourceMapData.inputSourceFileNames[decodedSourceMapping.sourceIndex]);
                 if (currentSourceFile !== prevSourceFile) {
                     SourceMapSpanWriter.recordNewSourceFileSpan(decodedSourceMapping, currentSourceFile.text);
                     prevSourceFile = currentSourceFile;

--- a/src/harness/sourceMapRecorder.ts
+++ b/src/harness/sourceMapRecorder.ts
@@ -1,6 +1,6 @@
 //
 // Copyright (c) Microsoft Corporation.  All rights reserved.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -143,7 +143,7 @@ module Harness.SourceMapRecoder {
                     return { error: errorDecodeOfEncodedMapping, sourceMapSpan: decodeOfEncodedMapping };
                 }
 
-                // 2. Relative sourceIndex 
+                // 2. Relative sourceIndex
                 decodeOfEncodedMapping.sourceIndex += base64VLQFormatDecode();
                 // Incorrect sourceIndex dont support this map
                 if (createErrorIfCondition(decodeOfEncodedMapping.sourceIndex < 0, "Invalid sourceIndex found")) {
@@ -165,7 +165,7 @@ module Harness.SourceMapRecoder {
                     return { error: errorDecodeOfEncodedMapping, sourceMapSpan: decodeOfEncodedMapping };
                 }
 
-                // 4. Relative sourceColumn 0 based 
+                // 4. Relative sourceColumn 0 based
                 decodeOfEncodedMapping.sourceColumn += base64VLQFormatDecode();
                 // Incorrect sourceColumn dont support this map
                 if (createErrorIfCondition(decodeOfEncodedMapping.sourceColumn < 1, "Invalid sourceLine found")) {
@@ -278,7 +278,7 @@ module Harness.SourceMapRecoder {
             }
 
             if (spansOnSingleLine.length && spansOnSingleLine[0].sourceMapSpan.emittedLine !== sourceMapSpan.emittedLine) {
-                // On different line from the one that we have been recording till now, 
+                // On different line from the one that we have been recording till now,
                 writeRecordedSpans();
                 spansOnSingleLine = [{ sourceMapSpan: sourceMapSpan, decodeErrors: decodedErrors }];
             }
@@ -329,6 +329,8 @@ module Harness.SourceMapRecoder {
         }
 
         function writeRecordedSpans() {
+            var markerIds: string[] = [];
+
             function getMarkerId(markerIndex: number) {
                 var markerId = "";
                 if (spanMarkerContinues) {
@@ -416,7 +418,6 @@ module Harness.SourceMapRecoder {
                 writeJsFileLines(currentJsLine);
 
                 // Emit markers
-                var markerIds: string[] = [];
                 iterateSpans(writeSourceMapMarker);
 
                 var jsFileText = getTextOfLine(currentJsLine, jsLineMap, jsFile.code);
@@ -455,7 +456,7 @@ module Harness.SourceMapRecoder {
                     SourceMapSpanWriter.recordSourceMapSpan(decodedSourceMapping);
                 }
             }
-            SourceMapSpanWriter.close();// If the last spans werent emitted, emit them
+            SourceMapSpanWriter.close(); // If the last spans werent emitted, emit them
         }
         sourceMapRecoder.Close();
         return sourceMapRecoder.lines.join('\r\n');

--- a/src/harness/test262Runner.ts
+++ b/src/harness/test262Runner.ts
@@ -81,7 +81,7 @@ class Test262BaselineRunner extends RunnerBase {
 
             it('satisfies inletiants', () => {
                 let sourceFile = testState.program.getSourceFile(Test262BaselineRunner.getTestFilePath(testState.filename));
-                Utils.assertInletiants(sourceFile, /*parent:*/ undefined);
+                Utils.assertInvariants(sourceFile, /*parent:*/ undefined);
             });
 
             it('has the expected AST', () => {

--- a/src/harness/test262Runner.ts
+++ b/src/harness/test262Runner.ts
@@ -27,7 +27,7 @@ class Test262BaselineRunner extends RunnerBase {
         describe('test262 test for ' + filePath, () => {
             // Mocha holds onto the closure environment of the describe callback even after the test is done.
             // Everything declared here should be cleared out in the "after" callback.
-            var testState: {
+            let testState: {
                 filename: string;
                 compilerResult: Harness.Compiler.CompilerResult;
                 inputFiles: { unitName: string; content: string }[];
@@ -35,11 +35,11 @@ class Test262BaselineRunner extends RunnerBase {
             };
 
             before(() => {
-                var content = Harness.IO.readFile(filePath);
-                var testFilename = ts.removeFileExtension(filePath).replace(/\//g, '_') + ".test";
-                var testCaseContent = Harness.TestCaseParser.makeUnitsFromTest(content, testFilename);
+                let content = Harness.IO.readFile(filePath);
+                let testFilename = ts.removeFileExtension(filePath).replace(/\//g, '_') + ".test";
+                let testCaseContent = Harness.TestCaseParser.makeUnitsFromTest(content, testFilename);
 
-                var inputFiles = testCaseContent.testUnitData.map(unit => {
+                let inputFiles = testCaseContent.testUnitData.map(unit => {
                     return { unitName: Test262BaselineRunner.getTestFilePath(unit.name), content: unit.content };
                 });
 
@@ -63,14 +63,14 @@ class Test262BaselineRunner extends RunnerBase {
 
             it('has the expected emitted code', () => {
                 Harness.Baseline.runBaseline('has the expected emitted code', testState.filename + '.output.js', () => {
-                    var files = testState.compilerResult.files.filter(f => f.fileName !== Test262BaselineRunner.helpersFilePath);
+                    let files = testState.compilerResult.files.filter(f => f.fileName !== Test262BaselineRunner.helpersFilePath);
                     return Harness.Compiler.collateOutputs(files);
                 }, false, Test262BaselineRunner.baselineOptions);
             });
 
             it('has the expected errors', () => {
                 Harness.Baseline.runBaseline('has the expected errors', testState.filename + '.errors.txt', () => {
-                    var errors = testState.compilerResult.errors;
+                    let errors = testState.compilerResult.errors;
                     if (errors.length === 0) {
                         return null;
                     }
@@ -79,14 +79,14 @@ class Test262BaselineRunner extends RunnerBase {
                 }, false, Test262BaselineRunner.baselineOptions);
             });
 
-            it('satisfies invariants', () => {
-                var sourceFile = testState.program.getSourceFile(Test262BaselineRunner.getTestFilePath(testState.filename));
-                Utils.assertInvariants(sourceFile, /*parent:*/ undefined);
+            it('satisfies inletiants', () => {
+                let sourceFile = testState.program.getSourceFile(Test262BaselineRunner.getTestFilePath(testState.filename));
+                Utils.assertInletiants(sourceFile, /*parent:*/ undefined);
             });
 
             it('has the expected AST', () => {
                 Harness.Baseline.runBaseline('has the expected AST', testState.filename + '.AST.txt', () => {
-                    var sourceFile = testState.program.getSourceFile(Test262BaselineRunner.getTestFilePath(testState.filename));
+                    let sourceFile = testState.program.getSourceFile(Test262BaselineRunner.getTestFilePath(testState.filename));
                     return Utils.sourceFileToJSON(sourceFile);
                 }, false, Test262BaselineRunner.baselineOptions);
             });
@@ -96,7 +96,7 @@ class Test262BaselineRunner extends RunnerBase {
     public initializeTests() {
         // this will set up a series of describe/it blocks to run between the setup and cleanup phases
         if (this.tests.length === 0) {
-            var testFiles = this.enumerateFiles(Test262BaselineRunner.basePath, Test262BaselineRunner.testFileExtensionRegex, { recursive: true });
+            let testFiles = this.enumerateFiles(Test262BaselineRunner.basePath, Test262BaselineRunner.testFileExtensionRegex, { recursive: true });
             testFiles.forEach(fn => {
                 this.runTest(ts.normalizePath(fn));
             });

--- a/src/harness/test262Runner.ts
+++ b/src/harness/test262Runner.ts
@@ -63,7 +63,7 @@ class Test262BaselineRunner extends RunnerBase {
 
             it('has the expected emitted code', () => {
                 Harness.Baseline.runBaseline('has the expected emitted code', testState.filename + '.output.js', () => {
-                    var files = testState.compilerResult.files.filter(f=> f.fileName !== Test262BaselineRunner.helpersFilePath);
+                    var files = testState.compilerResult.files.filter(f => f.fileName !== Test262BaselineRunner.helpersFilePath);
                     return Harness.Compiler.collateOutputs(files);
                 }, false, Test262BaselineRunner.baselineOptions);
             });
@@ -84,8 +84,8 @@ class Test262BaselineRunner extends RunnerBase {
                 Utils.assertInvariants(sourceFile, /*parent:*/ undefined);
             });
 
-            it('has the expected AST',() => {
-                Harness.Baseline.runBaseline('has the expected AST', testState.filename + '.AST.txt',() => {
+            it('has the expected AST', () => {
+                Harness.Baseline.runBaseline('has the expected AST', testState.filename + '.AST.txt', () => {
                     var sourceFile = testState.program.getSourceFile(Test262BaselineRunner.getTestFilePath(testState.filename));
                     return Utils.sourceFileToJSON(sourceFile);
                 }, false, Test262BaselineRunner.baselineOptions);
@@ -105,4 +105,4 @@ class Test262BaselineRunner extends RunnerBase {
             this.tests.forEach(test => this.runTest(test));
         }
     }
-}  
+}

--- a/src/harness/typeWriter.ts
+++ b/src/harness/typeWriter.ts
@@ -21,7 +21,7 @@ class TypeWriterWalker {
     }
 
     public getTypeAndSymbols(fileName: string): TypeWriterResult[] {
-        var sourceFile = this.program.getSourceFile(fileName);
+        let sourceFile = this.program.getSourceFile(fileName);
         this.currentSourceFile = sourceFile;
         this.results = [];
         this.visitNode(sourceFile);
@@ -37,19 +37,19 @@ class TypeWriterWalker {
     }
 
     private logTypeAndSymbol(node: ts.Node): void {
-        var actualPos = ts.skipTrivia(this.currentSourceFile.text, node.pos);
-        var lineAndCharacter = this.currentSourceFile.getLineAndCharacterOfPosition(actualPos);
-        var sourceText = ts.getTextOfNodeFromSourceText(this.currentSourceFile.text, node);
+        let actualPos = ts.skipTrivia(this.currentSourceFile.text, node.pos);
+        let lineAndCharacter = this.currentSourceFile.getLineAndCharacterOfPosition(actualPos);
+        let sourceText = ts.getTextOfNodeFromSourceText(this.currentSourceFile.text, node);
 
         // Workaround to ensure we output 'C' instead of 'typeof C' for base class expressions
-        // var type = this.checker.getTypeAtLocation(node);
-        var type = node.parent && ts.isExpressionWithTypeArgumentsInClassExtendsClause(node.parent) && this.checker.getTypeAtLocation(node.parent) || this.checker.getTypeAtLocation(node);
+        // let type = this.checker.getTypeAtLocation(node);
+        let type = node.parent && ts.isExpressionWithTypeArgumentsInClassExtendsClause(node.parent) && this.checker.getTypeAtLocation(node.parent) || this.checker.getTypeAtLocation(node);
 
         ts.Debug.assert(type !== undefined, "type doesn't exist");
-        var symbol = this.checker.getSymbolAtLocation(node);
+        let symbol = this.checker.getSymbolAtLocation(node);
 
-        var typeString = this.checker.typeToString(type, node.parent, ts.TypeFormatFlags.NoTruncation);
-        var symbolString: string;
+        let typeString = this.checker.typeToString(type, node.parent, ts.TypeFormatFlags.NoTruncation);
+        let symbolString: string;
         if (symbol) {
             symbolString = "Symbol(" + this.checker.symbolToString(symbol, node.parent);
             if (symbol.declarations) {
@@ -57,7 +57,7 @@ class TypeWriterWalker {
                     symbolString += ", ";
                     let declSourceFile = declaration.getSourceFile();
                     let declLineAndCharacter = declSourceFile.getLineAndCharacterOfPosition(declaration.pos);
-                    symbolString += `Decl(${ ts.getBaseFileName(declSourceFile.fileName) }, ${ declLineAndCharacter.line }, ${ declLineAndCharacter.character })`
+                    symbolString += `Decl(${ ts.getBaseFileName(declSourceFile.fileName) }, ${ declLineAndCharacter.line }, ${ declLineAndCharacter.character })`;
                 }
             }
             symbolString += ")";

--- a/src/harness/typeWriter.ts
+++ b/src/harness/typeWriter.ts
@@ -13,7 +13,7 @@ class TypeWriterWalker {
     private checker: ts.TypeChecker;
 
     constructor(private program: ts.Program, fullTypeCheck: boolean) {
-        // Consider getting both the diagnostics checker and the non-diagnostics checker to verify 
+        // Consider getting both the diagnostics checker and the non-diagnostics checker to verify
         // they are consistent.
         this.checker = fullTypeCheck
             ? program.getDiagnosticsProducingTypeChecker()


### PR DESCRIPTION
Just some basic clean up on the harness code following the recent cleanup of the compiler code. This gets the harness code near 0 TSLint errors with the current ruleset. 