### PR TITLE
Remove resolveLocation from the checker

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5841,32 +5841,15 @@ namespace ts {
             }
         }
 
-        function resolveLocation(node: Node) {
-            // Resolve location from top down towards node if it is a context sensitive expression
-            // That helps in making sure not assigning types as any when resolved out of order
-            let containerNodes: Node[] = [];
-            for (let parent = node.parent; parent; parent = parent.parent) {
-                if ((isExpression(parent) || isObjectLiteralMethod(node)) &&
-                    isContextSensitive(<Expression>parent)) {
-                    containerNodes.unshift(parent);
-                }
-            }
-
-            ts.forEach(containerNodes, node => { getTypeOfNode(node); });
-        }
-
         function getSymbolAtLocation(node: Node): Symbol {
-            resolveLocation(node);
             return getSymbolInfo(node);
         }
 
         function getTypeAtLocation(node: Node): Type {
-            resolveLocation(node);
             return getTypeOfNode(node);
         }
 
         function getTypeOfSymbolAtLocation(symbol: Symbol, node: Node): Type {
-            resolveLocation(node);
             // Get the narrowed type of symbol at given location instead of just getting
             // the type of the symbol.
             // eg.

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8522,6 +8522,9 @@ namespace ts {
             if (!produceDiagnostics) {
                 for (let candidate of candidates) {
                     if (hasCorrectArity(node, args, candidate)) {
+                        if (candidate.typeParameters && typeArguments) {
+                            candidate = getSignatureInstantiation(candidate, map(typeArguments, getTypeFromTypeNode));
+                        }
                         return candidate;
                     }
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -60,18 +60,8 @@ namespace ts {
             getDiagnostics,
             getGlobalDiagnostics,
 
-            // Get the narrowed type of symbol at given location instead of just getting
-            // the type of the symbol.
-            // eg.
-            // function foo(a: string | number) {
-            //     if (typeof a === "string") {
-            //         a/**/
-            //     }
-            // }
-            // getTypeOfSymbol for a would return type of parameter symbol string | number
-            // Unless we provide location /**/, checker wouldn't know how to narrow the type
-            // By using getNarrowedTypeOfSymbol would return string since it would be able to narrow
-            // it by typeguard in the if true condition
+            // The language service will always care about the narrowed type of a symbol, because that is
+            // the type the language says the symbol should have.
             getTypeOfSymbolAtLocation: getNarrowedTypeOfSymbol,
             getDeclaredTypeOfSymbol,
             getPropertiesOfType,
@@ -215,7 +205,9 @@ namespace ts {
         let assignableRelation: Map<RelationComparisonResult> = {};
         let identityRelation: Map<RelationComparisonResult> = {};
 
-        enum TypeSystemPropertyName {
+        type TypeSystemEntity = Symbol | Type | Signature;
+
+        const enum TypeSystemPropertyName {
             Type,
             ResolvedBaseConstructorType,
             DeclaredType,
@@ -2242,18 +2234,18 @@ namespace ts {
             if (propertyName === TypeSystemPropertyName.Type) {
                 return getSymbolLinks(<Symbol>target).type;
             }
-            else if (propertyName === TypeSystemPropertyName.DeclaredType) {
+            if (propertyName === TypeSystemPropertyName.DeclaredType) {
                 return getSymbolLinks(<Symbol>target).declaredType;
             }
-            else if (propertyName === TypeSystemPropertyName.ResolvedBaseConstructorType) {
+            if (propertyName === TypeSystemPropertyName.ResolvedBaseConstructorType) {
                 Debug.assert(!!((<Type>target).flags & TypeFlags.Class));
                 return (<InterfaceType>target).resolvedBaseConstructorType;
             }
-            else if (propertyName === TypeSystemPropertyName.ResolvedReturnType) {
+            if (propertyName === TypeSystemPropertyName.ResolvedReturnType) {
                 return (<Signature>target).resolvedReturnType;
             }
 
-            Debug.fail("Unhandled TypeSystemObjectKind");
+            Debug.fail("Unhandled TypeSystemPropertyName " + propertyName);
         }
 
         // Pop an entry from the type resolution stack and return its associated result value. The result value will

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1904,6 +1904,8 @@ namespace ts {
         isolatedSignatureType?: ObjectType; // A manufactured type that just contains the signature for purposes of signature comparison
     }
 
+    export type TypeSystemEntity = Symbol | Type | Signature;
+
     export const enum IndexKind {
         String,
         Number,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1904,8 +1904,6 @@ namespace ts {
         isolatedSignatureType?: ObjectType; // A manufactured type that just contains the signature for purposes of signature comparison
     }
 
-    export type TypeSystemEntity = Symbol | Type | Signature;
-
     export const enum IndexKind {
         String,
         Number,

--- a/tests/cases/fourslash/genericCombinators2.ts
+++ b/tests/cases/fourslash/genericCombinators2.ts
@@ -110,7 +110,7 @@ goTo.marker('15');
 verify.quickInfoIs('var r4a: Collection<number, any>');
 
 goTo.marker('17');
-verify.quickInfoIs('var r5a: Collection<T, V>'); // This is actually due to an error because toFixed does not return a Date
+verify.quickInfoIs('var r5a: Collection<number, Date>');
 
 goTo.marker('18');
 verify.quickInfoIs('var r5b: Collection<number, Date>');
@@ -122,10 +122,10 @@ goTo.marker('20');
 verify.quickInfoIs('var r6b: Collection<Collection<number, number>, Date>');
 
 goTo.marker('21');
-verify.quickInfoIs('var r7a: Collection<T, V>'); // This call is an error because y.foo() does not return a string
+verify.quickInfoIs('var r7a: Collection<number, string>');
 
 goTo.marker('22');
-verify.quickInfoIs('var r7b: Collection<T, V>'); // This call is an error because y.foo() does not return a string
+verify.quickInfoIs('var r7b: Collection<number, string>');
 
 goTo.marker('23');
 verify.quickInfoIs('var r8a: Collection<number, string>');


### PR DESCRIPTION
I removed the resolveLocation function from the checker. I fixed all resulting regressions in what I think are better ways.

Two side effects of my change

1. I cleaned up pushTypeResolution a bit, so now it should be easier to understand and use
2. I improved error recovery for overload resolution failures where type arguments are specified