### PR TITLE
isNaN accept all types of arguments

### DIFF
--- a/src/lib/core.d.ts
+++ b/src/lib/core.d.ts
@@ -30,9 +30,9 @@ declare function parseFloat(string: string): number;
 
 /**
   * Returns a Boolean value that indicates whether a value is the reserved value NaN (not a number). 
-  * @param number A numeric value.
+  * @param number A numeric or a string value.
   */
-declare function isNaN(number: number): boolean;
+declare function isNaN(number: any): boolean;
 
 /** 
   * Determines whether a supplied number is finite.


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN the argument can be a boolean, a string, a number or an object.