### PR TITLE
Correctly identify identifiers inside JSX exprs as expression identifiers

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1485,7 +1485,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     }
                 }
                 else if (languageVersion < ScriptTarget.ES6) {
-                    debugger;
                     let declaration = resolver.getReferencedImportDeclaration(node);
                     if (declaration) {
                         if (declaration.kind === SyntaxKind.ImportClause) {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1425,6 +1425,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     case SyntaxKind.IfStatement:
                     case SyntaxKind.JsxSelfClosingElement:
                     case SyntaxKind.JsxOpeningElement:
+                    case SyntaxKind.JsxExpression:
                     case SyntaxKind.NewExpression:
                     case SyntaxKind.ParenthesizedExpression:
                     case SyntaxKind.PostfixUnaryExpression:
@@ -1484,6 +1485,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     }
                 }
                 else if (languageVersion < ScriptTarget.ES6) {
+                    debugger;
                     let declaration = resolver.getReferencedImportDeclaration(node);
                     if (declaration) {
                         if (declaration.kind === SyntaxKind.ImportClause) {

--- a/tests/baselines/reference/jsxImportInAttribute.js
+++ b/tests/baselines/reference/jsxImportInAttribute.js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/jsxImportInAttribute.tsx] ////
+
+//// [component.d.ts]
+
+declare module "Test" {
+	export default class Text { }
+}
+
+//// [consumer.tsx]
+/// <reference path="component.d.ts" />
+import Test from 'Test';
+
+let x = Test; // emit test_1.default
+<anything attr={Test} />; // ?
+
+
+//// [consumer.jsx]
+/// <reference path="component.d.ts" />
+var Test_1 = require('Test');
+var x = Test_1["default"]; // emit test_1.default
+<anything attr={Test_1["default"]}/>; // ?

--- a/tests/baselines/reference/jsxImportInAttribute.symbols
+++ b/tests/baselines/reference/jsxImportInAttribute.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/consumer.tsx ===
+/// <reference path="component.d.ts" />
+import Test from 'Test';
+>Test : Symbol(Test, Decl(consumer.tsx, 1, 6))
+
+let x = Test; // emit test_1.default
+>x : Symbol(x, Decl(consumer.tsx, 3, 3))
+>Test : Symbol(Test, Decl(consumer.tsx, 1, 6))
+
+<anything attr={Test} />; // ?
+>attr : Symbol(unknown)
+
+=== tests/cases/compiler/component.d.ts ===
+
+declare module "Test" {
+	export default class Text { }
+>Text : Symbol(Text, Decl(component.d.ts, 1, 23))
+}
+

--- a/tests/baselines/reference/jsxImportInAttribute.types
+++ b/tests/baselines/reference/jsxImportInAttribute.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/consumer.tsx ===
+/// <reference path="component.d.ts" />
+import Test from 'Test';
+>Test : typeof Test
+
+let x = Test; // emit test_1.default
+>x : typeof Test
+>Test : typeof Test
+
+<anything attr={Test} />; // ?
+><anything attr={Test} /> : any
+>anything : any
+>attr : any
+>Test : any
+
+=== tests/cases/compiler/component.d.ts ===
+
+declare module "Test" {
+	export default class Text { }
+>Text : Text
+}
+

--- a/tests/cases/compiler/jsxImportInAttribute.tsx
+++ b/tests/cases/compiler/jsxImportInAttribute.tsx
@@ -1,0 +1,14 @@
+//@jsx: preserve
+//@module: commonjs
+
+//@filename: component.d.ts
+declare module "Test" {
+	export default class Text { }
+}
+
+//@filename: consumer.tsx
+/// <reference path="component.d.ts" />
+import Test from 'Test';
+
+let x = Test; // emit test_1.default
+<anything attr={Test} />; // ?


### PR DESCRIPTION
Fixes bug #3928.

I am inclined to start a campaign to make as many of our `switch` statements in the compiler exhaustive as possible?