### PR TITLE
Add references for fourslash in test dir

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1875,7 +1875,7 @@ module FourSlash {
             }
         }
 
-        private verifyProjectInfo(expected: string[]) {
+        public verifyProjectInfo(expected: string[]) {
             if (this.testType === FourSlashTestType.Server) {
                 let actual = (<ts.server.SessionClient>this.languageService).getProjectInfo(
                     this.activeFile.fileName,
@@ -2057,11 +2057,8 @@ module FourSlash {
             return result;
         }
 
-        public verifGetScriptLexicalStructureListContains(
-            name: string,
-            kind: string,
-            markerPosition?: number) {
-            this.taoInvalidReason = 'verifGetScriptLexicalStructureListContains impossible';
+        public verifyGetScriptLexicalStructureListContains(name: string, kind: string) {
+            this.taoInvalidReason = 'verifyGetScriptLexicalStructureListContains impossible';
 
             let items = this.languageService.getNavigationBarItems(this.activeFile.fileName);
 
@@ -2263,7 +2260,7 @@ module FourSlash {
             return 'line ' + (pos.line + 1) + ', col ' + pos.character;
         }
 
-        private getMarkerByName(markerName: string) {
+        public getMarkerByName(markerName: string) {
             let markerPos = this.testData.markerPositions[markerName];
             if (markerPos === undefined) {
                 let markerNames: string[] = [];

--- a/tests/cases/fourslash/addDeclareToFunction.ts
+++ b/tests/cases/fourslash/addDeclareToFunction.ts
@@ -1,7 +1,8 @@
+/// <reference path="fourslash.ts" />
+
 //// /*1*/function parseInt(s/*2*/:string):number;
 
 goTo.marker('2');
 edit.deleteAtCaret(':string'.length);
 goTo.marker('1');
 edit.insert('declare ');
-

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -1,3 +1,21 @@
+/// <reference path="../../../src/harness/fourslashRunner.ts"/>
+
+// declare var FourSlash;
+// module ts {
+//     export interface SymbolDisplayPart {
+//         text: string;
+//         kind: string;
+//     }
+// }
+
+// DO NOT EDIT ABOVE THIS LINE!
+// We want type-completion while we edit this file, but at compile time we don't want to include the above reference
+// because we are compiling this file in "--out" mode and don't want to rope in the entire codebase
+// for each fourslash test.
+// So, the compile script manually modifies the aboce code so that we compile correctly.
+
+//---------------------------------------------
+
 // Welcome to the FourSlash syntax guide!
 
 // A line in the source text is indicated by four slashes (////)
@@ -29,7 +47,7 @@
 // type 'fs.' as an alternate way of accessing the top-level objects
 // (e.g. 'fs.goTo.eof();')
 
-declare var FourSlash;
+//---------------------------------------
 
 // Return code used by getEmitOutput function to indicate status of the function
 // It is a duplicate of the one in types.ts to expose it to testcases in fourslash
@@ -698,12 +716,7 @@ module fs {
     export var format = new FourSlashInterface.format();
     export var cancellation = new FourSlashInterface.cancellation();
 }
-module ts {
-    export interface SymbolDisplayPart {
-        text: string;
-        kind: string;
-    }
-}
+
 function verifyOperationIsCancelled(f) {
     FourSlash.verifyOperationIsCancelled(f);
 }

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -39,7 +39,7 @@
 // Explanation:
 // We want type-completion while we edit this file, but at compile time/while editting fourslash tests,
 // we don't want to include the following reference because we are compiling this file in "--out" mode and don't want to rope
-// in the entire codebase into the compilattion each fourslash test. Additionally, we don't want to expose the
+// in the entire codebase into the compilation each fourslash test. Additionally, we don't want to expose the
 // src/harness/fourslash.ts API's (or the rest of the compiler) because they are unstable and complicate the
 // fourslash testing DSL. Finally, in this case, runtime reflection is (much) faster.
 //

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -1,21 +1,3 @@
-/// <reference path="../../../src/harness/fourslash.ts"/>
-
-// declare var FourSlash;
-// module ts {
-//     export interface SymbolDisplayPart {
-//         text: string;
-//         kind: string;
-//     }
-// }
-
-// DO NOT EDIT ABOVE THIS LINE!
-// We want type-completion while we edit this file, but at compile time we don't want to include the above reference
-// because we are compiling this file in "--out" mode and don't want to rope in the entire codebase
-// for each fourslash test.
-// So, the compile script manually modifies the aboce code so that we compile correctly.
-
-//---------------------------------------------
-
 // Welcome to the FourSlash syntax guide!
 
 // A line in the source text is indicated by four slashes (////)
@@ -48,6 +30,32 @@
 // (e.g. 'fs.goTo.eof();')
 
 //---------------------------------------
+// When editting this file, and only while editing this file, enable the reference comments
+// and comment out the declarations in this section to get proper type information.
+// Undo these changes before compiling/committing/editing any other fourslash tests.
+// The test suite will likely crash if you try 'jake runtests' with reference comments enabled.
+//
+// Explanation:
+// We want type-completion while we edit this file, but at compile time/while editting fourslash tests,
+// we don't want to include the following reference because we are compiling this file in "--out" mode and don't want to rope
+// in the entire codebase into the compilattion each fourslash test. Additionally, we don't want to expose the
+// src/harness/fourslash.ts API's (or the rest of the compiler) because they are unstable and complicate the
+// fourslash testing DSL. Finally, in this case, runtime reflection is (much) faster.
+//
+// TODO: figure out a better solution to the API exposure problem.
+
+// /// <reference path="../../../built/local/typescriptServices.d.ts"/>
+// /// <reference path="../../../src/harness/fourslash.ts"/>
+
+declare var FourSlash;
+module ts {
+    export interface SymbolDisplayPart {
+        text: string;
+        kind: string;
+    }
+}
+
+//---------------------------------------------
 
 // Return code used by getEmitOutput function to indicate status of the function
 // It is a duplicate of the one in types.ts to expose it to testcases in fourslash

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -1,4 +1,4 @@
-/// <reference path="../../../src/harness/fourslashRunner.ts"/>
+/// <reference path="../../../src/harness/fourslash.ts"/>
 
 // declare var FourSlash;
 // module ts {
@@ -60,7 +60,6 @@ enum EmitReturnStatus {
 }
 
 module FourSlashInterface {
-    declare var FourSlash;
 
     export interface Marker {
         fileName: string;
@@ -219,15 +218,6 @@ module FourSlashInterface {
             FourSlash.currentTestState.verifyReferencesAtPositionListContains(range.fileName, range.start, range.end, isWriteAccess);
         }
 
-        public implementorsCountIs(count: number) {
-            FourSlash.currentTestState.verifyImplementorsCountIs(count);
-        }
-
-        // Add tests for this.
-        public currentParameterIsVariable() {
-            FourSlash.currentTestState.verifyCurrentParameterIsVariable(!this.negative);
-        }
-
         public signatureHelpPresent() {
             FourSlash.currentTestState.verifySignatureHelpPresent(!this.negative);
         }
@@ -379,14 +369,11 @@ module FourSlashInterface {
             FourSlash.currentTestState.verifyNoMatchingBracePosition(bracePosition);
         }
 
-        public setVerifyDocComments(val: boolean) {
-            FourSlash.currentTestState.setVerifyDocComments(val);
-        }
-
         public getScriptLexicalStructureListCount(count: number) {
             FourSlash.currentTestState.verifyGetScriptLexicalStructureListCount(count);
         }
 
+        // TODO: figure out what to do with the unused arguments.
         public getScriptLexicalStructureListContains(
             name: string,
             kind: string,
@@ -394,13 +381,7 @@ module FourSlashInterface {
             parentName?: string,
             isAdditionalSpan?: boolean,
             markerPosition?: number) {
-            FourSlash.currentTestState.verifGetScriptLexicalStructureListContains(
-                name,
-                kind,
-                fileName,
-                parentName,
-                isAdditionalSpan,
-                markerPosition);
+            FourSlash.currentTestState.verifyGetScriptLexicalStructureListContains(name, kind);
         }
 
         public navigationItemsListCount(count: number, searchValue: string, matchKind?: string) {

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -30,6 +30,7 @@
 // (e.g. 'fs.goTo.eof();')
 
 //---------------------------------------
+// For API editors:
 // When editting this file, and only while editing this file, enable the reference comments
 // and comment out the declarations in this section to get proper type information.
 // Undo these changes before compiling/committing/editing any other fourslash tests.


### PR DESCRIPTION
We want to expose `src/harness/fourslash.ts` to `tests/cases/fourslash/fourslash.ts`, which defines the API/DSL for 4/ tests. However, we don't want to expose `src/harness/fourslash.ts` (or the rest of the compiler) to the tests themselves, since this crowds the `ts` namespace. Up to this point, we have decided to forgo the former, which makes contributing to the API difficult and error-prone (we give up static typing!).

As a temporary measure, I've added instructions on how to toggle between editing the API and using it.

One immediate issue: should these instructions immediately follow the 4/ guide? It may be somewhat disheartening to see the guide immediately followed by a hacky solution.