### PR TITLE
add transpileModule function that can return emitted source map

### DIFF
--- a/src/compiler/diagnosticInformationMap.generated.ts
+++ b/src/compiler/diagnosticInformationMap.generated.ts
@@ -509,7 +509,6 @@ namespace ts {
         Option_noEmit_cannot_be_specified_with_option_out_or_outDir: { code: 5040, category: DiagnosticCategory.Error, key: "Option 'noEmit' cannot be specified with option 'out' or 'outDir'." },
         Option_noEmit_cannot_be_specified_with_option_declaration: { code: 5041, category: DiagnosticCategory.Error, key: "Option 'noEmit' cannot be specified with option 'declaration'." },
         Option_project_cannot_be_mixed_with_source_files_on_a_command_line: { code: 5042, category: DiagnosticCategory.Error, key: "Option 'project' cannot be mixed with source files on a command line." },
-        Option_sourceMap_cannot_be_specified_with_option_isolatedModules: { code: 5043, category: DiagnosticCategory.Error, key: "Option 'sourceMap' cannot be specified with option 'isolatedModules'." },
         Option_declaration_cannot_be_specified_with_option_isolatedModules: { code: 5044, category: DiagnosticCategory.Error, key: "Option 'declaration' cannot be specified with option 'isolatedModules'." },
         Option_noEmitOnError_cannot_be_specified_with_option_isolatedModules: { code: 5045, category: DiagnosticCategory.Error, key: "Option 'noEmitOnError' cannot be specified with option 'isolatedModules'." },
         Option_out_cannot_be_specified_with_option_isolatedModules: { code: 5046, category: DiagnosticCategory.Error, key: "Option 'out' cannot be specified with option 'isolatedModules'." },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2025,10 +2025,6 @@
         "category": "Error",
         "code": 5042
     },
-    "Option 'sourceMap' cannot be specified with option 'isolatedModules'.": {
-        "category": "Error",
-        "code": 5043
-    },
     "Option 'declaration' cannot be specified with option 'isolatedModules'.": {
         "category": "Error",
         "code": 5044

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -602,10 +602,6 @@ namespace ts {
 
         function verifyCompilerOptions() {
             if (options.isolatedModules) {
-                if (options.sourceMap) {
-                    diagnostics.add(createCompilerDiagnostic(Diagnostics.Option_sourceMap_cannot_be_specified_with_option_isolatedModules));
-                }
-
                 if (options.declaration) {
                     diagnostics.add(createCompilerDiagnostic(Diagnostics.Option_declaration_cannot_be_specified_with_option_isolatedModules));
                 }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1754,18 +1754,31 @@ namespace ts {
         sourceFile.version = version;
         sourceFile.scriptSnapshot = scriptSnapshot;
     }
-
+    
+    export interface TranspileOptions {
+        compilerOptions?: CompilerOptions;
+        fileName?: string;
+        reportDiagnostics?: boolean;
+        moduleName?: string;
+    }
+    
+    export interface TranspileOutput {
+        outputText: string;
+        diagnostics?: Diagnostic[];
+        sourceMapText?: string;
+    }
+    
     /*
      * This function will compile source text from 'input' argument using specified compiler options.
      * If not options are provided - it will use a set of default compiler options.
-     * Extra compiler options that will unconditionally be used bu this function are:
+     * Extra compiler options that will unconditionally be used by this function are:
      * - isolatedModules = true
      * - allowNonTsExtensions = true
      * - noLib = true
      * - noResolve = true
-     */
-    export function transpile(input: string, compilerOptions?: CompilerOptions, fileName?: string, diagnostics?: Diagnostic[], moduleName?: string): string {
-        let options = compilerOptions ? clone(compilerOptions) : getDefaultCompilerOptions();
+     */    
+    export function transpileModule(input: string, transpileOptions?: TranspileOptions): TranspileOutput {
+        let options = transpileOptions.compilerOptions ? clone(transpileOptions.compilerOptions) : getDefaultCompilerOptions();
 
         options.isolatedModules = true;
 
@@ -1781,23 +1794,30 @@ namespace ts {
         options.noResolve = true;
 
         // Parse
-        let inputFileName = fileName || "module.ts";
+        let inputFileName = transpileOptions.fileName || "module.ts";
         let sourceFile = createSourceFile(inputFileName, input, options.target);
-        if (moduleName) {
-            sourceFile.moduleName = moduleName;
+        if (transpileOptions.moduleName) {
+            sourceFile.moduleName = transpileOptions.moduleName;
         }
 
         let newLine = getNewLineCharacter(options);
 
         // Output
         let outputText: string;
+        let sourceMapText: string;
 
         // Create a compilerHost object to allow the compiler to read and write files
         let compilerHost: CompilerHost = {
             getSourceFile: (fileName, target) => fileName === inputFileName ? sourceFile : undefined,
             writeFile: (name, text, writeByteOrderMark) => {
-                Debug.assert(outputText === undefined, "Unexpected multiple outputs for the file: " + name);
-                outputText = text;
+                if (fileExtensionIs(name, ".map")) {
+                    Debug.assert(sourceMapText === undefined, `Unexpected multiple source map outputs for the file '${name}'`);
+                    sourceMapText = text;
+                }
+                else {
+                    Debug.assert(outputText === undefined, "Unexpected multiple outputs for the file: " + name);
+                    outputText = text;
+                }
             },
             getDefaultLibFileName: () => "lib.d.ts",
             useCaseSensitiveFileNames: () => false,
@@ -1807,16 +1827,29 @@ namespace ts {
         };
 
         let program = createProgram([inputFileName], options, compilerHost);
-
-        addRange(/*to*/ diagnostics, /*from*/ program.getSyntacticDiagnostics(sourceFile));
-        addRange(/*to*/ diagnostics, /*from*/ program.getOptionsDiagnostics());
-
+        
+        let diagnostics: Diagnostic[];
+        if (transpileOptions.reportDiagnostics) {
+            diagnostics = [];
+            addRange(/*to*/ diagnostics, /*from*/ program.getSyntacticDiagnostics(sourceFile));
+            addRange(/*to*/ diagnostics, /*from*/ program.getOptionsDiagnostics());
+        }
         // Emit
         program.emit();
 
         Debug.assert(outputText !== undefined, "Output generation failed");
 
-        return outputText;
+        return { outputText, diagnostics, sourceMapText };        
+    }
+
+    /*
+     * This is a shortcut function for transpileModule - it accepts transpileOptions as parameters and returns only outputText part of the result. 
+     */
+    export function transpile(input: string, compilerOptions?: CompilerOptions, fileName?: string, diagnostics?: Diagnostic[], moduleName?: string): string {
+        let output = transpileModule(input, { compilerOptions, fileName, reportDiagnostics: !!diagnostics, moduleName });
+        // addRange correctly handles cases when wither 'from' or 'to' argument is missing
+        addRange(diagnostics, output.diagnostics);
+        return output.outputText;
     }
 
     export function createLanguageServiceSourceFile(fileName: string, scriptSnapshot: IScriptSnapshot, scriptTarget: ScriptTarget, version: string, setNodeParents: boolean): SourceFile {

--- a/tests/baselines/reference/isolatedModulesSourceMap.errors.txt
+++ b/tests/baselines/reference/isolatedModulesSourceMap.errors.txt
@@ -1,7 +1,0 @@
-error TS5043: Option 'sourceMap' cannot be specified with option 'isolatedModules'.
-
-
-!!! error TS5043: Option 'sourceMap' cannot be specified with option 'isolatedModules'.
-==== tests/cases/compiler/isolatedModulesSourceMap.ts (0 errors) ====
-    
-    export var x;

--- a/tests/baselines/reference/isolatedModulesSourceMap.js
+++ b/tests/baselines/reference/isolatedModulesSourceMap.js
@@ -1,7 +1,7 @@
 //// [isolatedModulesSourceMap.ts]
 
-export var x;
+export var x = 1;
 
 //// [isolatedModulesSourceMap.js]
-export var x;
+export var x = 1;
 //# sourceMappingURL=isolatedModulesSourceMap.js.map

--- a/tests/baselines/reference/isolatedModulesSourceMap.js.map
+++ b/tests/baselines/reference/isolatedModulesSourceMap.js.map
@@ -1,2 +1,2 @@
 //// [isolatedModulesSourceMap.js.map]
-{"version":3,"file":"isolatedModulesSourceMap.js","sourceRoot":"","sources":["isolatedModulesSourceMap.ts"],"names":[],"mappings":"AACA,WAAW,CAAC,CAAC"}
+{"version":3,"file":"isolatedModulesSourceMap.js","sourceRoot":"","sources":["isolatedModulesSourceMap.ts"],"names":[],"mappings":"AACA,WAAW,CAAC,GAAG,CAAC,CAAC"}

--- a/tests/baselines/reference/isolatedModulesSourceMap.sourcemap.txt
+++ b/tests/baselines/reference/isolatedModulesSourceMap.sourcemap.txt
@@ -8,20 +8,26 @@ sources: isolatedModulesSourceMap.ts
 emittedFile:tests/cases/compiler/isolatedModulesSourceMap.js
 sourceFile:isolatedModulesSourceMap.ts
 -------------------------------------------------------------------
->>>export var x;
+>>>export var x = 1;
 1 >
 2 >^^^^^^^^^^^
 3 >           ^
-4 >            ^
-5 >             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+4 >            ^^^
+5 >               ^
+6 >                ^
+7 >                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >
   >
 2 >export var 
 3 >           x
-4 >            ;
+4 >             = 
+5 >               1
+6 >                ;
 1 >Emitted(1, 1) Source(2, 1) + SourceIndex(0)
 2 >Emitted(1, 12) Source(2, 12) + SourceIndex(0)
 3 >Emitted(1, 13) Source(2, 13) + SourceIndex(0)
-4 >Emitted(1, 14) Source(2, 14) + SourceIndex(0)
+4 >Emitted(1, 16) Source(2, 16) + SourceIndex(0)
+5 >Emitted(1, 17) Source(2, 17) + SourceIndex(0)
+6 >Emitted(1, 18) Source(2, 18) + SourceIndex(0)
 ---
 >>>//# sourceMappingURL=isolatedModulesSourceMap.js.map

--- a/tests/baselines/reference/isolatedModulesSourceMap.symbols
+++ b/tests/baselines/reference/isolatedModulesSourceMap.symbols
@@ -1,0 +1,5 @@
+=== tests/cases/compiler/isolatedModulesSourceMap.ts ===
+
+export var x = 1;
+>x : Symbol(x, Decl(isolatedModulesSourceMap.ts, 1, 10))
+

--- a/tests/baselines/reference/isolatedModulesSourceMap.types
+++ b/tests/baselines/reference/isolatedModulesSourceMap.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/isolatedModulesSourceMap.ts ===
+
+export var x = 1;
+>x : number
+>1 : number
+

--- a/tests/cases/compiler/isolatedModulesSourceMap.ts
+++ b/tests/cases/compiler/isolatedModulesSourceMap.ts
@@ -3,4 +3,4 @@
 // @target: es6
 
 // @filename: file1.ts
-export var x;
+export var x = 1;


### PR DESCRIPTION
fixes #3363

existing `transpile` function returns emitted source code as a string so augmenting it to also return source map information will be a breaking change. Instead I've added new function `transpileModule` (suggestions for better names are welcome) that accepts arguments as record and returns an object containing generated code. source map data, diagnostics and any other stuff that we might want to add in the future.