### PR TITLE
Add getBaseTypes on TypeObject in services

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -68,6 +68,7 @@ namespace ts {
             getPropertyOfType,
             getSignaturesOfType,
             getIndexTypeOfType,
+            getBaseTypes,
             getReturnTypeOfSignature,
             getSymbolsInScope,
             getSymbolAtLocation,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1404,6 +1404,7 @@ namespace ts {
         getPropertyOfType(type: Type, propertyName: string): Symbol;
         getSignaturesOfType(type: Type, kind: SignatureKind): Signature[];
         getIndexTypeOfType(type: Type, kind: IndexKind): Type;
+        getBaseTypes(type: InterfaceType): ObjectType[];
         getReturnTypeOfSignature(signature: Signature): Type;
 
         getSymbolsInScope(location: Node, meaning: SymbolFlags): Symbol[];
@@ -1808,7 +1809,9 @@ namespace ts {
         typeParameters: TypeParameter[];           // Type parameters (undefined if non-generic)
         outerTypeParameters: TypeParameter[];      // Outer type parameters (undefined if none)
         localTypeParameters: TypeParameter[];      // Local type parameters (undefined if none)
+        /* @internal */
         resolvedBaseConstructorType?: Type;        // Resolved base constructor type of class
+        /* @internal */
         resolvedBaseTypes: ObjectType[];           // Resolved base types
     }
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -48,6 +48,7 @@ namespace ts {
         getConstructSignatures(): Signature[];
         getStringIndexType(): Type;
         getNumberIndexType(): Type;
+        getBaseTypes(): ObjectType[]
     }
 
     export interface Signature {
@@ -681,6 +682,11 @@ namespace ts {
         }
         getNumberIndexType(): Type {
             return this.checker.getIndexTypeOfType(this, IndexKind.Number);
+        }
+        getBaseTypes(): ObjectType[] {
+            return this.flags & (TypeFlags.Class | TypeFlags.Interface)
+                ? this.checker.getBaseTypes(<TypeObject & InterfaceType>this)
+                : undefined;
         }
     }
 


### PR DESCRIPTION
Fixes #3977.

This is just a request to expose getBaseTypes on the TypeObject in services. It seems like a reasonable addition to our API, even though it is not used directly by services.