### PR TITLE
Update tslint.json for latest versions of tslint

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -4,20 +4,31 @@
         "comment-format": [true,
             "check-space"
         ],
-        "indent": true,
+        "indent": [true,
+            "spaces"
+        ],
         "one-line": [true,
             "check-open-brace"
         ],
         "no-unreachable": true,
         "no-use-before-declare": true,
         "no-var-keyword": true,
-        "quotemark": true,
+        "quotemark": [true,
+            "double"
+        ],
         "semicolon": true,
         "whitespace": [true,
             "check-branch",
             "check-operator",
             "check-separator",
             "check-type"
-        ]
+        ],
+        "typedef-whitespace": [true, {
+            "call-signature": "nospace",
+            "index-signature": "nospace",
+            "parameter": "nospace",
+            "property-declaration": "nospace",
+            "variable-declaration": "nospace"
+        }]
   }
 }


### PR DESCRIPTION
Enforces spaces and double quotes again, and enforces no space before the colon for type definitions.

This should fix part of #3994. I couldn't find an existing rule to cover the no multiple declaration expressions style, so that is missing from this.