### PR TITLE
Fix jake lint with newest tslint

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -738,7 +738,7 @@ task("lint", [], function() {
     var lintTargets = compilerSources.concat(harnessCoreSources);
     for(var i in lintTargets) {
         var f = lintTargets[i];
-        var cmd = 'tslint -f ' + f;
+        var cmd = 'tslint -c tslint.json ' + f;
         exec(cmd, success(f), failure(f));
     }
 }, { async: true });

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -736,7 +736,7 @@ task("lint", [], function() {
     function failure(f) { return function() { console.log('FAILURE: Please fix linting errors in ' + f + '\n') }};
 
     var lintTargets = compilerSources.concat(harnessCoreSources);
-    for(var i in lintTargets) {
+    for (var i in lintTargets) {
         var f = lintTargets[i];
         var cmd = 'tslint -c tslint.json ' + f;
         exec(cmd, success(f), failure(f));


### PR DESCRIPTION
`-f` was removed from tslint, causing `jake lint` to always fail with usage errors.