### PR TITLE
Fix as many linter errors as possible

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -139,7 +139,7 @@ namespace ts {
         function getDeclarationName(node: Declaration): string {
             if (node.name) {
                 if (node.kind === SyntaxKind.ModuleDeclaration && node.name.kind === SyntaxKind.StringLiteral) {
-                    return '"' + (<LiteralExpression>node.name).text + '"';
+                    return `"${(<LiteralExpression>node.name).text}"`;
                 }
                 if (node.name.kind === SyntaxKind.ComputedPropertyName) {
                     let nameExpression = (<ComputedPropertyName>node.name).expression;
@@ -830,7 +830,7 @@ namespace ts {
 
             // Note: the node text must be exactly "use strict" or 'use strict'.  It is not ok for the
             // string to contain unicode escapes (as per ES5).
-            return nodeText === '"use strict"' || nodeText === "'use strict'";
+            return nodeText === "\"use strict\"" || nodeText === "'use strict'";
         }
 
         function bindWorker(node: Node) {
@@ -930,7 +930,7 @@ namespace ts {
         function bindSourceFileIfExternalModule() {
             setExportContextFlag(file);
             if (isExternalModule(file)) {
-                bindAnonymousDeclaration(file, SymbolFlags.ValueModule, '"' + removeFileExtension(file.fileName) + '"');
+                bindAnonymousDeclaration(file, SymbolFlags.ValueModule, `"${removeFileExtension(file.fileName)}"`);
             }
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7378,7 +7378,7 @@ namespace ts {
         function getJsxElementInstanceType(node: JsxOpeningLikeElement) {
             // There is no such thing as an instance type for a non-class element. This
             // line shouldn't be hit.
-            Debug.assert(!!(getNodeLinks(node).jsxFlags & JsxFlags.ClassElement), 'Should not call getJsxElementInstanceType on non-class Element');
+            Debug.assert(!!(getNodeLinks(node).jsxFlags & JsxFlags.ClassElement), "Should not call getJsxElementInstanceType on non-class Element");
 
             let classSymbol = getJsxElementTagSymbol(node);
             if (classSymbol === unknownSymbol) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -211,6 +211,9 @@ namespace ts {
         let assignableRelation: Map<RelationComparisonResult> = {};
         let identityRelation: Map<RelationComparisonResult> = {};
 
+        // This is for caching the result of getSymbolDisplayBuilder. Do not access directly.
+        let _displayBuilder: SymbolDisplayBuilder;
+
         type TypeSystemEntity = Symbol | Type | Signature;
 
         const enum TypeSystemPropertyName {
@@ -1490,8 +1493,6 @@ namespace ts {
             return undefined;
         }
 
-        // This is for caching the result of getSymbolDisplayBuilder. Do not access directly.
-        let _displayBuilder: SymbolDisplayBuilder;
         function getSymbolDisplayBuilder(): SymbolDisplayBuilder {
 
             function getNameOfSymbol(symbol: Symbol): string {
@@ -3448,7 +3449,7 @@ namespace ts {
         // type, a property is considered known if it is known in any constituent type.
         function isKnownProperty(type: Type, name: string): boolean {
             if (type.flags & TypeFlags.ObjectType && type !== globalObjectType) {
-                var resolved = resolveStructuredTypeMembers(type);
+                const resolved = resolveStructuredTypeMembers(type);
                 return !!(resolved.properties.length === 0 ||
                     resolved.stringIndexType ||
                     resolved.numberIndexType ||

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -968,7 +968,7 @@ namespace ts {
             if (!moduleName) return;
             let isRelative = isExternalModuleNameRelative(moduleName);
             if (!isRelative) {
-                let symbol = getSymbol(globals, '"' + moduleName + '"', SymbolFlags.ValueModule);
+                let symbol = getSymbol(globals, "\"" + moduleName + "\"", SymbolFlags.ValueModule);
                 if (symbol) {
                     return symbol;
                 }
@@ -7338,7 +7338,7 @@ namespace ts {
                     }
 
                     // Wasn't found
-                    error(node, Diagnostics.Property_0_does_not_exist_on_type_1, (<Identifier>node.tagName).text, 'JSX.' + JsxNames.IntrinsicElements);
+                    error(node, Diagnostics.Property_0_does_not_exist_on_type_1, (<Identifier>node.tagName).text, "JSX." + JsxNames.IntrinsicElements);
                     return unknownSymbol;
                 }
                 else {
@@ -7558,7 +7558,7 @@ namespace ts {
             // be marked as 'used' so we don't incorrectly elide its import. And if there
             // is no 'React' symbol in scope, we should issue an error.
             if (compilerOptions.jsx === JsxEmit.React) {
-                let reactSym = resolveName(node.tagName, 'React', SymbolFlags.Value, Diagnostics.Cannot_find_name_0, 'React');
+                let reactSym = resolveName(node.tagName, "React", SymbolFlags.Value, Diagnostics.Cannot_find_name_0, "React");
                 if (reactSym) {
                     getSymbolLinks(reactSym).referenced = true;
                 }

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -423,7 +423,7 @@ namespace ts {
                     fileNames = map(<string[]>json["files"], s => combinePaths(basePath, s));
                 }
                 else {
-                    errors.push(createCompilerDiagnostic(Diagnostics.Compiler_option_0_requires_a_value_of_type_1, 'files', 'Array'));                    
+                    errors.push(createCompilerDiagnostic(Diagnostics.Compiler_option_0_requires_a_value_of_type_1, "files", "Array"));                    
                 }
             }
             else {

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -335,7 +335,7 @@ namespace ts {
       * @param fileName The path to the config file
       */
     export function readConfigFile(fileName: string): { config?: any; error?: Diagnostic }  {
-        let text = '';
+        let text = "";
         try {
             text = sys.readFile(fileName);
         }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -219,10 +219,10 @@ namespace ts {
     export function reduceLeft<T, U>(array: T[], f: (a: U, x: T) => U, initial: U): U;
     export function reduceLeft<T, U>(array: T[], f: (a: U, x: T) => U, initial?: U): U {
         if (array) {
-            var count = array.length;
+            const count = array.length;
             if (count > 0) {
-                var pos = 0;
-                var result = arguments.length <= 2 ? array[pos++] : initial;
+                let pos = 0;
+                let result = arguments.length <= 2 ? array[pos++] : initial;
                 while (pos < count) {
                     result = f(<U>result, array[pos++]);
                 }
@@ -236,9 +236,9 @@ namespace ts {
     export function reduceRight<T, U>(array: T[], f: (a: U, x: T) => U, initial: U): U;
     export function reduceRight<T, U>(array: T[], f: (a: U, x: T) => U, initial?: U): U {
         if (array) {
-            var pos = array.length - 1;
+            let pos = array.length - 1;
             if (pos >= 0) {
-                var result = arguments.length <= 2 ? array[pos--] : initial;
+                let result = arguments.length <= 2 ? array[pos--] : initial;
                 while (pos >= 0) {
                     result = f(<U>result, array[pos--]);
                 }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -523,7 +523,7 @@ namespace ts {
         if (path.lastIndexOf("file:///", 0) === 0) {
             return "file:///".length;
         }
-        let idx = path.indexOf('://');
+        let idx = path.indexOf("://");
         if (idx !== -1) {
             return idx + "://".length;
         }

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1248,7 +1248,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                             // Don't emit empty strings
                             if (children[i].kind === SyntaxKind.JsxText) {
                                 let text = getTextToEmit(<JsxText>children[i]);
-                                if(text !== undefined) {
+                                if (text !== undefined) {
                                     write(', "');
                                     write(text);
                                     write('"');
@@ -4255,11 +4255,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     emitDetachedComments(ctor.body.statements);
                 }
                 emitCaptureThisForNodeIfNecessary(node);
+                let superCall: ExpressionStatement;
                 if (ctor) {
                     emitDefaultValueAssignments(ctor);
                     emitRestParameter(ctor);
                     if (baseTypeElement) {
-                        var superCall = findInitialSuperCall(ctor);
+                        superCall = findInitialSuperCall(ctor);
                         if (superCall) {
                             writeLine();
                             emit(superCall);
@@ -4936,7 +4937,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                         let temp = createAndRecordTempVariable(TempFlags.Auto);
                         write("(typeof (");
                         emitNodeWithoutSourceMap(temp);
-                        write(" = ")
+                        write(" = ");
                         emitEntityNameAsExpression(typeName, /*useFallback*/ true);
                         write(") === 'function' && ");
                         emitNodeWithoutSourceMap(temp);
@@ -4995,7 +4996,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 // 
                 // For the rules on serializing the type of each parameter declaration, see `serializeTypeOfDeclaration`.
                 if (node) {
-                    var valueDeclaration: FunctionLikeDeclaration;
+                    let valueDeclaration: FunctionLikeDeclaration;
                     if (node.kind === SyntaxKind.ClassDeclaration) {
                         valueDeclaration = getFirstConstructorWithBody(<ClassDeclaration>node);
                     }
@@ -5004,8 +5005,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     }
                     
                     if (valueDeclaration) {
-                        var parameters = valueDeclaration.parameters;
-                        var parameterCount = parameters.length;
+                        const parameters = valueDeclaration.parameters;
+                        const parameterCount = parameters.length;
                         if (parameterCount > 0) {
                             for (var i = 0; i < parameterCount; i++) {
                                 if (i > 0) {
@@ -5013,7 +5014,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                                 }
                                 
                                 if (parameters[i].dotDotDotToken) {
-                                    var parameterType = parameters[i].type;
+                                    let parameterType = parameters[i].type;
                                     if (parameterType.kind === SyntaxKind.ArrayType) {
                                         parameterType = (<ArrayTypeNode>parameterType).elementType;
                                     }
@@ -5825,7 +5826,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     writeLine();
                     write("}");
                     writeLine();
-                    write(`${exportFunctionForFile}(exports);`)
+                    write(`${exportFunctionForFile}(exports);`);
                     decreaseIndent();
                     writeLine();
                     write("}");
@@ -6173,7 +6174,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                                 // exports_(reexports);
                                 let reexportsVariableName = makeUniqueName("reexports");
                                 writeLine();
-                                write(`var ${reexportsVariableName} = {};`)
+                                write(`var ${reexportsVariableName} = {};`);
                                 writeLine();
                                 for (let e of (<ExportDeclaration>importNode).exportClause.elements) {
                                     write(`${reexportsVariableName}["`);

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -380,7 +380,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     function base64VLQFormatEncode(inValue: number) {
                         function base64FormatEncode(inValue: number) {
                             if (inValue < 64) {
-                                return 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'.charAt(inValue);
+                                return "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/".charAt(inValue);
                             }
                             throw TypeError(inValue + ": not a 64 based value");
                         }
@@ -895,7 +895,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 // Any template literal or string literal with an extended escape
                 // (e.g. "\u{0067}") will need to be downleveled as a escaped string literal.
                 if (languageVersion < ScriptTarget.ES6 && (isTemplateLiteralKind(node.kind) || node.hasExtendedUnicodeEscape)) {
-                    return getQuotedEscapedLiteralText('"', node.text, '"');
+                    return getQuotedEscapedLiteralText("\"", node.text, "\"");
                 }
 
                 // If we don't need to downlevel and we can reach the original source text using
@@ -908,15 +908,15 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 // or an escaped quoted form of the original text if it's string-like.
                 switch (node.kind) {
                     case SyntaxKind.StringLiteral:
-                        return getQuotedEscapedLiteralText('"', node.text, '"');
+                        return getQuotedEscapedLiteralText("\"", node.text, "\"");
                     case SyntaxKind.NoSubstitutionTemplateLiteral:
-                        return getQuotedEscapedLiteralText('`', node.text, '`');
+                        return getQuotedEscapedLiteralText("`", node.text, "`");
                     case SyntaxKind.TemplateHead:
-                        return getQuotedEscapedLiteralText('`', node.text, '${');
+                        return getQuotedEscapedLiteralText("`", node.text, "${");
                     case SyntaxKind.TemplateMiddle:
-                        return getQuotedEscapedLiteralText('}', node.text, '${');
+                        return getQuotedEscapedLiteralText("}", node.text, "${");
                     case SyntaxKind.TemplateTail:
-                        return getQuotedEscapedLiteralText('}', node.text, '`');
+                        return getQuotedEscapedLiteralText("}", node.text, "`");
                     case SyntaxKind.NumericLiteral:
                         return node.text;
                 }
@@ -947,7 +947,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 text = text.replace(/\r\n?/g, "\n");
                 text = escapeString(text);
 
-                write('"' + text + '"');
+                write(`"${text}"`);
             }
 
             function emitDownlevelTaggedTemplateArray(node: TaggedTemplateExpression, literalEmitter: (literal: LiteralExpression) => void) {
@@ -1134,9 +1134,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 /// 'Div' for upper-cased or dotted names
                 function emitTagName(name: Identifier|QualifiedName) {
                     if (name.kind === SyntaxKind.Identifier && isIntrinsicJsxName((<Identifier>name).text)) {
-                        write('"');
+                        write("\"");
                         emit(name);
-                        write('"');
+                        write("\"");
                     }
                     else {
                         emit(name);
@@ -1148,9 +1148,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 /// about keywords, just non-identifier characters
                 function emitAttributeName(name: Identifier) {
                     if (/[A-Za-z_]+[\w*]/.test(name.text)) {
-                        write('"');
+                        write("\"");
                         emit(name);
-                        write('"');
+                        write("\"");
                     }
                     else {
                         emit(name);
@@ -1249,9 +1249,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                             if (children[i].kind === SyntaxKind.JsxText) {
                                 let text = getTextToEmit(<JsxText>children[i]);
                                 if (text !== undefined) {
-                                    write(', "');
+                                    write(", \"");
                                     write(text);
-                                    write('"');
+                                    write("\"");
                                 }
                             }
                             else {
@@ -1491,7 +1491,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                         if (declaration.kind === SyntaxKind.ImportClause) {
                             // Identifier references default import
                             write(getGeneratedNameForNode(<ImportDeclaration>declaration.parent));
-                            write(languageVersion === ScriptTarget.ES3 ? '["default"]' : ".default");
+                            write(languageVersion === ScriptTarget.ES3 ? "[\"default\"]" : ".default");
                             return;
                         }
                         else if (declaration.kind === SyntaxKind.ImportSpecifier) {
@@ -6440,7 +6440,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     if (isLineBreak(c)) {
                         if (firstNonWhitespace !== -1 && (lastNonWhitespace - firstNonWhitespace + 1 > 0)) {
                             let part = text.substr(firstNonWhitespace, lastNonWhitespace - firstNonWhitespace + 1);
-                            result = (result ? result + '" + \' \' + "' : '') + part;
+                            result = (result ? result + "\" + ' ' + \"" : "") + part;
                         }
                         firstNonWhitespace = -1;
                     }
@@ -6453,7 +6453,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 }
                 if (firstNonWhitespace !== -1) {
                     let part = text.substr(firstNonWhitespace);
-                    result = (result ? result + '" + \' \' + "' : '') + part;
+                    result = (result ? result + "\" + ' ' + \"" : "") + part;
                 }
 
                 return result;
@@ -6478,9 +6478,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
             function emitJsxText(node: JsxText) {
                 switch (compilerOptions.jsx) {
                     case JsxEmit.React:
-                        write('"');
+                        write("\"");
                         write(trimReactWhitespace(node));
-                        write('"');
+                        write("\"");
                         break;
 
                     case JsxEmit.Preserve:
@@ -6495,9 +6495,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     switch (compilerOptions.jsx) {
                         case JsxEmit.Preserve:
                         default:
-                            write('{');
+                            write("{");
                             emit(node.expression);
-                            write('}');
+                            write("}");
                             break;
                         case JsxEmit.React:
                             emit(node.expression);

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3148,7 +3148,7 @@ namespace ts {
         }
 
         function parseAwaitExpression() {
-            var node = <AwaitExpression>createNode(SyntaxKind.AwaitExpression);
+            const node = <AwaitExpression>createNode(SyntaxKind.AwaitExpression);
             nextToken();
             node.expression = parseUnaryExpressionOrHigher();
             return finishNode(node);
@@ -5140,7 +5140,7 @@ namespace ts {
                 // the 'from' keyword can be parsed as a named export when the export clause is unterminated (i.e. `export { from "moduleName";`)
                 // If we don't have a 'from' keyword, see if we have a string literal such that ASI won't take effect.
                 if (token === SyntaxKind.FromKeyword || (token === SyntaxKind.StringLiteral && !scanner.hasPrecedingLineBreak())) {
-                    parseExpected(SyntaxKind.FromKeyword)
+                    parseExpected(SyntaxKind.FromKeyword);
                     node.moduleSpecifier = parseModuleSpecifier();
                 }
             }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3340,7 +3340,7 @@ namespace ts {
                 case SyntaxKind.LessThanToken:
                     return parseJsxElementOrSelfClosingElement();
             }
-            Debug.fail('Unknown JSX child kind ' + token);
+            Debug.fail("Unknown JSX child kind " + token);
         }
 
         function parseJsxChildren(openingTagName: EntityName): NodeArray<JsxChild> {
@@ -6011,7 +6011,7 @@ namespace ts {
             return;
 
             function visitNode(node: IncrementalNode) {
-                let text = '';
+                let text = "";
                 if (aggressiveChecks && shouldCheckNode(node)) {
                     text = oldText.substring(node.pos, node.end);
                 }

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1121,7 +1121,7 @@ namespace ts {
 
                 // Special handling for shebang
                 if (ch === CharacterCodes.hash && pos === 0 && isShebangTrivia(text, pos)) {
-                    pos = scanShebangTrivia(text ,pos);
+                    pos = scanShebangTrivia(text, pos);
                     if (skipTrivia) {
                         continue;
                     }

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -31,7 +31,7 @@ namespace ts {
     declare var __filename: string;
     declare var Buffer: {  
         new (str: string, encoding ?: string): any;  
-    }
+    };
 
     declare class Enumerator {
         public atEnd(): boolean;
@@ -188,13 +188,13 @@ namespace ts {
             };
         }
         function getNodeSystem(): System {
-            var _fs = require("fs");
-            var _path = require("path");
-            var _os = require('os');
+            const _fs = require("fs");
+            const _path = require("path");
+            const _os = require('os');
 
-            var platform: string = _os.platform();
+            const platform: string = _os.platform();
             // win32\win64 are case insensitive platforms, MacOS (darwin) by default is also case insensitive
-            var useCaseSensitiveFileNames = platform !== "win32" && platform !== "win64" && platform !== "darwin";
+            const useCaseSensitiveFileNames = platform !== "win32" && platform !== "win64" && platform !== "darwin";
 
             function readFile(fileName: string, encoding?: string): string {
                 if (!_fs.existsSync(fileName)) {
@@ -271,10 +271,10 @@ namespace ts {
                 newLine: _os.EOL,
                 useCaseSensitiveFileNames: useCaseSensitiveFileNames,
                 write(s: string): void {  
-                    var buffer = new Buffer(s, 'utf8');  
-                    var offset: number = 0;
-                    var toWrite: number = buffer.length;
-                    var written = 0;
+                    const buffer = new Buffer(s, 'utf8');  
+                    let offset: number = 0;
+                    let toWrite: number = buffer.length;
+                    let written = 0;
                     // 1 is a standard descriptor for stdout
                     while ((written = _fs.writeSync(1, buffer, offset, toWrite)) < toWrite) {
                         offset += written;
@@ -297,7 +297,7 @@ namespace ts {
                         }
 
                         callback(fileName);
-                    };
+                    }
                 },
                 resolvePath: function (path: string): string {
                     return _path.resolve(path);

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -30,7 +30,7 @@ namespace ts {
     declare var global: any;
     declare var __filename: string;
     declare var Buffer: {  
-        new (str: string, encoding ?: string): any;  
+        new (str: string, encoding?: string): any;  
     };
 
     declare class Enumerator {
@@ -190,7 +190,7 @@ namespace ts {
         function getNodeSystem(): System {
             const _fs = require("fs");
             const _path = require("path");
-            const _os = require('os');
+            const _os = require("os");
 
             const platform: string = _os.platform();
             // win32\win64 are case insensitive platforms, MacOS (darwin) by default is also case insensitive
@@ -228,7 +228,7 @@ namespace ts {
             function writeFile(fileName: string, data: string, writeByteOrderMark?: boolean): void {
                 // If a BOM is required, emit one
                 if (writeByteOrderMark) {
-                    data = '\uFEFF' + data;
+                    data = "\uFEFF" + data;
                 }
 
                 _fs.writeFileSync(fileName, data, "utf8");
@@ -271,7 +271,7 @@ namespace ts {
                 newLine: _os.EOL,
                 useCaseSensitiveFileNames: useCaseSensitiveFileNames,
                 write(s: string): void {  
-                    const buffer = new Buffer(s, 'utf8');  
+                    const buffer = new Buffer(s, "utf8");  
                     let offset: number = 0;
                     let toWrite: number = buffer.length;
                     let written = 0;

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -245,7 +245,7 @@ namespace ts {
             reportDiagnostic(createCompilerDiagnostic(Diagnostics.Compilation_complete_Watching_for_file_changes));
         }
 
-        function getSourceFile(fileName: string, languageVersion: ScriptTarget, onError ?: (message: string) => void) {
+        function getSourceFile(fileName: string, languageVersion: ScriptTarget, onError?: (message: string) => void) {
             // Return existing SourceFile object if one is available
             if (cachedProgram) {
                 let sourceFile = cachedProgram.getSourceFile(fileName);

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1866,7 +1866,7 @@ namespace ts {
 
         function writeTrimmedCurrentLine(pos: number, nextLineStart: number) {
             let end = Math.min(comment.end, nextLineStart - 1);
-            let currentLineText = currentSourceFile.text.substring(pos, end).replace(/^\s+|\s+$/g, '');
+            let currentLineText = currentSourceFile.text.substring(pos, end).replace(/^\s+|\s+$/g, "");
             if (currentLineText) {
                 // trimmed forward and ending spaces text
                 writer.write(currentLineText);

--- a/src/harness/compilerRunner.ts
+++ b/src/harness/compilerRunner.ts
@@ -1,6 +1,6 @@
-/// <reference path='harness.ts' />
-/// <reference path='runnerbase.ts' />
-/// <reference path='typeWriter.ts' />
+/// <reference path="harness.ts" />
+/// <reference path="runnerbase.ts" />
+/// <reference path="typeWriter.ts" />
 
 const enum CompilerTestType {
     Conformance,
@@ -9,7 +9,7 @@ const enum CompilerTestType {
 }
 
 class CompilerBaselineRunner extends RunnerBase {
-    private basePath = 'tests/cases';
+    private basePath = "tests/cases";
     private testSuiteName: string;
     private errors: boolean;
     private emit: boolean;
@@ -25,21 +25,21 @@ class CompilerBaselineRunner extends RunnerBase {
         this.decl = true;
         this.output = true;
         if (testType === CompilerTestType.Conformance) {
-            this.testSuiteName = 'conformance';
+            this.testSuiteName = "conformance";
         }
         else if (testType === CompilerTestType.Regressions) {
-            this.testSuiteName = 'compiler';
+            this.testSuiteName = "compiler";
         }
         else if (testType === CompilerTestType.Test262) {
-            this.testSuiteName = 'test262';
+            this.testSuiteName = "test262";
         } else {
-            this.testSuiteName = 'compiler'; // default to this for historical reasons
+            this.testSuiteName = "compiler"; // default to this for historical reasons
         }
-        this.basePath += '/' + this.testSuiteName;
+        this.basePath += "/" + this.testSuiteName;
     }
 
     public checkTestCodeOutput(fileName: string) {
-        describe('compiler tests for ' + fileName, () => {
+        describe("compiler tests for " + fileName, () => {
             // Mocha holds onto the closure environment of the describe callback even after the test is done.
             // Everything declared here should be cleared out in the "after" callback.
             let justName: string;
@@ -64,14 +64,14 @@ class CompilerBaselineRunner extends RunnerBase {
             let createNewInstance = false;
 
             before(() => {
-                justName = fileName.replace(/^.*[\\\/]/, ''); // strips the fileName from the path.
+                justName = fileName.replace(/^.*[\\\/]/, ""); // strips the fileName from the path.
                 content = Harness.IO.readFile(fileName);
                 testCaseContent = Harness.TestCaseParser.makeUnitsFromTest(content, fileName);
                 units = testCaseContent.testUnitData;
                 tcSettings = testCaseContent.settings;
                 createNewInstance = false;
                 lastUnit = units[units.length - 1];
-                rootDir = lastUnit.originalFilePath.indexOf('conformance') === -1 ? 'tests/cases/compiler/' : lastUnit.originalFilePath.substring(0, lastUnit.originalFilePath.lastIndexOf('/')) + '/';
+                rootDir = lastUnit.originalFilePath.indexOf("conformance") === -1 ? "tests/cases/compiler/" : lastUnit.originalFilePath.substring(0, lastUnit.originalFilePath.lastIndexOf("/")) + "/";
                 harnessCompiler = Harness.Compiler.getCompiler();
                 // We need to assemble the list of input files for the compiler and other related files on the 'filesystem' (ie in a multi-file test)
                 // If the last file in a test uses require or a triple slash reference we'll assume all other files will be brought in via references,
@@ -106,7 +106,7 @@ class CompilerBaselineRunner extends RunnerBase {
                    eventually to remove this limitation. */
                 for (let i = 0; i < tcSettings.length; ++i) {
                     // noImplicitAny is passed to getCompiler, but target is just passed in the settings blob to setCompilerSettings
-                    if (!createNewInstance && (tcSettings[i].flag == "noimplicitany" || tcSettings[i].flag === 'target')) {
+                    if (!createNewInstance && (tcSettings[i].flag == "noimplicitany" || tcSettings[i].flag === "target")) {
                         harnessCompiler = Harness.Compiler.getCompiler();
                         harnessCompiler.setCompilerSettings(tcSettings);
                         createNewInstance = true;
@@ -148,9 +148,9 @@ class CompilerBaselineRunner extends RunnerBase {
             }
 
             // check errors
-            it('Correct errors for ' + fileName, () => {
+            it("Correct errors for " + fileName, () => {
                 if (this.errors) {
-                    Harness.Baseline.runBaseline('Correct errors for ' + fileName, justName.replace(/\.tsx?$/, '.errors.txt'), (): string => {
+                    Harness.Baseline.runBaseline("Correct errors for " + fileName, justName.replace(/\.tsx?$/, ".errors.txt"), (): string => {
                         if (result.errors.length === 0) return null;
                         return getErrorBaseline(toBeCompiled, otherFiles, result);
                     });
@@ -158,12 +158,12 @@ class CompilerBaselineRunner extends RunnerBase {
             });
 
             // Source maps?
-            it('Correct sourcemap content for ' + fileName, () => {
+            it("Correct sourcemap content for " + fileName, () => {
                 if (options.sourceMap || options.inlineSourceMap) {
-                    Harness.Baseline.runBaseline('Correct sourcemap content for ' + fileName, justName.replace(/\.tsx?$/, '.sourcemap.txt'), () => {
+                    Harness.Baseline.runBaseline("Correct sourcemap content for " + fileName, justName.replace(/\.tsx?$/, ".sourcemap.txt"), () => {
                         let record = result.getSourceMapRecord();
                         if (options.noEmitOnError && result.errors.length !== 0 && record === undefined) {
-                            // Because of the noEmitOnError option no files are created. We need to return null because baselining isn't required.
+                            // Because of the noEmitOnError option no files are created. We need to return null because baselining isn"t required.
                             return null;
                         }
                         return record;
@@ -171,35 +171,35 @@ class CompilerBaselineRunner extends RunnerBase {
                 }
             });
 
-            it('Correct JS output for ' + fileName, () => {
-                if (!ts.fileExtensionIs(lastUnit.name, '.d.ts') && this.emit) {
+            it("Correct JS output for " + fileName, () => {
+                if (!ts.fileExtensionIs(lastUnit.name, ".d.ts") && this.emit) {
                     if (result.files.length === 0 && result.errors.length === 0) {
-                        throw new Error('Expected at least one js file to be emitted or at least one error to be created.');
+                        throw new Error("Expected at least one js file to be emitted or at least one error to be created.");
                     }
 
                     // check js output
-                    Harness.Baseline.runBaseline('Correct JS output for ' + fileName, justName.replace(/\.tsx?/, '.js'), () => {
-                        let tsCode = '';
+                    Harness.Baseline.runBaseline("Correct JS output for " + fileName, justName.replace(/\.tsx?/, ".js"), () => {
+                        let tsCode = "";
                         let tsSources = otherFiles.concat(toBeCompiled);
                         if (tsSources.length > 1) {
-                            tsCode += '//// [' + fileName + '] ////\r\n\r\n';
+                            tsCode += "//// [" + fileName + "] ////\r\n\r\n";
                         }
                         for (let i = 0; i < tsSources.length; i++) {
-                            tsCode += '//// [' + Harness.Path.getFileName(tsSources[i].unitName) + ']\r\n';
-                            tsCode += tsSources[i].content + (i < (tsSources.length - 1) ? '\r\n' : '');
+                            tsCode += "//// [" + Harness.Path.getFileName(tsSources[i].unitName) + "]\r\n";
+                            tsCode += tsSources[i].content + (i < (tsSources.length - 1) ? "\r\n" : "");
                         }
 
-                        let jsCode = '';
+                        let jsCode = "";
                         for (let i = 0; i < result.files.length; i++) {
-                            jsCode += '//// [' + Harness.Path.getFileName(result.files[i].fileName) + ']\r\n';
+                            jsCode += "//// [" + Harness.Path.getFileName(result.files[i].fileName) + "]\r\n";
                             jsCode += getByteOrderMarkText(result.files[i]);
                             jsCode += result.files[i].code;
                         }
 
                         if (result.declFilesCode.length > 0) {
-                            jsCode += '\r\n\r\n';
+                            jsCode += "\r\n\r\n";
                             for (let i = 0; i < result.declFilesCode.length; i++) {
-                                jsCode += '//// [' + Harness.Path.getFileName(result.declFilesCode[i].fileName) + ']\r\n';
+                                jsCode += "//// [" + Harness.Path.getFileName(result.declFilesCode[i].fileName) + "]\r\n";
                                 jsCode += getByteOrderMarkText(result.declFilesCode[i]);
                                 jsCode += result.declFilesCode[i].code;
                             }
@@ -210,13 +210,13 @@ class CompilerBaselineRunner extends RunnerBase {
                         }, options);
 
                         if (declFileCompilationResult && declFileCompilationResult.declResult.errors.length) {
-                            jsCode += '\r\n\r\n//// [DtsFileErrors]\r\n';
-                            jsCode += '\r\n\r\n';
+                            jsCode += "\r\n\r\n//// [DtsFileErrors]\r\n";
+                            jsCode += "\r\n\r\n";
                             jsCode += getErrorBaseline(declFileCompilationResult.declInputFiles, declFileCompilationResult.declOtherFiles, declFileCompilationResult.declResult);
                         }
 
                         if (jsCode.length > 0) {
-                            return tsCode + '\r\n\r\n' + jsCode;
+                            return tsCode + "\r\n\r\n" + jsCode;
                         } else {
                             return null;
                         }
@@ -224,28 +224,28 @@ class CompilerBaselineRunner extends RunnerBase {
                 }
             });
 
-            it('Correct Sourcemap output for ' + fileName, () => {
+            it("Correct Sourcemap output for " + fileName, () => {
                 if (options.inlineSourceMap) {
                     if (result.sourceMaps.length > 0) {
-                        throw new Error('No sourcemap files should be generated if inlineSourceMaps was set.');
+                        throw new Error("No sourcemap files should be generated if inlineSourceMaps was set.");
                     }
                     return null;
                 }
                 else if (options.sourceMap) {
                     if (result.sourceMaps.length !== result.files.length) {
-                        throw new Error('Number of sourcemap files should be same as js files.');
+                        throw new Error("Number of sourcemap files should be same as js files.");
                     }
 
-                    Harness.Baseline.runBaseline('Correct Sourcemap output for ' + fileName, justName.replace(/\.tsx?/, '.js.map'), () => {
+                    Harness.Baseline.runBaseline("Correct Sourcemap output for " + fileName, justName.replace(/\.tsx?/, ".js.map"), () => {
                         if (options.noEmitOnError && result.errors.length !== 0 && result.sourceMaps.length === 0) {
                             // We need to return null here or the runBaseLine will actually create a empty file.
                             // Baselining isn't required here because there is no output.
                             return null;
                         }
 
-                        let sourceMapCode = '';
+                        let sourceMapCode = "";
                         for (let i = 0; i < result.sourceMaps.length; i++) {
-                            sourceMapCode += '//// [' + Harness.Path.getFileName(result.sourceMaps[i].fileName) + ']\r\n';
+                            sourceMapCode += "//// [" + Harness.Path.getFileName(result.sourceMaps[i].fileName) + "]\r\n";
                             sourceMapCode += getByteOrderMarkText(result.sourceMaps[i]);
                             sourceMapCode += result.sourceMaps[i].code;
                         }
@@ -255,7 +255,7 @@ class CompilerBaselineRunner extends RunnerBase {
                 }
             });
 
-            it('Correct type/symbol baselines for ' + fileName, () => {
+            it("Correct type/symbol baselines for " + fileName, () => {
                 if (fileName.indexOf("APISample") >= 0) {
                     return;
                 }
@@ -317,15 +317,15 @@ class CompilerBaselineRunner extends RunnerBase {
                         let fullBaseLine = generateBaseLine(fullResults, isSymbolBaseLine);
                         let pullBaseLine = generateBaseLine(pullResults, isSymbolBaseLine);
 
-                        let fullExtension = isSymbolBaseLine ? '.symbols' : '.types';
-                        let pullExtension = isSymbolBaseLine ? '.symbols.pull' : '.types.pull';
+                        let fullExtension = isSymbolBaseLine ? ".symbols" : ".types";
+                        let pullExtension = isSymbolBaseLine ? ".symbols.pull" : ".types.pull";
 
                         if (fullBaseLine !== pullBaseLine) {
-                            Harness.Baseline.runBaseline('Correct full information for ' + fileName, justName.replace(/\.tsx?/, fullExtension), () => fullBaseLine);
-                            Harness.Baseline.runBaseline('Correct pull information for ' + fileName, justName.replace(/\.tsx?/, pullExtension), () => pullBaseLine);
+                            Harness.Baseline.runBaseline("Correct full information for " + fileName, justName.replace(/\.tsx?/, fullExtension), () => fullBaseLine);
+                            Harness.Baseline.runBaseline("Correct pull information for " + fileName, justName.replace(/\.tsx?/, pullExtension), () => pullBaseLine);
                         }
                         else {
-                            Harness.Baseline.runBaseline('Correct information for ' + fileName, justName.replace(/\.tsx?/, fullExtension), () => fullBaseLine);
+                            Harness.Baseline.runBaseline("Correct information for " + fileName, justName.replace(/\.tsx?/, fullExtension), () => fullBaseLine);
                         }
                     }
 
@@ -334,7 +334,7 @@ class CompilerBaselineRunner extends RunnerBase {
                         let typeMap: { [fileName: string]: { [lineNum: number]: string[]; } } = {};
 
                         allFiles.forEach(file => {
-                            let codeLines = file.content.split('\n');
+                            let codeLines = file.content.split("\n");
                             typeWriterResults[file.unitName].forEach(result => {
                                 if (isSymbolBaseline && !result.symbol) {
                                     return;
@@ -354,30 +354,30 @@ class CompilerBaselineRunner extends RunnerBase {
                                 typeMap[file.unitName][result.line] = typeInfo;
                             });
 
-                            typeLines.push('=== ' + file.unitName + ' ===\r\n');
+                            typeLines.push("=== " + file.unitName + " ===\r\n");
                             for (let i = 0; i < codeLines.length; i++) {
                                 let currentCodeLine = codeLines[i];
-                                typeLines.push(currentCodeLine + '\r\n');
+                                typeLines.push(currentCodeLine + "\r\n");
                                 if (typeMap[file.unitName]) {
                                     let typeInfo = typeMap[file.unitName][i];
                                     if (typeInfo) {
                                         typeInfo.forEach(ty => {
-                                            typeLines.push('>' + ty + '\r\n');
+                                            typeLines.push(">" + ty + "\r\n");
                                         });
-                                        if (i + 1 < codeLines.length && (codeLines[i + 1].match(/^\s*[{|}]\s*$/) || codeLines[i + 1].trim() === '')) {
+                                        if (i + 1 < codeLines.length && (codeLines[i + 1].match(/^\s*[{|}]\s*$/) || codeLines[i + 1].trim() === "")) {
                                         }
                                         else {
-                                            typeLines.push('\r\n');
+                                            typeLines.push("\r\n");
                                         }
                                     }
                                 }
                                 else {
-                                    typeLines.push('No type information for this code.');
+                                    typeLines.push("No type information for this code.");
                                 }
                             }
                         });
 
-                        return typeLines.join('');
+                        return typeLines.join("");
                     }
                 }
             });
@@ -385,7 +385,7 @@ class CompilerBaselineRunner extends RunnerBase {
     }
 
     public initializeTests() {
-        describe(this.testSuiteName + ' tests', () => {
+        describe(this.testSuiteName + " tests", () => {
             describe("Setup compiler for compiler baselines", () => {
                 let harnessCompiler = Harness.Compiler.getCompiler();
                 this.parseOptions();
@@ -416,23 +416,23 @@ class CompilerBaselineRunner extends RunnerBase {
             this.decl = false;
             this.output = false;
 
-            let opts = this.options.split(',');
+            let opts = this.options.split(",");
             for (let i = 0; i < opts.length; i++) {
                 switch (opts[i]) {
-                    case 'error':
+                    case "error":
                         this.errors = true;
                         break;
-                    case 'emit':
+                    case "emit":
                         this.emit = true;
                         break;
-                    case 'decl':
+                    case "decl":
                         this.decl = true;
                         break;
-                    case 'output':
+                    case "output":
                         this.output = true;
                         break;
                     default:
-                        throw new Error('unsupported flag');
+                        throw new Error("unsupported flag");
                 }
             }
         }

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -13,11 +13,11 @@
 // limitations under the License.
 //
 
-/// <reference path='..\services\services.ts' />
-/// <reference path='..\services\shims.ts' />
-/// <reference path='harnessLanguageService.ts' />
-/// <reference path='harness.ts' />
-/// <reference path='fourslashRunner.ts' />
+/// <reference path="..\services\services.ts" />
+/// <reference path="..\services\shims.ts" />
+/// <reference path="harnessLanguageService.ts" />
+/// <reference path="harness.ts" />
+/// <reference path="fourslashRunner.ts" />
 
 module FourSlash {
     ts.disableIncrementalParsing = false;
@@ -100,12 +100,12 @@ module FourSlash {
     }
 
     let entityMap: ts.Map<string> = {
-        '&': '&amp;',
-        '"': '&quot;',
-        "'": '&#39;',
-        '/': '&#47;',
-        '<': '&lt;',
-        '>': '&gt;'
+        "&": "&amp;",
+        "\"": "&quot;",
+        "'": "&#39;",
+        "/": "&#47;",
+        "<": "&lt;",
+        ">": "&gt;"
     };
 
     export function escapeXmlAttributeValue(s: string) {
@@ -116,18 +116,18 @@ module FourSlash {
     // To add additional option, add property into the testOptMetadataNames, refer the property in either globalMetadataNames or fileMetadataNames
     // Add cases into convertGlobalOptionsToCompilationsSettings function for the compiler to acknowledge such option from meta data
     let metadataOptionNames = {
-        baselineFile: 'BaselineFile',
-        declaration: 'declaration',
-        emitThisFile: 'emitThisFile',  // This flag is used for testing getEmitOutput feature. It allows test-cases to indicate what file to be output in multiple files project
-        fileName: 'Filename',
-        mapRoot: 'mapRoot',
-        module: 'module',
-        out: 'out',
-        outDir: 'outDir',
-        sourceMap: 'sourceMap',
-        sourceRoot: 'sourceRoot',
-        allowNonTsExtensions: 'allowNonTsExtensions',
-        resolveReference: 'ResolveReference',  // This flag is used to specify entry file for resolve file references. The flag is only allow once per test file
+        baselineFile: "BaselineFile",
+        declaration: "declaration",
+        emitThisFile: "emitThisFile",  // This flag is used for testing getEmitOutput feature. It allows test-cases to indicate what file to be output in multiple files project
+        fileName: "Filename",
+        mapRoot: "mapRoot",
+        module: "module",
+        out: "out",
+        outDir: "outDir",
+        sourceMap: "sourceMap",
+        sourceRoot: "sourceRoot",
+        allowNonTsExtensions: "allowNonTsExtensions",
+        resolveReference: "ResolveReference",  // This flag is used to specify entry file for resolve file references. The flag is only allow once per test file
     };
 
     // List of allowed metadata names
@@ -326,7 +326,7 @@ module FourSlash {
                 // Add triple reference files into language-service host
                 ts.forEach(referencedFiles, referenceFile => {
                     // Fourslash insert tests/cases/fourslash into inputFile.unitName so we will properly append the same base directory to refFile path
-                    let referenceFilePath = this.basePath + '/' + referenceFile.fileName;
+                    let referenceFilePath = this.basePath + "/" + referenceFile.fileName;
                     this.addMatchedInputFile(referenceFilePath);
                 });
 
@@ -334,7 +334,7 @@ module FourSlash {
                 ts.forEach(importedFiles, importedFile => {
                     // Fourslash insert tests/cases/fourslash into inputFile.unitName and import statement doesn't require ".ts"
                     // so convert them before making appropriate comparison
-                    let importedFilePath = this.basePath + '/' + importedFile.fileName + ".ts";
+                    let importedFilePath = this.basePath + "/" + importedFile.fileName + ".ts";
                     this.addMatchedInputFile(importedFilePath);
                 });
 
@@ -369,9 +369,9 @@ module FourSlash {
             };
 
             this.testData.files.forEach(file => {
-                let fileName = file.fileName.replace(Harness.IO.directoryName(file.fileName), '').substr(1);
+                let fileName = file.fileName.replace(Harness.IO.directoryName(file.fileName), "").substr(1);
                 let fileNameWithoutExtension = fileName.substr(0, fileName.lastIndexOf("."));
-                this.scenarioActions.push('<CreateFileOnDisk FileId="' + fileName + '" FileNameWithoutExtension="' + fileNameWithoutExtension + '" FileExtension=".ts"><![CDATA[' + file.content + ']]></CreateFileOnDisk>');
+                this.scenarioActions.push("<CreateFileOnDisk FileId=\"" + fileName + "\" FileNameWithoutExtension=\"" + fileNameWithoutExtension + "\" FileExtension=\".ts\"><![CDATA[" + file.content + "]]></CreateFileOnDisk>");
             });
 
             // Open the first file by default
@@ -384,7 +384,7 @@ module FourSlash {
         }
 
         // Entry points from fourslash.ts
-        public goToMarker(name = '') {
+        public goToMarker(name = "") {
             let marker = this.getMarkerByName(name);
             if (this.activeFile.fileName !== marker.fileName) {
                 this.openFile(marker.fileName);
@@ -392,7 +392,7 @@ module FourSlash {
 
             let content = this.getFileContent(marker.fileName);
             if (marker.position === -1 || marker.position > content.length) {
-                throw new Error('Marker "' + name + '" has been invalidated by unrecoverable edits to the file.');
+                throw new Error(`Marker "${name}" has been invalidated by unrecoverable edits to the file.`);
             }
             this.lastKnownMarker = name;
             this.goToPosition(marker.position);
@@ -410,9 +410,9 @@ module FourSlash {
             this.currentCaretPosition += count;
             this.currentCaretPosition = Math.min(this.currentCaretPosition, this.getFileContent(this.activeFile.fileName).length);
             if (count > 0) {
-                this.scenarioActions.push('<MoveCaretRight NumberOfChars="' + count + '" />');
+                this.scenarioActions.push(`<MoveCaretRight NumberOfChars="${count}" />`);
             } else {
-                this.scenarioActions.push('<MoveCaretLeft NumberOfChars="' + (-count) + '" />');
+                this.scenarioActions.push(`<MoveCaretLeft NumberOfChars="${-count}" />`);
             }
         }
 
@@ -423,8 +423,8 @@ module FourSlash {
             let fileToOpen: FourSlashFile = this.findFile(indexOrName);
             fileToOpen.fileName = ts.normalizeSlashes(fileToOpen.fileName);
             this.activeFile = fileToOpen;
-            let fileName = fileToOpen.fileName.replace(Harness.IO.directoryName(fileToOpen.fileName), '').substr(1);
-            this.scenarioActions.push('<OpenFile FileName="" SrcFileId="' + fileName + '" FileId="' + fileName + '" />');
+            let fileName = fileToOpen.fileName.replace(Harness.IO.directoryName(fileToOpen.fileName), "").substr(1);
+            this.scenarioActions.push(`<OpenFile FileName="" SrcFileId="${fileName}" FileId="${fileName}" />`);
 
             // Let the host know that this file is now open
             this.languageServiceAdapterHost.openFile(fileToOpen.fileName);
@@ -439,7 +439,7 @@ module FourSlash {
 
             let exists = this.anyErrorInRange(predicate, startMarker, endMarker);
 
-            this.taoInvalidReason = 'verifyErrorExistsBetweenMarkers NYI';
+            this.taoInvalidReason = "verifyErrorExistsBetweenMarkers NYI";
 
             if (exists !== negative) {
                 this.printErrorLog(negative, this.getAllDiagnostics());
@@ -492,7 +492,7 @@ module FourSlash {
                 };
             }
 
-            this.taoInvalidReason = 'verifyErrorExistsAfterMarker NYI';
+            this.taoInvalidReason = "verifyErrorExistsAfterMarker NYI";
 
             let exists = this.anyErrorInRange(predicate, marker);
             let diagnostics = this.getAllDiagnostics();
@@ -541,7 +541,7 @@ module FourSlash {
             let errors = this.getDiagnostics(this.activeFile.fileName);
             let actual = errors.length;
 
-            this.scenarioActions.push('<CheckErrorList ExpectedNumOfErrors="' + expected + '" />');
+            this.scenarioActions.push(`<CheckErrorList ExpectedNumOfErrors="${expected}" />`);
 
             if (actual !== expected) {
                 this.printErrorLog(false, errors);
@@ -557,11 +557,11 @@ module FourSlash {
                 throw new Error("Expected exactly one output from emit of " + this.activeFile.fileName);
             }
 
-            this.taoInvalidReason = 'verifyEval impossible';
+            this.taoInvalidReason = "verifyEval impossible";
 
-            let evaluation = new Function(emit.outputFiles[0].text + ';\r\nreturn (' + expr + ');')();
+            let evaluation = new Function(`${emit.outputFiles[0].text};\r\nreturn (${expr});`)();
             if (evaluation !== value) {
-                this.raiseError('Expected evaluation of expression "' + expr + '" to equal "' + value + '", but got "' + evaluation + '"');
+                this.raiseError(`Expected evaluation of expression "${expr}" to equal "${value}", but got "${evaluation}"`);
             }
         }
 
@@ -570,19 +570,19 @@ module FourSlash {
             if (emit.outputFiles.length !== 1) {
                 throw new Error("Expected exactly one output from emit of " + this.activeFile.fileName);
             }
-            this.taoInvalidReason = 'verifyGetEmitOutputForCurrentFile impossible';
+            this.taoInvalidReason = "verifyGetEmitOutputForCurrentFile impossible";
             let actual = emit.outputFiles[0].text;
             if (actual !== expected) {
-                this.raiseError("Expected emit output to be '" + expected + "', but got '" + actual + "'");
+                this.raiseError(`Expected emit output to be "${expected}", but got "${actual}"`);
             }
         }
 
         public verifyMemberListContains(symbol: string, text?: string, documentation?: string, kind?: string) {
-            this.scenarioActions.push('<ShowCompletionList />');
-            this.scenarioActions.push('<VerifyCompletionContainsItem ItemName="' + symbol + '"/>');
+            this.scenarioActions.push("<ShowCompletionList />");
+            this.scenarioActions.push(`<VerifyCompletionContainsItem ItemName="${symbol}"/>`);
 
             if (text || documentation || kind) {
-                this.taoInvalidReason = 'verifyMemberListContains only supports the "symbol" parameter';
+                this.taoInvalidReason = "verifyMemberListContains only supports the \"symbol\" parameter";
             }
 
             let members = this.getMemberListAtCaret();
@@ -600,11 +600,11 @@ module FourSlash {
                     this.verifyMemberListIsEmpty(false);
                     return;
                 } else {
-                    this.scenarioActions.push('<ShowCompletionList />');
+                    this.scenarioActions.push("<ShowCompletionList />");
                 }
             } else {
-                this.scenarioActions.push('<ShowCompletionList />');
-                this.scenarioActions.push('<VerifyCompletionItemsCount Count="' + expectedCount + '" ' + (negative ? 'ExpectsFailure="true"' : '') + ' />');
+                this.scenarioActions.push("<ShowCompletionList />");
+                this.scenarioActions.push(`<VerifyCompletionItemsCount Count="${expectedCount}" ${(negative ? "ExpectsFailure=\"true\" " : "")}/>`);
             }
 
             let members = this.getMemberListAtCaret();
@@ -622,31 +622,31 @@ module FourSlash {
         }
 
         public verifyMemberListDoesNotContain(symbol: string) {
-            this.scenarioActions.push('<ShowCompletionList />');
-            this.scenarioActions.push('<VerifyCompletionDoesNotContainItem ItemName="' + escapeXmlAttributeValue(symbol) + '" />');
+            this.scenarioActions.push("<ShowCompletionList />");
+            this.scenarioActions.push(`<VerifyCompletionDoesNotContainItem ItemName="${escapeXmlAttributeValue(symbol)}" />`);
 
             let members = this.getMemberListAtCaret();
             if (members && members.entries.filter(e => e.name === symbol).length !== 0) {
-                this.raiseError('Member list did contain ' + symbol);
+                this.raiseError(`Member list did contain ${symbol}`);
             }
         }
 
         public verifyCompletionListItemsCountIsGreaterThan(count: number) {
-            this.taoInvalidReason = 'verifyCompletionListItemsCountIsGreaterThan NYI';
+            this.taoInvalidReason = "verifyCompletionListItemsCountIsGreaterThan NYI";
 
             let completions = this.getCompletionListAtCaret();
             let itemsCount = completions.entries.length;
 
             if (itemsCount <= count) {
-                this.raiseError('Expected completion list items count to be greater than ' + count + ', but is actually ' + itemsCount);
+                this.raiseError(`Expected completion list items count to be greater than ${count}, but is actually ${itemsCount}`);
             }
         }
 
         public verifyMemberListIsEmpty(negative: boolean) {
             if (negative) {
-                this.scenarioActions.push('<ShowCompletionList />');
+                this.scenarioActions.push("<ShowCompletionList />");
             } else {
-                this.scenarioActions.push('<ShowCompletionList ExpectsFailure="true" />');
+                this.scenarioActions.push("<ShowCompletionList ExpectsFailure=\"true\" />");
             }
 
             let members = this.getMemberListAtCaret();
@@ -666,7 +666,7 @@ module FourSlash {
         }
 
         public verifyCompletionListIsEmpty(negative: boolean) {
-            this.scenarioActions.push('<ShowCompletionList ExpectsFailure="true" />');
+            this.scenarioActions.push("<ShowCompletionList ExpectsFailure=\"true\" />");
 
             let completions = this.getCompletionListAtCaret();
             if ((!completions || completions.entries.length === 0) && negative) {
@@ -730,12 +730,12 @@ module FourSlash {
                     return documentation === expectedDocumentation ? true : false;
                 }
                 // Because expectedText and expectedDocumentation are undefined, we assume that
-                // users don't care to compare them so we will treat that entry as if the entry has matching text and documentation
+                // users don"t care to compare them so we will treat that entry as if the entry has matching text and documentation
                 // and keep it in the list of filtered entry.
                 return true;
             }
-            this.scenarioActions.push('<ShowCompletionList />');
-            this.scenarioActions.push('<VerifyCompletionDoesNotContainItem ItemName="' + escapeXmlAttributeValue(symbol) + '" />');
+            this.scenarioActions.push("<ShowCompletionList />");
+            this.scenarioActions.push(`<VerifyCompletionDoesNotContainItem ItemName="${escapeXmlAttributeValue(symbol)}" />`);
 
             let completions = this.getCompletionListAtCaret();
             if (completions) {
@@ -763,7 +763,7 @@ module FourSlash {
         }
 
         public verifyCompletionEntryDetails(entryName: string, expectedText: string, expectedDocumentation?: string, kind?: string) {
-            this.taoInvalidReason = 'verifyCompletionEntryDetails NYI';
+            this.taoInvalidReason = "verifyCompletionEntryDetails NYI";
 
             let details = this.getCompletionEntryDetails(entryName);
 
@@ -779,30 +779,30 @@ module FourSlash {
         }
 
         public verifyReferencesAtPositionListContains(fileName: string, start: number, end: number, isWriteAccess?: boolean) {
-            this.taoInvalidReason = 'verifyReferencesAtPositionListContains NYI';
+            this.taoInvalidReason = "verifyReferencesAtPositionListContains NYI";
 
             let references = this.getReferencesAtCaret();
 
             if (!references || references.length === 0) {
-                this.raiseError('verifyReferencesAtPositionListContains failed - found 0 references, expected at least one.');
+                this.raiseError("verifyReferencesAtPositionListContains failed - found 0 references, expected at least one.");
             }
 
             for (let i = 0; i < references.length; i++) {
                 let reference = references[i];
                 if (reference && reference.fileName === fileName && reference.textSpan.start === start && ts.textSpanEnd(reference.textSpan) === end) {
                     if (typeof isWriteAccess !== "undefined" && reference.isWriteAccess !== isWriteAccess) {
-                        this.raiseError('verifyReferencesAtPositionListContains failed - item isWriteAccess value does not match, actual: ' + reference.isWriteAccess + ', expected: ' + isWriteAccess + '.');
+                        this.raiseError(`verifyReferencesAtPositionListContains failed - item isWriteAccess value does not match, actual: ${reference.isWriteAccess}, expected: ${isWriteAccess}.`);
                     }
                     return;
                 }
             }
 
             let missingItem = { fileName: fileName, start: start, end: end, isWriteAccess: isWriteAccess };
-            this.raiseError('verifyReferencesAtPositionListContains failed - could not find the item: ' + JSON.stringify(missingItem) + ' in the returned list: (' + JSON.stringify(references) + ')');
+            this.raiseError(`verifyReferencesAtPositionListContains failed - could not find the item: ${JSON.stringify(missingItem)} in the returned list: (${JSON.stringify(references)})`);
         }
 
         public verifyReferencesCountIs(count: number, localFilesOnly: boolean = true) {
-            this.taoInvalidReason = 'verifyReferences NYI';
+            this.taoInvalidReason = "verifyReferences NYI";
 
             let references = this.getReferencesAtCaret();
             let referencesCount = 0;
@@ -865,8 +865,8 @@ module FourSlash {
         public verifyQuickInfoString(negative: boolean, expectedText?: string, expectedDocumentation?: string) {
             [expectedText, expectedDocumentation].forEach(str => {
                 if (str) {
-                    this.scenarioActions.push('<ShowQuickInfo />');
-                    this.scenarioActions.push('<VerifyQuickInfoTextContains IgnoreSpacing="true" Text="' + escapeXmlAttributeValue(str) + '" ' + (negative ? 'ExpectsFailure="true"' : '') + ' />');
+                    this.scenarioActions.push("<ShowQuickInfo />");
+                    this.scenarioActions.push(`<VerifyQuickInfoTextContains IgnoreSpacing="true" Text="${escapeXmlAttributeValue(str)}" ${(negative ? "ExpectsFailure=\"true\" " : "")} />`);
                 }
             });
 
@@ -896,8 +896,8 @@ module FourSlash {
         public verifyQuickInfoDisplayParts(kind: string, kindModifiers: string, textSpan: { start: number; length: number; },
             displayParts: ts.SymbolDisplayPart[],
             documentation: ts.SymbolDisplayPart[]) {
-            this.scenarioActions.push('<ShowQuickInfo />');
-            this.scenarioActions.push('<Verify return values of quickInfo="' + JSON.stringify(displayParts) + '"/>');
+            this.scenarioActions.push("<ShowQuickInfo />");
+            this.scenarioActions.push(`<Verify return values of quickInfo="${JSON.stringify(displayParts)}"/>`);
 
             function getDisplayPartsJson(displayParts: ts.SymbolDisplayPart[]) {
                 let result = "";
@@ -964,23 +964,23 @@ module FourSlash {
         }
 
         public verifyQuickInfoExists(negative: boolean) {
-            this.taoInvalidReason = 'verifyQuickInfoExists NYI';
+            this.taoInvalidReason = "verifyQuickInfoExists NYI";
 
             let actualQuickInfo = this.languageService.getQuickInfoAtPosition(this.activeFile.fileName, this.currentCaretPosition);
             if (negative) {
                 if (actualQuickInfo) {
-                    this.raiseError('verifyQuickInfoExists failed. Expected quick info NOT to exist');
+                    this.raiseError("verifyQuickInfoExists failed. Expected quick info NOT to exist");
                 }
             }
             else {
                 if (!actualQuickInfo) {
-                    this.raiseError('verifyQuickInfoExists failed. Expected quick info to exist');
+                    this.raiseError("verifyQuickInfoExists failed. Expected quick info to exist");
                 }
             }
         }
 
         public verifyCurrentSignatureHelpIs(expected: string) {
-            this.taoInvalidReason = 'verifyCurrentSignatureHelpIs NYI';
+            this.taoInvalidReason = "verifyCurrentSignatureHelpIs NYI";
 
             let help = this.getActiveSignatureHelpItem();
             assert.equal(
@@ -990,7 +990,7 @@ module FourSlash {
         }
 
         public verifyCurrentParameterIsletiable(isVariable: boolean) {
-            this.taoInvalidReason = 'verifyCurrentParameterIsletiable NYI';
+            this.taoInvalidReason = "verifyCurrentParameterIsletiable NYI";
 
             let signature = this.getActiveSignatureHelpItem();
             assert.isNotNull(signature);
@@ -998,7 +998,7 @@ module FourSlash {
         }
 
         public verifyCurrentParameterHelpName(name: string) {
-            this.taoInvalidReason = 'verifyCurrentParameterHelpName NYI';
+            this.taoInvalidReason = "verifyCurrentParameterHelpName NYI";
 
             let activeParameter = this.getActiveParameter();
             let activeParameterName = activeParameter.name;
@@ -1006,7 +1006,7 @@ module FourSlash {
         }
 
         public verifyCurrentParameterSpanIs(parameter: string) {
-            this.taoInvalidReason = 'verifyCurrentParameterSpanIs NYI';
+            this.taoInvalidReason = "verifyCurrentParameterSpanIs NYI";
 
             let activeSignature = this.getActiveSignatureHelpItem();
             let activeParameter = this.getActiveParameter();
@@ -1014,7 +1014,7 @@ module FourSlash {
         }
 
         public verifyCurrentParameterHelpDocComment(docComment: string) {
-            this.taoInvalidReason = 'verifyCurrentParameterHelpDocComment NYI';
+            this.taoInvalidReason = "verifyCurrentParameterHelpDocComment NYI";
 
             let activeParameter = this.getActiveParameter();
             let activeParameterDocComment = activeParameter.documentation;
@@ -1022,27 +1022,27 @@ module FourSlash {
         }
 
         public verifyCurrentSignatureHelpParameterCount(expectedCount: number) {
-            this.taoInvalidReason = 'verifyCurrentSignatureHelpParameterCount NYI';
+            this.taoInvalidReason = "verifyCurrentSignatureHelpParameterCount NYI";
 
             assert.equal(this.getActiveSignatureHelpItem().parameters.length, expectedCount);
         }
 
         public verifyCurrentSignatureHelpTypeParameterCount(expectedCount: number) {
-            this.taoInvalidReason = 'verifyCurrentSignatureHelpTypeParameterCount NYI';
+            this.taoInvalidReason = "verifyCurrentSignatureHelpTypeParameterCount NYI";
 
             // assert.equal(this.getActiveSignatureHelpItem().typeParameters.length, expectedCount);
         }
 
         public verifyCurrentSignatureHelpDocComment(docComment: string) {
-            this.taoInvalidReason = 'verifyCurrentSignatureHelpDocComment NYI';
+            this.taoInvalidReason = "verifyCurrentSignatureHelpDocComment NYI";
 
             let actualDocComment = this.getActiveSignatureHelpItem().documentation;
             assert.equal(ts.displayPartsToString(actualDocComment), docComment, assertionMessage("current signature help doc comment"));
         }
 
         public verifySignatureHelpCount(expected: number) {
-            this.scenarioActions.push('<InvokeSignatureHelp />');
-            this.scenarioActions.push('<VerifySignatureHelpOverloadCountEquals Count="' + expected + '" />');
+            this.scenarioActions.push("<InvokeSignatureHelp />");
+            this.scenarioActions.push(`<VerifySignatureHelpOverloadCountEquals Count="${expected}" />`);
 
             let help = this.languageService.getSignatureHelpItems(this.activeFile.fileName, this.currentCaretPosition);
             let actual = help && help.items ? help.items.length : 0;
@@ -1050,14 +1050,14 @@ module FourSlash {
         }
 
         public verifySignatureHelpArgumentCount(expected: number) {
-            this.taoInvalidReason = 'verifySignatureHelpArgumentCount NYI';
+            this.taoInvalidReason = "verifySignatureHelpArgumentCount NYI";
             let signatureHelpItems = this.languageService.getSignatureHelpItems(this.activeFile.fileName, this.currentCaretPosition);
             let actual = signatureHelpItems.argumentCount;
             assert.equal(actual, expected);
         }
 
         public verifySignatureHelpPresent(shouldBePresent = true) {
-            this.taoInvalidReason = 'verifySignatureHelpPresent NYI';
+            this.taoInvalidReason = "verifySignatureHelpPresent NYI";
 
             let actual = this.languageService.getSignatureHelpItems(this.activeFile.fileName, this.currentCaretPosition);
             if (shouldBePresent) {
@@ -1066,7 +1066,7 @@ module FourSlash {
                 }
             } else {
                 if (actual) {
-                    this.raiseError("Expected no signature help, but got '" + JSON.stringify(actual) + "'");
+                    this.raiseError(`Expected no signature help, but got "${JSON.stringify(actual)}"`);
                 }
             }
         }
@@ -1200,12 +1200,12 @@ module FourSlash {
         }
 
         public getBreakpointStatementLocation(pos: number) {
-            this.taoInvalidReason = 'getBreakpointStatementLocation NYI';
+            this.taoInvalidReason = "getBreakpointStatementLocation NYI";
             return this.languageService.getBreakpointStatementAtPosition(this.activeFile.fileName, pos);
         }
 
         public baselineCurrentFileBreakpointLocations() {
-            this.taoInvalidReason = 'baselineCurrentFileBreakpointLocations impossible';
+            this.taoInvalidReason = "baselineCurrentFileBreakpointLocations impossible";
 
             Harness.Baseline.runBaseline(
                 "Breakpoint Locations for " + this.activeFile.fileName,
@@ -1217,7 +1217,7 @@ module FourSlash {
         }
 
         public baselineGetEmitOutput() {
-            this.taoInvalidReason = 'baselineGetEmitOutput impossible';
+            this.taoInvalidReason = "baselineGetEmitOutput impossible";
             // Find file to be emitted
             let emitFiles: FourSlashFile[] = [];  // List of FourSlashFile that has emitThisFile flag on
 
@@ -1288,7 +1288,7 @@ module FourSlash {
             let syntacticErrors = this.languageService.getSyntacticDiagnostics(this.activeFile.fileName);
             let semanticErrors = this.languageService.getSemanticDiagnostics(this.activeFile.fileName);
             let errorList = syntacticErrors.concat(semanticErrors);
-            Harness.IO.log('Error list (' + errorList.length + ' errors)');
+            Harness.IO.log(`Error list (${errorList.length} errors)`);
 
             if (errorList.length) {
                 errorList.forEach(err => {
@@ -1304,10 +1304,10 @@ module FourSlash {
             for (let i = 0; i < this.testData.files.length; i++) {
                 let file = this.testData.files[i];
                 let active = (this.activeFile === file);
-                Harness.IO.log('=== Script (' + file.fileName + ') ' + (active ? '(active, cursor at |)' : '') + ' ===');
+                Harness.IO.log(`=== Script (${file.fileName}) ${(active ? "(active, cursor at |)" : "")} ===`);
                 let content = this.getFileContent(file.fileName);
                 if (active) {
-                    content = content.substr(0, this.currentCaretPosition) + (makeCaretVisible ? '|' : "") + content.substr(this.currentCaretPosition);
+                    content = content.substr(0, this.currentCaretPosition) + (makeCaretVisible ? "|" : "") + content.substr(this.currentCaretPosition);
                 }
                 if (makeWhitespaceVisible) {
                     content = TestState.makeWhitespaceVisible(content);
@@ -1343,7 +1343,7 @@ module FourSlash {
         }
 
         public deleteChar(count = 1) {
-            this.scenarioActions.push('<DeleteCharNext Count="' + count + '" />');
+            this.scenarioActions.push(`<DeleteCharNext Count="${count}" />`);
 
             let offset = this.currentCaretPosition;
             let ch = "";
@@ -1377,7 +1377,7 @@ module FourSlash {
         }
 
         public replace(start: number, length: number, text: string) {
-            this.taoInvalidReason = 'replace NYI';
+            this.taoInvalidReason = "replace NYI";
 
             this.languageServiceAdapterHost.editScript(this.activeFile.fileName, start, start + length, text);
             this.updateMarkersForEdit(this.activeFile.fileName, start, start + length, text);
@@ -1385,7 +1385,7 @@ module FourSlash {
         }
 
         public deleteCharBehindMarker(count = 1) {
-            this.scenarioActions.push('<DeleteCharPrevious Count="' + count + '" />');
+            this.scenarioActions.push(`<DeleteCharPrevious Count="${count}" />`);
 
             let offset = this.currentCaretPosition;
             let ch = "";
@@ -1419,10 +1419,10 @@ module FourSlash {
 
         // Enters lines of text at the current caret position
         public type(text: string) {
-            if (text === '') {
-                this.taoInvalidReason = 'Test used empty-insert workaround.';
+            if (text === "") {
+                this.taoInvalidReason = "Test used empty-insert workaround.";
             } else {
-                this.scenarioActions.push('<InsertText><![CDATA[' + text + ']]></InsertText>');
+                this.scenarioActions.push(`<InsertText><![CDATA[${text}]]></InsertText>`);
             }
 
             return this.typeHighFidelity(text);
@@ -1433,7 +1433,7 @@ module FourSlash {
         // as much as possible
         private typeHighFidelity(text: string) {
             let offset = this.currentCaretPosition;
-            let prevChar = ' ';
+            let prevChar = " ";
             let checkCadence = (text.length >> 2) + 1;
 
             for (let i = 0; i < text.length; i++) {
@@ -1445,10 +1445,10 @@ module FourSlash {
                 this.updateMarkersForEdit(this.activeFile.fileName, offset, offset, ch);
                 offset++;
 
-                if (ch === '(' || ch === ',') {
+                if (ch === "(" || ch === ",") {
                     /* Signature help*/
                     this.languageService.getSignatureHelpItems(this.activeFile.fileName, offset);
-                } else if (prevChar === ' ' && /A-Za-z_/.test(ch)) {
+                } else if (prevChar === " " && /A-Za-z_/.test(ch)) {
                     /* Completions */
                     this.languageService.getCompletionsAtPosition(this.activeFile.fileName, offset);
                 }
@@ -1478,7 +1478,7 @@ module FourSlash {
 
         // Enters text as if the user had pasted it
         public paste(text: string) {
-            this.scenarioActions.push('<InsertText><![CDATA[' + text + ']]></InsertText>');
+            this.scenarioActions.push(`<InsertText><![CDATA[${text}]]></InsertText>`);
 
             let start = this.currentCaretPosition;
             let offset = this.currentCaretPosition;
@@ -1531,7 +1531,7 @@ module FourSlash {
             // that happens, move it back one character
             if (this.currentCaretPosition > 0) {
                 let ch = this.getFileContent(this.activeFile.fileName).substring(this.currentCaretPosition - 1, this.currentCaretPosition);
-                if (ch === '\r') {
+                if (ch === "\r") {
                     this.currentCaretPosition--;
                 }
             };
@@ -1556,8 +1556,8 @@ module FourSlash {
             if (isFormattingEdit) {
                 let newContent = this.getFileContent(fileName);
 
-                if (newContent.replace(/\s/g, '') !== oldContent.replace(/\s/g, '')) {
-                    this.raiseError('Formatting operation destroyed non-whitespace content');
+                if (newContent.replace(/\s/g, "") !== oldContent.replace(/\s/g, "")) {
+                    this.raiseError("Formatting operation destroyed non-whitespace content");
                 }
             }
             return runningOffset;
@@ -1574,7 +1574,7 @@ module FourSlash {
         }
 
         public formatDocument() {
-            this.scenarioActions.push('<FormatDocument />');
+            this.scenarioActions.push("<FormatDocument />");
 
             let edits = this.languageService.getFormattingEditsForDocument(this.activeFile.fileName, this.formatCodeOptions);
             this.currentCaretPosition += this.applyEdits(this.activeFile.fileName, edits, true);
@@ -1582,7 +1582,7 @@ module FourSlash {
         }
 
         public formatSelection(start: number, end: number) {
-            this.taoInvalidReason = 'formatSelection NYI';
+            this.taoInvalidReason = "formatSelection NYI";
 
             let edits = this.languageService.getFormattingEditsForRange(this.activeFile.fileName, start, end, this.formatCodeOptions);
             this.currentCaretPosition += this.applyEdits(this.activeFile.fileName, edits, true);
@@ -1617,18 +1617,18 @@ module FourSlash {
 
         public goToDefinition(definitionIndex: number) {
             if (definitionIndex === 0) {
-                this.scenarioActions.push('<GoToDefinition />');
+                this.scenarioActions.push("<GoToDefinition />");
             } else {
-                this.taoInvalidReason = 'GoToDefinition not supported for non-zero definition indices';
+                this.taoInvalidReason = "GoToDefinition not supported for non-zero definition indices";
             }
 
             let definitions = this.languageService.getDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition);
             if (!definitions || !definitions.length) {
-                this.raiseError('goToDefinition failed - expected to at least one definition location but got 0');
+                this.raiseError("goToDefinition failed - expected to at least one definition location but got 0");
             }
 
             if (definitionIndex >= definitions.length) {
-                this.raiseError('goToDefinition failed - definitionIndex value (' + definitionIndex + ') exceeds definition list size (' + definitions.length + ')');
+                this.raiseError(`goToDefinition failed - definitionIndex value (${definitionIndex}) exceeds definition list size (${definitions.length})`);
             }
 
             let definition = definitions[definitionIndex];
@@ -1638,19 +1638,19 @@ module FourSlash {
 
         public goToTypeDefinition(definitionIndex: number) {
             if (definitionIndex === 0) {
-                this.scenarioActions.push('<GoToTypeDefinition />');
+                this.scenarioActions.push("<GoToTypeDefinition />");
             }
             else {
-                this.taoInvalidReason = 'GoToTypeDefinition not supported for non-zero definition indices';
+                this.taoInvalidReason = "GoToTypeDefinition not supported for non-zero definition indices";
             }
 
             let definitions = this.languageService.getTypeDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition);
             if (!definitions || !definitions.length) {
-                this.raiseError('goToTypeDefinition failed - expected to at least one definition location but got 0');
+                this.raiseError("goToTypeDefinition failed - expected to at least one definition location but got 0");
             }
 
             if (definitionIndex >= definitions.length) {
-                this.raiseError('goToTypeDefinition failed - definitionIndex value (' + definitionIndex + ') exceeds definition list size (' + definitions.length + ')');
+                this.raiseError(`goToTypeDefinition failed - definitionIndex value (${definitionIndex}) exceeds definition list size (${definitions.length})`);
             }
 
             let definition = definitions[definitionIndex];
@@ -1659,17 +1659,17 @@ module FourSlash {
         }
 
         public verifyDefinitionLocationExists(negative: boolean) {
-            this.taoInvalidReason = 'verifyDefinitionLocationExists NYI';
+            this.taoInvalidReason = "verifyDefinitionLocationExists NYI";
 
             let definitions = this.languageService.getDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition);
 
             let foundDefinitions = definitions && definitions.length;
 
             if (foundDefinitions && negative) {
-                this.raiseError('goToDefinition - expected to 0 definition locations but got ' + definitions.length);
+                this.raiseError(`goToDefinition - expected to 0 definition locations but got ${definitions.length}`);
             }
             else if (!foundDefinitions && !negative) {
-                this.raiseError('goToDefinition - expected to at least one definition location but got 0');
+                this.raiseError("goToDefinition - expected to at least one definition location but got 0");
             }
         }
 
@@ -1692,7 +1692,7 @@ module FourSlash {
         }
 
         public verifyDefinitionsName(negative: boolean, expectedName: string, expectedContainerName: string) {
-            this.taoInvalidReason = 'verifyDefinititionsInfo NYI';
+            this.taoInvalidReason = "verifyDefinititionsInfo NYI";
 
             let definitions = this.languageService.getDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition);
             let actualDefinitionName = definitions && definitions.length ? definitions[0].name : "";
@@ -1716,15 +1716,15 @@ module FourSlash {
             return this.testData.ranges.slice(0);
         }
 
-        public verifyCaretAtMarker(markerName = '') {
-            this.taoInvalidReason = 'verifyCaretAtMarker NYI';
+        public verifyCaretAtMarker(markerName = "") {
+            this.taoInvalidReason = "verifyCaretAtMarker NYI";
 
             let pos = this.getMarkerByName(markerName);
             if (pos.fileName !== this.activeFile.fileName) {
-                throw new Error('verifyCaretAtMarker failed - expected to be in file "' + pos.fileName + '", but was in file "' + this.activeFile.fileName + '"');
+                throw new Error(`verifyCaretAtMarker failed - expected to be in file "${pos.fileName}", but was in file "${this.activeFile.fileName}"`);
             }
             if (pos.position !== this.currentCaretPosition) {
-                throw new Error('verifyCaretAtMarker failed - expected to be at marker "/*' + markerName + '*/, but was at position ' + this.currentCaretPosition + '(' + this.getLineColStringAtPosition(this.currentCaretPosition) + ')');
+                throw new Error(`verifyCaretAtMarker failed - expected to be at marker "/*${markerName}*/, but was at position ${this.currentCaretPosition}(${this.getLineColStringAtPosition(this.currentCaretPosition)})`);
             }
         }
 
@@ -1733,84 +1733,84 @@ module FourSlash {
         }
 
         public verifyIndentationAtCurrentPosition(numberOfSpaces: number) {
-            this.taoInvalidReason = 'verifyIndentationAtCurrentPosition NYI';
+            this.taoInvalidReason = "verifyIndentationAtCurrentPosition NYI";
 
             let actual = this.getIndentation(this.activeFile.fileName, this.currentCaretPosition);
             let lineCol = this.getLineColStringAtPosition(this.currentCaretPosition);
             if (actual !== numberOfSpaces) {
-                this.raiseError('verifyIndentationAtCurrentPosition failed at ' + lineCol + ' - expected: ' + numberOfSpaces + ', actual: ' + actual);
+                this.raiseError(`verifyIndentationAtCurrentPosition failed at ${lineCol} - expected: ${numberOfSpaces}, actual: ${actual}`);
             }
         }
 
         public verifyIndentationAtPosition(fileName: string, position: number, numberOfSpaces: number) {
-            this.taoInvalidReason = 'verifyIndentationAtPosition NYI';
+            this.taoInvalidReason = "verifyIndentationAtPosition NYI";
 
             let actual = this.getIndentation(fileName, position);
             let lineCol = this.getLineColStringAtPosition(position);
             if (actual !== numberOfSpaces) {
-                this.raiseError('verifyIndentationAtPosition failed at ' + lineCol + ' - expected: ' + numberOfSpaces + ', actual: ' + actual);
+                this.raiseError(`verifyIndentationAtPosition failed at ${lineCol} - expected: ${numberOfSpaces}, actual: ${actual}`);
             }
         }
 
         public verifyCurrentLineContent(text: string) {
-            this.taoInvalidReason = 'verifyCurrentLineContent NYI';
+            this.taoInvalidReason = "verifyCurrentLineContent NYI";
 
             let actual = this.getCurrentLineContent();
             if (actual !== text) {
-                throw new Error('verifyCurrentLineContent\n' +
-                    '\tExpected: "' + text + '"\n' +
-                    '\t  Actual: "' + actual + '"');
+                throw new Error("verifyCurrentLineContent\n" +
+                    "\tExpected: \"" + text + "\"\n" +
+                    "\t  Actual: \"" + actual + "\"");
             }
         }
 
         public verifyCurrentFileContent(text: string) {
-            this.taoInvalidReason = 'verifyCurrentFileContent NYI';
+            this.taoInvalidReason = "verifyCurrentFileContent NYI";
 
             let actual = this.getFileContent(this.activeFile.fileName);
             let replaceNewlines = (str: string) => str.replace(/\r\n/g, "\n");
             if (replaceNewlines(actual) !== replaceNewlines(text)) {
-                throw new Error('verifyCurrentFileContent\n' +
-                    '\tExpected: "' + text + '"\n' +
-                    '\t  Actual: "' + actual + '"');
+                throw new Error("verifyCurrentFileContent\n" +
+                    "\tExpected: \"" + text + "\"\n" +
+                    "\t  Actual: \"" + actual + "\"");
             }
         }
 
         public verifyTextAtCaretIs(text: string) {
-            this.taoInvalidReason = 'verifyCurrentFileContent NYI';
+            this.taoInvalidReason = "verifyCurrentFileContent NYI";
 
             let actual = this.getFileContent(this.activeFile.fileName).substring(this.currentCaretPosition, this.currentCaretPosition + text.length);
             if (actual !== text) {
-                throw new Error('verifyTextAtCaretIs\n' +
-                    '\tExpected: "' + text + '"\n' +
-                    '\t  Actual: "' + actual + '"');
+                throw new Error("verifyTextAtCaretIs\n" +
+                    "\tExpected: \"" + text + "\"\n" +
+                    "\t  Actual: \"" + actual + "\"");
             }
         }
 
         public verifyCurrentNameOrDottedNameSpanText(text: string) {
-            this.taoInvalidReason = 'verifyCurrentNameOrDottedNameSpanText NYI';
+            this.taoInvalidReason = "verifyCurrentNameOrDottedNameSpanText NYI";
 
             let span = this.languageService.getNameOrDottedNameSpan(this.activeFile.fileName, this.currentCaretPosition, this.currentCaretPosition);
             if (!span) {
-                this.raiseError('verifyCurrentNameOrDottedNameSpanText\n' +
-                    '\tExpected: "' + text + '"\n' +
-                    '\t  Actual: undefined');
+                this.raiseError("verifyCurrentNameOrDottedNameSpanText\n" +
+                    "\tExpected: \"" + text + "\"\n" +
+                    "\t  Actual: undefined");
             }
 
             let actual = this.getFileContent(this.activeFile.fileName).substring(span.start, ts.textSpanEnd(span));
             if (actual !== text) {
-                this.raiseError('verifyCurrentNameOrDottedNameSpanText\n' +
-                    '\tExpected: "' + text + '"\n' +
-                    '\t  Actual: "' + actual + '"');
+                this.raiseError("verifyCurrentNameOrDottedNameSpanText\n" +
+                    "\tExpected: \"" + text + "\"\n" +
+                    "\t  Actual: \"" + actual + "\"");
             }
         }
 
         private getNameOrDottedNameSpan(pos: number) {
-            this.taoInvalidReason = 'getNameOrDottedNameSpan NYI';
+            this.taoInvalidReason = "getNameOrDottedNameSpan NYI";
             return this.languageService.getNameOrDottedNameSpan(this.activeFile.fileName, pos, pos);
         }
 
         public baselineCurrentFileNameOrDottedNameSpans() {
-            this.taoInvalidReason = 'baselineCurrentFileNameOrDottedNameSpans impossible';
+            this.taoInvalidReason = "baselineCurrentFileNameOrDottedNameSpans impossible";
 
             Harness.Baseline.runBaseline(
                 "Name OrDottedNameSpans for " + this.activeFile.fileName,
@@ -1828,8 +1828,8 @@ module FourSlash {
 
         private verifyClassifications(expected: { classificationType: string; text: string; textSpan?: TextSpan }[], actual: ts.ClassifiedSpan[]) {
             if (actual.length !== expected.length) {
-                this.raiseError('verifyClassifications failed - expected total classifications to be ' + expected.length +
-                    ', but was ' + actual.length +
+                this.raiseError("verifyClassifications failed - expected total classifications to be " + expected.length +
+                    ", but was " + actual.length +
                     jsonMismatchString());
             }
 
@@ -1839,8 +1839,8 @@ module FourSlash {
 
                 let expectedType: string = (<any>ts.ClassificationTypeNames)[expectedClassification.classificationType];
                 if (expectedType !== actualClassification.classificationType) {
-                    this.raiseError('verifyClassifications failed - expected classifications type to be ' +
-                        expectedType + ', but was ' +
+                    this.raiseError("verifyClassifications failed - expected classifications type to be " +
+                        expectedType + ", but was " +
                         actualClassification.classificationType +
                         jsonMismatchString());
                 }
@@ -1861,8 +1861,8 @@ module FourSlash {
 
                 let actualText = this.activeFile.content.substr(actualSpan.start, actualSpan.length);
                 if (expectedClassification.text !== actualText) {
-                    this.raiseError('verifyClassifications failed - expected classified text to be ' +
-                        expectedClassification.text + ', but was ' +
+                    this.raiseError("verifyClassifications failed - expected classified text to be " +
+                        expectedClassification.text + ", but was " +
                         actualText +
                         jsonMismatchString());
                 }
@@ -1905,19 +1905,19 @@ module FourSlash {
         }
 
         public verifyOutliningSpans(spans: TextSpan[]) {
-            this.taoInvalidReason = 'verifyOutliningSpans NYI';
+            this.taoInvalidReason = "verifyOutliningSpans NYI";
 
             let actual = this.languageService.getOutliningSpans(this.activeFile.fileName);
 
             if (actual.length !== spans.length) {
-                this.raiseError('verifyOutliningSpans failed - expected total spans to be ' + spans.length + ', but was ' + actual.length);
+                this.raiseError(`verifyOutliningSpans failed - expected total spans to be ${spans.length}, but was ${actual.length}`);
             }
 
             for (let i = 0; i < spans.length; i++) {
                 let expectedSpan = spans[i];
                 let actualSpan = actual[i];
                 if (expectedSpan.start !== actualSpan.textSpan.start || expectedSpan.end !== ts.textSpanEnd(actualSpan.textSpan)) {
-                    this.raiseError('verifyOutliningSpans failed - span ' + (i + 1) + ' expected: (' + expectedSpan.start + ',' + expectedSpan.end + '),  actual: (' + actualSpan.textSpan.start + ',' + ts.textSpanEnd(actualSpan.textSpan) + ')');
+                    this.raiseError(`verifyOutliningSpans failed - span ${(i + 1)} expected: (${expectedSpan.start},${expectedSpan.end}),  actual: (${actualSpan.textSpan.start},${ts.textSpanEnd(actualSpan.textSpan)})`);
                 }
             }
         }
@@ -1927,7 +1927,7 @@ module FourSlash {
                 descriptors.map(d => { return { text: d, priority: 0 }; }));
 
             if (actual.length !== spans.length) {
-                this.raiseError('verifyTodoComments failed - expected total spans to be ' + spans.length + ', but was ' + actual.length);
+                this.raiseError(`verifyTodoComments failed - expected total spans to be ${spans.length}, but was ${actual.length}`);
             }
 
             for (let i = 0; i < spans.length; i++) {
@@ -1936,18 +1936,18 @@ module FourSlash {
                 let actualCommentSpan = ts.createTextSpan(actualComment.position, actualComment.message.length);
 
                 if (expectedSpan.start !== actualCommentSpan.start || expectedSpan.end !== ts.textSpanEnd(actualCommentSpan)) {
-                    this.raiseError('verifyOutliningSpans failed - span ' + (i + 1) + ' expected: (' + expectedSpan.start + ',' + expectedSpan.end + '),  actual: (' + actualCommentSpan.start + ',' + ts.textSpanEnd(actualCommentSpan) + ')');
+                    this.raiseError(`verifyOutliningSpans failed - span ${(i + 1)} expected: (${expectedSpan.start},${expectedSpan.end}),  actual: (${actualCommentSpan.start},${ts.textSpanEnd(actualCommentSpan)})`);
                 }
             }
         }
 
         public verifyMatchingBracePosition(bracePosition: number, expectedMatchPosition: number) {
-            this.taoInvalidReason = 'verifyMatchingBracePosition NYI';
+            this.taoInvalidReason = "verifyMatchingBracePosition NYI";
 
             let actual = this.languageService.getBraceMatchingAtPosition(this.activeFile.fileName, bracePosition);
 
             if (actual.length !== 2) {
-                this.raiseError('verifyMatchingBracePosition failed - expected result to contain 2 spans, but it had ' + actual.length);
+                this.raiseError(`verifyMatchingBracePosition failed - expected result to contain 2 spans, but it had ${actual.length}`);
             }
 
             let actualMatchPosition = -1;
@@ -1956,21 +1956,21 @@ module FourSlash {
             } else if (bracePosition === actual[1].start) {
                 actualMatchPosition = actual[0].start;
             } else {
-                this.raiseError('verifyMatchingBracePosition failed - could not find the brace position: ' + bracePosition + ' in the returned list: (' + actual[0].start + ',' + ts.textSpanEnd(actual[0]) + ') and (' + actual[1].start + ',' + ts.textSpanEnd(actual[1]) + ')');
+                this.raiseError(`verifyMatchingBracePosition failed - could not find the brace position: ${bracePosition} in the returned list: (${actual[0].start},${ts.textSpanEnd(actual[0])}) and (${actual[1].start},${ts.textSpanEnd(actual[1])})`);
             }
 
             if (actualMatchPosition !== expectedMatchPosition) {
-                this.raiseError('verifyMatchingBracePosition failed - expected: ' + actualMatchPosition + ',  actual: ' + expectedMatchPosition);
+                this.raiseError(`verifyMatchingBracePosition failed - expected: ${actualMatchPosition},  actual: ${expectedMatchPosition}`);
             }
         }
 
         public verifyNoMatchingBracePosition(bracePosition: number) {
-            this.taoInvalidReason = 'verifyNoMatchingBracePosition NYI';
+            this.taoInvalidReason = "verifyNoMatchingBracePosition NYI";
 
             let actual = this.languageService.getBraceMatchingAtPosition(this.activeFile.fileName, bracePosition);
 
             if (actual.length !== 0) {
-                this.raiseError('verifyNoMatchingBracePosition failed - expected: 0 spans, actual: ' + actual.length);
+                this.raiseError("verifyNoMatchingBracePosition failed - expected: 0 spans, actual: " + actual.length);
             }
         }
 
@@ -1979,7 +1979,7 @@ module FourSlash {
             Report an error if expected value and actual value do not match.
         */
         public verifyNavigationItemsCount(expected: number, searchValue: string, matchKind?: string) {
-            this.taoInvalidReason = 'verifyNavigationItemsCount NYI';
+            this.taoInvalidReason = "verifyNavigationItemsCount NYI";
 
             let items = this.languageService.getNavigateToItems(searchValue);
             let actual = 0;
@@ -1994,7 +1994,7 @@ module FourSlash {
             }
 
             if (expected !== actual) {
-                this.raiseError('verifyNavigationItemsCount failed - found: ' + actual + ' navigation items, expected: ' + expected + '.');
+                this.raiseError(`verifyNavigationItemsCount failed - found: ${actual} navigation items, expected: ${expected}.`);
             }
         }
 
@@ -2009,12 +2009,12 @@ module FourSlash {
             matchKind: string,
             fileName?: string,
             parentName?: string) {
-            this.taoInvalidReason = 'verifyNavigationItemsListContains NYI';
+            this.taoInvalidReason = "verifyNavigationItemsListContains NYI";
 
             let items = this.languageService.getNavigateToItems(searchValue);
 
             if (!items || items.length === 0) {
-                this.raiseError('verifyNavigationItemsListContains failed - found 0 navigation items, expected at least one.');
+                this.raiseError("verifyNavigationItemsListContains failed - found 0 navigation items, expected at least one.");
             }
 
             for (let i = 0; i < items.length; i++) {
@@ -2030,18 +2030,18 @@ module FourSlash {
             // if there was an explicit match kind specified, then it should be validated.
             if (matchKind !== undefined) {
                 let missingItem = { name: name, kind: kind, searchValue: searchValue, matchKind: matchKind, fileName: fileName, parentName: parentName };
-                this.raiseError('verifyNavigationItemsListContains failed - could not find the item: ' + JSON.stringify(missingItem) + ' in the returned list: (' + JSON.stringify(items) + ')');
+                this.raiseError(`verifyNavigationItemsListContains failed - could not find the item: ${JSON.stringify(missingItem)} in the returned list: (${JSON.stringify(items)})`);
             }
         }
 
         public verifyGetScriptLexicalStructureListCount(expected: number) {
-            this.taoInvalidReason = 'verifyNavigationItemsListContains impossible';
+            this.taoInvalidReason = "verifyNavigationItemsListContains impossible";
 
             let items = this.languageService.getNavigationBarItems(this.activeFile.fileName);
             let actual = this.getNavigationBarItemsCount(items);
 
             if (expected !== actual) {
-                this.raiseError('verifyGetScriptLexicalStructureListCount failed - found: ' + actual + ' navigation items, expected: ' + expected + '.');
+                this.raiseError(`verifyGetScriptLexicalStructureListCount failed - found: ${actual} navigation items, expected: ${expected}.`);
             }
         }
 
@@ -2058,12 +2058,12 @@ module FourSlash {
         }
 
         public verifyGetScriptLexicalStructureListContains(name: string, kind: string) {
-            this.taoInvalidReason = 'verifyGetScriptLexicalStructureListContains impossible';
+            this.taoInvalidReason = "verifyGetScriptLexicalStructureListContains impossible";
 
             let items = this.languageService.getNavigationBarItems(this.activeFile.fileName);
 
             if (!items || items.length === 0) {
-                this.raiseError('verifyGetScriptLexicalStructureListContains failed - found 0 navigation items, expected at least one.');
+                this.raiseError("verifyGetScriptLexicalStructureListContains failed - found 0 navigation items, expected at least one.");
             }
 
             if (this.navigationBarItemsContains(items, name, kind)) {
@@ -2071,7 +2071,7 @@ module FourSlash {
             }
 
             let missingItem = { name: name, kind: kind };
-            this.raiseError('verifyGetScriptLexicalStructureListContains failed - could not find the item: ' + JSON.stringify(missingItem) + ' in the returned list: (' + JSON.stringify(items, null, " ") + ')');
+            this.raiseError(`verifyGetScriptLexicalStructureListContains failed - could not find the item: ${JSON.stringify(missingItem)} in the returned list: (${JSON.stringify(items, null, " ")})`);
         }
 
         private navigationBarItemsContains(items: ts.NavigationBarItem[], name: string, kind: string) {
@@ -2095,11 +2095,11 @@ module FourSlash {
             let items = this.languageService.getNavigateToItems(searchValue);
             let length = items && items.length;
 
-            Harness.IO.log('NavigationItems list (' + length + ' items)');
+            Harness.IO.log(`NavigationItems list (${length} items)`);
 
             for (let i = 0; i < length; i++) {
                 let item = items[i];
-                Harness.IO.log('name: ' + item.name + ', kind: ' + item.kind + ', parentName: ' + item.containerName + ', fileName: ' + item.fileName);
+                Harness.IO.log(`name: ${item.name}, kind: ${item.kind}, parentName: ${item.containerName}, fileName: ${item.fileName}`);
             }
         }
 
@@ -2107,11 +2107,11 @@ module FourSlash {
             let items = this.languageService.getNavigationBarItems(this.activeFile.fileName);
             let length = items && items.length;
 
-            Harness.IO.log('NavigationItems list (' + length + ' items)');
+            Harness.IO.log(`NavigationItems list (${length} items)`);
 
             for (let i = 0; i < length; i++) {
                 let item = items[i];
-                Harness.IO.log('name: ' + item.text + ', kind: ' + item.kind);
+                Harness.IO.log(`name: ${item.text}, kind: ${item.kind}`);
             }
         }
 
@@ -2120,35 +2120,35 @@ module FourSlash {
         }
 
         public verifyOccurrencesAtPositionListContains(fileName: string, start: number, end: number, isWriteAccess?: boolean) {
-            this.taoInvalidReason = 'verifyOccurrencesAtPositionListContains NYI';
+            this.taoInvalidReason = "verifyOccurrencesAtPositionListContains NYI";
 
             let occurances = this.getOccurancesAtCurrentPosition();
 
             if (!occurances || occurances.length === 0) {
-                this.raiseError('verifyOccurancesAtPositionListContains failed - found 0 references, expected at least one.');
+                this.raiseError("verifyOccurancesAtPositionListContains failed - found 0 references, expected at least one.");
             }
 
             for (let i = 0; i < occurances.length; i++) {
                 let occurance = occurances[i];
                 if (occurance && occurance.fileName === fileName && occurance.textSpan.start === start && ts.textSpanEnd(occurance.textSpan) === end) {
                     if (typeof isWriteAccess !== "undefined" && occurance.isWriteAccess !== isWriteAccess) {
-                        this.raiseError('verifyOccurancesAtPositionListContains failed - item isWriteAccess value doe not match, actual: ' + occurance.isWriteAccess + ', expected: ' + isWriteAccess + '.');
+                        this.raiseError(`verifyOccurancesAtPositionListContains failed - item isWriteAccess value doe not match, actual: ${occurance.isWriteAccess}, expected: ${isWriteAccess}.`);
                     }
                     return;
                 }
             }
 
             let missingItem = { fileName: fileName, start: start, end: end, isWriteAccess: isWriteAccess };
-            this.raiseError('verifyOccurancesAtPositionListContains failed - could not find the item: ' + JSON.stringify(missingItem) + ' in the returned list: (' + JSON.stringify(occurances) + ')');
+            this.raiseError(`verifyOccurancesAtPositionListContains failed - could not find the item: ${JSON.stringify(missingItem)} in the returned list: (${JSON.stringify(occurances)})`);
         }
 
         public verifyOccurrencesAtPositionListCount(expectedCount: number) {
-            this.taoInvalidReason = 'verifyOccurrencesAtPositionListCount NYI';
+            this.taoInvalidReason = "verifyOccurrencesAtPositionListCount NYI";
 
             let occurances = this.getOccurancesAtCurrentPosition();
             let actualCount = occurances ? occurances.length : 0;
             if (expectedCount !== actualCount) {
-                this.raiseError('verifyOccurrencesAtPositionListCount failed - actual: ' + actualCount + ', expected:' + expectedCount);
+                this.raiseError(`verifyOccurrencesAtPositionListCount failed - actual: ${actualCount}, expected:${expectedCount}`);
             }
         }
 
@@ -2182,11 +2182,11 @@ module FourSlash {
         }
 
         private assertItemInCompletionList(items: ts.CompletionEntry[], name: string, text?: string, documentation?: string, kind?: string) {
-            this.scenarioActions.push('<ShowCompletionList />');
-            this.scenarioActions.push('<VerifyCompletionContainsItem ItemName="' + name + '"/>');
+            this.scenarioActions.push("<ShowCompletionList />");
+            this.scenarioActions.push(`<VerifyCompletionContainsItem ItemName="${name}"/>`);
 
             if (text || documentation || kind) {
-                this.taoInvalidReason = 'assertItemInCompletionList only supports the "name" parameter';
+                this.taoInvalidReason = "assertItemInCompletionList only supports the \"name\" parameter";
             }
 
             for (let i = 0; i < items.length; i++) {
@@ -2213,23 +2213,23 @@ module FourSlash {
 
             let itemsString = items.map((item) => JSON.stringify({ name: item.name, kind: item.kind })).join(",\n");
 
-            this.raiseError('Expected "' + JSON.stringify({ name, text, documentation, kind }) + '" to be in list [' + itemsString + ']');
+            this.raiseError(`Expected "${JSON.stringify({ name, text, documentation, kind })}" to be in list [${itemsString}]`);
         }
 
         private findFile(indexOrName: any) {
             let result: FourSlashFile = null;
-            if (typeof indexOrName === 'number') {
+            if (typeof indexOrName === "number") {
                 let index = <number>indexOrName;
                 if (index >= this.testData.files.length) {
-                    throw new Error('File index (' + index + ') in openFile was out of range. There are only ' + this.testData.files.length + ' files in this test.');
+                    throw new Error(`File index (${index}) in openFile was out of range. There are only ${this.testData.files.length} files in this test.`);
                 } else {
                     result = this.testData.files[index];
                 }
-            } else if (typeof indexOrName === 'string') {
+            } else if (typeof indexOrName === "string") {
                 let name = <string>indexOrName;
 
                 // names are stored in the compiler with this relative path, this allows people to use goTo.file on just the fileName
-                name = name.indexOf('/') === -1 ? (this.basePath + '/' + name) : name;
+                name = name.indexOf("/") === -1 ? (this.basePath + "/" + name) : name;
 
                 let availableNames: string[] = [];
                 let foundIt = false;
@@ -2246,10 +2246,10 @@ module FourSlash {
                 }
 
                 if (!foundIt) {
-                    throw new Error('No test file named "' + name + '" exists. Available file names are:' + availableNames.join(', '));
+                    throw new Error(`No test file named "${name}" exists. Available file names are: ${availableNames.join(", ")}`);
                 }
             } else {
-                throw new Error('Unknown argument type');
+                throw new Error("Unknown argument type");
             }
 
             return result;
@@ -2257,7 +2257,7 @@ module FourSlash {
 
         private getLineColStringAtPosition(position: number) {
             let pos = this.languageServiceAdapterHost.positionToLineAndCharacter(this.activeFile.fileName, position);
-            return 'line ' + (pos.line + 1) + ', col ' + pos.character;
+            return `line ${(pos.line + 1)}, col ${pos.character}`;
         }
 
         public getMarkerByName(markerName: string) {
@@ -2265,21 +2265,21 @@ module FourSlash {
             if (markerPos === undefined) {
                 let markerNames: string[] = [];
                 for (let m in this.testData.markerPositions) markerNames.push(m);
-                throw new Error('Unknown marker "' + markerName + '" Available markers: ' + markerNames.map(m => '"' + m + '"').join(', '));
+                throw new Error(`Unknown marker "${markerName}" Available markers: ${markerNames.map(m => "\"" + m + "\"").join(", ")}`);
             } else {
                 return markerPos;
             }
         }
 
         private static makeWhitespaceVisible(text: string) {
-            return text.replace(/ /g, '\u00B7').replace(/\r/g, '\u00B6').replace(/\n/g, '\u2193\n').replace(/\t/g, '\u2192\   ');
+            return text.replace(/ /g, "\u00B7").replace(/\r/g, "\u00B6").replace(/\n/g, "\u2193\n").replace(/\t/g, "\u2192\   ");
         }
 
         public getTestXmlData(): TestXmlData {
             return {
                 actions: this.scenarioActions,
                 invalidReason: this.taoInvalidReason,
-                originalName: ''
+                originalName: ""
             };
         }
 
@@ -2323,7 +2323,7 @@ module FourSlash {
 
         currentTestState = new TestState(basePath, testType, testData);
 
-        let result = '';
+        let result = "";
         let host = Harness.Compiler.createCompilerHost(
             [
                 { unitName: Harness.Compiler.fourslashFileName, content: undefined },
@@ -2339,12 +2339,12 @@ module FourSlash {
 
         let diagnostics = ts.getPreEmitDiagnostics(program, sourceFile);
         if (diagnostics.length > 0) {
-            throw new Error('Error compiling ' + fileName + ': ' +
-                diagnostics.map(e => ts.flattenDiagnosticMessageText(e.messageText, ts.sys.newLine)).join('\r\n'));
+            throw new Error(`Error compiling ${fileName}: ` +
+                diagnostics.map(e => ts.flattenDiagnosticMessageText(e.messageText, ts.sys.newLine)).join("\r\n"));
         }
 
         program.emit(sourceFile);
-        result = result || ''; // Might have an empty fourslash file
+        result = result || ""; // Might have an empty fourslash file
 
         result = fourslashJsOutput + "\r\n" + result;
 
@@ -2365,12 +2365,12 @@ module FourSlash {
     function chompLeadingSpace(content: string) {
         let lines = content.split("\n");
         for (let i = 0; i < lines.length; i++) {
-            if ((lines[i].length !== 0) && (lines[i].charAt(0) !== ' ')) {
+            if ((lines[i].length !== 0) && (lines[i].charAt(0) !== " ")) {
                 return content;
             }
         }
 
-        return lines.map(s => s.substr(1)).join('\n');
+        return lines.map(s => s.substr(1)).join("\n");
     }
 
     function parseTestData(basePath: string, contents: string, fileName: string): FourSlashData {
@@ -2386,7 +2386,7 @@ module FourSlash {
         // Split up the input file by line
         // Note: IE JS engine incorrectly handles consecutive delimiters here when using RegExp split, so
         // we have to string-based splitting instead and try to figure out the delimiting chars
-        let lines = contents.split('\n');
+        let lines = contents.split("\n");
 
         let markerPositions: MarkerMap = {};
         let markers: Marker[] = [];
@@ -2401,23 +2401,23 @@ module FourSlash {
             let line = lines[i];
             let lineLength = line.length;
 
-            if (lineLength > 0 && line.charAt(lineLength - 1) === '\r') {
+            if (lineLength > 0 && line.charAt(lineLength - 1) === "\r") {
                 line = line.substr(0, lineLength - 1);
             }
 
-            if (line.substr(0, 4) === '////') {
+            if (line.substr(0, 4) === "////") {
                 // Subfile content line
 
                 // Append to the current subfile content, inserting a newline needed
                 if (currentFileContent === null) {
-                    currentFileContent = '';
+                    currentFileContent = "";
                 } else {
                     // End-of-line
-                    currentFileContent = currentFileContent + '\n';
+                    currentFileContent = currentFileContent + "\n";
                 }
 
                 currentFileContent = currentFileContent + line.substr(4);
-            } else if (line.substr(0, 2) === '//') {
+            } else if (line.substr(0, 2) === "//") {
                 // Comment line, check for global/file @options and record them
                 let match = optionRegex.exec(line.substr(2));
                 if (match) {
@@ -2425,7 +2425,7 @@ module FourSlash {
                     let fileMetadataNamesIndex = fileMetadataNames.indexOf(match[1]);
                     if (globalMetadataNamesIndex === -1) {
                         if (fileMetadataNamesIndex === -1) {
-                            throw new Error('Unrecognized metadata name "' + match[1] + '". Available global metadata names are: ' + globalMetadataNames.join(', ') + '; file metadata names are: ' + fileMetadataNames.join(', '));
+                            throw new Error(`Unrecognized metadata name "${match[1]}". Available global metadata names are: ${globalMetadataNames.join(", ")}; file metadata names are: ${fileMetadataNames.join(", ")}`);
                         } else if (fileMetadataNamesIndex === fileMetadataNames.indexOf(metadataOptionNames.fileName)) {
                             // Found an @FileName directive, if this is not the first then create a new subfile
                             if (currentFileContent) {
@@ -2441,7 +2441,7 @@ module FourSlash {
                                 currentFileName = fileName;
                             }
 
-                            currentFileName = basePath + '/' + match[2];
+                            currentFileName = basePath + "/" + match[2];
                             currentFileOptions[match[1]] = match[2];
                         } else {
                             // Add other fileMetadata flag
@@ -2456,7 +2456,7 @@ module FourSlash {
                     }
                 }
             // TODO: should be '==='?
-            } else if (line == '' || lineLength === 0) {
+            } else if (line == "" || lineLength === 0) {
                 // Previously blank lines between fourslash content caused it to be considered as 2 files,
                 // Remove this behavior since it just causes errors now
             } else {
@@ -2576,7 +2576,7 @@ module FourSlash {
         content = chompLeadingSpace(content);
 
         // Any slash-star comment with a character not in this string is not a marker.
-        let validMarkerChars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz$1234567890_';
+        let validMarkerChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz$1234567890_";
 
         /// The file content (minus metacharacters) so far
         let output: string = "";
@@ -2711,7 +2711,7 @@ module FourSlash {
                             openMarker = null;
                             state = State.none;
                         } else if (validMarkerChars.indexOf(currentChar) < 0) {
-                            if (currentChar === '*' && i < content.length - 1 && content.charAt(i + 1) === '/') {
+                            if (currentChar === "*" && i < content.length - 1 && content.charAt(i + 1) === "/") {
                                 // The marker is about to be closed, ignore the 'invalid' char
                             } else {
                                 // We've hit a non-valid marker character, so we were actually in a block comment
@@ -2726,10 +2726,10 @@ module FourSlash {
                         break;
                 }
 
-                if (currentChar === '\n' && previousChar === '\r') {
+                if (currentChar === "\n" && previousChar === "\r") {
                     // Ignore trailing \n after a \r
                     continue;
-                } else if (currentChar === '\n' || currentChar === '\r') {
+                } else if (currentChar === "\n" || currentChar === "\r") {
                     line++;
                     column = 1;
                     continue;

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2497,7 +2497,7 @@ module FourSlash {
     }
 
     function containTSConfigJson(files: FourSlashFile[]): boolean {
-        return ts.forEach(files, f => f.fileOptions['Filename'] === 'tsconfig.json');
+        return ts.forEach(files, f => f.fileOptions["Filename"] === "tsconfig.json");
     }
 
     function getNonFileNameOptionInFileList(files: FourSlashFile[]): string {

--- a/src/harness/fourslashRunner.ts
+++ b/src/harness/fourslashRunner.ts
@@ -1,6 +1,6 @@
-///<reference path='fourslash.ts' />
-///<reference path='harness.ts'/>
-///<reference path='runnerbase.ts' />
+///<reference path="fourslash.ts" />
+///<reference path="harness.ts"/>
+///<reference path="runnerbase.ts" />
 
 const enum FourSlashTestType {
     Native,
@@ -16,16 +16,16 @@ class FourSlashRunner extends RunnerBase {
         super();
         switch (testType) {
             case FourSlashTestType.Native:
-                this.basePath = 'tests/cases/fourslash';
-                this.testSuiteName = 'fourslash';
+                this.basePath = "tests/cases/fourslash";
+                this.testSuiteName = "fourslash";
                 break;
             case FourSlashTestType.Shims:
-                this.basePath = 'tests/cases/fourslash/shims';
-                this.testSuiteName = 'fourslash-shims';
+                this.basePath = "tests/cases/fourslash/shims";
+                this.testSuiteName = "fourslash-shims";
                 break;
             case FourSlashTestType.Server:
-                this.basePath = 'tests/cases/fourslash/server';
-                this.testSuiteName = 'fourslash-server';
+                this.basePath = "tests/cases/fourslash/server";
+                this.testSuiteName = "fourslash-server";
                 break;
         }
     }
@@ -35,25 +35,25 @@ class FourSlashRunner extends RunnerBase {
             this.tests = this.enumerateFiles(this.basePath, /\.ts/i, { recursive: false });
         }
 
-        describe(this.testSuiteName + ' tests', () => {
+        describe(this.testSuiteName + " tests", () => {
             this.tests.forEach((fn: string) => {
                  describe(fn, () => {
                        fn = ts.normalizeSlashes(fn);
-                        let justName = fn.replace(/^.*[\\\/]/, '');
+                        let justName = fn.replace(/^.*[\\\/]/, "");
 
                         // Convert to relative path
-                        let testIndex = fn.indexOf('tests/');
+                        let testIndex = fn.indexOf("tests/");
                         if (testIndex >= 0) fn = fn.substr(testIndex);
 
                         if (justName && !justName.match(/fourslash\.ts$/i) && !justName.match(/\.d\.ts$/i)) {
-                            it(this.testSuiteName + ' test ' + justName + ' runs correctly', () => {
+                            it(this.testSuiteName + " test " + justName + " runs correctly", () => {
                                 FourSlash.runFourSlashTest(this.basePath, this.testType, fn);
                         });
                     }
                 });
             });
 
-            describe('Generate Tao XML', () => {
+            describe("Generate Tao XML", () => {
                 let invalidReasons: any = {};
                 FourSlash.xmlData.forEach(xml => {
                     if (xml.invalidReason !== null) {
@@ -69,37 +69,37 @@ class FourSlashRunner extends RunnerBase {
                 invalidReport.sort((lhs, rhs) => lhs.count > rhs.count ? -1 : lhs.count === rhs.count ? 0 : 1);
 
                 let lines: string[] = [];
-                lines.push('<!-- Blocked Test Report');
+                lines.push("<!-- Blocked Test Report");
                 invalidReport.forEach((reasonAndCount) => {
-                    lines.push(reasonAndCount.count + ' tests blocked by ' + reasonAndCount.reason);
+                    lines.push(reasonAndCount.count + " tests blocked by " + reasonAndCount.reason);
                 });
-                lines.push('-->');
-                lines.push('<TaoTest xmlns="http://microsoft.com/schemas/VSLanguages/TAO">');
-                lines.push('    <InitTest>');
-                lines.push('        <StartTarget />');
-                lines.push('    </InitTest>');
-                lines.push('    <ScenarioList>');
+                lines.push("-->");
+                lines.push("<TaoTest xmlns=\"http://microsoft.com/schemas/VSLanguages/TAO\">");
+                lines.push("    <InitTest>");
+                lines.push("        <StartTarget />");
+                lines.push("    </InitTest>");
+                lines.push("    <ScenarioList>");
                 FourSlash.xmlData.forEach(xml => {
                     if (xml.invalidReason !== null) {
-                        lines.push('<!-- Skipped ' + xml.originalName + ', reason: ' + xml.invalidReason + ' -->');
+                        lines.push("<!-- Skipped " + xml.originalName + ", reason: " + xml.invalidReason + " -->");
                     } else {
-                        lines.push('        <Scenario Name="' + xml.originalName + '">');
+                        lines.push("        <Scenario Name=\"" + xml.originalName + "\">");
                         xml.actions.forEach(action => {
-                            lines.push('            ' + action);
+                            lines.push("            " + action);
                         });
-                        lines.push('        </Scenario>');
+                        lines.push("        </Scenario>");
                     }
                 });
-                lines.push('    </ScenarioList>');
-                lines.push('    <CleanupScenario>');
-                lines.push('        <CloseAllDocuments />');
-                lines.push('        <CleanupCreatedFiles />');
-                lines.push('    </CleanupScenario>');
-                lines.push('    <CleanupTest>');
-                lines.push('        <CloseTarget />');
-                lines.push('    </CleanupTest>');
-                lines.push('</TaoTest>');
-                Harness.IO.writeFile('built/local/fourslash.xml', lines.join('\r\n'));
+                lines.push("    </ScenarioList>");
+                lines.push("    <CleanupScenario>");
+                lines.push("        <CloseAllDocuments />");
+                lines.push("        <CleanupCreatedFiles />");
+                lines.push("    </CleanupScenario>");
+                lines.push("    <CleanupTest>");
+                lines.push("        <CloseTarget />");
+                lines.push("    </CleanupTest>");
+                lines.push("</TaoTest>");
+                Harness.IO.writeFile("built/local/fourslash.xml", lines.join("\r\n"));
             });
         });
     }
@@ -108,6 +108,6 @@ class FourSlashRunner extends RunnerBase {
 class GeneratedFourslashRunner extends FourSlashRunner {
     constructor(testType: FourSlashTestType) {
         super(testType);
-        this.basePath += '/generated/';
+        this.basePath += "/generated/";
     }
 }

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -24,6 +24,8 @@
 /// <reference path='sourceMapRecorder.ts'/>
 /// <reference path='runnerbase.ts'/>
 
+// Block scoped definitions work poorly for global variables, temporarily enable var
+/* tslint:disable:no-var-keyword */
 var Buffer: BufferConstructor = require('buffer').Buffer;
 
 // this will work in the browser via browserify
@@ -32,6 +34,7 @@ var assert: typeof _chai.assert = _chai.assert;
 var expect: typeof _chai.expect = _chai.expect;
 declare var __dirname: string; // Node-specific
 var global = <any>Function("return this").call(null);
+/* tslint:enable:no-var-keyword */
 
 module Utils {
     // Setup some globals based on the current environment
@@ -412,6 +415,7 @@ module Harness {
         log(text: string): void;
         getMemoryUsage?(): number;
     }
+    export var IO: IO;
 
     module IOImpl {
         declare class Enumerator {
@@ -690,7 +694,6 @@ module Harness {
         }
     }
 
-    export var IO: IO;
     switch (Utils.getExecutionEnvironment()) {
         case Utils.ExecutionEnvironment.CScript:
             IO = IOImpl.CScript;

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -14,22 +14,22 @@
 // limitations under the License.
 //
 
-/// <reference path='..\services\services.ts' />
-/// <reference path='..\services\shims.ts' />
-/// <reference path='..\server\session.ts' />
-/// <reference path='..\server\client.ts' />
-/// <reference path='..\server\node.d.ts' />
-/// <reference path='external\mocha.d.ts'/>
-/// <reference path='external\chai.d.ts'/>
-/// <reference path='sourceMapRecorder.ts'/>
-/// <reference path='runnerbase.ts'/>
+/// <reference path="..\services\services.ts" />
+/// <reference path="..\services\shims.ts" />
+/// <reference path="..\server\session.ts" />
+/// <reference path="..\server\client.ts" />
+/// <reference path="..\server\node.d.ts" />
+/// <reference path="external\mocha.d.ts"/>
+/// <reference path="external\chai.d.ts"/>
+/// <reference path="sourceMapRecorder.ts"/>
+/// <reference path="runnerbase.ts"/>
 
 // Block scoped definitions work poorly for global variables, temporarily enable var
 /* tslint:disable:no-var-keyword */
-var Buffer: BufferConstructor = require('buffer').Buffer;
+var Buffer: BufferConstructor = require("buffer").Buffer;
 
 // this will work in the browser via browserify
-var _chai: typeof chai = require('chai');
+var _chai: typeof chai = require("chai");
 var assert: typeof _chai.assert = _chai.assert;
 var expect: typeof _chai.expect = _chai.expect;
 declare var __dirname: string; // Node-specific
@@ -66,7 +66,7 @@ module Utils {
                 eval(fileContents);
                 break;
             case ExecutionEnvironment.Node:
-                let vm = require('vm');
+                let vm = require("vm");
                 if (nodeContext) {
                     vm.runInNewContext(fileContents, nodeContext, fileName);
                 } else {
@@ -74,7 +74,7 @@ module Utils {
                 }
                 break;
             default:
-                throw new Error('Unknown context');
+                throw new Error("Unknown context");
         }
     }
 
@@ -83,9 +83,9 @@ module Utils {
         // Split up the input file by line
         // Note: IE JS engine incorrectly handles consecutive delimiters here when using RegExp split, so
         // we have to use string-based splitting instead and try to figure out the delimiting chars
-        let lines = content.split('\r\n');
+        let lines = content.split("\r\n");
         if (lines.length === 1) {
-            lines = content.split('\n');
+            lines = content.split("\n");
 
             if (lines.length === 1) {
                 lines = content.split("\r");
@@ -96,7 +96,7 @@ module Utils {
 
     /** Reads a file under /tests */
     export function readTestFile(path: string) {
-        if (path.indexOf('tests') < 0) {
+        if (path.indexOf("tests") < 0) {
             path = "tests/" + path;
         }
 
@@ -391,7 +391,7 @@ module Utils {
 
 module Harness.Path {
     export function getFileName(fullPath: string) {
-        return fullPath.replace(/^.*[\\\/]/, '');
+        return fullPath.replace(/^.*[\\\/]/, "");
     }
 
     export function filePath(fullPath: string) {
@@ -488,8 +488,8 @@ module Harness {
             declare let require: any;
             let fs: any, pathModule: any;
             if (require) {
-                fs = require('fs');
-                pathModule = require('path');
+                fs = require("fs");
+                pathModule = require("path");
             } else {
                 fs = pathModule = {};
             }
@@ -563,8 +563,8 @@ module Harness {
             let serverRoot = "http://localhost:8888/";
 
             // Unused?
-            let newLine = '\r\n';
-            let currentDirectory = () => '';
+            let newLine = "\r\n";
+            let currentDirectory = () => "";
             let supportsCodePage = () => false;
 
             module Http {
@@ -610,9 +610,9 @@ module Harness {
                 export function writeToServerSync(url: string, action: string, contents?: string): XHRResponse {
                     let xhr = new XMLHttpRequest();
                     try {
-                        let actionMsg = '?action=' + action;
-                        xhr.open('POST', url + actionMsg, false);
-                        xhr.setRequestHeader('Access-Control-Allow-Origin', '*');
+                        let actionMsg = "?action=" + action;
+                        xhr.open("POST", url + actionMsg, false);
+                        xhr.setRequestHeader("Access-Control-Allow-Origin", "*");
                         xhr.send(contents);
                     }
                     catch (e) {
@@ -628,7 +628,7 @@ module Harness {
             }
 
             export function deleteFile(path: string) {
-                Http.writeToServerSync(serverRoot + path, 'DELETE', null);
+                Http.writeToServerSync(serverRoot + path, "DELETE", null);
             }
 
             export function directoryExists(path: string): boolean {
@@ -641,15 +641,15 @@ module Harness {
                 if (dirPath.match(/localhost:\d+$/) || dirPath.match(/localhost:\d+\/$/)) {
                     dirPath = null;
                     // path + fileName
-                } else if (dirPath.indexOf('.') === -1) {
-                    dirPath = dirPath.substring(0, dirPath.lastIndexOf('/'));
+                } else if (dirPath.indexOf(".") === -1) {
+                    dirPath = dirPath.substring(0, dirPath.lastIndexOf("/"));
                     // path
                 } else {
                     // strip any trailing slash
                     if (dirPath.match(/.*\/$/)) {
                         dirPath = dirPath.substring(0, dirPath.length - 2);
                     }
-                    dirPath = dirPath.substring(0, dirPath.lastIndexOf('/'));
+                    dirPath = dirPath.substring(0, dirPath.lastIndexOf("/"));
                 }
 
                 return dirPath;
@@ -664,7 +664,7 @@ module Harness {
             export function _listFilesImpl(path: string, spec?: RegExp, options?: any) {
                 let response = Http.getFileFromServerSync(serverRoot + path);
                 if (response.status === 200) {
-                    let results = response.responseText.split(',');
+                    let results = response.responseText.split(",");
                     if (spec) {
                         return results.filter(file => spec.test(file));
                     } else {
@@ -672,7 +672,7 @@ module Harness {
                     }
                 }
                 else {
-                    return [''];
+                    return [""];
                 }
             };
             export let listFiles = Utils.memoize(_listFilesImpl);
@@ -689,7 +689,7 @@ module Harness {
             }
 
             export function writeFile(path: string, contents: string) {
-                Http.writeToServerSync(serverRoot + path, 'WRITE', contents);
+                Http.writeToServerSync(serverRoot + path, "WRITE", contents);
             }
         }
     }
@@ -725,7 +725,7 @@ module Harness {
             tcServicesFileName = "built/local/typescriptServices.js";
             break;
         default:
-            throw new Error('Unknown context');
+            throw new Error("Unknown context");
     }
     export let tcServicesFile = IO.readFile(tcServicesFileName);
 
@@ -748,12 +748,12 @@ module Harness {
 
             public Write(str: string) {
                 // out of memory usage concerns avoid using + or += if we're going to do any manipulation of this string later
-                this.currentLine = [(this.currentLine || ''), str].join('');
+                this.currentLine = [(this.currentLine || ""), str].join("");
             }
 
             public WriteLine(str: string) {
                 // out of memory usage concerns avoid using + or += if we're going to do any manipulation of this string later
-                this.lines.push([(this.currentLine || ''), str].join(''));
+                this.lines.push([(this.currentLine || ""), str].join(""));
                 this.currentLine = undefined;
             }
 
@@ -802,7 +802,7 @@ module Harness {
                     if (this.fileCollection.hasOwnProperty(p)) {
                         let current = <Harness.Compiler.WriterAggregator>this.fileCollection[p];
                         if (current.lines.length > 0) {
-                            if (p.indexOf('.d.ts') !== -1) { current.lines.unshift(['////[', Path.getFileName(p), ']'].join('')); }
+                            if (p.indexOf(".d.ts") !== -1) { current.lines.unshift(["////[", Path.getFileName(p), "]"].join("")); }
                             result.push({ fileName: p, file: this.fileCollection[p] });
                         }
                     }
@@ -831,12 +831,12 @@ module Harness {
         const carriageReturnLineFeed = "\r\n";
         const lineFeed = "\n";
 
-        export let defaultLibFileName = 'lib.d.ts';
-        export let defaultLibSourceFile = createSourceFileAndAssertInvariants(defaultLibFileName, IO.readFile(libFolder + 'lib.core.d.ts'), /*languageVersion*/ ts.ScriptTarget.Latest);
-        export let defaultES6LibSourceFile = createSourceFileAndAssertInvariants(defaultLibFileName, IO.readFile(libFolder + 'lib.core.es6.d.ts'), /*languageVersion*/ ts.ScriptTarget.Latest);
+        export let defaultLibFileName = "lib.d.ts";
+        export let defaultLibSourceFile = createSourceFileAndAssertInvariants(defaultLibFileName, IO.readFile(libFolder + "lib.core.d.ts"), /*languageVersion*/ ts.ScriptTarget.Latest);
+        export let defaultES6LibSourceFile = createSourceFileAndAssertInvariants(defaultLibFileName, IO.readFile(libFolder + "lib.core.es6.d.ts"), /*languageVersion*/ ts.ScriptTarget.Latest);
 
         // Cache these between executions so we don't have to re-parse them for every test
-        export let fourslashFileName = 'fourslash.ts';
+        export let fourslashFileName = "fourslash.ts";
         export let fourslashSourceFile: ts.SourceFile;
 
         export function getCanonicalFileName(fileName: string): string {
@@ -886,7 +886,7 @@ module Harness {
                         return Object.prototype.hasOwnProperty.call(filemap, getCanonicalFileName(canonicalAbsolutePath)) ? filemap[canonicalAbsolutePath] : undefined;
                     }
                     else if (fn === fourslashFileName) {
-                        let tsFn = 'tests/cases/fourslash/' + fourslashFileName;
+                        let tsFn = "tests/cases/fourslash/" + fourslashFileName;
                         fourslashSourceFile = fourslashSourceFile || createSourceFileAndAssertInvariants(tsFn, Harness.IO.readFile(tsFn), scriptTarget);
                         return fourslashSourceFile;
                     }
@@ -977,7 +977,7 @@ module Harness {
                     settingsCallback(null);
                 }
 
-                let newLine = '\r\n';
+                let newLine = "\r\n";
                 options.skipDefaultLibCheck = true;
 
                 // Files from built\local that are requested by test "@includeBuiltFiles" to be in the context.
@@ -1014,19 +1014,19 @@ module Harness {
                         // "fileName", "comments", "declaration", "module", "nolib", "sourcemap", "target", "out", "outdir", "noimplicitany", "noresolve"
                         case "module":
                         case "modulegentarget":
-                            if (typeof setting.value === 'string') {
-                                if (setting.value.toLowerCase() === 'amd') {
+                            if (typeof setting.value === "string") {
+                                if (setting.value.toLowerCase() === "amd") {
                                     options.module = ts.ModuleKind.AMD;
-                                } else if (setting.value.toLowerCase() === 'umd') {
+                                } else if (setting.value.toLowerCase() === "umd") {
                                     options.module = ts.ModuleKind.UMD;
-                                } else if (setting.value.toLowerCase() === 'commonjs') {
+                                } else if (setting.value.toLowerCase() === "commonjs") {
                                     options.module = ts.ModuleKind.CommonJS;
-                                } else if (setting.value.toLowerCase() === 'system') {
+                                } else if (setting.value.toLowerCase() === "system") {
                                     options.module = ts.ModuleKind.System;
-                                } else if (setting.value.toLowerCase() === 'unspecified') {
+                                } else if (setting.value.toLowerCase() === "unspecified") {
                                     options.module = ts.ModuleKind.None;
                                 } else {
-                                    throw new Error('Unknown module type ' + setting.value);
+                                    throw new Error("Unknown module type " + setting.value);
                                 }
                             } else {
                                 options.module = <any>setting.value;
@@ -1034,152 +1034,152 @@ module Harness {
                             break;
 
                         case "target":
-                        case 'codegentarget':
-                            if (typeof setting.value === 'string') {
-                                if (setting.value.toLowerCase() === 'es3') {
+                        case "codegentarget":
+                            if (typeof setting.value === "string") {
+                                if (setting.value.toLowerCase() === "es3") {
                                     options.target = ts.ScriptTarget.ES3;
-                                } else if (setting.value.toLowerCase() === 'es5') {
+                                } else if (setting.value.toLowerCase() === "es5") {
                                     options.target = ts.ScriptTarget.ES5;
-                                } else if (setting.value.toLowerCase() === 'es6') {
+                                } else if (setting.value.toLowerCase() === "es6") {
                                     options.target = ts.ScriptTarget.ES6;
                                 } else {
-                                    throw new Error('Unknown compile target ' + setting.value);
+                                    throw new Error("Unknown compile target " + setting.value);
                                 }
                             } else {
                                 options.target = <any>setting.value;
                             }
                             break;
                             
-                        case 'experimentaldecorators':
-                            options.experimentalDecorators = setting.value === 'true';
+                        case "experimentaldecorators":
+                            options.experimentalDecorators = setting.value === "true";
                             break;
 
-                        case 'emitdecoratormetadata':
-                            options.emitDecoratorMetadata = setting.value === 'true';
+                        case "emitdecoratormetadata":
+                            options.emitDecoratorMetadata = setting.value === "true";
                             break;
                             
-                        case 'experimentalasyncfunctions':
-                            options.experimentalAsyncFunctions = setting.value === 'true';
+                        case "experimentalasyncfunctions":
+                            options.experimentalAsyncFunctions = setting.value === "true";
                             break;
 
-                        case 'noemithelpers':
-                            options.noEmitHelpers = setting.value === 'true';
+                        case "noemithelpers":
+                            options.noEmitHelpers = setting.value === "true";
                             break;
 
-                        case 'noemitonerror':
-                            options.noEmitOnError = setting.value === 'true';
+                        case "noemitonerror":
+                            options.noEmitOnError = setting.value === "true";
                             break;
 
-                        case 'noresolve':
-                            options.noResolve = setting.value === 'true';
+                        case "noresolve":
+                            options.noResolve = setting.value === "true";
                             break;
 
-                        case 'noimplicitany':
-                            options.noImplicitAny = setting.value === 'true';
+                        case "noimplicitany":
+                            options.noImplicitAny = setting.value === "true";
                             break;
 
-                        case 'nolib':
-                            options.noLib = setting.value === 'true';
+                        case "nolib":
+                            options.noLib = setting.value === "true";
                             break;
 
-                        case 'out':
-                        case 'outfileoption':
+                        case "out":
+                        case "outfileoption":
                             options.out = setting.value;
                             break;
 
-                        case 'outdiroption':
-                        case 'outdir':
+                        case "outdiroption":
+                        case "outdir":
                             options.outDir = setting.value;
                             break;
 
-                        case 'skipdefaultlibcheck':
+                        case "skipdefaultlibcheck":
                             options.skipDefaultLibCheck = setting.value === "true";
                             break;
 
-                        case 'sourceroot':
+                        case "sourceroot":
                             options.sourceRoot = setting.value;
                             break;
 
-                        case 'maproot':
+                        case "maproot":
                             options.mapRoot = setting.value;
                             break;
 
-                        case 'sourcemap':
-                            options.sourceMap = setting.value === 'true';
+                        case "sourcemap":
+                            options.sourceMap = setting.value === "true";
                             break;
 
-                        case 'declaration':
-                            options.declaration = setting.value === 'true';
+                        case "declaration":
+                            options.declaration = setting.value === "true";
                             break;
 
-                        case 'newline':
-                            if (setting.value.toLowerCase() === 'crlf') {
+                        case "newline":
+                            if (setting.value.toLowerCase() === "crlf") {
                                 options.newLine = ts.NewLineKind.CarriageReturnLineFeed;
                             }
-                            else if (setting.value.toLowerCase() === 'lf') {
+                            else if (setting.value.toLowerCase() === "lf") {
                                 options.newLine = ts.NewLineKind.LineFeed;
                             }
                             else {
-                                throw new Error('Unknown option for newLine: ' + setting.value);
+                                throw new Error("Unknown option for newLine: " + setting.value);
                             }
                             break;
 
-                        case 'comments':
-                            options.removeComments = setting.value === 'false';
+                        case "comments":
+                            options.removeComments = setting.value === "false";
                             break;
 
-                        case 'stripinternal':
-                            options.stripInternal = setting.value === 'true';
+                        case "stripinternal":
+                            options.stripInternal = setting.value === "true";
 
-                        case 'usecasesensitivefilenames':
-                            useCaseSensitiveFileNames = setting.value === 'true';
+                        case "usecasesensitivefilenames":
+                            useCaseSensitiveFileNames = setting.value === "true";
                             break;
 
-                        case 'filename':
+                        case "filename":
                             // Not supported yet
                             break;
 
-                        case 'emitbom':
-                            options.emitBOM = setting.value === 'true';
+                        case "emitbom":
+                            options.emitBOM = setting.value === "true";
                             break;
 
-                        case 'errortruncation':
-                            options.noErrorTruncation = setting.value === 'false';
+                        case "errortruncation":
+                            options.noErrorTruncation = setting.value === "false";
                             break;
 
-                        case 'preserveconstenums':
-                            options.preserveConstEnums = setting.value === 'true';
+                        case "preserveconstenums":
+                            options.preserveConstEnums = setting.value === "true";
                             break;
 
-                        case 'isolatedmodules':
-                            options.isolatedModules = setting.value === 'true';
+                        case "isolatedmodules":
+                            options.isolatedModules = setting.value === "true";
                             break;
 
-                        case 'suppressimplicitanyindexerrors':
-                            options.suppressImplicitAnyIndexErrors = setting.value === 'true';
+                        case "suppressimplicitanyindexerrors":
+                            options.suppressImplicitAnyIndexErrors = setting.value === "true";
                             break;
 
-                        case 'includebuiltfile':
+                        case "includebuiltfile":
                             let builtFileName = libFolder + setting.value;
                             includeBuiltFiles.push({ unitName: builtFileName, content: normalizeLineEndings(IO.readFile(builtFileName), newLine) });
                             break;
 
-                        case 'inlinesourcemap':
-                            options.inlineSourceMap = setting.value === 'true';
+                        case "inlinesourcemap":
+                            options.inlineSourceMap = setting.value === "true";
                             break;
 
-                        case 'inlinesources':
-                            options.inlineSources = setting.value === 'true';
+                        case "inlinesources":
+                            options.inlineSources = setting.value === "true";
                             break;
 
-                        case 'jsx':
-                            options.jsx = setting.value.toLowerCase() === 'react' ? ts.JsxEmit.React :
-                                          setting.value.toLowerCase() === 'preserve' ? ts.JsxEmit.Preserve :
+                        case "jsx":
+                            options.jsx = setting.value.toLowerCase() === "react" ? ts.JsxEmit.React :
+                                          setting.value.toLowerCase() === "preserve" ? ts.JsxEmit.Preserve :
                                           ts.JsxEmit.None;
                             break;
 
                         default:
-                            throw new Error('Unsupported compiler setting ' + setting.flag);
+                            throw new Error("Unsupported compiler setting " + setting.flag);
                     }
                 }
             }
@@ -1192,7 +1192,7 @@ module Harness {
                 // Current directory is needed for rwcRunner to be able to use currentDirectory defined in json file
                 currentDirectory?: string) {
                 if (options.declaration && result.errors.length === 0 && result.declFilesCode.length !== result.files.length) {
-                    throw new Error('There were no errors and declFiles generated did not match number of js files generated');
+                    throw new Error("There were no errors and declFiles generated did not match number of js files generated");
                 }
 
                 let declInputFiles: { unitName: string; content: string }[] = [];
@@ -1253,8 +1253,8 @@ module Harness {
         }
 
         function normalizeLineEndings(text: string, lineEnding: string): string {
-            let normalized = text.replace(/\r\n?/g, '\n');
-            if (lineEnding !== '\n') {
+            let normalized = text.replace(/\r\n?/g, "\n");
+            if (lineEnding !== "\n") {
                 normalized = normalized.replace(/\n/g, lineEnding);
             }
             return normalized;
@@ -1285,10 +1285,10 @@ module Harness {
                 let message = ts.flattenDiagnosticMessageText(error.messageText, ts.sys.newLine);
 
                 let errLines = RunnerBase.removeFullPaths(message)
-                    .split('\n')
-                    .map(s => s.length > 0 && s.charAt(s.length - 1) === '\r' ? s.substr(0, s.length - 1) : s)
+                    .split("\n")
+                    .map(s => s.length > 0 && s.charAt(s.length - 1) === "\r" ? s.substr(0, s.length - 1) : s)
                     .filter(s => s.length > 0)
-                    .map(s => '!!! ' + ts.DiagnosticCategory[error.category].toLowerCase() + " TS" + error.code + ": " + s);
+                    .map(s => "!!! " + ts.DiagnosticCategory[error.category].toLowerCase() + " TS" + error.code + ": " + s);
                 errLines.forEach(e => outputLines.push(e));
 
                 totalErrorsReported++;
@@ -1308,7 +1308,7 @@ module Harness {
 
 
                 // Header
-                outputLines.push('==== ' + inputFile.unitName + ' (' + fileErrors.length + ' errors) ====');
+                outputLines.push("==== " + inputFile.unitName + " (" + fileErrors.length + " errors) ====");
 
                 // Make sure we emit something for every error
                 let markedErrorCount = 0;
@@ -1317,13 +1317,13 @@ module Harness {
                 // we have to string-based splitting instead and try to figure out the delimiting chars
 
                 let lineStarts = ts.computeLineStarts(inputFile.content);
-                let lines = inputFile.content.split('\n');
+                let lines = inputFile.content.split("\n");
                 if (lines.length === 1) {
                     lines = lines[0].split("\r");
                 }
 
                 lines.forEach((line, lineIndex) => {
-                    if (line.length > 0 && line.charAt(line.length - 1) === '\r') {
+                    if (line.length > 0 && line.charAt(line.length - 1) === "\r") {
                         line = line.substr(0, line.length - 1);
                     }
 
@@ -1336,7 +1336,7 @@ module Harness {
                         nextLineStart = lineStarts[lineIndex + 1];
                     }
                     // Emit this line from the original file
-                    outputLines.push('    ' + line);
+                    outputLines.push("    " + line);
                     fileErrors.forEach(err => {
                         // Does any error start or continue on to this line? Emit squiggles
                         let end = ts.textSpanEnd(err);
@@ -1348,7 +1348,7 @@ module Harness {
                             // Calculate the start of the squiggle
                             let squiggleStart = Math.max(0, relativeOffset);
                             // TODO/REVIEW: this doesn't work quite right in the browser if a multi file test has files whose names are just the right length relative to one another
-                            outputLines.push('    ' + line.substr(0, squiggleStart).replace(/[^\s]/g, ' ') + new Array(Math.min(length, line.length - squiggleStart) + 1).join('~'));
+                            outputLines.push("    " + line.substr(0, squiggleStart).replace(/[^\s]/g, " ") + new Array(Math.min(length, line.length - squiggleStart) + 1).join("~"));
 
                             // If the error ended here, or we're at the end of the file, emit its message
                             if ((lineIndex === lines.length - 1) || nextLineStart > end) {
@@ -1363,7 +1363,7 @@ module Harness {
                 });
 
                 // Verify we didn't miss any errors in this file
-                assert.equal(markedErrorCount, fileErrors.length, 'count of errors in ' + inputFile.unitName);
+                assert.equal(markedErrorCount, fileErrors.length, "count of errors in " + inputFile.unitName);
             });
 
             let numLibraryDiagnostics = ts.countWhere(diagnostics, diagnostic => {
@@ -1376,10 +1376,10 @@ module Harness {
             });
 
             // Verify we didn't miss any errors in total
-            assert.equal(totalErrorsReported + numLibraryDiagnostics + numTest262HarnessDiagnostics, diagnostics.length, 'total number of errors');
+            assert.equal(totalErrorsReported + numLibraryDiagnostics + numTest262HarnessDiagnostics, diagnostics.length, "total number of errors");
 
             return minimalDiagnosticsToString(diagnostics) +
-                ts.sys.newLine + ts.sys.newLine + outputLines.join('\r\n');
+                ts.sys.newLine + ts.sys.newLine + outputLines.join("\r\n");
         }
 
         export function collateOutputs(outputFiles: Harness.Compiler.GeneratedFile[]): string {
@@ -1387,15 +1387,15 @@ module Harness {
             outputFiles.sort((a, b) => cleanName(a.fileName).localeCompare(cleanName(b.fileName)));
 
             // Emit them
-            let result = '';
+            let result = "";
             for (let outputFile of outputFiles) {
                 // Some extra spacing if this isn't the first file
                 if (result.length) {
-                    result += '\r\n\r\n';
+                    result += "\r\n\r\n";
                 }
 
                 // FileName header + content
-                result += '/*====== ' + outputFile.fileName + ' ======*/\r\n';
+                result += "/*====== " + outputFile.fileName + " ======*/\r\n";
                 
                 result += outputFile.code;
             }
@@ -1403,7 +1403,7 @@ module Harness {
             return result;
 
             function cleanName(fn: string) {
-                let lastSlash = ts.normalizeSlashes(fn).lastIndexOf('/');
+                let lastSlash = ts.normalizeSlashes(fn).lastIndexOf("/");
                 return fn.substr(lastSlash + 1).toLowerCase();
             }
         }
@@ -1421,7 +1421,7 @@ module Harness {
         // This does not need to exist strictly speaking, but many tests will need to be updated if it's removed
         export function compileString(code: string, unitName: string, callback: (result: CompilerResult) => void) {
             // NEWTODO: Re-implement 'compileString'
-            throw new Error('compileString NYI');
+            throw new Error("compileString NYI");
         }
 
         export interface GeneratedFile {
@@ -1435,26 +1435,26 @@ module Harness {
         }
 
         export function isTS(fileName: string) {
-            return stringEndsWith(fileName, '.ts');
+            return stringEndsWith(fileName, ".ts");
         }
 
         export function isTSX(fileName: string) {
-            return stringEndsWith(fileName, '.tsx');
+            return stringEndsWith(fileName, ".tsx");
         }
 
         export function isDTS(fileName: string) {
-            return stringEndsWith(fileName, '.d.ts');
+            return stringEndsWith(fileName, ".d.ts");
         }
 
         export function isJS(fileName: string) {
-            return stringEndsWith(fileName, '.js');
+            return stringEndsWith(fileName, ".js");
         }
         export function isJSX(fileName: string) {
-            return stringEndsWith(fileName, '.jsx');
+            return stringEndsWith(fileName, ".jsx");
         }
 
         export function isJSMap(fileName: string) {
-            return stringEndsWith(fileName, '.js.map') || stringEndsWith(fileName, '.jsx.map');
+            return stringEndsWith(fileName, ".js.map") || stringEndsWith(fileName, ".jsx.map");
         }
 
         /** Contains the code and errors of a compilation and some helper methods to check its status. */
@@ -1481,7 +1481,7 @@ module Harness {
                         this.sourceMaps.push(emittedFile);
                     }
                     else {
-                        throw new Error('Unrecognized file extension for file ' + emittedFile.fileName);
+                        throw new Error("Unrecognized file extension for file " + emittedFile.fileName);
                     }
                 });
 
@@ -1590,10 +1590,10 @@ module Harness {
                     // Subfile content line
                     // Append to the current subfile content, inserting a newline needed
                     if (currentFileContent === null) {
-                        currentFileContent = '';
+                        currentFileContent = "";
                     } else {
                         // End-of-line
-                        currentFileContent = currentFileContent + '\n';
+                        currentFileContent = currentFileContent + "\n";
                     }
                     currentFileContent = currentFileContent + line;
                 }
@@ -1604,7 +1604,7 @@ module Harness {
 
             // EOF, push whatever remains
             let newTestFile2 = {
-                content: currentFileContent || '',
+                content: currentFileContent || "",
                 name: currentFileName,
                 fileOptions: currentFileOptions,
                 originalFilePath: fileName,
@@ -1626,27 +1626,27 @@ module Harness {
 
         export function localPath(fileName: string, baselineFolder?: string, subfolder?: string) {
             if (baselineFolder === undefined) {
-                return baselinePath(fileName, 'local', 'tests/baselines', subfolder);
+                return baselinePath(fileName, "local", "tests/baselines", subfolder);
             }
             else {
-                return baselinePath(fileName, 'local', baselineFolder, subfolder);
+                return baselinePath(fileName, "local", baselineFolder, subfolder);
             }
         }
 
         function referencePath(fileName: string, baselineFolder?: string, subfolder?: string) {
             if (baselineFolder === undefined) {
-                return baselinePath(fileName, 'reference', 'tests/baselines', subfolder);
+                return baselinePath(fileName, "reference", "tests/baselines", subfolder);
             }
             else {
-                return baselinePath(fileName, 'reference', baselineFolder, subfolder);
+                return baselinePath(fileName, "reference", baselineFolder, subfolder);
             }
         }
 
         function baselinePath(fileName: string, type: string, baselineFolder: string, subfolder?: string) {
             if (subfolder !== undefined) {
-                return Harness.userSpecifiedRoot + baselineFolder + '/' +  subfolder + '/' + type + '/' + fileName;
+                return Harness.userSpecifiedRoot + baselineFolder + "/" +  subfolder + "/" + type + "/" + fileName;
             } else {
-                return Harness.userSpecifiedRoot + baselineFolder + '/'  + type + '/' + fileName;
+                return Harness.userSpecifiedRoot + baselineFolder + "/"  + type + "/" + fileName;
             }
         }
 
@@ -1680,7 +1680,7 @@ module Harness {
             let actual = generateContent();
 
             if (actual === undefined) {
-                throw new Error('The generated content was "undefined". Return "null" if no baselining is required."');
+                throw new Error("The generated content was \"undefined\". Return \"null\" if no baselining is required.\"");
             }
 
             // Store the content in the 'local' folder so we
@@ -1703,10 +1703,10 @@ module Harness {
             let refFileName = referencePath(relativeFileName, opts && opts.Baselinefolder, opts && opts.Subfolder);
 
             if (actual === null) {
-                actual = '<no content>';
+                actual = "<no content>";
             }
 
-            let expected = '<no content>';
+            let expected = "<no content>";
             if (IO.fileExists(refFileName)) {
                 expected = IO.readFile(refFileName);
             }
@@ -1715,10 +1715,10 @@ module Harness {
         }
 
         function writeComparison(expected: string, actual: string, relativeFileName: string, actualFileName: string, descriptionForDescribe: string) {
-            let encoded_actual = (new Buffer(actual)).toString('utf8');
+            let encoded_actual = (new Buffer(actual)).toString("utf8");
             if (expected != encoded_actual) {
                 // Overwrite & issue error
-                let errMsg = 'The baseline file ' + relativeFileName + ' has changed';
+                let errMsg = "The baseline file " + relativeFileName + " has changed";
                 throw new Error(errMsg);
             }
         }
@@ -1747,7 +1747,7 @@ module Harness {
     }
 
     export function isLibraryFile(filePath: string): boolean {
-        return (Path.getFileName(filePath) === 'lib.d.ts') || (Path.getFileName(filePath) === 'lib.core.d.ts');
+        return (Path.getFileName(filePath) === "lib.d.ts") || (Path.getFileName(filePath) === "lib.core.d.ts");
     }
 
     export function isBuiltFile(filePath: string): boolean {

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -1,7 +1,7 @@
-/// <reference path='..\services\services.ts' />
-/// <reference path='..\services\shims.ts' />
-/// <reference path='..\server\client.ts' />
-/// <reference path='harness.ts' />
+/// <reference path="..\services\services.ts" />
+/// <reference path="..\services\shims.ts" />
+/// <reference path="..\server\client.ts" />
+/// <reference path="harness.ts" />
 
 module Harness.LanguageService {
     export class ScriptInfo {
@@ -242,7 +242,7 @@ module Harness.LanguageService {
             throw new Error("NYI");
         }
         getClassificationsForLine(text: string, lexState: ts.EndOfLineState, classifyKeywordsInGenerics?: boolean): ts.ClassificationResult {
-            let result = this.shim.getClassificationsForLine(text, lexState, classifyKeywordsInGenerics).split('\n');
+            let result = this.shim.getClassificationsForLine(text, lexState, classifyKeywordsInGenerics).split("\n");
             let entries: ts.ClassificationInfo[] = [];
             let i = 0;
             let position = 0;

--- a/src/harness/loggedIO.ts
+++ b/src/harness/loggedIO.ts
@@ -73,7 +73,7 @@ interface PlaybackControl {
 module Playback {
     let recordLog: IOLog = undefined;
     let replayLog: IOLog = undefined;
-    let recordLogFileNameBase = '';
+    let recordLogFileNameBase = "";
 
     interface Memoized<T> {
         (s: string): T;
@@ -99,7 +99,7 @@ module Playback {
         return {
             timestamp: (new Date()).toString(),
             arguments: [],
-            currentDirectory: '',
+            currentDirectory: "",
             filesRead: [],
             filesWritten: [],
             filesDeleted: [],
@@ -110,7 +110,7 @@ module Playback {
             dirExists: [],
             dirsCreated: [],
             pathsResolved: [],
-            executingPath: ''
+            executingPath: ""
         };
     }
 
@@ -170,7 +170,7 @@ module Playback {
             if (defaultValue !== undefined) {
                 return defaultValue;
             } else {
-                throw new Error('No matching result in log array for: ' + JSON.stringify(expectedFields));
+                throw new Error("No matching result in log array for: " + JSON.stringify(expectedFields));
             }
         }
         return results[0].result;
@@ -195,7 +195,7 @@ module Playback {
         }
         // If we got here, we didn't find a match
         if (defaultValue === undefined) {
-            throw new Error('No matching result in log array for path: ' + expectedPath);
+            throw new Error("No matching result in log array for path: " + expectedPath);
         } else {
             return defaultValue;
         }
@@ -203,7 +203,7 @@ module Playback {
 
     let pathEquivCache: any = {};
     function pathsAreEquivalent(left: string, right: string, wrapper: { resolvePath(s: string): string }) {
-        let key = left + '-~~-' + right;
+        let key = left + "-~~-" + right;
         function areSame(a: string, b: string) {
             return ts.normalizeSlashes(a).toLowerCase() === ts.normalizeSlashes(b).toLowerCase();
         }
@@ -233,14 +233,14 @@ module Playback {
         wrapper.endRecord = () => {
             if (recordLog !== undefined) {
                 let i = 0;
-                let fn = () => recordLogFileNameBase + i + '.json';
+                let fn = () => recordLogFileNameBase + i + ".json";
                 while (underlying.fileExists(fn())) i++;
                 underlying.writeFile(fn(), JSON.stringify(recordLog));
                 recordLog = undefined;
             }
         };
 
-        Object.defineProperty(wrapper, 'args', {
+        Object.defineProperty(wrapper, "args", {
             get() {
                 if (replayLog !== undefined) {
                     return replayLog.arguments;
@@ -276,7 +276,7 @@ module Playback {
 
         wrapper.getCurrentDirectory = () => {
             if (replayLog !== undefined) {
-                return replayLog.currentDirectory || '';
+                return replayLog.currentDirectory || "";
             } else if (recordLog !== undefined) {
                 return recordLog.currentDirectory = underlying.getCurrentDirectory();
             } else {
@@ -286,7 +286,7 @@ module Playback {
 
         wrapper.resolvePath = recordReplay(wrapper.resolvePath, underlying)(
             (path) => callAndRecord(underlying.resolvePath(path), recordLog.pathsResolved, { path: path }),
-            memoize((path) => findResultByFields(replayLog.pathsResolved, { path: path }, !ts.isRootedDiskPath(ts.normalizeSlashes(path)) && replayLog.currentDirectory ? replayLog.currentDirectory + '/' + path : ts.normalizeSlashes(path))));
+            memoize((path) => findResultByFields(replayLog.pathsResolved, { path: path }, !ts.isRootedDiskPath(ts.normalizeSlashes(path)) && replayLog.currentDirectory ? replayLog.currentDirectory + "/" + path : ts.normalizeSlashes(path))));
 
         wrapper.readFile = recordReplay(wrapper.readFile, underlying)(
             (path) => {
@@ -299,7 +299,7 @@ module Playback {
 
         wrapper.writeFile = recordReplay(wrapper.writeFile, underlying)(
             (path, contents) => callAndRecord(underlying.writeFile(path, contents), recordLog.filesWritten, { path: path, contents: contents, bom: false }),
-            (path, contents) => noOpReplay('writeFile'));
+            (path, contents) => noOpReplay("writeFile"));
 
         wrapper.exit = (exitCode) => {
             if (recordLog !== undefined) {

--- a/src/harness/projectsRunner.ts
+++ b/src/harness/projectsRunner.ts
@@ -74,7 +74,7 @@ class ProjectRunner extends RunnerBase {
         catch (e) {
             assert(false, "Testcase: " + testCaseFileName + " does not contain valid json format: " + e.message);
         }
-        let testCaseJustName = testCaseFileName.replace(/^.*[\\\/]/, '').replace(/\.json/, "");
+        let testCaseJustName = testCaseFileName.replace(/^.*[\\\/]/, "").replace(/\.json/, "");
 
         function moduleNameToString(moduleKind: ts.ModuleKind) {
             return moduleKind === ts.ModuleKind.AMD
@@ -331,9 +331,9 @@ class ProjectRunner extends RunnerBase {
             return Harness.Compiler.getErrorBaseline(inputFiles, compilerResult.errors);
         }
 
-        let name = 'Compiling project for ' + testCase.scenario + ': testcase ' + testCaseFileName;
+        let name = "Compiling project for " + testCase.scenario + ": testcase " + testCaseFileName;
 
-        describe('Projects tests', () => {
+        describe("Projects tests", () => {
             describe(name, () => {
                 function verifyCompilerResults(moduleKind: ts.ModuleKind) {
                     let compilerResult: BatchCompileProjectTestCaseResult;
@@ -367,27 +367,27 @@ class ProjectRunner extends RunnerBase {
                         compilerResult = batchCompilerProjectTestCase(moduleKind);
                     });
 
-                    it('Resolution information of (' + moduleNameToString(moduleKind) + '): ' + testCaseFileName, () => {
-                        Harness.Baseline.runBaseline('Resolution information of (' + moduleNameToString(compilerResult.moduleKind) + '): ' + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + '.json', () => {
+                    it("Resolution information of (" + moduleNameToString(moduleKind) + "): " + testCaseFileName, () => {
+                        Harness.Baseline.runBaseline("Resolution information of (" + moduleNameToString(compilerResult.moduleKind) + "): " + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + ".json", () => {
                             return JSON.stringify(getCompilerResolutionInfo(), undefined, "    ");
                         });
                     });
 
 
-                    it('Errors for (' + moduleNameToString(moduleKind) + '): ' + testCaseFileName, () => {
+                    it("Errors for (" + moduleNameToString(moduleKind) + "): " + testCaseFileName, () => {
                         if (compilerResult.errors.length) {
-                            Harness.Baseline.runBaseline('Errors for (' + moduleNameToString(compilerResult.moduleKind) + '): ' + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + '.errors.txt', () => {
+                            Harness.Baseline.runBaseline("Errors for (" + moduleNameToString(compilerResult.moduleKind) + "): " + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + ".errors.txt", () => {
                                 return getErrorsBaseline(compilerResult);
                             });
                         }
                     });
 
 
-                    it('Baseline of emitted result (' + moduleNameToString(moduleKind) + '): ' + testCaseFileName, () => {
+                    it("Baseline of emitted result (" + moduleNameToString(moduleKind) + "): " + testCaseFileName, () => {
                         if (testCase.baselineCheck) {
                             ts.forEach(compilerResult.outputFiles, outputFile => {
 
-                                Harness.Baseline.runBaseline('Baseline of emitted result (' + moduleNameToString(compilerResult.moduleKind) + '): ' + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + outputFile.fileName, () => {
+                                Harness.Baseline.runBaseline("Baseline of emitted result (" + moduleNameToString(compilerResult.moduleKind) + "): " + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + outputFile.fileName, () => {
                                     try {
                                         return ts.sys.readFile(getProjectOutputFolder(outputFile.fileName, compilerResult.moduleKind));
                                     }
@@ -400,9 +400,9 @@ class ProjectRunner extends RunnerBase {
                     });
 
 
-                    it('SourceMapRecord for (' + moduleNameToString(moduleKind) + '): ' + testCaseFileName, () => {
+                    it("SourceMapRecord for (" + moduleNameToString(moduleKind) + "): " + testCaseFileName, () => {
                         if (compilerResult.sourceMapData) {
-                            Harness.Baseline.runBaseline('SourceMapRecord for (' + moduleNameToString(compilerResult.moduleKind) + '): ' + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + '.sourcemap.txt', () => {
+                            Harness.Baseline.runBaseline("SourceMapRecord for (" + moduleNameToString(compilerResult.moduleKind) + "): " + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + ".sourcemap.txt", () => {
                                 return Harness.SourceMapRecoder.getSourceMapRecord(compilerResult.sourceMapData, compilerResult.program,
                                     ts.filter(compilerResult.outputFiles, outputFile => Harness.Compiler.isJS(outputFile.emittedFileName)));
                             });
@@ -411,11 +411,11 @@ class ProjectRunner extends RunnerBase {
 
                     // Verify that all the generated .d.ts files compile
 
-                    it('Errors in generated Dts files for (' + moduleNameToString(moduleKind) + '): ' + testCaseFileName, () => {
+                    it("Errors in generated Dts files for (" + moduleNameToString(moduleKind) + "): " + testCaseFileName, () => {
                         if (!compilerResult.errors.length && testCase.declaration) {
                             let dTsCompileResult = compileCompileDTsFiles(compilerResult);
                             if (dTsCompileResult.errors.length) {
-                                Harness.Baseline.runBaseline('Errors in generated Dts files for (' + moduleNameToString(compilerResult.moduleKind) + '): ' + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + '.dts.errors.txt', () => {
+                                Harness.Baseline.runBaseline("Errors in generated Dts files for (" + moduleNameToString(compilerResult.moduleKind) + "): " + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + ".dts.errors.txt", () => {
                                     return getErrorsBaseline(dTsCompileResult);
                                 });
                             }

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -13,12 +13,12 @@
 // limitations under the License.
 //
 
-/// <reference path='test262Runner.ts' />
-/// <reference path='compilerRunner.ts' />
-/// <reference path='fourslashRunner.ts' />
-/// <reference path='projectsRunner.ts' />
-/// <reference path='rwcRunner.ts' />
-/// <reference path='harness.ts' />
+/// <reference path="test262Runner.ts" />
+/// <reference path="compilerRunner.ts" />
+/// <reference path="fourslashRunner.ts" />
+/// <reference path="projectsRunner.ts" />
+/// <reference path="rwcRunner.ts" />
+/// <reference path="harness.ts" />
 
 let runners: RunnerBase[] = [];
 let iterations: number = 1;
@@ -32,13 +32,13 @@ function runTests(runners: RunnerBase[]) {
 }
 
 // users can define tests to run in mytest.config that will override cmd line args, otherwise use cmd line args (test.config), otherwise no options
-let mytestconfig = 'mytest.config';
-let testconfig = 'test.config';
+let mytestconfig = "mytest.config";
+let testconfig = "test.config";
 let testConfigFile =
     Harness.IO.fileExists(mytestconfig) ? Harness.IO.readFile(mytestconfig) :
-    (Harness.IO.fileExists(testconfig) ? Harness.IO.readFile(testconfig) : '');
+    (Harness.IO.fileExists(testconfig) ? Harness.IO.readFile(testconfig) : "");
 
-if (testConfigFile !== '') {
+if (testConfigFile !== "") {
     let testConfig = JSON.parse(testConfigFile);
     if (testConfig.light) {
         Harness.lightMode = true;
@@ -51,33 +51,33 @@ if (testConfigFile !== '') {
             }
 
             switch (option) {
-                case 'compiler':
+                case "compiler":
                     runners.push(new CompilerBaselineRunner(CompilerTestType.Conformance));
                     runners.push(new CompilerBaselineRunner(CompilerTestType.Regressions));
                     runners.push(new ProjectRunner());
                     break;
-                case 'conformance':
+                case "conformance":
                     runners.push(new CompilerBaselineRunner(CompilerTestType.Conformance));
                     break;
-                case 'project':
+                case "project":
                     runners.push(new ProjectRunner());
                     break;
-                case 'fourslash':
+                case "fourslash":
                     runners.push(new FourSlashRunner(FourSlashTestType.Native));
                     break;
-                case 'fourslash-shims':
+                case "fourslash-shims":
                     runners.push(new FourSlashRunner(FourSlashTestType.Shims));
                     break;
-                case 'fourslash-server':
+                case "fourslash-server":
                     runners.push(new FourSlashRunner(FourSlashTestType.Server));
                     break;
-                case 'fourslash-generated':
+                case "fourslash-generated":
                     runners.push(new GeneratedFourslashRunner(FourSlashTestType.Native));
                     break;
-                case 'rwc':
+                case "rwc":
                     runners.push(new RWCRunner());
                     break;
-                case 'test262':
+                case "test262":
                     runners.push(new Test262BaselineRunner());
                     break;
             }
@@ -102,6 +102,6 @@ if (runners.length === 0) {
     // runners.push(new GeneratedFourslashRunner());
 }
 
-ts.sys.newLine = '\r\n';
+ts.sys.newLine = "\r\n";
 
 runTests(runners);

--- a/src/harness/runnerbase.ts
+++ b/src/harness/runnerbase.ts
@@ -33,7 +33,7 @@ abstract class RunnerBase {
         
         // when running in the browser the 'full path' is the host name, shows up in error baselines
         let localHost = /http:\/localhost:\d+/g;
-        fixedPath = fixedPath.replace(localHost, '');
+        fixedPath = fixedPath.replace(localHost, "");
         return fixedPath;
     }
 }

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -74,10 +74,11 @@ module RWC {
                     });
 
                     // Add files to compilation
+                    let isInInputList = (resolvedPath: string) => (inputFile: { unitName: string; content: string; }) => inputFile.unitName === resolvedPath;
                     for (let fileRead of ioLog.filesRead) {
                         // Check if the file is already added into the set of input files.
-                        var resolvedPath = ts.normalizeSlashes(ts.sys.resolvePath(fileRead.path));
-                        let inInputList = ts.forEach(inputFiles, inputFile => inputFile.unitName === resolvedPath);
+                        const resolvedPath = ts.normalizeSlashes(ts.sys.resolvePath(fileRead.path));
+                        let inInputList = ts.forEach(inputFiles, isInInputList(resolvedPath));
 
                         if (!Harness.isLibraryFile(fileRead.path)) {
                             if (inInputList) {

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -1,7 +1,7 @@
-/// <reference path='harness.ts'/>
-/// <reference path='runnerbase.ts' />
-/// <reference path='loggedIO.ts' />
-/// <reference path='..\compiler\commandLineParser.ts'/>
+/// <reference path="harness.ts"/>
+/// <reference path="runnerbase.ts" />
+/// <reference path="loggedIO.ts" />
+/// <reference path="..\compiler\commandLineParser.ts"/>
 
 module RWC {
     function runWithIOLog(ioLog: IOLog, fn: () => void) {
@@ -26,8 +26,8 @@ module RWC {
             let compilerResult: Harness.Compiler.CompilerResult;
             let compilerOptions: ts.CompilerOptions;
             let baselineOpts: Harness.Baseline.BaselineOptions = {
-                Subfolder: 'rwc',
-                Baselinefolder: 'internal/baselines'
+                Subfolder: "rwc",
+                Baselinefolder: "internal/baselines"
             };
             let baseName = /(.*)\/(.*).json/.exec(ts.normalizeSlashes(jsonPath))[2];
             let currentDirectory: string;
@@ -49,7 +49,7 @@ module RWC {
                 useCustomLibraryFile = undefined;
             });
 
-            it('can compile', () => {
+            it("can compile", () => {
                 let harnessCompiler = Harness.Compiler.getCompiler();
                 let opts: ts.ParsedCommandLine;
 
@@ -131,14 +131,14 @@ module RWC {
             });
 
 
-            it('has the expected emitted code', () => {
-                Harness.Baseline.runBaseline('has the expected emitted code', baseName + '.output.js', () => {
+            it("has the expected emitted code", () => {
+                Harness.Baseline.runBaseline("has the expected emitted code", baseName + ".output.js", () => {
                     return Harness.Compiler.collateOutputs(compilerResult.files);
                 }, false, baselineOpts);
             });
 
-            it('has the expected declaration file content', () => {
-                Harness.Baseline.runBaseline('has the expected declaration file content', baseName + '.d.ts', () => {
+            it("has the expected declaration file content", () => {
+                Harness.Baseline.runBaseline("has the expected declaration file content", baseName + ".d.ts", () => {
                     if (!compilerResult.declFilesCode.length) {
                         return null;
                     }
@@ -147,8 +147,8 @@ module RWC {
                 }, false, baselineOpts);
             });
 
-            it('has the expected source maps', () => {
-                Harness.Baseline.runBaseline('has the expected source maps', baseName + '.map', () => {
+            it("has the expected source maps", () => {
+                Harness.Baseline.runBaseline("has the expected source maps", baseName + ".map", () => {
                     if (!compilerResult.sourceMaps.length) {
                         return null;
                     }
@@ -157,16 +157,16 @@ module RWC {
                 }, false, baselineOpts);
             });
 
-            /*it('has correct source map record', () => {
+            /*it("has correct source map record", () => {
                 if (compilerOptions.sourceMap) {
-                    Harness.Baseline.runBaseline('has correct source map record', baseName + '.sourcemap.txt', () => {
+                    Harness.Baseline.runBaseline("has correct source map record", baseName + ".sourcemap.txt", () => {
                         return compilerResult.getSourceMapRecord();
                     }, false, baselineOpts);
                 }
             });*/
 
-            it('has the expected errors', () => {
-                Harness.Baseline.runBaseline('has the expected errors', baseName + '.errors.txt', () => {
+            it("has the expected errors", () => {
+                Harness.Baseline.runBaseline("has the expected errors", baseName + ".errors.txt", () => {
                     if (compilerResult.errors.length === 0) {
                         return null;
                     }
@@ -177,9 +177,9 @@ module RWC {
 
             // Ideally, a generated declaration file will have no errors. But we allow generated
             // declaration file errors as part of the baseline.
-            it('has the expected errors in generated declaration files', () => {
+            it("has the expected errors in generated declaration files", () => {
                 if (compilerOptions.declaration && !compilerResult.errors.length) {
-                    Harness.Baseline.runBaseline('has the expected errors in generated declaration files', baseName + '.dts.errors.txt', () => {
+                    Harness.Baseline.runBaseline("has the expected errors in generated declaration files", baseName + ".dts.errors.txt", () => {
                         let declFileCompilationResult = Harness.Compiler.getCompiler().compileDeclarationFiles(inputFiles, otherFiles, compilerResult,
                             /*settingscallback*/ undefined, compilerOptions, currentDirectory);
                         if (declFileCompilationResult.declResult.errors.length === 0) {

--- a/src/harness/sourceMapRecorder.ts
+++ b/src/harness/sourceMapRecorder.ts
@@ -13,7 +13,7 @@
 // limitations under the License.
 //
 
-///<reference path='harness.ts'/>
+///<reference path="harness.ts"/>
 
 module Harness.SourceMapRecoder {
 
@@ -50,11 +50,11 @@ module Harness.SourceMapRecoder {
                 return true;
             }
 
-            if (sourceMapMappings.charAt(decodingIndex) == ',') {
+            if (sourceMapMappings.charAt(decodingIndex) == ",") {
                 return true;
             }
 
-            if (sourceMapMappings.charAt(decodingIndex) == ';') {
+            if (sourceMapMappings.charAt(decodingIndex) == ";") {
                 return true;
             }
 
@@ -117,7 +117,7 @@ module Harness.SourceMapRecoder {
             }
 
             while (decodingIndex < sourceMapMappings.length) {
-                if (sourceMapMappings.charAt(decodingIndex) == ';') {
+                if (sourceMapMappings.charAt(decodingIndex) == ";") {
                     // New line
                     decodeOfEncodedMapping.emittedLine++;
                     decodeOfEncodedMapping.emittedColumn = 1;
@@ -125,7 +125,7 @@ module Harness.SourceMapRecoder {
                     continue;
                 }
 
-                if (sourceMapMappings.charAt(decodingIndex) == ',') {
+                if (sourceMapMappings.charAt(decodingIndex) == ",") {
                     // Next entry is on same line - no action needed
                     decodingIndex++;
                     continue;
@@ -459,6 +459,6 @@ module Harness.SourceMapRecoder {
             SourceMapSpanWriter.close(); // If the last spans werent emitted, emit them
         }
         sourceMapRecoder.Close();
-        return sourceMapRecoder.lines.join('\r\n');
+        return sourceMapRecoder.lines.join("\r\n");
     }
 }

--- a/src/harness/test262Runner.ts
+++ b/src/harness/test262Runner.ts
@@ -1,9 +1,9 @@
-/// <reference path='harness.ts' />
-/// <reference path='runnerbase.ts' />
+/// <reference path="harness.ts" />
+/// <reference path="runnerbase.ts" />
 
 class Test262BaselineRunner extends RunnerBase {
-    private static basePath = 'internal/cases/test262';
-    private static helpersFilePath = 'tests/cases/test262-harness/helpers.d.ts';
+    private static basePath = "internal/cases/test262";
+    private static helpersFilePath = "tests/cases/test262-harness/helpers.d.ts";
     private static helperFile = {
         unitName: Test262BaselineRunner.helpersFilePath,
         content: Harness.IO.readFile(Test262BaselineRunner.helpersFilePath)
@@ -15,8 +15,8 @@ class Test262BaselineRunner extends RunnerBase {
         module: ts.ModuleKind.CommonJS
     };
     private static baselineOptions: Harness.Baseline.BaselineOptions = {
-        Subfolder: 'test262',
-        Baselinefolder: 'internal/baselines'
+        Subfolder: "test262",
+        Baselinefolder: "internal/baselines"
     };
 
     private static getTestFilePath(filename: string): string {
@@ -24,7 +24,7 @@ class Test262BaselineRunner extends RunnerBase {
     }
 
     private runTest(filePath: string) {
-        describe('test262 test for ' + filePath, () => {
+        describe("test262 test for " + filePath, () => {
             // Mocha holds onto the closure environment of the describe callback even after the test is done.
             // Everything declared here should be cleared out in the "after" callback.
             let testState: {
@@ -36,7 +36,7 @@ class Test262BaselineRunner extends RunnerBase {
 
             before(() => {
                 let content = Harness.IO.readFile(filePath);
-                let testFilename = ts.removeFileExtension(filePath).replace(/\//g, '_') + ".test";
+                let testFilename = ts.removeFileExtension(filePath).replace(/\//g, "_") + ".test";
                 let testCaseContent = Harness.TestCaseParser.makeUnitsFromTest(content, testFilename);
 
                 let inputFiles = testCaseContent.testUnitData.map(unit => {
@@ -61,15 +61,15 @@ class Test262BaselineRunner extends RunnerBase {
                 testState = undefined;
             });
 
-            it('has the expected emitted code', () => {
-                Harness.Baseline.runBaseline('has the expected emitted code', testState.filename + '.output.js', () => {
+            it("has the expected emitted code", () => {
+                Harness.Baseline.runBaseline("has the expected emitted code", testState.filename + ".output.js", () => {
                     let files = testState.compilerResult.files.filter(f => f.fileName !== Test262BaselineRunner.helpersFilePath);
                     return Harness.Compiler.collateOutputs(files);
                 }, false, Test262BaselineRunner.baselineOptions);
             });
 
-            it('has the expected errors', () => {
-                Harness.Baseline.runBaseline('has the expected errors', testState.filename + '.errors.txt', () => {
+            it("has the expected errors", () => {
+                Harness.Baseline.runBaseline("has the expected errors", testState.filename + ".errors.txt", () => {
                     let errors = testState.compilerResult.errors;
                     if (errors.length === 0) {
                         return null;
@@ -79,13 +79,13 @@ class Test262BaselineRunner extends RunnerBase {
                 }, false, Test262BaselineRunner.baselineOptions);
             });
 
-            it('satisfies inletiants', () => {
+            it("satisfies inletiants", () => {
                 let sourceFile = testState.program.getSourceFile(Test262BaselineRunner.getTestFilePath(testState.filename));
                 Utils.assertInvariants(sourceFile, /*parent:*/ undefined);
             });
 
-            it('has the expected AST', () => {
-                Harness.Baseline.runBaseline('has the expected AST', testState.filename + '.AST.txt', () => {
+            it("has the expected AST", () => {
+                Harness.Baseline.runBaseline("has the expected AST", testState.filename + ".AST.txt", () => {
                     let sourceFile = testState.program.getSourceFile(Test262BaselineRunner.getTestFilePath(testState.filename));
                     return Utils.sourceFileToJSON(sourceFile);
                 }, false, Test262BaselineRunner.baselineOptions);


### PR DESCRIPTION
There are still a number of linter errors left due to `tslint` not yet supporting [`abstract`](https://github.com/palantir/tslint/issues/528) or [`is`](https://github.com/palantir/tslint/issues/529). There is also an unreachable code lint error thrown on the final line of `src/compiler/binder.ts` - I can't find a cause for that one.