### PR TITLE
SourceFile.fileWatcher should be optional

### DIFF
--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -3,7 +3,7 @@
 
 namespace ts {
     export interface SourceFile {
-        fileWatcher: FileWatcher;
+        fileWatcher?: FileWatcher;
     }
 
     /**


### PR DESCRIPTION
Because its not always there