### PR TITLE
Correct type for Window.orientation is number.

### DIFF
--- a/bin/lib.dom.d.ts
+++ b/bin/lib.dom.d.ts
@@ -14455,7 +14455,7 @@ interface Window extends EventTarget, WindowTimers, WindowSessionStorage, Window
     onvolumechange: (ev: Event) => any;
     onwaiting: (ev: Event) => any;
     opener: Window;
-    orientation: string;
+    orientation: number;
     outerHeight: number;
     outerWidth: number;
     pageXOffset: number;


### PR DESCRIPTION
In mobile browsers the window.orientation property returns a number: 0,
90, -90, 180. Whoever set this to string got this confused with the
Screen Orientation spec: http://www.w3.org/TR/screen-orientation/
That uses screen.orientation, which is a string, whereas
window.orientation is a number.