### PR TITLE
Adds empty object narrowing to type guards

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6018,23 +6018,27 @@ namespace ts {
                                 // In a branch of an if statement, narrow based on controlling expression
                                 if (child !== (<IfStatement>node).expression) {
 
-                                    // Union types that got narrowed to one type is no longer union types. We want to return a
-                                    // void type in case if the type returned by one if-statement clause is the same as the
-                                    // narrowed type, given that the original type was a union type.
+                                    // We want to narrow a type to an empty object type `{}` when we exhaust all types.
+                                    // We can accomplish it by simply check if a clause return the same type as the
+                                    // ongoing narrowing type. Given that the ongoing narrowing type have been narrowed
+                                    // to one distinct type.
                                     //
                                     // Example:
                                     //
                                     //     let x: A | B | C;
                                     //
-                                    //     if (isA(x)) { // isA(...) returns A and the narrowing type has the value of A so narrow to void type.
-                                    //     }
-                                    //     else if (isB(x)) { //  narrow to A
-                                    //     }
-                                    //     else if (isC(x))  // narrow to A | B
-                                    //     }
-                                    //     else { // type begins with A | B | C
+                                    //     if (isA(x)) { // isA(...) clause returns A and the ongoing narrowing type has
+                                    //                   // the value of A and it is a distinct type so narrow x to an
+                                    //                   // empty object type.
                                     //
-                                    //          x // is void
+                                    //     }
+                                    //     else if (isB(x)) { //  narrow x to A
+                                    //     }
+                                    //     else if (isC(x))  // narrow x to A | B
+                                    //     }
+                                    //     else { // x begins with A | B | C
+                                    //
+                                    //          x // an empty object type
                                     //     }
                                     //
                                     if (!(type.flags & TypeFlags.Union)) {
@@ -6044,13 +6048,13 @@ namespace ts {
                                             //
                                             //     let x: A | B | C;
                                             //
-                                            //     if (isB(x)) { // narrow to A.
+                                            //     if (isB(x)) { // narrow x to A.
                                             //     }
-                                            //     else if (isB(x)) { // narrow to A
+                                            //     else if (isB(x)) { // narrow x to A
                                             //     }
-                                            //     else if (isC(x)) { // narrow to A | B
+                                            //     else if (isC(x)) { // narrow x to A | B
                                             //     }
-                                            //     else { // type begins with A | B | C
+                                            //     else { // x begins with A | B | C
                                             //         x
                                             //     }
                                             //
@@ -6058,36 +6062,36 @@ namespace ts {
                                             //
                                             //     let x: A | B | C;
                                             //
-                                            //     if (isA(x)) { // narrow to A (but also removes A).
+                                            //     if (isA(x)) { // narrow x to A (but also removes A).
                                             //     }
-                                            //     else if (isB(x)) { // narrow to A
+                                            //     else if (isB(x)) { // narrow x to A
                                             //     }
-                                            //     else if (isC(x)) {// narrow to A | B
+                                            //     else if (isC(x)) {// narrow x to A | B
                                             //     }
-                                            //     else { // type begins with A | B | C
+                                            //     else { //x begins with A | B | C
                                             //         x
                                             //     }
                                             //
-                                            // But we want only the latter to narrow the type to void.
+                                            // But we want only the latter to narrow the type to an empty object type.
                                             //
                                             type === narrowType(originalType, (<IfStatement>node).expression, /*assumeTrue*/ true) &&
                                             // If the first narrowed type yield a distinct type(not a union type). And it encounters
                                             // a narrowed type that yields the same type in some upper branches. It would then narrow
-                                            // the type to void instead of the distinct type. The below check, guards us from narrowing
-                                            // it to void instead of the distinct type.
+                                            // the type to an empty object type instead of the distinct type. The below check, guards
+                                            // us from narrowing it to an empty object type instead of the distinct type.
                                             //
-                                            //     if (isA(x)) { // narrow to void
+                                            //     if (isA(x)) { // narrow x to an empty object type
                                             //     }
-                                            //     else if (isB(x)) { // narrow to A
+                                            //     else if (isB(x)) { // narrow x to A
                                             //     }
-                                            //     else if (isA(x)) { // narrow to A
+                                            //     else if (isA(x)) { // narrow x to A
                                             //
-                                            //         x // is void, but should be A
+                                            //         x // is an empty object type, but should be A
                                             //     }
                                             //
                                             type !== firstNarrowedTypeFromIfStatement) {
 
-                                            return voidType;
+                                            return emptyObjectType;
                                         }
                                     }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6006,9 +6006,8 @@ namespace ts {
             if (node && symbol.flags & SymbolFlags.Variable) {
                 if (isTypeAny(type) || type.flags & (TypeFlags.ObjectType | TypeFlags.Union | TypeFlags.TypeParameter)) {
                     // `firstNarrowedTypeFromIfStatement` is only used when type is of union type.
-                    if (type.flags & TypeFlags.Union) {
-                        var firstNarrowedTypeFromIfStatement: Type;
-                    }
+                    let originalType = type;
+                    let firstNarrowedTypeFromIfStatement: Type;
 
                     loop: while (node.parent) {
                         let child = node;
@@ -6039,10 +6038,6 @@ namespace ts {
                                     //     }
                                     //
                                     if (!(type.flags & TypeFlags.Union)) {
-                                        // Get the original type again because we don't want to store it on a variable higher
-                                        // up to minimize memory allocation.
-                                        let originalType = getTypeOfSymbol(symbol);
-
                                         if (originalType.flags & TypeFlags.Union &&
                                             // Use the original type to check the narrowed type instead of the ongoing narrowing type.
                                             // This is to deal with cases like below:

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6028,13 +6028,10 @@ namespace ts {
                                     //     let x: A | B | C;
                                     //
                                     //     if (isA(x)) { // isA(...) returns A and the narrowing type has the value of A so narrow to void type.
-                                    //
                                     //     }
                                     //     else if (isB(x)) { //  narrow to A
-                                    //
                                     //     }
-                                    //     else if (isC(x)) { // narrow to A | B
-                                    //
+                                    //     else if (isC(x))  // narrow to A | B
                                     //     }
                                     //     else { // type begins with A | B | C
                                     //
@@ -6050,13 +6047,31 @@ namespace ts {
                                             // Use the original type to check the narrowed type instead of the ongoing narrowing type.
                                             // This is to deal with cases like below:
                                             //
-                                            //     if (isB(x)) // narrow to A.
-                                            //     else if (isB(x)) // narrow to A
+                                            //     let x: A | B | C;
+                                            //
+                                            //     if (isB(x)) { // narrow to A.
+                                            //     }
+                                            //     else if (isB(x)) { // narrow to A
+                                            //     }
+                                            //     else if (isC(x)) { // narrow to A | B
+                                            //     }
+                                            //     else { // type begins with A | B | C
+                                            //         x
+                                            //     }
                                             //
                                             // Which is the same as:
                                             //
-                                            //     if (isA(x)) // narrow to A (but also removes A).
-                                            //     else if (isB(x)) // narrow to A
+                                            //     let x: A | B | C;
+                                            //
+                                            //     if (isA(x)) { // narrow to A (but also removes A).
+                                            //     }
+                                            //     else if (isB(x)) { // narrow to A
+                                            //     }
+                                            //     else if (isC(x)) {// narrow to A | B
+                                            //     }
+                                            //     else { // type begins with A | B | C
+                                            //         x
+                                            //     }
                                             //
                                             // But we want only the latter to narrow the type to void.
                                             //
@@ -6066,9 +6081,12 @@ namespace ts {
                                             // the type to void instead of the distinct type. The below check, guards us from narrowing
                                             // it to void instead of the distinct type.
                                             //
-                                            //     if (isA(x)) // narrow to void
-                                            //     else if (isB(x)) // narrow to A
+                                            //     if (isA(x)) { // narrow to void
+                                            //     }
+                                            //     else if (isB(x)) { // narrow to A
+                                            //     }
                                             //     else if (isA(x)) { // narrow to A
+                                            //
                                             //         x // is void, but should be A
                                             //     }
                                             //

--- a/tests/baselines/reference/typeGuardNarrowingToVoidType.js
+++ b/tests/baselines/reference/typeGuardNarrowingToVoidType.js
@@ -1,0 +1,144 @@
+//// [typeGuardNarrowingToVoidType.ts]
+let x: number | string | boolean;
+
+if (typeof x === "number") {
+    x.toPrecision();
+}
+else if (typeof x === "string") {
+    x.charCodeAt(1);
+}
+else if(typeof x === "boolean") {
+    x.valueOf();
+}
+else {
+    x
+}
+
+if(typeof x === "boolean") {
+    x.valueOf();
+}
+else if (typeof x === "number") {
+    x.toPrecision();
+}
+else if (typeof x === "string") {
+    x.charCodeAt(1);
+}
+else if(typeof x === "boolean") {
+    x.valueOf();
+}
+else {
+    x
+}
+
+class A { a: string; }
+class B { b: string; }
+class C { c: string; }
+
+declare function isA(x: any): x is A;
+declare function isB(x: any): x is B;
+declare function isC(x: any): x is C;
+
+let y: A | B | C;
+
+if (isA(y)) {
+    y.a;
+}
+else if(isB(y)){
+    y.b;
+}
+else if(isC(y)) {
+    y.c;
+}
+else{
+    y
+}
+
+if (isB(y)) {
+    y.b;
+}
+else if (isA(y)) {
+    y.a;
+}
+else if(isB(y)){
+    y.b;
+}
+else if(isC(y)) {
+    y.c;
+}
+else{
+    y
+}
+
+
+//// [typeGuardNarrowingToVoidType.js]
+var x;
+if (typeof x === "number") {
+    x.toPrecision();
+}
+else if (typeof x === "string") {
+    x.charCodeAt(1);
+}
+else if (typeof x === "boolean") {
+    x.valueOf();
+}
+else {
+    x;
+}
+if (typeof x === "boolean") {
+    x.valueOf();
+}
+else if (typeof x === "number") {
+    x.toPrecision();
+}
+else if (typeof x === "string") {
+    x.charCodeAt(1);
+}
+else if (typeof x === "boolean") {
+    x.valueOf();
+}
+else {
+    x;
+}
+var A = (function () {
+    function A() {
+    }
+    return A;
+})();
+var B = (function () {
+    function B() {
+    }
+    return B;
+})();
+var C = (function () {
+    function C() {
+    }
+    return C;
+})();
+var y;
+if (isA(y)) {
+    y.a;
+}
+else if (isB(y)) {
+    y.b;
+}
+else if (isC(y)) {
+    y.c;
+}
+else {
+    y;
+}
+if (isB(y)) {
+    y.b;
+}
+else if (isA(y)) {
+    y.a;
+}
+else if (isB(y)) {
+    y.b;
+}
+else if (isC(y)) {
+    y.c;
+}
+else {
+    y;
+}

--- a/tests/baselines/reference/typeGuardNarrowingToVoidType.symbols
+++ b/tests/baselines/reference/typeGuardNarrowingToVoidType.symbols
@@ -1,0 +1,179 @@
+=== tests/cases/conformance/expressions/typeGuards/typeGuardNarrowingToVoidType.ts ===
+let x: number | string | boolean;
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+
+if (typeof x === "number") {
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+
+    x.toPrecision();
+>x.toPrecision : Symbol(Number.toPrecision, Decl(lib.d.ts, 475, 51))
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+>toPrecision : Symbol(Number.toPrecision, Decl(lib.d.ts, 475, 51))
+}
+else if (typeof x === "string") {
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+
+    x.charCodeAt(1);
+>x.charCodeAt : Symbol(String.charCodeAt, Decl(lib.d.ts, 285, 32))
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+>charCodeAt : Symbol(String.charCodeAt, Decl(lib.d.ts, 285, 32))
+}
+else if(typeof x === "boolean") {
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+
+    x.valueOf();
+>x.valueOf : Symbol(Boolean.valueOf, Decl(lib.d.ts, 445, 19))
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+>valueOf : Symbol(Boolean.valueOf, Decl(lib.d.ts, 445, 19))
+}
+else {
+    x
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+}
+
+if(typeof x === "boolean") {
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+
+    x.valueOf();
+>x.valueOf : Symbol(Boolean.valueOf, Decl(lib.d.ts, 445, 19))
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+>valueOf : Symbol(Boolean.valueOf, Decl(lib.d.ts, 445, 19))
+}
+else if (typeof x === "number") {
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+
+    x.toPrecision();
+>x.toPrecision : Symbol(Number.toPrecision, Decl(lib.d.ts, 475, 51))
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+>toPrecision : Symbol(Number.toPrecision, Decl(lib.d.ts, 475, 51))
+}
+else if (typeof x === "string") {
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+
+    x.charCodeAt(1);
+>x.charCodeAt : Symbol(String.charCodeAt, Decl(lib.d.ts, 285, 32))
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+>charCodeAt : Symbol(String.charCodeAt, Decl(lib.d.ts, 285, 32))
+}
+else if(typeof x === "boolean") {
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+
+    x.valueOf();
+>x.valueOf : Symbol(Boolean.valueOf, Decl(lib.d.ts, 445, 19))
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+>valueOf : Symbol(Boolean.valueOf, Decl(lib.d.ts, 445, 19))
+}
+else {
+    x
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 0, 3))
+}
+
+class A { a: string; }
+>A : Symbol(A, Decl(typeGuardNarrowingToVoidType.ts, 29, 1))
+>a : Symbol(a, Decl(typeGuardNarrowingToVoidType.ts, 31, 9))
+
+class B { b: string; }
+>B : Symbol(B, Decl(typeGuardNarrowingToVoidType.ts, 31, 22))
+>b : Symbol(b, Decl(typeGuardNarrowingToVoidType.ts, 32, 9))
+
+class C { c: string; }
+>C : Symbol(C, Decl(typeGuardNarrowingToVoidType.ts, 32, 22))
+>c : Symbol(c, Decl(typeGuardNarrowingToVoidType.ts, 33, 9))
+
+declare function isA(x: any): x is A;
+>isA : Symbol(isA, Decl(typeGuardNarrowingToVoidType.ts, 33, 22))
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 35, 21))
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 35, 21))
+>A : Symbol(A, Decl(typeGuardNarrowingToVoidType.ts, 29, 1))
+
+declare function isB(x: any): x is B;
+>isB : Symbol(isB, Decl(typeGuardNarrowingToVoidType.ts, 35, 37))
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 36, 21))
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 36, 21))
+>B : Symbol(B, Decl(typeGuardNarrowingToVoidType.ts, 31, 22))
+
+declare function isC(x: any): x is C;
+>isC : Symbol(isC, Decl(typeGuardNarrowingToVoidType.ts, 36, 37))
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 37, 21))
+>x : Symbol(x, Decl(typeGuardNarrowingToVoidType.ts, 37, 21))
+>C : Symbol(C, Decl(typeGuardNarrowingToVoidType.ts, 32, 22))
+
+let y: A | B | C;
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+>A : Symbol(A, Decl(typeGuardNarrowingToVoidType.ts, 29, 1))
+>B : Symbol(B, Decl(typeGuardNarrowingToVoidType.ts, 31, 22))
+>C : Symbol(C, Decl(typeGuardNarrowingToVoidType.ts, 32, 22))
+
+if (isA(y)) {
+>isA : Symbol(isA, Decl(typeGuardNarrowingToVoidType.ts, 33, 22))
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+
+    y.a;
+>y.a : Symbol(A.a, Decl(typeGuardNarrowingToVoidType.ts, 31, 9))
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+>a : Symbol(A.a, Decl(typeGuardNarrowingToVoidType.ts, 31, 9))
+}
+else if(isB(y)){
+>isB : Symbol(isB, Decl(typeGuardNarrowingToVoidType.ts, 35, 37))
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+
+    y.b;
+>y.b : Symbol(B.b, Decl(typeGuardNarrowingToVoidType.ts, 32, 9))
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+>b : Symbol(B.b, Decl(typeGuardNarrowingToVoidType.ts, 32, 9))
+}
+else if(isC(y)) {
+>isC : Symbol(isC, Decl(typeGuardNarrowingToVoidType.ts, 36, 37))
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+
+    y.c;
+>y.c : Symbol(C.c, Decl(typeGuardNarrowingToVoidType.ts, 33, 9))
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+>c : Symbol(C.c, Decl(typeGuardNarrowingToVoidType.ts, 33, 9))
+}
+else{
+    y
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+}
+
+if (isB(y)) {
+>isB : Symbol(isB, Decl(typeGuardNarrowingToVoidType.ts, 35, 37))
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+
+    y.b;
+>y.b : Symbol(B.b, Decl(typeGuardNarrowingToVoidType.ts, 32, 9))
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+>b : Symbol(B.b, Decl(typeGuardNarrowingToVoidType.ts, 32, 9))
+}
+else if (isA(y)) {
+>isA : Symbol(isA, Decl(typeGuardNarrowingToVoidType.ts, 33, 22))
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+
+    y.a;
+>y.a : Symbol(A.a, Decl(typeGuardNarrowingToVoidType.ts, 31, 9))
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+>a : Symbol(A.a, Decl(typeGuardNarrowingToVoidType.ts, 31, 9))
+}
+else if(isB(y)){
+>isB : Symbol(isB, Decl(typeGuardNarrowingToVoidType.ts, 35, 37))
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+
+    y.b;
+>y.b : Symbol(B.b, Decl(typeGuardNarrowingToVoidType.ts, 32, 9))
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+>b : Symbol(B.b, Decl(typeGuardNarrowingToVoidType.ts, 32, 9))
+}
+else if(isC(y)) {
+>isC : Symbol(isC, Decl(typeGuardNarrowingToVoidType.ts, 36, 37))
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+
+    y.c;
+>y.c : Symbol(C.c, Decl(typeGuardNarrowingToVoidType.ts, 33, 9))
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+>c : Symbol(C.c, Decl(typeGuardNarrowingToVoidType.ts, 33, 9))
+}
+else{
+    y
+>y : Symbol(y, Decl(typeGuardNarrowingToVoidType.ts, 39, 3))
+}
+

--- a/tests/baselines/reference/typeGuardNarrowingToVoidType.types
+++ b/tests/baselines/reference/typeGuardNarrowingToVoidType.types
@@ -41,7 +41,7 @@ else if(typeof x === "boolean") {
 }
 else {
     x
->x : void
+>x : {}
 }
 
 if(typeof x === "boolean") {
@@ -84,7 +84,7 @@ else if (typeof x === "string") {
 else if(typeof x === "boolean") {
 >typeof x === "boolean" : boolean
 >typeof x : string
->x : void
+>x : {}
 >"boolean" : string
 
     x.valueOf();
@@ -95,7 +95,7 @@ else if(typeof x === "boolean") {
 }
 else {
     x
->x : void
+>x : {}
 }
 
 class A { a: string; }
@@ -166,7 +166,7 @@ else if(isC(y)) {
 }
 else{
     y
->y : void
+>y : {}
 }
 
 if (isB(y)) {
@@ -211,6 +211,6 @@ else if(isC(y)) {
 }
 else{
     y
->y : void
+>y : {}
 }
 

--- a/tests/baselines/reference/typeGuardNarrowingToVoidType.types
+++ b/tests/baselines/reference/typeGuardNarrowingToVoidType.types
@@ -1,0 +1,216 @@
+=== tests/cases/conformance/expressions/typeGuards/typeGuardNarrowingToVoidType.ts ===
+let x: number | string | boolean;
+>x : number | string | boolean
+
+if (typeof x === "number") {
+>typeof x === "number" : boolean
+>typeof x : string
+>x : number | string | boolean
+>"number" : string
+
+    x.toPrecision();
+>x.toPrecision() : string
+>x.toPrecision : (precision?: number) => string
+>x : number
+>toPrecision : (precision?: number) => string
+}
+else if (typeof x === "string") {
+>typeof x === "string" : boolean
+>typeof x : string
+>x : string | boolean
+>"string" : string
+
+    x.charCodeAt(1);
+>x.charCodeAt(1) : number
+>x.charCodeAt : (index: number) => number
+>x : string
+>charCodeAt : (index: number) => number
+>1 : number
+}
+else if(typeof x === "boolean") {
+>typeof x === "boolean" : boolean
+>typeof x : string
+>x : boolean
+>"boolean" : string
+
+    x.valueOf();
+>x.valueOf() : boolean
+>x.valueOf : () => boolean
+>x : boolean
+>valueOf : () => boolean
+}
+else {
+    x
+>x : void
+}
+
+if(typeof x === "boolean") {
+>typeof x === "boolean" : boolean
+>typeof x : string
+>x : number | string | boolean
+>"boolean" : string
+
+    x.valueOf();
+>x.valueOf() : boolean
+>x.valueOf : () => boolean
+>x : boolean
+>valueOf : () => boolean
+}
+else if (typeof x === "number") {
+>typeof x === "number" : boolean
+>typeof x : string
+>x : number | string
+>"number" : string
+
+    x.toPrecision();
+>x.toPrecision() : string
+>x.toPrecision : (precision?: number) => string
+>x : number
+>toPrecision : (precision?: number) => string
+}
+else if (typeof x === "string") {
+>typeof x === "string" : boolean
+>typeof x : string
+>x : string
+>"string" : string
+
+    x.charCodeAt(1);
+>x.charCodeAt(1) : number
+>x.charCodeAt : (index: number) => number
+>x : string
+>charCodeAt : (index: number) => number
+>1 : number
+}
+else if(typeof x === "boolean") {
+>typeof x === "boolean" : boolean
+>typeof x : string
+>x : void
+>"boolean" : string
+
+    x.valueOf();
+>x.valueOf() : boolean
+>x.valueOf : () => boolean
+>x : boolean
+>valueOf : () => boolean
+}
+else {
+    x
+>x : void
+}
+
+class A { a: string; }
+>A : A
+>a : string
+
+class B { b: string; }
+>B : B
+>b : string
+
+class C { c: string; }
+>C : C
+>c : string
+
+declare function isA(x: any): x is A;
+>isA : (x: any) => x is A
+>x : any
+>x : any
+>A : A
+
+declare function isB(x: any): x is B;
+>isB : (x: any) => x is B
+>x : any
+>x : any
+>B : B
+
+declare function isC(x: any): x is C;
+>isC : (x: any) => x is C
+>x : any
+>x : any
+>C : C
+
+let y: A | B | C;
+>y : A | B | C
+>A : A
+>B : B
+>C : C
+
+if (isA(y)) {
+>isA(y) : boolean
+>isA : (x: any) => x is A
+>y : A | B | C
+
+    y.a;
+>y.a : string
+>y : A
+>a : string
+}
+else if(isB(y)){
+>isB(y) : boolean
+>isB : (x: any) => x is B
+>y : B | C
+
+    y.b;
+>y.b : string
+>y : B
+>b : string
+}
+else if(isC(y)) {
+>isC(y) : boolean
+>isC : (x: any) => x is C
+>y : C
+
+    y.c;
+>y.c : string
+>y : C
+>c : string
+}
+else{
+    y
+>y : void
+}
+
+if (isB(y)) {
+>isB(y) : boolean
+>isB : (x: any) => x is B
+>y : A | B | C
+
+    y.b;
+>y.b : string
+>y : B
+>b : string
+}
+else if (isA(y)) {
+>isA(y) : boolean
+>isA : (x: any) => x is A
+>y : A | C
+
+    y.a;
+>y.a : string
+>y : A
+>a : string
+}
+else if(isB(y)){
+>isB(y) : boolean
+>isB : (x: any) => x is B
+>y : C
+
+    y.b;
+>y.b : string
+>y : B
+>b : string
+}
+else if(isC(y)) {
+>isC(y) : boolean
+>isC : (x: any) => x is C
+>y : C
+
+    y.c;
+>y.c : string
+>y : C
+>c : string
+}
+else{
+    y
+>y : void
+}
+

--- a/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowingToVoidType.ts
+++ b/tests/cases/conformance/expressions/typeGuards/typeGuardNarrowingToVoidType.ts
@@ -1,0 +1,69 @@
+let x: number | string | boolean;
+
+if (typeof x === "number") {
+    x.toPrecision();
+}
+else if (typeof x === "string") {
+    x.charCodeAt(1);
+}
+else if(typeof x === "boolean") {
+    x.valueOf();
+}
+else {
+    x
+}
+
+if(typeof x === "boolean") {
+    x.valueOf();
+}
+else if (typeof x === "number") {
+    x.toPrecision();
+}
+else if (typeof x === "string") {
+    x.charCodeAt(1);
+}
+else if(typeof x === "boolean") {
+    x.valueOf();
+}
+else {
+    x
+}
+
+class A { a: string; }
+class B { b: string; }
+class C { c: string; }
+
+declare function isA(x: any): x is A;
+declare function isB(x: any): x is B;
+declare function isC(x: any): x is C;
+
+let y: A | B | C;
+
+if (isA(y)) {
+    y.a;
+}
+else if(isB(y)){
+    y.b;
+}
+else if(isC(y)) {
+    y.c;
+}
+else{
+    y
+}
+
+if (isB(y)) {
+    y.b;
+}
+else if (isA(y)) {
+    y.a;
+}
+else if(isB(y)){
+    y.b;
+}
+else if(isC(y)) {
+    y.c;
+}
+else{
+    y
+}


### PR DESCRIPTION
Fixes #4029.

Void narrowing only affects union types:
```typescript
let x: A | B;
if (isA(x)) {
}
else if(isB(x)) {
}
else {
   x// is void
}
```