### PR TITLE
Error if 'files' property is not an array

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -422,6 +422,9 @@ namespace ts {
                 if (json["files"] instanceof Array) {
                     fileNames = map(<string[]>json["files"], s => combinePaths(basePath, s));
                 }
+                else {
+                    errors.push(createCompilerDiagnostic(Diagnostics.Compiler_option_0_requires_a_value_of_type_1, 'files', 'Array'));                    
+                }
             }
             else {
                 let exclude = json["exclude"] instanceof Array ? map(<string[]>json["exclude"], normalizeSlashes) : undefined;


### PR DESCRIPTION
I wrote this
```ts
{
	"files": "tests.ts",
	"compilerOptions": {
		"module": "commonjs",
		"noImplicitAny": true
	}
}
```
and spent a long time trying to figure out what went wrong