### PR TITLE
Bind console log method so it works in the browser

### DIFF
--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -493,7 +493,7 @@ module Harness {
             export let readFile: typeof IO.readFile = ts.sys.readFile;
             export let writeFile: typeof IO.writeFile = ts.sys.writeFile;
             export let fileExists: typeof IO.fileExists = fs.existsSync;
-            export let log: typeof IO.log = console.log.bind(console);
+            export let log: typeof IO.log = s => console.log(s);
 
             export function createDirectory(path: string) {
                 if (!directoryExists(path)) {
@@ -673,7 +673,7 @@ module Harness {
             };
             export let listFiles = Utils.memoize(_listFilesImpl);
 
-            export let log = console.log.bind(console);
+            export let log = s => console.log(s);
 
             export function readFile(file: string) {
                 let response = Http.getFileFromServerSync(serverRoot + file);

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -493,7 +493,7 @@ module Harness {
             export let readFile: typeof IO.readFile = ts.sys.readFile;
             export let writeFile: typeof IO.writeFile = ts.sys.writeFile;
             export let fileExists: typeof IO.fileExists = fs.existsSync;
-            export let log: typeof IO.log = console.log;
+            export let log: typeof IO.log = console.log.bind(console);
 
             export function createDirectory(path: string) {
                 if (!directoryExists(path)) {
@@ -673,7 +673,7 @@ module Harness {
             };
             export let listFiles = Utils.memoize(_listFilesImpl);
 
-            export let log = console.log;
+            export let log = console.log.bind(console);
 
             export function readFile(file: string) {
                 let response = Http.getFileFromServerSync(serverRoot + file);


### PR DESCRIPTION
It's illegal to call unbound `console.log` in the browser. This causes a bunch of spurious exceptions when doing fourslash debugging in the browser because functions like `debug.printCurrentFileState` go through the harness layer's log function.