### PR TITLE
Don't emit in the presence of errors

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -218,7 +218,7 @@ var compilerFilename = "tsc.js";
 function compileFile(outFile, sources, prereqs, prefixes, useBuiltCompiler, noOutFile, generateDeclarations, outDir, preserveConstEnums, keepComments, noResolve, stripInternal, callback) {
     file(outFile, prereqs, function() {
         var dir = useBuiltCompiler ? builtLocalDirectory : LKGDirectory;
-        var options = "--module commonjs -noImplicitAny";
+        var options = "--module commonjs --noImplicitAny --noEmitOnError";
 
         // Keep comments when specifically requested
         // or when in debug mode.

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -673,7 +673,7 @@ module Harness {
             };
             export let listFiles = Utils.memoize(_listFilesImpl);
 
-            export let log = s => console.log(s);
+            export let log = (s: string) => console.log(s);
 
             export function readFile(file: string) {
                 let response = Http.getFileFromServerSync(serverRoot + file);


### PR DESCRIPTION
It not only makes very little sense to emit, it also crashes VS when one's language service points to `built/local/`