### PR TITLE
Fixes renaming not affecting JSX closing tags (#4093)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7180,13 +7180,17 @@ namespace ts {
         }
 
         function checkJsxElement(node: JsxElement) {
+            // Check attributes
+            checkJsxOpeningLikeElement(node.openingElement);
+
             // Check that the closing tag matches
             if (!tagNamesAreEquivalent(node.openingElement.tagName, node.closingElement.tagName)) {
                 error(node.closingElement, Diagnostics.Expected_corresponding_JSX_closing_tag_for_0, getTextOfNode(node.openingElement.tagName));
             }
-
-            // Check attributes
-            checkJsxOpeningLikeElement(node.openingElement);
+            else {
+                // Perform resolution on the closing tag so that rename/go to definition/etc work
+                getJsxElementTagSymbol(node.closingElement);
+            }
 
             // Check children
             for (let child of node.children) {
@@ -7297,7 +7301,7 @@ namespace ts {
         /// If this is a class-based tag (otherwise returns undefined), returns the symbol of the class
         /// type or factory function.
         /// Otherwise, returns unknownSymbol.
-        function getJsxElementTagSymbol(node: JsxOpeningLikeElement): Symbol {
+        function getJsxElementTagSymbol(node: JsxOpeningLikeElement|JsxClosingElement): Symbol {
             let flags: JsxFlags = JsxFlags.UnknownElement;
             let links = getNodeLinks(node);
             if (!links.resolvedSymbol) {
@@ -7309,7 +7313,7 @@ namespace ts {
             }
             return links.resolvedSymbol;
 
-            function lookupIntrinsicTag(node: JsxOpeningLikeElement): Symbol {
+            function lookupIntrinsicTag(node: JsxOpeningLikeElement|JsxClosingElement): Symbol {
                 let intrinsicElementsType = getJsxIntrinsicElementsType();
                 if (intrinsicElementsType !== unknownType) {
                     // Property case
@@ -7337,25 +7341,27 @@ namespace ts {
                 }
             }
 
-            function lookupClassTag(node: JsxOpeningLikeElement): Symbol {
-                let valueSymbol: Symbol;
+            function lookupClassTag(node: JsxOpeningLikeElement|JsxClosingElement): Symbol {
+                let valueSymbol: Symbol = resolveJsxTagName(node);
 
                 // Look up the value in the current scope
-                if (node.tagName.kind === SyntaxKind.Identifier) {
-                    let tag = <Identifier>node.tagName;
-                    let sym = getResolvedSymbol(tag);
-                    valueSymbol = sym.exportSymbol || sym;
-                }
-                else {
-                    valueSymbol = checkQualifiedName(<QualifiedName>node.tagName).symbol;
-                }
-
                 if (valueSymbol && valueSymbol !== unknownSymbol) {
                     links.jsxFlags |= JsxFlags.ClassElement;
                     getSymbolLinks(valueSymbol).referenced = true;
                 }
 
                 return valueSymbol || unknownSymbol;
+            }
+
+            function resolveJsxTagName(node: JsxOpeningLikeElement|JsxClosingElement): Symbol {
+                if (node.tagName.kind === SyntaxKind.Identifier) {
+                    let tag = <Identifier>node.tagName;
+                    let sym = getResolvedSymbol(tag);
+                    return sym.exportSymbol || sym;
+                }
+                else {
+                    return checkQualifiedName(<QualifiedName>node.tagName).symbol;
+                }
             }
         }
 
@@ -13879,7 +13885,9 @@ namespace ts {
                 meaning |= SymbolFlags.Alias;
                 return resolveEntityName(<EntityName>entityName, meaning);
             }
-            else if ((entityName.parent.kind === SyntaxKind.JsxOpeningElement) || (entityName.parent.kind === SyntaxKind.JsxSelfClosingElement)) {
+            else if ((entityName.parent.kind === SyntaxKind.JsxOpeningElement) ||
+                     (entityName.parent.kind === SyntaxKind.JsxSelfClosingElement) ||
+                     (entityName.parent.kind === SyntaxKind.JsxClosingElement)) {
                 return getJsxElementTagSymbol(<JsxOpeningLikeElement>entityName.parent);
             }
             else if (isExpression(entityName)) {

--- a/tests/baselines/reference/jsxInvalidEsprimaTestSuite.errors.txt
+++ b/tests/baselines/reference/jsxInvalidEsprimaTestSuite.errors.txt
@@ -30,6 +30,7 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(11,12): error TS2304:
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(11,16): error TS1109: Expression expected.
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(12,2): error TS2304: Cannot find name 'a'.
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(12,5): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(12,10): error TS2304: Cannot find name 'a'.
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(12,13): error TS1005: '>' expected.
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(12,14): error TS2304: Cannot find name 'c'.
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(12,16): error TS1109: Expression expected.
@@ -43,6 +44,7 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(14,8): error TS2304: 
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(14,10): error TS1109: Expression expected.
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(15,2): error TS2304: Cannot find name 'a'.
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(15,4): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(15,7): error TS2304: Cannot find name 'a'.
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(15,9): error TS1003: Identifier expected.
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(16,3): error TS1003: Identifier expected.
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(16,4): error TS2304: Cannot find name 'foo'.
@@ -71,7 +73,7 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,4): error TS1003: 
 tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,21): error TS17002: Expected corresponding JSX closing tag for 'a'.
 
 
-==== tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx (71 errors) ====
+==== tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx (73 errors) ====
     declare var React: any;
     
     </>;
@@ -148,6 +150,8 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,21): error TS17002
 !!! error TS2304: Cannot find name 'a'.
         ~
 !!! error TS1003: Identifier expected.
+             ~
+!!! error TS2304: Cannot find name 'a'.
                 ~
 !!! error TS1005: '>' expected.
                  ~
@@ -177,6 +181,8 @@ tests/cases/conformance/jsx/jsxInvalidEsprimaTestSuite.tsx(35,21): error TS17002
 !!! error TS2304: Cannot find name 'a'.
        ~
 !!! error TS1003: Identifier expected.
+          ~
+!!! error TS2304: Cannot find name 'a'.
             ~
 !!! error TS1003: Identifier expected.
     <a[foo]></a[foo]>;

--- a/tests/baselines/reference/jsxReactTestSuite.symbols
+++ b/tests/baselines/reference/jsxReactTestSuite.symbols
@@ -46,6 +46,7 @@ declare var hasOwnProperty:any;
   <div><br /></div>
   <Component>{foo}<br />{bar}</Component>
 >Component : Symbol(Component, Decl(jsxReactTestSuite.tsx, 2, 11))
+>Component : Symbol(Component, Decl(jsxReactTestSuite.tsx, 2, 11))
 
   <br />
 </div>;
@@ -56,6 +57,7 @@ declare var hasOwnProperty:any;
 
     {this.props.children}
 </Composite>;
+>Composite : Symbol(Composite, Decl(jsxReactTestSuite.tsx, 3, 11))
 
 <Composite>
 >Composite : Symbol(Composite, Decl(jsxReactTestSuite.tsx, 3, 11))
@@ -64,6 +66,7 @@ declare var hasOwnProperty:any;
 >Composite2 : Symbol(Composite2, Decl(jsxReactTestSuite.tsx, 4, 11))
 
 </Composite>;
+>Composite : Symbol(Composite, Decl(jsxReactTestSuite.tsx, 3, 11))
 
 var x =
 >x : Symbol(x, Decl(jsxReactTestSuite.tsx, 10, 11), Decl(jsxReactTestSuite.tsx, 35, 3))
@@ -181,6 +184,7 @@ var x =
 >x : Symbol(unknown)
 >y : Symbol(unknown)
 >Child : Symbol(Child, Decl(jsxReactTestSuite.tsx, 5, 11))
+>Component : Symbol(Component, Decl(jsxReactTestSuite.tsx, 2, 11))
 
 <Component x="1" {...(z = { y: 2 }, z)} z={3}>Text</Component>;
 >Component : Symbol(Component, Decl(jsxReactTestSuite.tsx, 2, 11))
@@ -189,6 +193,7 @@ var x =
 >y : Symbol(y, Decl(jsxReactTestSuite.tsx, 113, 27))
 >z : Symbol(z, Decl(jsxReactTestSuite.tsx, 11, 11))
 >z : Symbol(unknown)
+>Component : Symbol(Component, Decl(jsxReactTestSuite.tsx, 2, 11))
 
 
 

--- a/tests/baselines/reference/tsxEmit1.symbols
+++ b/tests/baselines/reference/tsxEmit1.symbols
@@ -57,16 +57,19 @@ var selfClosed7 = <div x={p} y='p' />;
 var openClosed1 = <div></div>;
 >openClosed1 : Symbol(openClosed1, Decl(tsxEmit1.tsx, 16, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 
 var openClosed2 = <div n='m'>foo</div>;
 >openClosed2 : Symbol(openClosed2, Decl(tsxEmit1.tsx, 17, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 >n : Symbol(unknown)
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 
 var openClosed3 = <div n='m'>{p}</div>;
 >openClosed3 : Symbol(openClosed3, Decl(tsxEmit1.tsx, 18, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 >n : Symbol(unknown)
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 
 var openClosed4 = <div n='m'>{p < p}</div>;
 >openClosed4 : Symbol(openClosed4, Decl(tsxEmit1.tsx, 19, 3))
@@ -74,6 +77,7 @@ var openClosed4 = <div n='m'>{p < p}</div>;
 >n : Symbol(unknown)
 >p : Symbol(p, Decl(tsxEmit1.tsx, 7, 3))
 >p : Symbol(p, Decl(tsxEmit1.tsx, 7, 3))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 
 var openClosed5 = <div n='m'>{p > p}</div>;
 >openClosed5 : Symbol(openClosed5, Decl(tsxEmit1.tsx, 20, 3))
@@ -81,6 +85,7 @@ var openClosed5 = <div n='m'>{p > p}</div>;
 >n : Symbol(unknown)
 >p : Symbol(p, Decl(tsxEmit1.tsx, 7, 3))
 >p : Symbol(p, Decl(tsxEmit1.tsx, 7, 3))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 
 class SomeClass {
 >SomeClass : Symbol(SomeClass, Decl(tsxEmit1.tsx, 20, 43))
@@ -92,6 +97,7 @@ class SomeClass {
 >rewrites1 : Symbol(rewrites1, Decl(tsxEmit1.tsx, 24, 5))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 >this : Symbol(SomeClass, Decl(tsxEmit1.tsx, 20, 43))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 
 		var rewrites2 = <div>{[p, ...p, p]}</div>;
 >rewrites2 : Symbol(rewrites2, Decl(tsxEmit1.tsx, 25, 5))
@@ -99,17 +105,20 @@ class SomeClass {
 >p : Symbol(p, Decl(tsxEmit1.tsx, 7, 3))
 >p : Symbol(p, Decl(tsxEmit1.tsx, 7, 3))
 >p : Symbol(p, Decl(tsxEmit1.tsx, 7, 3))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 
 		var rewrites3 = <div>{{p}}</div>;
 >rewrites3 : Symbol(rewrites3, Decl(tsxEmit1.tsx, 26, 5))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 >p : Symbol(p, Decl(tsxEmit1.tsx, 26, 25))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 
 		var rewrites4 = <div a={() => this}></div>;
 >rewrites4 : Symbol(rewrites4, Decl(tsxEmit1.tsx, 28, 5))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 >a : Symbol(unknown)
 >this : Symbol(SomeClass, Decl(tsxEmit1.tsx, 20, 43))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 
 		var rewrites5 = <div a={[p, ...p, p]}></div>;
 >rewrites5 : Symbol(rewrites5, Decl(tsxEmit1.tsx, 29, 5))
@@ -118,21 +127,25 @@ class SomeClass {
 >p : Symbol(p, Decl(tsxEmit1.tsx, 7, 3))
 >p : Symbol(p, Decl(tsxEmit1.tsx, 7, 3))
 >p : Symbol(p, Decl(tsxEmit1.tsx, 7, 3))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 
 		var rewrites6 = <div a={{p}}></div>;
 >rewrites6 : Symbol(rewrites6, Decl(tsxEmit1.tsx, 30, 5))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 >a : Symbol(unknown)
 >p : Symbol(p, Decl(tsxEmit1.tsx, 30, 27))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 	}
 }
 
 var whitespace1 = <div>      </div>;
 >whitespace1 : Symbol(whitespace1, Decl(tsxEmit1.tsx, 34, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 
 var whitespace2 = <div>  {p}    </div>;
 >whitespace2 : Symbol(whitespace2, Decl(tsxEmit1.tsx, 35, 3))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 
 var whitespace3 = <div>  
@@ -141,4 +154,5 @@ var whitespace3 = <div>
 
       {p}    
       </div>;
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 

--- a/tests/baselines/reference/tsxEmit2.symbols
+++ b/tests/baselines/reference/tsxEmit2.symbols
@@ -21,24 +21,29 @@ var p1, p2, p3;
 var spreads1 = <div {...p1}>{p2}</div>;
 >spreads1 : Symbol(spreads1, Decl(tsxEmit2.tsx, 8, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 
 var spreads2 = <div {...p1}>{p2}</div>;
 >spreads2 : Symbol(spreads2, Decl(tsxEmit2.tsx, 9, 3))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 
 var spreads3 = <div x={p3} {...p1}>{p2}</div>;
 >spreads3 : Symbol(spreads3, Decl(tsxEmit2.tsx, 10, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 >x : Symbol(unknown)
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 
 var spreads4 = <div {...p1} x={p3} >{p2}</div>;
 >spreads4 : Symbol(spreads4, Decl(tsxEmit2.tsx, 11, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 >x : Symbol(unknown)
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 
 var spreads5 = <div x={p2} {...p1} y={p3}>{p2}</div>;
 >spreads5 : Symbol(spreads5, Decl(tsxEmit2.tsx, 12, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 >x : Symbol(unknown)
 >y : Symbol(unknown)
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 

--- a/tests/baselines/reference/tsxExternalModuleEmit2.symbols
+++ b/tests/baselines/reference/tsxExternalModuleEmit2.symbols
@@ -20,9 +20,11 @@ declare var Foo, React;
 <Foo handler={Main}></Foo>;
 >Foo : Symbol(Foo, Decl(app.tsx, 1, 11))
 >handler : Symbol(unknown)
+>Foo : Symbol(Foo, Decl(app.tsx, 1, 11))
 
 // Should see mod_1['default'] in emit here
 <Foo {...Main}></Foo>;
+>Foo : Symbol(Foo, Decl(app.tsx, 1, 11))
 >Foo : Symbol(Foo, Decl(app.tsx, 1, 11))
 
 

--- a/tests/baselines/reference/tsxGenericArrowFunctionParsing.symbols
+++ b/tests/baselines/reference/tsxGenericArrowFunctionParsing.symbols
@@ -16,6 +16,7 @@ var T, T1, T2;
 var x1 = <T>() => {}</T>;
 >x1 : Symbol(x1, Decl(tsxGenericArrowFunctionParsing.tsx, 7, 3))
 >T : Symbol(T, Decl(tsxGenericArrowFunctionParsing.tsx, 4, 3))
+>T : Symbol(T, Decl(tsxGenericArrowFunctionParsing.tsx, 4, 3))
 
 x1.isElement;
 >x1.isElement : Symbol(JSX.Element.isElement, Decl(tsxGenericArrowFunctionParsing.tsx, 1, 20))
@@ -44,6 +45,7 @@ var x4 = <T extends={true}>() => {}</T>;
 >x4 : Symbol(x4, Decl(tsxGenericArrowFunctionParsing.tsx, 19, 3))
 >T : Symbol(T, Decl(tsxGenericArrowFunctionParsing.tsx, 4, 3))
 >extends : Symbol(unknown)
+>T : Symbol(T, Decl(tsxGenericArrowFunctionParsing.tsx, 4, 3))
 
 x4.isElement;
 >x4.isElement : Symbol(JSX.Element.isElement, Decl(tsxGenericArrowFunctionParsing.tsx, 1, 20))
@@ -55,6 +57,7 @@ var x5 = <T extends>() => {}</T>;
 >x5 : Symbol(x5, Decl(tsxGenericArrowFunctionParsing.tsx, 23, 3))
 >T : Symbol(T, Decl(tsxGenericArrowFunctionParsing.tsx, 4, 3))
 >extends : Symbol(unknown)
+>T : Symbol(T, Decl(tsxGenericArrowFunctionParsing.tsx, 4, 3))
 
 x5.isElement;
 >x5.isElement : Symbol(JSX.Element.isElement, Decl(tsxGenericArrowFunctionParsing.tsx, 1, 20))

--- a/tests/baselines/reference/tsxInArrowFunction.symbols
+++ b/tests/baselines/reference/tsxInArrowFunction.symbols
@@ -24,6 +24,7 @@ declare namespace JSX {
 >div : Symbol(JSX.IntrinsicElements.div, Decl(tsxInArrowFunction.tsx, 3, 33))
 >div : Symbol(JSX.IntrinsicElements.div, Decl(tsxInArrowFunction.tsx, 3, 33))
 >text : Symbol(text, Decl(tsxInArrowFunction.tsx, 4, 14))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(tsxInArrowFunction.tsx, 3, 33))
 
 // didn't work
 <div>{x => <div text="wat" />}</div>;
@@ -31,16 +32,20 @@ declare namespace JSX {
 >x : Symbol(x, Decl(tsxInArrowFunction.tsx, 15, 6))
 >div : Symbol(JSX.IntrinsicElements.div, Decl(tsxInArrowFunction.tsx, 3, 33))
 >text : Symbol(text, Decl(tsxInArrowFunction.tsx, 4, 14))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(tsxInArrowFunction.tsx, 3, 33))
 
 // worked
 <div>{() => (<div text="wat" />)}</div>;
 >div : Symbol(JSX.IntrinsicElements.div, Decl(tsxInArrowFunction.tsx, 3, 33))
 >div : Symbol(JSX.IntrinsicElements.div, Decl(tsxInArrowFunction.tsx, 3, 33))
 >text : Symbol(text, Decl(tsxInArrowFunction.tsx, 4, 14))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(tsxInArrowFunction.tsx, 3, 33))
 
 // worked (!)
 <div>{() => <div text="wat"></div>}</div>;
 >div : Symbol(JSX.IntrinsicElements.div, Decl(tsxInArrowFunction.tsx, 3, 33))
 >div : Symbol(JSX.IntrinsicElements.div, Decl(tsxInArrowFunction.tsx, 3, 33))
 >text : Symbol(text, Decl(tsxInArrowFunction.tsx, 4, 14))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(tsxInArrowFunction.tsx, 3, 33))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(tsxInArrowFunction.tsx, 3, 33))
 

--- a/tests/baselines/reference/tsxOpeningClosingNames.symbols
+++ b/tests/baselines/reference/tsxOpeningClosingNames.symbols
@@ -17,4 +17,5 @@ declare module A.B.C {
 
 <A.B.C.D>foo</A . B . C.D>
 >D : Symbol(unknown)
+>D : Symbol(unknown)
 

--- a/tests/baselines/reference/tsxParseTests1.symbols
+++ b/tests/baselines/reference/tsxParseTests1.symbols
@@ -17,4 +17,8 @@ var x = <div><div><span><div></div></span></div></div>;
 >div : Symbol(JSX.IntrinsicElements.div, Decl(tsxParseTests1.tsx, 2, 30))
 >span : Symbol(JSX.IntrinsicElements.span, Decl(tsxParseTests1.tsx, 2, 35))
 >div : Symbol(JSX.IntrinsicElements.div, Decl(tsxParseTests1.tsx, 2, 30))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(tsxParseTests1.tsx, 2, 30))
+>span : Symbol(JSX.IntrinsicElements.span, Decl(tsxParseTests1.tsx, 2, 35))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(tsxParseTests1.tsx, 2, 30))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(tsxParseTests1.tsx, 2, 30))
 

--- a/tests/baselines/reference/tsxReactEmit1.symbols
+++ b/tests/baselines/reference/tsxReactEmit1.symbols
@@ -60,16 +60,19 @@ var selfClosed7 = <div x={p} y='p' b />;
 var openClosed1 = <div></div>;
 >openClosed1 : Symbol(openClosed1, Decl(tsxReactEmit1.tsx, 17, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 
 var openClosed2 = <div n='m'>foo</div>;
 >openClosed2 : Symbol(openClosed2, Decl(tsxReactEmit1.tsx, 18, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 >n : Symbol(unknown)
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 
 var openClosed3 = <div n='m'>{p}</div>;
 >openClosed3 : Symbol(openClosed3, Decl(tsxReactEmit1.tsx, 19, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 >n : Symbol(unknown)
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 
 var openClosed4 = <div n='m'>{p < p}</div>;
 >openClosed4 : Symbol(openClosed4, Decl(tsxReactEmit1.tsx, 20, 3))
@@ -77,6 +80,7 @@ var openClosed4 = <div n='m'>{p < p}</div>;
 >n : Symbol(unknown)
 >p : Symbol(p, Decl(tsxReactEmit1.tsx, 8, 3))
 >p : Symbol(p, Decl(tsxReactEmit1.tsx, 8, 3))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 
 var openClosed5 = <div n='m' b>{p > p}</div>;
 >openClosed5 : Symbol(openClosed5, Decl(tsxReactEmit1.tsx, 21, 3))
@@ -85,6 +89,7 @@ var openClosed5 = <div n='m' b>{p > p}</div>;
 >b : Symbol(unknown)
 >p : Symbol(p, Decl(tsxReactEmit1.tsx, 8, 3))
 >p : Symbol(p, Decl(tsxReactEmit1.tsx, 8, 3))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 
 class SomeClass {
 >SomeClass : Symbol(SomeClass, Decl(tsxReactEmit1.tsx, 21, 45))
@@ -96,6 +101,7 @@ class SomeClass {
 >rewrites1 : Symbol(rewrites1, Decl(tsxReactEmit1.tsx, 25, 5))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 >this : Symbol(SomeClass, Decl(tsxReactEmit1.tsx, 21, 45))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 
 		var rewrites2 = <div>{[p, ...p, p]}</div>;
 >rewrites2 : Symbol(rewrites2, Decl(tsxReactEmit1.tsx, 26, 5))
@@ -103,17 +109,20 @@ class SomeClass {
 >p : Symbol(p, Decl(tsxReactEmit1.tsx, 8, 3))
 >p : Symbol(p, Decl(tsxReactEmit1.tsx, 8, 3))
 >p : Symbol(p, Decl(tsxReactEmit1.tsx, 8, 3))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 
 		var rewrites3 = <div>{{p}}</div>;
 >rewrites3 : Symbol(rewrites3, Decl(tsxReactEmit1.tsx, 27, 5))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 >p : Symbol(p, Decl(tsxReactEmit1.tsx, 27, 25))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 
 		var rewrites4 = <div a={() => this}></div>;
 >rewrites4 : Symbol(rewrites4, Decl(tsxReactEmit1.tsx, 29, 5))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 >a : Symbol(unknown)
 >this : Symbol(SomeClass, Decl(tsxReactEmit1.tsx, 21, 45))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 
 		var rewrites5 = <div a={[p, ...p, p]}></div>;
 >rewrites5 : Symbol(rewrites5, Decl(tsxReactEmit1.tsx, 30, 5))
@@ -122,21 +131,25 @@ class SomeClass {
 >p : Symbol(p, Decl(tsxReactEmit1.tsx, 8, 3))
 >p : Symbol(p, Decl(tsxReactEmit1.tsx, 8, 3))
 >p : Symbol(p, Decl(tsxReactEmit1.tsx, 8, 3))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 
 		var rewrites6 = <div a={{p}}></div>;
 >rewrites6 : Symbol(rewrites6, Decl(tsxReactEmit1.tsx, 31, 5))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 >a : Symbol(unknown)
 >p : Symbol(p, Decl(tsxReactEmit1.tsx, 31, 27))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 	}
 }
 
 var whitespace1 = <div>      </div>;
 >whitespace1 : Symbol(whitespace1, Decl(tsxReactEmit1.tsx, 35, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 
 var whitespace2 = <div>  {p}    </div>;
 >whitespace2 : Symbol(whitespace2, Decl(tsxReactEmit1.tsx, 36, 3))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 
 var whitespace3 = <div>  
@@ -145,4 +158,5 @@ var whitespace3 = <div>
 
       {p}    
       </div>;
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 

--- a/tests/baselines/reference/tsxReactEmit2.symbols
+++ b/tests/baselines/reference/tsxReactEmit2.symbols
@@ -23,24 +23,29 @@ var p1, p2, p3;
 var spreads1 = <div {...p1}>{p2}</div>;
 >spreads1 : Symbol(spreads1, Decl(tsxReactEmit2.tsx, 9, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 
 var spreads2 = <div {...p1}>{p2}</div>;
 >spreads2 : Symbol(spreads2, Decl(tsxReactEmit2.tsx, 10, 3))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 
 var spreads3 = <div x={p3} {...p1}>{p2}</div>;
 >spreads3 : Symbol(spreads3, Decl(tsxReactEmit2.tsx, 11, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 >x : Symbol(unknown)
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 
 var spreads4 = <div {...p1} x={p3} >{p2}</div>;
 >spreads4 : Symbol(spreads4, Decl(tsxReactEmit2.tsx, 12, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 >x : Symbol(unknown)
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 
 var spreads5 = <div x={p2} {...p1} y={p3}>{p2}</div>;
 >spreads5 : Symbol(spreads5, Decl(tsxReactEmit2.tsx, 13, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 >x : Symbol(unknown)
 >y : Symbol(unknown)
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 

--- a/tests/baselines/reference/tsxReactEmit3.symbols
+++ b/tests/baselines/reference/tsxReactEmit3.symbols
@@ -18,4 +18,6 @@ declare var Foo, Bar, baz;
 >Bar : Symbol(Bar, Decl(tsxReactEmit3.tsx, 4, 16))
 >Bar : Symbol(Bar, Decl(tsxReactEmit3.tsx, 4, 16))
 >Bar : Symbol(Bar, Decl(tsxReactEmit3.tsx, 4, 16))
+>Bar : Symbol(Bar, Decl(tsxReactEmit3.tsx, 4, 16))
+>Foo : Symbol(Foo, Decl(tsxReactEmit3.tsx, 4, 11))
 

--- a/tests/baselines/reference/tsxReactEmitWhitespace.symbols
+++ b/tests/baselines/reference/tsxReactEmitWhitespace.symbols
@@ -24,9 +24,11 @@ var p = 0;
 // Emit "   "
 <div>   </div>;
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 
 // Emit "  ", p, "   "
 <div>  {p}    </div>;
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 
 // Emit only p
@@ -35,6 +37,7 @@ var p = 0;
 
       {p}    
       </div>;
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 
 // Emit only p
 <div>
@@ -42,15 +45,18 @@ var p = 0;
 
   {p}
     </div>;
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 
 // Emit "  3"
 <div>  3  
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 
   </div>;
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 
 // Emit "  3  "
 <div>  3  </div>;
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 
 // Emit "3"
@@ -59,12 +65,14 @@ var p = 0;
 
    3    
    </div>;
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 
 // Emit no args
 <div>   
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 
    </div>;
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 
 // Emit "foo" + ' ' + "bar"
 <div>  
@@ -75,5 +83,6 @@ var p = 0;
  bar   
 
   </div>;
+>div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 
 

--- a/tests/cases/fourslash/tsxRename4.ts
+++ b/tests/cases/fourslash/tsxRename4.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts' />
+
+//@Filename: file.tsx
+//// declare module JSX {
+////     interface Element { }
+////     interface IntrinsicElements {
+////     }
+////     interface ElementAttributesProperty { props }
+//// }
+//// class [|MyClass|] {
+////   props: {
+////     name?: string;
+////     size?: number;
+//// }
+//// 
+//// 
+//// var x = <[|MyC/**/lass|] name='hello'></[|MyClass|]>;
+
+goTo.marker();
+debugger;
+verify.renameLocations(false, false);

--- a/tests/cases/fourslash/tsxRename4.ts
+++ b/tests/cases/fourslash/tsxRename4.ts
@@ -17,5 +17,4 @@
 //// var x = <[|MyC/**/lass|] name='hello'></[|MyClass|]>;
 
 goTo.marker();
-debugger;
 verify.renameLocations(false, false);


### PR DESCRIPTION
Fixes #4093

We weren't wiring up the closing tags to their corresponding symbols.

This does have a side effect of causing "name not found" errors on closing tags that will always match the opening tag names. We could probably fix this if it's problematic, but would require plumbing through another boolean fairly deep into the core identifier resolution functions.