### PR TITLE
Fix issue where exit code was not being appropriately returned

### DIFF
--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -355,18 +355,20 @@ namespace ts {
         return { program, exitStatus };
 
         function compileProgram(): ExitStatus {
-            // First get any syntactic errors.
-            let diagnostics = program.getSyntacticDiagnostics();
+            let diagnostics: Diagnostic[];
+            
+            // First get and report any syntactic errors.
+            diagnostics = program.getSyntacticDiagnostics();
             reportDiagnostics(diagnostics);
 
             // If we didn't have any syntactic errors, then also try getting the global and
             // semantic errors.
             if (diagnostics.length === 0) {
-                let diagnostics = program.getGlobalDiagnostics();
+                diagnostics = program.getGlobalDiagnostics();
                 reportDiagnostics(diagnostics);
 
                 if (diagnostics.length === 0) {
-                    let diagnostics = program.getSemanticDiagnostics();
+                    diagnostics = program.getSemanticDiagnostics();
                     reportDiagnostics(diagnostics);
                 }
             }

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -14,7 +14,7 @@ namespace ts {
         let matchResult = /^([a-z]+)([_\-]([a-z]+))?$/.exec(locale.toLowerCase());
 
         if (!matchResult) {
-            errors.push(createCompilerDiagnostic(Diagnostics.Locale_must_be_of_the_form_language_or_language_territory_For_example_0_or_1, 'en', 'ja-jp'));
+            errors.push(createCompilerDiagnostic(Diagnostics.Locale_must_be_of_the_form_language_or_language_territory_For_example_0_or_1, "en", "ja-jp"));
             return false;
         }
 
@@ -49,7 +49,7 @@ namespace ts {
         }
 
         // TODO: Add codePage support for readFile?
-        let fileContents = '';
+        let fileContents = "";
         try {
             fileContents = sys.readFile(filePath);
         }

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -359,19 +359,18 @@ namespace ts {
             
             // First get and report any syntactic errors.
             diagnostics = program.getSyntacticDiagnostics();
-            reportDiagnostics(diagnostics);
 
             // If we didn't have any syntactic errors, then also try getting the global and
             // semantic errors.
             if (diagnostics.length === 0) {
                 diagnostics = program.getGlobalDiagnostics();
-                reportDiagnostics(diagnostics);
 
                 if (diagnostics.length === 0) {
                     diagnostics = program.getSemanticDiagnostics();
-                    reportDiagnostics(diagnostics);
                 }
             }
+
+            reportDiagnostics(diagnostics);
 
             // If the user doesn't want us to emit, then we're done at this point.
             if (compilerOptions.noEmit) {


### PR DESCRIPTION
Essentially, instead of `diagnostics` referring to the same variable throughout `compileProgram`, each of the `let` declarations created a new scoped variable, meaning that the test at the end was not picking up "global" and "semantic" errors.

Fixes #4095.