### PR TITLE
Support non-object type constraints

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4710,7 +4710,7 @@ namespace ts {
                     }
                 }
                 else {
-                    // It is necessary to try "each" checks on both sides because there may be nested "some" checks
+                    // It is necessary to try "some" checks on both sides because there may be nested "each" checks
                     // on either side that need to be prioritized. For example, A | B = (A | B) & (C | D) or
                     // A & B = (A & B) | (C & D).
                     if (source.flags & TypeFlags.Intersection) {
@@ -4887,7 +4887,7 @@ namespace ts {
                 if (source.constraint === noConstraintType || target.constraint === noConstraintType) {
                     return Ternary.False;
                 }
-                return isRelatedTo(source.constraint, target.constraint, /*reportErrors*/ false);
+                return isIdenticalTo(source.constraint, target.constraint);
             }
 
             // Determine if two object types are related by structure. First, check if the result is already available in the global cache.

--- a/tests/baselines/reference/apparentTypeSupertype.errors.txt
+++ b/tests/baselines/reference/apparentTypeSupertype.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSupertype.ts(9,7): error TS2415: Class 'Derived<U>' incorrectly extends base class 'Base'.
   Types of property 'x' are incompatible.
     Type 'U' is not assignable to type 'string'.
+      Type 'String' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSupertype.ts (1 errors) ====
@@ -17,5 +18,6 @@ tests/cases/conformance/types/typeRelationships/apparentType/apparentTypeSuperty
 !!! error TS2415: Class 'Derived<U>' incorrectly extends base class 'Base'.
 !!! error TS2415:   Types of property 'x' are incompatible.
 !!! error TS2415:     Type 'U' is not assignable to type 'string'.
+!!! error TS2415:       Type 'String' is not assignable to type 'string'.
         x: U;
     }

--- a/tests/baselines/reference/assignmentCompatWithNumericIndexer.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithNumericIndexer.errors.txt
@@ -12,12 +12,14 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer.ts(33,9): error TS2322: Type 'A<T>' is not assignable to type '{ [x: number]: Derived; }'.
   Index signatures are incompatible.
     Type 'T' is not assignable to type 'Derived'.
+      Type 'Base' is not assignable to type 'Derived'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer.ts(36,9): error TS2322: Type '{ [x: number]: Derived2; }' is not assignable to type 'A<T>'.
   Index signatures are incompatible.
     Type 'Derived2' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer.ts(37,9): error TS2322: Type 'A<T>' is not assignable to type '{ [x: number]: Derived2; }'.
   Index signatures are incompatible.
     Type 'T' is not assignable to type 'Derived2'.
+      Type 'Base' is not assignable to type 'Derived2'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer.ts (6 errors) ====
@@ -72,6 +74,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 !!! error TS2322: Type 'A<T>' is not assignable to type '{ [x: number]: Derived; }'.
 !!! error TS2322:   Index signatures are incompatible.
 !!! error TS2322:     Type 'T' is not assignable to type 'Derived'.
+!!! error TS2322:       Type 'Base' is not assignable to type 'Derived'.
     
             var b2: { [x: number]: Derived2; }
             a = b2; // error
@@ -84,6 +87,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 !!! error TS2322: Type 'A<T>' is not assignable to type '{ [x: number]: Derived2; }'.
 !!! error TS2322:   Index signatures are incompatible.
 !!! error TS2322:     Type 'T' is not assignable to type 'Derived2'.
+!!! error TS2322:       Type 'Base' is not assignable to type 'Derived2'.
     
             var b3: { [x: number]: T; }
             a = b3; // ok

--- a/tests/baselines/reference/assignmentCompatWithNumericIndexer2.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithNumericIndexer2.errors.txt
@@ -12,12 +12,14 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer2.ts(33,9): error TS2322: Type 'A<T>' is not assignable to type '{ [x: number]: Derived; }'.
   Index signatures are incompatible.
     Type 'T' is not assignable to type 'Derived'.
+      Type 'Base' is not assignable to type 'Derived'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer2.ts(36,9): error TS2322: Type '{ [x: number]: Derived2; }' is not assignable to type 'A<T>'.
   Index signatures are incompatible.
     Type 'Derived2' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer2.ts(37,9): error TS2322: Type 'A<T>' is not assignable to type '{ [x: number]: Derived2; }'.
   Index signatures are incompatible.
     Type 'T' is not assignable to type 'Derived2'.
+      Type 'Base' is not assignable to type 'Derived2'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithNumericIndexer2.ts (6 errors) ====
@@ -72,6 +74,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 !!! error TS2322: Type 'A<T>' is not assignable to type '{ [x: number]: Derived; }'.
 !!! error TS2322:   Index signatures are incompatible.
 !!! error TS2322:     Type 'T' is not assignable to type 'Derived'.
+!!! error TS2322:       Type 'Base' is not assignable to type 'Derived'.
     
             var b2: { [x: number]: Derived2; }
             a = b2; // error
@@ -84,6 +87,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 !!! error TS2322: Type 'A<T>' is not assignable to type '{ [x: number]: Derived2; }'.
 !!! error TS2322:   Index signatures are incompatible.
 !!! error TS2322:     Type 'T' is not assignable to type 'Derived2'.
+!!! error TS2322:       Type 'Base' is not assignable to type 'Derived2'.
     
             var b3: { [x: number]: T; }
             a = b3; // ok

--- a/tests/baselines/reference/assignmentCompatWithStringIndexer.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithStringIndexer.errors.txt
@@ -18,12 +18,14 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer.ts(47,9): error TS2322: Type 'A<T>' is not assignable to type '{ [x: string]: Derived; }'.
   Index signatures are incompatible.
     Type 'T' is not assignable to type 'Derived'.
+      Type 'Base' is not assignable to type 'Derived'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer.ts(50,9): error TS2322: Type '{ [x: string]: Derived2; }' is not assignable to type 'A<T>'.
   Index signatures are incompatible.
     Type 'Derived2' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer.ts(51,9): error TS2322: Type 'A<T>' is not assignable to type '{ [x: string]: Derived2; }'.
   Index signatures are incompatible.
     Type 'T' is not assignable to type 'Derived2'.
+      Type 'Base' is not assignable to type 'Derived2'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer.ts (8 errors) ====
@@ -100,6 +102,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 !!! error TS2322: Type 'A<T>' is not assignable to type '{ [x: string]: Derived; }'.
 !!! error TS2322:   Index signatures are incompatible.
 !!! error TS2322:     Type 'T' is not assignable to type 'Derived'.
+!!! error TS2322:       Type 'Base' is not assignable to type 'Derived'.
     
             var b4: { [x: string]: Derived2; };
             a3 = b4; // error
@@ -112,5 +115,6 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 !!! error TS2322: Type 'A<T>' is not assignable to type '{ [x: string]: Derived2; }'.
 !!! error TS2322:   Index signatures are incompatible.
 !!! error TS2322:     Type 'T' is not assignable to type 'Derived2'.
+!!! error TS2322:       Type 'Base' is not assignable to type 'Derived2'.
         }
     }

--- a/tests/baselines/reference/assignmentCompatWithStringIndexer2.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithStringIndexer2.errors.txt
@@ -18,12 +18,14 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer2.ts(47,9): error TS2322: Type 'A<T>' is not assignable to type '{ [x: string]: Derived; }'.
   Index signatures are incompatible.
     Type 'T' is not assignable to type 'Derived'.
+      Type 'Base' is not assignable to type 'Derived'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer2.ts(50,9): error TS2322: Type '{ [x: string]: Derived2; }' is not assignable to type 'A<T>'.
   Index signatures are incompatible.
     Type 'Derived2' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer2.ts(51,9): error TS2322: Type 'A<T>' is not assignable to type '{ [x: string]: Derived2; }'.
   Index signatures are incompatible.
     Type 'T' is not assignable to type 'Derived2'.
+      Type 'Base' is not assignable to type 'Derived2'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer2.ts (8 errors) ====
@@ -100,6 +102,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 !!! error TS2322: Type 'A<T>' is not assignable to type '{ [x: string]: Derived; }'.
 !!! error TS2322:   Index signatures are incompatible.
 !!! error TS2322:     Type 'T' is not assignable to type 'Derived'.
+!!! error TS2322:       Type 'Base' is not assignable to type 'Derived'.
     
             var b4: { [x: string]: Derived2; };
             a3 = b4; // error
@@ -112,5 +115,6 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 !!! error TS2322: Type 'A<T>' is not assignable to type '{ [x: string]: Derived2; }'.
 !!! error TS2322:   Index signatures are incompatible.
 !!! error TS2322:     Type 'T' is not assignable to type 'Derived2'.
+!!! error TS2322:       Type 'Base' is not assignable to type 'Derived2'.
         }
     }

--- a/tests/baselines/reference/assignmentCompatWithStringIndexer3.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithStringIndexer3.errors.txt
@@ -5,6 +5,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer3.ts(21,9): error TS2322: Type 'A<T>' is not assignable to type '{ [x: string]: string; }'.
   Index signatures are incompatible.
     Type 'T' is not assignable to type 'string'.
+      Type 'Derived' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithStringIndexer3.ts (3 errors) ====
@@ -39,5 +40,6 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 !!! error TS2322: Type 'A<T>' is not assignable to type '{ [x: string]: string; }'.
 !!! error TS2322:   Index signatures are incompatible.
 !!! error TS2322:     Type 'T' is not assignable to type 'string'.
+!!! error TS2322:       Type 'Derived' is not assignable to type 'string'.
         }
     }

--- a/tests/baselines/reference/assignmentNonObjectTypeConstraints.js
+++ b/tests/baselines/reference/assignmentNonObjectTypeConstraints.js
@@ -1,0 +1,42 @@
+//// [assignmentNonObjectTypeConstraints.ts]
+const enum E { A, B, C }
+
+function foo<T extends number>(x: T) {
+    var y: number = x;  // Ok
+}
+
+foo(5);
+foo(E.A);
+
+class A { a }
+class B { b }
+
+function bar<T extends A | B>(x: T) {
+    var y: A | B = x;  // Ok
+}
+
+bar(new A);
+bar(new B);
+
+
+//// [assignmentNonObjectTypeConstraints.js]
+function foo(x) {
+    var y = x; // Ok
+}
+foo(5);
+foo(0 /* A */);
+var A = (function () {
+    function A() {
+    }
+    return A;
+})();
+var B = (function () {
+    function B() {
+    }
+    return B;
+})();
+function bar(x) {
+    var y = x; // Ok
+}
+bar(new A);
+bar(new B);

--- a/tests/baselines/reference/assignmentNonObjectTypeConstraints.symbols
+++ b/tests/baselines/reference/assignmentNonObjectTypeConstraints.symbols
@@ -1,0 +1,58 @@
+=== tests/cases/compiler/assignmentNonObjectTypeConstraints.ts ===
+const enum E { A, B, C }
+>E : Symbol(E, Decl(assignmentNonObjectTypeConstraints.ts, 0, 0))
+>A : Symbol(E.A, Decl(assignmentNonObjectTypeConstraints.ts, 0, 14))
+>B : Symbol(E.B, Decl(assignmentNonObjectTypeConstraints.ts, 0, 17))
+>C : Symbol(E.C, Decl(assignmentNonObjectTypeConstraints.ts, 0, 20))
+
+function foo<T extends number>(x: T) {
+>foo : Symbol(foo, Decl(assignmentNonObjectTypeConstraints.ts, 0, 24))
+>T : Symbol(T, Decl(assignmentNonObjectTypeConstraints.ts, 2, 13))
+>x : Symbol(x, Decl(assignmentNonObjectTypeConstraints.ts, 2, 31))
+>T : Symbol(T, Decl(assignmentNonObjectTypeConstraints.ts, 2, 13))
+
+    var y: number = x;  // Ok
+>y : Symbol(y, Decl(assignmentNonObjectTypeConstraints.ts, 3, 7))
+>x : Symbol(x, Decl(assignmentNonObjectTypeConstraints.ts, 2, 31))
+}
+
+foo(5);
+>foo : Symbol(foo, Decl(assignmentNonObjectTypeConstraints.ts, 0, 24))
+
+foo(E.A);
+>foo : Symbol(foo, Decl(assignmentNonObjectTypeConstraints.ts, 0, 24))
+>E.A : Symbol(E.A, Decl(assignmentNonObjectTypeConstraints.ts, 0, 14))
+>E : Symbol(E, Decl(assignmentNonObjectTypeConstraints.ts, 0, 0))
+>A : Symbol(E.A, Decl(assignmentNonObjectTypeConstraints.ts, 0, 14))
+
+class A { a }
+>A : Symbol(A, Decl(assignmentNonObjectTypeConstraints.ts, 7, 9))
+>a : Symbol(a, Decl(assignmentNonObjectTypeConstraints.ts, 9, 9))
+
+class B { b }
+>B : Symbol(B, Decl(assignmentNonObjectTypeConstraints.ts, 9, 13))
+>b : Symbol(b, Decl(assignmentNonObjectTypeConstraints.ts, 10, 9))
+
+function bar<T extends A | B>(x: T) {
+>bar : Symbol(bar, Decl(assignmentNonObjectTypeConstraints.ts, 10, 13))
+>T : Symbol(T, Decl(assignmentNonObjectTypeConstraints.ts, 12, 13))
+>A : Symbol(A, Decl(assignmentNonObjectTypeConstraints.ts, 7, 9))
+>B : Symbol(B, Decl(assignmentNonObjectTypeConstraints.ts, 9, 13))
+>x : Symbol(x, Decl(assignmentNonObjectTypeConstraints.ts, 12, 30))
+>T : Symbol(T, Decl(assignmentNonObjectTypeConstraints.ts, 12, 13))
+
+    var y: A | B = x;  // Ok
+>y : Symbol(y, Decl(assignmentNonObjectTypeConstraints.ts, 13, 7))
+>A : Symbol(A, Decl(assignmentNonObjectTypeConstraints.ts, 7, 9))
+>B : Symbol(B, Decl(assignmentNonObjectTypeConstraints.ts, 9, 13))
+>x : Symbol(x, Decl(assignmentNonObjectTypeConstraints.ts, 12, 30))
+}
+
+bar(new A);
+>bar : Symbol(bar, Decl(assignmentNonObjectTypeConstraints.ts, 10, 13))
+>A : Symbol(A, Decl(assignmentNonObjectTypeConstraints.ts, 7, 9))
+
+bar(new B);
+>bar : Symbol(bar, Decl(assignmentNonObjectTypeConstraints.ts, 10, 13))
+>B : Symbol(B, Decl(assignmentNonObjectTypeConstraints.ts, 9, 13))
+

--- a/tests/baselines/reference/assignmentNonObjectTypeConstraints.types
+++ b/tests/baselines/reference/assignmentNonObjectTypeConstraints.types
@@ -1,0 +1,65 @@
+=== tests/cases/compiler/assignmentNonObjectTypeConstraints.ts ===
+const enum E { A, B, C }
+>E : E
+>A : E
+>B : E
+>C : E
+
+function foo<T extends number>(x: T) {
+>foo : <T extends number>(x: T) => void
+>T : T
+>x : T
+>T : T
+
+    var y: number = x;  // Ok
+>y : number
+>x : T
+}
+
+foo(5);
+>foo(5) : void
+>foo : <T extends number>(x: T) => void
+>5 : number
+
+foo(E.A);
+>foo(E.A) : void
+>foo : <T extends number>(x: T) => void
+>E.A : E
+>E : typeof E
+>A : E
+
+class A { a }
+>A : A
+>a : any
+
+class B { b }
+>B : B
+>b : any
+
+function bar<T extends A | B>(x: T) {
+>bar : <T extends A | B>(x: T) => void
+>T : T
+>A : A
+>B : B
+>x : T
+>T : T
+
+    var y: A | B = x;  // Ok
+>y : A | B
+>A : A
+>B : B
+>x : T
+}
+
+bar(new A);
+>bar(new A) : void
+>bar : <T extends A | B>(x: T) => void
+>new A : A
+>A : typeof A
+
+bar(new B);
+>bar(new B) : void
+>bar : <T extends A | B>(x: T) => void
+>new B : B
+>B : typeof B
+

--- a/tests/baselines/reference/functionConstraintSatisfaction2.errors.txt
+++ b/tests/baselines/reference/functionConstraintSatisfaction2.errors.txt
@@ -14,7 +14,7 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstrain
 tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts(34,16): error TS2345: Argument of type 'F2' is not assignable to parameter of type '(x: string) => string'.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts(36,38): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts(37,10): error TS2345: Argument of type 'T' is not assignable to parameter of type '(x: string) => string'.
-  Type 'void' is not assignable to type 'string'.
+  Type '() => void' is not assignable to type '(x: string) => string'.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts(38,10): error TS2345: Argument of type 'U' is not assignable to parameter of type '(x: string) => string'.
 
 
@@ -85,7 +85,7 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstrain
         foo2(x);
              ~
 !!! error TS2345: Argument of type 'T' is not assignable to parameter of type '(x: string) => string'.
-!!! error TS2345:   Type 'void' is not assignable to type 'string'.
+!!! error TS2345:   Type '() => void' is not assignable to type '(x: string) => string'.
         foo2(y);
              ~
 !!! error TS2345: Argument of type 'U' is not assignable to parameter of type '(x: string) => string'.

--- a/tests/baselines/reference/genericCallWithGenericSignatureArguments2.errors.txt
+++ b/tests/baselines/reference/genericCallWithGenericSignatureArguments2.errors.txt
@@ -5,7 +5,8 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGen
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(25,23): error TS2345: Argument of type '(a: T) => T' is not assignable to parameter of type '(x: Date) => Date'.
   Types of parameters 'a' and 'x' are incompatible.
     Type 'T' is not assignable to type 'Date'.
-      Property 'toDateString' is missing in type 'RegExp'.
+      Type 'RegExp' is not assignable to type 'Date'.
+        Property 'toDateString' is missing in type 'RegExp'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(37,36): error TS2345: Argument of type '(x: E) => F' is not assignable to parameter of type '(x: E) => E'.
   Type 'F' is not assignable to type 'E'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(50,21): error TS2345: Argument of type 'Date' is not assignable to parameter of type 'T'.
@@ -13,6 +14,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGen
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(60,23): error TS2345: Argument of type '(a: T) => T' is not assignable to parameter of type '(x: Date) => Date'.
   Types of parameters 'a' and 'x' are incompatible.
     Type 'T' is not assignable to type 'Date'.
+      Type 'RegExp' is not assignable to type 'Date'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(67,51): error TS2304: Cannot find name 'U'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(67,57): error TS2304: Cannot find name 'U'.
 
@@ -54,7 +56,8 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGen
 !!! error TS2345: Argument of type '(a: T) => T' is not assignable to parameter of type '(x: Date) => Date'.
 !!! error TS2345:   Types of parameters 'a' and 'x' are incompatible.
 !!! error TS2345:     Type 'T' is not assignable to type 'Date'.
-!!! error TS2345:       Property 'toDateString' is missing in type 'RegExp'.
+!!! error TS2345:       Type 'RegExp' is not assignable to type 'Date'.
+!!! error TS2345:         Property 'toDateString' is missing in type 'RegExp'.
             var r7b = foo2((a) => a, (b) => b); // valid, T is inferred to be Date
         }
     
@@ -101,6 +104,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGen
 !!! error TS2345: Argument of type '(a: T) => T' is not assignable to parameter of type '(x: Date) => Date'.
 !!! error TS2345:   Types of parameters 'a' and 'x' are incompatible.
 !!! error TS2345:     Type 'T' is not assignable to type 'Date'.
+!!! error TS2345:       Type 'RegExp' is not assignable to type 'Date'.
             var r7b = foo2((a) => a, (b) => b); 
         }
     

--- a/tests/baselines/reference/genericCallWithObjectTypeArgsAndIndexersErrors.errors.txt
+++ b/tests/baselines/reference/genericCallWithObjectTypeArgsAndIndexersErrors.errors.txt
@@ -1,9 +1,8 @@
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndIndexersErrors.ts(15,17): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
-tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndIndexersErrors.ts(18,9): error TS2413: Numeric index type 'T' is not assignable to string index type 'Object'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndIndexersErrors.ts(23,9): error TS2322: Type 'T' is not assignable to type 'U'.
 
 
-==== tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndIndexersErrors.ts (3 errors) ====
+==== tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObjectTypeArgsAndIndexersErrors.ts (2 errors) ====
     // Type inference infers from indexers in target type, error cases
     
     function foo<T>(x: T) {
@@ -24,8 +23,6 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithObj
         var b: {
             [x: string]: Object;
             [x: number]: T;
-            ~~~~~~~~~~~~~~~
-!!! error TS2413: Numeric index type 'T' is not assignable to string index type 'Object'.
         };
         var r2 = foo(b);
         var d = r2[1];

--- a/tests/baselines/reference/genericTypeAssertions6.errors.txt
+++ b/tests/baselines/reference/genericTypeAssertions6.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/compiler/genericTypeAssertions6.ts(8,13): error TS2352: Neither type 'U' nor type 'T' is assignable to the other.
 tests/cases/compiler/genericTypeAssertions6.ts(9,13): error TS2352: Neither type 'T' nor type 'U' is assignable to the other.
 tests/cases/compiler/genericTypeAssertions6.ts(19,17): error TS2352: Neither type 'U' nor type 'T' is assignable to the other.
+  Type 'Date' is not assignable to type 'T'.
 
 
 ==== tests/cases/compiler/genericTypeAssertions6.ts (3 errors) ====
@@ -29,6 +30,7 @@ tests/cases/compiler/genericTypeAssertions6.ts(19,17): error TS2352: Neither typ
             var e = <T><U>new Date();
                     ~~~~~~~~~~~~~~~~
 !!! error TS2352: Neither type 'U' nor type 'T' is assignable to the other.
+!!! error TS2352:   Type 'Date' is not assignable to type 'T'.
         }
     }
     

--- a/tests/baselines/reference/genericTypeWithNonGenericBaseMisMatch.errors.txt
+++ b/tests/baselines/reference/genericTypeWithNonGenericBaseMisMatch.errors.txt
@@ -3,8 +3,9 @@ tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(4,7): error TS2420
     Type '(a: T) => void' is not assignable to type '(a: { a: number; }) => void'.
       Types of parameters 'a' and 'a' are incompatible.
         Type 'T' is not assignable to type '{ a: number; }'.
-          Types of property 'a' are incompatible.
-            Type 'string' is not assignable to type 'number'.
+          Type '{ a: string; }' is not assignable to type '{ a: number; }'.
+            Types of property 'a' are incompatible.
+              Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(8,5): error TS2322: Type 'X<{ a: string; }>' is not assignable to type 'I'.
   Types of property 'f' are incompatible.
     Type '(a: { a: string; }) => void' is not assignable to type '(a: { a: number; }) => void'.
@@ -25,8 +26,9 @@ tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(8,5): error TS2322
 !!! error TS2420:     Type '(a: T) => void' is not assignable to type '(a: { a: number; }) => void'.
 !!! error TS2420:       Types of parameters 'a' and 'a' are incompatible.
 !!! error TS2420:         Type 'T' is not assignable to type '{ a: number; }'.
-!!! error TS2420:           Types of property 'a' are incompatible.
-!!! error TS2420:             Type 'string' is not assignable to type 'number'.
+!!! error TS2420:           Type '{ a: string; }' is not assignable to type '{ a: number; }'.
+!!! error TS2420:             Types of property 'a' are incompatible.
+!!! error TS2420:               Type 'string' is not assignable to type 'number'.
     	f(a: T): void { }
     }
     var x = new X<{ a: string }>();

--- a/tests/baselines/reference/interfaceWithMultipleBaseTypes.errors.txt
+++ b/tests/baselines/reference/interfaceWithMultipleBaseTypes.errors.txt
@@ -18,11 +18,9 @@ tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBa
 tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes.ts(60,15): error TS2430: Interface 'Derived5<T>' incorrectly extends interface 'Base1<T>'.
   Types of property 'x' are incompatible.
     Type 'T' is not assignable to type '{ a: T; }'.
-      Property 'a' is missing in type '{}'.
 tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes.ts(60,15): error TS2430: Interface 'Derived5<T>' incorrectly extends interface 'Base2<T>'.
   Types of property 'x' are incompatible.
     Type 'T' is not assignable to type '{ b: T; }'.
-      Property 'b' is missing in type '{}'.
 
 
 ==== tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBaseTypes.ts (6 errors) ====
@@ -111,12 +109,10 @@ tests/cases/conformance/interfaces/interfaceDeclarations/interfaceWithMultipleBa
 !!! error TS2430: Interface 'Derived5<T>' incorrectly extends interface 'Base1<T>'.
 !!! error TS2430:   Types of property 'x' are incompatible.
 !!! error TS2430:     Type 'T' is not assignable to type '{ a: T; }'.
-!!! error TS2430:       Property 'a' is missing in type '{}'.
                   ~~~~~~~~
 !!! error TS2430: Interface 'Derived5<T>' incorrectly extends interface 'Base2<T>'.
 !!! error TS2430:   Types of property 'x' are incompatible.
 !!! error TS2430:     Type 'T' is not assignable to type '{ b: T; }'.
-!!! error TS2430:       Property 'b' is missing in type '{}'.
             x: T;
         }
     }

--- a/tests/baselines/reference/objectTypeWithRecursiveWrappedPropertyCheckedNominally.errors.txt
+++ b/tests/baselines/reference/objectTypeWithRecursiveWrappedPropertyCheckedNominally.errors.txt
@@ -5,9 +5,12 @@ tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRec
   Types of property 'data' are incompatible.
     Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts(30,5): error TS2322: Type 'U' is not assignable to type 'T'.
+  Type 'MyList<number>' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts(31,5): error TS2322: Type 'T' is not assignable to type 'U'.
+  Type 'List<number>' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts(41,15): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts(42,5): error TS2322: Type 'U' is not assignable to type 'T'.
+  Type 'MyList<number>' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts(43,5): error TS2322: Type 'T' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts(48,5): error TS2322: Type 'T' is not assignable to type 'List<number>'.
 tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRecursiveWrappedPropertyCheckedNominally.ts(50,5): error TS2322: Type 'T' is not assignable to type 'MyList<number>'.
@@ -54,9 +57,11 @@ tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRec
         t = u; // error
         ~
 !!! error TS2322: Type 'U' is not assignable to type 'T'.
+!!! error TS2322:   Type 'MyList<number>' is not assignable to type 'T'.
         u = t; // error
         ~
 !!! error TS2322: Type 'T' is not assignable to type 'U'.
+!!! error TS2322:   Type 'List<number>' is not assignable to type 'U'.
     
         var a: List<number>;
         var b: MyList<number>;
@@ -72,6 +77,7 @@ tests/cases/conformance/types/typeRelationships/recursiveTypes/objectTypeWithRec
         t = u; // error
         ~
 !!! error TS2322: Type 'U' is not assignable to type 'T'.
+!!! error TS2322:   Type 'MyList<number>' is not assignable to type 'T'.
         u = t; // was error, ok after constraint made illegal, doesn't matter
         ~
 !!! error TS2322: Type 'T' is not assignable to type 'U'.

--- a/tests/baselines/reference/subtypesOfTypeParameterWithConstraints.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameterWithConstraints.errors.txt
@@ -101,12 +101,14 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(132,7): error TS2415: Class 'D23<T, U, V>' incorrectly extends base class 'C3<T>'.
   Types of property 'foo' are incompatible.
     Type 'V' is not assignable to type 'T'.
+      Type 'Date' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(132,11): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(132,24): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(134,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(137,7): error TS2415: Class 'D24<T, U, V>' incorrectly extends base class 'C3<U>'.
   Types of property 'foo' are incompatible.
     Type 'V' is not assignable to type 'U'.
+      Type 'Date' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(137,11): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(137,24): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints.ts(139,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'U'.
@@ -441,6 +443,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 !!! error TS2415: Class 'D23<T, U, V>' incorrectly extends base class 'C3<T>'.
 !!! error TS2415:   Types of property 'foo' are incompatible.
 !!! error TS2415:     Type 'V' is not assignable to type 'T'.
+!!! error TS2415:       Type 'Date' is not assignable to type 'T'.
               ~~~~~~~~~~~
 !!! error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
                            ~~~~~~~~~~~
@@ -456,6 +459,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 !!! error TS2415: Class 'D24<T, U, V>' incorrectly extends base class 'C3<U>'.
 !!! error TS2415:   Types of property 'foo' are incompatible.
 !!! error TS2415:     Type 'V' is not assignable to type 'U'.
+!!! error TS2415:       Type 'Date' is not assignable to type 'U'.
               ~~~~~~~~~~~
 !!! error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
                            ~~~~~~~~~~~

--- a/tests/baselines/reference/subtypesOfTypeParameterWithConstraints4.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameterWithConstraints4.errors.txt
@@ -1,11 +1,11 @@
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(45,7): error TS2415: Class 'D3<T, U, V>' incorrectly extends base class 'B1<Foo>'.
   Types of property 'foo' are incompatible.
     Type 'V' is not assignable to type 'Foo'.
-      Property 'foo' is missing in type '{}'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(47,5): error TS2411: Property 'foo' of type 'V' is not assignable to string index type 'Foo'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(55,7): error TS2415: Class 'D5<T, U, V>' incorrectly extends base class 'B1<T>'.
   Types of property 'foo' are incompatible.
     Type 'U' is not assignable to type 'T'.
+      Type 'Foo' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(57,5): error TS2411: Property 'foo' of type 'U' is not assignable to string index type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(60,7): error TS2415: Class 'D6<T, U, V>' incorrectly extends base class 'B1<T>'.
   Types of property 'foo' are incompatible.
@@ -14,6 +14,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(65,7): error TS2415: Class 'D7<T, U, V>' incorrectly extends base class 'B1<U>'.
   Types of property 'foo' are incompatible.
     Type 'T' is not assignable to type 'U'.
+      Type 'Foo' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(67,5): error TS2411: Property 'foo' of type 'T' is not assignable to string index type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithConstraints4.ts(75,7): error TS2415: Class 'D9<T, U, V>' incorrectly extends base class 'B1<U>'.
   Types of property 'foo' are incompatible.
@@ -71,7 +72,6 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 !!! error TS2415: Class 'D3<T, U, V>' incorrectly extends base class 'B1<Foo>'.
 !!! error TS2415:   Types of property 'foo' are incompatible.
 !!! error TS2415:     Type 'V' is not assignable to type 'Foo'.
-!!! error TS2415:       Property 'foo' is missing in type '{}'.
         [x: string]: Foo;
         foo: V; // error
         ~~~~~~~
@@ -88,6 +88,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 !!! error TS2415: Class 'D5<T, U, V>' incorrectly extends base class 'B1<T>'.
 !!! error TS2415:   Types of property 'foo' are incompatible.
 !!! error TS2415:     Type 'U' is not assignable to type 'T'.
+!!! error TS2415:       Type 'Foo' is not assignable to type 'T'.
         [x: string]: T;
         foo: U; // error
         ~~~~~~~
@@ -110,6 +111,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 !!! error TS2415: Class 'D7<T, U, V>' incorrectly extends base class 'B1<U>'.
 !!! error TS2415:   Types of property 'foo' are incompatible.
 !!! error TS2415:     Type 'T' is not assignable to type 'U'.
+!!! error TS2415:       Type 'Foo' is not assignable to type 'U'.
         [x: string]: U;
         foo: T; // error
         ~~~~~~~

--- a/tests/baselines/reference/subtypesOfTypeParameterWithRecursiveConstraints.errors.txt
+++ b/tests/baselines/reference/subtypesOfTypeParameterWithRecursiveConstraints.errors.txt
@@ -7,6 +7,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(66,11): error TS2415: Class 'D2<T, U, V>' incorrectly extends base class 'Base<T>'.
   Types of property 'foo' are incompatible.
     Type 'U' is not assignable to type 'T'.
+      Type 'Foo<any>' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(66,14): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(66,32): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(66,50): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
@@ -14,6 +15,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(71,11): error TS2415: Class 'D3<T, U, V>' incorrectly extends base class 'Base<T>'.
   Types of property 'foo' are incompatible.
     Type 'V' is not assignable to type 'T'.
+      Type 'Foo<any>' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(71,14): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(71,32): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(71,50): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
@@ -21,6 +23,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(76,11): error TS2415: Class 'D4<T, U, V>' incorrectly extends base class 'Base<U>'.
   Types of property 'foo' are incompatible.
     Type 'T' is not assignable to type 'U'.
+      Type 'Foo<any>' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(76,14): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(76,32): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(76,50): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
@@ -31,6 +34,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(86,11): error TS2415: Class 'D6<T, U, V>' incorrectly extends base class 'Base<U>'.
   Types of property 'foo' are incompatible.
     Type 'V' is not assignable to type 'U'.
+      Type 'Foo<any>' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(86,14): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(86,32): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(86,50): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
@@ -38,6 +42,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(91,11): error TS2415: Class 'D7<T, U, V>' incorrectly extends base class 'Base<V>'.
   Types of property 'foo' are incompatible.
     Type 'T' is not assignable to type 'V'.
+      Type 'Foo<any>' is not assignable to type 'V'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(91,14): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(91,32): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(91,50): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
@@ -45,6 +50,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(96,11): error TS2415: Class 'D8<T, U, V>' incorrectly extends base class 'Base<V>'.
   Types of property 'foo' are incompatible.
     Type 'U' is not assignable to type 'V'.
+      Type 'Foo<any>' is not assignable to type 'V'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(96,14): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(96,32): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOfTypeParameterWithRecursiveConstraints.ts(96,50): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
@@ -170,6 +176,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 !!! error TS2415: Class 'D2<T, U, V>' incorrectly extends base class 'Base<T>'.
 !!! error TS2415:   Types of property 'foo' are incompatible.
 !!! error TS2415:     Type 'U' is not assignable to type 'T'.
+!!! error TS2415:       Type 'Foo<any>' is not assignable to type 'T'.
                  ~~~~~~~~~~~~~~~~
 !!! error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
                                    ~~~~~~~~~~~~~~~~
@@ -187,6 +194,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 !!! error TS2415: Class 'D3<T, U, V>' incorrectly extends base class 'Base<T>'.
 !!! error TS2415:   Types of property 'foo' are incompatible.
 !!! error TS2415:     Type 'V' is not assignable to type 'T'.
+!!! error TS2415:       Type 'Foo<any>' is not assignable to type 'T'.
                  ~~~~~~~~~~~~~~~~
 !!! error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
                                    ~~~~~~~~~~~~~~~~
@@ -204,6 +212,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 !!! error TS2415: Class 'D4<T, U, V>' incorrectly extends base class 'Base<U>'.
 !!! error TS2415:   Types of property 'foo' are incompatible.
 !!! error TS2415:     Type 'T' is not assignable to type 'U'.
+!!! error TS2415:       Type 'Foo<any>' is not assignable to type 'U'.
                  ~~~~~~~~~~~~~~~~
 !!! error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
                                    ~~~~~~~~~~~~~~~~
@@ -232,6 +241,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 !!! error TS2415: Class 'D6<T, U, V>' incorrectly extends base class 'Base<U>'.
 !!! error TS2415:   Types of property 'foo' are incompatible.
 !!! error TS2415:     Type 'V' is not assignable to type 'U'.
+!!! error TS2415:       Type 'Foo<any>' is not assignable to type 'U'.
                  ~~~~~~~~~~~~~~~~
 !!! error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
                                    ~~~~~~~~~~~~~~~~
@@ -249,6 +259,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 !!! error TS2415: Class 'D7<T, U, V>' incorrectly extends base class 'Base<V>'.
 !!! error TS2415:   Types of property 'foo' are incompatible.
 !!! error TS2415:     Type 'T' is not assignable to type 'V'.
+!!! error TS2415:       Type 'Foo<any>' is not assignable to type 'V'.
                  ~~~~~~~~~~~~~~~~
 !!! error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
                                    ~~~~~~~~~~~~~~~~
@@ -266,6 +277,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypesOf
 !!! error TS2415: Class 'D8<T, U, V>' incorrectly extends base class 'Base<V>'.
 !!! error TS2415:   Types of property 'foo' are incompatible.
 !!! error TS2415:     Type 'U' is not assignable to type 'V'.
+!!! error TS2415:       Type 'Foo<any>' is not assignable to type 'V'.
                  ~~~~~~~~~~~~~~~~
 !!! error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
                                    ~~~~~~~~~~~~~~~~

--- a/tests/baselines/reference/typeParameterAssignability2.errors.txt
+++ b/tests/baselines/reference/typeParameterAssignability2.errors.txt
@@ -16,9 +16,11 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typePara
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(24,28): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(25,5): error TS2322: Type 'U' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(26,5): error TS2322: Type 'V' is not assignable to type 'T'.
+  Type 'Date' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(27,5): error TS2322: Type 'Date' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(29,5): error TS2322: Type 'T' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(30,5): error TS2322: Type 'V' is not assignable to type 'U'.
+  Type 'Date' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(31,5): error TS2322: Type 'Date' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(33,5): error TS2322: Type 'T' is not assignable to type 'V'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(34,5): error TS2322: Type 'U' is not assignable to type 'V'.
@@ -29,9 +31,11 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typePara
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(44,44): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(45,5): error TS2322: Type 'U' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(46,5): error TS2322: Type 'V' is not assignable to type 'T'.
+  Type 'Date' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(47,5): error TS2322: Type 'Date' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(49,5): error TS2322: Type 'T' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(50,5): error TS2322: Type 'V' is not assignable to type 'U'.
+  Type 'Date' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(51,5): error TS2322: Type 'Date' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(53,5): error TS2322: Type 'T' is not assignable to type 'V'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability2.ts(54,5): error TS2322: Type 'U' is not assignable to type 'V'.
@@ -110,6 +114,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typePara
         t = v; // error
         ~
 !!! error TS2322: Type 'V' is not assignable to type 'T'.
+!!! error TS2322:   Type 'Date' is not assignable to type 'T'.
         t = new Date(); // error
         ~
 !!! error TS2322: Type 'Date' is not assignable to type 'T'.
@@ -120,6 +125,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typePara
         u = v; // error
         ~
 !!! error TS2322: Type 'V' is not assignable to type 'U'.
+!!! error TS2322:   Type 'Date' is not assignable to type 'U'.
         u = new Date(); // error
         ~
 !!! error TS2322: Type 'Date' is not assignable to type 'U'.
@@ -156,6 +162,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typePara
         t = v; // error
         ~
 !!! error TS2322: Type 'V' is not assignable to type 'T'.
+!!! error TS2322:   Type 'Date' is not assignable to type 'T'.
         t = new Date(); // error
         ~
 !!! error TS2322: Type 'Date' is not assignable to type 'T'.
@@ -166,6 +173,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typePara
         u = v; // error
         ~
 !!! error TS2322: Type 'V' is not assignable to type 'U'.
+!!! error TS2322:   Type 'Date' is not assignable to type 'U'.
         u = new Date(); // error
         ~
 !!! error TS2322: Type 'Date' is not assignable to type 'U'.

--- a/tests/baselines/reference/typeParameterAssignability3.errors.txt
+++ b/tests/baselines/reference/typeParameterAssignability3.errors.txt
@@ -1,7 +1,11 @@
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability3.ts(14,5): error TS2322: Type 'U' is not assignable to type 'T'.
+  Type 'Foo' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability3.ts(15,5): error TS2322: Type 'T' is not assignable to type 'U'.
+  Type 'Foo' is not assignable to type 'U'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability3.ts(22,9): error TS2322: Type 'U' is not assignable to type 'T'.
+  Type 'Foo' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability3.ts(23,9): error TS2322: Type 'T' is not assignable to type 'U'.
+  Type 'Foo' is not assignable to type 'U'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typeParameterAssignability3.ts (4 errors) ====
@@ -21,9 +25,11 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typePara
         t = u; // error
         ~
 !!! error TS2322: Type 'U' is not assignable to type 'T'.
+!!! error TS2322:   Type 'Foo' is not assignable to type 'T'.
         u = t; // error
         ~
 !!! error TS2322: Type 'T' is not assignable to type 'U'.
+!!! error TS2322:   Type 'Foo' is not assignable to type 'U'.
     }
     
     class C<T extends Foo, U extends Foo> {
@@ -33,8 +39,10 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/typePara
             this.t = this.u; // error
             ~~~~~~
 !!! error TS2322: Type 'U' is not assignable to type 'T'.
+!!! error TS2322:   Type 'Foo' is not assignable to type 'T'.
             this.u = this.t; // error
             ~~~~~~
 !!! error TS2322: Type 'T' is not assignable to type 'U'.
+!!! error TS2322:   Type 'Foo' is not assignable to type 'U'.
         }
     }

--- a/tests/baselines/reference/typeParameterDiamond3.errors.txt
+++ b/tests/baselines/reference/typeParameterDiamond3.errors.txt
@@ -4,6 +4,9 @@ tests/cases/compiler/typeParameterDiamond3.ts(9,13): error TS2322: Type 'Bottom'
   Type 'Top | T | U' is not assignable to type 'T | U'.
     Type 'Top' is not assignable to type 'T | U'.
       Type 'Top' is not assignable to type 'U'.
+        Type 'Bottom' is not assignable to type 'U'.
+          Type 'Top | T | U' is not assignable to type 'U'.
+            Type 'Top' is not assignable to type 'U'.
 tests/cases/compiler/typeParameterDiamond3.ts(10,13): error TS2322: Type 'Bottom' is not assignable to type 'Top'.
   Type 'Top | T | U' is not assignable to type 'Top'.
     Type 'T' is not assignable to type 'Top'.
@@ -27,6 +30,9 @@ tests/cases/compiler/typeParameterDiamond3.ts(10,13): error TS2322: Type 'Bottom
 !!! error TS2322:   Type 'Top | T | U' is not assignable to type 'T | U'.
 !!! error TS2322:     Type 'Top' is not assignable to type 'T | U'.
 !!! error TS2322:       Type 'Top' is not assignable to type 'U'.
+!!! error TS2322:         Type 'Bottom' is not assignable to type 'U'.
+!!! error TS2322:           Type 'Top | T | U' is not assignable to type 'U'.
+!!! error TS2322:             Type 'Top' is not assignable to type 'U'.
                 top = bottom;
                 ~~~
 !!! error TS2322: Type 'Bottom' is not assignable to type 'Top'.

--- a/tests/baselines/reference/typeParameterUsedAsTypeParameterConstraint4.errors.txt
+++ b/tests/baselines/reference/typeParameterUsedAsTypeParameterConstraint4.errors.txt
@@ -2,6 +2,7 @@ tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsed
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(4,25): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(5,8): error TS2304: Cannot find name 'W'.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(8,16): error TS2322: Type 'W' is not assignable to type 'T'.
+  Type 'V' is not assignable to type 'T'.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(12,16): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(12,29): error TS2313: Constraint of a type parameter cannot reference any type parameter from the same type parameter list.
 tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsedAsTypeParameterConstraint4.ts(15,8): error TS2304: Cannot find name 'W'.
@@ -42,6 +43,7 @@ tests/cases/conformance/types/objectTypeLiteral/callSignatures/typeParameterUsed
             return x;
                    ~
 !!! error TS2322: Type 'W' is not assignable to type 'T'.
+!!! error TS2322:   Type 'V' is not assignable to type 'T'.
         }
     }
     

--- a/tests/baselines/reference/typeParametersShouldNotBeEqual2.errors.txt
+++ b/tests/baselines/reference/typeParametersShouldNotBeEqual2.errors.txt
@@ -1,8 +1,11 @@
 tests/cases/compiler/typeParametersShouldNotBeEqual2.ts(4,5): error TS2322: Type 'U' is not assignable to type 'T'.
+  Type 'Date' is not assignable to type 'T'.
 tests/cases/compiler/typeParametersShouldNotBeEqual2.ts(5,5): error TS2322: Type 'V' is not assignable to type 'T'.
 tests/cases/compiler/typeParametersShouldNotBeEqual2.ts(6,5): error TS2322: Type 'T' is not assignable to type 'V'.
+  Type 'Date' is not assignable to type 'V'.
 tests/cases/compiler/typeParametersShouldNotBeEqual2.ts(7,5): error TS2322: Type 'V' is not assignable to type 'U'.
 tests/cases/compiler/typeParametersShouldNotBeEqual2.ts(8,5): error TS2322: Type 'U' is not assignable to type 'V'.
+  Type 'Date' is not assignable to type 'V'.
 tests/cases/compiler/typeParametersShouldNotBeEqual2.ts(9,5): error TS2322: Type 'Object' is not assignable to type 'T'.
 
 
@@ -13,18 +16,21 @@ tests/cases/compiler/typeParametersShouldNotBeEqual2.ts(9,5): error TS2322: Type
         x = y;  // Ok
         ~
 !!! error TS2322: Type 'U' is not assignable to type 'T'.
+!!! error TS2322:   Type 'Date' is not assignable to type 'T'.
         x = z;  // Error
         ~
 !!! error TS2322: Type 'V' is not assignable to type 'T'.
         z = x;  // Error
         ~
 !!! error TS2322: Type 'T' is not assignable to type 'V'.
+!!! error TS2322:   Type 'Date' is not assignable to type 'V'.
         y = z;  // Error
         ~
 !!! error TS2322: Type 'V' is not assignable to type 'U'.
         z = y;  // Error
         ~
 !!! error TS2322: Type 'U' is not assignable to type 'V'.
+!!! error TS2322:   Type 'Date' is not assignable to type 'V'.
         x = zz;  // Error
         ~
 !!! error TS2322: Type 'Object' is not assignable to type 'T'.

--- a/tests/baselines/reference/typeParametersShouldNotBeEqual3.errors.txt
+++ b/tests/baselines/reference/typeParametersShouldNotBeEqual3.errors.txt
@@ -1,4 +1,5 @@
 tests/cases/compiler/typeParametersShouldNotBeEqual3.ts(4,5): error TS2322: Type 'U' is not assignable to type 'T'.
+  Type 'Object' is not assignable to type 'T'.
 tests/cases/compiler/typeParametersShouldNotBeEqual3.ts(5,5): error TS2322: Type 'Object' is not assignable to type 'T'.
 
 
@@ -9,6 +10,7 @@ tests/cases/compiler/typeParametersShouldNotBeEqual3.ts(5,5): error TS2322: Type
         x = y;  // Ok
         ~
 !!! error TS2322: Type 'U' is not assignable to type 'T'.
+!!! error TS2322:   Type 'Object' is not assignable to type 'T'.
         x = z;  // Ok
         ~
 !!! error TS2322: Type 'Object' is not assignable to type 'T'.

--- a/tests/cases/compiler/assignmentNonObjectTypeConstraints.ts
+++ b/tests/cases/compiler/assignmentNonObjectTypeConstraints.ts
@@ -1,0 +1,18 @@
+const enum E { A, B, C }
+
+function foo<T extends number>(x: T) {
+    var y: number = x;  // Ok
+}
+
+foo(5);
+foo(E.A);
+
+class A { a }
+class B { b }
+
+function bar<T extends A | B>(x: T) {
+    var y: A | B = x;  // Ok
+}
+
+bar(new A);
+bar(new B);


### PR DESCRIPTION
This PR fixes #1935 by correcting type relationships involving type parameters with non-object type constraints. For example:

```typescript
function foo<T extends number>(x: T) {
    var y: number = x;  // Was error, now ok
}

function bar<T extends A | B>(x: T) {
    var y: A | B = x;  // Was error, now ok
}
```

The PR also cleans up the `isRelatedTo` method in the type checker by breaking out the type identity case as a separate function. This makes the logic a good deal easier to understand. Furthermore, when a type parameter has a constraint, we now properly report errors relating to assignment compatibility of the constraint.