### PR TITLE
Run builds, tests, etc. without global jake

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,11 @@
         "tslint": "latest"
     },
     "scripts": {
-        "test": "jake runtests"
+        "pretest": "jake tests",
+        "test": "jake runtests",
+        "build": "npm run build:compiler && npm run build:tests",
+        "build:compiler": "jake local",
+        "build:tests": "jake tests",
+        "clean": "jake clean"
     }
 }


### PR DESCRIPTION
`npm` is pretty great at helping do [sane builds within a package's namespace](http://blog.keithcirkel.co.uk/how-to-use-npm-as-a-build-tool/).

In this PR, I've added a few scripts that invoke `jake` from within `./node_modules/.bin` so I didn't have to install jake globally, set up an alias, or anything like that. `npm` is quite sharp and it's the way forward within the community.

Since `npm` installs devDependencies on a git clone, you get jake locally (no worry about global install).

To run tests, run

```
npm test
```