### PR TITLE
emit space before the dot for property/element access expressions if …

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2070,7 +2070,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     else {
                         // check if constant enum value is integer
                         let constantValue = tryGetConstEnumValue(node.expression);
-                        shouldEmitSpace = constantValue !== undefined && isFinite(constantValue) && Math.floor(constantValue) === constantValue;
+                        // isFinite handles cases when constantValue is undefined
+                        shouldEmitSpace = isFinite(constantValue) && Math.floor(constantValue) === constantValue;
                     }
                 }
 

--- a/tests/baselines/reference/constEnumToStringNoComments.js
+++ b/tests/baselines/reference/constEnumToStringNoComments.js
@@ -1,0 +1,22 @@
+//// [constEnumToStringNoComments.ts]
+const enum Foo {
+    X = 100,
+    Y = 0.5,
+    Z = 2.
+}
+
+let x0 = Foo.X.toString();
+let x1 = Foo["X"].toString();
+let y0 = Foo.Y.toString();
+let y1 = Foo["Y"].toString();
+let z0 = Foo.Z.toString();
+let z1 = Foo["Z"].toString();
+
+
+//// [constEnumToStringNoComments.js]
+var x0 = 100 .toString();
+var x1 = 100 .toString();
+var y0 = 0.5.toString();
+var y1 = 0.5.toString();
+var z0 = 2 .toString();
+var z1 = 2 .toString();

--- a/tests/baselines/reference/constEnumToStringNoComments.js
+++ b/tests/baselines/reference/constEnumToStringNoComments.js
@@ -2,7 +2,10 @@
 const enum Foo {
     X = 100,
     Y = 0.5,
-    Z = 2.
+    Z = 2.,
+    A = -1,
+    B = -1.5,
+    C = -1.
 }
 
 let x0 = Foo.X.toString();
@@ -11,6 +14,12 @@ let y0 = Foo.Y.toString();
 let y1 = Foo["Y"].toString();
 let z0 = Foo.Z.toString();
 let z1 = Foo["Z"].toString();
+let a0 = Foo.A.toString();
+let a1 = Foo["A"].toString();
+let b0 = Foo.B.toString();
+let b1 = Foo["B"].toString();
+let c0 = Foo.C.toString();
+let c1 = Foo["C"].toString();
 
 
 //// [constEnumToStringNoComments.js]
@@ -20,3 +29,9 @@ var y0 = 0.5.toString();
 var y1 = 0.5.toString();
 var z0 = 2 .toString();
 var z1 = 2 .toString();
+var a0 = -1 .toString();
+var a1 = -1 .toString();
+var b0 = -1.5.toString();
+var b1 = -1.5.toString();
+var c0 = -1 .toString();
+var c1 = -1 .toString();

--- a/tests/baselines/reference/constEnumToStringNoComments.symbols
+++ b/tests/baselines/reference/constEnumToStringNoComments.symbols
@@ -1,0 +1,59 @@
+=== tests/cases/compiler/constEnumToStringNoComments.ts ===
+const enum Foo {
+>Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
+
+    X = 100,
+>X : Symbol(Foo.X, Decl(constEnumToStringNoComments.ts, 0, 16))
+
+    Y = 0.5,
+>Y : Symbol(Foo.Y, Decl(constEnumToStringNoComments.ts, 1, 12))
+
+    Z = 2.
+>Z : Symbol(Foo.Z, Decl(constEnumToStringNoComments.ts, 2, 12))
+}
+
+let x0 = Foo.X.toString();
+>x0 : Symbol(x0, Decl(constEnumToStringNoComments.ts, 6, 3))
+>Foo.X.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo.X : Symbol(Foo.X, Decl(constEnumToStringNoComments.ts, 0, 16))
+>Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
+>X : Symbol(Foo.X, Decl(constEnumToStringNoComments.ts, 0, 16))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let x1 = Foo["X"].toString();
+>x1 : Symbol(x1, Decl(constEnumToStringNoComments.ts, 7, 3))
+>Foo["X"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
+>"X" : Symbol(Foo.X, Decl(constEnumToStringNoComments.ts, 0, 16))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let y0 = Foo.Y.toString();
+>y0 : Symbol(y0, Decl(constEnumToStringNoComments.ts, 8, 3))
+>Foo.Y.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo.Y : Symbol(Foo.Y, Decl(constEnumToStringNoComments.ts, 1, 12))
+>Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
+>Y : Symbol(Foo.Y, Decl(constEnumToStringNoComments.ts, 1, 12))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let y1 = Foo["Y"].toString();
+>y1 : Symbol(y1, Decl(constEnumToStringNoComments.ts, 9, 3))
+>Foo["Y"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
+>"Y" : Symbol(Foo.Y, Decl(constEnumToStringNoComments.ts, 1, 12))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let z0 = Foo.Z.toString();
+>z0 : Symbol(z0, Decl(constEnumToStringNoComments.ts, 10, 3))
+>Foo.Z.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo.Z : Symbol(Foo.Z, Decl(constEnumToStringNoComments.ts, 2, 12))
+>Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
+>Z : Symbol(Foo.Z, Decl(constEnumToStringNoComments.ts, 2, 12))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let z1 = Foo["Z"].toString();
+>z1 : Symbol(z1, Decl(constEnumToStringNoComments.ts, 11, 3))
+>Foo["Z"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
+>"Z" : Symbol(Foo.Z, Decl(constEnumToStringNoComments.ts, 2, 12))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+

--- a/tests/baselines/reference/constEnumToStringNoComments.symbols
+++ b/tests/baselines/reference/constEnumToStringNoComments.symbols
@@ -8,12 +8,21 @@ const enum Foo {
     Y = 0.5,
 >Y : Symbol(Foo.Y, Decl(constEnumToStringNoComments.ts, 1, 12))
 
-    Z = 2.
+    Z = 2.,
 >Z : Symbol(Foo.Z, Decl(constEnumToStringNoComments.ts, 2, 12))
+
+    A = -1,
+>A : Symbol(Foo.A, Decl(constEnumToStringNoComments.ts, 3, 11))
+
+    B = -1.5,
+>B : Symbol(Foo.B, Decl(constEnumToStringNoComments.ts, 4, 11))
+
+    C = -1.
+>C : Symbol(Foo.C, Decl(constEnumToStringNoComments.ts, 5, 13))
 }
 
 let x0 = Foo.X.toString();
->x0 : Symbol(x0, Decl(constEnumToStringNoComments.ts, 6, 3))
+>x0 : Symbol(x0, Decl(constEnumToStringNoComments.ts, 9, 3))
 >Foo.X.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 >Foo.X : Symbol(Foo.X, Decl(constEnumToStringNoComments.ts, 0, 16))
 >Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
@@ -21,14 +30,14 @@ let x0 = Foo.X.toString();
 >toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 
 let x1 = Foo["X"].toString();
->x1 : Symbol(x1, Decl(constEnumToStringNoComments.ts, 7, 3))
+>x1 : Symbol(x1, Decl(constEnumToStringNoComments.ts, 10, 3))
 >Foo["X"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 >Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
 >"X" : Symbol(Foo.X, Decl(constEnumToStringNoComments.ts, 0, 16))
 >toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 
 let y0 = Foo.Y.toString();
->y0 : Symbol(y0, Decl(constEnumToStringNoComments.ts, 8, 3))
+>y0 : Symbol(y0, Decl(constEnumToStringNoComments.ts, 11, 3))
 >Foo.Y.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 >Foo.Y : Symbol(Foo.Y, Decl(constEnumToStringNoComments.ts, 1, 12))
 >Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
@@ -36,14 +45,14 @@ let y0 = Foo.Y.toString();
 >toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 
 let y1 = Foo["Y"].toString();
->y1 : Symbol(y1, Decl(constEnumToStringNoComments.ts, 9, 3))
+>y1 : Symbol(y1, Decl(constEnumToStringNoComments.ts, 12, 3))
 >Foo["Y"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 >Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
 >"Y" : Symbol(Foo.Y, Decl(constEnumToStringNoComments.ts, 1, 12))
 >toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 
 let z0 = Foo.Z.toString();
->z0 : Symbol(z0, Decl(constEnumToStringNoComments.ts, 10, 3))
+>z0 : Symbol(z0, Decl(constEnumToStringNoComments.ts, 13, 3))
 >Foo.Z.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 >Foo.Z : Symbol(Foo.Z, Decl(constEnumToStringNoComments.ts, 2, 12))
 >Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
@@ -51,9 +60,54 @@ let z0 = Foo.Z.toString();
 >toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 
 let z1 = Foo["Z"].toString();
->z1 : Symbol(z1, Decl(constEnumToStringNoComments.ts, 11, 3))
+>z1 : Symbol(z1, Decl(constEnumToStringNoComments.ts, 14, 3))
 >Foo["Z"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 >Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
 >"Z" : Symbol(Foo.Z, Decl(constEnumToStringNoComments.ts, 2, 12))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let a0 = Foo.A.toString();
+>a0 : Symbol(a0, Decl(constEnumToStringNoComments.ts, 15, 3))
+>Foo.A.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo.A : Symbol(Foo.A, Decl(constEnumToStringNoComments.ts, 3, 11))
+>Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
+>A : Symbol(Foo.A, Decl(constEnumToStringNoComments.ts, 3, 11))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let a1 = Foo["A"].toString();
+>a1 : Symbol(a1, Decl(constEnumToStringNoComments.ts, 16, 3))
+>Foo["A"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
+>"A" : Symbol(Foo.A, Decl(constEnumToStringNoComments.ts, 3, 11))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let b0 = Foo.B.toString();
+>b0 : Symbol(b0, Decl(constEnumToStringNoComments.ts, 17, 3))
+>Foo.B.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo.B : Symbol(Foo.B, Decl(constEnumToStringNoComments.ts, 4, 11))
+>Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
+>B : Symbol(Foo.B, Decl(constEnumToStringNoComments.ts, 4, 11))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let b1 = Foo["B"].toString();
+>b1 : Symbol(b1, Decl(constEnumToStringNoComments.ts, 18, 3))
+>Foo["B"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
+>"B" : Symbol(Foo.B, Decl(constEnumToStringNoComments.ts, 4, 11))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let c0 = Foo.C.toString();
+>c0 : Symbol(c0, Decl(constEnumToStringNoComments.ts, 19, 3))
+>Foo.C.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo.C : Symbol(Foo.C, Decl(constEnumToStringNoComments.ts, 5, 13))
+>Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
+>C : Symbol(Foo.C, Decl(constEnumToStringNoComments.ts, 5, 13))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let c1 = Foo["C"].toString();
+>c1 : Symbol(c1, Decl(constEnumToStringNoComments.ts, 20, 3))
+>Foo["C"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo : Symbol(Foo, Decl(constEnumToStringNoComments.ts, 0, 0))
+>"C" : Symbol(Foo.C, Decl(constEnumToStringNoComments.ts, 5, 13))
 >toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 

--- a/tests/baselines/reference/constEnumToStringNoComments.types
+++ b/tests/baselines/reference/constEnumToStringNoComments.types
@@ -1,0 +1,71 @@
+=== tests/cases/compiler/constEnumToStringNoComments.ts ===
+const enum Foo {
+>Foo : Foo
+
+    X = 100,
+>X : Foo
+>100 : number
+
+    Y = 0.5,
+>Y : Foo
+>0.5 : number
+
+    Z = 2.
+>Z : Foo
+>2. : number
+}
+
+let x0 = Foo.X.toString();
+>x0 : string
+>Foo.X.toString() : string
+>Foo.X.toString : (radix?: number) => string
+>Foo.X : Foo
+>Foo : typeof Foo
+>X : Foo
+>toString : (radix?: number) => string
+
+let x1 = Foo["X"].toString();
+>x1 : string
+>Foo["X"].toString() : string
+>Foo["X"].toString : (radix?: number) => string
+>Foo["X"] : Foo
+>Foo : typeof Foo
+>"X" : string
+>toString : (radix?: number) => string
+
+let y0 = Foo.Y.toString();
+>y0 : string
+>Foo.Y.toString() : string
+>Foo.Y.toString : (radix?: number) => string
+>Foo.Y : Foo
+>Foo : typeof Foo
+>Y : Foo
+>toString : (radix?: number) => string
+
+let y1 = Foo["Y"].toString();
+>y1 : string
+>Foo["Y"].toString() : string
+>Foo["Y"].toString : (radix?: number) => string
+>Foo["Y"] : Foo
+>Foo : typeof Foo
+>"Y" : string
+>toString : (radix?: number) => string
+
+let z0 = Foo.Z.toString();
+>z0 : string
+>Foo.Z.toString() : string
+>Foo.Z.toString : (radix?: number) => string
+>Foo.Z : Foo
+>Foo : typeof Foo
+>Z : Foo
+>toString : (radix?: number) => string
+
+let z1 = Foo["Z"].toString();
+>z1 : string
+>Foo["Z"].toString() : string
+>Foo["Z"].toString : (radix?: number) => string
+>Foo["Z"] : Foo
+>Foo : typeof Foo
+>"Z" : string
+>toString : (radix?: number) => string
+

--- a/tests/baselines/reference/constEnumToStringNoComments.types
+++ b/tests/baselines/reference/constEnumToStringNoComments.types
@@ -10,9 +10,24 @@ const enum Foo {
 >Y : Foo
 >0.5 : number
 
-    Z = 2.
+    Z = 2.,
 >Z : Foo
 >2. : number
+
+    A = -1,
+>A : Foo
+>-1 : number
+>1 : number
+
+    B = -1.5,
+>B : Foo
+>-1.5 : number
+>1.5 : number
+
+    C = -1.
+>C : Foo
+>-1. : number
+>1. : number
 }
 
 let x0 = Foo.X.toString();
@@ -67,5 +82,59 @@ let z1 = Foo["Z"].toString();
 >Foo["Z"] : Foo
 >Foo : typeof Foo
 >"Z" : string
+>toString : (radix?: number) => string
+
+let a0 = Foo.A.toString();
+>a0 : string
+>Foo.A.toString() : string
+>Foo.A.toString : (radix?: number) => string
+>Foo.A : Foo
+>Foo : typeof Foo
+>A : Foo
+>toString : (radix?: number) => string
+
+let a1 = Foo["A"].toString();
+>a1 : string
+>Foo["A"].toString() : string
+>Foo["A"].toString : (radix?: number) => string
+>Foo["A"] : Foo
+>Foo : typeof Foo
+>"A" : string
+>toString : (radix?: number) => string
+
+let b0 = Foo.B.toString();
+>b0 : string
+>Foo.B.toString() : string
+>Foo.B.toString : (radix?: number) => string
+>Foo.B : Foo
+>Foo : typeof Foo
+>B : Foo
+>toString : (radix?: number) => string
+
+let b1 = Foo["B"].toString();
+>b1 : string
+>Foo["B"].toString() : string
+>Foo["B"].toString : (radix?: number) => string
+>Foo["B"] : Foo
+>Foo : typeof Foo
+>"B" : string
+>toString : (radix?: number) => string
+
+let c0 = Foo.C.toString();
+>c0 : string
+>Foo.C.toString() : string
+>Foo.C.toString : (radix?: number) => string
+>Foo.C : Foo
+>Foo : typeof Foo
+>C : Foo
+>toString : (radix?: number) => string
+
+let c1 = Foo["C"].toString();
+>c1 : string
+>Foo["C"].toString() : string
+>Foo["C"].toString : (radix?: number) => string
+>Foo["C"] : Foo
+>Foo : typeof Foo
+>"C" : string
 >toString : (radix?: number) => string
 

--- a/tests/baselines/reference/constEnumToStringWithComments.js
+++ b/tests/baselines/reference/constEnumToStringWithComments.js
@@ -2,7 +2,10 @@
 const enum Foo {
     X = 100,
     Y = 0.5,
-    Z = 2.
+    Z = 2.,
+    A = -1,
+    B = -1.5,
+    C = -1.
 }
 
 let x0 = Foo.X.toString();
@@ -11,6 +14,12 @@ let y0 = Foo.Y.toString();
 let y1 = Foo["Y"].toString();
 let z0 = Foo.Z.toString();
 let z1 = Foo["Z"].toString();
+let a0 = Foo.A.toString();
+let a1 = Foo["A"].toString();
+let b0 = Foo.B.toString();
+let b1 = Foo["B"].toString();
+let c0 = Foo.C.toString();
+let c1 = Foo["C"].toString();
 
 
 //// [constEnumToStringWithComments.js]
@@ -20,3 +29,9 @@ var y0 = 0.5 /* Y */.toString();
 var y1 = 0.5 /* "Y" */.toString();
 var z0 = 2 /* Z */ .toString();
 var z1 = 2 /* "Z" */ .toString();
+var a0 = -1 /* A */ .toString();
+var a1 = -1 /* "A" */ .toString();
+var b0 = -1.5 /* B */.toString();
+var b1 = -1.5 /* "B" */.toString();
+var c0 = -1 /* C */ .toString();
+var c1 = -1 /* "C" */ .toString();

--- a/tests/baselines/reference/constEnumToStringWithComments.js
+++ b/tests/baselines/reference/constEnumToStringWithComments.js
@@ -1,0 +1,22 @@
+//// [constEnumToStringWithComments.ts]
+const enum Foo {
+    X = 100,
+    Y = 0.5,
+    Z = 2.
+}
+
+let x0 = Foo.X.toString();
+let x1 = Foo["X"].toString();
+let y0 = Foo.Y.toString();
+let y1 = Foo["Y"].toString();
+let z0 = Foo.Z.toString();
+let z1 = Foo["Z"].toString();
+
+
+//// [constEnumToStringWithComments.js]
+var x0 = 100 /* X */ .toString();
+var x1 = 100 /* "X" */ .toString();
+var y0 = 0.5 /* Y */.toString();
+var y1 = 0.5 /* "Y" */.toString();
+var z0 = 2 /* Z */ .toString();
+var z1 = 2 /* "Z" */ .toString();

--- a/tests/baselines/reference/constEnumToStringWithComments.symbols
+++ b/tests/baselines/reference/constEnumToStringWithComments.symbols
@@ -8,12 +8,21 @@ const enum Foo {
     Y = 0.5,
 >Y : Symbol(Foo.Y, Decl(constEnumToStringWithComments.ts, 1, 12))
 
-    Z = 2.
+    Z = 2.,
 >Z : Symbol(Foo.Z, Decl(constEnumToStringWithComments.ts, 2, 12))
+
+    A = -1,
+>A : Symbol(Foo.A, Decl(constEnumToStringWithComments.ts, 3, 11))
+
+    B = -1.5,
+>B : Symbol(Foo.B, Decl(constEnumToStringWithComments.ts, 4, 11))
+
+    C = -1.
+>C : Symbol(Foo.C, Decl(constEnumToStringWithComments.ts, 5, 13))
 }
 
 let x0 = Foo.X.toString();
->x0 : Symbol(x0, Decl(constEnumToStringWithComments.ts, 6, 3))
+>x0 : Symbol(x0, Decl(constEnumToStringWithComments.ts, 9, 3))
 >Foo.X.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 >Foo.X : Symbol(Foo.X, Decl(constEnumToStringWithComments.ts, 0, 16))
 >Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
@@ -21,14 +30,14 @@ let x0 = Foo.X.toString();
 >toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 
 let x1 = Foo["X"].toString();
->x1 : Symbol(x1, Decl(constEnumToStringWithComments.ts, 7, 3))
+>x1 : Symbol(x1, Decl(constEnumToStringWithComments.ts, 10, 3))
 >Foo["X"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 >Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
 >"X" : Symbol(Foo.X, Decl(constEnumToStringWithComments.ts, 0, 16))
 >toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 
 let y0 = Foo.Y.toString();
->y0 : Symbol(y0, Decl(constEnumToStringWithComments.ts, 8, 3))
+>y0 : Symbol(y0, Decl(constEnumToStringWithComments.ts, 11, 3))
 >Foo.Y.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 >Foo.Y : Symbol(Foo.Y, Decl(constEnumToStringWithComments.ts, 1, 12))
 >Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
@@ -36,14 +45,14 @@ let y0 = Foo.Y.toString();
 >toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 
 let y1 = Foo["Y"].toString();
->y1 : Symbol(y1, Decl(constEnumToStringWithComments.ts, 9, 3))
+>y1 : Symbol(y1, Decl(constEnumToStringWithComments.ts, 12, 3))
 >Foo["Y"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 >Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
 >"Y" : Symbol(Foo.Y, Decl(constEnumToStringWithComments.ts, 1, 12))
 >toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 
 let z0 = Foo.Z.toString();
->z0 : Symbol(z0, Decl(constEnumToStringWithComments.ts, 10, 3))
+>z0 : Symbol(z0, Decl(constEnumToStringWithComments.ts, 13, 3))
 >Foo.Z.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 >Foo.Z : Symbol(Foo.Z, Decl(constEnumToStringWithComments.ts, 2, 12))
 >Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
@@ -51,9 +60,54 @@ let z0 = Foo.Z.toString();
 >toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 
 let z1 = Foo["Z"].toString();
->z1 : Symbol(z1, Decl(constEnumToStringWithComments.ts, 11, 3))
+>z1 : Symbol(z1, Decl(constEnumToStringWithComments.ts, 14, 3))
 >Foo["Z"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 >Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
 >"Z" : Symbol(Foo.Z, Decl(constEnumToStringWithComments.ts, 2, 12))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let a0 = Foo.A.toString();
+>a0 : Symbol(a0, Decl(constEnumToStringWithComments.ts, 15, 3))
+>Foo.A.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo.A : Symbol(Foo.A, Decl(constEnumToStringWithComments.ts, 3, 11))
+>Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
+>A : Symbol(Foo.A, Decl(constEnumToStringWithComments.ts, 3, 11))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let a1 = Foo["A"].toString();
+>a1 : Symbol(a1, Decl(constEnumToStringWithComments.ts, 16, 3))
+>Foo["A"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
+>"A" : Symbol(Foo.A, Decl(constEnumToStringWithComments.ts, 3, 11))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let b0 = Foo.B.toString();
+>b0 : Symbol(b0, Decl(constEnumToStringWithComments.ts, 17, 3))
+>Foo.B.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo.B : Symbol(Foo.B, Decl(constEnumToStringWithComments.ts, 4, 11))
+>Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
+>B : Symbol(Foo.B, Decl(constEnumToStringWithComments.ts, 4, 11))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let b1 = Foo["B"].toString();
+>b1 : Symbol(b1, Decl(constEnumToStringWithComments.ts, 18, 3))
+>Foo["B"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
+>"B" : Symbol(Foo.B, Decl(constEnumToStringWithComments.ts, 4, 11))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let c0 = Foo.C.toString();
+>c0 : Symbol(c0, Decl(constEnumToStringWithComments.ts, 19, 3))
+>Foo.C.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo.C : Symbol(Foo.C, Decl(constEnumToStringWithComments.ts, 5, 13))
+>Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
+>C : Symbol(Foo.C, Decl(constEnumToStringWithComments.ts, 5, 13))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let c1 = Foo["C"].toString();
+>c1 : Symbol(c1, Decl(constEnumToStringWithComments.ts, 20, 3))
+>Foo["C"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
+>"C" : Symbol(Foo.C, Decl(constEnumToStringWithComments.ts, 5, 13))
 >toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
 

--- a/tests/baselines/reference/constEnumToStringWithComments.symbols
+++ b/tests/baselines/reference/constEnumToStringWithComments.symbols
@@ -1,0 +1,59 @@
+=== tests/cases/compiler/constEnumToStringWithComments.ts ===
+const enum Foo {
+>Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
+
+    X = 100,
+>X : Symbol(Foo.X, Decl(constEnumToStringWithComments.ts, 0, 16))
+
+    Y = 0.5,
+>Y : Symbol(Foo.Y, Decl(constEnumToStringWithComments.ts, 1, 12))
+
+    Z = 2.
+>Z : Symbol(Foo.Z, Decl(constEnumToStringWithComments.ts, 2, 12))
+}
+
+let x0 = Foo.X.toString();
+>x0 : Symbol(x0, Decl(constEnumToStringWithComments.ts, 6, 3))
+>Foo.X.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo.X : Symbol(Foo.X, Decl(constEnumToStringWithComments.ts, 0, 16))
+>Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
+>X : Symbol(Foo.X, Decl(constEnumToStringWithComments.ts, 0, 16))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let x1 = Foo["X"].toString();
+>x1 : Symbol(x1, Decl(constEnumToStringWithComments.ts, 7, 3))
+>Foo["X"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
+>"X" : Symbol(Foo.X, Decl(constEnumToStringWithComments.ts, 0, 16))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let y0 = Foo.Y.toString();
+>y0 : Symbol(y0, Decl(constEnumToStringWithComments.ts, 8, 3))
+>Foo.Y.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo.Y : Symbol(Foo.Y, Decl(constEnumToStringWithComments.ts, 1, 12))
+>Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
+>Y : Symbol(Foo.Y, Decl(constEnumToStringWithComments.ts, 1, 12))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let y1 = Foo["Y"].toString();
+>y1 : Symbol(y1, Decl(constEnumToStringWithComments.ts, 9, 3))
+>Foo["Y"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
+>"Y" : Symbol(Foo.Y, Decl(constEnumToStringWithComments.ts, 1, 12))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let z0 = Foo.Z.toString();
+>z0 : Symbol(z0, Decl(constEnumToStringWithComments.ts, 10, 3))
+>Foo.Z.toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo.Z : Symbol(Foo.Z, Decl(constEnumToStringWithComments.ts, 2, 12))
+>Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
+>Z : Symbol(Foo.Z, Decl(constEnumToStringWithComments.ts, 2, 12))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+
+let z1 = Foo["Z"].toString();
+>z1 : Symbol(z1, Decl(constEnumToStringWithComments.ts, 11, 3))
+>Foo["Z"].toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+>Foo : Symbol(Foo, Decl(constEnumToStringWithComments.ts, 0, 0))
+>"Z" : Symbol(Foo.Z, Decl(constEnumToStringWithComments.ts, 2, 12))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, 458, 18))
+

--- a/tests/baselines/reference/constEnumToStringWithComments.types
+++ b/tests/baselines/reference/constEnumToStringWithComments.types
@@ -10,9 +10,24 @@ const enum Foo {
 >Y : Foo
 >0.5 : number
 
-    Z = 2.
+    Z = 2.,
 >Z : Foo
 >2. : number
+
+    A = -1,
+>A : Foo
+>-1 : number
+>1 : number
+
+    B = -1.5,
+>B : Foo
+>-1.5 : number
+>1.5 : number
+
+    C = -1.
+>C : Foo
+>-1. : number
+>1. : number
 }
 
 let x0 = Foo.X.toString();
@@ -67,5 +82,59 @@ let z1 = Foo["Z"].toString();
 >Foo["Z"] : Foo
 >Foo : typeof Foo
 >"Z" : string
+>toString : (radix?: number) => string
+
+let a0 = Foo.A.toString();
+>a0 : string
+>Foo.A.toString() : string
+>Foo.A.toString : (radix?: number) => string
+>Foo.A : Foo
+>Foo : typeof Foo
+>A : Foo
+>toString : (radix?: number) => string
+
+let a1 = Foo["A"].toString();
+>a1 : string
+>Foo["A"].toString() : string
+>Foo["A"].toString : (radix?: number) => string
+>Foo["A"] : Foo
+>Foo : typeof Foo
+>"A" : string
+>toString : (radix?: number) => string
+
+let b0 = Foo.B.toString();
+>b0 : string
+>Foo.B.toString() : string
+>Foo.B.toString : (radix?: number) => string
+>Foo.B : Foo
+>Foo : typeof Foo
+>B : Foo
+>toString : (radix?: number) => string
+
+let b1 = Foo["B"].toString();
+>b1 : string
+>Foo["B"].toString() : string
+>Foo["B"].toString : (radix?: number) => string
+>Foo["B"] : Foo
+>Foo : typeof Foo
+>"B" : string
+>toString : (radix?: number) => string
+
+let c0 = Foo.C.toString();
+>c0 : string
+>Foo.C.toString() : string
+>Foo.C.toString : (radix?: number) => string
+>Foo.C : Foo
+>Foo : typeof Foo
+>C : Foo
+>toString : (radix?: number) => string
+
+let c1 = Foo["C"].toString();
+>c1 : string
+>Foo["C"].toString() : string
+>Foo["C"].toString : (radix?: number) => string
+>Foo["C"] : Foo
+>Foo : typeof Foo
+>"C" : string
 >toString : (radix?: number) => string
 

--- a/tests/baselines/reference/constEnumToStringWithComments.types
+++ b/tests/baselines/reference/constEnumToStringWithComments.types
@@ -1,0 +1,71 @@
+=== tests/cases/compiler/constEnumToStringWithComments.ts ===
+const enum Foo {
+>Foo : Foo
+
+    X = 100,
+>X : Foo
+>100 : number
+
+    Y = 0.5,
+>Y : Foo
+>0.5 : number
+
+    Z = 2.
+>Z : Foo
+>2. : number
+}
+
+let x0 = Foo.X.toString();
+>x0 : string
+>Foo.X.toString() : string
+>Foo.X.toString : (radix?: number) => string
+>Foo.X : Foo
+>Foo : typeof Foo
+>X : Foo
+>toString : (radix?: number) => string
+
+let x1 = Foo["X"].toString();
+>x1 : string
+>Foo["X"].toString() : string
+>Foo["X"].toString : (radix?: number) => string
+>Foo["X"] : Foo
+>Foo : typeof Foo
+>"X" : string
+>toString : (radix?: number) => string
+
+let y0 = Foo.Y.toString();
+>y0 : string
+>Foo.Y.toString() : string
+>Foo.Y.toString : (radix?: number) => string
+>Foo.Y : Foo
+>Foo : typeof Foo
+>Y : Foo
+>toString : (radix?: number) => string
+
+let y1 = Foo["Y"].toString();
+>y1 : string
+>Foo["Y"].toString() : string
+>Foo["Y"].toString : (radix?: number) => string
+>Foo["Y"] : Foo
+>Foo : typeof Foo
+>"Y" : string
+>toString : (radix?: number) => string
+
+let z0 = Foo.Z.toString();
+>z0 : string
+>Foo.Z.toString() : string
+>Foo.Z.toString : (radix?: number) => string
+>Foo.Z : Foo
+>Foo : typeof Foo
+>Z : Foo
+>toString : (radix?: number) => string
+
+let z1 = Foo["Z"].toString();
+>z1 : string
+>Foo["Z"].toString() : string
+>Foo["Z"].toString : (radix?: number) => string
+>Foo["Z"] : Foo
+>Foo : typeof Foo
+>"Z" : string
+>toString : (radix?: number) => string
+

--- a/tests/cases/compiler/constEnumToStringNoComments.ts
+++ b/tests/cases/compiler/constEnumToStringNoComments.ts
@@ -2,7 +2,10 @@
 const enum Foo {
     X = 100,
     Y = 0.5,
-    Z = 2.
+    Z = 2.,
+    A = -1,
+    B = -1.5,
+    C = -1.
 }
 
 let x0 = Foo.X.toString();
@@ -11,3 +14,9 @@ let y0 = Foo.Y.toString();
 let y1 = Foo["Y"].toString();
 let z0 = Foo.Z.toString();
 let z1 = Foo["Z"].toString();
+let a0 = Foo.A.toString();
+let a1 = Foo["A"].toString();
+let b0 = Foo.B.toString();
+let b1 = Foo["B"].toString();
+let c0 = Foo.C.toString();
+let c1 = Foo["C"].toString();

--- a/tests/cases/compiler/constEnumToStringNoComments.ts
+++ b/tests/cases/compiler/constEnumToStringNoComments.ts
@@ -1,0 +1,13 @@
+// @comments: false
+const enum Foo {
+    X = 100,
+    Y = 0.5,
+    Z = 2.
+}
+
+let x0 = Foo.X.toString();
+let x1 = Foo["X"].toString();
+let y0 = Foo.Y.toString();
+let y1 = Foo["Y"].toString();
+let z0 = Foo.Z.toString();
+let z1 = Foo["Z"].toString();

--- a/tests/cases/compiler/constEnumToStringWithComments.ts
+++ b/tests/cases/compiler/constEnumToStringWithComments.ts
@@ -1,8 +1,11 @@
-// @comments: yes
+// @comments: true
 const enum Foo {
     X = 100,
     Y = 0.5,
-    Z = 2.
+    Z = 2.,
+    A = -1,
+    B = -1.5,
+    C = -1.
 }
 
 let x0 = Foo.X.toString();
@@ -11,3 +14,9 @@ let y0 = Foo.Y.toString();
 let y1 = Foo["Y"].toString();
 let z0 = Foo.Z.toString();
 let z1 = Foo["Z"].toString();
+let a0 = Foo.A.toString();
+let a1 = Foo["A"].toString();
+let b0 = Foo.B.toString();
+let b1 = Foo["B"].toString();
+let c0 = Foo.C.toString();
+let c1 = Foo["C"].toString();

--- a/tests/cases/compiler/constEnumToStringWithComments.ts
+++ b/tests/cases/compiler/constEnumToStringWithComments.ts
@@ -1,0 +1,13 @@
+// @comments: yes
+const enum Foo {
+    X = 100,
+    Y = 0.5,
+    Z = 2.
+}
+
+let x0 = Foo.X.toString();
+let x1 = Foo["X"].toString();
+let y0 = Foo.Y.toString();
+let y1 = Foo["Y"].toString();
+let z0 = Foo.Z.toString();
+let z1 = Foo["Z"].toString();


### PR DESCRIPTION
…expression part is integer const enum. Fixes #4155 