### PR TITLE
Always indent PropertyAccessExpression.

### DIFF
--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -418,6 +418,7 @@ namespace ts.formatting {
                 case SyntaxKind.DefaultClause:
                 case SyntaxKind.CaseClause:
                 case SyntaxKind.ParenthesizedExpression:
+                case SyntaxKind.PropertyAccessExpression:
                 case SyntaxKind.CallExpression:
                 case SyntaxKind.NewExpression:
                 case SyntaxKind.VariableStatement:

--- a/tests/cases/fourslash/formattingOnChainedCallbacksAndPropertyAccesses.ts
+++ b/tests/cases/fourslash/formattingOnChainedCallbacksAndPropertyAccesses.ts
@@ -1,0 +1,37 @@
+/// <reference path='fourslash.ts'/>
+
+////var x = 1;
+
+////x
+/////*1*/.toFixed
+
+////x
+/////*2*/.toFixed()
+
+////x
+/////*3*/.toFixed()
+/////*4*/.length
+/////*5*/.toString();
+
+////x
+/////*6*/.toFixed
+/////*7*/.toString()
+/////*8*/.length;
+
+format.document();
+goTo.marker('1');
+verify.currentLineContentIs('    .toFixed');
+goTo.marker('2');
+verify.currentLineContentIs('    .toFixed()');
+goTo.marker('3');
+verify.currentLineContentIs('    .toFixed()');
+goTo.marker('4');
+verify.currentLineContentIs('    .length');
+goTo.marker('5');
+verify.currentLineContentIs('    .toString();');
+goTo.marker('6');
+verify.currentLineContentIs('    .toFixed');
+goTo.marker('7');
+verify.currentLineContentIs('    .toString()');
+goTo.marker('8');
+verify.currentLineContentIs('    .length;');


### PR DESCRIPTION
This fixes https://github.com/Microsoft/TypeScript/issues/4198.

Before:
![image](https://cloud.githubusercontent.com/assets/1707813/9099386/28cfc446-3b85-11e5-8e7a-0333b8f4736f.png)

After:
![image](https://cloud.githubusercontent.com/assets/1707813/9099393/2d3d0a3e-3b85-11e5-9408-e9e1cf889c39.png)
