### PR TITLE
TEST UNIT with BUG REPORT: .d.ts missing generics of type definitions

### DIFF
--- a/tests/baselines/reference/typeDefinitionWithGeneric.js
+++ b/tests/baselines/reference/typeDefinitionWithGeneric.js
@@ -1,0 +1,22 @@
+//// [typeDefinitionWithGeneric.ts]
+
+/// <reference no-default-lib="true"/>
+
+export type Callback<T> = () => T;
+
+export function registerCallback<T>(callback: Callback<T>) {
+    //
+}
+
+
+//// [typeDefinitionWithGeneric.js]
+/// <reference no-default-lib="true"/>
+function registerCallback(callback) {
+    //
+}
+exports.registerCallback = registerCallback;
+
+
+//// [typeDefinitionWithGeneric.d.ts]
+export declare type Callback<T> = () => T;
+export declare function registerCallback<T>(callback: Callback<T>): void;

--- a/tests/cases/compiler/typeDefinitionWithGeneric.ts
+++ b/tests/cases/compiler/typeDefinitionWithGeneric.ts
@@ -1,0 +1,10 @@
+// @module: common
+// @declaration: true
+
+/// <reference no-default-lib="true"/>
+
+export type Callback<T> = () => T;
+
+export function registerCallback<T>(callback: Callback<T>) {
+    //
+}


### PR DESCRIPTION
hi, i'm trying to export a callback definition with generics.
```
export type Callback<T> = () => T;
```
bug the generated .d.ts file was:
```
export declare type Callback = () => T;
```
>> missing <T> after Callback.

Can someone help me?

I wrote a test to that case, 'cause maybe it's a compiler bug.