### PR TITLE
Fix generics/type-assertion formatting

### DIFF
--- a/tests/cases/fourslash/genericsFormatting.ts
+++ b/tests/cases/fourslash/genericsFormatting.ts
@@ -5,6 +5,7 @@
 ////    }
 ////}
 /////*typeArguments*/var foo = new Foo   <  number, Array <   number  >   >  (  );
+/////*typeArgumentsWithTypeLiterals*/foo = new Foo  <  {   bar  :  number }, Array   < {   baz :  string   }  >  >  (  );
 ////
 ////interface IFoo {
 /////*inNewSignature*/new < T  > ( a: T);
@@ -25,6 +26,8 @@ verify.currentLineContentIs("    public method<T3, T4>(a: T1, b: Array<T4>): Map
 
 goTo.marker("typeArguments");
 verify.currentLineContentIs("var foo = new Foo<number, Array<number>>();");
+goTo.marker("typeArgumentsWithTypeLiterals");
+verify.currentLineContentIs("foo = new Foo<{ bar: number }, Array<{ baz: string }>>();");
 
 goTo.marker("inNewSignature");
 verify.currentLineContentIs("    new <T>(a: T);");

--- a/tests/cases/fourslash/typeAssertionsFormatting.ts
+++ b/tests/cases/fourslash/typeAssertionsFormatting.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+////( <  any   >      publisher);/*1*/
+//// <  any  >      3;/*2*/
+
+
+format.document();
+
+goTo.marker("1");
+verify.currentLineContentIs("(<any>publisher);");
+
+goTo.marker("2");
+verify.currentLineContentIs("<any>3;");


### PR DESCRIPTION
Fixing #4221 

Current:

```typescript
interface Foo<T> {
}

let foo: Foo<  { bar: string }> = undefined

let publisher: {};

(<   any   >      publisher).subscribe(item => {

    console.log(item);
});
```

Fix:

```typescript
interface Foo<T> {
}

let foo: Foo<{ bar: string }> = undefined

let publisher: {};

(<any>publisher).subscribe(item => {

    console.log(item);
});
```