### PR TITLE
Add Intellisense to JsDoc

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5831,7 +5831,6 @@ namespace ts {
 
                     if (!name) {
                         parseErrorAtPosition(pos, 0, Diagnostics.Identifier_expected);
-                        return undefined;
                     }
 
                     let preName: Identifier, postName: Identifier;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2937,7 +2937,16 @@ namespace ts {
                     switch (tag.kind) {
                         case SyntaxKind.JSDocTypeTag:
                             let typeTag = <JSDocTypeTag>tag;
-                            insideJsDocTagExpression = position > typeTag.typeExpression.pos && position < typeTag.typeExpression.end;
+                            if (typeTag.typeExpression) {
+                                insideJsDocTagExpression = position > typeTag.typeExpression.pos && position < typeTag.typeExpression.end;
+                            };
+                            break;
+                        case SyntaxKind.JSDocParameterTag:
+                            let paramTag = <JSDocParameterTag>tag;
+                            if (paramTag.typeExpression) {
+                                insideJsDocTagExpression = position > paramTag.typeExpression.pos && position < paramTag.typeExpression.end;
+                            };
+                            break;
                     }
                 }
                 if (!insideJsDocTagExpression) {
@@ -3731,11 +3740,17 @@ namespace ts {
                 }
 
                 // The current position is right after an At sign
-                // Or if the current position is in a tag name
-                if (sourceFile.text.charCodeAt(position - 1) === CharacterCodes.at ||
-                    getJsDocTagAtPosition(sourceFile, position)) {
+                if (sourceFile.text.charCodeAt(position - 1) === CharacterCodes.at) {
                     return getAllJsDocCompletionEntries();
-                }                
+                }
+
+                // Or if the current position is in a tag name
+                let tag = getJsDocTagAtPosition(sourceFile, position);
+                if (tag) {
+                    if (position >= tag.atToken.end && position <= tag.tagName.end) {
+                        return getAllJsDocCompletionEntries();
+                    }
+                }
             }
 
             function getAllJsDocCompletionEntries(): CompletionEntry[] {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -132,7 +132,7 @@ namespace ts {
 
     let emptyArray: any[] = [];
     
-    const jsDocTagNames: string[] = [
+    const jsDocTagNames = [
         "augments", 
         "author", 
         "argument", 
@@ -2992,7 +2992,7 @@ namespace ts {
                             let tagWithExpression = <JSDocTypeTag | JSDocParameterTag>tag;
                             if (tagWithExpression.typeExpression) {
                                 insideJsDocTagExpression = tagWithExpression.typeExpression.pos < position && position < tagWithExpression.typeExpression.end;
-                            };
+                            }
                             break;
                     }
                 }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2989,7 +2989,8 @@ namespace ts {
                     switch (tag.kind) {
                         case SyntaxKind.JSDocTypeTag:
                         case SyntaxKind.JSDocParameterTag:
-                            let tagWithExpression = <JSDocTypeTag | JSDocParameterTag>tag;
+                        case SyntaxKind.JSDocReturnTag:
+                            let tagWithExpression = <JSDocTypeTag | JSDocParameterTag | JSDocReturnTag>tag;
                             if (tagWithExpression.typeExpression) {
                                 insideJsDocTagExpression = tagWithExpression.typeExpression.pos < position && position < tagWithExpression.typeExpression.end;
                             }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -486,9 +486,10 @@ namespace ts {
             }
             node = node.parent;
         }
+        
         if (jsDocComment) {
             for (let tag of jsDocComment.tags) {
-                if (position >= tag.pos && position <= tag.end) {
+                if (tag.pos <= position && position <= tag.end) {
                     return tag;
                 }
             }
@@ -666,7 +667,6 @@ namespace ts {
             else if (flags & SymbolFlags.TypeParameter) { return SymbolDisplayPartKind.typeParameterName; }
             else if (flags & SymbolFlags.TypeAlias) { return SymbolDisplayPartKind.aliasName; }
             else if (flags & SymbolFlags.Alias) { return SymbolDisplayPartKind.aliasName; }
-
 
             return SymbolDisplayPartKind.text;
         }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -469,6 +469,33 @@ namespace ts {
         }
     }
 
+    /**
+     * Get the corresponding JSDocTag node if the position is in a jsDoc commet
+     */
+    export function getJsDocTagAtPosition(sourceFile: SourceFile, position: number): JSDocTag {
+        let node = ts.getTokenAtPosition(sourceFile, position);
+        let jsDocComment: JSDocComment;
+        while (true) {
+            if (node === sourceFile ||
+                node.kind === SyntaxKind.VariableStatement ||
+                node.kind === SyntaxKind.FunctionDeclaration ||
+                node.kind === SyntaxKind.Parameter ||
+                node.jsDocComment) {
+                jsDocComment = node.jsDocComment;
+                break;
+            }
+            node = node.parent;
+        }
+        if (jsDocComment) {
+            for (let tag of jsDocComment.tags) {
+                if (position >= tag.pos && position <= tag.end) {
+                    return tag;
+                }
+            }
+        }
+        return undefined;
+    }
+
     function nodeHasTokens(n: Node): boolean {
         // If we have a token or node that has a non-zero width, it must have tokens.
         // Note, that getWidth() does not take trivia into account.

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -480,21 +480,21 @@ namespace ts {
                 case SyntaxKind.LetKeyword:
                 case SyntaxKind.ConstKeyword:
                     // if the current token is var, let or const, skip the VariableDeclarationList
-                    node = node.parent.parent;
+                    node = node.parent === undefined ? undefined : node.parent.parent;
                     break;
                 default:
                     node = node.parent;
                     break;
             }
-            if (!node.jsDocComment) {
-                node = node.parent;
-            }
         }
-        let jsDocComment = node.jsDocComment;
-        if (jsDocComment) {
-            for (let tag of jsDocComment.tags) {
-                if (tag.pos <= position && position <= tag.end) {
-                    return tag;
+
+        if (node) {
+            let jsDocComment = node.jsDocComment;
+            if (jsDocComment) {
+                for (let tag of jsDocComment.tags) {
+                    if (tag.pos <= position && position <= tag.end) {
+                        return tag;
+                    }
                 }
             }
         }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -475,18 +475,21 @@ namespace ts {
     export function getJsDocTagAtPosition(sourceFile: SourceFile, position: number): JSDocTag {
         let node = ts.getTokenAtPosition(sourceFile, position);
         let jsDocComment: JSDocComment;
-        while (true) {
-            if (node === sourceFile ||
-                node.kind === SyntaxKind.VariableStatement ||
-                node.kind === SyntaxKind.FunctionDeclaration ||
-                node.kind === SyntaxKind.Parameter ||
-                node.jsDocComment) {
-                jsDocComment = node.jsDocComment;
-                break;
-            }
-            node = node.parent;
+        if (node.jsDocComment) {
+            jsDocComment = node.jsDocComment;
         }
-        
+        else {
+            while (node) {
+                if (node.kind === SyntaxKind.VariableStatement ||
+                    node.kind === SyntaxKind.FunctionDeclaration ||
+                    node.kind === SyntaxKind.Parameter) {
+                    jsDocComment = node.jsDocComment;
+                    break;
+                }
+                node = node.parent;
+            }
+        }
+
         if (jsDocComment) {
             for (let tag of jsDocComment.tags) {
                 if (tag.pos <= position && position <= tag.end) {
@@ -494,6 +497,7 @@ namespace ts {
                 }
             }
         }
+
         return undefined;
     }
 

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -470,26 +470,27 @@ namespace ts {
     }
 
     /**
-     * Get the corresponding JSDocTag node if the position is in a jsDoc commet
+     * Get the corresponding JSDocTag node if the position is in a jsDoc comment
      */
     export function getJsDocTagAtPosition(sourceFile: SourceFile, position: number): JSDocTag {
         let node = ts.getTokenAtPosition(sourceFile, position);
-        let jsDocComment: JSDocComment;
-        if (node.jsDocComment) {
-            jsDocComment = node.jsDocComment;
-        }
-        else {
-            while (node) {
-                if (node.kind === SyntaxKind.VariableStatement ||
-                    node.kind === SyntaxKind.FunctionDeclaration ||
-                    node.kind === SyntaxKind.Parameter) {
-                    jsDocComment = node.jsDocComment;
+        if (isToken(node)) {
+            switch (node.kind) {
+                case SyntaxKind.VarKeyword:
+                case SyntaxKind.LetKeyword:
+                case SyntaxKind.ConstKeyword:
+                    // if the current token is var, let or const, skip the VariableDeclarationList
+                    node = node.parent.parent;
                     break;
-                }
+                default:
+                    node = node.parent;
+                    break;
+            }
+            if (!node.jsDocComment) {
                 node = node.parent;
             }
         }
-
+        let jsDocComment = node.jsDocComment;
         if (jsDocComment) {
             for (let tag of jsDocComment.tags) {
                 if (tag.pos <= position && position <= tag.end) {

--- a/tests/cases/fourslash/completionInJsDoc.ts
+++ b/tests/cases/fourslash/completionInJsDoc.ts
@@ -1,0 +1,39 @@
+///<reference path="fourslash.ts" />
+
+// @allowNonTsExtensions: true
+// @Filename: Foo.js
+/////** @/*1*/ */
+////var v1;
+////
+/////** @p/*2*/ */
+////var v2;
+////
+/////** @param /*3*/ */
+////var v3;
+////
+/////** @param { n/*4*/ } bar */
+////var v4;
+////
+/////** @type { n/*5*/ } */
+////var v5;
+
+goTo.marker('1');
+verify.completionListContains("constructor");
+verify.completionListContains("param");
+verify.completionListContains("type");
+
+goTo.marker('2');
+verify.completionListContains("constructor");
+verify.completionListContains("param");
+verify.completionListContains("type");
+
+goTo.marker('3');
+verify.completionListIsEmpty();
+
+goTo.marker('4');
+verify.completionListContains('number');
+
+goTo.marker('5');
+verify.completionListContains('number');
+
+

--- a/tests/cases/fourslash/completionInJsDoc.ts
+++ b/tests/cases/fourslash/completionInJsDoc.ts
@@ -16,6 +16,12 @@
 ////
 /////** @type { n/*5*/ } */
 ////var v5;
+////
+////// @/*6*/
+////var v6;
+////
+////// @pa/*7*/
+////var v7;
 
 goTo.marker('1');
 verify.completionListContains("constructor");
@@ -36,4 +42,9 @@ verify.completionListContains('number');
 goTo.marker('5');
 verify.completionListContains('number');
 
+goTo.marker('6');
+verify.completionListIsEmpty();
+
+goTo.marker('7');
+verify.completionListIsEmpty();
 

--- a/tests/cases/fourslash/completionInJsDoc.ts
+++ b/tests/cases/fourslash/completionInJsDoc.ts
@@ -22,6 +22,12 @@
 ////
 ////// @pa/*7*/
 ////var v7;
+////
+/////** @param { n/*8*/ } */
+////var v8;
+////
+/////** @return { n/*9*/ } */
+////var v9;
 
 goTo.marker('1');
 verify.completionListContains("constructor");
@@ -47,4 +53,10 @@ verify.completionListIsEmpty();
 
 goTo.marker('7');
 verify.completionListIsEmpty();
+
+goTo.marker('8');
+verify.completionListContains('number');
+
+goTo.marker('9');
+verify.completionListContains('number');
 


### PR DESCRIPTION
This PR provides completion list for the following cases:
- List all the JsDoc tag names right after the ``@`` sign or in the tagname, e.g.:
```javascript
/** @^ */
var foo = ...
```
and 
```javascript
/** @pa^ */
var foo = ...
```
- Full intellisense in certain JsDoc tag braces,  e.g.:
```javascript
/** @type { numbe^ } */
var foo = ...
```
```javascript
/** @param { numbe^ } bar */
var foo = ...
```

The initial implementation only applies to js files, as currently the parser stores the ``JSDocComment`` nodes in the tree for js files but not ts files. Support for ts files may need some discussion.