### PR TITLE
Fix formatting for class expression + expressionWithTypeArguments

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -715,6 +715,7 @@ namespace ts.formatting {
                 case SyntaxKind.TypeReference:
                 case SyntaxKind.TypeAssertionExpression:
                 case SyntaxKind.ClassDeclaration:
+                case SyntaxKind.ClassExpression:
                 case SyntaxKind.InterfaceDeclaration:
                 case SyntaxKind.FunctionDeclaration:
                 case SyntaxKind.FunctionExpression:
@@ -725,6 +726,7 @@ namespace ts.formatting {
                 case SyntaxKind.ConstructSignature:
                 case SyntaxKind.CallExpression:
                 case SyntaxKind.NewExpression:
+                case SyntaxKind.ExpressionWithTypeArguments:
                     return true;
                 default:
                     return false;

--- a/tests/cases/fourslash/genericsFormatting.ts
+++ b/tests/cases/fourslash/genericsFormatting.ts
@@ -14,6 +14,13 @@
 ////
 ////foo()<number, string, T >();
 ////(a + b)<number, string, T >();
+////
+////function bar<T>() {
+/////*inClassExpression*/    return class  <  T2 > {
+////    }
+////}
+/////*expressionWithTypeArguments*/class A < T > extends bar <  T >( )  <  T > {
+////}
 
 
 format.document();
@@ -34,3 +41,9 @@ verify.currentLineContentIs("    new <T>(a: T);");
 
 goTo.marker("inOptionalMethodSignature");
 verify.currentLineContentIs("    op?<T, M>(a: T, b: M);");
+
+goTo.marker("inClassExpression");
+verify.currentLineContentIs("    return class <T2> {");
+
+goTo.marker("expressionWithTypeArguments");
+verify.currentLineContentIs("class A<T> extends bar<T>()<T> {");


### PR DESCRIPTION
Fixing #3619.

Current:

```typescript
function bar<T>() {
    return class <    T2    > {
    }
}

class A<T> extends bar<T>() <   T   > {
}
```

```typescript
function bar<T>() {
    return class <T2> {
    }
}

class A<T> extends bar<T>()<T> {
}
```