### PR TITLE
Fix #4170, remove error when using import=require syntax in t=ES6 and in ambient context

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13315,7 +13315,7 @@ namespace ts {
                     }
                 }
                 else {
-                    if (languageVersion >= ScriptTarget.ES6) {
+                    if (languageVersion >= ScriptTarget.ES6 && !isInAmbientContext(node)) {
                         // Import equals declaration is deprecated in es6 or above
                         grammarErrorOnNode(node, Diagnostics.Import_assignment_cannot_be_used_when_targeting_ECMAScript_6_or_higher_Consider_using_import_Asterisk_as_ns_from_mod_import_a_from_mod_or_import_d_from_mod_instead);
                     }

--- a/tests/baselines/reference/es6ImportEqualsDeclaration2.js
+++ b/tests/baselines/reference/es6ImportEqualsDeclaration2.js
@@ -1,0 +1,23 @@
+//// [tests/cases/compiler/es6ImportEqualsDeclaration2.ts] ////
+
+//// [server.d.ts]
+
+declare module "other" {
+    export class C { }
+}
+
+declare module "server" {
+    import events = require("other"); // Ambient declaration, no error expected.
+
+    module S {
+        export var a: number;
+    }
+
+    export = S; // Ambient declaration, no error expected.
+}
+
+//// [client.ts]
+import {a} from "server";
+
+
+//// [client.js]

--- a/tests/baselines/reference/es6ImportEqualsDeclaration2.symbols
+++ b/tests/baselines/reference/es6ImportEqualsDeclaration2.symbols
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/server.d.ts ===
+
+declare module "other" {
+    export class C { }
+>C : Symbol(C, Decl(server.d.ts, 1, 24))
+}
+
+declare module "server" {
+    import events = require("other"); // Ambient declaration, no error expected.
+>events : Symbol(events, Decl(server.d.ts, 5, 25))
+
+    module S {
+>S : Symbol(S, Decl(server.d.ts, 6, 37))
+
+        export var a: number;
+>a : Symbol(a, Decl(server.d.ts, 9, 18))
+    }
+
+    export = S; // Ambient declaration, no error expected.
+>S : Symbol(S, Decl(server.d.ts, 6, 37))
+}
+
+=== tests/cases/compiler/client.ts ===
+import {a} from "server";
+>a : Symbol(a, Decl(client.ts, 0, 8))
+

--- a/tests/baselines/reference/es6ImportEqualsDeclaration2.types
+++ b/tests/baselines/reference/es6ImportEqualsDeclaration2.types
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/server.d.ts ===
+
+declare module "other" {
+    export class C { }
+>C : C
+}
+
+declare module "server" {
+    import events = require("other"); // Ambient declaration, no error expected.
+>events : typeof events
+
+    module S {
+>S : typeof S
+
+        export var a: number;
+>a : number
+    }
+
+    export = S; // Ambient declaration, no error expected.
+>S : typeof S
+}
+
+=== tests/cases/compiler/client.ts ===
+import {a} from "server";
+>a : number
+

--- a/tests/cases/compiler/es6ImportEqualsDeclaration2.ts
+++ b/tests/cases/compiler/es6ImportEqualsDeclaration2.ts
@@ -1,0 +1,19 @@
+// @target: es6
+
+// @filename: server.d.ts
+declare module "other" {
+    export class C { }
+}
+
+declare module "server" {
+    import events = require("other"); // Ambient declaration, no error expected.
+
+    module S {
+        export var a: number;
+    }
+
+    export = S; // Ambient declaration, no error expected.
+}
+
+// @filename: client.ts
+import {a} from "server";


### PR DESCRIPTION
Fix #4170

This allows existing typeings (on definitely typed) to be using with --t ES6 without having to fork them. 
The rational here is that there is no impact on emitted code. so no risk of emitting wrong code; also this is consistent with the behavior of "export=" in --t=ES6 and in ambient contexts.

Note, there is an existing test for the error message for non-ambient cases.