### PR TITLE
Add missing types to webworker.generated.ts

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -6865,7 +6865,7 @@ interface IDBDatabase extends EventTarget {
     createObjectStore(name: string, optionalParameters?: any): IDBObjectStore;
     deleteObjectStore(name: string): void;
     transaction(storeNames: any, mode?: string): IDBTransaction;
-    addEventListener(type: "abort", listener: (ev: UIEvent) => any, useCapture?: boolean): void;
+    addEventListener(type: "abort", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "error", listener: (ev: ErrorEvent) => any, useCapture?: boolean): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
 }

--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -6986,7 +6986,7 @@ interface IDBTransaction extends EventTarget {
     READ_ONLY: string;
     READ_WRITE: string;
     VERSION_CHANGE: string;
-    addEventListener(type: "abort", listener: (ev: UIEvent) => any, useCapture?: boolean): void;
+    addEventListener(type: "abort", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "complete", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "error", listener: (ev: ErrorEvent) => any, useCapture?: boolean): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
@@ -12169,7 +12169,7 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
     LOADING: number;
     OPENED: number;
     UNSENT: number;
-    addEventListener(type: "abort", listener: (ev: UIEvent) => any, useCapture?: boolean): void;
+    addEventListener(type: "abort", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "error", listener: (ev: ErrorEvent) => any, useCapture?: boolean): void;
     addEventListener(type: "load", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "loadend", listener: (ev: ProgressEvent) => any, useCapture?: boolean): void;
@@ -12439,7 +12439,7 @@ interface MSBaseReader {
     DONE: number;
     EMPTY: number;
     LOADING: number;
-    addEventListener(type: "abort", listener: (ev: UIEvent) => any, useCapture?: boolean): void;
+    addEventListener(type: "abort", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "error", listener: (ev: ErrorEvent) => any, useCapture?: boolean): void;
     addEventListener(type: "load", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "loadend", listener: (ev: ProgressEvent) => any, useCapture?: boolean): void;
@@ -12595,7 +12595,7 @@ interface XMLHttpRequestEventTarget {
     onloadstart: (ev: Event) => any;
     onprogress: (ev: ProgressEvent) => any;
     ontimeout: (ev: ProgressEvent) => any;
-    addEventListener(type: "abort", listener: (ev: UIEvent) => any, useCapture?: boolean): void;
+    addEventListener(type: "abort", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "error", listener: (ev: ErrorEvent) => any, useCapture?: boolean): void;
     addEventListener(type: "load", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "loadend", listener: (ev: ProgressEvent) => any, useCapture?: boolean): void;
@@ -12611,6 +12611,7 @@ interface NodeListOf<TNode extends Node> extends NodeList {
     item(index: number): TNode;
     [index: number]: TNode;
 }
+
 
 interface BlobPropertyBag {
     type?: string;

--- a/src/lib/webworker.generated.d.ts
+++ b/src/lib/webworker.generated.d.ts
@@ -3,6 +3,11 @@
 /// IE Worker APIs
 /////////////////////////////
 
+interface EventInit {
+    bubbles?: boolean;
+    cancelable?: boolean;
+}
+
 interface EventListener {
     (evt: Event): void;
 }

--- a/src/lib/webworker.generated.d.ts
+++ b/src/lib/webworker.generated.d.ts
@@ -435,7 +435,7 @@ interface IDBTransaction extends EventTarget {
     READ_ONLY: string;
     READ_WRITE: string;
     VERSION_CHANGE: string;
-    addEventListener(type: "abort", listener: (ev: UIEvent) => any, useCapture?: boolean): void;
+    addEventListener(type: "abort", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "complete", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "error", listener: (ev: ErrorEvent) => any, useCapture?: boolean): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
@@ -494,6 +494,11 @@ interface MSApp {
 declare var MSApp: MSApp;
 
 interface MSAppAsyncOperation extends EventTarget {
+    error: DOMError;
+    oncomplete: (ev: Event) => any;
+    onerror: (ev: Event) => any;
+    readyState: number;
+    result: any;
     start(): void;
     COMPLETED: number;
     ERROR: number;
@@ -710,7 +715,7 @@ interface XMLHttpRequest extends EventTarget, XMLHttpRequestEventTarget {
     LOADING: number;
     OPENED: number;
     UNSENT: number;
-    addEventListener(type: "abort", listener: (ev: UIEvent) => any, useCapture?: boolean): void;
+    addEventListener(type: "abort", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "error", listener: (ev: ErrorEvent) => any, useCapture?: boolean): void;
     addEventListener(type: "load", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "loadend", listener: (ev: ProgressEvent) => any, useCapture?: boolean): void;
@@ -760,7 +765,7 @@ interface MSBaseReader {
     DONE: number;
     EMPTY: number;
     LOADING: number;
-    addEventListener(type: "abort", listener: (ev: UIEvent) => any, useCapture?: boolean): void;
+    addEventListener(type: "abort", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "error", listener: (ev: ErrorEvent) => any, useCapture?: boolean): void;
     addEventListener(type: "load", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "loadend", listener: (ev: ProgressEvent) => any, useCapture?: boolean): void;
@@ -801,7 +806,7 @@ interface XMLHttpRequestEventTarget {
     onloadstart: (ev: Event) => any;
     onprogress: (ev: ProgressEvent) => any;
     ontimeout: (ev: ProgressEvent) => any;
-    addEventListener(type: "abort", listener: (ev: UIEvent) => any, useCapture?: boolean): void;
+    addEventListener(type: "abort", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "error", listener: (ev: ErrorEvent) => any, useCapture?: boolean): void;
     addEventListener(type: "load", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "loadend", listener: (ev: ProgressEvent) => any, useCapture?: boolean): void;
@@ -912,6 +917,12 @@ interface MediaQueryListListener {
 }
 interface MSLaunchUriCallback {
     (): void;
+}
+interface MSUnsafeFunctionCallback {
+    (): any;
+}
+interface MSExecAtPriorityFunctionCallback {
+    (...args: any[]): any;
 }
 interface DecodeSuccessCallback {
     (decodedData: AudioBuffer): void;

--- a/src/lib/webworker.generated.d.ts
+++ b/src/lib/webworker.generated.d.ts
@@ -7,6 +7,19 @@ interface EventListener {
     (evt: Event): void;
 }
 
+interface AudioBuffer {
+    duration: number;
+    length: number;
+    numberOfChannels: number;
+    sampleRate: number;
+    getChannelData(channel: number): any;
+}
+
+declare var AudioBuffer: {
+    prototype: AudioBuffer;
+    new(): AudioBuffer;
+}
+
 interface Blob {
     size: number;
     type: string;
@@ -58,6 +71,21 @@ interface Console {
 declare var Console: {
     prototype: Console;
     new(): Console;
+}
+
+interface Coordinates {
+    accuracy: number;
+    altitude: number;
+    altitudeAccuracy: number;
+    heading: number;
+    latitude: number;
+    longitude: number;
+    speed: number;
+}
+
+declare var Coordinates: {
+    prototype: Coordinates;
+    new(): Coordinates;
 }
 
 interface DOMError {
@@ -281,7 +309,7 @@ interface IDBDatabase extends EventTarget {
     createObjectStore(name: string, optionalParameters?: any): IDBObjectStore;
     deleteObjectStore(name: string): void;
     transaction(storeNames: any, mode?: string): IDBTransaction;
-    addEventListener(type: "abort", listener: (ev: UIEvent) => any, useCapture?: boolean): void;
+    addEventListener(type: "abort", listener: (ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "error", listener: (ev: ErrorEvent) => any, useCapture?: boolean): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
 }
@@ -460,6 +488,24 @@ interface MSApp {
 }
 declare var MSApp: MSApp;
 
+interface MSAppAsyncOperation extends EventTarget {
+    start(): void;
+    COMPLETED: number;
+    ERROR: number;
+    STARTED: number;
+    addEventListener(type: "complete", listener: (ev: Event) => any, useCapture?: boolean): void;
+    addEventListener(type: "error", listener: (ev: ErrorEvent) => any, useCapture?: boolean): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
+}
+
+declare var MSAppAsyncOperation: {
+    prototype: MSAppAsyncOperation;
+    new(): MSAppAsyncOperation;
+    COMPLETED: number;
+    ERROR: number;
+    STARTED: number;
+}
+
 interface MSBlobBuilder {
     append(data: any, endings?: string): void;
     getBlob(contentType?: string): Blob;
@@ -494,6 +540,18 @@ interface MSStreamReader extends EventTarget, MSBaseReader {
 declare var MSStreamReader: {
     prototype: MSStreamReader;
     new(): MSStreamReader;
+}
+
+interface MediaQueryList {
+    matches: boolean;
+    media: string;
+    addListener(listener: MediaQueryListListener): void;
+    removeListener(listener: MediaQueryListListener): void;
+}
+
+declare var MediaQueryList: {
+    prototype: MediaQueryList;
+    new(): MediaQueryList;
 }
 
 interface MessageChannel {
@@ -531,6 +589,33 @@ interface MessagePort extends EventTarget {
 declare var MessagePort: {
     prototype: MessagePort;
     new(): MessagePort;
+}
+
+interface Position {
+    coords: Coordinates;
+    timestamp: number;
+}
+
+declare var Position: {
+    prototype: Position;
+    new(): Position;
+}
+
+interface PositionError {
+    code: number;
+    message: string;
+    toString(): string;
+    PERMISSION_DENIED: number;
+    POSITION_UNAVAILABLE: number;
+    TIMEOUT: number;
+}
+
+declare var PositionError: {
+    prototype: PositionError;
+    new(): PositionError;
+    PERMISSION_DENIED: number;
+    POSITION_UNAVAILABLE: number;
+    TIMEOUT: number;
 }
 
 interface ProgressEvent extends Event {
@@ -640,6 +725,15 @@ declare var XMLHttpRequest: {
     OPENED: number;
     UNSENT: number;
     create(): XMLHttpRequest;
+}
+
+interface XMLHttpRequestUpload extends EventTarget, XMLHttpRequestEventTarget {
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
+}
+
+declare var XMLHttpRequestUpload: {
+    prototype: XMLHttpRequestUpload;
+    new(): XMLHttpRequestUpload;
 }
 
 interface AbstractWorker {
@@ -788,12 +882,6 @@ interface WorkerUtils extends Object, WindowBase64 {
 }
 
 
-interface NodeListOf<TNode extends Node> extends NodeList {
-    length: number;
-    item(index: number): TNode;
-    [index: number]: TNode;
-}
-
 interface BlobPropertyBag {
     type?: string;
     endings?: string;
@@ -819,12 +907,6 @@ interface MediaQueryListListener {
 }
 interface MSLaunchUriCallback {
     (): void;
-}
-interface FrameRequestCallback {
-    (time: number): void;
-}
-interface MutationCallback {
-    (mutations: MutationRecord[], observer: MutationObserver): void;
 }
 interface DecodeSuccessCallback {
     (decodedData: AudioBuffer): void;


### PR DESCRIPTION
Fix #4015 

Added missing types in webworker.generated.ts that are not related to ``window``, and removed the ones that are related, including ``MutationRecord``, ``MutationObserver``, ``NodeList``, ``Node``, ``NodeList``.