### PR TITLE
[WIP] Fix: static getters / setters can have incorrect `this` binding

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -18,8 +18,11 @@ namespace ts {
     export function emitFiles(resolver: EmitResolver, host: EmitHost, targetSourceFile: SourceFile): EmitResult {
         // emit output for the __extends helper function
         const extendsHelper = `
-var __extends = (this && this.__extends) || function (d, b) {
-    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+var __extends = (this && this.__extends) || function(d, b) {
+    var desc;
+    for (var p in b) {
+        if ((desc = Object.getOwnPropertyDescriptor(b, p))) Object.defineProperty(d, p, desc);
+    }
     function __() { this.constructor = d; }
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };`;

--- a/tests/baselines/reference/staticGetterAndSetterInheritance.js
+++ b/tests/baselines/reference/staticGetterAndSetterInheritance.js
@@ -1,0 +1,40 @@
+//// [staticGetterAndSetterInheritance.ts]
+
+class A {
+	static get foo(): any {
+		return this;
+	}
+}
+
+class B extends A{}
+
+A.foo;
+B.foo;
+
+//// [staticGetterAndSetterInheritance.js]
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var A = (function () {
+    function A() {
+    }
+    Object.defineProperty(A, "foo", {
+        get: function () {
+            return this;
+        },
+        enumerable: true,
+        configurable: true
+    });
+    return A;
+})();
+var B = (function (_super) {
+    __extends(B, _super);
+    function B() {
+        _super.apply(this, arguments);
+    }
+    return B;
+})(A);
+A.foo;
+B.foo;

--- a/tests/baselines/reference/staticGetterAndSetterInheritance.symbols
+++ b/tests/baselines/reference/staticGetterAndSetterInheritance.symbols
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/staticGetterAndSetterInheritance.ts ===
+
+class A {
+>A : Symbol(A, Decl(staticGetterAndSetterInheritance.ts, 0, 0))
+
+	static get foo(): any {
+>foo : Symbol(A.foo, Decl(staticGetterAndSetterInheritance.ts, 1, 9))
+
+		return this;
+>this : Symbol(A, Decl(staticGetterAndSetterInheritance.ts, 0, 0))
+	}
+}
+
+class B extends A{}
+>B : Symbol(B, Decl(staticGetterAndSetterInheritance.ts, 5, 1))
+>A : Symbol(A, Decl(staticGetterAndSetterInheritance.ts, 0, 0))
+
+A.foo;
+>A.foo : Symbol(A.foo, Decl(staticGetterAndSetterInheritance.ts, 1, 9))
+>A : Symbol(A, Decl(staticGetterAndSetterInheritance.ts, 0, 0))
+>foo : Symbol(A.foo, Decl(staticGetterAndSetterInheritance.ts, 1, 9))
+
+B.foo;
+>B.foo : Symbol(B.foo, Decl(staticGetterAndSetterInheritance.ts, 1, 9))
+>B : Symbol(B, Decl(staticGetterAndSetterInheritance.ts, 5, 1))
+>foo : Symbol(B.foo, Decl(staticGetterAndSetterInheritance.ts, 1, 9))
+

--- a/tests/baselines/reference/staticGetterAndSetterInheritance.types
+++ b/tests/baselines/reference/staticGetterAndSetterInheritance.types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/staticGetterAndSetterInheritance.ts ===
+
+class A {
+>A : A
+
+	static get foo(): any {
+>foo : any
+
+		return this;
+>this : typeof A
+	}
+}
+
+class B extends A{}
+>B : B
+>A : A
+
+A.foo;
+>A.foo : any
+>A : typeof A
+>foo : any
+
+B.foo;
+>B.foo : any
+>B : typeof B
+>foo : any
+

--- a/tests/cases/compiler/staticGetterAndSetterInheritance.ts
+++ b/tests/cases/compiler/staticGetterAndSetterInheritance.ts
@@ -1,0 +1,12 @@
+// @target: ES5
+
+class A {
+	static get foo(): any {
+		return this;
+	}
+}
+
+class B extends A{}
+
+A.foo;
+B.foo;


### PR DESCRIPTION
Please see #4327.

There's a modification to the `__extends` helper that fixes this issue, however I'm unsure how to write tests for this.

I've tried to add a compiler test case to cover this, but it's hard to see how I can use it to check that `this`'s runtime type is correct. 