### PR TITLE
Fix JsxElement formatting

### DIFF
--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -428,6 +428,7 @@ namespace ts.formatting {
                 case SyntaxKind.ConditionalExpression:
                 case SyntaxKind.ArrayBindingPattern:
                 case SyntaxKind.ObjectBindingPattern:
+                case SyntaxKind.JsxElement:
                     return true;
             }
             return false;

--- a/tests/cases/fourslash/formattingJsxElements.ts
+++ b/tests/cases/fourslash/formattingJsxElements.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts' />
+
+//@Filename: file.tsx
+////function () {
+////    return (
+////        <div className="commentBox" >
+////Hello, World!/*autoformat*/
+/////*indent*/
+////        </div>
+////    )
+////}
+////
+
+
+format.document();
+goTo.marker("autoformat");
+verify.currentLineContentIs('            Hello, World!');
+goTo.marker("indent");
+verify.indentationIs(12);


### PR DESCRIPTION
Fixing #3838.

Current:
```typescript
function () {
    return (
        <div className="commentBox" >
        Hello, World!
        /* 8-space smart indentation */
        </div>
    )
}
```

Fix:
```typescript
function () {
    return (
        <div className="commentBox" >
            Hello, World!
            /* 12-space smart indentation */
        </div>
    )
}
```