### PR TITLE
Emit tsx files correctly in getEmitOutput calls

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -85,7 +85,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
         else {
             // targetSourceFile is specified (e.g calling emitter from language service or calling getSemanticDiagnostic from language service)
             if (shouldEmitToOwnFile(targetSourceFile, compilerOptions)) {
-                let jsFilePath = getOwnEmitOutputFilePath(targetSourceFile, host, forEach(host.getSourceFiles(), shouldEmitJsx) ? ".jsx" : ".js");
+                let jsFilePath = getOwnEmitOutputFilePath(targetSourceFile, host, shouldEmitJsx(targetSourceFile) ? ".jsx" : ".js");
                 emitFile(jsFilePath, targetSourceFile);
             }
             else if (!isDeclarationFile(targetSourceFile) && compilerOptions.out) {

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -128,13 +128,14 @@ module FourSlash {
         sourceRoot: "sourceRoot",
         allowNonTsExtensions: "allowNonTsExtensions",
         resolveReference: "ResolveReference",  // This flag is used to specify entry file for resolve file references. The flag is only allow once per test file
+        jsx: "jsx",
     };
 
     // List of allowed metadata names
     let fileMetadataNames = [metadataOptionNames.fileName, metadataOptionNames.emitThisFile, metadataOptionNames.resolveReference];
     let globalMetadataNames = [metadataOptionNames.allowNonTsExtensions, metadataOptionNames.baselineFile, metadataOptionNames.declaration,
         metadataOptionNames.mapRoot, metadataOptionNames.module, metadataOptionNames.out,
-        metadataOptionNames.outDir, metadataOptionNames.sourceMap, metadataOptionNames.sourceRoot];
+        metadataOptionNames.outDir, metadataOptionNames.sourceMap, metadataOptionNames.sourceRoot, metadataOptionNames.jsx];
 
     function convertGlobalOptionsToCompilerOptions(globalOptions: { [idx: string]: string }): ts.CompilerOptions {
         let settings: ts.CompilerOptions = { target: ts.ScriptTarget.ES5 };
@@ -177,6 +178,20 @@ module FourSlash {
                         break;
                     case metadataOptionNames.sourceRoot:
                         settings.sourceRoot = globalOptions[prop];
+                        break;
+                    case metadataOptionNames.jsx:
+                        switch (globalOptions[prop].toLowerCase()) {
+                            case "react":
+                                settings.jsx = ts.JsxEmit.React;
+                                break;
+                            case "preserve":
+                                settings.jsx = ts.JsxEmit.Preserve;
+                                break;
+                            default:
+                                ts.Debug.assert(globalOptions[prop] === undefined || globalOptions[prop] === "None");
+                                settings.jsx = ts.JsxEmit.None;
+                                break;
+                        }
                         break;
                 }
             }

--- a/tests/baselines/reference/getEmitOutputTsxFile_Preserve.baseline
+++ b/tests/baselines/reference/getEmitOutputTsxFile_Preserve.baseline
@@ -1,0 +1,26 @@
+EmitSkipped: false
+FileName : tests/cases/fourslash/inputFile1.js.map
+{"version":3,"file":"inputFile1.js","sourceRoot":"","sources":["inputFile1.ts"],"names":["Bar","Bar.constructor"],"mappings":"AAAA,kBAAkB;AACjB,IAAI,CAAC,GAAW,CAAC,CAAC;AAClB;IAAAA;IAGAC,CAACA;IAADD,UAACA;AAADA,CAACA,AAHD,IAGC"}FileName : tests/cases/fourslash/inputFile1.js
+// regular ts file
+var t = 5;
+var Bar = (function () {
+    function Bar() {
+    }
+    return Bar;
+})();
+//# sourceMappingURL=inputFile1.js.mapFileName : tests/cases/fourslash/inputFile1.d.ts
+declare var t: number;
+declare class Bar {
+    x: string;
+    y: number;
+}
+
+EmitSkipped: false
+FileName : tests/cases/fourslash/inputFile2.jsx.map
+{"version":3,"file":"inputFile2.jsx","sourceRoot":"","sources":["inputFile2.tsx"],"names":[],"mappings":"AAAA,IAAI,CAAC,GAAG,QAAQ,CAAC;AACjB,IAAI,CAAC,GAAG,CAAC,GAAG,CAAC,IAAI,CAAE,CAAC,CAAC,CAAC,EAAG,CAAA"}FileName : tests/cases/fourslash/inputFile2.jsx
+var y = "my div";
+var x = <div name={y}/>;
+//# sourceMappingURL=inputFile2.jsx.mapFileName : tests/cases/fourslash/inputFile2.d.ts
+declare var y: string;
+declare var x: any;
+

--- a/tests/baselines/reference/getEmitOutputTsxFile_React.baseline
+++ b/tests/baselines/reference/getEmitOutputTsxFile_React.baseline
@@ -1,0 +1,26 @@
+EmitSkipped: false
+FileName : tests/cases/fourslash/inputFile1.js.map
+{"version":3,"file":"inputFile1.js","sourceRoot":"","sources":["inputFile1.ts"],"names":["Bar","Bar.constructor"],"mappings":"AAAA,kBAAkB;AACjB,IAAI,CAAC,GAAW,CAAC,CAAC;AAClB;IAAAA;IAGAC,CAACA;IAADD,UAACA;AAADA,CAACA,AAHD,IAGC"}FileName : tests/cases/fourslash/inputFile1.js
+// regular ts file
+var t = 5;
+var Bar = (function () {
+    function Bar() {
+    }
+    return Bar;
+})();
+//# sourceMappingURL=inputFile1.js.mapFileName : tests/cases/fourslash/inputFile1.d.ts
+declare var t: number;
+declare class Bar {
+    x: string;
+    y: number;
+}
+
+EmitSkipped: false
+FileName : tests/cases/fourslash/inputFile2.js.map
+{"version":3,"file":"inputFile2.js","sourceRoot":"","sources":["inputFile2.tsx"],"names":[],"mappings":"AAAA,IAAI,CAAC,GAAG,QAAQ,CAAC;AACjB,IAAI,CAAC,GAAG,qBAAC,GAAG,KAAC,IAAI,GAAG,CAAE,EAAG,CAAA"}FileName : tests/cases/fourslash/inputFile2.js
+var y = "my div";
+var x = React.createElement("div", {"name": y});
+//# sourceMappingURL=inputFile2.js.mapFileName : tests/cases/fourslash/inputFile2.d.ts
+declare var y: string;
+declare var x: any;
+

--- a/tests/cases/fourslash/getEmitOutputTsxFile_Preserve.ts
+++ b/tests/cases/fourslash/getEmitOutputTsxFile_Preserve.ts
@@ -1,0 +1,22 @@
+/// <reference path="fourslash.ts" />
+
+// @BaselineFile: getEmitOutputTsxFile_Preserve.baseline
+// @declaration: true
+// @sourceMap: true
+// @jsx: preserve
+
+// @Filename: inputFile1.ts
+// @emitThisFile: true
+////// regular ts file
+//// var t: number = 5;
+//// class Bar {
+////    x : string;
+////    y : number
+//// }
+
+// @Filename: inputFile2.tsx
+// @emitThisFile: true
+//// var y = "my div";
+//// var x = <div name= {y} />
+
+verify.baselineGetEmitOutput();

--- a/tests/cases/fourslash/getEmitOutputTsxFile_React.ts
+++ b/tests/cases/fourslash/getEmitOutputTsxFile_React.ts
@@ -1,0 +1,22 @@
+/// <reference path="fourslash.ts" />
+
+// @BaselineFile: getEmitOutputTsxFile_React.baseline
+// @declaration: true
+// @sourceMap: true
+// @jsx: react
+
+// @Filename: inputFile1.ts
+// @emitThisFile: true
+////// regular ts file
+//// var t: number = 5;
+//// class Bar {
+////    x : string;
+////    y : number
+//// }
+
+// @Filename: inputFile2.tsx
+// @emitThisFile: true
+//// var y = "my div";
+//// var x = <div name= {y} />
+
+verify.baselineGetEmitOutput();


### PR DESCRIPTION
When using `--jsx preserve` we were setting the extension of any file in Compile-on-Save scenarios to `.jsx` f there is at least one file that has `.tsx` extension. this does not match the command line compilation, which decides the emitted file extension on a file-per-file basis. fixing and adding a test.