### PR TITLE
Add `invalid regular expression literal` error #3432

### DIFF
--- a/src/compiler/diagnosticInformationMap.generated.ts
+++ b/src/compiler/diagnosticInformationMap.generated.ts
@@ -616,5 +616,6 @@ namespace ts {
         JSX_attribute_expected: { code: 17003, category: DiagnosticCategory.Error, key: "JSX attribute expected." },
         Cannot_use_JSX_unless_the_jsx_flag_is_provided: { code: 17004, category: DiagnosticCategory.Error, key: "Cannot use JSX unless the '--jsx' flag is provided." },
         A_constructor_cannot_contain_a_super_call_when_its_class_extends_null: { code: 17005, category: DiagnosticCategory.Error, key: "A constructor cannot contain a 'super' call when its class extends 'null'" },
+        Invalid_regular_expression_literal: { code: 17006, category: DiagnosticCategory.Error, key: "Invalid regular expression literal." },
     };
 }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2457,5 +2457,9 @@
     "A constructor cannot contain a 'super' call when its class extends 'null'": {
       "category": "Error",
       "code": 17005
+    },
+    "Invalid regular expression literal.": {
+      "category": "Error",
+      "code": 17006
     }
 }

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -347,6 +347,15 @@ namespace ts {
 
     let hasOwnProperty = Object.prototype.hasOwnProperty;
 
+    function isValidRegex(r : string): boolean {
+        try {
+            RegExp(r);
+        } catch (e) {
+            return false;
+        }
+        return true;
+    }
+
     export function isWhiteSpace(ch: number): boolean {
         // Note: nextLine is in the Zs space, and should be considered to be a whitespace.
         // It is explicitly not a line-break as it isn't in the exact set specified by EcmaScript.
@@ -1536,6 +1545,11 @@ namespace ts {
                 }
                 pos = p;
                 tokenValue = text.substring(tokenPos, pos);
+                
+                if (inCharacterClass || !isValidRegex(tokenValue)) {
+                    error(Diagnostics.Invalid_regular_expression_literal);
+                }
+                
                 token = SyntaxKind.RegularExpressionLiteral;
             }
             return token;

--- a/tests/baselines/reference/parser579071.errors.txt
+++ b/tests/baselines/reference/parser579071.errors.txt
@@ -1,0 +1,7 @@
+tests/cases/conformance/parser/ecmascript5/RegressionTests/parser579071.ts(1,15): error TS17006: Invalid regular expression literal.
+
+
+==== tests/cases/conformance/parser/ecmascript5/RegressionTests/parser579071.ts (1 errors) ====
+    var x = /fo(o/;
+                  
+!!! error TS17006: Invalid regular expression literal.

--- a/tests/baselines/reference/parser579071.symbols
+++ b/tests/baselines/reference/parser579071.symbols
@@ -1,4 +1,0 @@
-=== tests/cases/conformance/parser/ecmascript5/RegressionTests/parser579071.ts ===
-var x = /fo(o/;
->x : Symbol(x, Decl(parser579071.ts, 0, 3))
-

--- a/tests/baselines/reference/parser579071.types
+++ b/tests/baselines/reference/parser579071.types
@@ -1,5 +1,0 @@
-=== tests/cases/conformance/parser/ecmascript5/RegressionTests/parser579071.ts ===
-var x = /fo(o/;
->x : RegExp
->/fo(o/ : RegExp
-

--- a/tests/baselines/reference/parserRegularExpressionDivideAmbiguity4.errors.txt
+++ b/tests/baselines/reference/parserRegularExpressionDivideAmbiguity4.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity4.ts(1,1): error TS2304: Cannot find name 'foo'.
 tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity4.ts(1,6): error TS1161: Unterminated regular expression literal.
-tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity4.ts(1,17): error TS1005: ')' expected.
+tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity4.ts(1,17): error TS17006: Invalid regular expression literal.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpressionDivideAmbiguity4.ts (3 errors) ====
@@ -10,4 +10,4 @@ tests/cases/conformance/parser/ecmascript5/RegularExpressions/parserRegularExpre
          
 !!! error TS1161: Unterminated regular expression literal.
                     
-!!! error TS1005: ')' expected.
+!!! error TS17006: Invalid regular expression literal.


### PR DESCRIPTION
This adds an error "Invalid regular expression literal." to address issue #3432
Basically, at the end of `reScanSlashToken()` in scanner.ts, I take the tokenValue and create a `RegExp` in a try-catch.  If this throws an exception, it's not a valid regex.  Is this something like you guys imagined?
Note: This changes some of the results of the conformance tests that contained invalid regexes.