### PR TITLE
Keep typescript.d.ts and typescriptServices.d.ts in sync

### DIFF
--- a/lib/typescript.d.ts
+++ b/lib/typescript.d.ts
@@ -1450,6 +1450,7 @@ declare module "typescript" {
     function getTrailingCommentRanges(text: string, pos: number): CommentRange[];
     function isIdentifierStart(ch: number, languageVersion: ScriptTarget): boolean;
     function isIdentifierPart(ch: number, languageVersion: ScriptTarget): boolean;
+    function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean, languageVariant: LanguageVariant, text?: string, onError?: ErrorCallback, start?: number, length?: number): Scanner;
 }
 declare module "typescript" {
     function getDefaultLibFileName(options: CompilerOptions): string;

--- a/lib/typescriptServices.d.ts
+++ b/lib/typescriptServices.d.ts
@@ -1450,7 +1450,7 @@ declare namespace ts {
     function getTrailingCommentRanges(text: string, pos: number): CommentRange[];
     function isIdentifierStart(ch: number, languageVersion: ScriptTarget): boolean;
     function isIdentifierPart(ch: number, languageVersion: ScriptTarget): boolean;
-    function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean, languageVariant: ts.LanguageVariant, text?: string, onError?: ErrorCallback, start?: number, length?: number): Scanner;
+    function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean, languageVariant: LanguageVariant, text?: string, onError?: ErrorCallback, start?: number, length?: number): Scanner;
 }
 declare namespace ts {
     function getDefaultLibFileName(options: CompilerOptions): string;


### PR DESCRIPTION
Fixes an error introduced in fcc43a6 where typescriptServices.d.ts was
updated but typescript.d.ts was not.