### PR TITLE
use Harness.IO instead of sys in harness

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
         "clean": "jake clean"
     },
     "browser": {
+        "buffer": false,
         "fs": false,
         "os": false,
         "path": false

--- a/package.json
+++ b/package.json
@@ -45,9 +45,6 @@
         "clean": "jake clean"
     },
     "browser": {
-        "buffer": false,
-        "fs": false,
-        "os": false,
-        "path": false
-    }    
+        "fs": false
+    }
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
         "clean": "jake clean"
     },
     "browser": {
-        "fs": false
+        "fs": false,
+        "os": false,
+        "path": false
     }
 }

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -373,7 +373,7 @@ module FourSlash {
             this.formatCodeOptions = {
                 IndentSize: 4,
                 TabSize: 4,
-                NewLineCharacter: ts.sys.newLine,
+                NewLineCharacter: Harness.IO.newLine(),
                 ConvertTabsToSpaces: true,
                 InsertSpaceAfterCommaDelimiter: true,
                 InsertSpaceAfterSemicolonInForStatements: true,
@@ -551,7 +551,7 @@ module FourSlash {
             errors.forEach(function (error: ts.Diagnostic) {
                 Harness.IO.log("  minChar: " + error.start +
                     ", limChar: " + (error.start + error.length) +
-                    ", message: " + ts.flattenDiagnosticMessageText(error.messageText, ts.sys.newLine) + "\n");
+                    ", message: " + ts.flattenDiagnosticMessageText(error.messageText, Harness.IO.newLine()) + "\n");
             });
         }
 
@@ -1262,21 +1262,21 @@ module FourSlash {
                     emitFiles.forEach(emitFile => {
                         let emitOutput = this.languageService.getEmitOutput(emitFile.fileName);
                         // Print emitOutputStatus in readable format
-                        resultString += "EmitSkipped: " + emitOutput.emitSkipped + ts.sys.newLine;
+                        resultString += "EmitSkipped: " + emitOutput.emitSkipped + Harness.IO.newLine();
 
                         if (emitOutput.emitSkipped) {
-                            resultString += "Diagnostics:" + ts.sys.newLine;
+                            resultString += "Diagnostics:" + Harness.IO.newLine();
                             let diagnostics = ts.getPreEmitDiagnostics(this.languageService.getProgram());
                             for (let i = 0, n = diagnostics.length; i < n; i++) {
-                                resultString += "  " + diagnostics[0].messageText + ts.sys.newLine;
+                                resultString += "  " + diagnostics[0].messageText + Harness.IO.newLine();
                             }
                         }
 
                         emitOutput.outputFiles.forEach((outputFile, idx, array) => {
-                            let fileName = "FileName : " + outputFile.name + ts.sys.newLine;
+                            let fileName = "FileName : " + outputFile.name + Harness.IO.newLine();
                             resultString = resultString + fileName + outputFile.text;
                         });
-                        resultString += ts.sys.newLine;
+                        resultString += Harness.IO.newLine();
                     });
 
                     return resultString;
@@ -1313,7 +1313,7 @@ module FourSlash {
                     Harness.IO.log(
                         "start: " + err.start +
                         ", length: " + err.length +
-                        ", message: " + ts.flattenDiagnosticMessageText(err.messageText, ts.sys.newLine));
+                        ", message: " + ts.flattenDiagnosticMessageText(err.messageText, Harness.IO.newLine()));
                 });
             }
         }
@@ -1887,9 +1887,9 @@ module FourSlash {
             }
 
             function jsonMismatchString() {
-                return ts.sys.newLine +
-                    "expected: '" + ts.sys.newLine + JSON.stringify(expected, (k, v) => v, 2) + "'" + ts.sys.newLine +
-                    "actual:   '" + ts.sys.newLine + JSON.stringify(actual, (k, v) => v, 2) + "'";
+                return Harness.IO.newLine() +
+                    "expected: '" + Harness.IO.newLine() + JSON.stringify(expected, (k, v) => v, 2) + "'" + Harness.IO.newLine() +
+                    "actual:   '" + Harness.IO.newLine() + JSON.stringify(actual, (k, v) => v, 2) + "'";
             }
         }
 
@@ -2398,7 +2398,7 @@ module FourSlash {
         let host = Harness.Compiler.createCompilerHost([{ unitName: Harness.Compiler.fourslashFileName, content: undefined }],
             (fn, contents) => fourslashJsOutput = contents,
             ts.ScriptTarget.Latest,
-            ts.sys.useCaseSensitiveFileNames);
+            Harness.IO.useCaseSensitiveFileNames());
 
         let program = ts.createProgram([Harness.Compiler.fourslashFileName], { noResolve: true, target: ts.ScriptTarget.ES3 }, host);
 
@@ -2420,7 +2420,7 @@ module FourSlash {
             ],
             (fn, contents) => result = contents,
             ts.ScriptTarget.Latest,
-            ts.sys.useCaseSensitiveFileNames);
+            Harness.IO.useCaseSensitiveFileNames());
 
         let program = ts.createProgram([Harness.Compiler.fourslashFileName, fileName], { out: "fourslashTestOutput.js", noResolve: true, target: ts.ScriptTarget.ES3 }, host);
 
@@ -2429,7 +2429,7 @@ module FourSlash {
         let diagnostics = ts.getPreEmitDiagnostics(program, sourceFile);
         if (diagnostics.length > 0) {
             throw new Error(`Error compiling ${fileName}: ` +
-                diagnostics.map(e => ts.flattenDiagnosticMessageText(e.messageText, ts.sys.newLine)).join("\r\n"));
+                diagnostics.map(e => ts.flattenDiagnosticMessageText(e.messageText, Harness.IO.newLine())).join("\r\n"));
         }
 
         program.emit(sourceFile);

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -420,7 +420,10 @@ module Harness {
         getMemoryUsage?(): number;
     }
     export var IO: IO;
-
+    
+    // harness always uses one kind of new line
+    const harnessNewLine = "\r\n";
+    
     module IOImpl {
         declare class Enumerator {
             public atEnd(): boolean;
@@ -439,7 +442,7 @@ module Harness {
 
             export const resolvePath = (path: string) => ts.sys.resolvePath(path);
             export const getCurrentDirectory = () => ts.sys.getCurrentDirectory();
-            export const newLine = () => ts.sys.newLine;
+            export const newLine = () => harnessNewLine;
             export const useCaseSensitiveFileNames = () => ts.sys.useCaseSensitiveFileNames;
 
             export const readFile: typeof IO.readFile = path => ts.sys.readFile(path);
@@ -505,7 +508,7 @@ module Harness {
             
             export const resolvePath = (path: string) => ts.sys.resolvePath(path);
             export const getCurrentDirectory = () => ts.sys.getCurrentDirectory();
-            export const newLine = () => ts.sys.newLine;
+            export const newLine = () => harnessNewLine;
             export const useCaseSensitiveFileNames = () => ts.sys.useCaseSensitiveFileNames;
 
             export const readFile: typeof IO.readFile = path => ts.sys.readFile(path);
@@ -576,7 +579,7 @@ module Harness {
         export module Network {
             let serverRoot = "http://localhost:8888/";
 
-            export const newLine = () => "\r\n";
+            export const newLine = () => harnessNewLine;
             export const useCaseSensitiveFileNames = () => false;
             export const getCurrentDirectory = () => "";
             let supportsCodePage = () => false;

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -102,7 +102,7 @@ module Utils {
 
         let content: string = undefined;
         try {
-            content = ts.sys.readFile(Harness.userSpecifiedRoot + path);
+            content = Harness.IO.readFile(Harness.userSpecifiedRoot + path);
         }
         catch (err) {
             return undefined;
@@ -190,7 +190,7 @@ module Utils {
         return {
             start: diagnostic.start,
             length: diagnostic.length,
-            messageText: ts.flattenDiagnosticMessageText(diagnostic.messageText, ts.sys.newLine),
+            messageText: ts.flattenDiagnosticMessageText(diagnostic.messageText, Harness.IO.newLine()),
             category: (<any>ts).DiagnosticCategory[diagnostic.category],
             code: diagnostic.code
         };
@@ -323,8 +323,8 @@ module Utils {
             assert.equal(d1.start, d2.start, "d1.start !== d2.start");
             assert.equal(d1.length, d2.length, "d1.length !== d2.length");
             assert.equal(
-                ts.flattenDiagnosticMessageText(d1.messageText, ts.sys.newLine),
-                ts.flattenDiagnosticMessageText(d2.messageText, ts.sys.newLine), "d1.messageText !== d2.messageText");
+                ts.flattenDiagnosticMessageText(d1.messageText, Harness.IO.newLine()),
+                ts.flattenDiagnosticMessageText(d2.messageText, Harness.IO.newLine()), "d1.messageText !== d2.messageText");
             assert.equal(d1.category, d2.category, "d1.category !== d2.category");
             assert.equal(d1.code, d2.code, "d1.code !== d2.code");
         }
@@ -404,6 +404,10 @@ module Harness.Path {
 
 module Harness {
     export interface IO {
+        newLine(): string;
+        getCurrentDirectory(): string;
+        useCaseSensitiveFileNames(): boolean;
+        resolvePath(path: string): string;
         readFile(path: string): string;
         writeFile(path: string, contents: string): void;
         directoryName(path: string): string;
@@ -433,12 +437,17 @@ module Harness {
                 fso = {};
             }
 
-            export let readFile: typeof IO.readFile = ts.sys.readFile;
-            export let writeFile: typeof IO.writeFile = ts.sys.writeFile;
-            export let directoryName: typeof IO.directoryName = fso.GetParentFolderName;
-            export let directoryExists: typeof IO.directoryExists = fso.FolderExists;
-            export let fileExists: typeof IO.fileExists = fso.FileExists;
-            export let log: typeof IO.log = global.WScript && global.WScript.StdOut.WriteLine;
+            export const resolvePath = (path: string) => ts.sys.resolvePath(path);
+            export const getCurrentDirectory = () => ts.sys.getCurrentDirectory();
+            export const newLine = () => ts.sys.newLine;
+            export const useCaseSensitiveFileNames = () => ts.sys.useCaseSensitiveFileNames;
+
+            export const readFile: typeof IO.readFile = path => ts.sys.readFile(path);
+            export const writeFile: typeof IO.writeFile = (path, content) => ts.sys.writeFile(path, content);
+            export const directoryName: typeof IO.directoryName = fso.GetParentFolderName;
+            export const directoryExists: typeof IO.directoryExists = fso.FolderExists;
+            export const fileExists: typeof IO.fileExists = fso.FileExists;
+            export const log: typeof IO.log = global.WScript && global.WScript.StdOut.WriteLine;
 
             export function createDirectory(path: string) {
                 if (directoryExists(path)) {
@@ -493,11 +502,16 @@ module Harness {
             } else {
                 fs = pathModule = {};
             }
+            
+            export const resolvePath = (path: string) => ts.sys.resolvePath(path);
+            export const getCurrentDirectory = () => ts.sys.getCurrentDirectory();
+            export const newLine = () => ts.sys.newLine;
+            export const useCaseSensitiveFileNames = () => ts.sys.useCaseSensitiveFileNames;
 
-            export let readFile: typeof IO.readFile = ts.sys.readFile;
-            export let writeFile: typeof IO.writeFile = ts.sys.writeFile;
-            export let fileExists: typeof IO.fileExists = fs.existsSync;
-            export let log: typeof IO.log = s => console.log(s);
+            export const readFile: typeof IO.readFile = path => ts.sys.readFile(path);
+            export const writeFile: typeof IO.writeFile = (path, content) => ts.sys.writeFile(path, content);
+            export const fileExists: typeof IO.fileExists = fs.existsSync;
+            export const log: typeof IO.log = s => console.log(s);
 
             export function createDirectory(path: string) {
                 if (!directoryExists(path)) {
@@ -562,9 +576,9 @@ module Harness {
         export module Network {
             let serverRoot = "http://localhost:8888/";
 
-            // Unused?
-            let newLine = "\r\n";
-            let currentDirectory = () => "";
+            export const newLine = () => "\r\n";
+            export const useCaseSensitiveFileNames = () => false;
+            export const getCurrentDirectory = () => "";
             let supportsCodePage = () => false;
 
             module Http {
@@ -616,6 +630,7 @@ module Harness {
                         xhr.send(contents);
                     }
                     catch (e) {
+                        log(`XHR Error: ${e}`);
                         return { status: 500, responseText: null };
                     }
 
@@ -655,6 +670,7 @@ module Harness {
                 return dirPath;
             }
             export let directoryName: typeof IO.directoryName = Utils.memoize(directoryNameImpl);
+            export const resolvePath = (path: string) => directoryName(path);
 
             export function fileExists(path: string): boolean {
                 let response = Http.getFileFromServerSync(serverRoot + path);
@@ -840,7 +856,7 @@ module Harness {
         export let fourslashSourceFile: ts.SourceFile;
 
         export function getCanonicalFileName(fileName: string): string {
-            return ts.sys.useCaseSensitiveFileNames ? fileName : fileName.toLowerCase();
+            return Harness.IO.useCaseSensitiveFileNames() ? fileName : fileName.toLowerCase();
         }
 
         export function createCompilerHost(
@@ -858,7 +874,7 @@ module Harness {
             }
 
             let filemap: { [fileName: string]: ts.SourceFile; } = {};
-            let getCurrentDirectory = currentDirectory === undefined ? ts.sys.getCurrentDirectory : () => currentDirectory;
+            let getCurrentDirectory = currentDirectory === undefined ? Harness.IO.getCurrentDirectory : () => currentDirectory;
 
             // Register input files
             function register(file: { unitName: string; content: string; }) {
@@ -895,7 +911,7 @@ module Harness {
             let newLine =
                 newLineKind === ts.NewLineKind.CarriageReturnLineFeed ? carriageReturnLineFeed :
                     newLineKind === ts.NewLineKind.LineFeed ? lineFeed :
-                        ts.sys.newLine;
+                        Harness.IO.newLine();
 
             return {
                 getCurrentDirectory,
@@ -988,7 +1004,7 @@ module Harness {
                 // Treat them as library files, so include them in build, but not in baselines.
                 let includeBuiltFiles: { unitName: string; content: string }[] = [];
 
-                let useCaseSensitiveFileNames = ts.sys.useCaseSensitiveFileNames;
+                let useCaseSensitiveFileNames = Harness.IO.useCaseSensitiveFileNames();
                 this.settings.forEach(setCompilerOptionForSetting);
 
                 let fileOutputs: GeneratedFile[] = [];
@@ -1006,11 +1022,9 @@ module Harness {
                 let errors = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
                 this.lastErrors = errors;
 
-                let result = new CompilerResult(fileOutputs, errors, program, ts.sys.getCurrentDirectory(), emitResult.sourceMaps);
+                let result = new CompilerResult(fileOutputs, errors, program, Harness.IO.getCurrentDirectory(), emitResult.sourceMaps);
                 onComplete(result, program);
 
-                // reset what newline means in case the last test changed it
-                ts.sys.newLine = newLine;
                 return options;
                 
                 function setCompilerOptionForSetting(setting: Harness.TestCaseParser.CompilerSetting) {
@@ -1273,7 +1287,7 @@ module Harness {
                     errorOutput += diagnostic.file.fileName + "(" + (lineAndCharacter.line + 1) + "," + (lineAndCharacter.character + 1) + "): ";
                 }
 
-                errorOutput += ts.DiagnosticCategory[diagnostic.category].toLowerCase() + " TS" + diagnostic.code + ": " + ts.flattenDiagnosticMessageText(diagnostic.messageText, ts.sys.newLine) + ts.sys.newLine;
+                errorOutput += ts.DiagnosticCategory[diagnostic.category].toLowerCase() + " TS" + diagnostic.code + ": " + ts.flattenDiagnosticMessageText(diagnostic.messageText, Harness.IO.newLine()) + Harness.IO.newLine();
             });
 
             return errorOutput;
@@ -1286,7 +1300,7 @@ module Harness {
             let totalErrorsReported = 0;
 
             function outputErrorText(error: ts.Diagnostic) {
-                let message = ts.flattenDiagnosticMessageText(error.messageText, ts.sys.newLine);
+                let message = ts.flattenDiagnosticMessageText(error.messageText, Harness.IO.newLine());
 
                 let errLines = RunnerBase.removeFullPaths(message)
                     .split("\n")
@@ -1383,7 +1397,7 @@ module Harness {
             assert.equal(totalErrorsReported + numLibraryDiagnostics + numTest262HarnessDiagnostics, diagnostics.length, "total number of errors");
 
             return minimalDiagnosticsToString(diagnostics) +
-                ts.sys.newLine + ts.sys.newLine + outputLines.join("\r\n");
+                Harness.IO.newLine() + Harness.IO.newLine() + outputLines.join("\r\n");
         }
 
         export function collateOutputs(outputFiles: Harness.Compiler.GeneratedFile[]): string {

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -26,7 +26,6 @@
 
 // Block scoped definitions work poorly for global variables, temporarily enable var
 /* tslint:disable:no-var-keyword */
-var Buffer: BufferConstructor = require("buffer").Buffer;
 
 // this will work in the browser via browserify
 var _chai: typeof chai = require("chai");
@@ -55,9 +54,17 @@ module Utils {
             return ExecutionEnvironment.Node;
         }
     }
-
+    
     export let currentExecutionEnvironment = getExecutionEnvironment();
 
+    const Buffer: BufferConstructor = currentExecutionEnvironment !== ExecutionEnvironment.Browser 
+        ? require("buffer").Buffer 
+        : undefined;
+
+    export function encodeString(s: string): string {
+        return Buffer ? (new Buffer(s)).toString("utf8") : s;
+    }
+    
     export function evalFile(fileContents: string, fileName: string, nodeContext?: any) {
         let environment = getExecutionEnvironment();
         switch (environment) {
@@ -1736,7 +1743,7 @@ module Harness {
         }
 
         function writeComparison(expected: string, actual: string, relativeFileName: string, actualFileName: string, descriptionForDescribe: string) {
-            let encoded_actual = (new Buffer(actual)).toString("utf8");
+            let encoded_actual =  Utils.encodeString(actual);
             if (expected != encoded_actual) {
                 // Overwrite & issue error
                 let errMsg = "The baseline file " + relativeFileName + " has changed";

--- a/src/harness/projectsRunner.ts
+++ b/src/harness/projectsRunner.ts
@@ -62,7 +62,7 @@ class ProjectRunner extends RunnerBase {
 
         let testFileText: string = null;
         try {
-            testFileText = ts.sys.readFile(testCaseFileName);
+            testFileText = Harness.IO.readFile(testCaseFileName);
         }
         catch (e) {
             assert(false, "Unable to open testcase file: " + testCaseFileName + ": " + e.message);
@@ -98,7 +98,7 @@ class ProjectRunner extends RunnerBase {
         }
 
         function cleanProjectUrl(url: string) {
-            let diskProjectPath = ts.normalizeSlashes(ts.sys.resolvePath(testCase.projectRoot));
+            let diskProjectPath = ts.normalizeSlashes(Harness.IO.resolvePath(testCase.projectRoot));
             let projectRootUrl = "file:///" + diskProjectPath;
             let normalizedProjectRoot = ts.normalizeSlashes(testCase.projectRoot);
             diskProjectPath = diskProjectPath.substr(0, diskProjectPath.lastIndexOf(normalizedProjectRoot));
@@ -122,7 +122,7 @@ class ProjectRunner extends RunnerBase {
         }
 
         function getCurrentDirectory() {
-            return ts.sys.resolvePath(testCase.projectRoot);
+            return Harness.IO.resolvePath(testCase.projectRoot);
         }
 
         function compileProjectFiles(moduleKind: ts.ModuleKind, getInputFiles: () => string[],
@@ -160,8 +160,8 @@ class ProjectRunner extends RunnerBase {
                     sourceMap: !!testCase.sourceMap,
                     out: testCase.out,
                     outDir: testCase.outDir,
-                    mapRoot: testCase.resolveMapRoot && testCase.mapRoot ? ts.sys.resolvePath(testCase.mapRoot) : testCase.mapRoot,
-                    sourceRoot: testCase.resolveSourceRoot && testCase.sourceRoot ? ts.sys.resolvePath(testCase.sourceRoot) : testCase.sourceRoot,
+                    mapRoot: testCase.resolveMapRoot && testCase.mapRoot ? Harness.IO.resolvePath(testCase.mapRoot) : testCase.mapRoot,
+                    sourceRoot: testCase.resolveSourceRoot && testCase.sourceRoot ? Harness.IO.resolvePath(testCase.sourceRoot) : testCase.sourceRoot,
                     module: moduleKind,
                     noResolve: testCase.noResolve,
                     rootDir: testCase.rootDir
@@ -190,8 +190,8 @@ class ProjectRunner extends RunnerBase {
                     writeFile,
                     getCurrentDirectory,
                     getCanonicalFileName: Harness.Compiler.getCanonicalFileName,
-                    useCaseSensitiveFileNames: () => ts.sys.useCaseSensitiveFileNames,
-                    getNewLine: () => ts.sys.newLine,
+                    useCaseSensitiveFileNames: () => Harness.IO.useCaseSensitiveFileNames(),
+                    getNewLine: () => Harness.IO.newLine(),
                     fileExists: fileName => getSourceFile(fileName, ts.ScriptTarget.ES5) !== undefined,
                     readFile: fileName => Harness.IO.readFile(fileName)
                 };
@@ -216,7 +216,7 @@ class ProjectRunner extends RunnerBase {
             function getSourceFileText(fileName: string): string {
                 let text: string = undefined;
                 try {
-                    text = ts.sys.readFile(ts.isRootedDiskPath(fileName)
+                    text = Harness.IO.readFile(ts.isRootedDiskPath(fileName)
                         ? fileName
                         : ts.normalizeSlashes(testCase.projectRoot) + "/" + ts.normalizeSlashes(fileName));
                 }
@@ -263,14 +263,14 @@ class ProjectRunner extends RunnerBase {
                 // Actual writing of file as in tc.ts
                 function ensureDirectoryStructure(directoryname: string) {
                     if (directoryname) {
-                        if (!ts.sys.directoryExists(directoryname)) {
+                        if (!Harness.IO.directoryExists(directoryname)) {
                             ensureDirectoryStructure(ts.getDirectoryPath(directoryname));
-                            ts.sys.createDirectory(directoryname);
+                            Harness.IO.createDirectory(directoryname);
                         }
                     }
                 }
                 ensureDirectoryStructure(ts.getDirectoryPath(ts.normalizePath(outputFilePath)));
-                ts.sys.writeFile(outputFilePath, data, writeByteOrderMark);
+                Harness.IO.writeFile(outputFilePath, data);
 
                 outputFiles.push({ emittedFileName: fileName, code: data, fileName: diskRelativeName, writeByteOrderMark: writeByteOrderMark });
             }
@@ -391,7 +391,7 @@ class ProjectRunner extends RunnerBase {
 
                                 Harness.Baseline.runBaseline("Baseline of emitted result (" + moduleNameToString(compilerResult.moduleKind) + "): " + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + outputFile.fileName, () => {
                                     try {
-                                        return ts.sys.readFile(getProjectOutputFolder(outputFile.fileName, compilerResult.moduleKind));
+                                        return Harness.IO.readFile(getProjectOutputFolder(outputFile.fileName, compilerResult.moduleKind));
                                     }
                                     catch (e) {
                                         return undefined;

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -106,6 +106,4 @@ if (runners.length === 0) {
     // runners.push(new GeneratedFourslashRunner());
 }
 
-ts.sys.newLine = "\r\n";
-
 runTests(runners);

--- a/tests/baselines/reference/typeGuardsInIfStatement.js
+++ b/tests/baselines/reference/typeGuardsInIfStatement.js
@@ -1,9 +1,9 @@
 //// [typeGuardsInIfStatement.ts]
-// In the true branch statement of an �if� statement, 
-// the type of a variable or parameter is narrowed by any type guard in the �if� condition when true, 
+// In the true branch statement of an 'if' statement, 
+// the type of a variable or parameter is narrowed by any type guard in the 'if' condition when true, 
 // provided the true branch statement contains no assignments to the variable or parameter.
-// In the false branch statement of an �if� statement, 
-// the type of a variable or parameter is narrowed by any type guard in the �if� condition when false, 
+// In the false branch statement of an 'if' statement, 
+// the type of a variable or parameter is narrowed by any type guard in the 'if' condition when false, 
 // provided the false branch statement contains no assignments to the variable or parameter
 function foo(x: number | string) {
     if (typeof x === "string") {
@@ -149,11 +149,11 @@ function foo12(x: number | string | boolean) {
 }
 
 //// [typeGuardsInIfStatement.js]
-// In the true branch statement of an �if� statement, 
-// the type of a variable or parameter is narrowed by any type guard in the �if� condition when true, 
+// In the true branch statement of an 'if' statement, 
+// the type of a variable or parameter is narrowed by any type guard in the 'if' condition when true, 
 // provided the true branch statement contains no assignments to the variable or parameter.
-// In the false branch statement of an �if� statement, 
-// the type of a variable or parameter is narrowed by any type guard in the �if� condition when false, 
+// In the false branch statement of an 'if' statement, 
+// the type of a variable or parameter is narrowed by any type guard in the 'if' condition when false, 
 // provided the false branch statement contains no assignments to the variable or parameter
 function foo(x) {
     if (typeof x === "string") {

--- a/tests/baselines/reference/typeGuardsInIfStatement.symbols
+++ b/tests/baselines/reference/typeGuardsInIfStatement.symbols
@@ -1,9 +1,9 @@
 === tests/cases/conformance/expressions/typeGuards/typeGuardsInIfStatement.ts ===
-// In the true branch statement of an �if� statement, 
-// the type of a variable or parameter is narrowed by any type guard in the �if� condition when true, 
+// In the true branch statement of an 'if' statement, 
+// the type of a variable or parameter is narrowed by any type guard in the 'if' condition when true, 
 // provided the true branch statement contains no assignments to the variable or parameter.
-// In the false branch statement of an �if� statement, 
-// the type of a variable or parameter is narrowed by any type guard in the �if� condition when false, 
+// In the false branch statement of an 'if' statement, 
+// the type of a variable or parameter is narrowed by any type guard in the 'if' condition when false, 
 // provided the false branch statement contains no assignments to the variable or parameter
 function foo(x: number | string) {
 >foo : Symbol(foo, Decl(typeGuardsInIfStatement.ts, 0, 0))

--- a/tests/baselines/reference/typeGuardsInIfStatement.types
+++ b/tests/baselines/reference/typeGuardsInIfStatement.types
@@ -1,9 +1,9 @@
 === tests/cases/conformance/expressions/typeGuards/typeGuardsInIfStatement.ts ===
-// In the true branch statement of an �if� statement, 
-// the type of a variable or parameter is narrowed by any type guard in the �if� condition when true, 
+// In the true branch statement of an 'if' statement, 
+// the type of a variable or parameter is narrowed by any type guard in the 'if' condition when true, 
 // provided the true branch statement contains no assignments to the variable or parameter.
-// In the false branch statement of an �if� statement, 
-// the type of a variable or parameter is narrowed by any type guard in the �if� condition when false, 
+// In the false branch statement of an 'if' statement, 
+// the type of a variable or parameter is narrowed by any type guard in the 'if' condition when false, 
 // provided the false branch statement contains no assignments to the variable or parameter
 function foo(x: number | string) {
 >foo : (x: number | string) => number

--- a/tests/cases/conformance/expressions/typeGuards/typeGuardsInIfStatement.ts
+++ b/tests/cases/conformance/expressions/typeGuards/typeGuardsInIfStatement.ts
@@ -1,8 +1,8 @@
-// In the true branch statement of an ‘if’ statement, 
-// the type of a variable or parameter is narrowed by any type guard in the ‘if’ condition when true, 
+// In the true branch statement of an 'if' statement, 
+// the type of a variable or parameter is narrowed by any type guard in the 'if' condition when true, 
 // provided the true branch statement contains no assignments to the variable or parameter.
-// In the false branch statement of an ‘if’ statement, 
-// the type of a variable or parameter is narrowed by any type guard in the ‘if’ condition when false, 
+// In the false branch statement of an 'if' statement, 
+// the type of a variable or parameter is narrowed by any type guard in the 'if' condition when false, 
 // provided the false branch statement contains no assignments to the variable or parameter
 function foo(x: number | string) {
     if (typeof x === "string") {

--- a/tests/cases/unittests/transpile.ts
+++ b/tests/cases/unittests/transpile.ts
@@ -23,6 +23,13 @@ module ts {
         function test(input: string, testSettings: TranspileTestSettings): void {
             
             let transpileOptions: TranspileOptions = testSettings.options || {};
+            if (!transpileOptions.compilerOptions) {
+                transpileOptions.compilerOptions = {};
+            }
+            if(transpileOptions.compilerOptions.newLine === undefined) {
+                // use \r\n as default new line
+                transpileOptions.compilerOptions.newLine = ts.NewLineKind.CarriageReturnLineFeed;
+            }
             
             let canUseOldTranspile = !transpileOptions.renamedDependencies;  
             


### PR DESCRIPTION
alternative fix for #4359.

It is ok for `sys` to be undefined since it is just an implementation detail of the default version of `CompilerHost`. Compiler and language service can already handle this. However test harness still uses `sys` all over the place, in this PR usages of `sys` in tests were replaced with `Harness.IO`. Also I've kept only `fs` in 'package.json' since this is the only module we use that is not shimmed by the 'webpack'.