### PR TITLE
Fix issue when the newly added files in tsconfig is not opened

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1116,13 +1116,15 @@ namespace ts.server {
                         else {
                             // if the root file was opened by client, it would belong to either 
                             // openFileRoots or openFileReferenced.
-                            if (this.openFileRoots.indexOf(info) >= 0) {
-                                this.openFileRoots = copyListRemovingItem(info, this.openFileRoots);
+                            if (info.isOpen) {
+                                if (this.openFileRoots.indexOf(info) >= 0) {
+                                    this.openFileRoots = copyListRemovingItem(info, this.openFileRoots);
+                                }
+                                if (this.openFilesReferenced.indexOf(info) >= 0) {
+                                    this.openFilesReferenced = copyListRemovingItem(info, this.openFilesReferenced);
+                                }
+                                this.openFileRootsConfigured.push(info);
                             }
-                            if (this.openFilesReferenced.indexOf(info) >= 0) {
-                                this.openFilesReferenced = copyListRemovingItem(info, this.openFilesReferenced);
-                            }
-                            this.openFileRootsConfigured.push(info);
                         }
                         project.addRoot(info);
                     }


### PR DESCRIPTION
This PR fixes the issue that when the newly added files in tsconfig.json were previously opened, they would be added to the openFileRoots regardless of them being currently open or not. 