### PR TITLE
Correctly identify JSX Expressions as Expression parent nodes

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -978,6 +978,7 @@ namespace ts {
                     case SyntaxKind.ComputedPropertyName:
                         return node === (<ComputedPropertyName>parent).expression;
                     case SyntaxKind.Decorator:
+                    case SyntaxKind.JsxExpression:
                         return true;
                     case SyntaxKind.ExpressionWithTypeArguments:
                         return (<ExpressionWithTypeArguments>parent).expression === node && isExpressionWithTypeArgumentsInClassExtendsClause(parent);

--- a/tests/baselines/reference/jsxHash.types
+++ b/tests/baselines/reference/jsxHash.types
@@ -3,18 +3,21 @@ var t02 = <a>{0}#</a>;
 >t02 : any
 ><a>{0}#</a> : any
 >a : any
+>0 : number
 >a : any
 
 var t03 = <a>#{0}</a>;
 >t03 : any
 ><a>#{0}</a> : any
 >a : any
+>0 : number
 >a : any
 
 var t04 = <a>#{0}#</a>;
 >t04 : any
 ><a>#{0}#</a> : any
 >a : any
+>0 : number
 >a : any
 
 var t05 = <a>#<i></i></a>;

--- a/tests/baselines/reference/jsxImportInAttribute.symbols
+++ b/tests/baselines/reference/jsxImportInAttribute.symbols
@@ -9,6 +9,7 @@ let x = Test; // emit test_1.default
 
 <anything attr={Test} />; // ?
 >attr : Symbol(unknown)
+>Test : Symbol(Test, Decl(consumer.tsx, 1, 6))
 
 === tests/cases/compiler/component.d.ts ===
 

--- a/tests/baselines/reference/jsxImportInAttribute.types
+++ b/tests/baselines/reference/jsxImportInAttribute.types
@@ -11,7 +11,7 @@ let x = Test; // emit test_1.default
 ><anything attr={Test} /> : any
 >anything : any
 >attr : any
->Test : any
+>Test : typeof Test
 
 === tests/cases/compiler/component.d.ts ===
 

--- a/tests/baselines/reference/jsxReactTestSuite.symbols
+++ b/tests/baselines/reference/jsxReactTestSuite.symbols
@@ -46,6 +46,8 @@ declare var hasOwnProperty:any;
   <div><br /></div>
   <Component>{foo}<br />{bar}</Component>
 >Component : Symbol(Component, Decl(jsxReactTestSuite.tsx, 2, 11))
+>foo : Symbol(foo, Decl(jsxReactTestSuite.tsx, 7, 11))
+>bar : Symbol(bar, Decl(jsxReactTestSuite.tsx, 8, 11))
 >Component : Symbol(Component, Decl(jsxReactTestSuite.tsx, 2, 11))
 
   <br />
@@ -159,6 +161,7 @@ var x =
 <Component x={y} />;
 >Component : Symbol(Component, Decl(jsxReactTestSuite.tsx, 2, 11))
 >x : Symbol(unknown)
+>y : Symbol(y, Decl(jsxReactTestSuite.tsx, 9, 11))
 
 <x-component />;
 

--- a/tests/baselines/reference/jsxReactTestSuite.types
+++ b/tests/baselines/reference/jsxReactTestSuite.types
@@ -251,6 +251,7 @@ var x =
 >y : any
 
 ={2 } z />;
+>2 : number
 >z : any
 
 <Component
@@ -287,18 +288,21 @@ var x =
 >Component : any
 >x : any
 >y : any
+>2 : number
 
 <Component { ... x } y={2} z />;
 ><Component { ... x } y={2} z /> : any
 >Component : any
 >x : any
 >y : any
+>2 : number
 >z : any
 
 <Component x={1} {...y} />;
 ><Component x={1} {...y} /> : any
 >Component : any
 >x : any
+>1 : number
 >y : any
 
 
@@ -306,6 +310,7 @@ var x =
 ><Component x={1} y="2" {...z} {...z}><Child /></Component> : any
 >Component : any
 >x : any
+>1 : number
 >y : any
 >z : any
 >z : any
@@ -326,6 +331,7 @@ var x =
 >2 : number
 >z : any
 >z : any
+>3 : number
 >Component : any
 
 

--- a/tests/baselines/reference/tsxElementResolution13.types
+++ b/tests/baselines/reference/tsxElementResolution13.types
@@ -25,4 +25,5 @@ var obj1: Obj1;
 ><obj1 x={10} /> : JSX.Element
 >obj1 : Obj1
 >x : any
+>10 : number
 

--- a/tests/baselines/reference/tsxElementResolution14.types
+++ b/tests/baselines/reference/tsxElementResolution14.types
@@ -20,4 +20,5 @@ var obj1: Obj1;
 ><obj1 x={10} /> : JSX.Element
 >obj1 : Obj1
 >x : any
+>10 : number
 

--- a/tests/baselines/reference/tsxElementResolution9.types
+++ b/tests/baselines/reference/tsxElementResolution9.types
@@ -67,4 +67,5 @@ var Obj3: Obj3;
 ><Obj3 x={42} /> : JSX.Element
 >Obj3 : Obj3
 >x : any
+>42 : number
 

--- a/tests/baselines/reference/tsxEmit1.symbols
+++ b/tests/baselines/reference/tsxEmit1.symbols
@@ -52,6 +52,7 @@ var selfClosed7 = <div x={p} y='p' />;
 >selfClosed7 : Symbol(selfClosed7, Decl(tsxEmit1.tsx, 14, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 >x : Symbol(unknown)
+>p : Symbol(p, Decl(tsxEmit1.tsx, 7, 3))
 >y : Symbol(unknown)
 
 var openClosed1 = <div></div>;
@@ -69,6 +70,7 @@ var openClosed3 = <div n='m'>{p}</div>;
 >openClosed3 : Symbol(openClosed3, Decl(tsxEmit1.tsx, 18, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 >n : Symbol(unknown)
+>p : Symbol(p, Decl(tsxEmit1.tsx, 7, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 
 var openClosed4 = <div n='m'>{p < p}</div>;
@@ -146,6 +148,7 @@ var whitespace1 = <div>      </div>;
 var whitespace2 = <div>  {p}    </div>;
 >whitespace2 : Symbol(whitespace2, Decl(tsxEmit1.tsx, 35, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
+>p : Symbol(p, Decl(tsxEmit1.tsx, 7, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 
 var whitespace3 = <div>  
@@ -153,6 +156,8 @@ var whitespace3 = <div>
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 
       {p}    
+>p : Symbol(p, Decl(tsxEmit1.tsx, 7, 3))
+
       </div>;
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit1.tsx, 1, 22))
 

--- a/tests/baselines/reference/tsxEmit1.types
+++ b/tests/baselines/reference/tsxEmit1.types
@@ -45,6 +45,7 @@ var selfClosed5 = <div x={0} y='0' />;
 ><div x={0} y='0' /> : JSX.Element
 >div : any
 >x : any
+>0 : number
 >y : any
 
 var selfClosed6 = <div x={"1"} y='0' />;
@@ -52,6 +53,7 @@ var selfClosed6 = <div x={"1"} y='0' />;
 ><div x={"1"} y='0' /> : JSX.Element
 >div : any
 >x : any
+>"1" : string
 >y : any
 
 var selfClosed7 = <div x={p} y='p' />;

--- a/tests/baselines/reference/tsxEmit2.symbols
+++ b/tests/baselines/reference/tsxEmit2.symbols
@@ -21,29 +21,38 @@ var p1, p2, p3;
 var spreads1 = <div {...p1}>{p2}</div>;
 >spreads1 : Symbol(spreads1, Decl(tsxEmit2.tsx, 8, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
+>p2 : Symbol(p2, Decl(tsxEmit2.tsx, 7, 7))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 
 var spreads2 = <div {...p1}>{p2}</div>;
 >spreads2 : Symbol(spreads2, Decl(tsxEmit2.tsx, 9, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
+>p2 : Symbol(p2, Decl(tsxEmit2.tsx, 7, 7))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 
 var spreads3 = <div x={p3} {...p1}>{p2}</div>;
 >spreads3 : Symbol(spreads3, Decl(tsxEmit2.tsx, 10, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 >x : Symbol(unknown)
+>p3 : Symbol(p3, Decl(tsxEmit2.tsx, 7, 11))
+>p2 : Symbol(p2, Decl(tsxEmit2.tsx, 7, 7))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 
 var spreads4 = <div {...p1} x={p3} >{p2}</div>;
 >spreads4 : Symbol(spreads4, Decl(tsxEmit2.tsx, 11, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 >x : Symbol(unknown)
+>p3 : Symbol(p3, Decl(tsxEmit2.tsx, 7, 11))
+>p2 : Symbol(p2, Decl(tsxEmit2.tsx, 7, 7))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 
 var spreads5 = <div x={p2} {...p1} y={p3}>{p2}</div>;
 >spreads5 : Symbol(spreads5, Decl(tsxEmit2.tsx, 12, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 >x : Symbol(unknown)
+>p2 : Symbol(p2, Decl(tsxEmit2.tsx, 7, 7))
 >y : Symbol(unknown)
+>p3 : Symbol(p3, Decl(tsxEmit2.tsx, 7, 11))
+>p2 : Symbol(p2, Decl(tsxEmit2.tsx, 7, 7))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxEmit2.tsx, 1, 22))
 

--- a/tests/baselines/reference/tsxExternalModuleEmit2.symbols
+++ b/tests/baselines/reference/tsxExternalModuleEmit2.symbols
@@ -20,6 +20,7 @@ declare var Foo, React;
 <Foo handler={Main}></Foo>;
 >Foo : Symbol(Foo, Decl(app.tsx, 1, 11))
 >handler : Symbol(unknown)
+>Main : Symbol(Main, Decl(app.tsx, 0, 6))
 >Foo : Symbol(Foo, Decl(app.tsx, 1, 11))
 
 // Should see mod_1['default'] in emit here

--- a/tests/baselines/reference/tsxReactEmit1.symbols
+++ b/tests/baselines/reference/tsxReactEmit1.symbols
@@ -54,6 +54,7 @@ var selfClosed7 = <div x={p} y='p' b />;
 >selfClosed7 : Symbol(selfClosed7, Decl(tsxReactEmit1.tsx, 15, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 >x : Symbol(unknown)
+>p : Symbol(p, Decl(tsxReactEmit1.tsx, 8, 3))
 >y : Symbol(unknown)
 >b : Symbol(unknown)
 
@@ -72,6 +73,7 @@ var openClosed3 = <div n='m'>{p}</div>;
 >openClosed3 : Symbol(openClosed3, Decl(tsxReactEmit1.tsx, 19, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 >n : Symbol(unknown)
+>p : Symbol(p, Decl(tsxReactEmit1.tsx, 8, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 
 var openClosed4 = <div n='m'>{p < p}</div>;
@@ -150,6 +152,7 @@ var whitespace1 = <div>      </div>;
 var whitespace2 = <div>  {p}    </div>;
 >whitespace2 : Symbol(whitespace2, Decl(tsxReactEmit1.tsx, 36, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
+>p : Symbol(p, Decl(tsxReactEmit1.tsx, 8, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 
 var whitespace3 = <div>  
@@ -157,6 +160,8 @@ var whitespace3 = <div>
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 
       {p}    
+>p : Symbol(p, Decl(tsxReactEmit1.tsx, 8, 3))
+
       </div>;
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit1.tsx, 1, 22))
 

--- a/tests/baselines/reference/tsxReactEmit1.types
+++ b/tests/baselines/reference/tsxReactEmit1.types
@@ -47,6 +47,7 @@ var selfClosed5 = <div x={0} y='0' />;
 ><div x={0} y='0' /> : JSX.Element
 >div : any
 >x : any
+>0 : number
 >y : any
 
 var selfClosed6 = <div x={"1"} y='0' />;
@@ -54,6 +55,7 @@ var selfClosed6 = <div x={"1"} y='0' />;
 ><div x={"1"} y='0' /> : JSX.Element
 >div : any
 >x : any
+>"1" : string
 >y : any
 
 var selfClosed7 = <div x={p} y='p' b />;

--- a/tests/baselines/reference/tsxReactEmit2.symbols
+++ b/tests/baselines/reference/tsxReactEmit2.symbols
@@ -23,29 +23,38 @@ var p1, p2, p3;
 var spreads1 = <div {...p1}>{p2}</div>;
 >spreads1 : Symbol(spreads1, Decl(tsxReactEmit2.tsx, 9, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
+>p2 : Symbol(p2, Decl(tsxReactEmit2.tsx, 8, 7))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 
 var spreads2 = <div {...p1}>{p2}</div>;
 >spreads2 : Symbol(spreads2, Decl(tsxReactEmit2.tsx, 10, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
+>p2 : Symbol(p2, Decl(tsxReactEmit2.tsx, 8, 7))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 
 var spreads3 = <div x={p3} {...p1}>{p2}</div>;
 >spreads3 : Symbol(spreads3, Decl(tsxReactEmit2.tsx, 11, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 >x : Symbol(unknown)
+>p3 : Symbol(p3, Decl(tsxReactEmit2.tsx, 8, 11))
+>p2 : Symbol(p2, Decl(tsxReactEmit2.tsx, 8, 7))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 
 var spreads4 = <div {...p1} x={p3} >{p2}</div>;
 >spreads4 : Symbol(spreads4, Decl(tsxReactEmit2.tsx, 12, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 >x : Symbol(unknown)
+>p3 : Symbol(p3, Decl(tsxReactEmit2.tsx, 8, 11))
+>p2 : Symbol(p2, Decl(tsxReactEmit2.tsx, 8, 7))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 
 var spreads5 = <div x={p2} {...p1} y={p3}>{p2}</div>;
 >spreads5 : Symbol(spreads5, Decl(tsxReactEmit2.tsx, 13, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 >x : Symbol(unknown)
+>p2 : Symbol(p2, Decl(tsxReactEmit2.tsx, 8, 7))
 >y : Symbol(unknown)
+>p3 : Symbol(p3, Decl(tsxReactEmit2.tsx, 8, 11))
+>p2 : Symbol(p2, Decl(tsxReactEmit2.tsx, 8, 7))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmit2.tsx, 1, 22))
 

--- a/tests/baselines/reference/tsxReactEmitWhitespace.symbols
+++ b/tests/baselines/reference/tsxReactEmitWhitespace.symbols
@@ -29,6 +29,7 @@ var p = 0;
 // Emit "  ", p, "   "
 <div>  {p}    </div>;
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
+>p : Symbol(p, Decl(tsxReactEmitWhitespace.tsx, 11, 3))
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 
 // Emit only p
@@ -36,6 +37,8 @@ var p = 0;
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 
       {p}    
+>p : Symbol(p, Decl(tsxReactEmitWhitespace.tsx, 11, 3))
+
       </div>;
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 
@@ -44,6 +47,8 @@ var p = 0;
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 
   {p}
+>p : Symbol(p, Decl(tsxReactEmitWhitespace.tsx, 11, 3))
+
     </div>;
 >div : Symbol(JSX.IntrinsicElements, Decl(tsxReactEmitWhitespace.tsx, 1, 22))
 

--- a/tests/baselines/reference/tsxReactEmitWhitespace.types
+++ b/tests/baselines/reference/tsxReactEmitWhitespace.types
@@ -32,7 +32,7 @@ var p = 0;
 <div>  {p}    </div>;
 ><div>  {p}    </div> : JSX.Element
 >div : any
->p : any
+>p : number
 >div : any
 
 // Emit only p
@@ -41,7 +41,7 @@ var p = 0;
 >div : any
 
       {p}    
->p : any
+>p : number
 
       </div>;
 >div : any
@@ -52,7 +52,7 @@ var p = 0;
 >div : any
 
   {p}
->p : any
+>p : number
 
     </div>;
 >div : any

--- a/tests/baselines/reference/tsxTypeErrors.symbols
+++ b/tests/baselines/reference/tsxTypeErrors.symbols
@@ -18,6 +18,7 @@ var thing = { oops: 100 };
 var a3 = <div id={thing} />
 >a3 : Symbol(a3, Decl(tsxTypeErrors.tsx, 9, 3))
 >id : Symbol(unknown)
+>thing : Symbol(thing, Decl(tsxTypeErrors.tsx, 8, 3))
 
 // Mistyped html name (error)
 var e1 = <imag src="bar.jpg" />

--- a/tests/baselines/reference/tsxTypeErrors.types
+++ b/tests/baselines/reference/tsxTypeErrors.types
@@ -26,7 +26,7 @@ var a3 = <div id={thing} />
 ><div id={thing} /> : any
 >div : any
 >id : any
->thing : any
+>thing : { oops: number; }
 
 // Mistyped html name (error)
 var e1 = <imag src="bar.jpg" />

--- a/tests/cases/fourslash/tsxRename5.ts
+++ b/tests/cases/fourslash/tsxRename5.ts
@@ -17,5 +17,4 @@
 //// var x = <MyClass name={[|n/**/n|]}></MyClass>;
 
 goTo.marker();
-debugger;
 verify.renameLocations(false, false);

--- a/tests/cases/fourslash/tsxRename5.ts
+++ b/tests/cases/fourslash/tsxRename5.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts' />
+
+//@Filename: file.tsx
+//// declare module JSX {
+////     interface Element { }
+////     interface IntrinsicElements {
+////     }
+////     interface ElementAttributesProperty { props }
+//// }
+//// class MyClass {
+////   props: {
+////     name?: string;
+////     size?: number;
+//// }
+//// 
+//// var [|nn|]: string;
+//// var x = <MyClass name={[|n/**/n|]}></MyClass>;
+
+goTo.marker();
+debugger;
+verify.renameLocations(false, false);


### PR DESCRIPTION
Fixes bug #4404