### PR TITLE
Allow any file extensions if explicit file list is given

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -361,6 +361,10 @@ namespace ts.server {
         openRefCount = 0;
 
         constructor(public projectService: ProjectService, public projectOptions?: ProjectOptions) {
+            if(projectOptions && projectOptions.files){
+                // If files are listed explicitly, allow all extensions
+                projectOptions.compilerOptions.allowNonTsExtensions = true;
+            }
             this.compilerService = new CompilerService(this, projectOptions && projectOptions.compilerOptions);
         }
 


### PR DESCRIPTION
If an explicit list of files is given in a tsconfig.json file, then allow any file extensions in the project.