### PR TITLE
Add tslint rules for #3994

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -770,17 +770,34 @@ task("update-sublime", ["local", serverFile], function() {
     jake.cpR(serverFile + ".map", "../TypeScript-Sublime-Plugin/tsserver/");
 });
 
+var tslintRuleDir = "scripts/tslint";
+var tslintRules = ([
+    "nextLineRule",
+    "noInferrableTypesRule"
+]);
+var tslintRulesFiles = tslintRules.map(function(p) {
+    return path.join(tslintRuleDir, p + ".ts");
+});
+var tslintRulesOutFiles = tslintRules.map(function(p) {
+    return path.join(builtLocalDirectory, "tslint", p + ".js");
+});
+desc("Compiles tslint rules to js");
+task("build-rules", tslintRulesOutFiles);
+tslintRulesFiles.forEach(function(ruleFile, i) {
+    compileFile(tslintRulesOutFiles[i], [ruleFile], [ruleFile], [], /*useBuiltCompiler*/ true, /*noOutFile*/ true, /*generateDeclarations*/ false, path.join(builtLocalDirectory, "tslint")); 
+});
+
 // if the codebase were free of linter errors we could make jake runtests
 // run this task automatically
 desc("Runs tslint on the compiler sources");
-task("lint", [], function() {
+task("lint", ["build-rules"], function() {
     function success(f) { return function() { console.log('SUCCESS: No linter errors in ' + f + '\n'); }};
     function failure(f) { return function() { console.log('FAILURE: Please fix linting errors in ' + f + '\n') }};
 
     var lintTargets = compilerSources.concat(harnessCoreSources);
     for (var i in lintTargets) {
         var f = lintTargets[i];
-        var cmd = 'tslint -c tslint.json ' + f;
+        var cmd = 'tslint --rules-dir built/local/tslint -c tslint.json ' + f;
         exec(cmd, success(f), failure(f));
     }
 }, { async: true });

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -773,7 +773,8 @@ task("update-sublime", ["local", serverFile], function() {
 var tslintRuleDir = "scripts/tslint";
 var tslintRules = ([
     "nextLineRule",
-    "noInferrableTypesRule"
+    "noInferrableTypesRule",
+    "noNullRule"
 ]);
 var tslintRulesFiles = tslintRules.map(function(p) {
     return path.join(tslintRuleDir, p + ".ts");

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -774,7 +774,8 @@ var tslintRuleDir = "scripts/tslint";
 var tslintRules = ([
     "nextLineRule",
     "noInferrableTypesRule",
-    "noNullRule"
+    "noNullRule",
+    "booleanTriviaRule"
 ]);
 var tslintRulesFiles = tslintRules.map(function(p) {
     return path.join(tslintRuleDir, p + ".ts");

--- a/scripts/tslint/booleanTriviaRule.ts
+++ b/scripts/tslint/booleanTriviaRule.ts
@@ -1,0 +1,50 @@
+/// <reference path="../../node_modules/tslint/typings/typescriptServices.d.ts" />
+/// <reference path="../../node_modules/tslint/lib/tslint.d.ts" />
+
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING_FACTORY = (name: string, currently: string) => `Tag boolean argument as '${name}' (currently '${currently}')`;
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        const program = ts.createProgram([sourceFile.fileName], Lint.createCompilerOptions());
+        const checker = program.getTypeChecker();
+        return this.applyWithWalker(new BooleanTriviaWalker(checker, program.getSourceFile(sourceFile.fileName), this.getOptions()));
+    }
+}
+
+class BooleanTriviaWalker extends Lint.RuleWalker {
+    constructor(private checker: ts.TypeChecker, file: ts.SourceFile, opts: Lint.IOptions) {
+        super(file, opts);
+    }
+
+    visitCallExpression(node: ts.CallExpression) {
+        super.visitCallExpression(node);
+		if (node.arguments) {
+            const targetCallSignature = this.checker.getResolvedSignature(node);
+            if (!!targetCallSignature) {
+                const targetParameters = targetCallSignature.getParameters();
+                const source = this.getSourceFile();
+                for (let index = 0; index < targetParameters.length; index++) {
+                    const param = targetParameters[index];
+                    const arg = node.arguments[index];
+                    if (!(arg && param)) continue;
+
+                    const argType = this.checker.getContextualType(arg);
+                    if (argType && (argType.getFlags() & ts.TypeFlags.Boolean)) {
+                        if (arg.kind !== ts.SyntaxKind.TrueKeyword && arg.kind !== ts.SyntaxKind.FalseKeyword) {
+                            continue;
+                        }
+                        let triviaContent: string;
+                        const ranges = ts.getLeadingCommentRanges(arg.getFullText(), 0);
+                        if (ranges && ranges.length === 1 && ranges[0].kind === ts.SyntaxKind.MultiLineCommentTrivia) {
+                            triviaContent = arg.getFullText().slice(ranges[0].pos + 2, ranges[0].end - 2); //+/-2 to remove /**/
+                        }
+                        if (triviaContent !== param.getName()) {
+                            this.addFailure(this.createFailure(arg.getStart(source), arg.getWidth(source), Rule.FAILURE_STRING_FACTORY(param.getName(), triviaContent)));
+                        }
+                    }
+                }
+            }
+		}			
+    }
+}

--- a/scripts/tslint/nextLineRule.ts
+++ b/scripts/tslint/nextLineRule.ts
@@ -1,4 +1,4 @@
-/// <reference path="../../lib/typescriptServices.d.ts" />
+/// <reference path="../../node_modules/tslint/typings/typescriptServices.d.ts" />
 /// <reference path="../../node_modules/tslint/lib/tslint.d.ts" />
 
 const OPTION_CATCH = "check-catch";

--- a/scripts/tslint/nextLineRule.ts
+++ b/scripts/tslint/nextLineRule.ts
@@ -24,9 +24,9 @@ class NextLineWalker extends Lint.RuleWalker {
             const elseKeyword = getFirstChildOfKind(node, ts.SyntaxKind.ElseKeyword);
             if (this.hasOption(OPTION_ELSE) && !!elseKeyword) {
                 const thenStatementEndLoc = sourceFile.getLineAndCharacterOfPosition(thenStatement.getEnd());
-                const elseKeywordLoc = sourceFile.getLineAndCharacterOfPosition(elseKeyword.getStart());
+                const elseKeywordLoc = sourceFile.getLineAndCharacterOfPosition(elseKeyword.getStart(sourceFile));
                 if (thenStatementEndLoc.line !== (elseKeywordLoc.line - 1)) {
-                    const failure = this.createFailure(elseKeyword.getStart(), elseKeyword.getWidth(), Rule.ELSE_FAILURE_STRING);
+                    const failure = this.createFailure(elseKeyword.getStart(sourceFile), elseKeyword.getWidth(sourceFile), Rule.ELSE_FAILURE_STRING);
                     this.addFailure(failure);
                 }
             }
@@ -40,17 +40,15 @@ class NextLineWalker extends Lint.RuleWalker {
         const catchClause = node.catchClause;
 
         // "visit" try block
-        const tryKeyword = node.getChildAt(0);
         const tryBlock = node.tryBlock;
-        const tryOpeningBrace = tryBlock.getChildAt(0);
 
         if (this.hasOption(OPTION_CATCH) && !!catchClause) {
-            const tryClosingBrace = node.tryBlock.getChildAt(node.tryBlock.getChildCount() - 1);
-            const catchKeyword = catchClause.getChildAt(0);
+            const tryClosingBrace = tryBlock.getLastToken(sourceFile);
+            const catchKeyword = catchClause.getFirstToken(sourceFile);
             const tryClosingBraceLoc = sourceFile.getLineAndCharacterOfPosition(tryClosingBrace.getEnd());
-            const catchKeywordLoc = sourceFile.getLineAndCharacterOfPosition(catchKeyword.getStart());
+            const catchKeywordLoc = sourceFile.getLineAndCharacterOfPosition(catchKeyword.getStart(sourceFile));
             if (tryClosingBraceLoc.line !== (catchKeywordLoc.line - 1)) {
-                const failure = this.createFailure(catchKeyword.getStart(), catchKeyword.getWidth(), Rule.CATCH_FAILURE_STRING);
+                const failure = this.createFailure(catchKeyword.getStart(sourceFile), catchKeyword.getWidth(sourceFile), Rule.CATCH_FAILURE_STRING);
                 this.addFailure(failure);
             }
         }

--- a/scripts/tslint/nextLineRule.ts
+++ b/scripts/tslint/nextLineRule.ts
@@ -1,0 +1,63 @@
+/// <reference path="../../lib/typescriptServices.d.ts" />
+/// <reference path="../../node_modules/tslint/lib/tslint.d.ts" />
+
+const OPTION_CATCH = "check-catch";
+const OPTION_ELSE = "check-else";
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static CATCH_FAILURE_STRING = "'catch' should be on the line following the previous block's ending curly brace";
+    public static ELSE_FAILURE_STRING = "'else' should be on the line following the previous block's ending curly brace";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NextLineWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class NextLineWalker extends Lint.RuleWalker {
+    public visitIfStatement(node: ts.IfStatement) {
+        const sourceFile = node.getSourceFile();
+        const thenStatement = node.thenStatement;
+
+        const elseStatement = node.elseStatement;
+        if (!!elseStatement) {
+            // find the else keyword
+            const elseKeyword = getFirstChildOfKind(node, ts.SyntaxKind.ElseKeyword);
+            if (this.hasOption(OPTION_ELSE) && !!elseKeyword) {
+                const thenStatementEndLoc = sourceFile.getLineAndCharacterOfPosition(thenStatement.getEnd());
+                const elseKeywordLoc = sourceFile.getLineAndCharacterOfPosition(elseKeyword.getStart());
+                if (thenStatementEndLoc.line !== (elseKeywordLoc.line - 1)) {
+                    const failure = this.createFailure(elseKeyword.getStart(), elseKeyword.getWidth(), Rule.ELSE_FAILURE_STRING);
+                    this.addFailure(failure);
+                }
+            }
+        }
+
+        super.visitIfStatement(node);
+    }
+
+    public visitTryStatement(node: ts.TryStatement) {
+        const sourceFile = node.getSourceFile();
+        const catchClause = node.catchClause;
+
+        // "visit" try block
+        const tryKeyword = node.getChildAt(0);
+        const tryBlock = node.tryBlock;
+        const tryOpeningBrace = tryBlock.getChildAt(0);
+
+        if (this.hasOption(OPTION_CATCH) && !!catchClause) {
+            const tryClosingBrace = node.tryBlock.getChildAt(node.tryBlock.getChildCount() - 1);
+            const catchKeyword = catchClause.getChildAt(0);
+            const tryClosingBraceLoc = sourceFile.getLineAndCharacterOfPosition(tryClosingBrace.getEnd());
+            const catchKeywordLoc = sourceFile.getLineAndCharacterOfPosition(catchKeyword.getStart());
+            if (tryClosingBraceLoc.line !== (catchKeywordLoc.line - 1)) {
+                const failure = this.createFailure(catchKeyword.getStart(), catchKeyword.getWidth(), Rule.CATCH_FAILURE_STRING);
+                this.addFailure(failure);
+            }
+        }
+        super.visitTryStatement(node);
+    }
+}
+
+function getFirstChildOfKind(node: ts.Node, kind: ts.SyntaxKind) {
+    return node.getChildren().filter((child) => child.kind === kind)[0];
+}

--- a/scripts/tslint/noInferrableTypesRule.ts
+++ b/scripts/tslint/noInferrableTypesRule.ts
@@ -11,17 +11,6 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 class InferrableTypeWalker extends Lint.RuleWalker {
-    private originalService: ts.LanguageService;
-    private fileName: string;
-    private originalContent: string;
-    
-    constructor(file: ts.SourceFile, opts: Lint.IOptions) {
-        this.fileName = file.fileName;
-        this.originalContent = file.getFullText();
-        this.originalService = ts.createLanguageService(Lint.createLanguageServiceHost(this.fileName, this.originalContent));
-        super(this.originalService.getSourceFile(this.fileName), opts);
-    }
-
     visitVariableStatement(node: ts.VariableStatement) {
         node.declarationList.declarations.forEach(e => {
             if ((!!e.type) && (!!e.initializer)) {

--- a/scripts/tslint/noInferrableTypesRule.ts
+++ b/scripts/tslint/noInferrableTypesRule.ts
@@ -1,4 +1,4 @@
-/// <reference path="../../lib/typescriptServices.d.ts" />
+/// <reference path="../../node_modules/tslint/typings/typescriptServices.d.ts" />
 /// <reference path="../../node_modules/tslint/lib/tslint.d.ts" />
 
 

--- a/scripts/tslint/noInferrableTypesRule.ts
+++ b/scripts/tslint/noInferrableTypesRule.ts
@@ -3,30 +3,52 @@
 
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static FAILURE_STRING = "LHS type inferred by RHS expression, remove type annotation";
+    public static FAILURE_STRING_FACTORY = (type: string) => `LHS type (${type}) inferred by RHS expression, remove type annotation`;
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        const program = ts.createProgram([sourceFile.fileName], Lint.createCompilerOptions());
-        return this.applyWithWalker(new InferrableTypeWalker(sourceFile, this.getOptions(), program));
+        return this.applyWithWalker(new InferrableTypeWalker(sourceFile, this.getOptions()));
     }
 }
 
 class InferrableTypeWalker extends Lint.RuleWalker {
-    constructor(file: ts.SourceFile, opts: Lint.IOptions, private program: ts.Program) {
-        super(program.getSourceFile(file.fileName), opts);
+    private originalService: ts.LanguageService;
+    private fileName: string;
+    private originalContent: string;
+    
+    constructor(file: ts.SourceFile, opts: Lint.IOptions) {
+        this.fileName = file.fileName;
+        this.originalContent = file.getFullText();
+        this.originalService = ts.createLanguageService(Lint.createLanguageServiceHost(this.fileName, this.originalContent));
+        super(this.originalService.getSourceFile(this.fileName), opts);
     }
 
     visitVariableStatement(node: ts.VariableStatement) {
         node.declarationList.declarations.forEach(e => {
-            if (
-                (!!e.type) &&
-                (!!e.initializer) &&
-                (this.program.getTypeChecker().getTypeAtLocation(e.type) === this.program.getTypeChecker().getContextualType(e.initializer))
-               ) {
-                this.addFailure(this.createFailure(e.type.getStart(), e.type.getWidth(), Rule.FAILURE_STRING));
+            if ((!!e.type) && (!!e.initializer)) {
+                let failure: string;
+                switch (e.type.kind) {
+                    case ts.SyntaxKind.BooleanKeyword:
+                        if (e.initializer.kind === ts.SyntaxKind.TrueKeyword || e.initializer.kind === ts.SyntaxKind.FalseKeyword) {
+                            failure = 'boolean';
+                        }
+                    break;
+                    case ts.SyntaxKind.NumberKeyword:
+                        if (e.initializer.kind === ts.SyntaxKind.NumericLiteral) {
+                            failure = 'number';
+                        }
+                    break;
+                    case ts.SyntaxKind.StringKeyword:
+                        if (e.initializer.kind === ts.SyntaxKind.StringLiteral || e.initializer.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral) {
+                            failure = 'string';
+                        }
+                    break;
+                }
+                if (failure) {
+                    this.addFailure(this.createFailure(e.type.getStart(), e.type.getWidth(), Rule.FAILURE_STRING_FACTORY(failure)));
+                }
             }
         });
-        
+
         super.visitVariableStatement(node);
     }
 }

--- a/scripts/tslint/noInferrableTypesRule.ts
+++ b/scripts/tslint/noInferrableTypesRule.ts
@@ -27,8 +27,14 @@ class InferrableTypeWalker extends Lint.RuleWalker {
                         }
                     break;
                     case ts.SyntaxKind.StringKeyword:
-                        if (e.initializer.kind === ts.SyntaxKind.StringLiteral || e.initializer.kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral) {
-                            failure = 'string';
+                        switch (e.initializer.kind) {
+                            case ts.SyntaxKind.StringLiteral:
+                            case ts.SyntaxKind.NoSubstitutionTemplateLiteral:
+                            case ts.SyntaxKind.TemplateExpression:
+                                failure = 'string';
+                                break;
+                            default:
+                                break;
                         }
                     break;
                 }

--- a/scripts/tslint/noInferrableTypesRule.ts
+++ b/scripts/tslint/noInferrableTypesRule.ts
@@ -1,0 +1,32 @@
+/// <reference path="../../lib/typescriptServices.d.ts" />
+/// <reference path="../../node_modules/tslint/lib/tslint.d.ts" />
+
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "LHS type inferred by RHS expression, remove type annotation";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        const program = ts.createProgram([sourceFile.fileName], Lint.createCompilerOptions());
+        return this.applyWithWalker(new InferrableTypeWalker(sourceFile, this.getOptions(), program));
+    }
+}
+
+class InferrableTypeWalker extends Lint.RuleWalker {
+    constructor(file: ts.SourceFile, opts: Lint.IOptions, private program: ts.Program) {
+        super(program.getSourceFile(file.fileName), opts);
+    }
+
+    visitVariableStatement(node: ts.VariableStatement) {
+        node.declarationList.declarations.forEach(e => {
+            if (
+                (!!e.type) &&
+                (!!e.initializer) &&
+                (this.program.getTypeChecker().getTypeAtLocation(e.type) === this.program.getTypeChecker().getContextualType(e.initializer))
+               ) {
+                this.addFailure(this.createFailure(e.type.getStart(), e.type.getWidth(), Rule.FAILURE_STRING));
+            }
+        });
+        
+        super.visitVariableStatement(node);
+    }
+}

--- a/scripts/tslint/noNullRule.ts
+++ b/scripts/tslint/noNullRule.ts
@@ -1,0 +1,20 @@
+/// <reference path="../../node_modules/tslint/typings/typescriptServices.d.ts" />
+/// <reference path="../../node_modules/tslint/lib/tslint.d.ts" />
+
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "Don't use the 'null' keyword - use 'undefined' for missing values instead";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new NullWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class NullWalker extends Lint.RuleWalker {
+    visitNode(node: ts.Node) {
+        super.visitNode(node);
+        if (node.kind === ts.SyntaxKind.NullKeyword) {
+            this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+        }
+    }
+}

--- a/scripts/tslint/tsconfig.json
+++ b/scripts/tslint/tsconfig.json
@@ -1,0 +1,7 @@
+{
+	"compilerOptions": {
+		"noImplicitAny": true,
+		"module": "commonjs",
+		"outDir": "../../built/local/tslint"
+	}
+}

--- a/tslint.json
+++ b/tslint.json
@@ -39,6 +39,7 @@
         "no-internal-module": true,
         "no-trailing-whitespace": true,
         "no-inferrable-types": true,
-        "no-null": true
+        "no-null": true,
+        "boolean-trivia": true
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -38,6 +38,7 @@
         ],
         "no-internal-module": true,
         "no-trailing-whitespace": true,
-        "no-inferrable-types": true
+        "no-inferrable-types": true,
+        "no-null": true
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -8,7 +8,8 @@
             "spaces"
         ],
         "one-line": [true,
-            "check-open-brace"
+            "check-open-brace",
+            "check-whitespace"
         ],
         "no-unreachable": true,
         "no-use-before-declare": true,
@@ -21,7 +22,8 @@
             "check-branch",
             "check-operator",
             "check-separator",
-            "check-type"
+            "check-type",
+            "check-module"
         ],
         "typedef-whitespace": [true, {
             "call-signature": "nospace",
@@ -29,6 +31,13 @@
             "parameter": "nospace",
             "property-declaration": "nospace",
             "variable-declaration": "nospace"
-        }]
+        }],
+        "next-line": [true, 
+            "check-catch",
+            "check-else"
+        ],
+        "no-internal-module": true,
+        "no-trailing-whitespace": true,
+        "no-inferrable-types": true
   }
 }


### PR DESCRIPTION
> - [x] One variable declaration per variable statement (see palantir/tslint#525)
> - [x] Spaces, not tabs
> - [x] No space preceding colons
> - [x] Double quotes for strings (though, depending on TSLint's behavior on this, we can be flexible.
> - [x] No explicit types for inferrable primitives (can't really use the typesystem on individual files to check for any inference)
> - [x] use namespace instead of module (see palantir/tslint#517)
> - [x] else/catch/etc. on a different line (see palantir/tslint#88)
> - [x] Space before { in interfaces, classes, enums, any sort of attached statement body, or type annotation.
> - [x] No trailing whitespace
> - [x] Forbid boolean/undefined parameters who aren't named.
> - [x] Forbid null

