### PR TITLE
Fix issue with go-to-definition when first declaration of symbol is not specifically a class declaration

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -611,11 +611,11 @@ namespace ts {
         return false;
     }
 
-    export function isAccessor(node: Node): boolean {
+    export function isAccessor(node: Node): node is AccessorDeclaration {
         return node && (node.kind === SyntaxKind.GetAccessor || node.kind === SyntaxKind.SetAccessor);
     }
 
-    export function isClassLike(node: Node): boolean {
+    export function isClassLike(node: Node): node is ClassLikeDeclaration {
         return node && (node.kind === SyntaxKind.ClassDeclaration || node.kind === SyntaxKind.ClassExpression);
     }
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -4480,10 +4480,19 @@ namespace ts {
                 // and in either case the symbol has a construct signature definition, i.e. class
                 if (isNewExpressionTarget(location) || location.kind === SyntaxKind.ConstructorKeyword) {
                     if (symbol.flags & SymbolFlags.Class) {
-                        let classDeclaration = <ClassDeclaration>symbol.getDeclarations()[0];
-                        Debug.assert(classDeclaration && classDeclaration.kind === SyntaxKind.ClassDeclaration);
+                        // Find the first class-like declaration and try to get the construct signature.
+                        for (let declaration of symbol.getDeclarations()) {
+                            if (isClassLike(declaration)) {
+                                return tryAddSignature(declaration.members,
+                                                       /*selectConstructors*/ true,
+                                                       symbolKind,
+                                                       symbolName,
+                                                       containerName,
+                                                       result);
+                            }
+                        }
 
-                        return tryAddSignature(classDeclaration.members, /*selectConstructors*/ true, symbolKind, symbolName, containerName, result);
+                        Debug.fail("Expected declaration to have at least one class-like declaration");
                     }
                 }
                 return false;

--- a/tests/cases/fourslash/goToDefinitionConstructorOfClassExpression01.ts
+++ b/tests/cases/fourslash/goToDefinitionConstructorOfClassExpression01.ts
@@ -1,0 +1,11 @@
+/// <reference path='fourslash.ts' />
+
+////var x = class C {
+////    /*definition*/constructor() {
+////        var other = new /*usage*/C;
+////    }
+////}
+
+goTo.marker("usage");
+goTo.definition();
+verify.caretAtMarker("definition");

--- a/tests/cases/fourslash/goToDefinitionConstructorOfClassWhenClassIsPrecededByNamespace01.ts
+++ b/tests/cases/fourslash/goToDefinitionConstructorOfClassWhenClassIsPrecededByNamespace01.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+////namespace Foo {
+////    export var x;
+////}
+////
+////class Foo {
+////    /*definition*/constructor() {
+////    }
+////}
+////
+////var x = new /*usage*/Foo();
+
+goTo.marker("usage");
+goTo.definition();
+verify.caretAtMarker("definition");


### PR DESCRIPTION
Fixes #4477 and fixes #4478.