### PR TITLE
Adding -suppressExcessPropertyErrors compiler option

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7161,7 +7161,7 @@ namespace ts {
             let propertiesTable: SymbolTable = {};
             let propertiesArray: Symbol[] = [];
             let contextualType = getContextualType(node);
-            let typeFlags: TypeFlags;
+            let typeFlags: TypeFlags = 0;
 
             for (let memberDecl of node.properties) {
                 let member = memberDecl.symbol;
@@ -7210,7 +7210,8 @@ namespace ts {
             let stringIndexType = getIndexType(IndexKind.String);
             let numberIndexType = getIndexType(IndexKind.Number);
             let result = createAnonymousType(node.symbol, propertiesTable, emptyArray, emptyArray, stringIndexType, numberIndexType);
-            result.flags |= TypeFlags.ObjectLiteral | TypeFlags.FreshObjectLiteral | TypeFlags.ContainsObjectLiteral | (typeFlags & TypeFlags.PropagatingFlags);
+            let freshObjectLiteralFlag = compilerOptions.suppressExcessPropertyErrors ? 0 : TypeFlags.FreshObjectLiteral;
+            result.flags |= TypeFlags.ObjectLiteral | TypeFlags.ContainsObjectLiteral | freshObjectLiteralFlag | (typeFlags & TypeFlags.PropagatingFlags);
             return result;
 
             function getIndexType(kind: IndexKind) {

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -185,6 +185,12 @@ namespace ts {
             paramType: Diagnostics.LOCATION,
         },
         {
+            name: "suppressExcessPropertyErrors",
+            type: "boolean",
+            description: Diagnostics.Suppress_excess_property_checks_for_object_literals,
+            experimental: true
+        },
+        {
             name: "suppressImplicitAnyIndexErrors",
             type: "boolean",
             description: Diagnostics.Suppress_noImplicitAny_errors_for_indexing_objects_lacking_index_signatures,

--- a/src/compiler/diagnosticInformationMap.generated.ts
+++ b/src/compiler/diagnosticInformationMap.generated.ts
@@ -569,6 +569,7 @@ namespace ts {
         Specifies_module_resolution_strategy_Colon_node_Node_or_classic_TypeScript_pre_1_6: { code: 6069, category: DiagnosticCategory.Message, key: "Specifies module resolution strategy: 'node' (Node) or 'classic' (TypeScript pre 1.6) ." },
         Initializes_a_TypeScript_project_and_creates_a_tsconfig_json_file: { code: 6070, category: DiagnosticCategory.Message, key: "Initializes a TypeScript project and creates a tsconfig.json file." },
         Successfully_created_a_tsconfig_json_file: { code: 6071, category: DiagnosticCategory.Message, key: "Successfully created a tsconfig.json file." },
+        Suppress_excess_property_checks_for_object_literals: { code: 6072, category: DiagnosticCategory.Message, key: "Suppress excess property checks for object literals." },
         Variable_0_implicitly_has_an_1_type: { code: 7005, category: DiagnosticCategory.Error, key: "Variable '{0}' implicitly has an '{1}' type." },
         Parameter_0_implicitly_has_an_1_type: { code: 7006, category: DiagnosticCategory.Error, key: "Parameter '{0}' implicitly has an '{1}' type." },
         Member_0_implicitly_has_an_1_type: { code: 7008, category: DiagnosticCategory.Error, key: "Member '{0}' implicitly has an '{1}' type." },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2266,6 +2266,10 @@
         "category": "Message",
         "code": 6071
     },
+    "Suppress excess property checks for object literals.": {
+        "category": "Message",
+        "code": 6072
+    },
 
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2048,6 +2048,7 @@ namespace ts {
         rootDir?: string;
         sourceMap?: boolean;
         sourceRoot?: string;
+        suppressExcessPropertyErrors?: boolean;
         suppressImplicitAnyIndexErrors?: boolean;
         target?: ScriptTarget;
         version?: boolean;

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1203,6 +1203,10 @@ module Harness {
                             options.isolatedModules = setting.value === "true";
                             break;
 
+                        case "suppressexcesspropertyerrors":
+                            options.suppressExcessPropertyErrors = setting.value === "true";
+                            break;
+
                         case "suppressimplicitanyindexerrors":
                             options.suppressImplicitAnyIndexErrors = setting.value === "true";
                             break;
@@ -1569,7 +1573,7 @@ module Harness {
             "nolib", "sourcemap", "target", "out", "outdir", "noemithelpers", "noemitonerror",
             "noimplicitany", "noresolve", "newline", "normalizenewline", "emitbom",
             "errortruncation", "usecasesensitivefilenames", "preserveconstenums",
-            "includebuiltfile", "suppressimplicitanyindexerrors", "stripinternal",
+            "includebuiltfile", "suppressexcesspropertyerrors", "suppressimplicitanyindexerrors", "stripinternal",
             "isolatedmodules", "inlinesourcemap", "maproot", "sourceroot",
             "inlinesources", "emitdecoratormetadata", "experimentaldecorators",
             "skipdefaultlibcheck", "jsx"];

--- a/tests/baselines/reference/excessPropertyErrorsSuppressed.js
+++ b/tests/baselines/reference/excessPropertyErrorsSuppressed.js
@@ -1,0 +1,7 @@
+//// [excessPropertyErrorsSuppressed.ts]
+
+var x: { a: string } = { a: "hello", b: 42 };  // No error
+
+
+//// [excessPropertyErrorsSuppressed.js]
+var x = { a: "hello", b: 42 }; // No error

--- a/tests/baselines/reference/excessPropertyErrorsSuppressed.symbols
+++ b/tests/baselines/reference/excessPropertyErrorsSuppressed.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/excessPropertyErrorsSuppressed.ts ===
+
+var x: { a: string } = { a: "hello", b: 42 };  // No error
+>x : Symbol(x, Decl(excessPropertyErrorsSuppressed.ts, 1, 3))
+>a : Symbol(a, Decl(excessPropertyErrorsSuppressed.ts, 1, 8))
+>a : Symbol(a, Decl(excessPropertyErrorsSuppressed.ts, 1, 24))
+>b : Symbol(b, Decl(excessPropertyErrorsSuppressed.ts, 1, 36))
+

--- a/tests/baselines/reference/excessPropertyErrorsSuppressed.types
+++ b/tests/baselines/reference/excessPropertyErrorsSuppressed.types
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/excessPropertyErrorsSuppressed.ts ===
+
+var x: { a: string } = { a: "hello", b: 42 };  // No error
+>x : { a: string; }
+>a : string
+>{ a: "hello", b: 42 } : { a: string; b: number; }
+>a : string
+>"hello" : string
+>b : number
+>42 : number
+

--- a/tests/cases/compiler/excessPropertyErrorsSuppressed.ts
+++ b/tests/cases/compiler/excessPropertyErrorsSuppressed.ts
@@ -1,0 +1,3 @@
+﻿//@suppressExcessPropertyErrors: true
+
+var x: { a: string } = { a: "hello", b: 42 };  // No error


### PR DESCRIPTION
This PR adds a `-suppressExcessPropertyErrors` experimental compiler option that the disables strict object literal assignment checking implemented in #3823. The intent of this compiler option is to allow existing code bases to compile until issues found by the strict object literal assignment checking are addressed.