### PR TITLE
Add system argument to readConfigFile

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -374,10 +374,10 @@ namespace ts {
       * Read tsconfig.json file
       * @param fileName The path to the config file
       */
-    export function readConfigFile(fileName: string): { config?: any; error?: Diagnostic }  {
+    export function readConfigFile(fileName: string, system: System = sys): { config?: any; error?: Diagnostic }  {
         let text = "";
         try {
-            text = sys.readFile(fileName);
+            text = system.readFile(fileName);
         }
         catch (e) {
             return { error: createCompilerDiagnostic(Diagnostics.Cannot_read_file_0_Colon_1, fileName, e.message) };

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -374,7 +374,7 @@ namespace ts {
       * Read tsconfig.json file
       * @param fileName The path to the config file
       */
-    export function readConfigFile(fileName: string, system: System = sys): { config?: any; error?: Diagnostic }  {
+    export function readConfigFile(fileName: string, system: System): { config?: any; error?: Diagnostic }  {
         let text = "";
         try {
             text = system.readFile(fileName);

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -374,10 +374,10 @@ namespace ts {
       * Read tsconfig.json file
       * @param fileName The path to the config file
       */
-    export function readConfigFile(fileName: string, system: System): { config?: any; error?: Diagnostic }  {
+    export function readConfigFile(fileName: string, readFile: (path: string) => string): { config?: any; error?: Diagnostic }  {
         let text = "";
         try {
-            text = system.readFile(fileName);
+            text = readFile(fileName);
         }
         catch (e) {
             return { error: createCompilerDiagnostic(Diagnostics.Cannot_read_file_0_Colon_1, fileName, e.message) };

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -216,7 +216,7 @@ namespace ts {
             if (!cachedProgram) {
                 if (configFileName) {
 
-                    let result = readConfigFile(configFileName);
+                    let result = readConfigFile(configFileName, sys);
                     if (result.error) {
                         reportDiagnostic(result.error);
                         return sys.exit(ExitStatus.DiagnosticsPresent_OutputsSkipped);

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -216,7 +216,7 @@ namespace ts {
             if (!cachedProgram) {
                 if (configFileName) {
 
-                    let result = readConfigFile(configFileName, sys);
+                    let result = readConfigFile(configFileName, sys.readFile);
                     if (result.error) {
                         reportDiagnostic(result.error);
                         return sys.exit(ExitStatus.DiagnosticsPresent_OutputsSkipped);


### PR DESCRIPTION
Which allows the caller to specify the `System` used to read the file.