### PR TITLE
 Indexed access by enum constant

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -134,6 +134,7 @@ var harnessCoreSources = [
 var harnessSources = harnessCoreSources.concat([
     "incrementalParser.ts",
     "jsDocParsing.ts",
+    "services/api.ts",
     "services/colorization.ts",
     "services/documentRegistry.ts",
     "services/preProcessFile.ts",

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7932,6 +7932,14 @@ namespace ts {
             if (indexArgumentExpression.kind === SyntaxKind.StringLiteral || indexArgumentExpression.kind === SyntaxKind.NumericLiteral) {
                 return (<LiteralExpression>indexArgumentExpression).text;
             }
+
+            if (indexArgumentExpression.kind === SyntaxKind.ElementAccessExpression || indexArgumentExpression.kind === SyntaxKind.PropertyAccessExpression) {
+                let constant = getConstant(<ElementAccessExpression | PropertyAccessExpression>indexArgumentExpression);
+                if (constant) {
+                    return constant.value.toString();
+                }
+            }
+
             if (checkThatExpressionIsProperSymbolReference(indexArgumentExpression, indexArgumentType, /*reportError*/ false)) {
                 let rightHandSideName = (<Identifier>(<PropertyAccessExpression>indexArgumentExpression).name).text;
                 return getPropertyNameForKnownSymbolName(rightHandSideName);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -83,6 +83,7 @@ namespace ts {
             getFullyQualifiedName,
             getResolvedSignature,
             getConstantValue,
+            getConstant,
             isValidPropertyAccess,
             getSignatureFromDeclaration,
             isImplementationOfOverload,
@@ -13000,57 +13001,18 @@ namespace ts {
                         case SyntaxKind.PropertyAccessExpression:
                             let member = initializer.parent;
                             let currentType = getTypeOfSymbol(getSymbolOfNode(member.parent));
-                            let enumType: Type;
-                            let propertyName: string;
+                            let property: Symbol;
 
                             if (e.kind === SyntaxKind.Identifier) {
                                 // unqualified names can refer to member that reside in different declaration of the enum so just doing name resolution won't work.
                                 // instead pick current enum type and later try to fetch member from the type
-                                enumType = currentType;
-                                propertyName = (<Identifier>e).text;
+                                property = getPropertyOfObjectType(currentType, (<Identifier>e).text);
                             }
                             else {
-                                let expression: Expression;
-                                if (e.kind === SyntaxKind.ElementAccessExpression) {
-                                    if ((<ElementAccessExpression>e).argumentExpression === undefined ||
-                                        (<ElementAccessExpression>e).argumentExpression.kind !== SyntaxKind.StringLiteral) {
-                                        return undefined;
-                                    }
-                                    expression = (<ElementAccessExpression>e).expression;
-                                    propertyName = (<LiteralExpression>(<ElementAccessExpression>e).argumentExpression).text;
-                                }
-                                else {
-                                    expression = (<PropertyAccessExpression>e).expression;
-                                    propertyName = (<PropertyAccessExpression>e).name.text;
-                                }
-
-                                // expression part in ElementAccess\PropertyAccess should be either identifier or dottedName
-                                let current = expression;
-                                while (current) {
-                                    if (current.kind === SyntaxKind.Identifier) {
-                                        break;
-                                    }
-                                    else if (current.kind === SyntaxKind.PropertyAccessExpression) {
-                                        current = (<ElementAccessExpression>current).expression;
-                                    }
-                                    else {
-                                        return undefined;
-                                    }
-                                }
-
-                                enumType = checkExpression(expression);
-                                // allow references to constant members of other enums
-                                if (!(enumType.symbol && (enumType.symbol.flags & SymbolFlags.Enum))) {
-                                    return undefined;
-                                }
+                                property = resolveEnumMember(<ElementAccessExpression | PropertyAccessExpression>e);
                             }
 
-                            if (propertyName === undefined) {
-                                return undefined;
-                            }
-
-                            let property = getPropertyOfObjectType(enumType, propertyName);
-                            if (!property || !(property.flags & SymbolFlags.EnumMember)) {
+                            if (!property) {
                                 return undefined;
                             }
 
@@ -13070,6 +13032,54 @@ namespace ts {
                             return <number>getNodeLinks(propertyDecl).enumMemberValue;
                     }
                 }
+            }
+        }
+
+        function resolveEnumMember(e: ElementAccessExpression | PropertyAccessExpression) {
+            let expression: Expression;
+            let propertyName: string;
+
+            if (e.kind === SyntaxKind.ElementAccessExpression) {
+                if ((<ElementAccessExpression>e).argumentExpression === undefined ||
+                    (<ElementAccessExpression>e).argumentExpression.kind !== SyntaxKind.StringLiteral) {
+                    return undefined;
+                }
+                expression = (<ElementAccessExpression>e).expression;
+                propertyName = (<LiteralExpression>(<ElementAccessExpression>e).argumentExpression).text;
+            }
+            else if (e.kind === SyntaxKind.PropertyAccessExpression) {
+                expression = (<PropertyAccessExpression>e).expression;
+                propertyName = (<PropertyAccessExpression>e).name.text;
+            }
+
+            if (propertyName === undefined) {
+                return undefined;
+            }
+
+            // expression part in ElementAccess\PropertyAccess should be either identifier or dottedName
+            let current = expression;
+            while (current) {
+                if (current.kind === SyntaxKind.Identifier) {
+                    break;
+                }
+                else if (current.kind === SyntaxKind.PropertyAccessExpression) {
+                    current = (<ElementAccessExpression>current).expression;
+                }
+                else {
+                    return undefined;
+                }
+            }
+
+            let enumType = checkExpression(expression);
+            // allow references to constant members of other enums
+            if (!(enumType.symbol && (enumType.symbol.flags & SymbolFlags.Enum))) {
+                return undefined;
+            }
+
+            let property = getPropertyOfObjectType(enumType, propertyName);
+            if (property && (property.flags & SymbolFlags.EnumMember)) {
+                getNodeLinks(e).resolvedSymbol = property;
+                return property;
             }
         }
 
@@ -14384,24 +14394,47 @@ namespace ts {
             return getNodeLinks(node).flags;
         }
 
-        function getEnumMemberValue(node: EnumMember): number {
-            computeEnumMemberValues(<EnumDeclaration>node.parent);
-            return getNodeLinks(node).enumMemberValue;
+        function resolveEnumExpression(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): Symbol {
+            if (node.kind === SyntaxKind.EnumMember) {
+                computeEnumMemberValues(<EnumDeclaration>node.parent);
+                return node.symbol;
+            }
+            let symbol = getNodeLinks(node).resolvedSymbol || resolveEnumMember(<PropertyAccessExpression | ElementAccessExpression>node);
+            if (symbol && (symbol.flags & SymbolFlags.EnumMember)) {
+                computeEnumMemberValues(<EnumDeclaration>symbol.valueDeclaration.parent);
+                return symbol;
+            }
+            return undefined;
+        }
+
+        function getConstant(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): Constant {
+            let symbol = resolveEnumExpression(node);
+            if (symbol) {
+                let value = getNodeLinks(symbol.valueDeclaration).enumMemberValue;
+                if (value !== undefined) {
+                    return {
+                        value,
+                        flags: getConstantFlags(node, symbol)
+                    };
+                }
+            }
+            return undefined;
+        }
+
+        function getConstantFlags(node: Node, symbol: Symbol) {
+            let flags = 0;
+            // Always inline const enum member references
+            if (node !== symbol.valueDeclaration && isConstEnumDeclaration(symbol.valueDeclaration.parent)) {
+                flags |= ConstantFlags.Inline;
+            }
+            return flags;
         }
 
         function getConstantValue(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): number {
-            if (node.kind === SyntaxKind.EnumMember) {
-                return getEnumMemberValue(<EnumMember>node);
+            let symbol = resolveEnumExpression(node);
+            if (symbol) {
+                return getNodeLinks(symbol.valueDeclaration).enumMemberValue;
             }
-
-            let symbol = getNodeLinks(node).resolvedSymbol;
-            if (symbol && (symbol.flags & SymbolFlags.EnumMember)) {
-                // inline property\index accesses only for const enums
-                if (isConstEnumDeclaration(symbol.valueDeclaration.parent)) {
-                    return getEnumMemberValue(<EnumMember>symbol.valueDeclaration);
-                }
-            }
-
             return undefined;
         }
 
@@ -14553,6 +14586,7 @@ namespace ts {
                 isSymbolAccessible,
                 isEntityNameVisible,
                 getConstantValue,
+                getConstant,
                 collectLinkedAliases,
                 getBlockScopedVariableId,
                 getReferencedValueDeclaration,

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2029,10 +2029,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 }
             }
 
-            function tryEmitConstantValue(node: PropertyAccessExpression | ElementAccessExpression): boolean {
-                let constantValue = tryGetConstEnumValue(node);
-                if (constantValue !== undefined) {
-                    write(constantValue.toString());
+            function tryInlineConstantValue(node: PropertyAccessExpression | ElementAccessExpression): boolean {
+                if (compilerOptions.isolatedModules) {
+                    return false;
+                }
+
+                let constant = getConstantInline(node);
+                if (constant) {
+                    write(constant.value.toString());
                     if (!compilerOptions.removeComments) {
                         let propertyName: string = node.kind === SyntaxKind.PropertyAccessExpression ? declarationNameToString((<PropertyAccessExpression>node).name) : getTextOfNode((<ElementAccessExpression>node).argumentExpression);
                         write(" /* " + propertyName + " */");
@@ -2041,15 +2045,15 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 }
                 return false;
             }
-            
-            function tryGetConstEnumValue(node: Node): number {
-                if (compilerOptions.isolatedModules) {
-                    return undefined;
+
+            function getConstantInline(node: Node): Constant {
+                if ((node.kind === SyntaxKind.PropertyAccessExpression || node.kind === SyntaxKind.ElementAccessExpression)
+                    && !nodeIsSynthesized(node)) {
+                    let constant = resolver.getConstant(<PropertyAccessExpression | ElementAccessExpression>node);
+                    if (constant && (constant.flags & ConstantFlags.Inline)) {
+                        return constant;
+                    }
                 }
-                
-                return node.kind === SyntaxKind.PropertyAccessExpression || node.kind === SyntaxKind.ElementAccessExpression 
-                    ? resolver.getConstantValue(<PropertyAccessExpression | ElementAccessExpression>node)
-                    : undefined
             }
 
             // Returns 'true' if the code was actually indented, false otherwise.
@@ -2075,7 +2079,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
             }
 
             function emitPropertyAccess(node: PropertyAccessExpression) {
-                if (tryEmitConstantValue(node)) {
+                if (tryInlineConstantValue(node)) {
                     return;
                 }
 
@@ -2093,9 +2097,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     }
                     else {
                         // check if constant enum value is integer
-                        let constantValue = tryGetConstEnumValue(node.expression);
-                        // isFinite handles cases when constantValue is undefined
-                        shouldEmitSpace = isFinite(constantValue) && Math.floor(constantValue) === constantValue;
+                        let constant = getConstantInline(node.expression);
+                        if (constant) {
+                            shouldEmitSpace = Math.floor(constant.value) === constant.value;
+                        }
                     }
                 }
 
@@ -2157,7 +2162,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
             }
 
             function emitIndexedAccess(node: ElementAccessExpression) {
-                if (tryEmitConstantValue(node)) {
+                if (tryInlineConstantValue(node)) {
                     return;
                 }
                 emit(node.expression);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1447,6 +1447,7 @@ namespace ts {
         isArgumentsSymbol(symbol: Symbol): boolean;
 
         getConstantValue(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): number;
+        getConstant(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): Constant;
         isValidPropertyAccess(node: PropertyAccessExpression | QualifiedName, propertyName: string): boolean;
         getAliasedSymbol(symbol: Symbol): Symbol;
         getExportsOfModule(moduleSymbol: Symbol): Symbol[];
@@ -1595,10 +1596,22 @@ namespace ts {
         isEntityNameVisible(entityName: EntityName | Expression, enclosingDeclaration: Node): SymbolVisibilityResult;
         // Returns the constant value this property access resolves to, or 'undefined' for a non-constant
         getConstantValue(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): number;
+        getConstant(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): Constant;
         getBlockScopedVariableId(node: Identifier): number;
         getReferencedValueDeclaration(reference: Identifier): Declaration;
         getTypeReferenceSerializationKind(typeName: EntityName): TypeReferenceSerializationKind; 
         isOptionalParameter(node: ParameterDeclaration): boolean;
+    }
+
+    export type ConstantValue = number;
+
+    export type Constant = {
+        value: ConstantValue
+        flags: ConstantFlags
+    }
+
+    export const enum ConstantFlags {
+        Inline = 1
     }
 
     export const enum SymbolFlags {

--- a/tests/baselines/reference/constIndexedAccess.js
+++ b/tests/baselines/reference/constIndexedAccess.js
@@ -1,0 +1,59 @@
+//// [constIndexedAccess.ts]
+
+const enum numbers {
+	zero,
+	one
+}
+
+interface access {
+	0: string;
+	1: number;
+}
+
+let test: access;
+
+let s = test[0];
+let n = test[1];
+
+let s1 = test[numbers.zero];
+let n1 = test[numbers.one];
+
+// TODO: Not working
+const zero = 0;
+const one = 1;
+
+let s2 = test[zero];
+let n2 = test[one];
+
+const zeroRef = zero;
+const oneRef = one;
+
+let s3 = test[zeroRef];
+let n3 = test[oneRef];
+
+const zeroRefEnum = numbers.zero;
+const oneRefEnum = numbers.one;
+
+let s4 = test[zeroRefEnum];
+let n4 = test[oneRefEnum];
+
+
+//// [constIndexedAccess.js]
+var test;
+var s = test[0];
+var n = test[1];
+var s1 = test[0 /* zero */];
+var n1 = test[1 /* one */];
+// TODO: Not working
+var zero = 0;
+var one = 1;
+var s2 = test[zero];
+var n2 = test[one];
+var zeroRef = zero;
+var oneRef = one;
+var s3 = test[zeroRef];
+var n3 = test[oneRef];
+var zeroRefEnum = 0 /* zero */;
+var oneRefEnum = 1 /* one */;
+var s4 = test[zeroRefEnum];
+var n4 = test[oneRefEnum];

--- a/tests/baselines/reference/constIndexedAccess.symbols
+++ b/tests/baselines/reference/constIndexedAccess.symbols
@@ -1,0 +1,104 @@
+=== tests/cases/compiler/constIndexedAccess.ts ===
+
+const enum numbers {
+>numbers : Symbol(numbers, Decl(constIndexedAccess.ts, 0, 0))
+
+	zero,
+>zero : Symbol(numbers.zero, Decl(constIndexedAccess.ts, 1, 20))
+
+	one
+>one : Symbol(numbers.one, Decl(constIndexedAccess.ts, 2, 6))
+}
+
+interface access {
+>access : Symbol(access, Decl(constIndexedAccess.ts, 4, 1))
+
+	0: string;
+	1: number;
+}
+
+let test: access;
+>test : Symbol(test, Decl(constIndexedAccess.ts, 11, 3))
+>access : Symbol(access, Decl(constIndexedAccess.ts, 4, 1))
+
+let s = test[0];
+>s : Symbol(s, Decl(constIndexedAccess.ts, 13, 3))
+>test : Symbol(test, Decl(constIndexedAccess.ts, 11, 3))
+>0 : Symbol(access.0, Decl(constIndexedAccess.ts, 6, 18))
+
+let n = test[1];
+>n : Symbol(n, Decl(constIndexedAccess.ts, 14, 3))
+>test : Symbol(test, Decl(constIndexedAccess.ts, 11, 3))
+>1 : Symbol(access.1, Decl(constIndexedAccess.ts, 7, 11))
+
+let s1 = test[numbers.zero];
+>s1 : Symbol(s1, Decl(constIndexedAccess.ts, 16, 3))
+>test : Symbol(test, Decl(constIndexedAccess.ts, 11, 3))
+>numbers.zero : Symbol(numbers.zero, Decl(constIndexedAccess.ts, 1, 20))
+>numbers : Symbol(numbers, Decl(constIndexedAccess.ts, 0, 0))
+>zero : Symbol(numbers.zero, Decl(constIndexedAccess.ts, 1, 20))
+
+let n1 = test[numbers.one];
+>n1 : Symbol(n1, Decl(constIndexedAccess.ts, 17, 3))
+>test : Symbol(test, Decl(constIndexedAccess.ts, 11, 3))
+>numbers.one : Symbol(numbers.one, Decl(constIndexedAccess.ts, 2, 6))
+>numbers : Symbol(numbers, Decl(constIndexedAccess.ts, 0, 0))
+>one : Symbol(numbers.one, Decl(constIndexedAccess.ts, 2, 6))
+
+// TODO: Not working
+const zero = 0;
+>zero : Symbol(zero, Decl(constIndexedAccess.ts, 20, 5))
+
+const one = 1;
+>one : Symbol(one, Decl(constIndexedAccess.ts, 21, 5))
+
+let s2 = test[zero];
+>s2 : Symbol(s2, Decl(constIndexedAccess.ts, 23, 3))
+>test : Symbol(test, Decl(constIndexedAccess.ts, 11, 3))
+>zero : Symbol(zero, Decl(constIndexedAccess.ts, 20, 5))
+
+let n2 = test[one];
+>n2 : Symbol(n2, Decl(constIndexedAccess.ts, 24, 3))
+>test : Symbol(test, Decl(constIndexedAccess.ts, 11, 3))
+>one : Symbol(one, Decl(constIndexedAccess.ts, 21, 5))
+
+const zeroRef = zero;
+>zeroRef : Symbol(zeroRef, Decl(constIndexedAccess.ts, 26, 5))
+>zero : Symbol(zero, Decl(constIndexedAccess.ts, 20, 5))
+
+const oneRef = one;
+>oneRef : Symbol(oneRef, Decl(constIndexedAccess.ts, 27, 5))
+>one : Symbol(one, Decl(constIndexedAccess.ts, 21, 5))
+
+let s3 = test[zeroRef];
+>s3 : Symbol(s3, Decl(constIndexedAccess.ts, 29, 3))
+>test : Symbol(test, Decl(constIndexedAccess.ts, 11, 3))
+>zeroRef : Symbol(zeroRef, Decl(constIndexedAccess.ts, 26, 5))
+
+let n3 = test[oneRef];
+>n3 : Symbol(n3, Decl(constIndexedAccess.ts, 30, 3))
+>test : Symbol(test, Decl(constIndexedAccess.ts, 11, 3))
+>oneRef : Symbol(oneRef, Decl(constIndexedAccess.ts, 27, 5))
+
+const zeroRefEnum = numbers.zero;
+>zeroRefEnum : Symbol(zeroRefEnum, Decl(constIndexedAccess.ts, 32, 5))
+>numbers.zero : Symbol(numbers.zero, Decl(constIndexedAccess.ts, 1, 20))
+>numbers : Symbol(numbers, Decl(constIndexedAccess.ts, 0, 0))
+>zero : Symbol(numbers.zero, Decl(constIndexedAccess.ts, 1, 20))
+
+const oneRefEnum = numbers.one;
+>oneRefEnum : Symbol(oneRefEnum, Decl(constIndexedAccess.ts, 33, 5))
+>numbers.one : Symbol(numbers.one, Decl(constIndexedAccess.ts, 2, 6))
+>numbers : Symbol(numbers, Decl(constIndexedAccess.ts, 0, 0))
+>one : Symbol(numbers.one, Decl(constIndexedAccess.ts, 2, 6))
+
+let s4 = test[zeroRefEnum];
+>s4 : Symbol(s4, Decl(constIndexedAccess.ts, 35, 3))
+>test : Symbol(test, Decl(constIndexedAccess.ts, 11, 3))
+>zeroRefEnum : Symbol(zeroRefEnum, Decl(constIndexedAccess.ts, 32, 5))
+
+let n4 = test[oneRefEnum];
+>n4 : Symbol(n4, Decl(constIndexedAccess.ts, 36, 3))
+>test : Symbol(test, Decl(constIndexedAccess.ts, 11, 3))
+>oneRefEnum : Symbol(oneRefEnum, Decl(constIndexedAccess.ts, 33, 5))
+

--- a/tests/baselines/reference/constIndexedAccess.types
+++ b/tests/baselines/reference/constIndexedAccess.types
@@ -1,0 +1,116 @@
+=== tests/cases/compiler/constIndexedAccess.ts ===
+
+const enum numbers {
+>numbers : numbers
+
+	zero,
+>zero : numbers
+
+	one
+>one : numbers
+}
+
+interface access {
+>access : access
+
+	0: string;
+	1: number;
+}
+
+let test: access;
+>test : access
+>access : access
+
+let s = test[0];
+>s : string
+>test[0] : string
+>test : access
+>0 : number
+
+let n = test[1];
+>n : number
+>test[1] : number
+>test : access
+>1 : number
+
+let s1 = test[numbers.zero];
+>s1 : string
+>test[numbers.zero] : string
+>test : access
+>numbers.zero : numbers
+>numbers : typeof numbers
+>zero : numbers
+
+let n1 = test[numbers.one];
+>n1 : number
+>test[numbers.one] : number
+>test : access
+>numbers.one : numbers
+>numbers : typeof numbers
+>one : numbers
+
+// TODO: Not working
+const zero = 0;
+>zero : number
+>0 : number
+
+const one = 1;
+>one : number
+>1 : number
+
+let s2 = test[zero];
+>s2 : any
+>test[zero] : any
+>test : access
+>zero : number
+
+let n2 = test[one];
+>n2 : any
+>test[one] : any
+>test : access
+>one : number
+
+const zeroRef = zero;
+>zeroRef : number
+>zero : number
+
+const oneRef = one;
+>oneRef : number
+>one : number
+
+let s3 = test[zeroRef];
+>s3 : any
+>test[zeroRef] : any
+>test : access
+>zeroRef : number
+
+let n3 = test[oneRef];
+>n3 : any
+>test[oneRef] : any
+>test : access
+>oneRef : number
+
+const zeroRefEnum = numbers.zero;
+>zeroRefEnum : numbers
+>numbers.zero : numbers
+>numbers : typeof numbers
+>zero : numbers
+
+const oneRefEnum = numbers.one;
+>oneRefEnum : numbers
+>numbers.one : numbers
+>numbers : typeof numbers
+>one : numbers
+
+let s4 = test[zeroRefEnum];
+>s4 : any
+>test[zeroRefEnum] : any
+>test : access
+>zeroRefEnum : numbers
+
+let n4 = test[oneRefEnum];
+>n4 : any
+>test[oneRefEnum] : any
+>test : access
+>oneRefEnum : numbers
+

--- a/tests/cases/compiler/constIndexedAccess.ts
+++ b/tests/cases/compiler/constIndexedAccess.ts
@@ -1,0 +1,37 @@
+
+const enum numbers {
+	zero,
+	one
+}
+
+interface access {
+	0: string;
+	1: number;
+}
+
+let test: access;
+
+let s = test[0];
+let n = test[1];
+
+let s1 = test[numbers.zero];
+let n1 = test[numbers.one];
+
+// TODO: Not working
+const zero = 0;
+const one = 1;
+
+let s2 = test[zero];
+let n2 = test[one];
+
+const zeroRef = zero;
+const oneRef = one;
+
+let s3 = test[zeroRef];
+let n3 = test[oneRef];
+
+const zeroRefEnum = numbers.zero;
+const oneRefEnum = numbers.one;
+
+let s4 = test[zeroRefEnum];
+let n4 = test[oneRefEnum];

--- a/tests/cases/unittests/services/api.ts
+++ b/tests/cases/unittests/services/api.ts
@@ -1,0 +1,74 @@
+﻿/// <reference path="..\..\..\..\src\harness\external\mocha.d.ts" />
+/// <reference path="..\..\..\..\src\harness\harnessLanguageService.ts" />
+
+module ts {
+    let source: SourceFile;
+    function getTypeChecker(code: string): TypeChecker {
+        let options: CompilerOptions = { target: ScriptTarget.ES5 };
+        let host = createCompilerHost(options, true);
+        source = createSourceFile("test.ts", code, ts.ScriptTarget.ES5, true);
+
+        return createTypeChecker(getEmitHost(host, source, options), true);
+    }
+
+    function getChildNodes(source: SourceFile, filter: (n: Node) => boolean): Node[] {
+        let nodes: Node[] = [];
+        forEachChild(source, function (node) {
+            if (filter(node)) {
+                nodes.push(node);
+            }
+        });
+        return nodes;
+    }
+
+    describe('api.getTypeChecker()', function () {
+
+        describe("getConstant", function () {
+            it("enum", function () {
+
+let checker = getTypeChecker(`
+const enum numbers {
+  one = 1,
+  two,
+  three = invalid
+}
+let one = numbers.one;
+let two = numbers["two"];
+let bad = numbers.three;
+let num = 1;
+function do() { return 1; }
+`);
+                let nodes = getChildNodes(source, (n) => n.kind === SyntaxKind.VariableStatement);
+                assert.equal(4, nodes.length);
+
+                assert.equal(1, checker.getConstant((<any>nodes[0]).declarationList.declarations[0].initializer).value);
+                assert.equal(2, checker.getConstant((<any>nodes[1]).declarationList.declarations[0].initializer).value);
+                assert.equal(undefined, checker.getConstant((<any>nodes[2]).declarationList.declarations[0].initializer));
+
+                assert.equal(1, checker.getConstantValue((<any>nodes[0]).declarationList.declarations[0].initializer));
+                assert.equal(2, checker.getConstantValue((<any>nodes[1]).declarationList.declarations[0].initializer));
+                assert.equal(undefined, checker.getConstantValue((<any>nodes[2]).declarationList.declarations[0].initializer));
+            });
+        });
+
+    });
+
+    function getEmitHost(host: CompilerHost, file: SourceFile, options: CompilerOptions): EmitHost {
+        let files: SourceFile[] = [];
+        let lib = host.getSourceFile(host.getDefaultLibFileName(options), ScriptTarget.ES5);
+        lib.isDefaultLib = true;
+        files.push(lib);
+        files.push(file);
+
+        return {
+            getCanonicalFileName: fileName => host.getCanonicalFileName(fileName),
+            getCommonSourceDirectory: () => host.getCurrentDirectory(),
+            getCompilerOptions: () => options,
+            getCurrentDirectory: () => host.getCurrentDirectory(),
+            getNewLine: () => host.getNewLine(),
+            getSourceFile: () => file,
+            getSourceFiles: () => files,
+            writeFile: (fileName, data, writeByteOrderMark, onError) => host.writeFile(fileName, data, writeByteOrderMark, onError),
+        };
+    }
+}


### PR DESCRIPTION
This builds on top of #4498 to allow indexed access typing with a const enum reference #3411. Does not do const propagation or constants other than enum.