### PR TITLE
Fixes #3440 (typeof const enum)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10363,20 +10363,27 @@ namespace ts {
             }
 
             if (isConstEnumObjectType(type)) {
-                // enum object type for const enums are only permitted in:
-                // - 'left' in property access
-                // - 'object' in indexed access
-                // - target in rhs of import statement
-                let ok =
-                    (node.parent.kind === SyntaxKind.PropertyAccessExpression && (<PropertyAccessExpression>node.parent).expression === node) ||
-                    (node.parent.kind === SyntaxKind.ElementAccessExpression && (<ElementAccessExpression>node.parent).expression === node) ||
-                    ((node.kind === SyntaxKind.Identifier || node.kind === SyntaxKind.QualifiedName) && isInRightSideOfImportOrExportAssignment(<Identifier>node));
-
-                if (!ok) {
-                    error(node, Diagnostics.const_enums_can_only_be_used_in_property_or_index_access_expressions_or_the_right_hand_side_of_an_import_declaration_or_export_assignment);
-                }
+                checkConstEnumPosition(node);
             }
             return type;
+        }
+
+        function checkConstEnumPosition(node: Node) {
+            // const enums are only permitted in:
+            // - 'left' in property access
+            // - 'object' in indexed access
+            // - target in rhs of import statement
+            // - in a type query
+            let parent = node.parent;
+            let ok =
+                (parent.kind === SyntaxKind.PropertyAccessExpression && (<PropertyAccessExpression>parent).expression === node) ||
+                (parent.kind === SyntaxKind.ElementAccessExpression && (<ElementAccessExpression>parent).expression === node) ||
+                ((node.kind === SyntaxKind.Identifier || node.kind === SyntaxKind.QualifiedName) && isInRightSideOfImportOrExportAssignment(<Identifier>node)) ||
+                isInTypeQuery(node);
+
+            if (!ok) {
+                error(node, Diagnostics.A_const_enum_is_only_allowed_in_a_property_access_import_declaration_export_assignment_or_type_query);
+            }
         }
 
         function checkNumericLiteral(node: LiteralExpression): Type {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1452,7 +1452,7 @@
         "category": "Error",
         "code": 2474
     },
-    "'const' enums can only be used in property or index access expressions or the right hand side of an import declaration or export assignment.": {
+    "A 'const' enum is only allowed in a property access, import declaration, export assignment, or type query.": {
         "category": "Error",
         "code": 2475
     },

--- a/tests/baselines/reference/constEnumErrors.errors.txt
+++ b/tests/baselines/reference/constEnumErrors.errors.txt
@@ -51,7 +51,7 @@ tests/cases/compiler/constEnumErrors.ts(50,9): error TS2478: 'const' enum member
                 ~
 !!! error TS2476: A const enum member can only be accessed using a string literal.
     var name = "A";
-    var y1 = E2[name];
+    var y1 = E2[name]; // error
                 ~~~~
 !!! error TS2476: A const enum member can only be accessed using a string literal.
     

--- a/tests/baselines/reference/constEnumErrors.errors.txt
+++ b/tests/baselines/reference/constEnumErrors.errors.txt
@@ -5,15 +5,17 @@ tests/cases/compiler/constEnumErrors.ts(14,9): error TS2474: In 'const' enum dec
 tests/cases/compiler/constEnumErrors.ts(15,10): error TS2474: In 'const' enum declarations member initializer must be constant expression.
 tests/cases/compiler/constEnumErrors.ts(22,13): error TS2476: A const enum member can only be accessed using a string literal.
 tests/cases/compiler/constEnumErrors.ts(24,13): error TS2476: A const enum member can only be accessed using a string literal.
-tests/cases/compiler/constEnumErrors.ts(26,9): error TS2475: 'const' enums can only be used in property or index access expressions or the right hand side of an import declaration or export assignment.
-tests/cases/compiler/constEnumErrors.ts(27,10): error TS2475: 'const' enums can only be used in property or index access expressions or the right hand side of an import declaration or export assignment.
-tests/cases/compiler/constEnumErrors.ts(32,5): error TS2475: 'const' enums can only be used in property or index access expressions or the right hand side of an import declaration or export assignment.
-tests/cases/compiler/constEnumErrors.ts(40,9): error TS2477: 'const' enum member initializer was evaluated to a non-finite value.
-tests/cases/compiler/constEnumErrors.ts(41,9): error TS2477: 'const' enum member initializer was evaluated to a non-finite value.
-tests/cases/compiler/constEnumErrors.ts(42,9): error TS2478: 'const' enum member initializer was evaluated to disallowed value 'NaN'.
+tests/cases/compiler/constEnumErrors.ts(26,9): error TS2475: A 'const' enum is only allowed in a property access, import declaration, export assignment, or type query.
+tests/cases/compiler/constEnumErrors.ts(27,10): error TS2475: A 'const' enum is only allowed in a property access, import declaration, export assignment, or type query.
+tests/cases/compiler/constEnumErrors.ts(34,5): error TS2475: A 'const' enum is only allowed in a property access, import declaration, export assignment, or type query.
+tests/cases/compiler/constEnumErrors.ts(39,1): error TS2475: A 'const' enum is only allowed in a property access, import declaration, export assignment, or type query.
+tests/cases/compiler/constEnumErrors.ts(40,1): error TS2475: A 'const' enum is only allowed in a property access, import declaration, export assignment, or type query.
+tests/cases/compiler/constEnumErrors.ts(48,9): error TS2477: 'const' enum member initializer was evaluated to a non-finite value.
+tests/cases/compiler/constEnumErrors.ts(49,9): error TS2477: 'const' enum member initializer was evaluated to a non-finite value.
+tests/cases/compiler/constEnumErrors.ts(50,9): error TS2478: 'const' enum member initializer was evaluated to disallowed value 'NaN'.
 
 
-==== tests/cases/compiler/constEnumErrors.ts (13 errors) ====
+==== tests/cases/compiler/constEnumErrors.ts (15 errors) ====
     const enum E {
                ~
 !!! error TS2300: Duplicate identifier 'E'.
@@ -53,19 +55,31 @@ tests/cases/compiler/constEnumErrors.ts(42,9): error TS2478: 'const' enum member
                 ~~~~
 !!! error TS2476: A const enum member can only be accessed using a string literal.
     
-    var x = E2;
+    var x = E2; // error
             ~~
-!!! error TS2475: 'const' enums can only be used in property or index access expressions or the right hand side of an import declaration or export assignment.
-    var y = [E2];
+!!! error TS2475: A 'const' enum is only allowed in a property access, import declaration, export assignment, or type query.
+    var y = [E2]; // error
              ~~
-!!! error TS2475: 'const' enums can only be used in property or index access expressions or the right hand side of an import declaration or export assignment.
+!!! error TS2475: A 'const' enum is only allowed in a property access, import declaration, export assignment, or type query.
+    var enumType: typeof E2;
+    var enumMember: typeof E2.A;
     
     function foo(t: any): void {
     }
     
-    foo(E2);
+    foo(E2); // error
         ~~
-!!! error TS2475: 'const' enums can only be used in property or index access expressions or the right hand side of an import declaration or export assignment.
+!!! error TS2475: A 'const' enum is only allowed in a property access, import declaration, export assignment, or type query.
+    
+    namespace N {
+        export const enum E { }
+    }
+    N.E; // error
+    ~~~
+!!! error TS2475: A 'const' enum is only allowed in a property access, import declaration, export assignment, or type query.
+    N["E"] // error
+    ~~~~~~
+!!! error TS2475: A 'const' enum is only allowed in a property access, import declaration, export assignment, or type query.
     
     const enum NaNOrInfinity {
         A = 9007199254740992,

--- a/tests/baselines/reference/constEnumErrors.js
+++ b/tests/baselines/reference/constEnumErrors.js
@@ -22,7 +22,7 @@ const enum E2 {
 
 var y0 = E2[1]
 var name = "A";
-var y1 = E2[name];
+var y1 = E2[name]; // error
 
 var x = E2; // error
 var y = [E2]; // error
@@ -58,7 +58,7 @@ var E;
 })(E || (E = {}));
 var y0 = E2[1];
 var name = "A";
-var y1 = E2[name];
+var y1 = E2[name]; // error
 var x = E2; // error
 var y = [E2]; // error
 var enumType;

--- a/tests/baselines/reference/constEnumErrors.js
+++ b/tests/baselines/reference/constEnumErrors.js
@@ -24,13 +24,21 @@ var y0 = E2[1]
 var name = "A";
 var y1 = E2[name];
 
-var x = E2;
-var y = [E2];
+var x = E2; // error
+var y = [E2]; // error
+var enumType: typeof E2;
+var enumMember: typeof E2.A;
 
 function foo(t: any): void {
 }
 
-foo(E2);
+foo(E2); // error
+
+namespace N {
+    export const enum E { }
+}
+N.E; // error
+N["E"] // error
 
 const enum NaNOrInfinity {
     A = 9007199254740992,
@@ -51,8 +59,12 @@ var E;
 var y0 = E2[1];
 var name = "A";
 var y1 = E2[name];
-var x = E2;
-var y = [E2];
+var x = E2; // error
+var y = [E2]; // error
+var enumType;
+var enumMember;
 function foo(t) {
 }
-foo(E2);
+foo(E2); // error
+N.E; // error
+N["E"]; // error

--- a/tests/baselines/reference/constEnumPropertyAccess2.errors.txt
+++ b/tests/baselines/reference/constEnumPropertyAccess2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/constEnums/constEnumPropertyAccess2.ts(14,9): error TS2475: 'const' enums can only be used in property or index access expressions or the right hand side of an import declaration or export assignment.
+tests/cases/conformance/constEnums/constEnumPropertyAccess2.ts(14,9): error TS2475: A 'const' enum is only allowed in a property access, import declaration, export assignment, or type query.
 tests/cases/conformance/constEnums/constEnumPropertyAccess2.ts(15,12): error TS2476: A const enum member can only be accessed using a string literal.
 tests/cases/conformance/constEnums/constEnumPropertyAccess2.ts(17,1): error TS2322: Type 'string' is not assignable to type 'G'.
 tests/cases/conformance/constEnums/constEnumPropertyAccess2.ts(19,1): error TS2364: Invalid left-hand side of assignment expression.
@@ -20,7 +20,7 @@ tests/cases/conformance/constEnums/constEnumPropertyAccess2.ts(19,1): error TS23
     // Error from referring constant enum in any other context than a property access
     var z = G;
             ~
-!!! error TS2475: 'const' enums can only be used in property or index access expressions or the right hand side of an import declaration or export assignment.
+!!! error TS2475: A 'const' enum is only allowed in a property access, import declaration, export assignment, or type query.
     var z1 = G[G.A];
                ~~~
 !!! error TS2476: A const enum member can only be accessed using a string literal.

--- a/tests/cases/compiler/constEnumErrors.ts
+++ b/tests/cases/compiler/constEnumErrors.ts
@@ -21,15 +21,23 @@ const enum E2 {
 
 var y0 = E2[1]
 var name = "A";
-var y1 = E2[name];
+var y1 = E2[name]; // error
 
-var x = E2;
-var y = [E2];
+var x = E2; // error
+var y = [E2]; // error
+var enumType: typeof E2;
+var enumMember: typeof E2.A;
 
 function foo(t: any): void {
 }
 
-foo(E2);
+foo(E2); // error
+
+namespace N {
+    export const enum E { }
+}
+N.E; // error
+N["E"] // error
 
 const enum NaNOrInfinity {
     A = 9007199254740992,


### PR DESCRIPTION
```
const enum numbers {
   a,
   b,
}
var a: typeof numbers // ok
```