### PR TITLE
Fix occurrences for classexpressions

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -5885,6 +5885,7 @@ namespace ts {
                                     result.push(getReferenceEntryFromNode(node));
                                 }
                                 break;
+                            case SyntaxKind.ClassExpression:
                             case SyntaxKind.ClassDeclaration:
                                 // Make sure the container belongs to the same class
                                 // and has the appropriate static modifier from the original container.

--- a/tests/cases/fourslash/getOccurrencesClassExpressionStaticThis.ts
+++ b/tests/cases/fourslash/getOccurrencesClassExpressionStaticThis.ts
@@ -1,0 +1,56 @@
+/// <reference path='fourslash.ts' />
+
+////var x = class C {
+////    public x;
+////    public y;
+////    public z;
+////    public staticX;
+////    constructor() {
+////        this;
+////        this.x;
+////        this.y;
+////        this.z;
+////    }
+////    foo() {
+////        this;
+////        () => this;
+////        () => {
+////            if (this) {
+////                this;
+////            }
+////        }
+////        function inside() {
+////            this;
+////            (function (_) {
+////                this;
+////            })(this);
+////        }
+////        return this.x;
+////    }
+////
+////    static bar() {
+////        [|this|];
+////        [|this|].staticX;
+////        () => [|this|];
+////        () => {
+////            if ([|this|]) {
+////                [|this|];
+////            }
+////        }
+////        function inside() {
+////            this;
+////            (function (_) {
+////                this;
+////            })(this);
+////        }
+////    }
+////}
+
+const ranges = test.ranges();
+for (let r of ranges) {
+    goTo.position(r.start);
+
+    for (let range of ranges) {
+        verify.occurrencesAtPositionContains(range, false);
+    }
+}

--- a/tests/cases/fourslash/getOccurrencesClassExpressionThis.ts
+++ b/tests/cases/fourslash/getOccurrencesClassExpressionThis.ts
@@ -1,0 +1,54 @@
+/// <reference path='fourslash.ts' />
+
+////var x = class C {
+////    public x;
+////    public y;
+////    public z;
+////    constructor() {
+////        [|this|];
+////        [|this|].x;
+////        [|this|].y;
+////        [|this|].z;
+////    }
+////    foo() {
+////        [|this|];
+////        () => [|this|];
+////        () => {
+////            if ([|this|]) {
+////                [|this|];
+////            }
+////        }
+////        function inside() {
+////            this;
+////            (function (_) {
+////                this;
+////            })(this);
+////        }
+////        return [|this|].x;
+////    }
+////
+////    static bar() {
+////        this;
+////        () => this;
+////        () => {
+////            if (this) {
+////                this;
+////            }
+////        }
+////        function inside() {
+////            this;
+////            (function (_) {
+////                this;
+////            })(this);
+////        }
+////    }
+////}
+
+const ranges = test.ranges();
+for (let r of ranges) {
+    goTo.position(r.start);
+
+    for (let range of ranges) {
+        verify.occurrencesAtPositionContains(range, false);
+    }
+}


### PR DESCRIPTION
I looked at some other tests for the getOccurrences and I think I got most of the possibilities.
Tested in highlighting of the occurrences in VS2015.

One small question, the original issue is also talking about find all references on `this`  but that doesn't work in classes either and according to a comment in one of the tests that is currently by design.

>The CURRENT behavior is that findAllRefs doesn't work on 'this' or 'super' keywords

____

*Edit by @DanielRosenwasser: This fixes #4479.*