### PR TITLE
Fixes fallback checks that cause an exception during call resolution …

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4036,7 +4036,7 @@ namespace ts {
           */
         function createTypedPropertyDescriptorType(propertyType: Type): Type {
             let globalTypedPropertyDescriptorType = getGlobalTypedPropertyDescriptorType();
-            return globalTypedPropertyDescriptorType !== emptyObjectType
+            return globalTypedPropertyDescriptorType !== emptyGenericType
                 ? createTypeReference(<GenericType>globalTypedPropertyDescriptorType, [propertyType])
                 : emptyObjectType;
         }
@@ -9176,7 +9176,7 @@ namespace ts {
         function createPromiseType(promisedType: Type): Type {
             // creates a `Promise<T>` type where `T` is the promisedType argument
             let globalPromiseType = getGlobalPromiseType();
-            if (globalPromiseType !== emptyObjectType) {
+            if (globalPromiseType !== emptyGenericType) {
                 // if the promised type is itself a promise, get the underlying type; otherwise, fallback to the promised type
                 promisedType = getAwaitedType(promisedType);
                 return createTypeReference(<GenericType>globalPromiseType, [promisedType]);
@@ -14633,7 +14633,7 @@ namespace ts {
 
         function createInstantiatedPromiseLikeType(): ObjectType {
             let promiseLikeType = getGlobalPromiseLikeType();
-            if (promiseLikeType !== emptyObjectType) {
+            if (promiseLikeType !== emptyGenericType) {
                 return createTypeReference(<GenericType>promiseLikeType, [anyType]);
             }
 


### PR DESCRIPTION
Fixes #3978.

The `getGlobalType` function returns `emptyGenericType` rather than `emptyObjectType` when a global symbol with a specified arity cannot be resolved.

Several fallback tests for decorators and async functions were checking for `emptyObjectType` rather than `emptyGenericType`, so the fallback cases would not be executed.

During call resolution to an async function with no return type, the return type is inferred using the global `Promise` type. If this type cannot be found (such as when targeting ES5 or using a lib.d.ts without the global `Promise` type defined), then the wrong type is returned due to the aforementioned errors during fallback. This would finally result in an exception in `resolveDeclaredMembers` since the `emptyGenericType` does not have an associated symbol. 