### PR TITLE
Better error spans for object literal excess properties (into branch 'master')

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4548,7 +4548,7 @@ namespace ts {
          * @param target The right-hand-side of the relation.
          * @param relation The relation considered. One of 'identityRelation', 'assignableRelation', or 'subTypeRelation'.
          * Used as both to determine which checks are performed and as a cache of previously computed results.
-         * @param errorNode The node upon which all errors will be reported, if defined.
+         * @param errorNode The suggested node upon which all errors will be reported, if defined. This may or may not be the actual node used.
          * @param headMessage If the error chain should be prepended by a head message, then headMessage will be used.
          * @param containingMessageChain A chain of errors to prepend any new errors found.
          */
@@ -4592,16 +4592,6 @@ namespace ts {
                 diagnostics.add(createDiagnosticForNodeFromMessageChain(errorNode, errorInfo));
             }
             return result !== Ternary.False;
-
-            function reportErrorAndTryImproveErrorNode(
-                    newErrorNode: Node,
-                    message: DiagnosticMessage,
-                    arg0?: string,
-                    arg1?: string,
-                    arg2?: string) {
-                errorNode = newErrorNode || errorNode;
-                reportError(message, arg0, arg1, arg2);
-            }
 
             function reportError(message: DiagnosticMessage, arg0?: string, arg1?: string, arg2?: string): void {
                 errorInfo = chainDiagnosticMessages(errorInfo, message, arg0, arg1, arg2);
@@ -4777,11 +4767,13 @@ namespace ts {
                 for (let prop of getPropertiesOfObjectType(source)) {
                     if (!isKnownProperty(target, prop.name)) {
                         if (reportErrors) {
-                            reportErrorAndTryImproveErrorNode(
-                                prop.valueDeclaration,
-                                Diagnostics.Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1,
-                                symbolToString(prop),
-                                typeToString(target));
+                            // We know *exactly* where things went wrong when comparing the types.
+                            // Use this property as the error node as this will be more helpful in
+                            // reasoning about what went wrong.
+                            errorNode = prop.valueDeclaration
+                            reportError(Diagnostics.Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1,
+                                        symbolToString(prop),
+                                        typeToString(target));
                         }
                         return true;
                     }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4593,6 +4593,16 @@ namespace ts {
             }
             return result !== Ternary.False;
 
+            function reportErrorAndTryImproveErrorNode(
+                    newErrorNode: Node,
+                    message: DiagnosticMessage,
+                    arg0?: string,
+                    arg1?: string,
+                    arg2?: string) {
+                errorNode = newErrorNode || errorNode;
+                reportError(message, arg0, arg1, arg2);
+            }
+
             function reportError(message: DiagnosticMessage, arg0?: string, arg1?: string, arg2?: string): void {
                 errorInfo = chainDiagnosticMessages(errorInfo, message, arg0, arg1, arg2);
             }
@@ -4767,7 +4777,8 @@ namespace ts {
                 for (let prop of getPropertiesOfObjectType(source)) {
                     if (!isKnownProperty(target, prop.name)) {
                         if (reportErrors) {
-                            reportError(Diagnostics.Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1, symbolToString(prop), typeToString(target));
+                            reportErrorAndTryImproveErrorNode(prop.valueDeclaration,
+                                Diagnostics.Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1, symbolToString(prop), typeToString(target));
                         }
                         return true;
                     }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4777,8 +4777,11 @@ namespace ts {
                 for (let prop of getPropertiesOfObjectType(source)) {
                     if (!isKnownProperty(target, prop.name)) {
                         if (reportErrors) {
-                            reportErrorAndTryImproveErrorNode(prop.valueDeclaration,
-                                Diagnostics.Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1, symbolToString(prop), typeToString(target));
+                            reportErrorAndTryImproveErrorNode(
+                                prop.valueDeclaration,
+                                Diagnostics.Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1,
+                                symbolToString(prop),
+                                typeToString(target));
                         }
                         return true;
                     }

--- a/tests/baselines/reference/arrayCast.errors.txt
+++ b/tests/baselines/reference/arrayCast.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/arrayCast.ts(3,1): error TS2352: Neither type '{ foo: string; }[]' nor type '{ id: number; }[]' is assignable to the other.
+tests/cases/compiler/arrayCast.ts(3,23): error TS2352: Neither type '{ foo: string; }[]' nor type '{ id: number; }[]' is assignable to the other.
   Type '{ foo: string; }' is not assignable to type '{ id: number; }'.
     Object literal may only specify known properties, and 'foo' does not exist in type '{ id: number; }'.
 
@@ -7,7 +7,7 @@ tests/cases/compiler/arrayCast.ts(3,1): error TS2352: Neither type '{ foo: strin
     // Should fail. Even though the array is contextually typed with { id: number }[], it still
     // has type { foo: string }[], which is not assignable to { id: number }[].
     <{ id: number; }[]>[{ foo: "s" }];
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                          ~~~~~~~~
 !!! error TS2352: Neither type '{ foo: string; }[]' nor type '{ id: number; }[]' is assignable to the other.
 !!! error TS2352:   Type '{ foo: string; }' is not assignable to type '{ id: number; }'.
 !!! error TS2352:     Object literal may only specify known properties, and 'foo' does not exist in type '{ id: number; }'.

--- a/tests/baselines/reference/arrayLiteralTypeInference.errors.txt
+++ b/tests/baselines/reference/arrayLiteralTypeInference.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/compiler/arrayLiteralTypeInference.ts(13,5): error TS2322: Type '({ id: number; trueness: boolean; } | { id: number; name: string; })[]' is not assignable to type 'Action[]'.
+tests/cases/compiler/arrayLiteralTypeInference.ts(14,14): error TS2322: Type '({ id: number; trueness: boolean; } | { id: number; name: string; })[]' is not assignable to type 'Action[]'.
   Type '{ id: number; trueness: boolean; } | { id: number; name: string; }' is not assignable to type 'Action'.
     Type '{ id: number; trueness: boolean; }' is not assignable to type 'Action'.
       Object literal may only specify known properties, and 'trueness' does not exist in type 'Action'.
-tests/cases/compiler/arrayLiteralTypeInference.ts(29,5): error TS2322: Type '({ id: number; trueness: boolean; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
+tests/cases/compiler/arrayLiteralTypeInference.ts(31,18): error TS2322: Type '({ id: number; trueness: boolean; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
   Type '{ id: number; trueness: boolean; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
     Type '{ id: number; trueness: boolean; }' is not assignable to type '{ id: number; }'.
       Object literal may only specify known properties, and 'trueness' does not exist in type '{ id: number; }'.
@@ -22,12 +22,12 @@ tests/cases/compiler/arrayLiteralTypeInference.ts(29,5): error TS2322: Type '({ 
     }
     
     var x1: Action[] = [
-        ~~
+        { id: 2, trueness: false },
+                 ~~~~~~~~~~~~~~~
 !!! error TS2322: Type '({ id: number; trueness: boolean; } | { id: number; name: string; })[]' is not assignable to type 'Action[]'.
 !!! error TS2322:   Type '{ id: number; trueness: boolean; } | { id: number; name: string; }' is not assignable to type 'Action'.
 !!! error TS2322:     Type '{ id: number; trueness: boolean; }' is not assignable to type 'Action'.
 !!! error TS2322:       Object literal may only specify known properties, and 'trueness' does not exist in type 'Action'.
-        { id: 2, trueness: false },
         { id: 3, name: "three" }
     ]
     
@@ -43,13 +43,13 @@ tests/cases/compiler/arrayLiteralTypeInference.ts(29,5): error TS2322: Type '({ 
     ]
     
     var z1: { id: number }[] =
-        ~~
+        [
+            { id: 2, trueness: false },
+                     ~~~~~~~~~~~~~~~
 !!! error TS2322: Type '({ id: number; trueness: boolean; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
 !!! error TS2322:   Type '{ id: number; trueness: boolean; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
 !!! error TS2322:     Type '{ id: number; trueness: boolean; }' is not assignable to type '{ id: number; }'.
 !!! error TS2322:       Object literal may only specify known properties, and 'trueness' does not exist in type '{ id: number; }'.
-        [
-            { id: 2, trueness: false },
             { id: 3, name: "three" }
         ]
     

--- a/tests/baselines/reference/arrayLiterals.errors.txt
+++ b/tests/baselines/reference/arrayLiterals.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts(24,5): error TS2322: Type '({ a: string; b: number; c: string; } | { a: string; b: number; c: number; })[]' is not assignable to type '{ [n: number]: { a: string; b: number; }; }'.
+tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts(24,77): error TS2322: Type '({ a: string; b: number; c: string; } | { a: string; b: number; c: number; })[]' is not assignable to type '{ [n: number]: { a: string; b: number; }; }'.
   Index signatures are incompatible.
     Type '{ a: string; b: number; c: string; } | { a: string; b: number; c: number; }' is not assignable to type '{ a: string; b: number; }'.
       Type '{ a: string; b: number; c: string; }' is not assignable to type '{ a: string; b: number; }'.
@@ -30,7 +30,7 @@ tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts(24,5): error 
     
     // Contextual type C with numeric index signature makes array literal of EveryType E of type BCT(E,C)[]
     var context1: { [n: number]: { a: string; b: number; }; } = [{ a: '', b: 0, c: '' }, { a: "", b: 3, c: 0 }];
-        ~~~~~~~~
+                                                                                ~~~~~
 !!! error TS2322: Type '({ a: string; b: number; c: string; } | { a: string; b: number; c: number; })[]' is not assignable to type '{ [n: number]: { a: string; b: number; }; }'.
 !!! error TS2322:   Index signatures are incompatible.
 !!! error TS2322:     Type '{ a: string; b: number; c: string; } | { a: string; b: number; c: number; }' is not assignable to type '{ a: string; b: number; }'.

--- a/tests/baselines/reference/assignmentCompatBug2.errors.txt
+++ b/tests/baselines/reference/assignmentCompatBug2.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/compiler/assignmentCompatBug2.ts(1,5): error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
+tests/cases/compiler/assignmentCompatBug2.ts(1,27): error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
-tests/cases/compiler/assignmentCompatBug2.ts(3,1): error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
+tests/cases/compiler/assignmentCompatBug2.ts(3,8): error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
-tests/cases/compiler/assignmentCompatBug2.ts(5,1): error TS2322: Type '{ b: number; a: number; }' is not assignable to type '{ b: number; }'.
+tests/cases/compiler/assignmentCompatBug2.ts(5,13): error TS2322: Type '{ b: number; a: number; }' is not assignable to type '{ b: number; }'.
   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
 tests/cases/compiler/assignmentCompatBug2.ts(15,1): error TS2322: Type '{ f: (n: number) => number; g: (s: string) => number; }' is not assignable to type '{ f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; }'.
   Property 'm' is missing in type '{ f: (n: number) => number; g: (s: string) => number; }'.
@@ -14,17 +14,17 @@ tests/cases/compiler/assignmentCompatBug2.ts(33,1): error TS2322: Type '{ f: (n:
 
 ==== tests/cases/compiler/assignmentCompatBug2.ts (6 errors) ====
     var b2: { b: number;} = { a: 0 }; // error
-        ~~
+                              ~~~~
 !!! error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
     
     b2 = { a: 0 }; // error
-    ~~
+           ~~~~
 !!! error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
     
     b2 = {b: 0, a: 0 };
-    ~~
+                ~~~~
 !!! error TS2322: Type '{ b: number; a: number; }' is not assignable to type '{ b: number; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
     

--- a/tests/baselines/reference/assignmentCompatBug5.errors.txt
+++ b/tests/baselines/reference/assignmentCompatBug5.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/assignmentCompatBug5.ts(2,6): error TS2345: Argument of type '{ b: number; }' is not assignable to parameter of type '{ a: number; }'.
+tests/cases/compiler/assignmentCompatBug5.ts(2,8): error TS2345: Argument of type '{ b: number; }' is not assignable to parameter of type '{ a: number; }'.
   Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
 tests/cases/compiler/assignmentCompatBug5.ts(5,6): error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'number[]'.
   Type 'string' is not assignable to type 'number'.
@@ -12,7 +12,7 @@ tests/cases/compiler/assignmentCompatBug5.ts(9,6): error TS2345: Argument of typ
 ==== tests/cases/compiler/assignmentCompatBug5.ts (4 errors) ====
     function foo1(x: { a: number; }) { }
     foo1({ b: 5 });
-         ~~~~~~~~
+           ~~~~
 !!! error TS2345: Argument of type '{ b: number; }' is not assignable to parameter of type '{ a: number; }'.
 !!! error TS2345:   Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
     

--- a/tests/baselines/reference/contextualTyping12.errors.txt
+++ b/tests/baselines/reference/contextualTyping12.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/contextualTyping12.ts(1,13): error TS2322: Type '({ id: number; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
+tests/cases/compiler/contextualTyping12.ts(1,57): error TS2322: Type '({ id: number; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
   Type '{ id: number; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
     Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
       Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
@@ -6,7 +6,7 @@ tests/cases/compiler/contextualTyping12.ts(1,13): error TS2322: Type '({ id: num
 
 ==== tests/cases/compiler/contextualTyping12.ts (1 errors) ====
     class foo { public bar:{id:number;}[] = [{id:1}, {id:2, name:"foo"}]; }
-                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                                            ~~~~~~~~~~
 !!! error TS2322: Type '({ id: number; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
 !!! error TS2322:   Type '{ id: number; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
 !!! error TS2322:     Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.

--- a/tests/baselines/reference/contextualTyping17.errors.txt
+++ b/tests/baselines/reference/contextualTyping17.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/contextualTyping17.ts(1,33): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
+tests/cases/compiler/contextualTyping17.ts(1,47): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/contextualTyping17.ts (1 errors) ====
     var foo: {id:number;} = {id:4}; foo = {id: 5, name:"foo"};
-                                    ~~~
+                                                  ~~~~~~~~~~
 !!! error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.

--- a/tests/baselines/reference/contextualTyping2.errors.txt
+++ b/tests/baselines/reference/contextualTyping2.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/contextualTyping2.ts(1,5): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
+tests/cases/compiler/contextualTyping2.ts(1,32): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/contextualTyping2.ts (1 errors) ====
     var foo: {id:number;} = {id:4, name:"foo"};
-        ~~~
+                                   ~~~~~~~~~~
 !!! error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.

--- a/tests/baselines/reference/contextualTyping20.errors.txt
+++ b/tests/baselines/reference/contextualTyping20.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/contextualTyping20.ts(1,36): error TS2322: Type '({ id: number; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
+tests/cases/compiler/contextualTyping20.ts(1,58): error TS2322: Type '({ id: number; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
   Type '{ id: number; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
     Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
       Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
@@ -6,7 +6,7 @@ tests/cases/compiler/contextualTyping20.ts(1,36): error TS2322: Type '({ id: num
 
 ==== tests/cases/compiler/contextualTyping20.ts (1 errors) ====
     var foo:{id:number;}[] = [{id:1}]; foo = [{id:1}, {id:2, name:"foo"}];
-                                       ~~~
+                                                             ~~~~~~~~~~
 !!! error TS2322: Type '({ id: number; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
 !!! error TS2322:   Type '{ id: number; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
 !!! error TS2322:     Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.

--- a/tests/baselines/reference/contextualTyping4.errors.txt
+++ b/tests/baselines/reference/contextualTyping4.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/contextualTyping4.ts(1,13): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
+tests/cases/compiler/contextualTyping4.ts(1,46): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/contextualTyping4.ts (1 errors) ====
     class foo { public bar:{id:number;} = {id:5, name:"foo"}; }
-                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                                 ~~~~~~~~~~
 !!! error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.

--- a/tests/baselines/reference/contextualTyping9.errors.txt
+++ b/tests/baselines/reference/contextualTyping9.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/contextualTyping9.ts(1,5): error TS2322: Type '({ id: number; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
+tests/cases/compiler/contextualTyping9.ts(1,42): error TS2322: Type '({ id: number; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
   Type '{ id: number; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
     Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
       Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
@@ -6,7 +6,7 @@ tests/cases/compiler/contextualTyping9.ts(1,5): error TS2322: Type '({ id: numbe
 
 ==== tests/cases/compiler/contextualTyping9.ts (1 errors) ====
     var foo:{id:number;}[] = [{id:1}, {id:2, name:"foo"}];
-        ~~~
+                                             ~~~~~~~~~~
 !!! error TS2322: Type '({ id: number; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
 !!! error TS2322:   Type '{ id: number; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
 !!! error TS2322:     Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.

--- a/tests/baselines/reference/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.errors.txt
+++ b/tests/baselines/reference/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.ts(14,28): error TS2345: Argument of type '{ a: number; b: number; }' is not assignable to parameter of type '{ a: number; }'.
+tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.ts(14,36): error TS2345: Argument of type '{ a: number; b: number; }' is not assignable to parameter of type '{ a: number; }'.
   Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
 
 
@@ -17,7 +17,7 @@ tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclara
         bar() {
             var r = super.foo({ a: 1 }); // { a: number }
             var r2 = super.foo({ a: 1, b: 2 }); // { a: number }
-                               ~~~~~~~~~~~~~~
+                                       ~~~~
 !!! error TS2345: Argument of type '{ a: number; b: number; }' is not assignable to parameter of type '{ a: number; }'.
 !!! error TS2345:   Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
             var r3 = this.foo({ a: 1, b: 2 }); // { a: number; b: number; }

--- a/tests/baselines/reference/destructuringParameterProperties5.errors.txt
+++ b/tests/baselines/reference/destructuringParameterProperties5.errors.txt
@@ -7,7 +7,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7,51): error TS2339: Property 'x3' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7,62): error TS2339: Property 'y' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7,72): error TS2339: Property 'z' does not exist on type 'C1'.
-tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(11,16): error TS2345: Argument of type '[{ x1: number; x2: string; x3: boolean; }, string, boolean]' is not assignable to parameter of type '[{ x: number; y: string; z: boolean; }, number, string]'.
+tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(11,19): error TS2345: Argument of type '[{ x1: number; x2: string; x3: boolean; }, string, boolean]' is not assignable to parameter of type '[{ x: number; y: string; z: boolean; }, number, string]'.
   Types of property '0' are incompatible.
     Type '{ x1: number; x2: string; x3: boolean; }' is not assignable to type '{ x: number; y: string; z: boolean; }'.
       Object literal may only specify known properties, and 'x1' does not exist in type '{ x: number; y: string; z: boolean; }'.
@@ -43,7 +43,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(1
     }
     
     var a = new C1([{ x1: 10, x2: "", x3: true }, "", false]);
-                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                      ~~~~~~
 !!! error TS2345: Argument of type '[{ x1: number; x2: string; x3: boolean; }, string, boolean]' is not assignable to parameter of type '[{ x: number; y: string; z: boolean; }, number, string]'.
 !!! error TS2345:   Types of property '0' are incompatible.
 !!! error TS2345:     Type '{ x1: number; x2: string; x3: boolean; }' is not assignable to type '{ x: number; y: string; z: boolean; }'.

--- a/tests/baselines/reference/incompatibleTypes.errors.txt
+++ b/tests/baselines/reference/incompatibleTypes.errors.txt
@@ -18,9 +18,9 @@ tests/cases/compiler/incompatibleTypes.ts(42,5): error TS2345: Argument of type 
   Types of property 'p1' are incompatible.
     Type '() => string' is not assignable to type '(s: string) => number'.
       Type 'string' is not assignable to type 'number'.
-tests/cases/compiler/incompatibleTypes.ts(49,5): error TS2345: Argument of type '{ e: number; f: number; }' is not assignable to parameter of type '{ c: { b: string; }; d: string; }'.
+tests/cases/compiler/incompatibleTypes.ts(49,7): error TS2345: Argument of type '{ e: number; f: number; }' is not assignable to parameter of type '{ c: { b: string; }; d: string; }'.
   Object literal may only specify known properties, and 'e' does not exist in type '{ c: { b: string; }; d: string; }'.
-tests/cases/compiler/incompatibleTypes.ts(66,5): error TS2322: Type '{ e: number; f: number; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
+tests/cases/compiler/incompatibleTypes.ts(66,47): error TS2322: Type '{ e: number; f: number; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
   Object literal may only specify known properties, and 'e' does not exist in type '{ a: { a: string; }; b: string; }'.
 tests/cases/compiler/incompatibleTypes.ts(72,5): error TS2322: Type 'number' is not assignable to type '() => string'.
 tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) => number' is not assignable to type '() => any'.
@@ -101,7 +101,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     function of1(a: any) { return null; }
     
     of1({ e: 0, f: 0 });
-        ~~~~~~~~~~~~~~
+          ~~~~
 !!! error TS2345: Argument of type '{ e: number; f: number; }' is not assignable to parameter of type '{ c: { b: string; }; d: string; }'.
 !!! error TS2345:   Object literal may only specify known properties, and 'e' does not exist in type '{ c: { b: string; }; d: string; }'.
     
@@ -121,7 +121,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     }
     
     var o1: { a: { a: string; }; b: string; } = { e: 0, f: 0 };
-        ~~
+                                                  ~~~~
 !!! error TS2322: Type '{ e: number; f: number; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'e' does not exist in type '{ a: { a: string; }; b: string; }'.
     

--- a/tests/baselines/reference/logicalOrExpressionIsContextuallyTyped.errors.txt
+++ b/tests/baselines/reference/logicalOrExpressionIsContextuallyTyped.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrExpressionIsContextuallyTyped.ts(6,5): error TS2322: Type '{ a: string; b: number; } | { a: string; b: boolean; }' is not assignable to type '{ a: string; }'.
+tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrExpressionIsContextuallyTyped.ts(6,33): error TS2322: Type '{ a: string; b: number; } | { a: string; b: boolean; }' is not assignable to type '{ a: string; }'.
   Type '{ a: string; b: number; }' is not assignable to type '{ a: string; }'.
     Object literal may only specify known properties, and 'b' does not exist in type '{ a: string; }'.
 
@@ -10,7 +10,7 @@ tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrE
     // operand types.
     
     var r: { a: string } = { a: '', b: 123 } || { a: '', b: true };
-        ~
+                                    ~~~~~~
 !!! error TS2322: Type '{ a: string; b: number; } | { a: string; b: boolean; }' is not assignable to type '{ a: string; }'.
 !!! error TS2322:   Type '{ a: string; b: number; }' is not assignable to type '{ a: string; }'.
 !!! error TS2322:     Object literal may only specify known properties, and 'b' does not exist in type '{ a: string; }'.

--- a/tests/baselines/reference/objectLitStructuralTypeMismatch.errors.txt
+++ b/tests/baselines/reference/objectLitStructuralTypeMismatch.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/compiler/objectLitStructuralTypeMismatch.ts(2,5): error TS2322: Type '{ b: number; }' is not assignable to type '{ a: number; }'.
+tests/cases/compiler/objectLitStructuralTypeMismatch.ts(2,27): error TS2322: Type '{ b: number; }' is not assignable to type '{ a: number; }'.
   Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
 
 
 ==== tests/cases/compiler/objectLitStructuralTypeMismatch.ts (1 errors) ====
     // Shouldn't compile
     var x: { a: number; } = { b: 5 };
-        ~
+                              ~~~~
 !!! error TS2322: Type '{ b: number; }' is not assignable to type '{ a: number; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.

--- a/tests/baselines/reference/objectLiteralFunctionArgContextualTyping.errors.txt
+++ b/tests/baselines/reference/objectLiteralFunctionArgContextualTyping.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(8,4): error TS2345: Argument of type '{ hello: number; }' is not assignable to parameter of type 'I'.
+tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(8,6): error TS2345: Argument of type '{ hello: number; }' is not assignable to parameter of type 'I'.
   Object literal may only specify known properties, and 'hello' does not exist in type 'I'.
-tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(10,4): error TS2345: Argument of type '{ value: string; what: number; }' is not assignable to parameter of type 'I'.
+tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(10,17): error TS2345: Argument of type '{ value: string; what: number; }' is not assignable to parameter of type 'I'.
   Object literal may only specify known properties, and 'what' does not exist in type 'I'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(11,4): error TS2345: Argument of type '{ toString: (s: string) => string; }' is not assignable to parameter of type 'I'.
   Property 'value' is missing in type '{ toString: (s: string) => string; }'.
@@ -18,12 +18,12 @@ tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(13,36): error T
     function f2(args: I) { }
     
     f2({ hello: 1 }) // error 
-       ~~~~~~~~~~~~
+         ~~~~~~~~
 !!! error TS2345: Argument of type '{ hello: number; }' is not assignable to parameter of type 'I'.
 !!! error TS2345:   Object literal may only specify known properties, and 'hello' does not exist in type 'I'.
     f2({ value: '' }) // missing toString satisfied by Object's member
     f2({ value: '', what: 1 }) // missing toString satisfied by Object's member
-       ~~~~~~~~~~~~~~~~~~~~~~
+                    ~~~~~~~
 !!! error TS2345: Argument of type '{ value: string; what: number; }' is not assignable to parameter of type 'I'.
 !!! error TS2345:   Object literal may only specify known properties, and 'what' does not exist in type 'I'.
     f2({ toString: (s) => s }) // error, missing property value from ArgsString

--- a/tests/baselines/reference/objectLiteralFunctionArgContextualTyping2.errors.txt
+++ b/tests/baselines/reference/objectLiteralFunctionArgContextualTyping2.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(8,4): error TS2345: Argument of type '{ hello: number; }' is not assignable to parameter of type 'I2'.
+tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(8,6): error TS2345: Argument of type '{ hello: number; }' is not assignable to parameter of type 'I2'.
   Object literal may only specify known properties, and 'hello' does not exist in type 'I2'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(9,4): error TS2345: Argument of type '{ value: string; }' is not assignable to parameter of type 'I2'.
   Property 'doStuff' is missing in type '{ value: string; }'.
-tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(10,4): error TS2345: Argument of type '{ value: string; what: number; }' is not assignable to parameter of type 'I2'.
+tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(10,17): error TS2345: Argument of type '{ value: string; what: number; }' is not assignable to parameter of type 'I2'.
   Object literal may only specify known properties, and 'what' does not exist in type 'I2'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(11,4): error TS2345: Argument of type '{ toString: (s: any) => any; }' is not assignable to parameter of type 'I2'.
   Property 'value' is missing in type '{ toString: (s: any) => any; }'.
@@ -21,7 +21,7 @@ tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(13,4): error T
     function f2(args: I2) { }
     
     f2({ hello: 1 }) 
-       ~~~~~~~~~~~~
+         ~~~~~~~~
 !!! error TS2345: Argument of type '{ hello: number; }' is not assignable to parameter of type 'I2'.
 !!! error TS2345:   Object literal may only specify known properties, and 'hello' does not exist in type 'I2'.
     f2({ value: '' })
@@ -29,7 +29,7 @@ tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(13,4): error T
 !!! error TS2345: Argument of type '{ value: string; }' is not assignable to parameter of type 'I2'.
 !!! error TS2345:   Property 'doStuff' is missing in type '{ value: string; }'.
     f2({ value: '', what: 1 }) 
-       ~~~~~~~~~~~~~~~~~~~~~~
+                    ~~~~~~~
 !!! error TS2345: Argument of type '{ value: string; what: number; }' is not assignable to parameter of type 'I2'.
 !!! error TS2345:   Object literal may only specify known properties, and 'what' does not exist in type 'I2'.
     f2({ toString: (s) => s }) 

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentError.errors.txt
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentError.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(4,5): error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ b: string; id: number; }'.
+tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(4,43): error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ b: string; id: number; }'.
   Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(5,16): error TS1131: Property or signature expected.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(5,22): error TS2403: Subsequent variable declarations must have the same type.  Variable 'id' must be of type 'number', but here has type 'any'.
@@ -16,7 +16,7 @@ tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPr
     var name: string = "my name";
     
     var person: { b: string; id: number } = { name, id };  // error
-        ~~~~~~
+                                              ~~~~
 !!! error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ b: string; id: number; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
     var person1: { name, id };  // error: can't use short-hand property assignment in type position

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.errors.txt
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts(4,5): error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ b: string; id: number; }'.
+tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts(4,43): error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ b: string; id: number; }'.
   Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts(5,79): error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ name: number; id: string; }'.
   Types of property 'name' are incompatible.
@@ -16,7 +16,7 @@ tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPr
     var name: string = "my name";
     
     var person: { b: string; id: number } = { name, id };  // error
-        ~~~~~~
+                                              ~~~~
 !!! error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ b: string; id: number; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
     function bar(name: string, id: number): { name: number, id: string } { return { name, id }; }  // error

--- a/tests/baselines/reference/orderMattersForSignatureGroupIdentity.errors.txt
+++ b/tests/baselines/reference/orderMattersForSignatureGroupIdentity.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(19,3): error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
+tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(19,5): error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
   Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.
 tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(22,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'w' must be of type 'A', but here has type 'C'.
-tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(24,3): error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
+tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(24,5): error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
   Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.
 
 
@@ -25,7 +25,7 @@ tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(24,3): error TS234
     var v: B;
     
     v({ s: "", n: 0 }).toLowerCase();
-      ~~~~~~~~~~~~~~~
+        ~~~~~
 !!! error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
 !!! error TS2345:   Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.
     
@@ -35,6 +35,6 @@ tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(24,3): error TS234
 !!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'w' must be of type 'A', but here has type 'C'.
     
     w({ s: "", n: 0 }).toLowerCase();
-      ~~~~~~~~~~~~~~~
+        ~~~~~
 !!! error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
 !!! error TS2345:   Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.

--- a/tests/baselines/reference/switchStatements.errors.txt
+++ b/tests/baselines/reference/switchStatements.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/statements/switchStatements/switchStatements.ts(35,10): error TS2322: Type '{ id: number; name: string; }' is not assignable to type 'C'.
+tests/cases/conformance/statements/switchStatements/switchStatements.ts(35,20): error TS2322: Type '{ id: number; name: string; }' is not assignable to type 'C'.
   Object literal may only specify known properties, and 'name' does not exist in type 'C'.
 
 
@@ -38,7 +38,7 @@ tests/cases/conformance/statements/switchStatements/switchStatements.ts(35,10): 
     switch (new C()) {
         case new D():
         case { id: 12, name: '' }:
-             ~~~~~~~~~~~~~~~~~~~~
+                       ~~~~~~~~
 !!! error TS2322: Type '{ id: number; name: string; }' is not assignable to type 'C'.
 !!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type 'C'.
         case new C():

--- a/tests/baselines/reference/symbolProperty21.errors.txt
+++ b/tests/baselines/reference/symbolProperty21.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/Symbols/symbolProperty21.ts(8,5): error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: boolean; }' is not assignable to parameter of type 'I<boolean, string>'.
+tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: boolean; }' is not assignable to parameter of type 'I<boolean, string>'.
   Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
 
 
@@ -11,14 +11,10 @@ tests/cases/conformance/es6/Symbols/symbolProperty21.ts(8,5): error TS2345: Argu
     declare function foo<T, U>(p: I<T, U>): { t: T; u: U };
     
     foo({
-        ~
         [Symbol.isConcatSpreadable]: "",
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         [Symbol.toPrimitive]: 0,
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-        [Symbol.unscopables]: true
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    });
-    ~
+        ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: boolean; }' is not assignable to parameter of type 'I<boolean, string>'.
 !!! error TS2345:   Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
+        [Symbol.unscopables]: true
+    });

--- a/tests/baselines/reference/taggedTemplateStringsTypeArgumentInference.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsTypeArgumentInference.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInference.ts(64,11): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'string' is not a valid type argument because it is not a supertype of candidate 'number'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInference.ts(77,11): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
+tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInference.ts(77,79): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate '{ x: number; z: Date; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
     Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
 
@@ -86,7 +86,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInference
     }
     
     var a9e = someGenerics9 `${ undefined }${ { x: 6, z: new Date() } }${ { x: 6, y: '' } }`;
-              ~~~~~~~~~~~~~
+                                                                                  ~~~~~
 !!! error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
 !!! error TS2453:   Type argument candidate '{ x: number; z: Date; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
 !!! error TS2453:     Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.

--- a/tests/baselines/reference/taggedTemplateStringsTypeArgumentInferenceES6.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsTypeArgumentInferenceES6.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInferenceES6.ts(63,11): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'string' is not a valid type argument because it is not a supertype of candidate 'number'.
-tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInferenceES6.ts(76,11): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
+tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInferenceES6.ts(76,79): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate '{ x: number; z: Date; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
     Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
 
@@ -85,7 +85,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInference
     }
     
     var a9e = someGenerics9 `${ undefined }${ { x: 6, z: new Date() } }${ { x: 6, y: '' } }`;
-              ~~~~~~~~~~~~~
+                                                                                  ~~~~~
 !!! error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
 !!! error TS2453:   Type argument candidate '{ x: number; z: Date; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
 !!! error TS2453:     Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.

--- a/tests/baselines/reference/typeArgInference2.errors.txt
+++ b/tests/baselines/reference/typeArgInference2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/typeArgInference2.ts(12,10): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
+tests/cases/compiler/typeArgInference2.ts(12,52): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate '{ name: string; a: number; }' is not a valid type argument because it is not a supertype of candidate '{ name: string; b: number; }'.
     Object literal may only specify known properties, and 'b' does not exist in type '{ name: string; a: number; }'.
 
@@ -16,7 +16,7 @@ tests/cases/compiler/typeArgInference2.ts(12,10): error TS2453: The type argumen
     var z4 = foo({ name: "abc" });        // { name: string }
     var z5 = foo({ name: "abc", a: 5 });  // { name: string; a: number }
     var z6 = foo({ name: "abc", a: 5 }, { name: "def", b: 5 });  // error
-             ~~~
+                                                       ~~~~
 !!! error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
 !!! error TS2453:   Type argument candidate '{ name: string; a: number; }' is not a valid type argument because it is not a supertype of candidate '{ name: string; b: number; }'.
 !!! error TS2453:     Object literal may only specify known properties, and 'b' does not exist in type '{ name: string; a: number; }'.

--- a/tests/baselines/reference/typeArgumentInference.errors.txt
+++ b/tests/baselines/reference/typeArgumentInference.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(68,11): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'string' is not a valid type argument because it is not a supertype of candidate 'number'.
-tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(82,11): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
+tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(82,69): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate '{ x: number; z: Date; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
     Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
-tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(84,66): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
+tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(84,74): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
 
 
@@ -93,13 +93,13 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(84,66
         z?: Date;
     }
     var a9e = someGenerics9(undefined, { x: 6, z: new Date() }, { x: 6, y: '' });
-              ~~~~~~~~~~~~~
+                                                                        ~~~~~
 !!! error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
 !!! error TS2453:   Type argument candidate '{ x: number; z: Date; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
 !!! error TS2453:     Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
     var a9e: {};
     var a9f = someGenerics9<A92>(undefined, { x: 6, z: new Date() }, { x: 6, y: '' });
-                                                                     ~~~~~~~~~~~~~~~
+                                                                             ~~~~~
 !!! error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
 !!! error TS2345:   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
     var a9f: A92;

--- a/tests/baselines/reference/typeArgumentInferenceConstructSignatures.errors.txt
+++ b/tests/baselines/reference/typeArgumentInferenceConstructSignatures.errors.txt
@@ -12,12 +12,12 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstruct
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(106,15): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'string' is not a valid type argument because it is not a supertype of candidate 'number'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(118,9): error TS2304: Cannot find name 'Window'.
-tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(120,15): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
+tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(120,51): error TS2304: Cannot find name 'window'.
+tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(120,69): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate '{ x: number; z: any; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
     Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: any; }'.
-tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(120,51): error TS2304: Cannot find name 'window'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(122,56): error TS2304: Cannot find name 'window'.
-tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(122,66): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
+tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(122,74): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
 
 
@@ -163,17 +163,17 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstruct
 !!! error TS2304: Cannot find name 'Window'.
     }
     var a9e = new someGenerics9(undefined, { x: 6, z: window }, { x: 6, y: '' });
-                  ~~~~~~~~~~~~~
+                                                      ~~~~~~
+!!! error TS2304: Cannot find name 'window'.
+                                                                        ~~~~~
 !!! error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
 !!! error TS2453:   Type argument candidate '{ x: number; z: any; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
 !!! error TS2453:     Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: any; }'.
-                                                      ~~~~~~
-!!! error TS2304: Cannot find name 'window'.
     var a9e: {};
     var a9f = new someGenerics9<A92>(undefined, { x: 6, z: window }, { x: 6, y: '' });
                                                            ~~~~~~
 !!! error TS2304: Cannot find name 'window'.
-                                                                     ~~~~~~~~~~~~~~~
+                                                                             ~~~~~
 !!! error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
 !!! error TS2345:   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
     var a9f: A92;

--- a/tests/baselines/reference/typeArgumentInferenceWithConstraints.errors.txt
+++ b/tests/baselines/reference/typeArgumentInferenceWithConstraints.errors.txt
@@ -17,12 +17,12 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConst
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(73,11): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'string' is not a valid type argument because it is not a supertype of candidate 'number'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(85,9): error TS2304: Cannot find name 'Window'.
-tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(87,11): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
+tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(87,47): error TS2304: Cannot find name 'window'.
+tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(87,65): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate '{ x: number; z: any; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
     Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: any; }'.
-tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(87,47): error TS2304: Cannot find name 'window'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(89,52): error TS2304: Cannot find name 'window'.
-tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(89,62): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
+tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(89,70): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
 
 
@@ -145,17 +145,17 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConst
 !!! error TS2304: Cannot find name 'Window'.
     }
     var a9e = someGenerics9(undefined, { x: 6, z: window }, { x: 6, y: '' });
-              ~~~~~~~~~~~~~
+                                                  ~~~~~~
+!!! error TS2304: Cannot find name 'window'.
+                                                                    ~~~~~
 !!! error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
 !!! error TS2453:   Type argument candidate '{ x: number; z: any; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
 !!! error TS2453:     Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: any; }'.
-                                                  ~~~~~~
-!!! error TS2304: Cannot find name 'window'.
     var a9e: {};
     var a9f = someGenerics9<A92>(undefined, { x: 6, z: window }, { x: 6, y: '' });
                                                        ~~~~~~
 !!! error TS2304: Cannot find name 'window'.
-                                                                 ~~~~~~~~~~~~~~~
+                                                                         ~~~~~
 !!! error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
 !!! error TS2345:   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
     var a9f: A92;

--- a/tests/baselines/reference/typeInfer1.errors.txt
+++ b/tests/baselines/reference/typeInfer1.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/typeInfer1.ts(11,5): error TS2322: Type '{ Moo: () => string; }' is not assignable to type 'ITextWriter2'.
+tests/cases/compiler/typeInfer1.ts(12,5): error TS2322: Type '{ Moo: () => string; }' is not assignable to type 'ITextWriter2'.
   Object literal may only specify known properties, and 'Moo' does not exist in type 'ITextWriter2'.
 
 
@@ -14,8 +14,8 @@ tests/cases/compiler/typeInfer1.ts(11,5): error TS2322: Type '{ Moo: () => strin
     }
     
     var yyyyyyyy: ITextWriter2 = {
-        ~~~~~~~~
+        Moo: function() { return "cow"; }
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ Moo: () => string; }' is not assignable to type 'ITextWriter2'.
 !!! error TS2322:   Object literal may only specify known properties, and 'Moo' does not exist in type 'ITextWriter2'.
-        Moo: function() { return "cow"; }
     }

--- a/tests/baselines/reference/typeMatch2.errors.txt
+++ b/tests/baselines/reference/typeMatch2.errors.txt
@@ -2,9 +2,9 @@ tests/cases/compiler/typeMatch2.ts(3,2): error TS2322: Type '{}' is not assignab
   Property 'x' is missing in type '{}'.
 tests/cases/compiler/typeMatch2.ts(4,5): error TS2322: Type '{ x: number; }' is not assignable to type '{ x: number; y: number; }'.
   Property 'y' is missing in type '{ x: number; }'.
-tests/cases/compiler/typeMatch2.ts(5,2): error TS2322: Type '{ x: number; y: number; z: number; }' is not assignable to type '{ x: number; y: number; }'.
+tests/cases/compiler/typeMatch2.ts(5,20): error TS2322: Type '{ x: number; y: number; z: number; }' is not assignable to type '{ x: number; y: number; }'.
   Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
-tests/cases/compiler/typeMatch2.ts(6,5): error TS2322: Type '{ x: number; z: number; }' is not assignable to type '{ x: number; y: number; }'.
+tests/cases/compiler/typeMatch2.ts(6,17): error TS2322: Type '{ x: number; z: number; }' is not assignable to type '{ x: number; y: number; }'.
   Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
 tests/cases/compiler/typeMatch2.ts(18,5): error TS2322: Type 'Animal[]' is not assignable to type 'Giraffe[]'.
   Type 'Animal' is not assignable to type 'Giraffe'.
@@ -13,7 +13,7 @@ tests/cases/compiler/typeMatch2.ts(22,5): error TS2322: Type '{ f1: number; f2: 
   Types of property 'f2' are incompatible.
     Type 'Animal[]' is not assignable to type 'Giraffe[]'.
       Type 'Animal' is not assignable to type 'Giraffe'.
-tests/cases/compiler/typeMatch2.ts(34,5): error TS2322: Type '{ x: number; y: any; z: number; }' is not assignable to type '{ x: number; y: number; }'.
+tests/cases/compiler/typeMatch2.ts(34,26): error TS2322: Type '{ x: number; y: any; z: number; }' is not assignable to type '{ x: number; y: number; }'.
   Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
 tests/cases/compiler/typeMatch2.ts(35,5): error TS2322: Type '{ x: number; }' is not assignable to type '{ x: number; y: number; }'.
   Property 'y' is missing in type '{ x: number; }'.
@@ -31,11 +31,11 @@ tests/cases/compiler/typeMatch2.ts(35,5): error TS2322: Type '{ x: number; }' is
 !!! error TS2322: Type '{ x: number; }' is not assignable to type '{ x: number; y: number; }'.
 !!! error TS2322:   Property 'y' is missing in type '{ x: number; }'.
     	a = { x: 1, y: 2, z: 3 };
-    	~
+    	                  ~~~~
 !!! error TS2322: Type '{ x: number; y: number; z: number; }' is not assignable to type '{ x: number; y: number; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
         a = { x: 1, z: 3 };  // error
-        ~
+                    ~~~~
 !!! error TS2322: Type '{ x: number; z: number; }' is not assignable to type '{ x: number; y: number; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
     }
@@ -75,7 +75,7 @@ tests/cases/compiler/typeMatch2.ts(35,5): error TS2322: Type '{ x: number; }' is
         a = { x: 1, y: undefined }; 
         a = { x: 1, y: _any }; 
         a = { x: 1, y: _any, z:1 }; 
-        ~
+                             ~~~
 !!! error TS2322: Type '{ x: number; y: any; z: number; }' is not assignable to type '{ x: number; y: number; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
         a = { x: 1 }; // error


### PR DESCRIPTION
This pull request aims to redirect the error message span for an excess property error from the usual target of the assignment to the invalid property itself. I believe this is a positive change in that the resulting error span is actually helpful for users.

See the release-1.6 PR: #4552