### PR TITLE
Fix definition of Array.isArray

### DIFF
--- a/lib/lib.core.d.ts
+++ b/lib/lib.core.d.ts
@@ -1165,7 +1165,7 @@ interface ArrayConstructor {
     (arrayLength?: number): any[];
     <T>(arrayLength: number): T[];
     <T>(...items: T[]): T[];
-    isArray(arg: any): arg is Array<any>;
+    isArray(arg: any): boolean;
     prototype: Array<any>;
 }
 

--- a/lib/lib.core.es6.d.ts
+++ b/lib/lib.core.es6.d.ts
@@ -1165,7 +1165,7 @@ interface ArrayConstructor {
     (arrayLength?: number): any[];
     <T>(arrayLength: number): T[];
     <T>(...items: T[]): T[];
-    isArray(arg: any): arg is Array<any>;
+    isArray(arg: any): boolean;
     prototype: Array<any>;
 }
 

--- a/lib/lib.d.ts
+++ b/lib/lib.d.ts
@@ -1165,7 +1165,7 @@ interface ArrayConstructor {
     (arrayLength?: number): any[];
     <T>(arrayLength: number): T[];
     <T>(...items: T[]): T[];
-    isArray(arg: any): arg is Array<any>;
+    isArray(arg: any): boolean;
     prototype: Array<any>;
 }
 

--- a/lib/lib.es6.d.ts
+++ b/lib/lib.es6.d.ts
@@ -1165,7 +1165,7 @@ interface ArrayConstructor {
     (arrayLength?: number): any[];
     <T>(arrayLength: number): T[];
     <T>(...items: T[]): T[];
-    isArray(arg: any): arg is Array<any>;
+    isArray(arg: any): boolean;
     prototype: Array<any>;
 }
 


### PR DESCRIPTION
Fix #4624

When trying to interpret the .d.ts files using "tsc" an obvious
syntax error was reported. According to the spec, Array.isArray
should return either "true" or "false".