### PR TITLE
Change typescript.d.ts to be an external module instead of an ambient external module declaration

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -394,6 +394,7 @@ var servicesFile = path.join(builtLocalDirectory, "typescriptServices.js");
 var standaloneDefinitionsFile = path.join(builtLocalDirectory, "typescriptServices.d.ts");
 var nodePackageFile = path.join(builtLocalDirectory, "typescript.js");
 var nodeDefinitionsFile = path.join(builtLocalDirectory, "typescript.d.ts");
+var nodeStandaloneDefinitionsFile = path.join(builtLocalDirectory, "typescript_standalone.d.ts");
 
 compileFile(servicesFile, servicesSources,[builtLocalDirectory, copyright].concat(servicesSources),
             /*prefixes*/ [copyright],
@@ -410,11 +411,19 @@ compileFile(servicesFile, servicesSources,[builtLocalDirectory, copyright].conca
 
                 prependFile(copyright, standaloneDefinitionsFile);
 
-                // Create the node definition file by replacing 'ts' module with '"typescript"' as a module.
+                // Stanalone/web definition file using global 'ts' namespace
                 jake.cpR(standaloneDefinitionsFile, nodeDefinitionsFile, {silent: true});
                 var definitionFileContents = fs.readFileSync(nodeDefinitionsFile).toString();
-                definitionFileContents = definitionFileContents.replace(/declare (namespace|module) ts/g, 'declare module "typescript"');
-                fs.writeFileSync(nodeDefinitionsFile, definitionFileContents);
+
+                // Official node package definition file, pointed to by 'typings' in package.json
+                // Created by appending 'export = ts;' at the end of the standalone file to turn it into an external module
+                var nodeDefinitionsFileContents = definitionFileContents + "\r\nexport = ts;";
+                fs.writeFileSync(nodeDefinitionsFile, nodeDefinitionsFileContents);
+
+                // Node package definition file to be distributed without the package. Created by replacing 
+                // 'ts' namespace with '"typescript"' as a module.
+                var nodeStandaloneDefinitionsFileContents = definitionFileContents.replace(/declare (namespace|module) ts/g, 'declare module "typescript"');
+                fs.writeFileSync(nodeStandaloneDefinitionsFile, nodeStandaloneDefinitionsFileContents);
             });
 
 

--- a/lib/typescript.d.ts
+++ b/lib/typescript.d.ts
@@ -13,7 +13,7 @@ See the Apache Version 2.0 License for specific language governing permissions
 and limitations under the License.
 ***************************************************************************** */
 
-declare module "typescript" {
+declare namespace ts {
     interface Map<T> {
         [index: string]: T;
     }
@@ -1405,7 +1405,7 @@ declare module "typescript" {
         newLength: number;
     }
 }
-declare module "typescript" {
+declare namespace ts {
     interface System {
         args: string[];
         newLine: string;
@@ -1429,7 +1429,7 @@ declare module "typescript" {
     }
     var sys: System;
 }
-declare module "typescript" {
+declare namespace ts {
     interface ErrorCallback {
         (message: DiagnosticMessage, length: number): void;
     }
@@ -1474,7 +1474,7 @@ declare module "typescript" {
     function isIdentifierPart(ch: number, languageVersion: ScriptTarget): boolean;
     function createScanner(languageVersion: ScriptTarget, skipTrivia: boolean, languageVariant?: LanguageVariant, text?: string, onError?: ErrorCallback, start?: number, length?: number): Scanner;
 }
-declare module "typescript" {
+declare namespace ts {
     function getDefaultLibFileName(options: CompilerOptions): string;
     function textSpanEnd(span: TextSpan): number;
     function textSpanIsEmpty(span: TextSpan): boolean;
@@ -1504,14 +1504,14 @@ declare module "typescript" {
     function collapseTextChangeRangesAcrossMultipleVersions(changes: TextChangeRange[]): TextChangeRange;
     function getTypeParameterOwner(d: Declaration): Declaration;
 }
-declare module "typescript" {
+declare namespace ts {
     function getNodeConstructor(kind: SyntaxKind): new () => Node;
     function createNode(kind: SyntaxKind): Node;
     function forEachChild<T>(node: Node, cbNode: (node: Node) => T, cbNodeArray?: (nodes: Node[]) => T): T;
     function createSourceFile(fileName: string, sourceText: string, languageVersion: ScriptTarget, setParentNodes?: boolean): SourceFile;
     function updateSourceFile(sourceFile: SourceFile, newText: string, textChangeRange: TextChangeRange, aggressiveChecks?: boolean): SourceFile;
 }
-declare module "typescript" {
+declare namespace ts {
     const version: string;
     function findConfigFile(searchPath: string): string;
     function resolveTripleslashReference(moduleName: string, containingFile: string): string;
@@ -1524,7 +1524,7 @@ declare module "typescript" {
     function flattenDiagnosticMessageText(messageText: string | DiagnosticMessageChain, newLine: string): string;
     function createProgram(rootNames: string[], options: CompilerOptions, host?: CompilerHost, oldProgram?: Program): Program;
 }
-declare module "typescript" {
+declare namespace ts {
     function parseCommandLine(commandLine: string[], readFile?: (path: string) => string): ParsedCommandLine;
     /**
       * Read tsconfig.json file
@@ -1551,7 +1551,7 @@ declare module "typescript" {
       */
     function parseConfigFile(json: any, host: ParseConfigHost, basePath: string): ParsedCommandLine;
 }
-declare module "typescript" {
+declare namespace ts {
     /** The version of the language service API */
     let servicesVersion: string;
     interface Node {
@@ -2139,3 +2139,5 @@ declare module "typescript" {
       */
     function getDefaultLibFilePath(options: CompilerOptions): string;
 }
+
+export = ts;

--- a/tests/cases/compiler/APISample_compile.ts
+++ b/tests/cases/compiler/APISample_compile.ts
@@ -1,5 +1,5 @@
 ﻿// @module: commonjs
-// @includebuiltfile: typescript.d.ts
+// @includebuiltfile: typescript_standalone.d.ts
 // @stripInternal:true
 
 /*

--- a/tests/cases/compiler/APISample_linter.ts
+++ b/tests/cases/compiler/APISample_linter.ts
@@ -1,5 +1,5 @@
 ﻿// @module: commonjs
-// @includebuiltfile: typescript.d.ts
+// @includebuiltfile: typescript_standalone.d.ts
 // @stripInternal:true
 
 /*

--- a/tests/cases/compiler/APISample_transform.ts
+++ b/tests/cases/compiler/APISample_transform.ts
@@ -1,5 +1,5 @@
 ﻿// @module: commonjs
-// @includebuiltfile: typescript.d.ts
+// @includebuiltfile: typescript_standalone.d.ts
 // @stripInternal:true
 
 /*

--- a/tests/cases/compiler/APISample_watcher.ts
+++ b/tests/cases/compiler/APISample_watcher.ts
@@ -1,5 +1,5 @@
 ﻿// @module: commonjs
-// @includebuiltfile: typescript.d.ts
+// @includebuiltfile: typescript_standalone.d.ts
 // @stripInternal:true
 
 /*


### PR DESCRIPTION
Changing the format of the output file `typescript.d.ts` to make it a proper external module, since it is mainly distributed through the node package with typings field.

also keep the old format to share on definitelytyped for the short term.