### PR TITLE
Only obtain regular type of fresh object literal type if necessary

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5507,6 +5507,7 @@ namespace ts {
                     regularType.constructSignatures = (<ResolvedType>type).constructSignatures;
                     regularType.stringIndexType = (<ResolvedType>type).stringIndexType;
                     regularType.numberIndexType = (<ResolvedType>type).numberIndexType;
+                    (<FreshObjectLiteralType>type).regularType = regularType;
                 }
                 return regularType;
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4640,7 +4640,9 @@ namespace ts {
                     // and intersection types are further deconstructed on the target side, we don't want to
                     // make the check again (as it might fail for a partial target type). Therefore we obtain
                     // the regular source type and proceed with that.
-                    source = getRegularTypeOfObjectLiteral(source);
+                    if (target.flags & TypeFlags.UnionOrIntersection) {
+                        source = getRegularTypeOfObjectLiteral(source);
+                    }
                 }
 
                 let saveErrorInfo = errorInfo;


### PR DESCRIPTION
During type relalationship processing we currently obtain the regular (non-fresh) version of an object literal type after performing the excess property check. There's no reason to do this unless the type being compared against is a union or intersection type (which it rarely is). This PR implements that simple optimization.

No new tests in this PR as no behaviors change. Only difference is that we allocate fewer type instances.