### PR TITLE
Account for path options when pointing to the current working directory

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -446,6 +446,9 @@ namespace ts {
                             }
                             if (opt.isFilePath) {
                                 value = normalizePath(combinePaths(basePath, value));
+                                if (value === "") {
+                                    value = ".";
+                                }
                             }
                             options[opt.name] = value;
                         }


### PR DESCRIPTION
This makes relative outDir and other file path options not ignored when they point to the working directory (issue #4721).

Another way to fix this is to use `typeof options.somePathOprtion === "string"` check everywhere where we need to know if a path option is specified, but it would be a more complex change.
What do you think?