### PR TITLE
Update Visual Studio Code ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,5 +48,6 @@ scripts/*.js.map
 coverage/
 internal/
 **/.DS_Store
-.settings/*
-!.settings/tasks.json
+.settings
+.vscode/*
+!.vscode/tasks.json

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,4 @@ tests
 Jakefile
 .travis.yml
 .settings/
+.vscode/


### PR DESCRIPTION
In Visual Studio Code 0.8.0, .settings is renamed to .vscode; adds .vscode ignores to .gitignore with an override for tasks.json per #3156.

Rename of .settings to .vscode is introduced in #4739.