### PR TITLE
fix types : export the base as children are exported

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2116,7 +2116,7 @@ namespace ts {
     }
 
     /* @internal */
-    interface CommandLineOptionBase {
+    export interface CommandLineOptionBase {
         name: string;
         type: string | Map<number>;         // "string", "number", "boolean", or an object literal mapping named values to actual values
         isFilePath?: boolean;               // True if option value is a path or fileName


### PR DESCRIPTION
Fixes error: 

```
../src/compiler/types.ts(2130,63): error TS4022: Extends clause of exported interface 'CommandLineOptionOfPrimitiveType' has or is using private name 'CommandLineOptionBase'.
../src/compiler/types.ts(2135,60): error TS4022: Extends clause of exported interface 'CommandLineOptionOfCustomType' has or is using private name 'CommandLineOptionBase'.
```

Ref : https://travis-ci.org/TypeStrong/ntypescript/builds/80545233#L143-L144

:rose: 