### PR TITLE
Fix importDefinitelyTypedTests script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ tests/services/browser/typescriptServices.js
 scripts/configureNightly.js
 scripts/processDiagnosticMessages.d.ts
 scripts/processDiagnosticMessages.js
-scripts/importDefinitelyTypedTests.js
+scripts/importDefinitelyTypedTests/importDefinitelyTypedTests.js
 src/harness/*.js
 rwc-report.html
 *.swp
@@ -45,6 +45,7 @@ scripts/run.bat
 scripts/word2md.js
 scripts/ior.js
 scripts/*.js.map
+scripts/typings/
 coverage/
 internal/
 **/.DS_Store

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -386,6 +386,27 @@ task("publish-nightly", ["configure-nightly", "LKG", "clean", "setDebugMode", "r
     exec(cmd);
 });
 
+var scriptsTsdJson = path.join(scriptsDirectory, "tsd.json");
+file(scriptsTsdJson);
+
+task("tsd-scripts", [scriptsTsdJson], function () {
+    var cmd = "tsd --config " + scriptsTsdJson + " install";
+    console.log(cmd)
+    exec(cmd);
+}, { async: true })
+
+var importDefinitelyTypedTestsDirectory = path.join(scriptsDirectory, "importDefinitelyTypedTests");
+var importDefinitelyTypedTestsJs = path.join(importDefinitelyTypedTestsDirectory, "importDefinitelyTypedTests.js");
+var importDefinitelyTypedTestsTs = path.join(importDefinitelyTypedTestsDirectory, "importDefinitelyTypedTests.ts");
+
+file(importDefinitelyTypedTestsJs);
+file(importDefinitelyTypedTestsTs, ["tsd-scripts", importDefinitelyTypedTestsJs])
+task("importDefinitelyTyped", importDefinitelyTypedTestsTs, function () {
+    var cmd = "node " +  importDefinitelyTypedTestsJs + " ./ ../DefinitelyTyped";
+    console.log(cmd);
+    exec(cmd);
+}, { async: true })
+
 // Local target to build the compiler and services
 var tscFile = path.join(builtLocalDirectory, compilerFilename);
 compileFile(tscFile, compilerSources, [builtLocalDirectory, copyright].concat(compilerSources), [copyright], /*useBuiltCompiler:*/ false);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
         "browserify": "latest",
         "istanbul": "latest",
         "mocha-fivemat-progress-reporter": "latest",
-        "tslint": "latest"
+        "tslint": "latest",
+        "tsd": "latest"
     },
     "scripts": {
         "pretest": "jake tests",

--- a/scripts/importDefinitelyTypedTests/importDefinitelyTypedTests.ts
+++ b/scripts/importDefinitelyTypedTests/importDefinitelyTypedTests.ts
@@ -107,9 +107,12 @@ function importDefinitelyTypedTests(tscPath: string, rwcTestPath: string, defini
             throw err;
         }
 
+        // When you just want to test the script out on one or two files,
+        // just add a line like the following:
+        //
+        //   .filter(d => d.indexOf("sipml") >= 0 )
         subDirectories
             .filter(d => ["_infrastructure", "node_modules", ".git"].indexOf(d) < 0)
-            // .filter(i => i.indexOf("sipml") >= 0 ) // Uncomment when you want to test :)
             .filter(i => fs.statSync(path.join(definitelyTypedRoot, i)).isDirectory())
             .forEach(d => {
                 const directoryPath = path.join(definitelyTypedRoot, d);
@@ -137,7 +140,7 @@ function importDefinitelyTypedTests(tscPath: string, rwcTestPath: string, defini
 
                     if (testFiles.length === 0) {
                         // no test files but multiple d.ts's, e.g. winjs
-                        let regexp = new RegExp(d + "(([-][0-9])|([\.]d[\.]ts))");
+                        const regexp = new RegExp(d + "(([-][0-9])|([\.]d[\.]ts))");
                         if (tsFiles.length > 1 && tsFiles.every(t => filePathEndsWith(t, ".d.ts") && regexp.test(t))) {
                             for (const fileName of tsFiles) {
                                 importDefinitelyTypedTest(tscPath, rwcTestPath, path.basename(fileName, ".d.ts"), [fileName], paramFile);

--- a/scripts/importDefinitelyTypedTests/importDefinitelyTypedTests.ts
+++ b/scripts/importDefinitelyTypedTests/importDefinitelyTypedTests.ts
@@ -1,6 +1,3 @@
-declare var require: any, process: any;
-declare var __dirname: any;
-
 var fs = require("fs");
 var path = require("path");
 var child_process = require('child_process');

--- a/scripts/importDefinitelyTypedTests/importDefinitelyTypedTests.ts
+++ b/scripts/importDefinitelyTypedTests/importDefinitelyTypedTests.ts
@@ -26,11 +26,12 @@ function main() {
     }
 
     const tscPath = path.resolve(tscRoot, "built", "local", "tsc.js");
-    const rwcTestPath = path.resolve(tscRoot, "tests", "cases", "rwc", "dt");
+    const rwcTestPath = path.resolve(tscRoot, "internal", "cases", "rwc");
     const resolvedDefinitelyTypedRoot = path.resolve(definitelyTypedRoot);
 
-    console.log(`Resolved TypeScript Repo Root: '${tscRoot}'.`);
-    console.log(`Resolved DefinitelyTyped Repo Root: '${definitelyTypedRoot}'.`);
+    console.log(`Resolved TypeScript Compiler Path: '${tscPath}'.`);
+    console.log(`Resolved TypeScript RWC Path: '${rwcTestPath}'.`);
+    console.log(`Resolved DefinitelyTyped Repo Root: '${resolvedDefinitelyTypedRoot}'.`);
     importDefinitelyTypedTests(tscPath, rwcTestPath, resolvedDefinitelyTypedRoot);
 }
 
@@ -42,7 +43,7 @@ function filePathEndsWith(path: string, endingString: string): boolean {
 
 function copyFileSync(source: string, destination: string) {
     let text = fs.readFileSync(source);
-    fs.writeFileSync(destination, text, {});
+    fs.writeFileSync(destination, text);
 }
 
 function importDefinitelyTypedTest(tscPath: string, rwcTestPath: string, testCaseName: string, testFiles: string[], responseFile: string ) {
@@ -108,7 +109,7 @@ function importDefinitelyTypedTests(tscPath: string, rwcTestPath: string, defini
 
         subDirectories
             .filter(d => ["_infrastructure", "node_modules", ".git"].indexOf(d) < 0)
-            .filter(i => i.indexOf("sipml") >=0 )
+            // .filter(i => i.indexOf("sipml") >= 0 ) // Uncomment when you want to test :)
             .filter(i => fs.statSync(path.join(definitelyTypedRoot, i)).isDirectory())
             .forEach(d => {
                 const directoryPath = path.join(definitelyTypedRoot, d);

--- a/scripts/importDefinitelyTypedTests/tsconfig.json
+++ b/scripts/importDefinitelyTypedTests/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es3",
+        "noImplicitAny": true,
+        "outDir": "./",
+        "rootDir": ".",
+        "sourceMap": false
+    },
+    "files": [
+        "../typings/node/node.d.ts",
+        "importDefinitelyTypedTests.ts"
+    ],
+    "exclude": [
+    ]
+}

--- a/scripts/importDefinitelyTypedTests/tsconfig.json
+++ b/scripts/importDefinitelyTypedTests/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "module": "commonjs",
-        "target": "es3",
+        "target": "ES5",
         "noImplicitAny": true,
         "outDir": "./",
         "rootDir": ".",

--- a/scripts/tsd.json
+++ b/scripts/tsd.json
@@ -1,0 +1,12 @@
+{
+  "version": "v4",
+  "repo": "borisyankov/DefinitelyTyped",
+  "ref": "master",
+  "path": "typings",
+  "bundle": "typings/tsd.d.ts",
+  "installed": {
+    "node/node.d.ts": {
+      "commit": "5f480287834a2615274eea31574b713e64decf17"
+    }
+  }
+}


### PR DESCRIPTION
Fixes the broken script.

Notable changes:
* Introduced `tsd.json` to `scripts`
* Use a `tsconfig.json` for the script.
* Made the script a module
* Added a `jake` task to run the script.