### PR TITLE
Rework lint to use tslint-as-a-lib

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -32,8 +32,8 @@
                     "location": 3,
                     "message": 4
                 },
-				"watchedTaskBeginsRegExp": "^\\*\\*\\*Lint failure\\*\\*\\*$",
-				"watchedTaskEndsRegExp": "^\\*\\*\\* Total \\d+ failures\\.$"
+                "watchedTaskBeginsRegExp": "^\\*\\*\\*Lint failure\\*\\*\\*$",
+                "watchedTaskEndsRegExp": "^\\*\\*\\* Total \\d+ failures\\.$"
             },
             "showOutput": "always",
             "isWatching": true

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -18,6 +18,25 @@
             "problemMatcher": [
                 "$tsc"
             ]
+        },
+        {
+            "taskName": "lint-server",
+            "args": [],
+            "problemMatcher": {
+                "owner": "typescript",
+                "fileLocation": ["relative", "${workspaceRoot}"],
+                "pattern": {
+                    "regexp": "^(warning|error)\\s+([^(]+)\\s+\\((\\d+|\\d+,\\d+|\\d+,\\d+,\\d+,\\d+)\\):\\s+(.*)$",
+                    "severity": 1,
+                    "file": 2,
+                    "location": 3,
+                    "message": 4
+                },
+				"watchedTaskBeginsRegExp": "^\\*\\*\\*Lint failure\\*\\*\\*$",
+				"watchedTaskEndsRegExp": "^\\*\\*\\* Total \\d+ failures\\.$"
+            },
+            "showOutput": "always",
+            "isWatching": true
         }
     ]
 }

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -844,6 +844,13 @@ task("lint", ["build-rules"], function() {
     }
 });
 
+/**
+ * This is required because file watches on Windows get fires _twice_
+ * when a file changes on some node/windows version configuations
+ * (node v4 and win 10, for example). By not running a lint for a file
+ * which already has a pending lint, we avoid duplicating our work.
+ * (And avoid printing duplicate results!)
+ */
 var lintSemaphores = {};
 
 function lintWatchFile(filename) {

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -864,11 +864,11 @@ function lintWatchFile(filename) {
                     console.log("***Lint failure***");
                     for (var i = 0; i < result.failures.length; i++) {
                         var failure = result.failures[i];
-                        var s = failure.startPosition.lineAndCharacter;
-                        var e = failure.endPosition.lineAndCharacter;
-                        console.log("warning "+filename+" ("+(s.line+1)+","+(s.character+1)+","+(e.line+1)+","+(e.character+1)+"): "+failure.failure);
+                        var start = failure.startPosition.lineAndCharacter;
+                        var end = failure.endPosition.lineAndCharacter;
+                        console.log("warning " + filename + " (" + (start.line + 1) + "," + (start.character + 1) + "," + (end.line + 1) + "," + (end.character + 1) + "): " + failure.failure);
                     }
-                    console.log("*** Total "+result.failureCount+" failures.");
+                    console.log("*** Total " + result.failureCount + " failures.");
                 }
             });
         }
@@ -877,8 +877,8 @@ function lintWatchFile(filename) {
 
 desc("Watches files for changes to rerun a lint pass");
 task("lint-server", ["build-rules"], function() {
-    console.log('Watching ./src for changes to linted files');
-    for (var i=0; i<lintTargets.length; i++) {
+    console.log("Watching ./src for changes to linted files");
+    for (var i = 0; i < lintTargets.length; i++) {
         lintWatchFile(lintTargets[i]);
     }
 });


### PR DESCRIPTION
Adds a task to `.vscode/tasks.json` and `jake` which, when started from vscode, enables in-editor on-save linting support for all linted files. :smile: