### PR TITLE
Parser error type identifier

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2477,5 +2477,13 @@
     "A type assertion expression is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.": {
       "category": "Error",
       "code": 17007
+    },
+    "Invalid type. To avoid ambiguity, add parentheses: '{0}'": {
+        "category": "Error",
+        "code": 17008
+    },
+    "Identifier expected, reserved word '{0}' not allowed here.": {
+        "category": "Error",
+        "code": 17009
     }
 }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -937,8 +937,8 @@ namespace ts {
             return token > SyntaxKind.LastReservedWord;
         }
 
-        module errors {
-            export function invalidTypeReferenceOrTypePredicate(node: TypeReferenceNode | TypePredicateNode): void {
+            // ERRORS
+            function invalidTypeReferenceOrTypePredicate(node: TypeReferenceNode | TypePredicateNode): void {
                 if (node.kind === SyntaxKind.TypePredicate) {
                     if ((<TypePredicateNode>node).type.parserContextFlags & ParserContextFlags.ThisNodeHasError) {
                         parseErrorAtPosition((<TypePredicateNode>node).type.pos, 0, Diagnostics.Type_expected);
@@ -987,7 +987,6 @@ namespace ts {
                     }
                 }
             }
-        }
 
         function parseExpected(kind: SyntaxKind, diagnosticMessage?: DiagnosticMessage, shouldAdvance = true): boolean {
             if (token === kind) {
@@ -2001,7 +2000,7 @@ namespace ts {
         // TYPES
 
         function parseTypeReferenceOrTypePredicate(): TypeReferenceNode | TypePredicateNode {
-            contextualError.callback = errors.invalidTypeReferenceOrTypePredicate;
+            contextualError.callback = invalidTypeReferenceOrTypePredicate;
 
             let typeName = parseEntityName(/*allowReservedWords*/ false);
             if (typeName.kind === SyntaxKind.Identifier && token === SyntaxKind.IsKeyword && !scanner.hasPrecedingLineBreak()) {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1942,14 +1942,15 @@ namespace ts {
             let node = <TypeReferenceNode>createNode(SyntaxKind.TypeReference, typeName.pos);
             if (typeName.flags & NodeFlags.Missing) {
                 errorOnInvalidTypeReference(typeName);
-            } else {
+            }
+            else {
                 node.typeName = typeName;
                 if (token === SyntaxKind.LessThanToken && !scanner.hasPrecedingLineBreak()) {
                     node.typeArguments = parseBracketedList(ParsingContext.TypeArguments, parseType, SyntaxKind.LessThanToken, SyntaxKind.GreaterThanToken);
                 }
             }
             if ((<QualifiedName>typeName).right && ((<QualifiedName>typeName).right.flags & NodeFlags.Missing)) {
-                errorOnQualifiedTypeIdentifier()
+                errorOnInvalidTypeQualifiedName()
             }
             return finishNode(node);
         }
@@ -1961,25 +1962,28 @@ namespace ts {
             }
             else if (token === SyntaxKind.NewKeyword) {
                 parseFunctionOrConstructorType(SyntaxKind.ConstructorType);
-            } else {
+            }
+            else {
                 needsParentheses = false;
             }
             if (needsParentheses) {
                 let hint = "(" + sourceFile.text.substring(node.pos, scanner.getStartPos()).trim() + ")";
                 parseErrorAtPosition(node.pos, scanner.getStartPos() - node.pos, Diagnostics.Invalid_type_To_avoid_ambiguity_add_parentheses_Colon_0, hint);
-            } else {
+            }
+            else {
                 parseErrorAtCurrentToken(Diagnostics.Type_expected);
             }
         }
 
-        function errorOnQualifiedTypeIdentifier(): void {
+        function errorOnInvalidTypeQualifiedName(): void {
             if (scanner.isReservedWord()) {
                 parseErrorAtCurrentToken(Diagnostics.Identifier_expected_reserved_word_0_not_allowed_here, tokenToString(token));
             }
             else {
                 if (scanner.hasPrecedingLineBreak()) {
                     parseErrorAtPosition(scanner.getStartPos(), 0, Diagnostics.Identifier_expected);
-                } else {
+                }
+                else {
                     parseErrorAtCurrentToken(Diagnostics.Identifier_expected);
                 }
             }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -380,6 +380,7 @@ namespace ts {
         Namespace =         0x00020000,  // Namespace declaration
         ExportContext =     0x00040000,  // Export context (initialized by binding)
         ContainsThis =      0x00080000,  // Interface contains references to "this"
+        Missing =           0x00100000,  // Node which is invalid/missing
 
         Modifier = Export | Ambient | Public | Private | Protected | Static | Abstract | Default | Async,
         AccessibilityModifier = Public | Private | Protected,

--- a/tests/baselines/reference/errorParserTypeIdentifier.errors.txt
+++ b/tests/baselines/reference/errorParserTypeIdentifier.errors.txt
@@ -1,0 +1,66 @@
+tests/cases/compiler/errorParserTypeIdentifier.ts(3,26): error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(new() => void)'
+tests/cases/compiler/errorParserTypeIdentifier.ts(5,16): error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(new () => void)'
+tests/cases/compiler/errorParserTypeIdentifier.ts(7,16): error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(new () => void)'
+tests/cases/compiler/errorParserTypeIdentifier.ts(8,16): error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(new () => void | number)'
+tests/cases/compiler/errorParserTypeIdentifier.ts(9,16): error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(<T>(...) => void | void)'
+tests/cases/compiler/errorParserTypeIdentifier.ts(9,24): error TS1003: Identifier expected.
+tests/cases/compiler/errorParserTypeIdentifier.ts(12,8): error TS2503: Cannot find namespace 'TypeModule1'.
+tests/cases/compiler/errorParserTypeIdentifier.ts(12,20): error TS1003: Identifier expected.
+tests/cases/compiler/errorParserTypeIdentifier.ts(17,8): error TS2503: Cannot find namespace 'x'.
+tests/cases/compiler/errorParserTypeIdentifier.ts(17,10): error TS17007: Identifier expected, reserved word 'void' not allowed here.
+tests/cases/compiler/errorParserTypeIdentifier.ts(17,14): error TS1109: Expression expected.
+tests/cases/compiler/errorParserTypeIdentifier.ts(18,13): error TS1110: Type expected.
+tests/cases/compiler/errorParserTypeIdentifier.ts(20,1): error TS2304: Cannot find name 'Foo'.
+tests/cases/compiler/errorParserTypeIdentifier.ts(20,8): error TS1110: Type expected.
+
+
+==== tests/cases/compiler/errorParserTypeIdentifier.ts (14 errors) ====
+    
+    // Union or intersection ambiguity
+    function test(x: string | new() => void) { }
+                             ~~~~~~~~~~~~~~
+!!! error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(new() => void)'
+    
+    let a: string | new () => void;
+                   ~~~~~~~~~~~~~~~
+!!! error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(new () => void)'
+    let b: string | (new () => void);
+    let c: string | new () => void /* not part of error */
+                   ~~~~~~~~~~~~~~~
+!!! error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(new () => void)'
+    let d: string | new () => void | number;
+                   ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(new () => void | number)'
+    let e: string | <T>(...) => void | void;
+                   ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(<T>(...) => void | void)'
+                           ~
+!!! error TS1003: Identifier expected.
+    
+    // Missing identifier or keyword
+    let f: TypeModule1.
+           ~~~~~~~~~~~
+!!! error TS2503: Cannot find namespace 'TypeModule1'.
+                       
+!!! error TS1003: Identifier expected.
+    
+    module TypeModule2 {
+    }
+    
+    let g: x.void;
+           ~
+!!! error TS2503: Cannot find namespace 'x'.
+             ~~~~
+!!! error TS17007: Identifier expected, reserved word 'void' not allowed here.
+                 ~
+!!! error TS1109: Expression expected.
+    let h = (a: ) => {
+                ~
+!!! error TS1110: Type expected.
+    }
+    Foo<a, , b>();
+    ~~~
+!!! error TS2304: Cannot find name 'Foo'.
+           ~
+!!! error TS1110: Type expected.
+    

--- a/tests/baselines/reference/errorParserTypeIdentifier.errors.txt
+++ b/tests/baselines/reference/errorParserTypeIdentifier.errors.txt
@@ -1,13 +1,13 @@
-tests/cases/compiler/errorParserTypeIdentifier.ts(3,26): error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(new() => void)'
-tests/cases/compiler/errorParserTypeIdentifier.ts(5,16): error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(new () => void)'
-tests/cases/compiler/errorParserTypeIdentifier.ts(7,16): error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(new () => void)'
-tests/cases/compiler/errorParserTypeIdentifier.ts(8,16): error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(new () => void | number)'
-tests/cases/compiler/errorParserTypeIdentifier.ts(9,16): error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(<T>(...) => void | void)'
+tests/cases/compiler/errorParserTypeIdentifier.ts(3,26): error TS17008: Invalid type. To avoid ambiguity, add parentheses: '(new() => void)'
+tests/cases/compiler/errorParserTypeIdentifier.ts(5,16): error TS17008: Invalid type. To avoid ambiguity, add parentheses: '(new () => void)'
+tests/cases/compiler/errorParserTypeIdentifier.ts(7,16): error TS17008: Invalid type. To avoid ambiguity, add parentheses: '(new () => void)'
+tests/cases/compiler/errorParserTypeIdentifier.ts(8,16): error TS17008: Invalid type. To avoid ambiguity, add parentheses: '(new () => void | number)'
+tests/cases/compiler/errorParserTypeIdentifier.ts(9,16): error TS17008: Invalid type. To avoid ambiguity, add parentheses: '(<T>(...) => void | void)'
 tests/cases/compiler/errorParserTypeIdentifier.ts(9,24): error TS1003: Identifier expected.
 tests/cases/compiler/errorParserTypeIdentifier.ts(12,8): error TS2503: Cannot find namespace 'TypeModule1'.
 tests/cases/compiler/errorParserTypeIdentifier.ts(12,20): error TS1003: Identifier expected.
 tests/cases/compiler/errorParserTypeIdentifier.ts(17,8): error TS2503: Cannot find namespace 'x'.
-tests/cases/compiler/errorParserTypeIdentifier.ts(17,10): error TS17007: Identifier expected, reserved word 'void' not allowed here.
+tests/cases/compiler/errorParserTypeIdentifier.ts(17,10): error TS17009: Identifier expected, reserved word 'void' not allowed here.
 tests/cases/compiler/errorParserTypeIdentifier.ts(17,14): error TS1109: Expression expected.
 tests/cases/compiler/errorParserTypeIdentifier.ts(18,13): error TS1110: Type expected.
 tests/cases/compiler/errorParserTypeIdentifier.ts(20,1): error TS2304: Cannot find name 'Foo'.
@@ -19,21 +19,21 @@ tests/cases/compiler/errorParserTypeIdentifier.ts(20,8): error TS1110: Type expe
     // Union or intersection ambiguity
     function test(x: string | new() => void) { }
                              ~~~~~~~~~~~~~~
-!!! error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(new() => void)'
+!!! error TS17008: Invalid type. To avoid ambiguity, add parentheses: '(new() => void)'
     
     let a: string | new () => void;
                    ~~~~~~~~~~~~~~~
-!!! error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(new () => void)'
+!!! error TS17008: Invalid type. To avoid ambiguity, add parentheses: '(new () => void)'
     let b: string | (new () => void);
     let c: string | new () => void /* not part of error */
                    ~~~~~~~~~~~~~~~
-!!! error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(new () => void)'
+!!! error TS17008: Invalid type. To avoid ambiguity, add parentheses: '(new () => void)'
     let d: string | new () => void | number;
                    ~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(new () => void | number)'
+!!! error TS17008: Invalid type. To avoid ambiguity, add parentheses: '(new () => void | number)'
     let e: string | <T>(...) => void | void;
                    ~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS17006: Invalid type. To avoid ambiguity, add parentheses: '(<T>(...) => void | void)'
+!!! error TS17008: Invalid type. To avoid ambiguity, add parentheses: '(<T>(...) => void | void)'
                            ~
 !!! error TS1003: Identifier expected.
     
@@ -51,7 +51,7 @@ tests/cases/compiler/errorParserTypeIdentifier.ts(20,8): error TS1110: Type expe
            ~
 !!! error TS2503: Cannot find namespace 'x'.
              ~~~~
-!!! error TS17007: Identifier expected, reserved word 'void' not allowed here.
+!!! error TS17009: Identifier expected, reserved word 'void' not allowed here.
                  ~
 !!! error TS1109: Expression expected.
     let h = (a: ) => {

--- a/tests/baselines/reference/errorParserTypeIdentifier.js
+++ b/tests/baselines/reference/errorParserTypeIdentifier.js
@@ -1,0 +1,37 @@
+//// [errorParserTypeIdentifier.ts]
+
+// Union or intersection ambiguity
+function test(x: string | new() => void) { }
+
+let a: string | new () => void;
+let b: string | (new () => void);
+let c: string | new () => void /* not part of error */
+let d: string | new () => void | number;
+let e: string | <T>(...) => void | void;
+
+// Missing identifier or keyword
+let f: TypeModule1.
+
+module TypeModule2 {
+}
+
+let g: x.void;
+let h = (a: ) => {
+}
+Foo<a, , b>();
+
+
+//// [errorParserTypeIdentifier.js]
+// Union or intersection ambiguity
+function test(x) { }
+var a;
+var b;
+var c; /* not part of error */
+var d;
+var e;
+// Missing identifier or keyword
+var f;
+var g = void ;
+var h = function (a) {
+};
+Foo();

--- a/tests/baselines/reference/parserSkippedTokens20.errors.txt
+++ b/tests/baselines/reference/parserSkippedTokens20.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens20.ts(1,8): error TS2304: Cannot find name 'X'.
-tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens20.ts(1,12): error TS1127: Invalid character.
+tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens20.ts(1,12): error TS1005: ',' expected.
 tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens20.ts(1,13): error TS1005: '>' expected.
 
 
@@ -7,7 +7,7 @@ tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens20.t
     var v: X<T \
            ~
 !!! error TS2304: Cannot find name 'X'.
-               
-!!! error TS1127: Invalid character.
+               ~
+!!! error TS1005: ',' expected.
                 
 !!! error TS1005: '>' expected.

--- a/tests/baselines/reference/parserUnterminatedGeneric1.errors.txt
+++ b/tests/baselines/reference/parserUnterminatedGeneric1.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGeneric1.ts(2,23): error TS2304: Cannot find name 'IPromise'.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGeneric1.ts(2,45): error TS2304: Cannot find name 'IPromise'.
-tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGeneric1.ts(2,54): error TS1005: '>' expected.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGeneric1.ts(2,54): error TS1005: '}' expected.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGeneric1.ts (3 errors) ====
@@ -11,4 +11,4 @@ tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGener
                                                 ~~~~~~~~
 !!! error TS2304: Cannot find name 'IPromise'.
                                                          
-!!! error TS1005: '>' expected.
+!!! error TS1005: '}' expected.

--- a/tests/baselines/reference/parserUnterminatedGeneric2.errors.txt
+++ b/tests/baselines/reference/parserUnterminatedGeneric2.errors.txt
@@ -12,7 +12,7 @@ tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGener
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGeneric2.ts(4,43): error TS2304: Cannot find name 'any'.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGeneric2.ts(8,23): error TS2304: Cannot find name 'IPromise'.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGeneric2.ts(8,45): error TS2304: Cannot find name 'IPromise'.
-tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGeneric2.ts(8,54): error TS1005: '>' expected.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGeneric2.ts(8,54): error TS1005: '}' expected.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGeneric2.ts (15 errors) ====
@@ -53,4 +53,4 @@ tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserUnterminatedGener
                                                 ~~~~~~~~
 !!! error TS2304: Cannot find name 'IPromise'.
                                                          
-!!! error TS1005: '>' expected.
+!!! error TS1005: '}' expected.

--- a/tests/baselines/reference/parservoidInQualifiedName2.errors.txt
+++ b/tests/baselines/reference/parservoidInQualifiedName2.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/parser/ecmascript5/parservoidInQualifiedName2.ts(1,9): error TS2503: Cannot find namespace 'x'.
-tests/cases/conformance/parser/ecmascript5/parservoidInQualifiedName2.ts(1,11): error TS17007: Identifier expected, reserved word 'void' not allowed here.
+tests/cases/conformance/parser/ecmascript5/parservoidInQualifiedName2.ts(1,11): error TS17009: Identifier expected, reserved word 'void' not allowed here.
 tests/cases/conformance/parser/ecmascript5/parservoidInQualifiedName2.ts(1,15): error TS1109: Expression expected.
 
 
@@ -8,6 +8,6 @@ tests/cases/conformance/parser/ecmascript5/parservoidInQualifiedName2.ts(1,15): 
             ~
 !!! error TS2503: Cannot find namespace 'x'.
               ~~~~
-!!! error TS17007: Identifier expected, reserved word 'void' not allowed here.
+!!! error TS17009: Identifier expected, reserved word 'void' not allowed here.
                   ~
 !!! error TS1109: Expression expected.

--- a/tests/baselines/reference/parservoidInQualifiedName2.errors.txt
+++ b/tests/baselines/reference/parservoidInQualifiedName2.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/parser/ecmascript5/parservoidInQualifiedName2.ts(1,9): error TS2503: Cannot find namespace 'x'.
-tests/cases/conformance/parser/ecmascript5/parservoidInQualifiedName2.ts(1,11): error TS1003: Identifier expected.
+tests/cases/conformance/parser/ecmascript5/parservoidInQualifiedName2.ts(1,11): error TS17007: Identifier expected, reserved word 'void' not allowed here.
 tests/cases/conformance/parser/ecmascript5/parservoidInQualifiedName2.ts(1,15): error TS1109: Expression expected.
 
 
@@ -8,6 +8,6 @@ tests/cases/conformance/parser/ecmascript5/parservoidInQualifiedName2.ts(1,15): 
             ~
 !!! error TS2503: Cannot find namespace 'x'.
               ~~~~
-!!! error TS1003: Identifier expected.
+!!! error TS17007: Identifier expected, reserved word 'void' not allowed here.
                   ~
 !!! error TS1109: Expression expected.

--- a/tests/baselines/reference/typeGuardFunctionErrors.errors.txt
+++ b/tests/baselines/reference/typeGuardFunctionErrors.errors.txt
@@ -2,7 +2,7 @@ tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(15,12)
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(22,33): error TS2304: Cannot find name 'x'.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(26,33): error TS1225: Cannot find parameter 'x'.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(30,10): error TS2391: Function implementation is missing or not immediately following the declaration.
-tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(31,5): error TS1131: Property or signature expected.
+tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(30,48): error TS1110: Type expected.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(32,1): error TS1128: Declaration or statement expected.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(34,38): error TS1225: Cannot find parameter 'x'.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(38,51): error TS2322: Type 'B' is not assignable to type 'A'.
@@ -76,9 +76,9 @@ tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(137,39
     function hasMissingTypeInTypeGuardType(x): x is {
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2391: Function implementation is missing or not immediately following the declaration.
+                                                   
+!!! error TS1110: Type expected.
         return true;
-        ~~~~~~
-!!! error TS1131: Property or signature expected.
     }
     ~
 !!! error TS1128: Declaration or statement expected.

--- a/tests/cases/compiler/errors/errorParserTypeIdentifier.ts
+++ b/tests/cases/compiler/errors/errorParserTypeIdentifier.ts
@@ -1,0 +1,20 @@
+﻿
+// Union or intersection ambiguity
+function test(x: string | new() => void) { }
+
+let a: string | new () => void;
+let b: string | (new () => void);
+let c: string | new () => void /* not part of error */
+let d: string | new () => void | number;
+let e: string | <T>(...) => void | void;
+
+// Missing identifier or keyword
+let f: TypeModule1.
+
+module TypeModule2 {
+}
+
+let g: x.void;
+let h = (a: ) => {
+}
+Foo<a, , b>();


### PR DESCRIPTION
This improves parsing an invalid type identifier #4067
```
let d: string | new () => void | number; // Invalid type. To avoid ambiguity, add parentheses: '(new () => void | number)'
let g: x.void; // Identifier expected, reserved word 'void' not allowed here.
```
Was tricky, added a ```ParserContextFlags.NoError``` flag to disable errors on parsing, then check for missing node(s) to improve the error(s).
