### PR TITLE
Bump versions to 1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "typescript",
     "author": "Microsoft Corp.",
     "homepage": "http://typescriptlang.org/",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "license": "Apache-2.0",
     "description": "TypeScript is a language for application scale JavaScript development",
     "keywords": [

--- a/scripts/configureNightly.ts
+++ b/scripts/configureNightly.ts
@@ -44,7 +44,7 @@ function main(): void {
             err += `The file seems to no longer have a string matching '${versionAssignmentRegExp}'.`;
         }
 
-        throw err + "\n";
+        throw new Error(err + "\n");
     }
 
     // Finally write the changes to disk.
@@ -53,7 +53,7 @@ function main(): void {
 }
 
 function getNightlyVersionString(versionString: string): string {
-    // If the version string already contains "-nightly",
+    // If the version string already contains "-dev",
     // then get the base string and update based on that.
     const dashNightlyPos = versionString.indexOf("-dev");
     if (dashNightlyPos >= 0) {

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -12,7 +12,7 @@ namespace ts {
     
     let emptyArray: any[] = [];
     
-    export const version = "1.7.0";
+    export const version = "1.8.0";
 
     export function findConfigFile(searchPath: string): string {
         let fileName = "tsconfig.json";


### PR DESCRIPTION
Seems that the next release will be 1.8, so let's appropriately publish nightlies that way.