### PR TITLE
Git post-checkout hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
         "istanbul": "latest",
         "mocha-fivemat-progress-reporter": "latest",
         "tslint": "latest",
-        "tsd": "latest"
+        "tsd": "latest",
+        "npm": "^2"
     },
     "scripts": {
         "pretest": "jake tests",
@@ -44,7 +45,9 @@
         "build": "npm run build:compiler && npm run build:tests",
         "build:compiler": "jake local",
         "build:tests": "jake tests",
-        "clean": "jake clean"
+        "clean": "jake clean",
+		"jake": "jake",
+        "postinstall": "node scripts/link-hooks.js"
     },
     "browser": {
         "buffer": false,

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
         "istanbul": "latest",
         "mocha-fivemat-progress-reporter": "latest",
         "tslint": "latest",
-        "tsd": "latest",
-        "npm": "^2"
+        "tsd": "latest"
     },
     "scripts": {
         "pretest": "jake tests",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "build:compiler": "jake local",
         "build:tests": "jake tests",
         "clean": "jake clean",
-		"jake": "jake",
+        "jake": "jake",
         "postinstall": "node scripts/link-hooks.js"
     },
     "browser": {

--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "var npm = require("npm"); npm.load(function (err) {if (err) { throw err; } npm.commands.run(['jake', 'generate-diagnostics']); )" | node

--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -1,2 +1,2 @@
 #!/bin/sh
-echo "var npm = require("npm"); npm.load(function (err) {if (err) { throw err; } npm.commands.run(['jake', 'generate-diagnostics']); )" | node
+echo "var npm = require('npm'); npm.load(function (err) {if (err) { throw err; } npm.commands.run(['jake', 'generate-diagnostics']); })" | node

--- a/scripts/hooks/post-checkout
+++ b/scripts/hooks/post-checkout
@@ -1,2 +1,2 @@
 #!/bin/sh
-echo "var npm = require('npm'); npm.load(function (err) {if (err) { throw err; } npm.commands.run(['jake', 'generate-diagnostics']); })" | node
+npm run jake -- generate-diagnostics

--- a/scripts/link-hooks.js
+++ b/scripts/link-hooks.js
@@ -1,0 +1,20 @@
+var fs = require("fs");
+var path = require("path");
+
+var hooks = [
+	"post-checkout"
+];
+
+hooks.forEach(function (hook) {
+    var hookInSourceControl = path.resolve(__dirname, "hooks", hook);
+
+    if (fs.existsSync(hookInSourceControl)) {
+        var hookInHiddenDirectory = path.resolve(__dirname, "..", ".git", "hooks", hook);
+
+        if (fs.existsSync(hookInHiddenDirectory)) {
+            fs.unlinkSync(hookInHiddenDirectory);
+        }
+
+        fs.linkSync(hookInSourceControl, hookInHiddenDirectory);
+    }
+});


### PR DESCRIPTION
@DanielRosenwasser commented in #4915 stating that he didn't like how he lost intellisense for the diagnostics file. Adding this git hook to your repo makes it so that it gets regenerated each time you checkout.

There's a `postinstall` to run the script to link it into `.git/hooks`, so a simple `npm install` (done as part of the existing setup) sets these up, too.