### PR TITLE
4699 fix

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -3,6 +3,6 @@ doc
 scripts
 src
 tests
-Jakefile
+Jakefile.js
 .travis.yml
 .settings/

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "build:tests": "jake tests",
         "clean": "jake clean",
         "jake": "jake",
-        "postinstall": "echo \"try {require('./scripts/link-hooks.js'); console.log('Git hooks installed.');} catch (e) {console.log('Script not run, git hooks not installed.')}\" | node"
+        "setup-hooks": "node scripts/lint-hooks.js"
     },
     "browser": {
         "buffer": false,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "build:tests": "jake tests",
         "clean": "jake clean",
         "jake": "jake",
-        "postinstall": "echo \"try {require('./scripts/link-hooks.js')} catch (e) {console.log('Script not found, git hooks not installed.')}\" | node"
+        "postinstall": "echo \"try {require('./scripts/link-hooks.js'); console.log('Git hooks installed.');} catch (e) {console.log('Script not run, git hooks not installed.')}\" | node"
     },
     "browser": {
         "buffer": false,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "build:tests": "jake tests",
         "clean": "jake clean",
         "jake": "jake",
-        "postinstall": "node scripts/link-hooks.js"
+        "postinstall": "echo \"try {require('./scripts/link-hooks.js')} catch (e) {console.log('Script not found, git hooks not installed.')}\" | node"
     },
     "browser": {
         "buffer": false,

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
         "build:tests": "jake tests",
         "clean": "jake clean",
         "jake": "jake",
-        "setup-hooks": "node scripts/lint-hooks.js"
+        "setup-hooks": "node scripts/link-hooks.js"
     },
     "browser": {
         "buffer": false,


### PR DESCRIPTION
Fixes #4699, remove git hook setting from postinstall, `npm run setup-hooks` must be run by hand after a dev install if you'd like the autoregeneration feature now. This should no longer impact package consumers.

Additionally, the `.npmignore` had `Jakefile` and not `Jakefile.js`, so the jakefile was in our package. I've corrected it.