### PR TITLE
record resolution for relative file name if file was found via absolu…

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -775,60 +775,62 @@ namespace ts {
 
         // Get source file from normalized fileName
         function findSourceFile(fileName: string, isDefaultLib: boolean, refFile?: SourceFile, refPos?: number, refEnd?: number): SourceFile {
-            let canonicalName = host.getCanonicalFileName(normalizeSlashes(fileName));
-            if (filesByName.contains(canonicalName)) {
+            if (filesByName.contains(fileName)) {
                 // We've already looked for this file, use cached result
-                return getSourceFileFromCache(fileName, canonicalName, /*useAbsolutePath*/ false);
+                return getSourceFileFromCache(fileName, /*useAbsolutePath*/ false);
             }
-            else {
-                let normalizedAbsolutePath = getNormalizedAbsolutePath(fileName, host.getCurrentDirectory());
-                let canonicalAbsolutePath = host.getCanonicalFileName(normalizedAbsolutePath);
-                if (filesByName.contains(canonicalAbsolutePath)) {
-                    return getSourceFileFromCache(normalizedAbsolutePath, canonicalAbsolutePath, /*useAbsolutePath*/ true);
-                }
-
-                // We haven't looked for this file, do so now and cache result
-                let file = host.getSourceFile(fileName, options.target, hostErrorMessage => {
-                    if (refFile !== undefined && refPos !== undefined && refEnd !== undefined) {
-                        fileProcessingDiagnostics.add(createFileDiagnostic(refFile, refPos, refEnd - refPos,
-                            Diagnostics.Cannot_read_file_0_Colon_1, fileName, hostErrorMessage));
-                    }
-                    else {
-                        fileProcessingDiagnostics.add(createCompilerDiagnostic(Diagnostics.Cannot_read_file_0_Colon_1, fileName, hostErrorMessage));
-                    }
-                });
-                filesByName.set(canonicalName, file);
-                if (file) {
-                    skipDefaultLib = skipDefaultLib || file.hasNoDefaultLib;
-
-                    // Set the source file for normalized absolute path
-                    filesByName.set(canonicalAbsolutePath, file);
-                    
-                    let basePath = getDirectoryPath(fileName);
-                    if (!options.noResolve) {
-                        processReferencedFiles(file, basePath);
-                    }
-
-                    // always process imported modules to record module name resolutions
-                    processImportedModules(file, basePath);
-
-                    if (isDefaultLib) {
-                        file.isDefaultLib = true;
-                        files.unshift(file);
-                    }
-                    else {
-                        files.push(file);
-                    }
-                }
-
+            
+            let normalizedAbsolutePath = getNormalizedAbsolutePath(fileName, host.getCurrentDirectory());
+            if (filesByName.contains(normalizedAbsolutePath)) {
+                const file = getSourceFileFromCache(normalizedAbsolutePath, /*useAbsolutePath*/ true);
+                // we don't have resolution for this relative file name but the match was found by absolute file name
+                // store resolution for relative name as well 
+                filesByName.set(fileName, file);
                 return file;
             }
 
-            function getSourceFileFromCache(fileName: string, canonicalName: string, useAbsolutePath: boolean): SourceFile {
-                let file = filesByName.get(canonicalName);
+            // We haven't looked for this file, do so now and cache result
+            let file = host.getSourceFile(fileName, options.target, hostErrorMessage => {
+                if (refFile !== undefined && refPos !== undefined && refEnd !== undefined) {
+                    fileProcessingDiagnostics.add(createFileDiagnostic(refFile, refPos, refEnd - refPos,
+                        Diagnostics.Cannot_read_file_0_Colon_1, fileName, hostErrorMessage));
+                }
+                else {
+                    fileProcessingDiagnostics.add(createCompilerDiagnostic(Diagnostics.Cannot_read_file_0_Colon_1, fileName, hostErrorMessage));
+                }
+            });
+            
+            filesByName.set(fileName, file);
+            if (file) {
+                skipDefaultLib = skipDefaultLib || file.hasNoDefaultLib;
+
+                // Set the source file for normalized absolute path
+                filesByName.set(normalizedAbsolutePath, file);
+                
+                let basePath = getDirectoryPath(fileName);
+                if (!options.noResolve) {
+                    processReferencedFiles(file, basePath);
+                }
+
+                // always process imported modules to record module name resolutions
+                processImportedModules(file, basePath);
+
+                if (isDefaultLib) {
+                    file.isDefaultLib = true;
+                    files.unshift(file);
+                }
+                else {
+                    files.push(file);
+                }
+            }
+
+            return file;
+
+            function getSourceFileFromCache(fileName: string, useAbsolutePath: boolean): SourceFile {
+                let file = filesByName.get(fileName);
                 if (file && host.useCaseSensitiveFileNames()) {
                     let sourceFileName = useAbsolutePath ? getNormalizedAbsolutePath(file.fileName, host.getCurrentDirectory()) : file.fileName;
-                    if (canonicalName !== sourceFileName) {
+                    if (normalizeSlashes(fileName) !== normalizeSlashes(sourceFileName)) {
                         if (refFile !== undefined && refPos !== undefined && refEnd !== undefined) {
                             fileProcessingDiagnostics.add(createFileDiagnostic(refFile, refPos, refEnd - refPos,
                                 Diagnostics.File_name_0_differs_from_already_included_file_name_1_only_in_casing, fileName, sourceFileName));

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -568,7 +568,9 @@ namespace ts {
         }
 
         function getSourceFile(fileName: string) {
-            return filesByName.get(fileName);
+            // first try to use file name as is to find file
+            // then try to convert relative file name to absolute and use it to retrieve source file
+            return filesByName.get(fileName) || filesByName.get(getNormalizedAbsolutePath(fileName, host.getCurrentDirectory()));
         }
 
         function getDiagnosticsHelper(

--- a/tests/cases/unittests/moduleResolution.ts
+++ b/tests/cases/unittests/moduleResolution.ts
@@ -163,4 +163,66 @@ module ts {
             ]);
         });
     });
+    
+    describe("Module resolution - relative imports", () => {
+       it("should find all modules", () => {
+           const options: CompilerOptions = { module: ModuleKind.CommonJS };
+           const files: Map<string> = {
+               "/a/b/c/first/shared.ts": `
+class A {}
+export = A`,
+               "/a/b/c/first/second/class_a.ts": `
+import Shared = require('../shared');
+import C = require('../../third/class_c');
+class B {}
+export = B;`,
+               "/a/b/c/third/class_c.ts":`
+import Shared = require('../first/shared');
+class C {}
+export = C;
+                `
+           };
+           const currentDirectory = "/a/b/c/first/second";
+           const host: CompilerHost = {
+               getSourceFile: (fileName: string, languageVersion: ScriptTarget) => {
+                   let path = normalizePath(combinePaths(currentDirectory, fileName));
+                   return hasProperty(files, path) ? createSourceFile(fileName, files[path], languageVersion) : undefined;
+               },
+                getDefaultLibFileName: () => "lib.d.ts",
+                writeFile: (fileName, content): void => { throw new Error("NotImplemented"); },
+                getCurrentDirectory: () => currentDirectory,
+                getCanonicalFileName: fileName => fileName.toLowerCase(),
+                getNewLine: () => "\r\n",
+                useCaseSensitiveFileNames: () => false,
+                fileExists: fileName => {
+                   let path = normalizePath(combinePaths(currentDirectory, fileName));
+                   return hasProperty(files, path);
+                },
+                readFile: (fileName): string => { throw new Error("NotImplemented"); }
+           };
+
+           const program = createProgram(["class_a.ts"], options, host);
+
+           assert.equal(program.getSourceFiles().length, 3);
+           const syntacticDiagnostics = program.getSyntacticDiagnostics();
+           assert.equal(syntacticDiagnostics.length, 0, `expect no syntactic diagnostics, got: ${JSON.stringify(syntacticDiagnostics.map(diagnosticToString))}`);
+           const semanticDiagnostics = program.getSemanticDiagnostics();
+           assert.equal(semanticDiagnostics.length, 0, `expect no semantic diagnostics, got: ${JSON.stringify(semanticDiagnostics.map(diagnosticToString))}`);
+       });
+       
+        function diagnosticToString(diagnostic: Diagnostic) {
+            let output = "";
+    
+            if (diagnostic.file) {
+                let loc = getLineAndCharacterOfPosition(diagnostic.file, diagnostic.start);
+    
+                output += `${ diagnostic.file.fileName }(${ loc.line + 1 },${ loc.character + 1 }): `;
+            }
+    
+            let category = DiagnosticCategory[diagnostic.category].toLowerCase();
+            output += `${ category } TS${ diagnostic.code }: ${ flattenDiagnosticMessageText(diagnostic.messageText, sys.newLine) }${ sys.newLine }`;
+    
+            return output;
+        }
+    });
 }

--- a/tests/cases/unittests/moduleResolution.ts
+++ b/tests/cases/unittests/moduleResolution.ts
@@ -208,6 +208,10 @@ export = C;
            assert.equal(syntacticDiagnostics.length, 0, `expect no syntactic diagnostics, got: ${JSON.stringify(syntacticDiagnostics.map(diagnosticToString))}`);
            const semanticDiagnostics = program.getSemanticDiagnostics();
            assert.equal(semanticDiagnostics.length, 0, `expect no semantic diagnostics, got: ${JSON.stringify(semanticDiagnostics.map(diagnosticToString))}`);
+
+           // try to get file using a relative name
+           const fileC = program.getSourceFile("../../../c/third/class_c.ts");
+           assert.isTrue(fileC !== undefined, `expected to get file by relative name, got ${fileC}`);
        });
        
         function diagnosticToString(diagnostic: Diagnostic) {


### PR DESCRIPTION
…te name. Fixes #2192.

The same file can be referenced using different relative names. For example:
```
 folder1
   |---folder2
   |      |---file1.ts
   |      |---folder3
```
if `folder3` is current directory then `file1.ts` can be referenced as `../file1.ts` or as `../../folder2/file1.ts`. Both these names are correct however now we'll record resolutions for both relative and and absolute names only for the first requested file i.e. `../file1.ts`. Subsequent request to find source file for `../../folder2/file1.ts` will fail to find it for relative name but will succeed to do it for absolute name and this result will be returned without recording association 'relative name' -> 'resolved file'. This means that calling `program.getSourceFile('../../folder2/file1.ts')` will return `undefined` though clearly this file is in the program. Solution: when lookup fails for relative name but succeeds for absolute - record association for relative as well. 

Also PR reduces nesting in `findSourceFile` and drops unnecessary calls to `CompilerHost.getCannonicalFileName` -  `FileMap` will do this internally anyways so there is no need to do it several times