### PR TITLE
using process.stdout.write

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -29,9 +29,6 @@ namespace ts {
     declare var process: any;
     declare var global: any;
     declare var __filename: string;
-    declare var Buffer: {  
-        new (str: string, encoding?: string): any;  
-    };
 
     declare class Enumerator {
         public atEnd(): boolean;
@@ -270,17 +267,9 @@ namespace ts {
                 args: process.argv.slice(2),
                 newLine: _os.EOL,
                 useCaseSensitiveFileNames: useCaseSensitiveFileNames,
-                write(s: string): void {  
-                    const buffer = new Buffer(s, "utf8");  
-                    let offset: number = 0;
-                    let toWrite: number = buffer.length;
-                    let written = 0;
-                    // 1 is a standard descriptor for stdout
-                    while ((written = _fs.writeSync(1, buffer, offset, toWrite)) < toWrite) {
-                        offset += written;
-                        toWrite -= written;
-                    }
-                },  
+                write(s: string): void {
+                    process.stdout.write(s);
+                },
                 readFile,
                 writeFile,
                 watchFile: (fileName, callback) => {


### PR DESCRIPTION
i'm using a typescript plugin for emacs -- [tide](https://github.com/ananthakumaran/tide). When the output is too large, the output string will alwayls be truncated and lead to a JSON parsing error. So i modified the NodeSystem write function.