### PR TITLE
Do not auto-generate names for anonymous class expressions

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4529,8 +4529,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
 
                 write("class");
 
-                // check if this is an "export default class" as it may not have a name. Do not emit the name if the class is decorated.
-                if ((node.name || !(node.flags & NodeFlags.Default)) && !thisNodeIsDecorated) {
+                // emit name if
+                // - node has a name
+                // - this is default export and target is not ES6 (for ES6 `export default` does not need to be compiled downlevel)                
+                if ((node.name || (node.flags & NodeFlags.Default && languageVersion < ScriptTarget.ES6)) && !thisNodeIsDecorated) {
                     write(" ");
                     emitDeclarationName(node);
                 }

--- a/tests/baselines/reference/classExpressionES63.js
+++ b/tests/baselines/reference/classExpressionES63.js
@@ -7,7 +7,7 @@ c.c;
 
 
 //// [classExpressionES63.js]
-let C = class class_1 extends class class_2 extends class class_3 {
+let C = class extends class extends class {
     constructor() {
         this.a = 1;
     }


### PR DESCRIPTION
Proposed fix for #4908 

Can anybody confirm if I'm on a right track?