### PR TITLE
tsc --watch should show more information(eg: time) when recompiling

### DIFF
--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -86,7 +86,6 @@ namespace ts {
 
         if (diagnostic.file) {
             let loc = getLineAndCharacterOfPosition(diagnostic.file, diagnostic.start);
-
             output += `${ diagnostic.file.fileName }(${ loc.line + 1 },${ loc.character + 1 }): `;
         }
 
@@ -102,6 +101,19 @@ namespace ts {
         }
     }
 
+    function reportWatchDiagnostic(diagnostic: Diagnostic) {
+        let output = new Date().toLocaleTimeString() + " - ";
+		
+        if (diagnostic.file) {
+            let loc = getLineAndCharacterOfPosition(diagnostic.file, diagnostic.start);
+            output += `${ diagnostic.file.fileName }(${ loc.line + 1 },${ loc.character + 1 }): `;
+        }
+
+        output += `${ flattenDiagnosticMessageText(diagnostic.messageText, sys.newLine) }${ sys.newLine }`;
+
+        sys.write(output);
+    }
+	
     function padLeft(s: string, length: number) {
         while (s.length < length) {
             s = " " + s;
@@ -218,7 +230,7 @@ namespace ts {
 
                     let result = readConfigFile(configFileName, sys.readFile);
                     if (result.error) {
-                        reportDiagnostic(result.error);
+                        reportWatchDiagnostic(result.error);
                         return sys.exit(ExitStatus.DiagnosticsPresent_OutputsSkipped);
                     }
 
@@ -247,7 +259,7 @@ namespace ts {
             }
 
             setCachedProgram(compileResult.program);
-            reportDiagnostic(createCompilerDiagnostic(Diagnostics.Compilation_complete_Watching_for_file_changes));
+            reportWatchDiagnostic(createCompilerDiagnostic(Diagnostics.Compilation_complete_Watching_for_file_changes));
         }
 
         function getSourceFile(fileName: string, languageVersion: ScriptTarget, onError?: (message: string) => void) {
@@ -309,7 +321,7 @@ namespace ts {
 
         function recompile() {
             timerHandle = undefined;
-            reportDiagnostic(createCompilerDiagnostic(Diagnostics.File_change_detected_Starting_incremental_compilation));
+            reportWatchDiagnostic(createCompilerDiagnostic(Diagnostics.File_change_detected_Starting_incremental_compilation));
             performCompilation();
         }
     }


### PR DESCRIPTION
Show date and time when using `--watch` flag

**Scenario 1:** 
```
c:\Work\TypeScript>node built/local/tsc.js --watch hello.ts
9/28/2015, 9:12:06 AM - message TS6042: Compilation complete. Watching for file changes.
9/28/2015, 9:12:12 AM - message TS6032: File change detected. Starting incremental compilation...
9/28/2015, 9:12:13 AM - message TS6042: Compilation complete. Watching for file changes.
```

**Scenario 2:**

```
c:\Work\TypeScript>node built/local/tsc.js --watch hello.ts
9/28/2015, 9:37:36 AM - message TS6042: Compilation complete. Watching for file changes.
9/28/2015, 9:37:39 AM - message TS6032: File change detected. Starting incremental compilation...
hello.ts(1,19): error TS1005: ')' expected.
9/28/2015, 9:37:40 AM - message TS6042: Compilation complete. Watching for file changes.
```
Note:  There is no date and time for the generated error. I'm not sure if it is needed.

Proposed fix for #4986