### PR TITLE
Get linter integrated into build/test process

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,12 +40,13 @@
     },
     "scripts": {
         "pretest": "jake tests",
-        "test": "jake runtests",
+        "test": "jake runtests && npm run lint",
         "build": "npm run build:compiler && npm run build:tests",
         "build:compiler": "jake local",
         "build:tests": "jake tests",
         "clean": "jake clean",
         "jake": "jake",
+        "lint": "jake lint",
         "setup-hooks": "node scripts/link-hooks.js"
     },
     "browser": {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2386,7 +2386,7 @@ namespace ts {
             if (isBindingPattern(declaration.parent)) {
                 return getTypeForBindingElement(<BindingElement>declaration);
             }
-            
+
             // Use type from type annotation if one is present
             if (declaration.type) {
                 return getTypeFromTypeNode(declaration.type);
@@ -2407,12 +2407,12 @@ namespace ts {
                     return type;
                 }
             }
-            
+
             // Use the type of the initializer expression if one is present
             if (declaration.initializer) {
                 return checkExpressionCached(declaration.initializer);
             }
-            
+
             // If it is a short-hand property assignment, use the type of the identifier
             if (declaration.kind === SyntaxKind.ShorthandPropertyAssignment) {
                 return checkIdentifier(<Identifier>declaration.name);
@@ -2507,10 +2507,10 @@ namespace ts {
                 // tools see the actual type.
                 return declaration.kind !== SyntaxKind.PropertyAssignment ? getWidenedType(type) : type;
             }
-            
+
             // Rest parameters default to type any[], other parameters default to type any
             type = declaration.dotDotDotToken ? anyArrayType : anyType;
-            
+
             // Report implicit any errors unless this is a private property within an ambient declaration
             if (reportErrors && compilerOptions.noImplicitAny) {
                 let root = getRootDeclaration(declaration);
@@ -4501,7 +4501,7 @@ namespace ts {
                 }
                 return t;
             };
-            
+
             mapper.context = context;
             return mapper;
         }
@@ -4935,7 +4935,7 @@ namespace ts {
                             // We know *exactly* where things went wrong when comparing the types.
                             // Use this property as the error node as this will be more helpful in
                             // reasoning about what went wrong.
-                            errorNode = prop.valueDeclaration
+                            errorNode = prop.valueDeclaration;
                             reportError(Diagnostics.Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1,
                                         symbolToString(prop),
                                         typeToString(target));
@@ -5240,7 +5240,7 @@ namespace ts {
 
                 if (kind === SignatureKind.Construct) {
                     // Only want to compare the construct signatures for abstractness guarantees.
-                    
+
                     // Because the "abstractness" of a class is the same across all construct signatures
                     // (internally we are checking the corresponding declaration), it is enough to perform 
                     // the check and report an error once over all pairs of source and target construct signatures.
@@ -6410,7 +6410,7 @@ namespace ts {
                         return getUnionType(assignableConstituents);
                     }
                 }
-                
+
                 if (isTypeAssignableTo(narrowedTypeCandidate, originalType)) {
                     // Narrow to the target type if it's assignable to the current type
                     return narrowedTypeCandidate;
@@ -6637,46 +6637,46 @@ namespace ts {
             let classType = classDeclaration && <InterfaceType>getDeclaredTypeOfSymbol(getSymbolOfNode(classDeclaration));
             let baseClassType = classType && getBaseTypes(classType)[0];
 
-            let container = getSuperContainer(node, /*includeFunctions*/ true);            
+            let container = getSuperContainer(node, /*includeFunctions*/ true);
             let needToCaptureLexicalThis = false;
 
-            if (!isCallExpression) {                    
+            if (!isCallExpression) {
                 // adjust the container reference in case if super is used inside arrow functions with arbitrary deep nesting                                    
                 while (container && container.kind === SyntaxKind.ArrowFunction) {
                     container = getSuperContainer(container, /*includeFunctions*/ true);
                     needToCaptureLexicalThis = languageVersion < ScriptTarget.ES6;
                 }
             }
-            
+
             let canUseSuperExpression = isLegalUsageOfSuperExpression(container);
             let nodeCheckFlag: NodeCheckFlags = 0;
-            
+
             // always set NodeCheckFlags for 'super' expression node            
-            if (canUseSuperExpression) {               
+            if (canUseSuperExpression) {
                 if ((container.flags & NodeFlags.Static) || isCallExpression) {
                     nodeCheckFlag = NodeCheckFlags.SuperStatic;
                 }
                 else {
                     nodeCheckFlag = NodeCheckFlags.SuperInstance;
                 }
-                
+
                 getNodeLinks(node).flags |= nodeCheckFlag;
-                
+
                 if (needToCaptureLexicalThis) {
                     // call expressions are allowed only in constructors so they should always capture correct 'this'
                     // super property access expressions can also appear in arrow functions -
                     // in this case they should also use correct lexical this
                     captureLexicalThis(node.parent, container);
-                }                                
+                }
             }
-            
+
             if (!baseClassType) {
                 if (!classDeclaration || !getClassExtendsHeritageClauseElement(classDeclaration)) {
                     error(node, Diagnostics.super_can_only_be_referenced_in_a_derived_class);
                 }
-                return unknownType;                
+                return unknownType;
             }
-            
+
             if (!canUseSuperExpression) {
                 if (container && container.kind === SyntaxKind.ComputedPropertyName) {
                     error(node, Diagnostics.super_cannot_be_referenced_in_a_computed_property_name);
@@ -6687,20 +6687,20 @@ namespace ts {
                 else {
                     error(node, Diagnostics.super_property_access_is_permitted_only_in_a_constructor_member_function_or_member_accessor_of_a_derived_class);
                 }
-                
+
                 return unknownType;
             }
-            
+
             if (container.kind === SyntaxKind.Constructor && isInConstructorArgumentInitializer(node, container)) {
                 // issue custom error message for super property access in constructor arguments (to be aligned with old compiler)
                 error(node, Diagnostics.super_cannot_be_referenced_in_constructor_arguments);
                 return unknownType;
             }
-            
+
             return nodeCheckFlag === NodeCheckFlags.SuperStatic
                 ? getBaseConstructorTypeOfClass(classType)
                 : baseClassType;
-            
+
             function isLegalUsageOfSuperExpression(container: Node): boolean {
                 if (!container) {
                     return false;
@@ -6736,9 +6736,9 @@ namespace ts {
                         }
                     }
                 }
-                
+
                 return false;
-            }            
+            }
         }
 
         // Return contextual type of parameter or undefined if no contextual type is available
@@ -7251,7 +7251,7 @@ namespace ts {
                     }
                 }
             }
-            return createArrayType(elementTypes.length ? getUnionType(elementTypes) : undefinedType)
+            return createArrayType(elementTypes.length ? getUnionType(elementTypes) : undefinedType);
         }
 
         function isNumericName(name: DeclarationName): boolean {
@@ -7522,7 +7522,7 @@ namespace ts {
                     // Maybe there's a string indexer?
                     let indexerType = getIndexTypeOfType(elementAttributesType, IndexKind.String);
                     if (indexerType) {
-                        correspondingPropType = indexerType
+                        correspondingPropType = indexerType;
                     }
                     else {
                         // If there's no corresponding property with this name, error
@@ -7590,7 +7590,8 @@ namespace ts {
             if (!links.resolvedSymbol) {
                 if (isJsxIntrinsicIdentifier(node.tagName)) {
                     links.resolvedSymbol = lookupIntrinsicTag(node);
-                } else {
+                }
+                else {
                     links.resolvedSymbol = lookupClassTag(node);
                 }
             }
@@ -8214,9 +8215,9 @@ namespace ts {
         function reorderCandidates(signatures: Signature[], result: Signature[]): void {
             let lastParent: Node;
             let lastSymbol: Symbol;
-            let cutoffIndex: number = 0;
+            let cutoffIndex = 0;
             let index: number;
-            let specializedIndex: number = -1;
+            let specializedIndex = -1;
             let spliceIndex: number;
             Debug.assert(!result.length);
             for (let signature of signatures) {
@@ -10815,7 +10816,7 @@ namespace ts {
                         }
                         if (!superCallStatement) {
                             error(node, Diagnostics.A_super_call_must_be_the_first_statement_in_the_constructor_when_a_class_contains_initialized_properties_or_has_parameter_properties);
-                        } 
+                        }
                         else {
                             // In such a required super call, it is a compile-time error for argument expressions to reference this.
                             markThisReferencesAsErrors(superCallStatement.expression);
@@ -11254,7 +11255,7 @@ namespace ts {
 
             // Spaces for anyting not declared a 'default export'.
             let nonDefaultExportedDeclarationSpaces = exportedDeclarationSpaces | nonExportedDeclarationSpaces;
-            
+
             let commonDeclarationSpacesForExportsAndLocals = exportedDeclarationSpaces & nonExportedDeclarationSpaces;
             let commonDeclarationSpacesForDefaultAndNonDefault = defaultExportedDeclarationSpaces & nonDefaultExportedDeclarationSpaces;
 
@@ -11262,7 +11263,7 @@ namespace ts {
                 // declaration spaces for exported and non-exported declarations intersect
                 for (let d of symbol.declarations) {
                     let declarationSpaces = getDeclarationSpaces(d);
-                    
+
                     // Only error on the declarations that conributed to the intersecting spaces.
                     if (declarationSpaces & commonDeclarationSpacesForDefaultAndNonDefault) {
                         error(d.name, Diagnostics.Merged_declaration_0_cannot_include_a_default_export_declaration_Consider_adding_a_separate_export_default_0_declaration_instead, declarationNameToString(d.name));
@@ -12089,7 +12090,7 @@ namespace ts {
 
         function checkGrammarDisallowedModifiersOnObjectLiteralExpressionMethod(node: Node) {
             // We only disallow modifier on a method declaration if it is a property of object-literal-expression
-            if (node.modifiers && node.parent.kind === SyntaxKind.ObjectLiteralExpression){
+            if (node.modifiers && node.parent.kind === SyntaxKind.ObjectLiteralExpression) {
                 if (isAsyncFunctionLike(node)) {
                     if (node.modifiers.length > 1) {
                         return grammarErrorOnFirstToken(node, Diagnostics.Modifiers_cannot_appear_here);
@@ -13138,7 +13139,7 @@ namespace ts {
                     }
 
                     const previousEnumMemberIsNonConstant = autoValue === undefined;
-                    
+
                     let initializer = member.initializer;
                     if (initializer) {
                         autoValue = computeConstantValueForEnumMemberInitializer(initializer, enumType, enumIsConst, ambient);
@@ -13177,7 +13178,7 @@ namespace ts {
                         }
                         else if (ambient) {
                             error(initializer, Diagnostics.In_ambient_enum_declarations_member_initializer_must_be_constant_expression);
-                        } 
+                        }
                         else {
                             // Only here do we need to check that the initializer is assignable to the enum type.
                             checkTypeAssignableTo(checkExpression(initializer), enumType, initializer, /*headMessage*/ undefined);
@@ -13477,7 +13478,7 @@ namespace ts {
             Debug.assert(node.kind === SyntaxKind.Identifier);
             return <Identifier>node;
         }
-        
+
         function checkExternalImportOrExportDeclaration(node: ImportDeclaration | ImportEqualsDeclaration | ExportDeclaration): boolean {
             let moduleName = getExternalModuleName(node);
             if (!nodeIsMissing(moduleName) && moduleName.kind !== SyntaxKind.StringLiteral) {
@@ -14104,11 +14105,11 @@ namespace ts {
                             }
                             break;
                     }
-                    
+
                     if (introducesArgumentsExoticObject(location)) {
                         copySymbol(argumentsSymbol, meaning);
                     }
-                    
+
                     memberFlags = location.flags;
                     location = location.parent;
                 }
@@ -14580,9 +14581,9 @@ namespace ts {
             }
             // const enums and modules that contain only const enums are not considered values from the emit perespective
             // unless 'preserveConstEnums' option is set to true
-            return target !== unknownSymbol && 
-                target && 
-                target.flags & SymbolFlags.Value && 
+            return target !== unknownSymbol &&
+                target &&
+                target.flags & SymbolFlags.Value &&
                 (compilerOptions.preserveConstEnums || !isConstEnumOrConstEnumOnlyModule(target));
         }
 
@@ -14653,7 +14654,7 @@ namespace ts {
         function isFunctionType(type: Type): boolean {
             return type.flags & TypeFlags.ObjectType && getSignaturesOfType(type, SignatureKind.Call).length > 0;
         }
-        
+
         function getTypeReferenceSerializationKind(typeName: EntityName): TypeReferenceSerializationKind {
             // Resolve the symbol as a value to ensure the type can be reached at runtime during emit.
             let valueSymbol = resolveEntityName(typeName, SymbolFlags.Value, /*ignoreErrors*/ true);
@@ -14666,7 +14667,7 @@ namespace ts {
             let typeSymbol = resolveEntityName(typeName, SymbolFlags.Type, /*ignoreErrors*/ true);
             // We might not be able to resolve type symbol so use unknown type in that case (eg error case)
             if (!typeSymbol) {
-                return TypeReferenceSerializationKind.ObjectType; 
+                return TypeReferenceSerializationKind.ObjectType;
             }
             let type = getDeclaredTypeOfSymbol(typeSymbol);
             if (type === unknownType) {

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -470,7 +470,7 @@ namespace ts {
                     fileNames = map(<string[]>json["files"], s => combinePaths(basePath, s));
                 }
                 else {
-                    errors.push(createCompilerDiagnostic(Diagnostics.Compiler_option_0_requires_a_value_of_type_1, "files", "Array"));                    
+                    errors.push(createCompilerDiagnostic(Diagnostics.Compiler_option_0_requires_a_value_of_type_1, "files", "Array"));
                 }
             }
             else {

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -52,7 +52,7 @@ namespace ts {
         function normalizeKey(key: string) {
             return getCanonicalFileName(normalizeSlashes(key));
         }
-        
+
         function clear() {
             files = {};
         }
@@ -117,7 +117,7 @@ namespace ts {
         return count;
     }
 
-    export function filter<T>(array: T[], f: (x: T) => boolean): T[]{
+    export function filter<T>(array: T[], f: (x: T) => boolean): T[] {
         let result: T[];
         if (array) {
             result = [];
@@ -130,7 +130,7 @@ namespace ts {
         return result;
     }
 
-    export function map<T, U>(array: T[], f: (x: T) => U): U[]{
+    export function map<T, U>(array: T[], f: (x: T) => U): U[] {
         let result: U[];
         if (array) {
             result = [];
@@ -148,7 +148,7 @@ namespace ts {
         return array1.concat(array2);
     }
 
-    export function deduplicate<T>(array: T[]): T[]{
+    export function deduplicate<T>(array: T[]): T[] {
         let result: T[];
         if (array) {
             result = [];
@@ -486,7 +486,7 @@ namespace ts {
         return text1 ? Comparison.GreaterThan : Comparison.LessThan;
     }
 
-    export function sortAndDeduplicateDiagnostics(diagnostics: Diagnostic[]): Diagnostic[]{
+    export function sortAndDeduplicateDiagnostics(diagnostics: Diagnostic[]): Diagnostic[] {
         return deduplicateSortedDiagnostics(diagnostics.sort(compareDiagnostics));
     }
 
@@ -795,7 +795,7 @@ namespace ts {
         VeryAggressive = 3,
     }
 
-    export module Debug {
+    export namespace Debug {
         let currentAssertionLevel = AssertionLevel.None;
 
         export function shouldAssert(level: AssertionLevel): boolean {

--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -180,9 +180,11 @@ namespace ts {
                 let nodeToCheck: Node;
                 if (declaration.kind === SyntaxKind.VariableDeclaration) {
                     nodeToCheck = declaration.parent.parent;
-                } else if (declaration.kind === SyntaxKind.NamedImports || declaration.kind === SyntaxKind.ImportSpecifier || declaration.kind === SyntaxKind.ImportClause) {
+                }
+                else if (declaration.kind === SyntaxKind.NamedImports || declaration.kind === SyntaxKind.ImportSpecifier || declaration.kind === SyntaxKind.ImportClause) {
                     Debug.fail("We should be getting ImportDeclaration instead to write");
-                } else {
+                }
+                else {
                     nodeToCheck = declaration;
                 }
 
@@ -1082,7 +1084,7 @@ namespace ts {
                 //      emitted: declare var c: number; // instead of declare var c:number, ;
                 let elements: Node[] = [];
                 for (let element of bindingPattern.elements) {
-                    if (element.kind !== SyntaxKind.OmittedExpression){
+                    if (element.kind !== SyntaxKind.OmittedExpression) {
                         elements.push(element);
                     }
                 }

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -7,6 +7,264 @@ namespace ts {
         return isExternalModule(sourceFile) || isDeclarationFile(sourceFile);
     }
 
+    type DependencyGroup = Array<ImportDeclaration | ImportEqualsDeclaration | ExportDeclaration>;
+
+    let entities: Map<number> = {
+        "quot": 0x0022,
+        "amp": 0x0026,
+        "apos": 0x0027,
+        "lt": 0x003C,
+        "gt": 0x003E,
+        "nbsp": 0x00A0,
+        "iexcl": 0x00A1,
+        "cent": 0x00A2,
+        "pound": 0x00A3,
+        "curren": 0x00A4,
+        "yen": 0x00A5,
+        "brvbar": 0x00A6,
+        "sect": 0x00A7,
+        "uml": 0x00A8,
+        "copy": 0x00A9,
+        "ordf": 0x00AA,
+        "laquo": 0x00AB,
+        "not": 0x00AC,
+        "shy": 0x00AD,
+        "reg": 0x00AE,
+        "macr": 0x00AF,
+        "deg": 0x00B0,
+        "plusmn": 0x00B1,
+        "sup2": 0x00B2,
+        "sup3": 0x00B3,
+        "acute": 0x00B4,
+        "micro": 0x00B5,
+        "para": 0x00B6,
+        "middot": 0x00B7,
+        "cedil": 0x00B8,
+        "sup1": 0x00B9,
+        "ordm": 0x00BA,
+        "raquo": 0x00BB,
+        "frac14": 0x00BC,
+        "frac12": 0x00BD,
+        "frac34": 0x00BE,
+        "iquest": 0x00BF,
+        "Agrave": 0x00C0,
+        "Aacute": 0x00C1,
+        "Acirc": 0x00C2,
+        "Atilde": 0x00C3,
+        "Auml": 0x00C4,
+        "Aring": 0x00C5,
+        "AElig": 0x00C6,
+        "Ccedil": 0x00C7,
+        "Egrave": 0x00C8,
+        "Eacute": 0x00C9,
+        "Ecirc": 0x00CA,
+        "Euml": 0x00CB,
+        "Igrave": 0x00CC,
+        "Iacute": 0x00CD,
+        "Icirc": 0x00CE,
+        "Iuml": 0x00CF,
+        "ETH": 0x00D0,
+        "Ntilde": 0x00D1,
+        "Ograve": 0x00D2,
+        "Oacute": 0x00D3,
+        "Ocirc": 0x00D4,
+        "Otilde": 0x00D5,
+        "Ouml": 0x00D6,
+        "times": 0x00D7,
+        "Oslash": 0x00D8,
+        "Ugrave": 0x00D9,
+        "Uacute": 0x00DA,
+        "Ucirc": 0x00DB,
+        "Uuml": 0x00DC,
+        "Yacute": 0x00DD,
+        "THORN": 0x00DE,
+        "szlig": 0x00DF,
+        "agrave": 0x00E0,
+        "aacute": 0x00E1,
+        "acirc": 0x00E2,
+        "atilde": 0x00E3,
+        "auml": 0x00E4,
+        "aring": 0x00E5,
+        "aelig": 0x00E6,
+        "ccedil": 0x00E7,
+        "egrave": 0x00E8,
+        "eacute": 0x00E9,
+        "ecirc": 0x00EA,
+        "euml": 0x00EB,
+        "igrave": 0x00EC,
+        "iacute": 0x00ED,
+        "icirc": 0x00EE,
+        "iuml": 0x00EF,
+        "eth": 0x00F0,
+        "ntilde": 0x00F1,
+        "ograve": 0x00F2,
+        "oacute": 0x00F3,
+        "ocirc": 0x00F4,
+        "otilde": 0x00F5,
+        "ouml": 0x00F6,
+        "divide": 0x00F7,
+        "oslash": 0x00F8,
+        "ugrave": 0x00F9,
+        "uacute": 0x00FA,
+        "ucirc": 0x00FB,
+        "uuml": 0x00FC,
+        "yacute": 0x00FD,
+        "thorn": 0x00FE,
+        "yuml": 0x00FF,
+        "OElig": 0x0152,
+        "oelig": 0x0153,
+        "Scaron": 0x0160,
+        "scaron": 0x0161,
+        "Yuml": 0x0178,
+        "fnof": 0x0192,
+        "circ": 0x02C6,
+        "tilde": 0x02DC,
+        "Alpha": 0x0391,
+        "Beta": 0x0392,
+        "Gamma": 0x0393,
+        "Delta": 0x0394,
+        "Epsilon": 0x0395,
+        "Zeta": 0x0396,
+        "Eta": 0x0397,
+        "Theta": 0x0398,
+        "Iota": 0x0399,
+        "Kappa": 0x039A,
+        "Lambda": 0x039B,
+        "Mu": 0x039C,
+        "Nu": 0x039D,
+        "Xi": 0x039E,
+        "Omicron": 0x039F,
+        "Pi": 0x03A0,
+        "Rho": 0x03A1,
+        "Sigma": 0x03A3,
+        "Tau": 0x03A4,
+        "Upsilon": 0x03A5,
+        "Phi": 0x03A6,
+        "Chi": 0x03A7,
+        "Psi": 0x03A8,
+        "Omega": 0x03A9,
+        "alpha": 0x03B1,
+        "beta": 0x03B2,
+        "gamma": 0x03B3,
+        "delta": 0x03B4,
+        "epsilon": 0x03B5,
+        "zeta": 0x03B6,
+        "eta": 0x03B7,
+        "theta": 0x03B8,
+        "iota": 0x03B9,
+        "kappa": 0x03BA,
+        "lambda": 0x03BB,
+        "mu": 0x03BC,
+        "nu": 0x03BD,
+        "xi": 0x03BE,
+        "omicron": 0x03BF,
+        "pi": 0x03C0,
+        "rho": 0x03C1,
+        "sigmaf": 0x03C2,
+        "sigma": 0x03C3,
+        "tau": 0x03C4,
+        "upsilon": 0x03C5,
+        "phi": 0x03C6,
+        "chi": 0x03C7,
+        "psi": 0x03C8,
+        "omega": 0x03C9,
+        "thetasym": 0x03D1,
+        "upsih": 0x03D2,
+        "piv": 0x03D6,
+        "ensp": 0x2002,
+        "emsp": 0x2003,
+        "thinsp": 0x2009,
+        "zwnj": 0x200C,
+        "zwj": 0x200D,
+        "lrm": 0x200E,
+        "rlm": 0x200F,
+        "ndash": 0x2013,
+        "mdash": 0x2014,
+        "lsquo": 0x2018,
+        "rsquo": 0x2019,
+        "sbquo": 0x201A,
+        "ldquo": 0x201C,
+        "rdquo": 0x201D,
+        "bdquo": 0x201E,
+        "dagger": 0x2020,
+        "Dagger": 0x2021,
+        "bull": 0x2022,
+        "hellip": 0x2026,
+        "permil": 0x2030,
+        "prime": 0x2032,
+        "Prime": 0x2033,
+        "lsaquo": 0x2039,
+        "rsaquo": 0x203A,
+        "oline": 0x203E,
+        "frasl": 0x2044,
+        "euro": 0x20AC,
+        "image": 0x2111,
+        "weierp": 0x2118,
+        "real": 0x211C,
+        "trade": 0x2122,
+        "alefsym": 0x2135,
+        "larr": 0x2190,
+        "uarr": 0x2191,
+        "rarr": 0x2192,
+        "darr": 0x2193,
+        "harr": 0x2194,
+        "crarr": 0x21B5,
+        "lArr": 0x21D0,
+        "uArr": 0x21D1,
+        "rArr": 0x21D2,
+        "dArr": 0x21D3,
+        "hArr": 0x21D4,
+        "forall": 0x2200,
+        "part": 0x2202,
+        "exist": 0x2203,
+        "empty": 0x2205,
+        "nabla": 0x2207,
+        "isin": 0x2208,
+        "notin": 0x2209,
+        "ni": 0x220B,
+        "prod": 0x220F,
+        "sum": 0x2211,
+        "minus": 0x2212,
+        "lowast": 0x2217,
+        "radic": 0x221A,
+        "prop": 0x221D,
+        "infin": 0x221E,
+        "ang": 0x2220,
+        "and": 0x2227,
+        "or": 0x2228,
+        "cap": 0x2229,
+        "cup": 0x222A,
+        "int": 0x222B,
+        "there4": 0x2234,
+        "sim": 0x223C,
+        "cong": 0x2245,
+        "asymp": 0x2248,
+        "ne": 0x2260,
+        "equiv": 0x2261,
+        "le": 0x2264,
+        "ge": 0x2265,
+        "sub": 0x2282,
+        "sup": 0x2283,
+        "nsub": 0x2284,
+        "sube": 0x2286,
+        "supe": 0x2287,
+        "oplus": 0x2295,
+        "otimes": 0x2297,
+        "perp": 0x22A5,
+        "sdot": 0x22C5,
+        "lceil": 0x2308,
+        "rceil": 0x2309,
+        "lfloor": 0x230A,
+        "rfloor": 0x230B,
+        "lang": 0x2329,
+        "rang": 0x232A,
+        "loz": 0x25CA,
+        "spades": 0x2660,
+        "clubs": 0x2663,
+        "hearts": 0x2665,
+        "diams": 0x2666
+    };
+
     // Flags enum to track count of temp variables and a few dedicated names
     const enum TempFlags {
         Auto      = 0x00000000,  // No preferred name
@@ -189,7 +447,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
 
             /** If removeComments is true, no leading-comments needed to be emitted **/
             let emitLeadingCommentsOfPosition = compilerOptions.removeComments ? function (pos: number) { } : emitLeadingCommentsOfPositionWorker;
-            
+
             let moduleEmitDelegates: Map<(node: SourceFile, startIndex: number) => void> = {
                 [ModuleKind.ES6]: emitES6Module,
                 [ModuleKind.AMD]: emitAMDModule,
@@ -695,7 +953,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                         }
                     }
                 }
-                
+
                 function emitNodeWithCommentsAndWithSourcemap(node: Node) {
                     emitNodeConsideringCommentsOption(node, emitNodeWithSourceMap);
                 }
@@ -1190,7 +1448,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
 
                 function emitJsxElement(openingNode: JsxOpeningLikeElement, children?: JsxChild[]) {
                     let syntheticReactRef = <Identifier>createSynthesizedNode(SyntaxKind.Identifier);
-                    syntheticReactRef.text = 'React';
+                    syntheticReactRef.text = "React";
                     syntheticReactRef.parent = openingNode;
 
                     // Call React.createElement(tag, ...
@@ -1525,8 +1783,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                         else if (declaration.kind === SyntaxKind.ImportSpecifier) {
                             // Identifier references named import
                             write(getGeneratedNameForNode(<ImportDeclaration>declaration.parent.parent.parent));
-                            var name =  (<ImportSpecifier>declaration).propertyName || (<ImportSpecifier>declaration).name;
-                            var identifier = getSourceTextOfNodeFromSourceFile(currentSourceFile, name);
+                            let name =  (<ImportSpecifier>declaration).propertyName || (<ImportSpecifier>declaration).name;
+                            let identifier = getSourceTextOfNodeFromSourceFile(currentSourceFile, name);
                             if (languageVersion === ScriptTarget.ES3 && identifier === "default") {
                                 write(`["default"]`);
                             }
@@ -2069,15 +2327,15 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 }
                 return false;
             }
-            
+
             function tryGetConstEnumValue(node: Node): number {
                 if (compilerOptions.isolatedModules) {
                     return undefined;
                 }
-                
-                return node.kind === SyntaxKind.PropertyAccessExpression || node.kind === SyntaxKind.ElementAccessExpression 
+
+                return node.kind === SyntaxKind.PropertyAccessExpression || node.kind === SyntaxKind.ElementAccessExpression
                     ? resolver.getConstantValue(<PropertyAccessExpression | ElementAccessExpression>node)
-                    : undefined
+                    : undefined;
             }
 
             // Returns 'true' if the code was actually indented, false otherwise.
@@ -3147,7 +3405,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 if (modulekind === ModuleKind.System) {
                     return;
                 }
-                
+
                 if (!exportEquals && exportSpecifiers && hasProperty(exportSpecifiers, name.text)) {
                     for (let specifier of exportSpecifiers[name.text]) {
                         writeLine();
@@ -3162,14 +3420,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     }
                 }
             }
-            
+
             function emitExportSpecifierInSystemModule(specifier: ExportSpecifier): void {
                 Debug.assert(modulekind === ModuleKind.System);
 
                 if (!resolver.getReferencedValueDeclaration(specifier.propertyName || specifier.name) && !resolver.isValueAliasDeclaration(specifier) ) {
                     return;
                 }
-                
+
                 writeLine();
                 emitStart(specifier.name);
                 write(`${exportFunctionForFile}("`);
@@ -5402,14 +5660,14 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     emitExportMemberAssignments(<Identifier>node.name);
                 }
             }
-            
+
             /*
              * Some bundlers (SystemJS builder) sometimes want to rename dependencies. 
              * Here we check if alternative name was provided for a given moduleName and return it if possible. 
              */
             function tryRenameExternalModule(moduleName: LiteralExpression): string {
                 if (currentSourceFile.renamedDependencies && hasProperty(currentSourceFile.renamedDependencies, moduleName.text)) {
-                    return `"${currentSourceFile.renamedDependencies[moduleName.text]}"`
+                    return `"${currentSourceFile.renamedDependencies[moduleName.text]}"`;
                 }
                 return undefined;
             }
@@ -5731,7 +5989,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                             emitContainingModuleName(node);
                             if (languageVersion === ScriptTarget.ES3) {
                                 write("[\"default\"] = ");
-                            } else {
+                            }
+                            else {
                                 write(".default = ");
                             }
                             emit(node.expression);
@@ -5824,7 +6083,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
             function getExternalModuleNameText(importNode: ImportDeclaration | ExportDeclaration | ImportEqualsDeclaration): string {
                 let moduleName = getExternalModuleName(importNode);
                 if (moduleName.kind === SyntaxKind.StringLiteral) {
-                    return tryRenameExternalModule(<LiteralExpression>moduleName) || getLiteralText(<LiteralExpression>moduleName); 
+                    return tryRenameExternalModule(<LiteralExpression>moduleName) || getLiteralText(<LiteralExpression>moduleName);
                 }
 
                 return undefined;
@@ -6226,7 +6485,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
 
             function emitSetters(exportStarFunction: string, dependencyGroups: DependencyGroup[]) {
                 write("setters:[");
-                
+
                 for (let i = 0; i < dependencyGroups.length; ++i) {
                     if (i !== 0) {
                         write(",");
@@ -6234,17 +6493,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
 
                     writeLine();
                     increaseIndent();
-                    
+
                     let group = dependencyGroups[i];
-                    
+
                     // derive a unique name for parameter from the first named entry in the group
                     let parameterName = makeUniqueName(forEach(group, getLocalNameForExternalImport) || "");
                     write(`function (${parameterName}) {`);
                     increaseIndent();
-                    
-                    for(let entry of group) {
+
+                    for (let entry of group) {
                         let importVariableName = getLocalNameForExternalImport(entry) || "";
-                        
+
                         switch (entry.kind) {
                             case SyntaxKind.ImportDeclaration:
                                 if (!(<ImportDeclaration>entry).importClause) {
@@ -6280,7 +6539,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                                             write(",");
                                             writeLine();
                                         }
-                                        
+
                                         let e = (<ExportDeclaration>entry).exportClause.elements[i];
                                         write(`"`);
                                         emitNodeWithCommentsAndWithoutSourcemap(e.name);
@@ -6290,7 +6549,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                                     }
                                     decreaseIndent();
                                     writeLine();
-                                    write("});")
+                                    write("});");
                                 }
                                 else {
                                     writeLine();
@@ -6325,7 +6584,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                         // - import declarations are not emitted since they are already handled in setters
                         // - export declarations with module specifiers are not emitted since they were already written in setters
                         // - export declarations without module specifiers are emitted preserving the order
-                        case SyntaxKind.FunctionDeclaration:                        
+                        case SyntaxKind.FunctionDeclaration:
                         case SyntaxKind.ImportDeclaration:
                             continue;
                         case SyntaxKind.ExportDeclaration:
@@ -6345,15 +6604,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                         default:
                             writeLine();
                             emit(statement);
-                    }                    
+                    }
                 }
                 decreaseIndent();
                 writeLine();
                 write("}"); // execute
             }
-            
-            type DependencyGroup = Array<ImportDeclaration | ImportEqualsDeclaration | ExportDeclaration>;
-            
+
             function emitSystemModule(node: SourceFile, startIndex: number): void {
                 collectExternalModuleInfo(node);
                 // System modules has the following shape
@@ -6373,7 +6630,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     write(`"${node.moduleName}", `);
                 }
                 write("[");
-                
+
                 let groupIndices: Map<number> = {};
                 let dependencyGroups: DependencyGroup[] = [];
 
@@ -6393,7 +6650,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     if (i !== 0) {
                         write(", ");
                     }
-                    
+
                     write(text);
                 }
                 write(`], function(${exportFunctionForFile}) {`);
@@ -7104,7 +7361,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 if (compilerOptions.removeComments) {
                     return;
                 }
-            
+
                 let leadingComments: CommentRange[];
                 if (isEmittedNode) {
                     leadingComments = getLeadingCommentsToEmit(node);
@@ -7237,7 +7494,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     }
                 }
             }
-            
+
             function emitShebang() {
                 let shebang = getShebang(currentSourceFile.text);
                 if (shebang) {
@@ -7253,261 +7510,5 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 writeDeclarationFile(jsFilePath, sourceFile, host, resolver, diagnostics);
             }
         }
-    }
-
-    var entities: Map<number> = {
-        "quot": 0x0022,
-        "amp": 0x0026,
-        "apos": 0x0027,
-        "lt": 0x003C,
-        "gt": 0x003E,
-        "nbsp": 0x00A0,
-        "iexcl": 0x00A1,
-        "cent": 0x00A2,
-        "pound": 0x00A3,
-        "curren": 0x00A4,
-        "yen": 0x00A5,
-        "brvbar": 0x00A6,
-        "sect": 0x00A7,
-        "uml": 0x00A8,
-        "copy": 0x00A9,
-        "ordf": 0x00AA,
-        "laquo": 0x00AB,
-        "not": 0x00AC,
-        "shy": 0x00AD,
-        "reg": 0x00AE,
-        "macr": 0x00AF,
-        "deg": 0x00B0,
-        "plusmn": 0x00B1,
-        "sup2": 0x00B2,
-        "sup3": 0x00B3,
-        "acute": 0x00B4,
-        "micro": 0x00B5,
-        "para": 0x00B6,
-        "middot": 0x00B7,
-        "cedil": 0x00B8,
-        "sup1": 0x00B9,
-        "ordm": 0x00BA,
-        "raquo": 0x00BB,
-        "frac14": 0x00BC,
-        "frac12": 0x00BD,
-        "frac34": 0x00BE,
-        "iquest": 0x00BF,
-        "Agrave": 0x00C0,
-        "Aacute": 0x00C1,
-        "Acirc": 0x00C2,
-        "Atilde": 0x00C3,
-        "Auml": 0x00C4,
-        "Aring": 0x00C5,
-        "AElig": 0x00C6,
-        "Ccedil": 0x00C7,
-        "Egrave": 0x00C8,
-        "Eacute": 0x00C9,
-        "Ecirc": 0x00CA,
-        "Euml": 0x00CB,
-        "Igrave": 0x00CC,
-        "Iacute": 0x00CD,
-        "Icirc": 0x00CE,
-        "Iuml": 0x00CF,
-        "ETH": 0x00D0,
-        "Ntilde": 0x00D1,
-        "Ograve": 0x00D2,
-        "Oacute": 0x00D3,
-        "Ocirc": 0x00D4,
-        "Otilde": 0x00D5,
-        "Ouml": 0x00D6,
-        "times": 0x00D7,
-        "Oslash": 0x00D8,
-        "Ugrave": 0x00D9,
-        "Uacute": 0x00DA,
-        "Ucirc": 0x00DB,
-        "Uuml": 0x00DC,
-        "Yacute": 0x00DD,
-        "THORN": 0x00DE,
-        "szlig": 0x00DF,
-        "agrave": 0x00E0,
-        "aacute": 0x00E1,
-        "acirc": 0x00E2,
-        "atilde": 0x00E3,
-        "auml": 0x00E4,
-        "aring": 0x00E5,
-        "aelig": 0x00E6,
-        "ccedil": 0x00E7,
-        "egrave": 0x00E8,
-        "eacute": 0x00E9,
-        "ecirc": 0x00EA,
-        "euml": 0x00EB,
-        "igrave": 0x00EC,
-        "iacute": 0x00ED,
-        "icirc": 0x00EE,
-        "iuml": 0x00EF,
-        "eth": 0x00F0,
-        "ntilde": 0x00F1,
-        "ograve": 0x00F2,
-        "oacute": 0x00F3,
-        "ocirc": 0x00F4,
-        "otilde": 0x00F5,
-        "ouml": 0x00F6,
-        "divide": 0x00F7,
-        "oslash": 0x00F8,
-        "ugrave": 0x00F9,
-        "uacute": 0x00FA,
-        "ucirc": 0x00FB,
-        "uuml": 0x00FC,
-        "yacute": 0x00FD,
-        "thorn": 0x00FE,
-        "yuml": 0x00FF,
-        "OElig": 0x0152,
-        "oelig": 0x0153,
-        "Scaron": 0x0160,
-        "scaron": 0x0161,
-        "Yuml": 0x0178,
-        "fnof": 0x0192,
-        "circ": 0x02C6,
-        "tilde": 0x02DC,
-        "Alpha": 0x0391,
-        "Beta": 0x0392,
-        "Gamma": 0x0393,
-        "Delta": 0x0394,
-        "Epsilon": 0x0395,
-        "Zeta": 0x0396,
-        "Eta": 0x0397,
-        "Theta": 0x0398,
-        "Iota": 0x0399,
-        "Kappa": 0x039A,
-        "Lambda": 0x039B,
-        "Mu": 0x039C,
-        "Nu": 0x039D,
-        "Xi": 0x039E,
-        "Omicron": 0x039F,
-        "Pi": 0x03A0,
-        "Rho": 0x03A1,
-        "Sigma": 0x03A3,
-        "Tau": 0x03A4,
-        "Upsilon": 0x03A5,
-        "Phi": 0x03A6,
-        "Chi": 0x03A7,
-        "Psi": 0x03A8,
-        "Omega": 0x03A9,
-        "alpha": 0x03B1,
-        "beta": 0x03B2,
-        "gamma": 0x03B3,
-        "delta": 0x03B4,
-        "epsilon": 0x03B5,
-        "zeta": 0x03B6,
-        "eta": 0x03B7,
-        "theta": 0x03B8,
-        "iota": 0x03B9,
-        "kappa": 0x03BA,
-        "lambda": 0x03BB,
-        "mu": 0x03BC,
-        "nu": 0x03BD,
-        "xi": 0x03BE,
-        "omicron": 0x03BF,
-        "pi": 0x03C0,
-        "rho": 0x03C1,
-        "sigmaf": 0x03C2,
-        "sigma": 0x03C3,
-        "tau": 0x03C4,
-        "upsilon": 0x03C5,
-        "phi": 0x03C6,
-        "chi": 0x03C7,
-        "psi": 0x03C8,
-        "omega": 0x03C9,
-        "thetasym": 0x03D1,
-        "upsih": 0x03D2,
-        "piv": 0x03D6,
-        "ensp": 0x2002,
-        "emsp": 0x2003,
-        "thinsp": 0x2009,
-        "zwnj": 0x200C,
-        "zwj": 0x200D,
-        "lrm": 0x200E,
-        "rlm": 0x200F,
-        "ndash": 0x2013,
-        "mdash": 0x2014,
-        "lsquo": 0x2018,
-        "rsquo": 0x2019,
-        "sbquo": 0x201A,
-        "ldquo": 0x201C,
-        "rdquo": 0x201D,
-        "bdquo": 0x201E,
-        "dagger": 0x2020,
-        "Dagger": 0x2021,
-        "bull": 0x2022,
-        "hellip": 0x2026,
-        "permil": 0x2030,
-        "prime": 0x2032,
-        "Prime": 0x2033,
-        "lsaquo": 0x2039,
-        "rsaquo": 0x203A,
-        "oline": 0x203E,
-        "frasl": 0x2044,
-        "euro": 0x20AC,
-        "image": 0x2111,
-        "weierp": 0x2118,
-        "real": 0x211C,
-        "trade": 0x2122,
-        "alefsym": 0x2135,
-        "larr": 0x2190,
-        "uarr": 0x2191,
-        "rarr": 0x2192,
-        "darr": 0x2193,
-        "harr": 0x2194,
-        "crarr": 0x21B5,
-        "lArr": 0x21D0,
-        "uArr": 0x21D1,
-        "rArr": 0x21D2,
-        "dArr": 0x21D3,
-        "hArr": 0x21D4,
-        "forall": 0x2200,
-        "part": 0x2202,
-        "exist": 0x2203,
-        "empty": 0x2205,
-        "nabla": 0x2207,
-        "isin": 0x2208,
-        "notin": 0x2209,
-        "ni": 0x220B,
-        "prod": 0x220F,
-        "sum": 0x2211,
-        "minus": 0x2212,
-        "lowast": 0x2217,
-        "radic": 0x221A,
-        "prop": 0x221D,
-        "infin": 0x221E,
-        "ang": 0x2220,
-        "and": 0x2227,
-        "or": 0x2228,
-        "cap": 0x2229,
-        "cup": 0x222A,
-        "int": 0x222B,
-        "there4": 0x2234,
-        "sim": 0x223C,
-        "cong": 0x2245,
-        "asymp": 0x2248,
-        "ne": 0x2260,
-        "equiv": 0x2261,
-        "le": 0x2264,
-        "ge": 0x2265,
-        "sub": 0x2282,
-        "sup": 0x2283,
-        "nsub": 0x2284,
-        "sube": 0x2286,
-        "supe": 0x2287,
-        "oplus": 0x2295,
-        "otimes": 0x2297,
-        "perp": 0x22A5,
-        "sdot": 0x22C5,
-        "lceil": 0x2308,
-        "rceil": 0x2309,
-        "lfloor": 0x230A,
-        "rfloor": 0x230B,
-        "lang": 0x2329,
-        "rang": 0x232A,
-        "loz": 0x25CA,
-        "spades": 0x2660,
-        "clubs": 0x2663,
-        "hearts": 0x2665,
-        "diams": 0x2666
     }
 }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -425,7 +425,7 @@ namespace ts {
     // Implement the parser as a singleton module.  We do this for perf reasons because creating
     // parser instances can actually be expensive enough to impact us on projects with many source
     // files.
-    module Parser {
+    namespace Parser {
         // Share a single scanner across all calls to parse a source file.  This helps speed things
         // up by avoiding the cost of creating/compiling scanners over and over again.
         const scanner = createScanner(ScriptTarget.Latest, /*skipTrivia*/ true);
@@ -518,7 +518,7 @@ namespace ts {
         //
         // Note: any errors at the end of the file that do not precede a regular node, should get
         // attached to the EOF token.
-        let parseErrorBeforeNextFinishedNode: boolean = false;
+        let parseErrorBeforeNextFinishedNode = false;
 
         export function parseSourceFile(fileName: string, _sourceText: string, languageVersion: ScriptTarget, _syntaxCursor: IncrementalParser.SyntaxCursor, setParentNodes?: boolean): SourceFile {
             initializeState(fileName, _sourceText, languageVersion, _syntaxCursor);
@@ -3940,7 +3940,8 @@ namespace ts {
                 forOfStatement.expression = allowInAnd(parseAssignmentExpressionOrHigher);
                 parseExpected(SyntaxKind.CloseParenToken);
                 forOrForInOrForOfStatement = forOfStatement;
-            } else {
+            }
+            else {
                 let forStatement = <ForStatement>createNode(SyntaxKind.ForStatement, pos);
                 forStatement.initializer = initializer;
                 parseExpected(SyntaxKind.SemicolonToken);
@@ -4827,7 +4828,7 @@ namespace ts {
 
             return finishNode(node);
         }
-        
+
         function parseNameOfClassDeclarationOrExpression(): Identifier {
             // implements is a future reserved word so
             // 'class implements' might mean either
@@ -4838,11 +4839,11 @@ namespace ts {
                 ? parseIdentifier()
                 : undefined;
         }
-        
+
         function isImplementsClause() {
-            return token === SyntaxKind.ImplementsKeyword && lookAhead(nextTokenIsIdentifierOrKeyword)
+            return token === SyntaxKind.ImplementsKeyword && lookAhead(nextTokenIsIdentifierOrKeyword);
         }
-        
+
         function parseHeritageClauses(isClassHeritageClause: boolean): NodeArray<HeritageClause> {
             // ClassTail[Yield,Await] : (Modified) See 14.5
             //      ClassHeritage[?Yield,?Await]opt { ClassBody[?Yield,?Await]opt }
@@ -5317,7 +5318,7 @@ namespace ts {
             Unknown
         }
 
-        export module JSDocParser {
+        export namespace JSDocParser {
             export function isJSDocType() {
                 switch (token) {
                     case SyntaxKind.AsteriskToken:
@@ -5962,7 +5963,7 @@ namespace ts {
         }
     }
 
-    module IncrementalParser {
+    namespace IncrementalParser {
         export function updateSourceFile(sourceFile: SourceFile, newText: string, textChangeRange: TextChangeRange, aggressiveChecks: boolean): SourceFile {
             aggressiveChecks = aggressiveChecks || Debug.shouldAssert(AssertionLevel.Aggressive);
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -9,9 +9,9 @@ namespace ts {
     /* @internal */ export let ioWriteTime = 0;
 
     /** The version of the TypeScript compiler release */
-    
+
     let emptyArray: any[] = [];
-    
+
     export const version = "1.7.0";
 
     export function findConfigFile(searchPath: string): string {
@@ -29,36 +29,36 @@ namespace ts {
         }
         return undefined;
     }
-    
+
     export function resolveTripleslashReference(moduleName: string, containingFile: string): string {
         let basePath = getDirectoryPath(containingFile);
         let referencedFileName = isRootedDiskPath(moduleName) ? moduleName : combinePaths(basePath, moduleName);
         return normalizePath(referencedFileName);
     }
-    
+
     export function resolveModuleName(moduleName: string, containingFile: string, compilerOptions: CompilerOptions, host: ModuleResolutionHost): ResolvedModuleWithFailedLookupLocations {
-        let moduleResolution = compilerOptions.moduleResolution !== undefined 
+        let moduleResolution = compilerOptions.moduleResolution !== undefined
             ? compilerOptions.moduleResolution
             : compilerOptions.module === ModuleKind.CommonJS ? ModuleResolutionKind.NodeJs : ModuleResolutionKind.Classic;
-            
+
         switch (moduleResolution) {
             case ModuleResolutionKind.NodeJs: return nodeModuleNameResolver(moduleName, containingFile, host);
             case ModuleResolutionKind.Classic: return classicNameResolver(moduleName, containingFile, compilerOptions, host);
         }
     }
-    
+
     export function nodeModuleNameResolver(moduleName: string, containingFile: string, host: ModuleResolutionHost): ResolvedModuleWithFailedLookupLocations {
-        let containingDirectory = getDirectoryPath(containingFile);        
+        let containingDirectory = getDirectoryPath(containingFile);
 
         if (getRootLength(moduleName) !== 0 || nameStartsWithDotSlashOrDotDotSlash(moduleName)) {
             let failedLookupLocations: string[] = [];
             let candidate = normalizePath(combinePaths(containingDirectory, moduleName));
             let resolvedFileName = loadNodeModuleFromFile(candidate, /* loadOnlyDts */ false, failedLookupLocations, host);
-            
+
             if (resolvedFileName) {
                 return { resolvedModule: { resolvedFileName }, failedLookupLocations };
             }
-            
+
             resolvedFileName = loadNodeModuleFromDirectory(candidate, /* loadOnlyDts */ false, failedLookupLocations, host);
             return resolvedFileName
                 ? { resolvedModule: { resolvedFileName }, failedLookupLocations }
@@ -68,7 +68,7 @@ namespace ts {
             return loadModuleFromNodeModules(moduleName, containingDirectory, host);
         }
     }
-    
+
     function loadNodeModuleFromFile(candidate: string, loadOnlyDts: boolean, failedLookupLocation: string[], host: ModuleResolutionHost): string {
         if (loadOnlyDts) {
             return tryLoad(".d.ts");
@@ -76,7 +76,7 @@ namespace ts {
         else {
             return forEach(supportedExtensions, tryLoad);
         }
-        
+
         function tryLoad(ext: string): string {
             let fileName = fileExtensionIs(candidate, ext) ? candidate : candidate + ext;
             if (host.fileExists(fileName)) {
@@ -88,13 +88,13 @@ namespace ts {
             }
         }
     }
-    
+
     function loadNodeModuleFromDirectory(candidate: string, loadOnlyDts: boolean, failedLookupLocation: string[], host: ModuleResolutionHost): string {
         let packageJsonPath = combinePaths(candidate, "package.json");
         if (host.fileExists(packageJsonPath)) {
-            
+
             let jsonContent: { typings?: string };
-            
+
             try {
                 let jsonText = host.readFile(packageJsonPath);
                 jsonContent = jsonText ? <{ typings?: string }>JSON.parse(jsonText) : { typings: undefined };
@@ -103,7 +103,7 @@ namespace ts {
                 // gracefully handle if readFile fails or returns not JSON 
                 jsonContent = { typings: undefined };
             }
-            
+
             if (jsonContent.typings) {
                 let result = loadNodeModuleFromFile(normalizePath(combinePaths(candidate, jsonContent.typings)), loadOnlyDts, failedLookupLocation, host);
                 if (result) {
@@ -115,12 +115,12 @@ namespace ts {
             // record package json as one of failed lookup locations - in the future if this file will appear it will invalidate resolution results
             failedLookupLocation.push(packageJsonPath);
         }
-        
+
         return loadNodeModuleFromFile(combinePaths(candidate, "index"), loadOnlyDts, failedLookupLocation, host);
     }
-    
+
     function loadModuleFromNodeModules(moduleName: string, directory: string, host: ModuleResolutionHost): ResolvedModuleWithFailedLookupLocations {
-        let failedLookupLocations: string[] = []; 
+        let failedLookupLocations: string[] = [];
         directory = normalizeSlashes(directory);
         while (true) {
             let baseName = getBaseFileName(directory);
@@ -131,36 +131,36 @@ namespace ts {
                 if (result) {
                     return { resolvedModule: { resolvedFileName: result, isExternalLibraryImport: true }, failedLookupLocations };
                 }
-                
+
                 result = loadNodeModuleFromDirectory(candidate, /* loadOnlyDts */ true, failedLookupLocations, host);
                 if (result) {
                     return { resolvedModule: { resolvedFileName: result, isExternalLibraryImport: true }, failedLookupLocations };
                 }
             }
-            
+
             let parentPath = getDirectoryPath(directory);
             if (parentPath === directory) {
                 break;
             }
-            
+
             directory = parentPath;
         }
-        
+
         return { resolvedModule: undefined, failedLookupLocations };
     }
-    
+
     function nameStartsWithDotSlashOrDotDotSlash(name: string) {
         let i = name.lastIndexOf("./", 1);
         return i === 0 || (i === 1 && name.charCodeAt(0) === CharacterCodes.dot);
     }
 
     export function classicNameResolver(moduleName: string, containingFile: string, compilerOptions: CompilerOptions, host: ModuleResolutionHost): ResolvedModuleWithFailedLookupLocations {
-        
+
         // module names that contain '!' are used to reference resources and are not resolved to actual files on disk
-        if (moduleName.indexOf('!') != -1) {
+        if (moduleName.indexOf("!") != -1) {
             return { resolvedModule: undefined, failedLookupLocations: [] };
         }
-        
+
         let searchPath = getDirectoryPath(containingFile);
         let searchName: string;
 
@@ -175,7 +175,7 @@ namespace ts {
                     // 'logical not' handles both undefined and None cases
                     return undefined;
                 }
-                
+
                 let candidate = searchName + extension;
                 if (host.fileExists(candidate)) {
                     return candidate;
@@ -277,8 +277,7 @@ namespace ts {
         }
 
         const newLine = getNewLineCharacter(options);
-        
-    
+
         return {
             getSourceFile,
             getDefaultLibFileName: options => combinePaths(getDirectoryPath(normalizePath(sys.getExecutingFilePath())), getDefaultLibFileName(options)),
@@ -347,26 +346,26 @@ namespace ts {
         let start = new Date().getTime();
 
         host = host || createCompilerHost(options);
-        
+
         const resolveModuleNamesWorker = host.resolveModuleNames
             ? ((moduleNames: string[], containingFile: string) => host.resolveModuleNames(moduleNames, containingFile))
             : ((moduleNames: string[], containingFile: string) => map(moduleNames, moduleName => resolveModuleName(moduleName, containingFile, options, host).resolvedModule));
 
         let filesByName = createFileMap<SourceFile>(fileName => host.getCanonicalFileName(fileName));
-        
+
         if (oldProgram) {
             // check properties that can affect structure of the program or module resolution strategy
             // if any of these properties has changed - structure cannot be reused
             let oldOptions = oldProgram.getCompilerOptions();
-            if ((oldOptions.module !== options.module) || 
-                (oldOptions.noResolve !== options.noResolve) || 
-                (oldOptions.target !== options.target) || 
+            if ((oldOptions.module !== options.module) ||
+                (oldOptions.noResolve !== options.noResolve) ||
+                (oldOptions.target !== options.target) ||
                 (oldOptions.noLib !== options.noLib) ||
                 (oldOptions.jsx !== options.jsx)) {
                 oldProgram = undefined;
             }
         }
-        
+
         if (!tryReuseStructureFromOldProgram()) {
             forEach(rootNames, name => processRootFile(name, false));
             // Do not process the default library if:
@@ -427,7 +426,7 @@ namespace ts {
             if (!oldProgram) {
                 return false;
             }
-            
+
             Debug.assert(!oldProgram.structureIsReused);
 
             // there is an old program, check if we can reuse its structure
@@ -435,7 +434,7 @@ namespace ts {
             if (!arrayIsEqualTo(oldRootNames, rootNames)) {
                 return false;
             }
-            
+
             // check if program source files has changed in the way that can affect structure of the program
             let newSourceFiles: SourceFile[] = [];
             let modifiedSourceFiles: SourceFile[] = [];
@@ -445,7 +444,7 @@ namespace ts {
                     return false;
                 }
 
-                if (oldSourceFile !== newSourceFile) {                    
+                if (oldSourceFile !== newSourceFile) {
                     if (oldSourceFile.hasNoDefaultLib !== newSourceFile.hasNoDefaultLib) {
                         // value of no-default-lib has changed
                         // this will affect if default library is injected into the list of files
@@ -457,14 +456,14 @@ namespace ts {
                         // tripleslash references has changed
                         return false;
                     }
-                    
+
                     // check imports
                     collectExternalModuleReferences(newSourceFile);
                     if (!arrayIsEqualTo(oldSourceFile.imports, newSourceFile.imports, moduleNameIsEqualTo)) {
                         // imports has changed
                         return false;
                     }
-                    
+
                     if (resolveModuleNamesWorker) {
                         let moduleNames = map(newSourceFile.imports, name => name.text);
                         let resolutions = resolveModuleNamesWorker(moduleNames, newSourceFile.fileName);
@@ -473,11 +472,11 @@ namespace ts {
                             let newResolution = resolutions[i];
                             let oldResolution = getResolvedModule(oldSourceFile, moduleNames[i]);
                             let resolutionChanged = oldResolution
-                                ? !newResolution || 
+                                ? !newResolution ||
                                   oldResolution.resolvedFileName !== newResolution.resolvedFileName ||
                                   !!oldResolution.isExternalLibraryImport !== !!newResolution.isExternalLibraryImport
                                 : newResolution;
-                                
+
                             if (resolutionChanged) {
                                 return false;
                             }
@@ -491,24 +490,24 @@ namespace ts {
                     // file has no changes - use it as is
                     newSourceFile = oldSourceFile;
                 }
-                
+
                 // if file has passed all checks it should be safe to reuse it
                 newSourceFiles.push(newSourceFile);
             }
-            
+
             // update fileName -> file mapping
             for (let file of newSourceFiles) {
                 filesByName.set(file.fileName, file);
             }
-            
+
             files = newSourceFiles;
             fileProcessingDiagnostics = oldProgram.getFileProcessingDiagnostics();
-            
+
             for (let modifiedFile of modifiedSourceFiles) {
                 fileProcessingDiagnostics.reattachFileDiagnostics(modifiedFile);
             }
             oldProgram.structureIsReused = true;
-                
+
             return true;
         }
 
@@ -554,7 +553,7 @@ namespace ts {
             // This is because in the -out scenario all files need to be emitted, and therefore all
             // files need to be type checked. And the way to specify that all files need to be type
             // checked is to not pass the file to getEmitResolver.
-            let emitResolver = getDiagnosticsProducingTypeChecker().getEmitResolver((options.outFile || options.out)? undefined : sourceFile);
+            let emitResolver = getDiagnosticsProducingTypeChecker().getEmitResolver((options.outFile || options.out) ? undefined : sourceFile);
 
             let start = new Date().getTime();
 
@@ -658,7 +657,7 @@ namespace ts {
 
         function getOptionsDiagnostics(): Diagnostic[] {
             let allDiagnostics: Diagnostic[] = [];
-            addRange(allDiagnostics, fileProcessingDiagnostics.getGlobalDiagnostics())
+            addRange(allDiagnostics, fileProcessingDiagnostics.getGlobalDiagnostics());
             addRange(allDiagnostics, programDiagnostics.getGlobalDiagnostics());
             return sortAndDeduplicateDiagnostics(allDiagnostics);
         }
@@ -675,28 +674,28 @@ namespace ts {
 
         function processRootFile(fileName: string, isDefaultLib: boolean) {
             processSourceFile(normalizePath(fileName), isDefaultLib);
-        }        
-    
+        }
+
         function fileReferenceIsEqualTo(a: FileReference, b: FileReference): boolean {
             return a.fileName === b.fileName;
         }
-        
+
         function moduleNameIsEqualTo(a: LiteralExpression, b: LiteralExpression): boolean {
             return a.text === b.text;
         }
-        
+
         function collectExternalModuleReferences(file: SourceFile): void {
             if (file.imports) {
                 return;
             }
-            
+
             let imports: LiteralExpression[];
             for (let node of file.statements) {
                 collect(node, /* allowRelativeModuleNames */ true);
             }
 
             file.imports = imports || emptyArray;
-            
+
             function collect(node: Node, allowRelativeModuleNames: boolean): void {
                 switch (node.kind) {
                     case SyntaxKind.ImportDeclaration:
@@ -781,7 +780,7 @@ namespace ts {
                 // We've already looked for this file, use cached result
                 return getSourceFileFromCache(fileName, /*useAbsolutePath*/ false);
             }
-            
+
             let normalizedAbsolutePath = getNormalizedAbsolutePath(fileName, host.getCurrentDirectory());
             if (filesByName.contains(normalizedAbsolutePath)) {
                 const file = getSourceFileFromCache(normalizedAbsolutePath, /*useAbsolutePath*/ true);
@@ -801,14 +800,14 @@ namespace ts {
                     fileProcessingDiagnostics.add(createCompilerDiagnostic(Diagnostics.Cannot_read_file_0_Colon_1, fileName, hostErrorMessage));
                 }
             });
-            
+
             filesByName.set(fileName, file);
             if (file) {
                 skipDefaultLib = skipDefaultLib || file.hasNoDefaultLib;
 
                 // Set the source file for normalized absolute path
                 filesByName.set(normalizedAbsolutePath, file);
-                
+
                 let basePath = getDirectoryPath(fileName);
                 if (!options.noResolve) {
                     processReferencedFiles(file, basePath);
@@ -852,7 +851,7 @@ namespace ts {
                 processSourceFile(referencedFileName, /* isDefaultLib */ false, file, ref.pos, ref.end);
             });
         }
-       
+
         function processImportedModules(file: SourceFile, basePath: string) {
             collectExternalModuleReferences(file);
             if (file.imports.length) {
@@ -866,11 +865,11 @@ namespace ts {
                         const importedFile = findModuleSourceFile(resolution.resolvedFileName, file.imports[i]);
                         if (importedFile && resolution.isExternalLibraryImport) {
                             if (!isExternalModule(importedFile)) {
-                                let start = getTokenPosOfNode(file.imports[i], file)
+                                let start = getTokenPosOfNode(file.imports[i], file);
                                 fileProcessingDiagnostics.add(createFileDiagnostic(file, start, file.imports[i].end - start, Diagnostics.Exported_external_package_typings_file_0_is_not_a_module_Please_contact_the_package_author_to_update_the_package_definition, importedFile.fileName));
                             }
                             else if (!fileExtensionIs(importedFile.fileName, ".d.ts")) {
-                                let start = getTokenPosOfNode(file.imports[i], file)
+                                let start = getTokenPosOfNode(file.imports[i], file);
                                 fileProcessingDiagnostics.add(createFileDiagnostic(file, start, file.imports[i].end - start, Diagnostics.Exported_external_package_typings_can_only_be_in_d_ts_files_Please_contact_the_package_author_to_update_the_package_definition));
                             }
                             else if (importedFile.referencedFiles.length) {

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -224,7 +224,7 @@ namespace ts {
         }
 
         // Perform binary search in one of the Unicode range maps
-        let lo: number = 0;
+        let lo = 0;
         let hi: number = map.length;
         let mid: number;
 
@@ -657,7 +657,7 @@ namespace ts {
     export function getTrailingCommentRanges(text: string, pos: number): CommentRange[] {
         return getCommentRanges(text, pos, /*trailing*/ true);
     }
-    
+
     /** Optionally, get the shebang */
     export function getShebang(text: string): string {
         return shebangTriviaRegex.test(text)

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -29,8 +29,8 @@ namespace ts {
     declare var process: any;
     declare var global: any;
     declare var __filename: string;
-    declare var Buffer: {  
-        new (str: string, encoding?: string): any;  
+    declare var Buffer: {
+        new (str: string, encoding?: string): any;
     };
 
     declare class Enumerator {
@@ -116,7 +116,7 @@ namespace ts {
                 return path.toLowerCase();
             }
 
-            function getNames(collection: any): string[]{
+            function getNames(collection: any): string[] {
                 let result: string[] = [];
                 for (let e = new Enumerator(collection); !e.atEnd(); e.moveNext()) {
                     result.push(e.item().Name);
@@ -270,9 +270,9 @@ namespace ts {
                 args: process.argv.slice(2),
                 newLine: _os.EOL,
                 useCaseSensitiveFileNames: useCaseSensitiveFileNames,
-                write(s: string): void {  
-                    const buffer = new Buffer(s, "utf8");  
-                    let offset: number = 0;
+                write(s: string): void {
+                    const buffer = new Buffer(s, "utf8");
+                    let offset = 0;
                     let toWrite: number = buffer.length;
                     let written = 0;
                     // 1 is a standard descriptor for stdout
@@ -280,7 +280,7 @@ namespace ts {
                         offset += written;
                         toWrite -= written;
                     }
-                },  
+                },
                 readFile,
                 writeFile,
                 watchFile: (fileName, callback) => {

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -103,7 +103,7 @@ namespace ts {
 
     function reportWatchDiagnostic(diagnostic: Diagnostic) {
         let output = new Date().toLocaleTimeString() + " - ";
-		
+
         if (diagnostic.file) {
             let loc = getLineAndCharacterOfPosition(diagnostic.file, diagnostic.start);
             output += `${ diagnostic.file.fileName }(${ loc.line + 1 },${ loc.character + 1 }): `;
@@ -113,7 +113,7 @@ namespace ts {
 
         sys.write(output);
     }
-	
+
     function padLeft(s: string, length: number) {
         while (s.length < length) {
             s = " " + s;
@@ -373,7 +373,7 @@ namespace ts {
 
         function compileProgram(): ExitStatus {
             let diagnostics: Diagnostic[];
-            
+
             // First get and report any syntactic errors.
             diagnostics = program.getSyntacticDiagnostics();
 
@@ -509,7 +509,7 @@ namespace ts {
 
     function writeConfigFile(options: CompilerOptions, fileNames: string[]) {
         let currentDirectory = sys.getCurrentDirectory();
-        let file = combinePaths(currentDirectory, 'tsconfig.json');
+        let file = combinePaths(currentDirectory, "tsconfig.json");
         if (sys.fileExists(file)) {
             reportDiagnostic(createCompilerDiagnostic(Diagnostics.A_tsconfig_json_file_is_already_defined_at_Colon_0, file));
         }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1245,7 +1245,7 @@ namespace ts {
         moduleName: string;
         referencedFiles: FileReference[];
         languageVariant: LanguageVariant;
-        
+
         // this map is used by transpiler to supply alternative names for dependencies (i.e. in case of bundling)
         /* @internal */
         renamedDependencies?: Map<string>;
@@ -1313,12 +1313,12 @@ namespace ts {
     }
 
     export interface Program extends ScriptReferenceHost {
-        
+
         /**
          * Get a list of root file names that were passed to a 'createProgram'
          */
-        getRootFileNames(): string[]
-        
+        getRootFileNames(): string[];
+
         /**
          * Get a list of files in the program
          */
@@ -1600,7 +1600,7 @@ namespace ts {
         getConstantValue(node: EnumMember | PropertyAccessExpression | ElementAccessExpression): number;
         getBlockScopedVariableId(node: Identifier): number;
         getReferencedValueDeclaration(reference: Identifier): Declaration;
-        getTypeReferenceSerializationKind(typeName: EntityName): TypeReferenceSerializationKind; 
+        getTypeReferenceSerializationKind(typeName: EntityName): TypeReferenceSerializationKind;
         isOptionalParameter(node: ParameterDeclaration): boolean;
     }
 
@@ -2025,12 +2025,12 @@ namespace ts {
         Error,
         Message,
     }
-    
+
     export const enum ModuleResolutionKind {
         Classic  = 1,
         NodeJs  = 2
     }
-    
+
     export interface CompilerOptions {
         allowNonTsExtensions?: boolean;
         charset?: string;
@@ -2072,7 +2072,7 @@ namespace ts {
         experimentalDecorators?: boolean;
         experimentalAsyncFunctions?: boolean;
         emitDecoratorMetadata?: boolean;
-        moduleResolution?: ModuleResolutionKind
+        moduleResolution?: ModuleResolutionKind;
         /* @internal */ stripInternal?: boolean;
 
         // Skip checking lib.d.ts to help speed up tests.
@@ -2287,15 +2287,15 @@ namespace ts {
         byteOrderMark = 0xFEFF,
         tab = 0x09,                   // \t
         verticalTab = 0x0B,           // \v
-    }   
-    
+    }
+
     export interface ModuleResolutionHost {
         fileExists(fileName: string): boolean;
         // readFile function is used to read arbitrary text files on disk, i.e. when resolution procedure needs the content of 'package.json'
         // to determine location of bundled typings for node module 
         readFile(fileName: string): string;
     }
-    
+
     export interface ResolvedModule {
         resolvedFileName: string;
         /*
@@ -2306,12 +2306,12 @@ namespace ts {
          */
         isExternalLibraryImport?: boolean;
     }
-    
+
     export interface ResolvedModuleWithFailedLookupLocations {
         resolvedModule: ResolvedModule;
         failedLookupLocations: string[];
     }
-    
+
     export interface CompilerHost extends ModuleResolutionHost {
         getSourceFile(fileName: string, languageVersion: ScriptTarget, onError?: (message: string) => void): SourceFile;
         getCancellationToken?(): CancellationToken;
@@ -2321,7 +2321,7 @@ namespace ts {
         getCanonicalFileName(fileName: string): string;
         useCaseSensitiveFileNames(): boolean;
         getNewLine(): string;
-        
+
         /*
          * CompilerHost must either implement resolveModuleNames (in case if it wants to be completely in charge of 
          * module name resolution) or provide implementation for methods from ModuleResolutionHost (in this case compiler 
@@ -2360,7 +2360,7 @@ namespace ts {
         // operation caused diagnostics to be returned by storing and comparing the return value
         // of this method before/after the operation is performed.
         getModificationCount(): number;
-        
+
         /* @internal */ reattachFileDiagnostics(newFile: SourceFile): void;
     }
 }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -99,8 +99,8 @@ namespace ts {
         }
 
         return true;
-    }    
-   
+    }
+
     export function hasResolvedModule(sourceFile: SourceFile, moduleNameText: string): boolean {
         return sourceFile.resolvedModules && hasProperty(sourceFile.resolvedModules, moduleNameText);
     }
@@ -996,7 +996,7 @@ namespace ts {
         }
         return false;
     }
-    
+
     export function isExternalModuleNameRelative(moduleName: string): boolean {
         // TypeScript 1.0 spec (April 2014): 11.2.1
         // An external module name is "relative" if the first term is "." or "..".
@@ -1526,12 +1526,12 @@ namespace ts {
         function getModificationCount() {
             return modificationCount;
         }
-        
+
         function reattachFileDiagnostics(newFile: SourceFile): void {
             if (!hasProperty(fileDiagnostics, newFile.fileName)) {
                 return;
             }
-            
+
             for (let diagnostic of fileDiagnostics[newFile.fileName]) {
                 diagnostic.file = newFile;
             }

--- a/src/harness/compilerRunner.ts
+++ b/src/harness/compilerRunner.ts
@@ -1,6 +1,7 @@
 /// <reference path="harness.ts" />
 /// <reference path="runnerbase.ts" />
 /// <reference path="typeWriter.ts" />
+/* tslint:disable:no-null */
 
 const enum CompilerTestType {
     Conformance,
@@ -32,7 +33,8 @@ class CompilerBaselineRunner extends RunnerBase {
         }
         else if (testType === CompilerTestType.Test262) {
             this.testSuiteName = "test262";
-        } else {
+        }
+        else {
             this.testSuiteName = "compiler"; // default to this for historical reasons
         }
         this.basePath += "/" + this.testSuiteName;
@@ -82,7 +84,8 @@ class CompilerBaselineRunner extends RunnerBase {
                             otherFiles.push({ unitName: rootDir + unit.name, content: unit.content });
                         }
                     });
-                } else {
+                }
+                else {
                     toBeCompiled = units.map(unit => {
                         return { unitName: rootDir + unit.name, content: unit.content };
                     });
@@ -193,7 +196,8 @@ class CompilerBaselineRunner extends RunnerBase {
 
                         if (jsCode.length > 0) {
                             return tsCode + "\r\n\r\n" + jsCode;
-                        } else {
+                        }
+                        else {
                             return null;
                         }
                     });

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -18,8 +18,9 @@
 /// <reference path="harnessLanguageService.ts" />
 /// <reference path="harness.ts" />
 /// <reference path="fourslashRunner.ts" />
+/* tslint:disable:no-null */
 
-module FourSlash {
+namespace FourSlash {
     ts.disableIncrementalParsing = false;
 
     // Represents a parsed source file with metadata
@@ -258,7 +259,8 @@ module FourSlash {
                 this.inputFiles[file.fileName] = file.content;
                 if (!startResolveFileRef && file.fileOptions[metadataOptionNames.resolveReference] === "true") {
                     startResolveFileRef = file;
-                } else if (startResolveFileRef) {
+                }
+                else if (startResolveFileRef) {
                     // If entry point for resolving file references is already specified, report duplication error
                     throw new Error("There exists a Fourslash file which has resolveReference flag specified; remove duplicated resolveReference flag");
                 }
@@ -361,7 +363,8 @@ module FourSlash {
             this.currentCaretPosition = Math.min(this.currentCaretPosition, this.getFileContent(this.activeFile.fileName).length);
             if (count > 0) {
                 this.scenarioActions.push(`<MoveCaretRight NumberOfChars="${count}" />`);
-            } else {
+            }
+            else {
                 this.scenarioActions.push(`<MoveCaretLeft NumberOfChars="${-count}" />`);
             }
         }
@@ -436,7 +439,8 @@ module FourSlash {
                 predicate = function (errorMinChar: number, errorLimChar: number, startPos: number, endPos: number) {
                     return ((errorMinChar >= startPos) && (errorLimChar >= startPos)) ? true : false;
                 };
-            } else {
+            }
+            else {
                 predicate = function (errorMinChar: number, errorLimChar: number, startPos: number, endPos: number) {
                     return ((errorMinChar <= startPos) && (errorLimChar <= startPos)) ? true : false;
                 };
@@ -476,7 +480,8 @@ module FourSlash {
         private printErrorLog(expectErrors: boolean, errors: ts.Diagnostic[]) {
             if (expectErrors) {
                 Harness.IO.log("Expected error not found.  Error list is:");
-            } else {
+            }
+            else {
                 Harness.IO.log("Unexpected error(s) found.  Error list is:");
             }
 
@@ -549,10 +554,12 @@ module FourSlash {
                 if (negative) {
                     this.verifyMemberListIsEmpty(false);
                     return;
-                } else {
+                }
+                else {
                     this.scenarioActions.push("<ShowCompletionList />");
                 }
-            } else {
+            }
+            else {
                 this.scenarioActions.push("<ShowCompletionList />");
                 this.scenarioActions.push(`<VerifyCompletionItemsCount Count="${expectedCount}" ${(negative ? "ExpectsFailure=\"true\" " : "")}/>`);
             }
@@ -595,14 +602,16 @@ module FourSlash {
         public verifyMemberListIsEmpty(negative: boolean) {
             if (negative) {
                 this.scenarioActions.push("<ShowCompletionList />");
-            } else {
+            }
+            else {
                 this.scenarioActions.push("<ShowCompletionList ExpectsFailure=\"true\" />");
             }
 
             let members = this.getMemberListAtCaret();
             if ((!members || members.entries.length === 0) && negative) {
                 this.raiseError("Member list is empty at Caret");
-            } else if ((members && members.entries.length !== 0) && !negative) {
+            }
+            else if ((members && members.entries.length !== 0) && !negative) {
 
                 let errorMsg = "\n" + "Member List contains: [" + members.entries[0].name;
                 for (let i = 1; i < members.entries.length; i++) {
@@ -639,7 +648,8 @@ module FourSlash {
 
             if ((completions && !completions.isNewIdentifierLocation) && !negative) {
                 this.raiseError("Expected builder completion entry");
-            } else if ((completions && completions.isNewIdentifierLocation) && negative) {
+            }
+            else if ((completions && completions.isNewIdentifierLocation) && negative) {
                 this.raiseError("Un-expected builder completion entry");
             }
         }
@@ -832,7 +842,8 @@ module FourSlash {
                 if (expectedDocumentation != undefined) {
                     assert.notEqual(actualQuickInfoDocumentation, expectedDocumentation, this.messageAtLastKnownMarker("quick info doc comment"));
                 }
-            } else {
+            }
+            else {
                 if (expectedText !== undefined) {
                     assert.equal(actualQuickInfoText, expectedText, this.messageAtLastKnownMarker("quick info text"));
                 }
@@ -1014,7 +1025,8 @@ module FourSlash {
                 if (!actual) {
                     this.raiseError("Expected signature help to be present, but it wasn't");
                 }
-            } else {
+            }
+            else {
                 if (actual) {
                     this.raiseError(`Expected no signature help, but got "${JSON.stringify(actual)}"`);
                 }
@@ -1371,7 +1383,8 @@ module FourSlash {
         public type(text: string) {
             if (text === "") {
                 this.taoInvalidReason = "Test used empty-insert workaround.";
-            } else {
+            }
+            else {
                 this.scenarioActions.push(`<InsertText><![CDATA[${text}]]></InsertText>`);
             }
 
@@ -1398,7 +1411,8 @@ module FourSlash {
                 if (ch === "(" || ch === ",") {
                     /* Signature help*/
                     this.languageService.getSignatureHelpItems(this.activeFile.fileName, offset);
-                } else if (prevChar === " " && /A-Za-z_/.test(ch)) {
+                }
+                else if (prevChar === " " && /A-Za-z_/.test(ch)) {
                     /* Completions */
                     this.languageService.getCompletionsAtPosition(this.activeFile.fileName, offset);
                 }
@@ -1547,7 +1561,8 @@ module FourSlash {
                         if (marker.position < limChar) {
                             // Marker is inside the edit - mark it as invalidated (?)
                             marker.position = -1;
-                        } else {
+                        }
+                        else {
                             // Move marker back/forward by the appropriate amount
                             marker.position += (minChar - limChar) + text.length;
                         }
@@ -1568,7 +1583,8 @@ module FourSlash {
         public goToDefinition(definitionIndex: number) {
             if (definitionIndex === 0) {
                 this.scenarioActions.push("<GoToDefinition />");
-            } else {
+            }
+            else {
                 this.taoInvalidReason = "GoToDefinition not supported for non-zero definition indices";
             }
 
@@ -1650,7 +1666,8 @@ module FourSlash {
             if (negative) {
                 assert.notEqual(actualDefinitionName, expectedName, this.messageAtLastKnownMarker("Definition Info Name"));
                 assert.notEqual(actualDefinitionContainerName, expectedContainerName, this.messageAtLastKnownMarker("Definition Info Container Name"));
-            } else {
+            }
+            else {
                 assert.equal(actualDefinitionName, expectedName, this.messageAtLastKnownMarker("Definition Info Name"));
                 assert.equal(actualDefinitionContainerName, expectedContainerName, this.messageAtLastKnownMarker("Definition Info Container Name"));
             }
@@ -1897,22 +1914,22 @@ module FourSlash {
 
             if (expected === undefined) {
                 if (actual) {
-                    this.raiseError(name + ' failed - expected no template but got {newText: \"' + actual.newText + '\" caretOffset: ' + actual.caretOffset + '}');
+                    this.raiseError(name + " failed - expected no template but got {newText: \"" + actual.newText + "\" caretOffset: " + actual.caretOffset + "}");
                 }
 
                 return;
             }
             else {
                 if (actual === undefined) {
-                    this.raiseError(name + ' failed - expected the template {newText: \"' + actual.newText + '\" caretOffset: ' + actual.caretOffset + '} but got nothing instead');
+                    this.raiseError(name + " failed - expected the template {newText: \"" + actual.newText + "\" caretOffset: " + actual.caretOffset + "} but got nothing instead");
                 }
 
                 if (actual.newText !== expected.newText) {
-                    this.raiseError(name + ' failed - expected insertion:\n' + this.clarifyNewlines(expected.newText) + '\nactual insertion:\n' + this.clarifyNewlines(actual.newText));
+                    this.raiseError(name + " failed - expected insertion:\n" + this.clarifyNewlines(expected.newText) + "\nactual insertion:\n" + this.clarifyNewlines(actual.newText));
                 }
 
                 if (actual.caretOffset !== expected.caretOffset) {
-                    this.raiseError(name + ' failed - expected caretOffset: ' + expected.caretOffset + ',\nactual caretOffset:' + actual.caretOffset);
+                    this.raiseError(name + " failed - expected caretOffset: " + expected.caretOffset + ",\nactual caretOffset:" + actual.caretOffset);
                 }
             }
         }
@@ -1936,9 +1953,11 @@ module FourSlash {
             let actualMatchPosition = -1;
             if (bracePosition === actual[0].start) {
                 actualMatchPosition = actual[1].start;
-            } else if (bracePosition === actual[1].start) {
+            }
+            else if (bracePosition === actual[1].start) {
                 actualMatchPosition = actual[0].start;
-            } else {
+            }
+            else {
                 this.raiseError(`verifyMatchingBracePosition failed - could not find the brace position: ${bracePosition} in the returned list: (${actual[0].start},${ts.textSpanEnd(actual[0])}) and (${actual[1].start},${ts.textSpanEnd(actual[1])})`);
             }
 
@@ -2108,7 +2127,7 @@ module FourSlash {
             let occurrences = this.getOccurrencesAtCurrentPosition();
 
             if (!occurrences || occurrences.length === 0) {
-                this.raiseError('verifyOccurrencesAtPositionListContains failed - found 0 references, expected at least one.');
+                this.raiseError("verifyOccurrencesAtPositionListContains failed - found 0 references, expected at least one.");
             }
 
             for (let occurrence of occurrences) {
@@ -2140,12 +2159,12 @@ module FourSlash {
         }
 
         public verifyDocumentHighlightsAtPositionListContains(fileName: string, start: number, end: number, fileNamesToSearch: string[], kind?: string) {
-            this.taoInvalidReason = 'verifyDocumentHighlightsAtPositionListContains NYI';
+            this.taoInvalidReason = "verifyDocumentHighlightsAtPositionListContains NYI";
 
             let documentHighlights = this.getDocumentHighlightsAtCurrentPosition(fileNamesToSearch);
 
             if (!documentHighlights || documentHighlights.length === 0) {
-                this.raiseError('verifyDocumentHighlightsAtPositionListContains failed - found 0 highlights, expected at least one.');
+                this.raiseError("verifyDocumentHighlightsAtPositionListContains failed - found 0 highlights, expected at least one.");
             }
 
             for (let documentHighlight of documentHighlights) {
@@ -2168,15 +2187,15 @@ module FourSlash {
         }
 
         public verifyDocumentHighlightsAtPositionListCount(expectedCount: number, fileNamesToSearch: string[]) {
-            this.taoInvalidReason = 'verifyDocumentHighlightsAtPositionListCount NYI';
+            this.taoInvalidReason = "verifyDocumentHighlightsAtPositionListCount NYI";
 
             let documentHighlights = this.getDocumentHighlightsAtCurrentPosition(fileNamesToSearch);
-            let actualCount = documentHighlights 
-                ? documentHighlights.reduce((currentCount, { highlightSpans }) => currentCount + highlightSpans.length, 0) 
+            let actualCount = documentHighlights
+                ? documentHighlights.reduce((currentCount, { highlightSpans }) => currentCount + highlightSpans.length, 0)
                 : 0;
 
             if (expectedCount !== actualCount) {
-                this.raiseError('verifyDocumentHighlightsAtPositionListCount failed - actual: ' + actualCount + ', expected:' + expectedCount);
+                this.raiseError("verifyDocumentHighlightsAtPositionListCount failed - actual: " + actualCount + ", expected:" + expectedCount);
             }
         }
 
@@ -2250,10 +2269,12 @@ module FourSlash {
                 let index = <number>indexOrName;
                 if (index >= this.testData.files.length) {
                     throw new Error(`File index (${index}) in openFile was out of range. There are only ${this.testData.files.length} files in this test.`);
-                } else {
+                }
+                else {
                     result = this.testData.files[index];
                 }
-            } else if (typeof indexOrName === "string") {
+            }
+            else if (typeof indexOrName === "string") {
                 let name = <string>indexOrName;
 
                 // names are stored in the compiler with this relative path, this allows people to use goTo.file on just the fileName
@@ -2276,7 +2297,8 @@ module FourSlash {
                 if (!foundIt) {
                     throw new Error(`No test file named "${name}" exists. Available file names are: ${availableNames.join(", ")}`);
                 }
-            } else {
+            }
+            else {
                 throw new Error("Unknown argument type");
             }
 
@@ -2294,7 +2316,8 @@ module FourSlash {
                 let markerNames: string[] = [];
                 for (let m in this.testData.markerPositions) markerNames.push(m);
                 throw new Error(`Unknown marker "${markerName}" Available markers: ${markerNames.map(m => "\"" + m + "\"").join(", ")}`);
-            } else {
+            }
+            else {
                 return markerPos;
             }
         }
@@ -2439,13 +2462,15 @@ module FourSlash {
                 // Append to the current subfile content, inserting a newline needed
                 if (currentFileContent === null) {
                     currentFileContent = "";
-                } else {
+                }
+                else {
                     // End-of-line
                     currentFileContent = currentFileContent + "\n";
                 }
 
                 currentFileContent = currentFileContent + line.substr(4);
-            } else if (line.substr(0, 2) === "//") {
+            }
+            else if (line.substr(0, 2) === "//") {
                 // Comment line, check for global/file @options and record them
                 let match = optionRegex.exec(line.substr(2));
                 if (match) {
@@ -2475,17 +2500,20 @@ module FourSlash {
 
                             currentFileName = basePath + "/" + match[2];
                             currentFileOptions[match[1]] = match[2];
-                        } else {
+                        }
+                        else {
                             // Add other fileMetadata flag
                             currentFileOptions[match[1]] = match[2];
                         }
                     }
                 }
             // TODO: should be '==='?
-            } else if (line == "" || lineLength === 0) {
+            }
+            else if (line == "" || lineLength === 0) {
                 // Previously blank lines between fourslash content caused it to be considered as 2 files,
                 // Remove this behavior since it just causes errors now
-            } else {
+            }
+            else {
                 // Empty line or code line, terminate current subfile if there is one
                 if (currentFileContent) {
                     let file = parseFileContent(currentFileContent, currentFileName, markerPositions, markers, ranges);
@@ -2555,7 +2583,8 @@ module FourSlash {
         try {
             // Attempt to parse the marker value as JSON
             markerValue = JSON.parse("{ " + text + " }");
-        } catch (e) {
+        }
+        catch (e) {
             reportError(fileName, location.sourceLine, location.sourceColumn, "Unable to parse marker text " + e.message);
         }
 
@@ -2591,7 +2620,8 @@ module FourSlash {
             let message = "Marker '" + name + "' is duplicated in the source file contents.";
             reportError(marker.fileName, location.sourceLine, location.sourceColumn, message);
             return null;
-        } else {
+        }
+        else {
             markerMap[name] = marker;
             markers.push(marker);
             return marker;
@@ -2605,7 +2635,7 @@ module FourSlash {
         let validMarkerChars = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz$1234567890_";
 
         /// The file content (minus metacharacters) so far
-        let output: string = "";
+        let output = "";
 
         /// The current marker (or maybe multi-line comment?) we're parsing, possibly
         let openMarker: ILocationInformation = null;
@@ -2617,22 +2647,23 @@ module FourSlash {
         let localRanges: Range[] = [];
 
         /// The latest position of the start of an unflushed plain text area
-        let lastNormalCharPosition: number = 0;
+        let lastNormalCharPosition = 0;
 
         /// The total number of metacharacters removed from the file (so far)
-        let difference: number = 0;
+        let difference = 0;
 
         /// The fourslash file state object we are generating
         let state: State = State.none;
 
         /// Current position data
-        let line: number = 1;
-        let column: number = 1;
+        let line = 1;
+        let column = 1;
 
         let flush = (lastSafeCharIndex: number) => {
             if (lastSafeCharIndex === undefined) {
                 output = output + content.substr(lastNormalCharPosition);
-            } else {
+            }
+            else {
                 output = output + content.substr(lastNormalCharPosition, lastSafeCharIndex - lastNormalCharPosition);
             }
         };
@@ -2655,7 +2686,8 @@ module FourSlash {
                             flush(i - 1);
                             lastNormalCharPosition = i + 1;
                             difference += 2;
-                        } else if (previousChar === "|" && currentChar === "]") {
+                        }
+                        else if (previousChar === "|" && currentChar === "]") {
                             // found a range end
                             let rangeStart = openRanges.pop();
                             if (!rangeStart) {
@@ -2674,7 +2706,8 @@ module FourSlash {
                             flush(i - 1);
                             lastNormalCharPosition = i + 1;
                             difference += 2;
-                        } else if (previousChar === "/" && currentChar === "*") {
+                        }
+                        else if (previousChar === "/" && currentChar === "*") {
                             // found a possible marker start
                             state = State.inSlashStarMarker;
                             openMarker = {
@@ -2683,7 +2716,8 @@ module FourSlash {
                                 sourceLine: line,
                                 sourceColumn: column,
                             };
-                        } else if (previousChar === "{" && currentChar === "|") {
+                        }
+                        else if (previousChar === "{" && currentChar === "|") {
                             // found an object marker start
                             state = State.inObjectMarker;
                             openMarker = {
@@ -2736,10 +2770,12 @@ module FourSlash {
                             // Reset the state
                             openMarker = null;
                             state = State.none;
-                        } else if (validMarkerChars.indexOf(currentChar) < 0) {
+                        }
+                        else if (validMarkerChars.indexOf(currentChar) < 0) {
                             if (currentChar === "*" && i < content.length - 1 && content.charAt(i + 1) === "/") {
                                 // The marker is about to be closed, ignore the 'invalid' char
-                            } else {
+                            }
+                            else {
                                 // We've hit a non-valid marker character, so we were actually in a block comment
                                 // Bail out the text we've gathered so far back into the output
                                 flush(i);
@@ -2755,7 +2791,8 @@ module FourSlash {
                 if (currentChar === "\n" && previousChar === "\r") {
                     // Ignore trailing \n after a \r
                     continue;
-                } else if (currentChar === "\n" || currentChar === "\r") {
+                }
+                else if (currentChar === "\n" || currentChar === "\r") {
                     line++;
                     column = 1;
                     continue;

--- a/src/harness/fourslashRunner.ts
+++ b/src/harness/fourslashRunner.ts
@@ -1,6 +1,7 @@
 ///<reference path="fourslash.ts" />
 ///<reference path="harness.ts"/>
 ///<reference path="runnerbase.ts" />
+/* tslint:disable:no-null */
 
 const enum FourSlashTestType {
     Native,
@@ -25,8 +26,8 @@ class FourSlashRunner extends RunnerBase {
                 this.testSuiteName = "fourslash-shims";
                 break;
             case FourSlashTestType.ShimsWithPreprocess:
-                this.basePath = 'tests/cases/fourslash/shims-pp';
-                this.testSuiteName = 'fourslash-shims-pp';
+                this.basePath = "tests/cases/fourslash/shims-pp";
+                this.testSuiteName = "fourslash-shims-pp";
                 break;
             case FourSlashTestType.Server:
                 this.basePath = "tests/cases/fourslash/server";
@@ -87,7 +88,8 @@ class FourSlashRunner extends RunnerBase {
                 FourSlash.xmlData.forEach(xml => {
                     if (xml.invalidReason !== null) {
                         lines.push("<!-- Skipped " + xml.originalName + ", reason: " + xml.invalidReason + " -->");
-                    } else {
+                    }
+                    else {
                         lines.push("        <Scenario Name=\"" + xml.originalName + "\">");
                         xml.actions.forEach(action => {
                             lines.push("            " + action);

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -23,6 +23,7 @@
 /// <reference path="external\chai.d.ts"/>
 /// <reference path="sourceMapRecorder.ts"/>
 /// <reference path="runnerbase.ts"/>
+/* tslint:disable:no-null */
 
 // Block scoped definitions work poorly for global variables, temporarily enable var
 /* tslint:disable:no-var-keyword */
@@ -35,7 +36,7 @@ declare var __dirname: string; // Node-specific
 var global = <any>Function("return this").call(null);
 /* tslint:enable:no-var-keyword */
 
-module Utils {
+namespace Utils {
     // Setup some globals based on the current environment
     export const enum ExecutionEnvironment {
         Node,
@@ -54,17 +55,17 @@ module Utils {
             return ExecutionEnvironment.Node;
         }
     }
-    
+
     export let currentExecutionEnvironment = getExecutionEnvironment();
 
-    const Buffer: BufferConstructor = currentExecutionEnvironment !== ExecutionEnvironment.Browser 
-        ? require("buffer").Buffer 
+    const Buffer: BufferConstructor = currentExecutionEnvironment !== ExecutionEnvironment.Browser
+        ? require("buffer").Buffer
         : undefined;
 
     export function encodeString(s: string): string {
         return Buffer ? (new Buffer(s)).toString("utf8") : s;
     }
-    
+
     export function evalFile(fileContents: string, fileName: string, nodeContext?: any) {
         let environment = getExecutionEnvironment();
         switch (environment) {
@@ -76,7 +77,8 @@ module Utils {
                 let vm = require("vm");
                 if (nodeContext) {
                     vm.runInNewContext(fileContents, nodeContext, fileName);
-                } else {
+                }
+                else {
                     vm.runInThisContext(fileContents, fileName);
                 }
                 break;
@@ -126,7 +128,8 @@ module Utils {
             let cachedResult = cache[key];
             if (cachedResult) {
                 return cachedResult;
-            } else {
+            }
+            else {
                 return cache[key] = f.apply(this, arguments);
             }
         });
@@ -396,7 +399,7 @@ module Utils {
     }
 }
 
-module Harness.Path {
+namespace Harness.Path {
     export function getFileName(fullPath: string) {
         return fullPath.replace(/^.*[\\\/]/, "");
     }
@@ -409,7 +412,7 @@ module Harness.Path {
     }
 }
 
-module Harness {
+namespace Harness {
     export interface IO {
         newLine(): string;
         getCurrentDirectory(): string;
@@ -431,11 +434,11 @@ module Harness {
         readDirectory(path: string, extension?: string, exclude?: string[]): string[];
     }
     export var IO: IO;
-    
+
     // harness always uses one kind of new line
     const harnessNewLine = "\r\n";
-    
-    module IOImpl {
+
+    namespace IOImpl {
         declare class Enumerator {
             public atEnd(): boolean;
             public moveNext(): boolean;
@@ -443,14 +446,15 @@ module Harness {
             constructor(o: any);
         }
 
-        export module CScript {
+        export namespace CScript {
             let fso: any;
             if (global.ActiveXObject) {
                 fso = new global.ActiveXObject("Scripting.FileSystemObject");
-            } else {
+            }
+            else {
                 fso = {};
             }
-            
+
             export const args = () => ts.sys.args;
             export const getExecutingFilePath = () => ts.sys.getExecutingFilePath();
             export const exit = (exitCode: number) => ts.sys.exit(exitCode);
@@ -511,16 +515,17 @@ module Harness {
             };
         }
 
-        export module Node {
+        export namespace Node {
             declare let require: any;
             let fs: any, pathModule: any;
             if (require) {
                 fs = require("fs");
                 pathModule = require("path");
-            } else {
+            }
+            else {
                 fs = pathModule = {};
             }
-            
+
             export const resolvePath = (path: string) => ts.sys.resolvePath(path);
             export const getCurrentDirectory = () => ts.sys.getCurrentDirectory();
             export const newLine = () => harnessNewLine;
@@ -545,7 +550,8 @@ module Harness {
             export function deleteFile(path: string) {
                 try {
                     fs.unlinkSync(path);
-                } catch (e) {
+                }
+                catch (e) {
                 }
             }
 
@@ -559,7 +565,8 @@ module Harness {
                 // Node will just continue to repeat the root path, rather than return null
                 if (dirPath === path) {
                     dirPath = null;
-                } else {
+                }
+                else {
                     return dirPath;
                 }
             }
@@ -596,7 +603,7 @@ module Harness {
             };
         }
 
-        export module Network {
+        export namespace Network {
             let serverRoot = "http://localhost:8888/";
 
             export const newLine = () => harnessNewLine;
@@ -605,10 +612,11 @@ module Harness {
             export const args = () => <string[]>[];
             export const getExecutingFilePath = () => "";
             export const exit = (exitCode: number) => {};
-            
-            let supportsCodePage = () => false;
 
-            module Http {
+            let supportsCodePage = () => false;
+            export let log = (s: string) => console.log(s);
+
+            namespace Http {
                 function waitForXHR(xhr: XMLHttpRequest) {
                     while (xhr.readyState !== 4) { }
                     return { status: xhr.status, responseText: xhr.responseText };
@@ -683,10 +691,12 @@ module Harness {
                 if (dirPath.match(/localhost:\d+$/) || dirPath.match(/localhost:\d+\/$/)) {
                     dirPath = null;
                     // path + fileName
-                } else if (dirPath.indexOf(".") === -1) {
+                }
+                else if (dirPath.indexOf(".") === -1) {
                     dirPath = dirPath.substring(0, dirPath.lastIndexOf("/"));
                     // path
-                } else {
+                }
+                else {
                     // strip any trailing slash
                     if (dirPath.match(/.*\/$/)) {
                         dirPath = dirPath.substring(0, dirPath.length - 2);
@@ -710,7 +720,8 @@ module Harness {
                     let results = response.responseText.split(",");
                     if (spec) {
                         return results.filter(file => spec.test(file));
-                    } else {
+                    }
+                    else {
                         return results;
                     }
                 }
@@ -720,13 +731,12 @@ module Harness {
             };
             export let listFiles = Utils.memoize(_listFilesImpl);
 
-            export let log = (s: string) => console.log(s);
-
             export function readFile(file: string) {
                 let response = Http.getFileFromServerSync(serverRoot + file);
                 if (response.status === 200) {
                     return response.responseText;
-                } else {
+                }
+                else {
                     return null;
                 }
             }
@@ -754,7 +764,7 @@ module Harness {
     }
 }
 
-module Harness {
+namespace Harness {
     let tcServicesFileName = "typescriptServices.js";
 
     export let libFolder: string;
@@ -785,7 +795,7 @@ module Harness {
     export let lightMode = false;
 
     /** Functionality for compiling TypeScript code */
-    export module Compiler {
+    export namespace Compiler {
         /** Aggregate various writes into a single array of lines. Useful for passing to the
          *  TypeScript compiler to fill with source code or errors.
          */
@@ -864,7 +874,7 @@ module Harness {
             languageVersion: ts.ScriptTarget) {
             // We'll only assert inletiants outside of light mode. 
             const shouldAssertInvariants = !Harness.lightMode;
-            
+
             // Only set the parent nodes if we're asserting inletiants.  We don't need them otherwise.
             let result = ts.createSourceFile(fileName, sourceText, languageVersion, /*setParentNodes:*/ shouldAssertInvariants);
 
@@ -1102,7 +1112,7 @@ module Harness {
                 }
 
                 let useCaseSensitiveFileNames = options.useCaseSensitiveFileNames !== undefined ? options.useCaseSensitiveFileNames : Harness.IO.useCaseSensitiveFileNames();
-               
+
                 let fileOutputs: GeneratedFile[] = [];
 
                 let programFiles = inputFiles.concat(includeBuiltFiles).map(file => file.unitName);
@@ -1231,12 +1241,12 @@ module Harness {
                     .filter(s => s.length > 0)
                     .map(s => "!!! " + ts.DiagnosticCategory[error.category].toLowerCase() + " TS" + error.code + ": " + s);
                 errLines.forEach(e => outputLines.push(e));
-                
+
                 // do not count errors from lib.d.ts here, they are computed separately as numLibraryDiagnostics
                 // if lib.d.ts is explicitly included in input files and there are some errors in it (i.e. because of duplicate identifiers) 
                 // then they will be added twice thus triggering 'total errors' assertion with condition
                 // 'totalErrorsReportedInNonLibraryFiles + numLibraryDiagnostics + numTest262HarnessDiagnostics, diagnostics.length
-                 
+
                 if (!error.file || !isLibraryFile(error.file.fileName)) {
                     totalErrorsReportedInNonLibraryFiles++;
                 }
@@ -1280,7 +1290,8 @@ module Harness {
                     // On the last line of the file, fake the next line start number so that we handle errors on the last character of the file correctly
                     if (lineIndex === lines.length - 1) {
                         nextLineStart = inputFile.content.length;
-                    } else {
+                    }
+                    else {
                         nextLineStart = lineStarts[lineIndex + 1];
                     }
                     // Emit this line from the original file
@@ -1344,7 +1355,7 @@ module Harness {
 
                 // FileName header + content
                 result += "/*====== " + outputFile.fileName + " ======*/\r\n";
-                
+
                 result += outputFile.code;
             }
 
@@ -1444,7 +1455,7 @@ module Harness {
         }
     }
 
-    export module TestCaseParser {
+    export namespace TestCaseParser {
         /** all the necessary information to set the right compiler settings */
         export interface CompilerSettings {
             [name: string]: string;
@@ -1497,7 +1508,8 @@ module Harness {
                     let metaDataName = testMetaData[1].toLowerCase();
                     if (metaDataName === "filename") {
                         currentFileOptions[testMetaData[1]] = testMetaData[2];
-                    } else {
+                    }
+                    else {
                         continue;
                     }
 
@@ -1518,16 +1530,19 @@ module Harness {
                         currentFileOptions = {};
                         currentFileName = testMetaData[2];
                         refs = [];
-                    } else {
+                    }
+                    else {
                         // First metadata marker in the file
                         currentFileName = testMetaData[2];
                     }
-                } else {
+                }
+                else {
                     // Subfile content line
                     // Append to the current subfile content, inserting a newline needed
                     if (currentFileContent === null) {
                         currentFileContent = "";
-                    } else {
+                    }
+                    else {
                         // End-of-line
                         currentFileContent = currentFileContent + "\n";
                     }
@@ -1553,7 +1568,7 @@ module Harness {
     }
 
     /** Support class for baseline files */
-    export module Baseline {
+    export namespace Baseline {
 
         export interface BaselineOptions {
             Subfolder?: string;
@@ -1581,7 +1596,8 @@ module Harness {
         function baselinePath(fileName: string, type: string, baselineFolder: string, subfolder?: string) {
             if (subfolder !== undefined) {
                 return Harness.userSpecifiedRoot + baselineFolder + "/" +  subfolder + "/" + type + "/" + fileName;
-            } else {
+            }
+            else {
                 return Harness.userSpecifiedRoot + baselineFolder + "/"  + type + "/" + fileName;
             }
         }
@@ -1673,7 +1689,8 @@ module Harness {
                 actual = generateActual(actualFileName, generateContent);
                 let comparison = compareToBaseline(actual, relativeFileName, opts);
                 writeComparison(comparison.expected, comparison.actual, relativeFileName, actualFileName, descriptionForDescribe);
-            } else {
+            }
+            else {
                 actual = generateActual(actualFileName, generateContent);
 
                 let comparison = compareToBaseline(actual, relativeFileName, opts);

--- a/src/harness/loggedIO.ts
+++ b/src/harness/loggedIO.ts
@@ -1,6 +1,7 @@
 /// <reference path="..\..\src\compiler\sys.ts" />
 /// <reference path="..\..\src\harness\harness.ts" />
 /// <reference path="..\..\src\harness\runnerbase.ts" />
+/* tslint:disable:no-null */
 
 interface FileInformation {
     contents: string;
@@ -76,7 +77,7 @@ interface PlaybackControl {
     endRecord(): void;
 }
 
-module Playback {
+namespace Playback {
     let recordLog: IOLog = undefined;
     let replayLog: IOLog = undefined;
     let recordLogFileNameBase = "";
@@ -95,7 +96,7 @@ module Playback {
         run.reset = () => {
             lookup = null;
         };
-    
+
         return run;
     }
 

--- a/src/harness/projectsRunner.ts
+++ b/src/harness/projectsRunner.ts
@@ -1,5 +1,6 @@
 ///<reference path="harness.ts" />
 ///<reference path="runnerbase.ts" />
+/* tslint:disable:no-null */
 
 // Test case is json of below type in tests/cases/project/
 interface ProjectRunnerTestCase {
@@ -199,7 +200,7 @@ class ProjectRunner extends RunnerBase {
             }
         }
 
-        function batchCompilerProjectTestCase(moduleKind: ts.ModuleKind): BatchCompileProjectTestCaseResult{
+        function batchCompilerProjectTestCase(moduleKind: ts.ModuleKind): BatchCompileProjectTestCaseResult {
             let nonSubfolderDiskFiles = 0;
 
             let outputFiles: BatchCompileProjectTestCaseEmittedFile[] = [];
@@ -300,7 +301,7 @@ class ProjectRunner extends RunnerBase {
                     allInputFiles.unshift(findOutpuDtsFile(outputDtsFileName));
                 }
                 else {
-                    let outputDtsFileName = ts.removeFileExtension(compilerOptions.outFile|| compilerOptions.out) + ".d.ts";
+                    let outputDtsFileName = ts.removeFileExtension(compilerOptions.outFile || compilerOptions.out) + ".d.ts";
                     let outputDtsFile = findOutpuDtsFile(outputDtsFileName);
                     if (!ts.contains(allInputFiles, outputDtsFile)) {
                         allInputFiles.unshift(outputDtsFile);

--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -20,8 +20,10 @@
 /// <reference path="rwcRunner.ts" />
 /// <reference path="harness.ts" />
 
+/* tslint:disable:no-null */
+
 let runners: RunnerBase[] = [];
-let iterations: number = 1;
+let iterations = 1;
 
 function runTests(runners: RunnerBase[]) {
     for (let i = iterations; i > 0; i--) {
@@ -68,10 +70,10 @@ if (testConfigFile !== "") {
                 case "fourslash-shims":
                     runners.push(new FourSlashRunner(FourSlashTestType.Shims));
                     break;
-                case 'fourslash-shims-pp':
+                case "fourslash-shims-pp":
                     runners.push(new FourSlashRunner(FourSlashTestType.ShimsWithPreprocess));
                     break;
-                case 'fourslash-server':
+                case "fourslash-server":
                     runners.push(new FourSlashRunner(FourSlashTestType.Server));
                     break;
                 case "fourslash-generated":

--- a/src/harness/runnerbase.ts
+++ b/src/harness/runnerbase.ts
@@ -25,12 +25,12 @@ abstract class RunnerBase {
         let fixedPath = path;
 
         // full paths either start with a drive letter or / for *nix, shouldn't have \ in the path at this point
-        let fullPath = /(\w+:|\/)?([\w+\-\.]|\/)*\.tsx?/g; 
+        let fullPath = /(\w+:|\/)?([\w+\-\.]|\/)*\.tsx?/g;
         let fullPathList = fixedPath.match(fullPath);
         if (fullPathList) {
             fullPathList.forEach((match: string) => fixedPath = fixedPath.replace(match, Harness.Path.getFileName(match)));
         }
-        
+
         // when running in the browser the 'full path' is the host name, shows up in error baselines
         let localHost = /http:\/localhost:\d+/g;
         fixedPath = fixedPath.replace(localHost, "");

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -2,8 +2,9 @@
 /// <reference path="runnerbase.ts" />
 /// <reference path="loggedIO.ts" />
 /// <reference path="..\compiler\commandLineParser.ts"/>
+/* tslint:disable:no-null */
 
-module RWC {
+namespace RWC {
     function runWithIOLog(ioLog: IOLog, fn: (oldIO: Harness.IO) => void) {
         let oldIO = Harness.IO;
 
@@ -105,7 +106,7 @@ module RWC {
                             }
                             otherFiles.push(getHarnessCompilerInputUnit(fileRead.path));
                         }
-                        else if (!opts.options.noLib && Harness.isLibraryFile(fileRead.path)){
+                        else if (!opts.options.noLib && Harness.isLibraryFile(fileRead.path)) {
                             if (!inInputList) {
                                 // If useCustomLibraryFile is true, we will use lib.d.ts from json object
                                 // otherwise use the lib.d.ts from built/local

--- a/src/harness/sourceMapRecorder.ts
+++ b/src/harness/sourceMapRecorder.ts
@@ -15,14 +15,14 @@
 
 ///<reference path="harness.ts"/>
 
-module Harness.SourceMapRecoder {
+namespace Harness.SourceMapRecoder {
 
     interface SourceMapSpanWithDecodeErrors {
         sourceMapSpan: ts.SourceMapSpan;
         decodeErrors: string[];
     }
 
-    module SourceMapDecoder {
+    namespace SourceMapDecoder {
         let sourceMapMappings: string;
         let sourceMapNames: string[];
         let decodingIndex: number;
@@ -202,7 +202,7 @@ module Harness.SourceMapRecoder {
         }
     }
 
-    module SourceMapSpanWriter {
+    namespace SourceMapSpanWriter {
         let sourceMapRecoder: Compiler.WriterAggregator;
         let sourceMapSources: string[];
         let sourceMapNames: string[];
@@ -442,7 +442,7 @@ module Harness.SourceMapRecoder {
 
         for (let i = 0; i < sourceMapDataList.length; i++) {
             let sourceMapData = sourceMapDataList[i];
-            let prevSourceFile: ts.SourceFile = null;
+            let prevSourceFile: ts.SourceFile;
 
             SourceMapSpanWriter.intializeSourceMapSpanWriter(sourceMapRecoder, sourceMapData, jsFiles[i]);
             for (let j = 0; j < sourceMapData.sourceMapDecodedMappings.length; j++) {

--- a/src/harness/test262Runner.ts
+++ b/src/harness/test262Runner.ts
@@ -1,5 +1,6 @@
 /// <reference path="harness.ts" />
 /// <reference path="runnerbase.ts" />
+/* tslint:disable:no-null */
 
 class Test262BaselineRunner extends RunnerBase {
     private static basePath = "internal/cases/test262";

--- a/tslint.json
+++ b/tslint.json
@@ -11,8 +11,6 @@
             "check-open-brace",
             "check-whitespace"
         ],
-        "no-unreachable": true,
-        "no-use-before-declare": true,
         "no-var-keyword": true,
         "quotemark": [true,
             "double"


### PR DESCRIPTION
By fixing every lint issue in the compiler/services/harness, and disabling the `no-unreachable` and `no-use-before-declare` rules. Both of these had issues with various constructs used in the compiler and yielded false positives. (`no-unreachable` is triggered by local interface declarations and type aliases, when both behave as though hoisted. `no-use-before-declare` doesn't handle exported namespace members which are out-of-order.) Both can but re-enabled in the future when they get fixed. `no-null` is disabled in most of the harness as @DanielRosenwasser mentioned that it used null as part of its API.

Hopefully this should save @DanielRosenwasser some time on CRs. :smile: 