### PR TITLE
Make build actually fail on lint fail

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -869,6 +869,7 @@ task("lint", ["build-rules"], function() {
         var result = lintFile(lintOptions, lintTargets[i]);
         if (result.failureCount > 0) {
             console.log(result.output);
+            fail('Linter errors.', result.failureCount);
         }
     }
 });


### PR DESCRIPTION
This should cause travis to make PRs which fail lints with a red x.