### PR TITLE
Add node 4.1 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
+  - '4.1'
   - '0.10'
 
 sudo: false


### PR DESCRIPTION
Node 4 is the latest LTS node, we should probably do CI against it (and the perf isn't as bad as the regressions present in 0.12).