### PR TITLE
Format template internal spaces

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -216,8 +216,10 @@ namespace ts.formatting {
         // Async functions
         public SpaceBetweenAsyncAndFunctionKeyword: Rule;
 
-        // Tagged template string
+        // Template strings
         public SpaceBetweenTagAndTemplateString: Rule;
+        public NoSpaceAfterTemplateHeadAndMiddle: Rule;
+        public NoSpaceBeforeTemplateMiddleAndTail: Rule;
 
         constructor() {
             ///
@@ -371,6 +373,8 @@ namespace ts.formatting {
 
             // template string
             this.SpaceBetweenTagAndTemplateString = new Rule(RuleDescriptor.create3(SyntaxKind.Identifier, Shared.TokenRange.FromTokens([SyntaxKind.NoSubstitutionTemplateLiteral, SyntaxKind.TemplateHead])), RuleOperation.create2(new RuleOperationContext(Rules.IsSameLineTokenContext), RuleAction.Space));
+            this.NoSpaceAfterTemplateHeadAndMiddle = new Rule(RuleDescriptor.create4(Shared.TokenRange.FromTokens([SyntaxKind.TemplateHead, SyntaxKind.TemplateMiddle]), Shared.TokenRange.Any), RuleOperation.create2(new RuleOperationContext(Rules.IsSameLineTokenContext), RuleAction.Delete));
+            this.NoSpaceBeforeTemplateMiddleAndTail = new Rule(RuleDescriptor.create4(Shared.TokenRange.Any, Shared.TokenRange.FromTokens([SyntaxKind.TemplateMiddle, SyntaxKind.TemplateTail])), RuleOperation.create2(new RuleOperationContext(Rules.IsSameLineTokenContext), RuleAction.Delete));
 
             // These rules are higher in priority than user-configurable rules.
             this.HighPriorityCommonRules =
@@ -399,7 +403,7 @@ namespace ts.formatting {
                 this.SpaceBeforeBinaryKeywordOperator, this.SpaceAfterBinaryKeywordOperator,
                 this.SpaceAfterVoidOperator,
                 this.SpaceBetweenAsyncAndFunctionKeyword,
-                this.SpaceBetweenTagAndTemplateString,
+                this.SpaceBetweenTagAndTemplateString, this.NoSpaceAfterTemplateHeadAndMiddle, this.NoSpaceBeforeTemplateMiddleAndTail,
 
                 // TypeScript-specific rules
                 this.NoSpaceAfterConstructor, this.NoSpaceAfterModuleImport,

--- a/tests/cases/fourslash/formatTemplateLiteral.ts
+++ b/tests/cases/fourslash/formatTemplateLiteral.ts
@@ -2,12 +2,16 @@
 ////var x = `sadasdasdasdasfegsfd
 /////*1*/rasdesgeryt35t35y35 e4 ergt er 35t 3535 `;
 ////var y = `1${2}/*2*/3`;
-////let z=    `foo`/*3*/
-////let w=  `bar${3}`/*4*/
+////
+/////*formatStart*/
+////let z=    `foo`;/*3*/
+////let w=  `bar${3}`;/*4*/
 ////String.raw
-//// `template`/*5*/
-////String.raw`foo`/*6*/
-////String.raw  `bar${3}`/*7*/
+//// `template`;/*5*/
+////String.raw`foo`;/*6*/
+////String.raw  `bar${3}`;/*7*/
+////`Write ${   JSON.stringify("")   } and ${    (765)   } and ${   346  }`;/*spaceInside*/
+/////*formatEnd*/
 
 
 goTo.marker("1");
@@ -18,19 +22,19 @@ edit.insert("\r\n");
 verify.indentationIs(0);
 verify.currentLineContentIs("3`;")
 
+format.selection("formatStart", "formatEnd");
+
 goTo.marker("3");
-edit.insert(";");
 verify.currentLineContentIs("let z = `foo`;");
 goTo.marker("4");
-edit.insert(";");
 verify.currentLineContentIs("let w = `bar${3}`;");
 
 goTo.marker("5");
-edit.insert(";");
 verify.currentLineContentIs("    `template`;");
 goTo.marker("6");
-edit.insert(";");
 verify.currentLineContentIs("String.raw `foo`;");
 goTo.marker("7");
-edit.insert(";");
 verify.currentLineContentIs("String.raw `bar${3}`;");
+
+goTo.marker("spaceInside");
+verify.currentLineContentIs('`Write ${JSON.stringify("")} and ${(765)} and ${346}`;');


### PR DESCRIPTION
Fixes #5030

Current:
```typescript
throw Error(`${          JSON.stringify("") } cannot be found in ${                  JSON.stringify("") } while ${   3   }`);
```

Fix:
```typescript
throw Error(`${JSON.stringify("")} cannot be found in ${JSON.stringify("")} while ${3}`);
```