### PR TITLE
Fix super in async method

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4787,7 +4787,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 // - node has a name
                 // - this is default export and target is not ES6 (for ES6 `export default` does not need to be compiled downlevel)
                 // - this is default export with static initializers
-                if ((node.name || (node.flags & NodeFlags.Default && (languageVersion < ScriptTarget.ES6 
+                if ((node.name || (node.flags & NodeFlags.Default && (languageVersion < ScriptTarget.ES6
                     || staticProperties.length > 0))) && !thisNodeIsDecorated) {
                     write(" ");
                     emitDeclarationName(node);
@@ -5647,8 +5647,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
             }
 
             /*
-             * Some bundlers (SystemJS builder) sometimes want to rename dependencies. 
-             * Here we check if alternative name was provided for a given moduleName and return it if possible. 
+             * Some bundlers (SystemJS builder) sometimes want to rename dependencies.
+             * Here we check if alternative name was provided for a given moduleName and return it if possible.
              */
             function tryRenameExternalModule(moduleName: LiteralExpression): string {
                 if (currentSourceFile.renamedDependencies && hasProperty(currentSourceFile.renamedDependencies, moduleName.text)) {
@@ -7076,7 +7076,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                         return shouldEmitEnumDeclaration(<EnumDeclaration>node);
                 }
 
-                // If the node is emitted in specialized fashion, dont emit comments as this node will handle 
+                // If the node is emitted in specialized fashion, dont emit comments as this node will handle
                 // emitting comments when emitting itself
                 Debug.assert(!isSpecializedCommentHandling(node));
 

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4785,8 +4785,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
 
                 // emit name if
                 // - node has a name
-                // - this is default export and target is not ES6 (for ES6 `export default` does not need to be compiled downlevel)                
-                if ((node.name || (node.flags & NodeFlags.Default && languageVersion < ScriptTarget.ES6)) && !thisNodeIsDecorated) {
+                // - this is default export and target is not ES6 (for ES6 `export default` does not need to be compiled downlevel)
+                // - this is default export with static initializers
+                if ((node.name || (node.flags & NodeFlags.Default && (languageVersion < ScriptTarget.ES6 
+                    || staticProperties.length > 0))) && !thisNodeIsDecorated) {
                     write(" ");
                     emitDeclarationName(node);
                 }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1740,7 +1740,7 @@ namespace ts {
         SuperInstance               = 0x00000100,  // Instance 'super' reference
         SuperStatic                 = 0x00000200,  // Static 'super' reference
         ContextChecked              = 0x00000400,  // Contextual types have been assigned
-        LexicalArguments            = 0x00000800,
+        AsyncMethodWithSuper        = 0x00000800,  // Split async method into two methods to preserve `super` references.
         CaptureArguments            = 0x00001000,  // Lexical 'arguments' used in body (for async functions)
 
         // Values for enum members have been computed, and any errors have been reported for them.

--- a/tests/baselines/reference/asyncArrowFunctionCapturesArguments_es6.js
+++ b/tests/baselines/reference/asyncArrowFunctionCapturesArguments_es6.js
@@ -11,6 +11,6 @@ class C {
 class C {
     method() {
         function other() { }
-        var fn = () => __awaiter(this, arguments, Promise, function* (_arguments) { return yield other.apply(this, _arguments); });
+        var fn = () => __awaiter(this, arguments, Promise, function* () { return yield other.apply(this, arguments); });
     }
 }

--- a/tests/baselines/reference/asyncAwaitIsolatedModules_es6.js
+++ b/tests/baselines/reference/asyncAwaitIsolatedModules_es6.js
@@ -42,7 +42,7 @@ module M {
 //// [asyncAwaitIsolatedModules_es6.js]
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promise, generator) {
     return new Promise(function (resolve, reject) {
-        generator = generator.call(thisArg, _arguments);
+        generator = generator.apply(thisArg, _arguments);
         function cast(value) { return value instanceof Promise && value.constructor === Promise ? value : new Promise(function (resolve) { resolve(value); }); }
         function onfulfill(value) { try { step("next", value); } catch (e) { reject(e); } }
         function onreject(value) { try { step("throw", value); } catch (e) { reject(e); } }

--- a/tests/baselines/reference/asyncAwait_es6.js
+++ b/tests/baselines/reference/asyncAwait_es6.js
@@ -42,7 +42,7 @@ module M {
 //// [asyncAwait_es6.js]
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promise, generator) {
     return new Promise(function (resolve, reject) {
-        generator = generator.call(thisArg, _arguments);
+        generator = generator.apply(thisArg, _arguments);
         function cast(value) { return value instanceof Promise && value.constructor === Promise ? value : new Promise(function (resolve) { resolve(value); }); }
         function onfulfill(value) { try { step("next", value); } catch (e) { reject(e); } }
         function onreject(value) { try { step("throw", value); } catch (e) { reject(e); } }

--- a/tests/baselines/reference/asyncMethodDeclaration1.es6.js
+++ b/tests/baselines/reference/asyncMethodDeclaration1.es6.js
@@ -1,0 +1,24 @@
+//// [asyncMethodDeclaration1.es6.ts]
+class C {
+    async method() {
+        await undefined;
+    }
+    
+    static async staticMethod() {
+        await undefined;
+    }
+}
+
+//// [asyncMethodDeclaration1.es6.js]
+class C {
+    method() {
+        return __awaiter(this, void 0, Promise, function* () {
+            yield undefined;
+        });
+    }
+    static staticMethod() {
+        return __awaiter(this, void 0, Promise, function* () {
+            yield undefined;
+        });
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration1.es6.symbols
+++ b/tests/baselines/reference/asyncMethodDeclaration1.es6.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration1.es6.ts ===
+class C {
+>C : Symbol(C, Decl(asyncMethodDeclaration1.es6.ts, 0, 0))
+
+    async method() {
+>method : Symbol(method, Decl(asyncMethodDeclaration1.es6.ts, 0, 9))
+
+        await undefined;
+>undefined : Symbol(undefined)
+    }
+    
+    static async staticMethod() {
+>staticMethod : Symbol(C.staticMethod, Decl(asyncMethodDeclaration1.es6.ts, 3, 5))
+
+        await undefined;
+>undefined : Symbol(undefined)
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration1.es6.types
+++ b/tests/baselines/reference/asyncMethodDeclaration1.es6.types
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration1.es6.ts ===
+class C {
+>C : C
+
+    async method() {
+>method : () => Promise<void>
+
+        await undefined;
+>await undefined : any
+>undefined : undefined
+    }
+    
+    static async staticMethod() {
+>staticMethod : () => Promise<void>
+
+        await undefined;
+>await undefined : any
+>undefined : undefined
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration2.es6.js
+++ b/tests/baselines/reference/asyncMethodDeclaration2.es6.js
@@ -1,0 +1,25 @@
+//// [asyncMethodDeclaration2.es6.ts]
+let c = class C {
+    async method() {
+        await undefined;
+    }
+    
+    static async staticMethod() {
+        await undefined;
+    }
+}
+
+//// [asyncMethodDeclaration2.es6.js]
+let c = class C {
+    method() {
+        return __awaiter(this, void 0, Promise, function* () {
+            yield undefined;
+        });
+    }
+    static staticMethod() {
+        return __awaiter(this, void 0, Promise, function* () {
+            yield undefined;
+        });
+    }
+}
+;

--- a/tests/baselines/reference/asyncMethodDeclaration2.es6.symbols
+++ b/tests/baselines/reference/asyncMethodDeclaration2.es6.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration2.es6.ts ===
+let c = class C {
+>c : Symbol(c, Decl(asyncMethodDeclaration2.es6.ts, 0, 3))
+>C : Symbol(C, Decl(asyncMethodDeclaration2.es6.ts, 0, 7))
+
+    async method() {
+>method : Symbol(C.method, Decl(asyncMethodDeclaration2.es6.ts, 0, 17))
+
+        await undefined;
+>undefined : Symbol(undefined)
+    }
+    
+    static async staticMethod() {
+>staticMethod : Symbol(C.staticMethod, Decl(asyncMethodDeclaration2.es6.ts, 3, 5))
+
+        await undefined;
+>undefined : Symbol(undefined)
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration2.es6.types
+++ b/tests/baselines/reference/asyncMethodDeclaration2.es6.types
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration2.es6.ts ===
+let c = class C {
+>c : typeof C
+>class C {    async method() {        await undefined;    }        static async staticMethod() {        await undefined;    }} : typeof C
+>C : typeof C
+
+    async method() {
+>method : () => Promise<void>
+
+        await undefined;
+>await undefined : any
+>undefined : undefined
+    }
+    
+    static async staticMethod() {
+>staticMethod : () => Promise<void>
+
+        await undefined;
+>await undefined : any
+>undefined : undefined
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration3.es6.js
+++ b/tests/baselines/reference/asyncMethodDeclaration3.es6.js
@@ -1,0 +1,25 @@
+//// [asyncMethodDeclaration3.es6.ts]
+let c = class {
+    async method() {
+        await undefined;
+    }
+    
+    static async staticMethod() {
+        await undefined;
+    }
+}
+
+//// [asyncMethodDeclaration3.es6.js]
+let c = class {
+    method() {
+        return __awaiter(this, void 0, Promise, function* () {
+            yield undefined;
+        });
+    }
+    static staticMethod() {
+        return __awaiter(this, void 0, Promise, function* () {
+            yield undefined;
+        });
+    }
+}
+;

--- a/tests/baselines/reference/asyncMethodDeclaration3.es6.symbols
+++ b/tests/baselines/reference/asyncMethodDeclaration3.es6.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration3.es6.ts ===
+let c = class {
+>c : Symbol(c, Decl(asyncMethodDeclaration3.es6.ts, 0, 3))
+
+    async method() {
+>method : Symbol((Anonymous class).method, Decl(asyncMethodDeclaration3.es6.ts, 0, 15))
+
+        await undefined;
+>undefined : Symbol(undefined)
+    }
+    
+    static async staticMethod() {
+>staticMethod : Symbol((Anonymous class).staticMethod, Decl(asyncMethodDeclaration3.es6.ts, 3, 5))
+
+        await undefined;
+>undefined : Symbol(undefined)
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration3.es6.types
+++ b/tests/baselines/reference/asyncMethodDeclaration3.es6.types
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration3.es6.ts ===
+let c = class {
+>c : typeof (Anonymous class)
+>class {    async method() {        await undefined;    }        static async staticMethod() {        await undefined;    }} : typeof (Anonymous class)
+
+    async method() {
+>method : () => Promise<void>
+
+        await undefined;
+>await undefined : any
+>undefined : undefined
+    }
+    
+    static async staticMethod() {
+>staticMethod : () => Promise<void>
+
+        await undefined;
+>await undefined : any
+>undefined : undefined
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration4.es6.js
+++ b/tests/baselines/reference/asyncMethodDeclaration4.es6.js
@@ -1,0 +1,24 @@
+//// [asyncMethodDeclaration4.es6.ts]
+export default class {
+    async method() {
+        await undefined;
+    }
+    
+    static async staticMethod() {
+        await undefined;
+    }
+}
+
+//// [asyncMethodDeclaration4.es6.js]
+export default class {
+    method() {
+        return __awaiter(this, void 0, Promise, function* () {
+            yield undefined;
+        });
+    }
+    static staticMethod() {
+        return __awaiter(this, void 0, Promise, function* () {
+            yield undefined;
+        });
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration4.es6.symbols
+++ b/tests/baselines/reference/asyncMethodDeclaration4.es6.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration4.es6.ts ===
+export default class {
+    async method() {
+>method : Symbol(method, Decl(asyncMethodDeclaration4.es6.ts, 0, 22))
+
+        await undefined;
+>undefined : Symbol(undefined)
+    }
+    
+    static async staticMethod() {
+>staticMethod : Symbol(default.staticMethod, Decl(asyncMethodDeclaration4.es6.ts, 3, 5))
+
+        await undefined;
+>undefined : Symbol(undefined)
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration4.es6.types
+++ b/tests/baselines/reference/asyncMethodDeclaration4.es6.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration4.es6.ts ===
+export default class {
+    async method() {
+>method : () => Promise<void>
+
+        await undefined;
+>await undefined : any
+>undefined : undefined
+    }
+    
+    static async staticMethod() {
+>staticMethod : () => Promise<void>
+
+        await undefined;
+>await undefined : any
+>undefined : undefined
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration5.es6.errors.txt
+++ b/tests/baselines/reference/asyncMethodDeclaration5.es6.errors.txt
@@ -1,0 +1,24 @@
+tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration5.es6.ts(7,9): error TS2335: 'super' can only be referenced in a derived class.
+tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration5.es6.ts(12,9): error TS2335: 'super' can only be referenced in a derived class.
+
+
+==== tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration5.es6.ts (2 errors) ====
+    class D {
+        superMethod() {}
+        static staticSuperMethod() {}
+    }
+    class C {
+        async method() {
+            super.superMethod();
+            ~~~~~
+!!! error TS2335: 'super' can only be referenced in a derived class.
+            await undefined;
+        }
+        
+        static async staticMethod() {
+            super.staticSuperMethod();
+            ~~~~~
+!!! error TS2335: 'super' can only be referenced in a derived class.
+            await undefined;
+        }
+    }

--- a/tests/baselines/reference/asyncMethodDeclaration5.es6.js
+++ b/tests/baselines/reference/asyncMethodDeclaration5.es6.js
@@ -1,0 +1,38 @@
+//// [asyncMethodDeclaration5.es6.ts]
+class D {
+    superMethod() {}
+    static staticSuperMethod() {}
+}
+class C {
+    async method() {
+        super.superMethod();
+        await undefined;
+    }
+    
+    static async staticMethod() {
+        super.staticSuperMethod();
+        await undefined;
+    }
+}
+
+//// [asyncMethodDeclaration5.es6.js]
+class D {
+    superMethod() { }
+    static staticSuperMethod() { }
+}
+class C {
+    method() {
+        return __awaiter(this, void 0, Promise, C.prototype._method_async);
+    }
+    *_method_async() {
+        super.superMethod();
+        yield undefined;
+    }
+    static staticMethod() {
+        return __awaiter(this, void 0, Promise, C._staticMethod_async);
+    }
+    static *_staticMethod_async() {
+        super.staticSuperMethod();
+        yield undefined;
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration6.es6.js
+++ b/tests/baselines/reference/asyncMethodDeclaration6.es6.js
@@ -1,0 +1,39 @@
+//// [asyncMethodDeclaration6.es6.ts]
+class D {
+    superMethod() {}
+    static staticSuperMethod() {}
+}
+let c = class C extends D {
+    async method() {
+        super.superMethod();
+        await undefined;
+    }
+    
+    static async staticMethod() {
+        super.staticSuperMethod();
+        await undefined;
+    }
+}
+
+//// [asyncMethodDeclaration6.es6.js]
+class D {
+    superMethod() { }
+    static staticSuperMethod() { }
+}
+let c = class C extends D {
+    method() {
+        return __awaiter(this, void 0, Promise, C.prototype._method_async);
+    }
+    *_method_async() {
+        super.superMethod();
+        yield undefined;
+    }
+    static staticMethod() {
+        return __awaiter(this, void 0, Promise, C._staticMethod_async);
+    }
+    static *_staticMethod_async() {
+        super.staticSuperMethod();
+        yield undefined;
+    }
+}
+;

--- a/tests/baselines/reference/asyncMethodDeclaration6.es6.symbols
+++ b/tests/baselines/reference/asyncMethodDeclaration6.es6.symbols
@@ -1,0 +1,39 @@
+=== tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration6.es6.ts ===
+class D {
+>D : Symbol(D, Decl(asyncMethodDeclaration6.es6.ts, 0, 0))
+
+    superMethod() {}
+>superMethod : Symbol(superMethod, Decl(asyncMethodDeclaration6.es6.ts, 0, 9))
+
+    static staticSuperMethod() {}
+>staticSuperMethod : Symbol(D.staticSuperMethod, Decl(asyncMethodDeclaration6.es6.ts, 1, 20))
+}
+let c = class C extends D {
+>c : Symbol(c, Decl(asyncMethodDeclaration6.es6.ts, 4, 3))
+>C : Symbol(C, Decl(asyncMethodDeclaration6.es6.ts, 4, 7))
+>D : Symbol(D, Decl(asyncMethodDeclaration6.es6.ts, 0, 0))
+
+    async method() {
+>method : Symbol(C.method, Decl(asyncMethodDeclaration6.es6.ts, 4, 27))
+
+        super.superMethod();
+>super.superMethod : Symbol(D.superMethod, Decl(asyncMethodDeclaration6.es6.ts, 0, 9))
+>super : Symbol(D, Decl(asyncMethodDeclaration6.es6.ts, 0, 0))
+>superMethod : Symbol(D.superMethod, Decl(asyncMethodDeclaration6.es6.ts, 0, 9))
+
+        await undefined;
+>undefined : Symbol(undefined)
+    }
+    
+    static async staticMethod() {
+>staticMethod : Symbol(C.staticMethod, Decl(asyncMethodDeclaration6.es6.ts, 8, 5))
+
+        super.staticSuperMethod();
+>super.staticSuperMethod : Symbol(D.staticSuperMethod, Decl(asyncMethodDeclaration6.es6.ts, 1, 20))
+>super : Symbol(D, Decl(asyncMethodDeclaration6.es6.ts, 0, 0))
+>staticSuperMethod : Symbol(D.staticSuperMethod, Decl(asyncMethodDeclaration6.es6.ts, 1, 20))
+
+        await undefined;
+>undefined : Symbol(undefined)
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration6.es6.types
+++ b/tests/baselines/reference/asyncMethodDeclaration6.es6.types
@@ -1,0 +1,44 @@
+=== tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration6.es6.ts ===
+class D {
+>D : D
+
+    superMethod() {}
+>superMethod : () => void
+
+    static staticSuperMethod() {}
+>staticSuperMethod : () => void
+}
+let c = class C extends D {
+>c : typeof C
+>class C extends D {    async method() {        super.superMethod();        await undefined;    }        static async staticMethod() {        super.staticSuperMethod();        await undefined;    }} : typeof C
+>C : typeof C
+>D : D
+
+    async method() {
+>method : () => Promise<void>
+
+        super.superMethod();
+>super.superMethod() : void
+>super.superMethod : () => void
+>super : D
+>superMethod : () => void
+
+        await undefined;
+>await undefined : any
+>undefined : undefined
+    }
+    
+    static async staticMethod() {
+>staticMethod : () => Promise<void>
+
+        super.staticSuperMethod();
+>super.staticSuperMethod() : void
+>super.staticSuperMethod : () => void
+>super : typeof D
+>staticSuperMethod : () => void
+
+        await undefined;
+>await undefined : any
+>undefined : undefined
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration7.es6.js
+++ b/tests/baselines/reference/asyncMethodDeclaration7.es6.js
@@ -1,0 +1,39 @@
+//// [asyncMethodDeclaration7.es6.ts]
+class D {
+    superMethod() {}
+    static staticSuperMethod() {}
+}
+let c = class extends D {
+    async method() {
+        super.superMethod();
+        await undefined;
+    }
+    
+    static async staticMethod() {
+        super.staticSuperMethod();
+        await undefined;
+    }
+}
+
+//// [asyncMethodDeclaration7.es6.js]
+class D {
+    superMethod() { }
+    static staticSuperMethod() { }
+}
+let c = (class_1 = class extends D {
+    method() {
+        return __awaiter(this, void 0, Promise, class_1.prototype._method_async);
+    }
+    *_method_async() {
+        super.superMethod();
+        yield undefined;
+    }
+    static staticMethod() {
+        return __awaiter(this, void 0, Promise, class_1._staticMethod_async);
+    }
+    static *_staticMethod_async() {
+        super.staticSuperMethod();
+        yield undefined;
+    }
+});
+var class_1;

--- a/tests/baselines/reference/asyncMethodDeclaration7.es6.symbols
+++ b/tests/baselines/reference/asyncMethodDeclaration7.es6.symbols
@@ -1,0 +1,38 @@
+=== tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration7.es6.ts ===
+class D {
+>D : Symbol(D, Decl(asyncMethodDeclaration7.es6.ts, 0, 0))
+
+    superMethod() {}
+>superMethod : Symbol(superMethod, Decl(asyncMethodDeclaration7.es6.ts, 0, 9))
+
+    static staticSuperMethod() {}
+>staticSuperMethod : Symbol(D.staticSuperMethod, Decl(asyncMethodDeclaration7.es6.ts, 1, 20))
+}
+let c = class extends D {
+>c : Symbol(c, Decl(asyncMethodDeclaration7.es6.ts, 4, 3))
+>D : Symbol(D, Decl(asyncMethodDeclaration7.es6.ts, 0, 0))
+
+    async method() {
+>method : Symbol((Anonymous class).method, Decl(asyncMethodDeclaration7.es6.ts, 4, 25))
+
+        super.superMethod();
+>super.superMethod : Symbol(D.superMethod, Decl(asyncMethodDeclaration7.es6.ts, 0, 9))
+>super : Symbol(D, Decl(asyncMethodDeclaration7.es6.ts, 0, 0))
+>superMethod : Symbol(D.superMethod, Decl(asyncMethodDeclaration7.es6.ts, 0, 9))
+
+        await undefined;
+>undefined : Symbol(undefined)
+    }
+    
+    static async staticMethod() {
+>staticMethod : Symbol((Anonymous class).staticMethod, Decl(asyncMethodDeclaration7.es6.ts, 8, 5))
+
+        super.staticSuperMethod();
+>super.staticSuperMethod : Symbol(D.staticSuperMethod, Decl(asyncMethodDeclaration7.es6.ts, 1, 20))
+>super : Symbol(D, Decl(asyncMethodDeclaration7.es6.ts, 0, 0))
+>staticSuperMethod : Symbol(D.staticSuperMethod, Decl(asyncMethodDeclaration7.es6.ts, 1, 20))
+
+        await undefined;
+>undefined : Symbol(undefined)
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration7.es6.types
+++ b/tests/baselines/reference/asyncMethodDeclaration7.es6.types
@@ -1,0 +1,43 @@
+=== tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration7.es6.ts ===
+class D {
+>D : D
+
+    superMethod() {}
+>superMethod : () => void
+
+    static staticSuperMethod() {}
+>staticSuperMethod : () => void
+}
+let c = class extends D {
+>c : typeof (Anonymous class)
+>class extends D {    async method() {        super.superMethod();        await undefined;    }        static async staticMethod() {        super.staticSuperMethod();        await undefined;    }} : typeof (Anonymous class)
+>D : D
+
+    async method() {
+>method : () => Promise<void>
+
+        super.superMethod();
+>super.superMethod() : void
+>super.superMethod : () => void
+>super : D
+>superMethod : () => void
+
+        await undefined;
+>await undefined : any
+>undefined : undefined
+    }
+    
+    static async staticMethod() {
+>staticMethod : () => Promise<void>
+
+        super.staticSuperMethod();
+>super.staticSuperMethod() : void
+>super.staticSuperMethod : () => void
+>super : typeof D
+>staticSuperMethod : () => void
+
+        await undefined;
+>await undefined : any
+>undefined : undefined
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration8.es6.js
+++ b/tests/baselines/reference/asyncMethodDeclaration8.es6.js
@@ -1,0 +1,38 @@
+//// [asyncMethodDeclaration8.es6.ts]
+class D {
+    superMethod() {}
+    static staticSuperMethod() {}
+}
+export default class extends D {
+    async method() {
+        super.superMethod();
+        await undefined;
+    }
+    
+    static async staticMethod() {
+        super.staticSuperMethod();
+        await undefined;
+    }
+}
+
+//// [asyncMethodDeclaration8.es6.js]
+class D {
+    superMethod() { }
+    static staticSuperMethod() { }
+}
+export default class default_1 extends D {
+    method() {
+        return __awaiter(this, void 0, Promise, default_1.prototype._method_async);
+    }
+    *_method_async() {
+        super.superMethod();
+        yield undefined;
+    }
+    static staticMethod() {
+        return __awaiter(this, void 0, Promise, default_1._staticMethod_async);
+    }
+    static *_staticMethod_async() {
+        super.staticSuperMethod();
+        yield undefined;
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration8.es6.symbols
+++ b/tests/baselines/reference/asyncMethodDeclaration8.es6.symbols
@@ -1,0 +1,37 @@
+=== tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration8.es6.ts ===
+class D {
+>D : Symbol(D, Decl(asyncMethodDeclaration8.es6.ts, 0, 0))
+
+    superMethod() {}
+>superMethod : Symbol(superMethod, Decl(asyncMethodDeclaration8.es6.ts, 0, 9))
+
+    static staticSuperMethod() {}
+>staticSuperMethod : Symbol(D.staticSuperMethod, Decl(asyncMethodDeclaration8.es6.ts, 1, 20))
+}
+export default class extends D {
+>D : Symbol(D, Decl(asyncMethodDeclaration8.es6.ts, 0, 0))
+
+    async method() {
+>method : Symbol(method, Decl(asyncMethodDeclaration8.es6.ts, 4, 32))
+
+        super.superMethod();
+>super.superMethod : Symbol(D.superMethod, Decl(asyncMethodDeclaration8.es6.ts, 0, 9))
+>super : Symbol(D, Decl(asyncMethodDeclaration8.es6.ts, 0, 0))
+>superMethod : Symbol(D.superMethod, Decl(asyncMethodDeclaration8.es6.ts, 0, 9))
+
+        await undefined;
+>undefined : Symbol(undefined)
+    }
+    
+    static async staticMethod() {
+>staticMethod : Symbol(default.staticMethod, Decl(asyncMethodDeclaration8.es6.ts, 8, 5))
+
+        super.staticSuperMethod();
+>super.staticSuperMethod : Symbol(D.staticSuperMethod, Decl(asyncMethodDeclaration8.es6.ts, 1, 20))
+>super : Symbol(D, Decl(asyncMethodDeclaration8.es6.ts, 0, 0))
+>staticSuperMethod : Symbol(D.staticSuperMethod, Decl(asyncMethodDeclaration8.es6.ts, 1, 20))
+
+        await undefined;
+>undefined : Symbol(undefined)
+    }
+}

--- a/tests/baselines/reference/asyncMethodDeclaration8.es6.types
+++ b/tests/baselines/reference/asyncMethodDeclaration8.es6.types
@@ -1,0 +1,41 @@
+=== tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration8.es6.ts ===
+class D {
+>D : D
+
+    superMethod() {}
+>superMethod : () => void
+
+    static staticSuperMethod() {}
+>staticSuperMethod : () => void
+}
+export default class extends D {
+>D : D
+
+    async method() {
+>method : () => Promise<void>
+
+        super.superMethod();
+>super.superMethod() : void
+>super.superMethod : () => void
+>super : D
+>superMethod : () => void
+
+        await undefined;
+>await undefined : any
+>undefined : undefined
+    }
+    
+    static async staticMethod() {
+>staticMethod : () => Promise<void>
+
+        super.staticSuperMethod();
+>super.staticSuperMethod() : void
+>super.staticSuperMethod : () => void
+>super : typeof D
+>staticSuperMethod : () => void
+
+        await undefined;
+>await undefined : any
+>undefined : undefined
+    }
+}

--- a/tests/baselines/reference/exportDefaultClassWithStaticPropertyAssignmentsInES6.js
+++ b/tests/baselines/reference/exportDefaultClassWithStaticPropertyAssignmentsInES6.js
@@ -1,0 +1,9 @@
+//// [exportDefaultClassWithStaticPropertyAssignmentsInES6.ts]
+export default class {
+    static z: string = "Foo";
+}
+
+//// [exportDefaultClassWithStaticPropertyAssignmentsInES6.js]
+export default class default_1 {
+}
+default_1.z = "Foo";

--- a/tests/baselines/reference/exportDefaultClassWithStaticPropertyAssignmentsInES6.symbols
+++ b/tests/baselines/reference/exportDefaultClassWithStaticPropertyAssignmentsInES6.symbols
@@ -1,0 +1,5 @@
+=== tests/cases/conformance/es6/classDeclaration/exportDefaultClassWithStaticPropertyAssignmentsInES6.ts ===
+export default class {
+    static z: string = "Foo";
+>z : Symbol(default.z, Decl(exportDefaultClassWithStaticPropertyAssignmentsInES6.ts, 0, 22))
+}

--- a/tests/baselines/reference/exportDefaultClassWithStaticPropertyAssignmentsInES6.types
+++ b/tests/baselines/reference/exportDefaultClassWithStaticPropertyAssignmentsInES6.types
@@ -1,0 +1,6 @@
+=== tests/cases/conformance/es6/classDeclaration/exportDefaultClassWithStaticPropertyAssignmentsInES6.ts ===
+export default class {
+    static z: string = "Foo";
+>z : string
+>"Foo" : string
+}

--- a/tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration1.es6.ts
+++ b/tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration1.es6.ts
@@ -1,0 +1,12 @@
+// @target: ES6
+// @noEmitHelpers: true
+// @experimentalAsyncFunctions: true
+class C {
+    async method() {
+        await undefined;
+    }
+    
+    static async staticMethod() {
+        await undefined;
+    }
+}

--- a/tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration2.es6.ts
+++ b/tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration2.es6.ts
@@ -1,0 +1,12 @@
+// @target: ES6
+// @noEmitHelpers: true
+// @experimentalAsyncFunctions: true
+let c = class C {
+    async method() {
+        await undefined;
+    }
+    
+    static async staticMethod() {
+        await undefined;
+    }
+}

--- a/tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration3.es6.ts
+++ b/tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration3.es6.ts
@@ -1,0 +1,12 @@
+// @target: ES6
+// @noEmitHelpers: true
+// @experimentalAsyncFunctions: true
+let c = class {
+    async method() {
+        await undefined;
+    }
+    
+    static async staticMethod() {
+        await undefined;
+    }
+}

--- a/tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration4.es6.ts
+++ b/tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration4.es6.ts
@@ -1,0 +1,12 @@
+// @target: ES6
+// @noEmitHelpers: true
+// @experimentalAsyncFunctions: true
+export default class {
+    async method() {
+        await undefined;
+    }
+    
+    static async staticMethod() {
+        await undefined;
+    }
+}

--- a/tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration5.es6.ts
+++ b/tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration5.es6.ts
@@ -1,0 +1,18 @@
+// @target: ES6
+// @noEmitHelpers: true
+// @experimentalAsyncFunctions: true
+class D {
+    superMethod() {}
+    static staticSuperMethod() {}
+}
+class C {
+    async method() {
+        super.superMethod();
+        await undefined;
+    }
+    
+    static async staticMethod() {
+        super.staticSuperMethod();
+        await undefined;
+    }
+}

--- a/tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration6.es6.ts
+++ b/tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration6.es6.ts
@@ -1,0 +1,18 @@
+// @target: ES6
+// @noEmitHelpers: true
+// @experimentalAsyncFunctions: true
+class D {
+    superMethod() {}
+    static staticSuperMethod() {}
+}
+let c = class C extends D {
+    async method() {
+        super.superMethod();
+        await undefined;
+    }
+    
+    static async staticMethod() {
+        super.staticSuperMethod();
+        await undefined;
+    }
+}

--- a/tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration7.es6.ts
+++ b/tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration7.es6.ts
@@ -1,0 +1,18 @@
+// @target: ES6
+// @noEmitHelpers: true
+// @experimentalAsyncFunctions: true
+class D {
+    superMethod() {}
+    static staticSuperMethod() {}
+}
+let c = class extends D {
+    async method() {
+        super.superMethod();
+        await undefined;
+    }
+    
+    static async staticMethod() {
+        super.staticSuperMethod();
+        await undefined;
+    }
+}

--- a/tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration8.es6.ts
+++ b/tests/cases/conformance/async/es6/asyncMethodDeclaration/asyncMethodDeclaration8.es6.ts
@@ -1,0 +1,18 @@
+// @target: ES6
+// @noEmitHelpers: true
+// @experimentalAsyncFunctions: true
+class D {
+    superMethod() {}
+    static staticSuperMethod() {}
+}
+export default class extends D {
+    async method() {
+        super.superMethod();
+        await undefined;
+    }
+    
+    static async staticMethod() {
+        super.staticSuperMethod();
+        await undefined;
+    }
+}

--- a/tests/cases/conformance/es6/classDeclaration/exportDefaultClassWithStaticPropertyAssignmentsInES6.ts
+++ b/tests/cases/conformance/es6/classDeclaration/exportDefaultClassWithStaticPropertyAssignmentsInES6.ts
@@ -1,0 +1,4 @@
+// @target:es6
+export default class {
+    static z: string = "Foo";
+}


### PR DESCRIPTION
Fixes #5124.

Note that this changes the runtime semantics for async methods somewhat to make `super` calls work. 

Currently, if there is an exception thrown during parameter destructuring in an async function it is thrown immediately, rather than propagated as a rejection of the async function's promise. For example:

```ts
// ts
let obj = { get x() { throw new Error(); } };
async function fn({ x }) { }
fn(obj);

// js
let obj = { get x() { throw new Error(); } };
function fn({ x }) { // exception thrown here, before Promise is created
  return __awaiter(this, void 0, Promise, function *() { });
}
fn(obj); 
```

With this change, async methods with a super call have a different emit that results in parameter destructuring executing inside of the Promise, and as a result any exceptions in these cases will be propagated as a rejection:

```ts
// ts
let obj = { get x() { throw new Error; } };
class C extends B {
  async m({ x }) { }
}
new C().m(obj);

// js
let obj = { get x() { throw new Error(); } };
class C extends B {
  m() { 
    return __awaiter(this, void 0, Promise, C.prototype._m_async);
  }
  _m_async({ x }) { // exception thrown here, inside the promise which triggers rejection.
  }
}
new C().m(obj);
```

If we would rather have consistency between all async functions/methods then we have several alternatives:

1. Move parameter destructuring from `_m_async` here back to `m`, but pass all locals to `_m_async`. This would result in more complicated emit, but return to having the exception propagate to the call site rather than as a rejection.
2. Change the emit for all async functions such that exceptions during parameter destructuring always happen inside the body of the promise, by creating a pair of functions each time.
  * This has the downside of emitting a lot of messy duplicate code.
3. Modify `__awaiter` or add a new `__async` helper to act as a decorator to an async function/method to emulate the paired functions of (2) above.
  * This looks relatively clean, but has the downside of introducing TDZ for function declarations without even more complex emit (see below).
4. Add local `__superGet`/`__superSet` variables that point to arrows that capture `super`, or a Proxy.
  * This would work for only basic cases, as there are several corner cases where this doesn't work:
    * Destructuring patterns require a reference, so these would need to be wrapped in something with a setter to ensure any side effects are preserved:  
      `let { x: { set ref(v) { __superSet("x", v); } }.ref } = { x: 1 };`
    * Doesn't cover cases such as `delete super.x`. 
  * Proxies are only supported in Node v4 with a command-line switch.

It may be possible to avoid TDZ for function declarations (as per option 3 above) using the following approach:

```ts
// ts 
async function fn({ x }) { }

// js
var __async = ...;
function fn() {
  // reassign outer binding for `fn` on the first invocation.
  fn = __async(Promise)(function* ({ x }) {

  });

  // forward the invocation
  return fn.apply(this, arguments);
}
```
