### PR TITLE
Adds 'symbol constraints' for easier checking of assignments.

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -242,6 +242,22 @@ namespace ts {
             addDeclarationToSymbol(symbol, node, includes);
             symbol.parent = parent;
 
+            if (node.flags & NodeFlags.Const ||
+                (node.kind === SyntaxKind.VariableDeclaration && node.parent.flags & NodeFlags.Const)) {
+                if (symbol.flags & SymbolFlags.ConstEnum) {
+                    symbol.constraints |= SymbolConstraints.Immutable;
+                }
+                else {
+                    symbol.constraints |= SymbolConstraints.notWritable;
+                }
+            }
+
+            // Only true for 'const enum' which its members are implicitly not writable
+            // Note: Immutable class/container could exist iff all its members are notWritable/const
+            if(symbol.parent && symbol.parent.constraints & SymbolConstraints.Immutable) {
+                symbol.constraints |= SymbolConstraints.notWritable;
+            }
+
             return symbol;
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9744,7 +9744,7 @@ namespace ts {
                         return !symbol || symbol === unknownSymbol || (symbol.flags & ~SymbolFlags.EnumMember) !== 0;
                     }
                     case SyntaxKind.ElementAccessExpression:
-                        //  old compiler doesn't check indexed assess
+                        //  old compiler doesn't check indexed access
                         return true;
                     case SyntaxKind.ParenthesizedExpression:
                         return isReferenceOrErrorExpression((<ParenthesizedExpression>n).expression);
@@ -9753,12 +9753,12 @@ namespace ts {
                 }
             }
 
-            function isConstVariableReference(n: Node): boolean {
+            function isNotWritableVariableReference(n: Node): boolean {
                 switch (n.kind) {
                     case SyntaxKind.Identifier:
                     case SyntaxKind.PropertyAccessExpression: {
                         let symbol = findSymbol(n);
-                        return symbol && (symbol.flags & SymbolFlags.Variable) !== 0 && (getDeclarationFlagsFromSymbol(symbol) & NodeFlags.Const) !== 0;
+                        return symbol && (symbol.constraints & SymbolConstraints.notWritable) !== 0;
                     }
                     case SyntaxKind.ElementAccessExpression: {
                         let index = (<ElementAccessExpression>n).argumentExpression;
@@ -9766,12 +9766,12 @@ namespace ts {
                         if (symbol && index && index.kind === SyntaxKind.StringLiteral) {
                             let name = (<LiteralExpression>index).text;
                             let prop = getPropertyOfType(getTypeOfSymbol(symbol), name);
-                            return prop && (prop.flags & SymbolFlags.Variable) !== 0 && (getDeclarationFlagsFromSymbol(prop) & NodeFlags.Const) !== 0;
+                            return prop && (prop.constraints & SymbolConstraints.notWritable) !== 0;
                         }
                         return false;
                     }
                     case SyntaxKind.ParenthesizedExpression:
-                        return isConstVariableReference((<ParenthesizedExpression>n).expression);
+                        return isNotWritableVariableReference((<ParenthesizedExpression>n).expression);
                     default:
                         return false;
                 }
@@ -9782,7 +9782,7 @@ namespace ts {
                 return false;
             }
 
-            if (isConstVariableReference(n)) {
+            if (isNotWritableVariableReference(n)) {
                 error(n, constantVariableMessage);
                 return false;
             }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -377,10 +377,12 @@ namespace ts {
         Namespace =         0x00020000,  // Namespace declaration
         ExportContext =     0x00040000,  // Export context (initialized by binding)
         ContainsThis =      0x00080000,  // Interface contains references to "this"
+        ConstValue =        0x00100000,  // Node that represents a constant value (1, "a", true/false, null) 
 
         Modifier = Export | Ambient | Public | Private | Protected | Static | Abstract | Default | Async,
         AccessibilityModifier = Public | Private | Protected,
-        BlockScoped = Let | Const
+        BlockScoped = Let | Const,
+        Constant = Const | ConstValue
     }
 
     /* @internal */
@@ -1693,6 +1695,7 @@ namespace ts {
         name: string;                           // Name of symbol
         declarations?: Declaration[];           // Declarations associated with this symbol
         valueDeclaration?: Declaration;         // First value declaration of the symbol
+        constraints?: SymbolConstraints;        // Symbol constraints
 
         members?: SymbolTable;                  // Class, interface or literal instance members
         exports?: SymbolTable;                  // Module exports
@@ -1701,6 +1704,12 @@ namespace ts {
         /* @internal */ parent?: Symbol;        // Parent symbol
         /* @internal */ exportSymbol?: Symbol;  // Exported symbol associated with this symbol
         /* @internal */ constEnumOnlyModule?: boolean; // True if module contains only const enums or other modules with only const enums
+    }
+
+    export const enum SymbolConstraints {
+        notWritable = 1,
+        notMutable,
+        Immutable = notWritable | notMutable,
     }
 
     /* @internal */


### PR DESCRIPTION
I'll work on a proposal to explain what this solves:
### SymbolConstraints
- Adds extra bits since none left in SymbolFlags
- Gives an easy way to check assignments to something that is notWritable

Fixes #2215
Possibly can solve: #2456, ?

### ConstValue
- Gives some knowledge that a ```Node``` has a constant value.

