### PR TITLE
Fix emit for `export {...}` with ES6 target and non-ES6 modules

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -3785,7 +3785,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                         write(";");
                     }
                 }
-                if (languageVersion < ScriptTarget.ES6 && node.parent === currentSourceFile) {
+                if (modulekind !== ModuleKind.ES6 && node.parent === currentSourceFile) {
                     forEach(node.declarationList.declarations, emitExportVariableAssignments);
                 }
             }
@@ -4011,7 +4011,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 }
 
                 emitSignatureAndBody(node);
-                if (languageVersion < ScriptTarget.ES6 && node.kind === SyntaxKind.FunctionDeclaration && node.parent === currentSourceFile && node.name) {
+                if (modulekind !== ModuleKind.ES6 && node.kind === SyntaxKind.FunctionDeclaration && node.parent === currentSourceFile && node.name) {
                     emitExportMemberAssignments((<FunctionDeclaration>node).name);
                 }
 
@@ -4687,6 +4687,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 else {
                     emitClassLikeDeclarationForES6AndHigher(node);
                 }
+                if (modulekind !== ModuleKind.ES6 && node.parent === currentSourceFile && node.name) {
+                    emitExportMemberAssignments(node.name);
+                }
             }
 
             function emitClassLikeDeclarationForES6AndHigher(node: ClassLikeDeclaration) {
@@ -4933,10 +4936,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
 
                 if (node.kind === SyntaxKind.ClassDeclaration) {
                     emitExportMemberAssignment(<ClassDeclaration>node);
-                }
-
-                if (languageVersion < ScriptTarget.ES6 && node.parent === currentSourceFile && node.name) {
-                    emitExportMemberAssignments(node.name);
                 }
             }
 
@@ -5509,7 +5508,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     emitEnd(node);
                     write(";");
                 }
-                if (languageVersion < ScriptTarget.ES6 && node.parent === currentSourceFile) {
+                if (modulekind !== ModuleKind.ES6 && node.parent === currentSourceFile) {
                     if (modulekind === ModuleKind.System && (node.flags & NodeFlags.Export)) {
                         // write the call to exporter for enum
                         writeLine();

--- a/tests/baselines/reference/exportsAndImports1-es6.js
+++ b/tests/baselines/reference/exportsAndImports1-es6.js
@@ -1,0 +1,73 @@
+//// [tests/cases/conformance/es6/modules/exportsAndImports1-es6.ts] ////
+
+//// [t1.ts]
+
+var v = 1;
+function f() { }
+class C {
+}
+interface I {
+}
+enum E {
+    A, B, C
+}
+const enum D {
+    A, B, C
+}
+module M {
+    export var x;
+}
+module N {
+    export interface I {
+    }
+}
+type T = number;
+import a = M.x;
+
+export { v, f, C, I, E, D, M, N, T, a };
+
+//// [t2.ts]
+export { v, f, C, I, E, D, M, N, T, a } from "./t1";
+
+//// [t3.ts]
+import { v, f, C, I, E, D, M, N, T, a } from "./t1";
+export { v, f, C, I, E, D, M, N, T, a };
+
+
+//// [t1.js]
+var v = 1;
+exports.v = v;
+function f() { }
+exports.f = f;
+class C {
+}
+exports.C = C;
+var E;
+(function (E) {
+    E[E["A"] = 0] = "A";
+    E[E["B"] = 1] = "B";
+    E[E["C"] = 2] = "C";
+})(E || (E = {}));
+exports.E = E;
+var M;
+(function (M) {
+})(M || (M = {}));
+exports.M = M;
+var a = M.x;
+exports.a = a;
+//// [t2.js]
+var t1_1 = require("./t1");
+exports.v = t1_1.v;
+exports.f = t1_1.f;
+exports.C = t1_1.C;
+exports.E = t1_1.E;
+exports.M = t1_1.M;
+exports.a = t1_1.a;
+//// [t3.js]
+var t1_1 = require("./t1");
+exports.v = t1_1.v;
+exports.f = t1_1.f;
+exports.C = t1_1.C;
+exports.E = t1_1.E;
+exports.M = t1_1.M;
+exports.a = t1_1.a;

--- a/tests/baselines/reference/exportsAndImports1-es6.symbols
+++ b/tests/baselines/reference/exportsAndImports1-es6.symbols
@@ -1,0 +1,101 @@
+=== tests/cases/conformance/es6/modules/t1.ts ===
+
+var v = 1;
+>v : Symbol(v, Decl(t1.ts, 1, 3))
+
+function f() { }
+>f : Symbol(f, Decl(t1.ts, 1, 10))
+
+class C {
+>C : Symbol(C, Decl(t1.ts, 2, 16))
+}
+interface I {
+>I : Symbol(I, Decl(t1.ts, 4, 1))
+}
+enum E {
+>E : Symbol(E, Decl(t1.ts, 6, 1))
+
+    A, B, C
+>A : Symbol(E.A, Decl(t1.ts, 7, 8))
+>B : Symbol(E.B, Decl(t1.ts, 8, 6))
+>C : Symbol(E.C, Decl(t1.ts, 8, 9))
+}
+const enum D {
+>D : Symbol(D, Decl(t1.ts, 9, 1))
+
+    A, B, C
+>A : Symbol(D.A, Decl(t1.ts, 10, 14))
+>B : Symbol(D.B, Decl(t1.ts, 11, 6))
+>C : Symbol(D.C, Decl(t1.ts, 11, 9))
+}
+module M {
+>M : Symbol(M, Decl(t1.ts, 12, 1))
+
+    export var x;
+>x : Symbol(x, Decl(t1.ts, 14, 14))
+}
+module N {
+>N : Symbol(N, Decl(t1.ts, 15, 1))
+
+    export interface I {
+>I : Symbol(I, Decl(t1.ts, 16, 10))
+    }
+}
+type T = number;
+>T : Symbol(T, Decl(t1.ts, 19, 1))
+
+import a = M.x;
+>a : Symbol(a, Decl(t1.ts, 20, 16))
+>M : Symbol(M, Decl(t1.ts, 12, 1))
+>x : Symbol(a, Decl(t1.ts, 14, 14))
+
+export { v, f, C, I, E, D, M, N, T, a };
+>v : Symbol(v, Decl(t1.ts, 23, 8))
+>f : Symbol(f, Decl(t1.ts, 23, 11))
+>C : Symbol(C, Decl(t1.ts, 23, 14))
+>I : Symbol(I, Decl(t1.ts, 23, 17))
+>E : Symbol(E, Decl(t1.ts, 23, 20))
+>D : Symbol(D, Decl(t1.ts, 23, 23))
+>M : Symbol(M, Decl(t1.ts, 23, 26))
+>N : Symbol(N, Decl(t1.ts, 23, 29))
+>T : Symbol(T, Decl(t1.ts, 23, 32))
+>a : Symbol(a, Decl(t1.ts, 23, 35))
+
+=== tests/cases/conformance/es6/modules/t2.ts ===
+export { v, f, C, I, E, D, M, N, T, a } from "./t1";
+>v : Symbol(v, Decl(t2.ts, 0, 8))
+>f : Symbol(f, Decl(t2.ts, 0, 11))
+>C : Symbol(C, Decl(t2.ts, 0, 14))
+>I : Symbol(I, Decl(t2.ts, 0, 17))
+>E : Symbol(E, Decl(t2.ts, 0, 20))
+>D : Symbol(D, Decl(t2.ts, 0, 23))
+>M : Symbol(M, Decl(t2.ts, 0, 26))
+>N : Symbol(N, Decl(t2.ts, 0, 29))
+>T : Symbol(T, Decl(t2.ts, 0, 32))
+>a : Symbol(a, Decl(t2.ts, 0, 35))
+
+=== tests/cases/conformance/es6/modules/t3.ts ===
+import { v, f, C, I, E, D, M, N, T, a } from "./t1";
+>v : Symbol(v, Decl(t3.ts, 0, 8))
+>f : Symbol(f, Decl(t3.ts, 0, 11))
+>C : Symbol(C, Decl(t3.ts, 0, 14))
+>I : Symbol(I, Decl(t3.ts, 0, 17))
+>E : Symbol(E, Decl(t3.ts, 0, 20))
+>D : Symbol(D, Decl(t3.ts, 0, 23))
+>M : Symbol(M, Decl(t3.ts, 0, 26))
+>N : Symbol(N, Decl(t3.ts, 0, 29))
+>T : Symbol(T, Decl(t3.ts, 0, 32))
+>a : Symbol(a, Decl(t3.ts, 0, 35))
+
+export { v, f, C, I, E, D, M, N, T, a };
+>v : Symbol(v, Decl(t3.ts, 1, 8))
+>f : Symbol(f, Decl(t3.ts, 1, 11))
+>C : Symbol(C, Decl(t3.ts, 1, 14))
+>I : Symbol(I, Decl(t3.ts, 1, 17))
+>E : Symbol(E, Decl(t3.ts, 1, 20))
+>D : Symbol(D, Decl(t3.ts, 1, 23))
+>M : Symbol(M, Decl(t3.ts, 1, 26))
+>N : Symbol(N, Decl(t3.ts, 1, 29))
+>T : Symbol(T, Decl(t3.ts, 1, 32))
+>a : Symbol(a, Decl(t3.ts, 1, 35))
+

--- a/tests/baselines/reference/exportsAndImports1-es6.types
+++ b/tests/baselines/reference/exportsAndImports1-es6.types
@@ -1,0 +1,102 @@
+=== tests/cases/conformance/es6/modules/t1.ts ===
+
+var v = 1;
+>v : number
+>1 : number
+
+function f() { }
+>f : () => void
+
+class C {
+>C : C
+}
+interface I {
+>I : I
+}
+enum E {
+>E : E
+
+    A, B, C
+>A : E
+>B : E
+>C : E
+}
+const enum D {
+>D : D
+
+    A, B, C
+>A : D
+>B : D
+>C : D
+}
+module M {
+>M : typeof M
+
+    export var x;
+>x : any
+}
+module N {
+>N : any
+
+    export interface I {
+>I : I
+    }
+}
+type T = number;
+>T : number
+
+import a = M.x;
+>a : any
+>M : typeof M
+>x : any
+
+export { v, f, C, I, E, D, M, N, T, a };
+>v : number
+>f : () => void
+>C : typeof C
+>I : any
+>E : typeof E
+>D : typeof D
+>M : typeof M
+>N : any
+>T : any
+>a : any
+
+=== tests/cases/conformance/es6/modules/t2.ts ===
+export { v, f, C, I, E, D, M, N, T, a } from "./t1";
+>v : number
+>f : () => void
+>C : typeof C
+>I : any
+>E : typeof E
+>D : typeof D
+>M : typeof M
+>N : any
+>T : any
+>a : any
+
+=== tests/cases/conformance/es6/modules/t3.ts ===
+import { v, f, C, I, E, D, M, N, T, a } from "./t1";
+>v : number
+>f : () => void
+>C : typeof C
+>I : any
+>E : typeof E
+>D : typeof D
+>M : typeof M
+>N : any
+>T : any
+>a : any
+
+export { v, f, C, I, E, D, M, N, T, a };
+>v : number
+>f : () => void
+>C : typeof C
+>I : any
+>E : typeof E
+>D : typeof D
+>M : typeof M
+>N : any
+>T : any
+>a : any
+

--- a/tests/baselines/reference/exportsAndImports2-es6.js
+++ b/tests/baselines/reference/exportsAndImports2-es6.js
@@ -1,0 +1,26 @@
+//// [tests/cases/conformance/es6/modules/exportsAndImports2-es6.ts] ////
+
+//// [t1.ts]
+
+export var x = "x";
+export var y = "y";
+
+//// [t2.ts]
+export { x as y, y as x } from "./t1";
+
+//// [t3.ts]
+import { x, y } from "./t1";
+export { x as y, y as x };
+
+
+//// [t1.js]
+exports.x = "x";
+exports.y = "y";
+//// [t2.js]
+var t1_1 = require("./t1");
+exports.y = t1_1.x;
+exports.x = t1_1.y;
+//// [t3.js]
+var t1_1 = require("./t1");
+exports.y = t1_1.x;
+exports.x = t1_1.y;

--- a/tests/baselines/reference/exportsAndImports2-es6.symbols
+++ b/tests/baselines/reference/exportsAndImports2-es6.symbols
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/es6/modules/t1.ts ===
+
+export var x = "x";
+>x : Symbol(x, Decl(t1.ts, 1, 10))
+
+export var y = "y";
+>y : Symbol(y, Decl(t1.ts, 2, 10))
+
+=== tests/cases/conformance/es6/modules/t2.ts ===
+export { x as y, y as x } from "./t1";
+>x : Symbol(y, Decl(t2.ts, 0, 8))
+>y : Symbol(y, Decl(t2.ts, 0, 8))
+>y : Symbol(x, Decl(t2.ts, 0, 16))
+>x : Symbol(x, Decl(t2.ts, 0, 16))
+
+=== tests/cases/conformance/es6/modules/t3.ts ===
+import { x, y } from "./t1";
+>x : Symbol(x, Decl(t3.ts, 0, 8))
+>y : Symbol(y, Decl(t3.ts, 0, 11))
+
+export { x as y, y as x };
+>x : Symbol(y, Decl(t3.ts, 1, 8))
+>y : Symbol(y, Decl(t3.ts, 1, 8))
+>y : Symbol(x, Decl(t3.ts, 1, 16))
+>x : Symbol(x, Decl(t3.ts, 1, 16))
+

--- a/tests/baselines/reference/exportsAndImports2-es6.types
+++ b/tests/baselines/reference/exportsAndImports2-es6.types
@@ -1,0 +1,28 @@
+=== tests/cases/conformance/es6/modules/t1.ts ===
+
+export var x = "x";
+>x : string
+>"x" : string
+
+export var y = "y";
+>y : string
+>"y" : string
+
+=== tests/cases/conformance/es6/modules/t2.ts ===
+export { x as y, y as x } from "./t1";
+>x : string
+>y : string
+>y : string
+>x : string
+
+=== tests/cases/conformance/es6/modules/t3.ts ===
+import { x, y } from "./t1";
+>x : string
+>y : string
+
+export { x as y, y as x };
+>x : string
+>y : string
+>y : string
+>x : string
+

--- a/tests/baselines/reference/exportsAndImports3-es6.js
+++ b/tests/baselines/reference/exportsAndImports3-es6.js
@@ -1,0 +1,75 @@
+//// [tests/cases/conformance/es6/modules/exportsAndImports3-es6.ts] ////
+
+//// [t1.ts]
+
+export var v = 1;
+export function f() { }
+export class C {
+}
+export interface I {
+}
+export enum E {
+    A, B, C
+}
+export const enum D {
+    A, B, C
+}
+export module M {
+    export var x;
+}
+export module N {
+    export interface I {
+    }
+}
+export type T = number;
+export import a = M.x;
+
+export { v as v1, f as f1, C as C1, I as I1, E as E1, D as D1, M as M1, N as N1, T as T1, a as a1 };
+
+//// [t2.ts]
+export { v1 as v, f1 as f, C1 as C, I1 as I, E1 as E, D1 as D, M1 as M, N1 as N, T1 as T, a1 as a } from "./t1";
+
+//// [t3.ts]
+import { v1 as v, f1 as f, C1 as C, I1 as I, E1 as E, D1 as D, M1 as M, N1 as N, T1 as T, a1 as a } from "./t1";
+export { v, f, C, I, E, D, M, N, T, a };
+
+
+//// [t1.js]
+exports.v = 1;
+exports.v1 = exports.v;
+function f() { }
+exports.f = f;
+exports.f1 = f;
+class C {
+}
+exports.C = C;
+exports.C1 = C;
+(function (E) {
+    E[E["A"] = 0] = "A";
+    E[E["B"] = 1] = "B";
+    E[E["C"] = 2] = "C";
+})(exports.E || (exports.E = {}));
+var E = exports.E;
+exports.E1 = E;
+var M;
+(function (M) {
+})(M = exports.M || (exports.M = {}));
+exports.M1 = M;
+exports.a = M.x;
+exports.a1 = exports.a;
+//// [t2.js]
+var t1_1 = require("./t1");
+exports.v = t1_1.v1;
+exports.f = t1_1.f1;
+exports.C = t1_1.C1;
+exports.E = t1_1.E1;
+exports.M = t1_1.M1;
+exports.a = t1_1.a1;
+//// [t3.js]
+var t1_1 = require("./t1");
+exports.v = t1_1.v1;
+exports.f = t1_1.f1;
+exports.C = t1_1.C1;
+exports.E = t1_1.E1;
+exports.M = t1_1.M1;
+exports.a = t1_1.a1;

--- a/tests/baselines/reference/exportsAndImports3-es6.symbols
+++ b/tests/baselines/reference/exportsAndImports3-es6.symbols
@@ -1,0 +1,131 @@
+=== tests/cases/conformance/es6/modules/t1.ts ===
+
+export var v = 1;
+>v : Symbol(v, Decl(t1.ts, 1, 10))
+
+export function f() { }
+>f : Symbol(f, Decl(t1.ts, 1, 17))
+
+export class C {
+>C : Symbol(C, Decl(t1.ts, 2, 23))
+}
+export interface I {
+>I : Symbol(I, Decl(t1.ts, 4, 1))
+}
+export enum E {
+>E : Symbol(E, Decl(t1.ts, 6, 1))
+
+    A, B, C
+>A : Symbol(E.A, Decl(t1.ts, 7, 15))
+>B : Symbol(E.B, Decl(t1.ts, 8, 6))
+>C : Symbol(E.C, Decl(t1.ts, 8, 9))
+}
+export const enum D {
+>D : Symbol(D, Decl(t1.ts, 9, 1))
+
+    A, B, C
+>A : Symbol(D.A, Decl(t1.ts, 10, 21))
+>B : Symbol(D.B, Decl(t1.ts, 11, 6))
+>C : Symbol(D.C, Decl(t1.ts, 11, 9))
+}
+export module M {
+>M : Symbol(M, Decl(t1.ts, 12, 1))
+
+    export var x;
+>x : Symbol(x, Decl(t1.ts, 14, 14))
+}
+export module N {
+>N : Symbol(N, Decl(t1.ts, 15, 1))
+
+    export interface I {
+>I : Symbol(I, Decl(t1.ts, 16, 17))
+    }
+}
+export type T = number;
+>T : Symbol(T, Decl(t1.ts, 19, 1))
+
+export import a = M.x;
+>a : Symbol(a, Decl(t1.ts, 20, 23))
+>M : Symbol(M, Decl(t1.ts, 12, 1))
+>x : Symbol(a, Decl(t1.ts, 14, 14))
+
+export { v as v1, f as f1, C as C1, I as I1, E as E1, D as D1, M as M1, N as N1, T as T1, a as a1 };
+>v : Symbol(v1, Decl(t1.ts, 23, 8))
+>v1 : Symbol(v1, Decl(t1.ts, 23, 8))
+>f : Symbol(f1, Decl(t1.ts, 23, 17))
+>f1 : Symbol(f1, Decl(t1.ts, 23, 17))
+>C : Symbol(C1, Decl(t1.ts, 23, 26))
+>C1 : Symbol(C1, Decl(t1.ts, 23, 26))
+>I : Symbol(I1, Decl(t1.ts, 23, 35))
+>I1 : Symbol(I1, Decl(t1.ts, 23, 35))
+>E : Symbol(E1, Decl(t1.ts, 23, 44))
+>E1 : Symbol(E1, Decl(t1.ts, 23, 44))
+>D : Symbol(D1, Decl(t1.ts, 23, 53))
+>D1 : Symbol(D1, Decl(t1.ts, 23, 53))
+>M : Symbol(M1, Decl(t1.ts, 23, 62))
+>M1 : Symbol(M1, Decl(t1.ts, 23, 62))
+>N : Symbol(N1, Decl(t1.ts, 23, 71))
+>N1 : Symbol(N1, Decl(t1.ts, 23, 71))
+>T : Symbol(T1, Decl(t1.ts, 23, 80))
+>T1 : Symbol(T1, Decl(t1.ts, 23, 80))
+>a : Symbol(a1, Decl(t1.ts, 23, 89))
+>a1 : Symbol(a1, Decl(t1.ts, 23, 89))
+
+=== tests/cases/conformance/es6/modules/t2.ts ===
+export { v1 as v, f1 as f, C1 as C, I1 as I, E1 as E, D1 as D, M1 as M, N1 as N, T1 as T, a1 as a } from "./t1";
+>v1 : Symbol(v, Decl(t2.ts, 0, 8))
+>v : Symbol(v, Decl(t2.ts, 0, 8))
+>f1 : Symbol(f, Decl(t2.ts, 0, 17))
+>f : Symbol(f, Decl(t2.ts, 0, 17))
+>C1 : Symbol(C, Decl(t2.ts, 0, 26))
+>C : Symbol(C, Decl(t2.ts, 0, 26))
+>I1 : Symbol(I, Decl(t2.ts, 0, 35))
+>I : Symbol(I, Decl(t2.ts, 0, 35))
+>E1 : Symbol(E, Decl(t2.ts, 0, 44))
+>E : Symbol(E, Decl(t2.ts, 0, 44))
+>D1 : Symbol(D, Decl(t2.ts, 0, 53))
+>D : Symbol(D, Decl(t2.ts, 0, 53))
+>M1 : Symbol(M, Decl(t2.ts, 0, 62))
+>M : Symbol(M, Decl(t2.ts, 0, 62))
+>N1 : Symbol(N, Decl(t2.ts, 0, 71))
+>N : Symbol(N, Decl(t2.ts, 0, 71))
+>T1 : Symbol(T, Decl(t2.ts, 0, 80))
+>T : Symbol(T, Decl(t2.ts, 0, 80))
+>a1 : Symbol(a, Decl(t2.ts, 0, 89))
+>a : Symbol(a, Decl(t2.ts, 0, 89))
+
+=== tests/cases/conformance/es6/modules/t3.ts ===
+import { v1 as v, f1 as f, C1 as C, I1 as I, E1 as E, D1 as D, M1 as M, N1 as N, T1 as T, a1 as a } from "./t1";
+>v1 : Symbol(v, Decl(t3.ts, 0, 8))
+>v : Symbol(v, Decl(t3.ts, 0, 8))
+>f1 : Symbol(f, Decl(t3.ts, 0, 17))
+>f : Symbol(f, Decl(t3.ts, 0, 17))
+>C1 : Symbol(C, Decl(t3.ts, 0, 26))
+>C : Symbol(C, Decl(t3.ts, 0, 26))
+>I1 : Symbol(I, Decl(t3.ts, 0, 35))
+>I : Symbol(I, Decl(t3.ts, 0, 35))
+>E1 : Symbol(E, Decl(t3.ts, 0, 44))
+>E : Symbol(E, Decl(t3.ts, 0, 44))
+>D1 : Symbol(D, Decl(t3.ts, 0, 53))
+>D : Symbol(D, Decl(t3.ts, 0, 53))
+>M1 : Symbol(M, Decl(t3.ts, 0, 62))
+>M : Symbol(M, Decl(t3.ts, 0, 62))
+>N1 : Symbol(N, Decl(t3.ts, 0, 71))
+>N : Symbol(N, Decl(t3.ts, 0, 71))
+>T1 : Symbol(T, Decl(t3.ts, 0, 80))
+>T : Symbol(T, Decl(t3.ts, 0, 80))
+>a1 : Symbol(a, Decl(t3.ts, 0, 89))
+>a : Symbol(a, Decl(t3.ts, 0, 89))
+
+export { v, f, C, I, E, D, M, N, T, a };
+>v : Symbol(v, Decl(t3.ts, 1, 8))
+>f : Symbol(f, Decl(t3.ts, 1, 11))
+>C : Symbol(C, Decl(t3.ts, 1, 14))
+>I : Symbol(I, Decl(t3.ts, 1, 17))
+>E : Symbol(E, Decl(t3.ts, 1, 20))
+>D : Symbol(D, Decl(t3.ts, 1, 23))
+>M : Symbol(M, Decl(t3.ts, 1, 26))
+>N : Symbol(N, Decl(t3.ts, 1, 29))
+>T : Symbol(T, Decl(t3.ts, 1, 32))
+>a : Symbol(a, Decl(t3.ts, 1, 35))
+

--- a/tests/baselines/reference/exportsAndImports3-es6.types
+++ b/tests/baselines/reference/exportsAndImports3-es6.types
@@ -1,0 +1,132 @@
+=== tests/cases/conformance/es6/modules/t1.ts ===
+
+export var v = 1;
+>v : number
+>1 : number
+
+export function f() { }
+>f : () => void
+
+export class C {
+>C : C
+}
+export interface I {
+>I : I
+}
+export enum E {
+>E : E
+
+    A, B, C
+>A : E
+>B : E
+>C : E
+}
+export const enum D {
+>D : D
+
+    A, B, C
+>A : D
+>B : D
+>C : D
+}
+export module M {
+>M : typeof M
+
+    export var x;
+>x : any
+}
+export module N {
+>N : any
+
+    export interface I {
+>I : I
+    }
+}
+export type T = number;
+>T : number
+
+export import a = M.x;
+>a : any
+>M : typeof M
+>x : any
+
+export { v as v1, f as f1, C as C1, I as I1, E as E1, D as D1, M as M1, N as N1, T as T1, a as a1 };
+>v : number
+>v1 : number
+>f : () => void
+>f1 : () => void
+>C : typeof C
+>C1 : typeof C
+>I : any
+>I1 : any
+>E : typeof E
+>E1 : typeof E
+>D : typeof D
+>D1 : typeof D
+>M : typeof M
+>M1 : typeof M
+>N : any
+>N1 : any
+>T : any
+>T1 : any
+>a : any
+>a1 : any
+
+=== tests/cases/conformance/es6/modules/t2.ts ===
+export { v1 as v, f1 as f, C1 as C, I1 as I, E1 as E, D1 as D, M1 as M, N1 as N, T1 as T, a1 as a } from "./t1";
+>v1 : number
+>v : number
+>f1 : () => void
+>f : () => void
+>C1 : typeof C
+>C : typeof C
+>I1 : any
+>I : any
+>E1 : typeof E
+>E : typeof E
+>D1 : typeof D
+>D : typeof D
+>M1 : typeof M
+>M : typeof M
+>N1 : any
+>N : any
+>T1 : any
+>T : any
+>a1 : any
+>a : any
+
+=== tests/cases/conformance/es6/modules/t3.ts ===
+import { v1 as v, f1 as f, C1 as C, I1 as I, E1 as E, D1 as D, M1 as M, N1 as N, T1 as T, a1 as a } from "./t1";
+>v1 : number
+>v : number
+>f1 : () => void
+>f : () => void
+>C1 : typeof C
+>C : typeof C
+>I1 : any
+>I : any
+>E1 : typeof E
+>E : typeof E
+>D1 : typeof D
+>D : typeof D
+>M1 : typeof M
+>M : typeof M
+>N1 : any
+>N : any
+>T1 : any
+>T : any
+>a1 : any
+>a : any
+
+export { v, f, C, I, E, D, M, N, T, a };
+>v : number
+>f : () => void
+>C : typeof C
+>I : any
+>E : typeof E
+>D : typeof D
+>M : typeof M
+>N : any
+>T : any
+>a : any
+

--- a/tests/baselines/reference/exportsAndImports4-es6.js
+++ b/tests/baselines/reference/exportsAndImports4-es6.js
@@ -1,0 +1,66 @@
+//// [tests/cases/conformance/es6/modules/exportsAndImports4-es6.ts] ////
+
+//// [t1.ts]
+
+export default "hello";
+
+//// [t2.ts]
+import a = require("./t1");
+a.default;
+import b from "./t1";
+b;
+import * as c from "./t1";
+c.default;
+import { default as d } from "./t1";
+d;
+import e1, * as e2 from "./t1";
+e1;
+e2.default;
+import f1, { default as f2 } from "./t1";
+f1;
+f2;
+import "./t1";
+
+//// [t3.ts]
+import a = require("./t1");
+a.default;
+import b from "./t1";
+b;
+import * as c from "./t1";
+c.default;
+import { default as d } from "./t1";
+d;
+import e1, * as e2 from "./t1";
+e1;
+e2.default;
+import f1, { default as f2 } from "./t1";
+f1;
+f2;
+export { a, b, c, d, e1, e2, f1, f2 };
+
+
+//// [t1.js]
+exports.default = "hello";
+//// [t3.js]
+var a = require("./t1");
+exports.a = a;
+a.default;
+var t1_1 = require("./t1");
+exports.b = t1_1.default;
+t1_1.default;
+var c = require("./t1");
+exports.c = c;
+c.default;
+var t1_2 = require("./t1");
+exports.d = t1_2.default;
+t1_2.default;
+var t1_3 = require("./t1"), e2 = t1_3;
+exports.e1 = t1_3.default;
+exports.e2 = e2;
+t1_3.default;
+e2.default;
+var t1_4 = require("./t1");
+exports.f1 = t1_4.default;
+exports.f2 = t1_4.default;
+t1_4.default;
+t1_4.default;

--- a/tests/baselines/reference/exportsAndImports4-es6.symbols
+++ b/tests/baselines/reference/exportsAndImports4-es6.symbols
@@ -1,0 +1,68 @@
+=== tests/cases/conformance/es6/modules/t3.ts ===
+import a = require("./t1");
+>a : Symbol(a, Decl(t3.ts, 0, 0))
+
+a.default;
+>a.default : Symbol(a.default, Decl(t1.ts, 0, 0))
+>a : Symbol(a, Decl(t3.ts, 0, 0))
+>default : Symbol(a.default, Decl(t1.ts, 0, 0))
+
+import b from "./t1";
+>b : Symbol(b, Decl(t3.ts, 2, 6))
+
+b;
+>b : Symbol(b, Decl(t3.ts, 2, 6))
+
+import * as c from "./t1";
+>c : Symbol(c, Decl(t3.ts, 4, 6))
+
+c.default;
+>c.default : Symbol(a.default, Decl(t1.ts, 0, 0))
+>c : Symbol(c, Decl(t3.ts, 4, 6))
+>default : Symbol(a.default, Decl(t1.ts, 0, 0))
+
+import { default as d } from "./t1";
+>default : Symbol(d, Decl(t3.ts, 6, 8))
+>d : Symbol(d, Decl(t3.ts, 6, 8))
+
+d;
+>d : Symbol(d, Decl(t3.ts, 6, 8))
+
+import e1, * as e2 from "./t1";
+>e1 : Symbol(e1, Decl(t3.ts, 8, 6))
+>e2 : Symbol(e2, Decl(t3.ts, 8, 10))
+
+e1;
+>e1 : Symbol(e1, Decl(t3.ts, 8, 6))
+
+e2.default;
+>e2.default : Symbol(a.default, Decl(t1.ts, 0, 0))
+>e2 : Symbol(e2, Decl(t3.ts, 8, 10))
+>default : Symbol(a.default, Decl(t1.ts, 0, 0))
+
+import f1, { default as f2 } from "./t1";
+>f1 : Symbol(f1, Decl(t3.ts, 11, 6))
+>default : Symbol(f2, Decl(t3.ts, 11, 12))
+>f2 : Symbol(f2, Decl(t3.ts, 11, 12))
+
+f1;
+>f1 : Symbol(f1, Decl(t3.ts, 11, 6))
+
+f2;
+>f2 : Symbol(f2, Decl(t3.ts, 11, 12))
+
+export { a, b, c, d, e1, e2, f1, f2 };
+>a : Symbol(a, Decl(t3.ts, 14, 8))
+>b : Symbol(b, Decl(t3.ts, 14, 11))
+>c : Symbol(c, Decl(t3.ts, 14, 14))
+>d : Symbol(d, Decl(t3.ts, 14, 17))
+>e1 : Symbol(e1, Decl(t3.ts, 14, 20))
+>e2 : Symbol(e2, Decl(t3.ts, 14, 24))
+>f1 : Symbol(f1, Decl(t3.ts, 14, 28))
+>f2 : Symbol(f2, Decl(t3.ts, 14, 32))
+
+=== tests/cases/conformance/es6/modules/t1.ts ===
+
+No type information for this code.export default "hello";
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/exportsAndImports4-es6.types
+++ b/tests/baselines/reference/exportsAndImports4-es6.types
@@ -1,0 +1,68 @@
+=== tests/cases/conformance/es6/modules/t3.ts ===
+import a = require("./t1");
+>a : typeof a
+
+a.default;
+>a.default : string
+>a : typeof a
+>default : string
+
+import b from "./t1";
+>b : string
+
+b;
+>b : string
+
+import * as c from "./t1";
+>c : typeof a
+
+c.default;
+>c.default : string
+>c : typeof a
+>default : string
+
+import { default as d } from "./t1";
+>default : string
+>d : string
+
+d;
+>d : string
+
+import e1, * as e2 from "./t1";
+>e1 : string
+>e2 : typeof a
+
+e1;
+>e1 : string
+
+e2.default;
+>e2.default : string
+>e2 : typeof a
+>default : string
+
+import f1, { default as f2 } from "./t1";
+>f1 : string
+>default : string
+>f2 : string
+
+f1;
+>f1 : string
+
+f2;
+>f2 : string
+
+export { a, b, c, d, e1, e2, f1, f2 };
+>a : typeof a
+>b : string
+>c : typeof a
+>d : string
+>e1 : string
+>e2 : typeof a
+>f1 : string
+>f2 : string
+
+=== tests/cases/conformance/es6/modules/t1.ts ===
+
+No type information for this code.export default "hello";
+No type information for this code.
+No type information for this code.

--- a/tests/cases/conformance/es6/modules/exportsAndImports1-es6.ts
+++ b/tests/cases/conformance/es6/modules/exportsAndImports1-es6.ts
@@ -1,0 +1,34 @@
+// @target: es6
+// @module: commonjs
+
+// @filename: t1.ts
+var v = 1;
+function f() { }
+class C {
+}
+interface I {
+}
+enum E {
+    A, B, C
+}
+const enum D {
+    A, B, C
+}
+module M {
+    export var x;
+}
+module N {
+    export interface I {
+    }
+}
+type T = number;
+import a = M.x;
+
+export { v, f, C, I, E, D, M, N, T, a };
+
+// @filename: t2.ts
+export { v, f, C, I, E, D, M, N, T, a } from "./t1";
+
+// @filename: t3.ts
+import { v, f, C, I, E, D, M, N, T, a } from "./t1";
+export { v, f, C, I, E, D, M, N, T, a };

--- a/tests/cases/conformance/es6/modules/exportsAndImports2-es6.ts
+++ b/tests/cases/conformance/es6/modules/exportsAndImports2-es6.ts
@@ -1,0 +1,13 @@
+// @target: es6
+// @module: commonjs
+
+// @filename: t1.ts
+export var x = "x";
+export var y = "y";
+
+// @filename: t2.ts
+export { x as y, y as x } from "./t1";
+
+// @filename: t3.ts
+import { x, y } from "./t1";
+export { x as y, y as x };

--- a/tests/cases/conformance/es6/modules/exportsAndImports3-es6.ts
+++ b/tests/cases/conformance/es6/modules/exportsAndImports3-es6.ts
@@ -1,0 +1,34 @@
+// @target: es6
+// @module: commonjs
+
+// @filename: t1.ts
+export var v = 1;
+export function f() { }
+export class C {
+}
+export interface I {
+}
+export enum E {
+    A, B, C
+}
+export const enum D {
+    A, B, C
+}
+export module M {
+    export var x;
+}
+export module N {
+    export interface I {
+    }
+}
+export type T = number;
+export import a = M.x;
+
+export { v as v1, f as f1, C as C1, I as I1, E as E1, D as D1, M as M1, N as N1, T as T1, a as a1 };
+
+// @filename: t2.ts
+export { v1 as v, f1 as f, C1 as C, I1 as I, E1 as E, D1 as D, M1 as M, N1 as N, T1 as T, a1 as a } from "./t1";
+
+// @filename: t3.ts
+import { v1 as v, f1 as f, C1 as C, I1 as I, E1 as E, D1 as D, M1 as M, N1 as N, T1 as T, a1 as a } from "./t1";
+export { v, f, C, I, E, D, M, N, T, a };

--- a/tests/cases/conformance/es6/modules/exportsAndImports4-es6.ts
+++ b/tests/cases/conformance/es6/modules/exportsAndImports4-es6.ts
@@ -1,0 +1,39 @@
+// @target: es6
+// @module: commonjs
+
+// @filename: t1.ts
+export default "hello";
+
+// @filename: t2.ts
+import a = require("./t1");
+a.default;
+import b from "./t1";
+b;
+import * as c from "./t1";
+c.default;
+import { default as d } from "./t1";
+d;
+import e1, * as e2 from "./t1";
+e1;
+e2.default;
+import f1, { default as f2 } from "./t1";
+f1;
+f2;
+import "./t1";
+
+// @filename: t3.ts
+import a = require("./t1");
+a.default;
+import b from "./t1";
+b;
+import * as c from "./t1";
+c.default;
+import { default as d } from "./t1";
+d;
+import e1, * as e2 from "./t1";
+e1;
+e2.default;
+import f1, { default as f2 } from "./t1";
+f1;
+f2;
+export { a, b, c, d, e1, e2, f1, f2 };


### PR DESCRIPTION
Fixes #5175.