### PR TITLE
Change the definition of NodeFilter in lib.d.ts

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -7893,6 +7893,11 @@ declare var Node: {
 }
 
 interface NodeFilter {
+    acceptNode(n: Node): number;
+}
+
+declare var NodeFilter: {
+    prototype: NodeFilter;
     FILTER_ACCEPT: number;
     FILTER_REJECT: number;
     FILTER_SKIP: number;
@@ -7910,7 +7915,6 @@ interface NodeFilter {
     SHOW_PROCESSING_INSTRUCTION: number;
     SHOW_TEXT: number;
 }
-declare var NodeFilter: NodeFilter;
 
 interface NodeIterator {
     expandEntityReferences: boolean;

--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -7897,7 +7897,6 @@ interface NodeFilter {
 }
 
 declare var NodeFilter: {
-    prototype: NodeFilter;
     FILTER_ACCEPT: number;
     FILTER_REJECT: number;
     FILTER_SKIP: number;


### PR DESCRIPTION
NodeFilter is a static type with instance member, which wasn't handled correctly in the script generating lib.d.ts. 

Fix #4684 