### PR TITLE
Escape quotes when emitting React

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -6848,7 +6848,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     if (isLineBreak(c)) {
                         if (firstNonWhitespace !== -1 && (lastNonWhitespace - firstNonWhitespace + 1 > 0)) {
                             let part = text.substr(firstNonWhitespace, lastNonWhitespace - firstNonWhitespace + 1);
-                            result = (result ? result + "\" + ' ' + \"" : "") + part;
+                            result = (result ? result + "\" + ' ' + \"" : "") + escapeString(part);
                         }
                         firstNonWhitespace = -1;
                     }
@@ -6862,7 +6862,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
 
                 if (firstNonWhitespace !== -1) {
                     let part = text.substr(firstNonWhitespace);
-                    result = (result ? result + "\" + ' ' + \"" : "") + part;
+                    result = (result ? result + "\" + ' ' + \"" : "") + escapeString(part);
                 }
 
                 if (result) {

--- a/tests/baselines/reference/tsxReactEmit6.js
+++ b/tests/baselines/reference/tsxReactEmit6.js
@@ -19,7 +19,11 @@ namespace M {
 	//  and M.React.__spread
 	var foo;
 	var spread1 = <div x='' {...foo} y='' />;
+
+	// Quotes
+	var x = <div>This "quote" thing</div>;
 }
+
 
 
 //// [file.js]
@@ -33,4 +37,6 @@ var M;
     //  and M.React.__spread
     var foo;
     var spread1 = M.React.createElement("div", M.React.__spread({x: ''}, foo, {y: ''}));
+    // Quotes
+    var x = M.React.createElement("div", null, "This \"quote\" thing");
 })(M || (M = {}));

--- a/tests/baselines/reference/tsxReactEmit6.symbols
+++ b/tests/baselines/reference/tsxReactEmit6.symbols
@@ -36,5 +36,12 @@ namespace M {
 >x : Symbol(unknown)
 >foo : Symbol(foo, Decl(react-consumer.tsx, 7, 4))
 >y : Symbol(unknown)
+
+	// Quotes
+	var x = <div>This "quote" thing</div>;
+>x : Symbol(x, Decl(react-consumer.tsx, 11, 4))
+>div : Symbol(JSX.IntrinsicElements, Decl(file.tsx, 2, 22))
+>div : Symbol(JSX.IntrinsicElements, Decl(file.tsx, 2, 22))
 }
+
 

--- a/tests/baselines/reference/tsxReactEmit6.types
+++ b/tests/baselines/reference/tsxReactEmit6.types
@@ -37,5 +37,13 @@ namespace M {
 >x : any
 >foo : any
 >y : any
+
+	// Quotes
+	var x = <div>This "quote" thing</div>;
+>x : JSX.Element
+><div>This "quote" thing</div> : JSX.Element
+>div : any
+>div : any
 }
+
 

--- a/tests/cases/conformance/jsx/tsxReactEmit6.tsx
+++ b/tests/cases/conformance/jsx/tsxReactEmit6.tsx
@@ -19,4 +19,8 @@ namespace M {
 	//  and M.React.__spread
 	var foo;
 	var spread1 = <div x='' {...foo} y='' />;
+
+	// Quotes
+	var x = <div>This "quote" thing</div>;
 }
+


### PR DESCRIPTION
Fixes #5132.

It's tempting to try to fix this on line 6903, but that breaks multi-line JSX text literals.