### PR TITLE
Namespace before ambient derived class finds heritage

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -130,7 +130,9 @@ namespace ts {
                 symbol.members = {};
             }
 
-            if (symbolFlags & SymbolFlags.Value && !symbol.valueDeclaration) {
+            if (symbolFlags & SymbolFlags.Value &&
+                (!symbol.valueDeclaration || symbol.valueDeclaration.kind === SyntaxKind.ModuleDeclaration)) {
+                // other kinds of value declarations take precedence over modules
                 symbol.valueDeclaration = node;
             }
         }

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -131,7 +131,8 @@ namespace ts {
             }
 
             if (symbolFlags & SymbolFlags.Value &&
-                (!symbol.valueDeclaration || symbol.valueDeclaration.kind === SyntaxKind.ModuleDeclaration)) {
+                (!symbol.valueDeclaration ||
+                 (symbol.valueDeclaration.kind === SyntaxKind.ModuleDeclaration && node.kind !== SyntaxKind.ModuleDeclaration))) {
                 // other kinds of value declarations take precedence over modules
                 symbol.valueDeclaration = node;
             }

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -130,12 +130,14 @@ namespace ts {
                 symbol.members = {};
             }
 
-            if (symbolFlags & SymbolFlags.Value &&
-                (!symbol.valueDeclaration ||
-                 (symbol.valueDeclaration.kind === SyntaxKind.ModuleDeclaration && node.kind !== SyntaxKind.ModuleDeclaration))) {
-                // other kinds of value declarations take precedence over modules
-                symbol.valueDeclaration = node;
-            }
+            if (symbolFlags & SymbolFlags.Value) {
+                const valueDeclaration = symbol.valueDeclaration;
+                if (!valueDeclaration ||
+                    (valueDeclaration.kind !== node.kind && valueDeclaration.kind === SyntaxKind.ModuleDeclaration)) {
+                    // other kinds of value declarations take precedence over modules
+                    symbol.valueDeclaration = node;
+                }
+        }
         }
 
         // Should not be called on a declaration with a computed property name,

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -294,7 +294,8 @@ namespace ts {
                 }
                 target.flags |= source.flags;
                 if (source.valueDeclaration &&
-                    (!target.valueDeclaration || target.valueDeclaration.kind === SyntaxKind.ModuleDeclaration)) {
+                    (!target.valueDeclaration ||
+                     (target.valueDeclaration.kind === SyntaxKind.ModuleDeclaration && source.valueDeclaration.kind !== SyntaxKind.ModuleDeclaration))) {
                     // other kinds of value declarations take precedence over modules
                     target.valueDeclaration = source.valueDeclaration;
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2766,10 +2766,9 @@ namespace ts {
         }
 
         function getBaseTypeNodeOfClass(type: InterfaceType): ExpressionWithTypeArguments {
-            let classDeclaration = getDeclarationOfKind(type.symbol, SyntaxKind.ClassDeclaration);
-            if (classDeclaration) {
-                return getClassExtendsHeritageClauseElement(classDeclaration as ClassLikeDeclaration);
-            }
+            let classDeclaration =
+                getDeclarationOfKind(type.symbol, SyntaxKind.ClassDeclaration) || type.symbol.valueDeclaration;
+            return getClassExtendsHeritageClauseElement(classDeclaration as ClassLikeDeclaration);
         }
 
         function getConstructorsForTypeArguments(type: ObjectType, typeArgumentNodes: TypeNode[]): Signature[] {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2766,7 +2766,10 @@ namespace ts {
         }
 
         function getBaseTypeNodeOfClass(type: InterfaceType): ExpressionWithTypeArguments {
-            return getClassExtendsHeritageClauseElement(<ClassLikeDeclaration>type.symbol.valueDeclaration);
+            let classDeclaration = getDeclarationOfKind(type.symbol, SyntaxKind.ClassDeclaration);
+            if (classDeclaration) {
+                return getClassExtendsHeritageClauseElement(classDeclaration as ClassLikeDeclaration);
+            }
         }
 
         function getConstructorsForTypeArguments(type: ObjectType, typeArgumentNodes: TypeNode[]): Signature[] {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -293,7 +293,11 @@ namespace ts {
                     target.constEnumOnlyModule = false;
                 }
                 target.flags |= source.flags;
-                if (!target.valueDeclaration && source.valueDeclaration) target.valueDeclaration = source.valueDeclaration;
+                if (source.valueDeclaration &&
+                    (!target.valueDeclaration || target.valueDeclaration.kind === SyntaxKind.ModuleDeclaration)) {
+                    // other kinds of value declarations take precedence over modules
+                    target.valueDeclaration = source.valueDeclaration;
+                }
                 forEach(source.declarations, node => {
                     target.declarations.push(node);
                 });
@@ -2766,9 +2770,7 @@ namespace ts {
         }
 
         function getBaseTypeNodeOfClass(type: InterfaceType): ExpressionWithTypeArguments {
-            let classDeclaration =
-                getDeclarationOfKind(type.symbol, SyntaxKind.ClassDeclaration) || type.symbol.valueDeclaration;
-            return getClassExtendsHeritageClauseElement(classDeclaration as ClassLikeDeclaration);
+            return getClassExtendsHeritageClauseElement(<ClassLikeDeclaration>type.symbol.valueDeclaration);
         }
 
         function getConstructorsForTypeArguments(type: ObjectType, typeArgumentNodes: TypeNode[]): Signature[] {

--- a/tests/baselines/reference/ambientClassDeclarationWithExtends.js
+++ b/tests/baselines/reference/ambientClassDeclarationWithExtends.js
@@ -1,4 +1,6 @@
-//// [ambientClassDeclarationWithExtends.ts]
+//// [tests/cases/compiler/ambientClassDeclarationWithExtends.ts] ////
+
+//// [ambientClassDeclarationExtends_singleFile.ts]
 declare class A { }
 declare class B extends A { }
 
@@ -10,10 +12,29 @@ declare class D extends C { }
 
 var d: C = new D();
 
+//// [ambientClassDeclarationExtends_file1.ts]
 
-//// [ambientClassDeclarationWithExtends.js]
+declare class E {
+    public bar;
+}
+namespace F { var y; }
+
+//// [ambientClassDeclarationExtends_file2.ts]
+
+declare class F extends E { }
+var f: E = new F();
+
+
+//// [ambientClassDeclarationExtends_singleFile.js]
 var D;
 (function (D) {
     var x;
 })(D || (D = {}));
 var d = new D();
+//// [ambientClassDeclarationExtends_file1.js]
+var F;
+(function (F) {
+    var y;
+})(F || (F = {}));
+//// [ambientClassDeclarationExtends_file2.js]
+var f = new F();

--- a/tests/baselines/reference/ambientClassDeclarationWithExtends.js
+++ b/tests/baselines/reference/ambientClassDeclarationWithExtends.js
@@ -2,5 +2,18 @@
 declare class A { }
 declare class B extends A { }
 
+declare class C {
+    public foo;
+}
+namespace D { var x; }
+declare class D extends C { }
+
+var d: C = new D();
+
 
 //// [ambientClassDeclarationWithExtends.js]
+var D;
+(function (D) {
+    var x;
+})(D || (D = {}));
+var d = new D();

--- a/tests/baselines/reference/ambientClassDeclarationWithExtends.symbols
+++ b/tests/baselines/reference/ambientClassDeclarationWithExtends.symbols
@@ -1,27 +1,50 @@
-=== tests/cases/compiler/ambientClassDeclarationWithExtends.ts ===
+=== tests/cases/compiler/ambientClassDeclarationExtends_singleFile.ts ===
 declare class A { }
->A : Symbol(A, Decl(ambientClassDeclarationWithExtends.ts, 0, 0))
+>A : Symbol(A, Decl(ambientClassDeclarationExtends_singleFile.ts, 0, 0))
 
 declare class B extends A { }
->B : Symbol(B, Decl(ambientClassDeclarationWithExtends.ts, 0, 19))
->A : Symbol(A, Decl(ambientClassDeclarationWithExtends.ts, 0, 0))
+>B : Symbol(B, Decl(ambientClassDeclarationExtends_singleFile.ts, 0, 19))
+>A : Symbol(A, Decl(ambientClassDeclarationExtends_singleFile.ts, 0, 0))
 
 declare class C {
->C : Symbol(C, Decl(ambientClassDeclarationWithExtends.ts, 1, 29))
+>C : Symbol(C, Decl(ambientClassDeclarationExtends_singleFile.ts, 1, 29))
 
     public foo;
->foo : Symbol(foo, Decl(ambientClassDeclarationWithExtends.ts, 3, 17))
+>foo : Symbol(foo, Decl(ambientClassDeclarationExtends_singleFile.ts, 3, 17))
 }
 namespace D { var x; }
->D : Symbol(D, Decl(ambientClassDeclarationWithExtends.ts, 5, 1), Decl(ambientClassDeclarationWithExtends.ts, 6, 22))
->x : Symbol(x, Decl(ambientClassDeclarationWithExtends.ts, 6, 17))
+>D : Symbol(D, Decl(ambientClassDeclarationExtends_singleFile.ts, 5, 1), Decl(ambientClassDeclarationExtends_singleFile.ts, 6, 22))
+>x : Symbol(x, Decl(ambientClassDeclarationExtends_singleFile.ts, 6, 17))
 
 declare class D extends C { }
->D : Symbol(D, Decl(ambientClassDeclarationWithExtends.ts, 5, 1), Decl(ambientClassDeclarationWithExtends.ts, 6, 22))
->C : Symbol(C, Decl(ambientClassDeclarationWithExtends.ts, 1, 29))
+>D : Symbol(D, Decl(ambientClassDeclarationExtends_singleFile.ts, 5, 1), Decl(ambientClassDeclarationExtends_singleFile.ts, 6, 22))
+>C : Symbol(C, Decl(ambientClassDeclarationExtends_singleFile.ts, 1, 29))
 
 var d: C = new D();
->d : Symbol(d, Decl(ambientClassDeclarationWithExtends.ts, 9, 3))
->C : Symbol(C, Decl(ambientClassDeclarationWithExtends.ts, 1, 29))
->D : Symbol(D, Decl(ambientClassDeclarationWithExtends.ts, 5, 1), Decl(ambientClassDeclarationWithExtends.ts, 6, 22))
+>d : Symbol(d, Decl(ambientClassDeclarationExtends_singleFile.ts, 9, 3))
+>C : Symbol(C, Decl(ambientClassDeclarationExtends_singleFile.ts, 1, 29))
+>D : Symbol(D, Decl(ambientClassDeclarationExtends_singleFile.ts, 5, 1), Decl(ambientClassDeclarationExtends_singleFile.ts, 6, 22))
+
+=== tests/cases/compiler/ambientClassDeclarationExtends_file1.ts ===
+
+declare class E {
+>E : Symbol(E, Decl(ambientClassDeclarationExtends_file1.ts, 0, 0))
+
+    public bar;
+>bar : Symbol(bar, Decl(ambientClassDeclarationExtends_file1.ts, 1, 17))
+}
+namespace F { var y; }
+>F : Symbol(F, Decl(ambientClassDeclarationExtends_file1.ts, 3, 1), Decl(ambientClassDeclarationExtends_file2.ts, 0, 0))
+>y : Symbol(y, Decl(ambientClassDeclarationExtends_file1.ts, 4, 17))
+
+=== tests/cases/compiler/ambientClassDeclarationExtends_file2.ts ===
+
+declare class F extends E { }
+>F : Symbol(F, Decl(ambientClassDeclarationExtends_file1.ts, 3, 1), Decl(ambientClassDeclarationExtends_file2.ts, 0, 0))
+>E : Symbol(E, Decl(ambientClassDeclarationExtends_file1.ts, 0, 0))
+
+var f: E = new F();
+>f : Symbol(f, Decl(ambientClassDeclarationExtends_file2.ts, 2, 3))
+>E : Symbol(E, Decl(ambientClassDeclarationExtends_file1.ts, 0, 0))
+>F : Symbol(F, Decl(ambientClassDeclarationExtends_file1.ts, 3, 1), Decl(ambientClassDeclarationExtends_file2.ts, 0, 0))
 

--- a/tests/baselines/reference/ambientClassDeclarationWithExtends.symbols
+++ b/tests/baselines/reference/ambientClassDeclarationWithExtends.symbols
@@ -6,3 +6,22 @@ declare class B extends A { }
 >B : Symbol(B, Decl(ambientClassDeclarationWithExtends.ts, 0, 19))
 >A : Symbol(A, Decl(ambientClassDeclarationWithExtends.ts, 0, 0))
 
+declare class C {
+>C : Symbol(C, Decl(ambientClassDeclarationWithExtends.ts, 1, 29))
+
+    public foo;
+>foo : Symbol(foo, Decl(ambientClassDeclarationWithExtends.ts, 3, 17))
+}
+namespace D { var x; }
+>D : Symbol(D, Decl(ambientClassDeclarationWithExtends.ts, 5, 1), Decl(ambientClassDeclarationWithExtends.ts, 6, 22))
+>x : Symbol(x, Decl(ambientClassDeclarationWithExtends.ts, 6, 17))
+
+declare class D extends C { }
+>D : Symbol(D, Decl(ambientClassDeclarationWithExtends.ts, 5, 1), Decl(ambientClassDeclarationWithExtends.ts, 6, 22))
+>C : Symbol(C, Decl(ambientClassDeclarationWithExtends.ts, 1, 29))
+
+var d: C = new D();
+>d : Symbol(d, Decl(ambientClassDeclarationWithExtends.ts, 9, 3))
+>C : Symbol(C, Decl(ambientClassDeclarationWithExtends.ts, 1, 29))
+>D : Symbol(D, Decl(ambientClassDeclarationWithExtends.ts, 5, 1), Decl(ambientClassDeclarationWithExtends.ts, 6, 22))
+

--- a/tests/baselines/reference/ambientClassDeclarationWithExtends.types
+++ b/tests/baselines/reference/ambientClassDeclarationWithExtends.types
@@ -1,4 +1,4 @@
-=== tests/cases/compiler/ambientClassDeclarationWithExtends.ts ===
+=== tests/cases/compiler/ambientClassDeclarationExtends_singleFile.ts ===
 declare class A { }
 >A : A
 
@@ -25,4 +25,28 @@ var d: C = new D();
 >C : C
 >new D() : D
 >D : typeof D
+
+=== tests/cases/compiler/ambientClassDeclarationExtends_file1.ts ===
+
+declare class E {
+>E : E
+
+    public bar;
+>bar : any
+}
+namespace F { var y; }
+>F : typeof F
+>y : any
+
+=== tests/cases/compiler/ambientClassDeclarationExtends_file2.ts ===
+
+declare class F extends E { }
+>F : F
+>E : E
+
+var f: E = new F();
+>f : E
+>E : E
+>new F() : F
+>F : typeof F
 

--- a/tests/baselines/reference/ambientClassDeclarationWithExtends.types
+++ b/tests/baselines/reference/ambientClassDeclarationWithExtends.types
@@ -6,3 +6,23 @@ declare class B extends A { }
 >B : B
 >A : A
 
+declare class C {
+>C : C
+
+    public foo;
+>foo : any
+}
+namespace D { var x; }
+>D : typeof D
+>x : any
+
+declare class D extends C { }
+>D : D
+>C : C
+
+var d: C = new D();
+>d : C
+>C : C
+>new D() : D
+>D : typeof D
+

--- a/tests/cases/compiler/ambientClassDeclarationWithExtends.ts
+++ b/tests/cases/compiler/ambientClassDeclarationWithExtends.ts
@@ -1,2 +1,10 @@
 declare class A { }
 declare class B extends A { }
+
+declare class C {
+    public foo;
+}
+namespace D { var x; }
+declare class D extends C { }
+
+var d: C = new D();

--- a/tests/cases/compiler/ambientClassDeclarationWithExtends.ts
+++ b/tests/cases/compiler/ambientClassDeclarationWithExtends.ts
@@ -1,3 +1,4 @@
+// @Filename: ambientClassDeclarationExtends_singleFile.ts
 declare class A { }
 declare class B extends A { }
 
@@ -8,3 +9,15 @@ namespace D { var x; }
 declare class D extends C { }
 
 var d: C = new D();
+
+// @Filename: ambientClassDeclarationExtends_file1.ts
+
+declare class E {
+    public bar;
+}
+namespace F { var y; }
+
+// @Filename: ambientClassDeclarationExtends_file2.ts
+
+declare class F extends E { }
+var f: E = new F();


### PR DESCRIPTION
This fixes #4485 by making `getBaseTypeNodeOfClass` look for the declaration that is a class instead of assuming that `valueDeclaration` is a class. In the test case, it's a namespace, which is correct since namespaces have a value side.

I'm not sure whether other places that reference `valueDeclaration` assume they are dealing with a class even when they have a merged namespace+class. I'll take a look. In the meantime, @ahejlsberg, can you take a look to see whether this localised fix is appropriate?