### PR TITLE
Give a better message for multiple default exported functions of differing names

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11186,7 +11186,7 @@ namespace ts {
                     Diagnostics.Duplicate_function_implementation;
 
                 for (let declaration of declarations) {
-                    error(declaration.name, message);
+                    error(declaration.name || declaration, message);
                 }
             }
 

--- a/tests/baselines/reference/multipleDefaultExports02.errors.txt
+++ b/tests/baselines/reference/multipleDefaultExports02.errors.txt
@@ -1,18 +1,18 @@
-tests/cases/conformance/es6/modules/m1.ts(2,25): error TS2393: Duplicate function implementation.
-tests/cases/conformance/es6/modules/m1.ts(6,25): error TS2393: Duplicate function implementation.
+tests/cases/conformance/es6/modules/m1.ts(2,25): error TS2528: A module cannot have multiple default exports.
+tests/cases/conformance/es6/modules/m1.ts(6,25): error TS2528: A module cannot have multiple default exports.
 
 
 ==== tests/cases/conformance/es6/modules/m1.ts (2 errors) ====
     
     export default function foo() {
                             ~~~
-!!! error TS2393: Duplicate function implementation.
+!!! error TS2528: A module cannot have multiple default exports.
     
     }
     
     export default function bar() {
                             ~~~
-!!! error TS2393: Duplicate function implementation.
+!!! error TS2528: A module cannot have multiple default exports.
     
     }
     

--- a/tests/baselines/reference/multipleDefaultExports05.errors.txt
+++ b/tests/baselines/reference/multipleDefaultExports05.errors.txt
@@ -1,0 +1,58 @@
+error TS2393: Duplicate function implementation.
+tests/cases/conformance/es6/modules/m2.ts(1,1): error TS2528: A module cannot have multiple default exports.
+tests/cases/conformance/es6/modules/m2.ts(5,1): error TS2528: A module cannot have multiple default exports.
+tests/cases/conformance/es6/modules/m3.ts(1,1): error TS2528: A module cannot have multiple default exports.
+tests/cases/conformance/es6/modules/m3.ts(5,22): error TS2528: A module cannot have multiple default exports.
+tests/cases/conformance/es6/modules/m4.ts(1,25): error TS2528: A module cannot have multiple default exports.
+tests/cases/conformance/es6/modules/m4.ts(5,1): error TS2528: A module cannot have multiple default exports.
+
+
+!!! error TS2393: Duplicate function implementation.
+==== tests/cases/conformance/es6/modules/m1.ts (0 errors) ====
+    
+    export default function () {
+    
+    }
+    
+    export default function () {
+    
+    }
+    
+==== tests/cases/conformance/es6/modules/m2.ts (2 errors) ====
+    export default function () {
+    ~~~~~~
+!!! error TS2528: A module cannot have multiple default exports.
+    
+    }
+    
+    export default class {
+    ~~~~~~
+!!! error TS2528: A module cannot have multiple default exports.
+    
+    }
+    
+==== tests/cases/conformance/es6/modules/m3.ts (2 errors) ====
+    export default function () {
+    ~~~~~~
+!!! error TS2528: A module cannot have multiple default exports.
+    
+    }
+    
+    export default class C {
+                         ~
+!!! error TS2528: A module cannot have multiple default exports.
+    
+    }
+    
+==== tests/cases/conformance/es6/modules/m4.ts (2 errors) ====
+    export default function f() {
+                            ~
+!!! error TS2528: A module cannot have multiple default exports.
+    
+    }
+    
+    export default class {
+    ~~~~~~
+!!! error TS2528: A module cannot have multiple default exports.
+    
+    }

--- a/tests/baselines/reference/multipleDefaultExports05.errors.txt
+++ b/tests/baselines/reference/multipleDefaultExports05.errors.txt
@@ -1,4 +1,5 @@
-error TS2393: Duplicate function implementation.
+tests/cases/conformance/es6/modules/m1.ts(2,1): error TS2393: Duplicate function implementation.
+tests/cases/conformance/es6/modules/m1.ts(6,1): error TS2393: Duplicate function implementation.
 tests/cases/conformance/es6/modules/m2.ts(1,1): error TS2528: A module cannot have multiple default exports.
 tests/cases/conformance/es6/modules/m2.ts(5,1): error TS2528: A module cannot have multiple default exports.
 tests/cases/conformance/es6/modules/m3.ts(1,1): error TS2528: A module cannot have multiple default exports.
@@ -7,14 +8,17 @@ tests/cases/conformance/es6/modules/m4.ts(1,25): error TS2528: A module cannot h
 tests/cases/conformance/es6/modules/m4.ts(5,1): error TS2528: A module cannot have multiple default exports.
 
 
-!!! error TS2393: Duplicate function implementation.
-==== tests/cases/conformance/es6/modules/m1.ts (0 errors) ====
+==== tests/cases/conformance/es6/modules/m1.ts (2 errors) ====
     
     export default function () {
+    ~~~~~~
+!!! error TS2393: Duplicate function implementation.
     
     }
     
     export default function () {
+    ~~~~~~
+!!! error TS2393: Duplicate function implementation.
     
     }
     

--- a/tests/baselines/reference/multipleDefaultExports05.js
+++ b/tests/baselines/reference/multipleDefaultExports05.js
@@ -1,0 +1,84 @@
+//// [tests/cases/conformance/es6/modules/multipleDefaultExports05.ts] ////
+
+//// [m1.ts]
+
+export default function () {
+
+}
+
+export default function () {
+
+}
+
+//// [m2.ts]
+export default function () {
+
+}
+
+export default class {
+
+}
+
+//// [m3.ts]
+export default function () {
+
+}
+
+export default class C {
+
+}
+
+//// [m4.ts]
+export default function f() {
+
+}
+
+export default class {
+
+}
+
+//// [m1.js]
+function default_1() {
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = default_1;
+function default_2() {
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = default_2;
+//// [m2.js]
+function default_1() {
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = default_1;
+var default_2 = (function () {
+    function default_2() {
+    }
+    return default_2;
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = default_2;
+//// [m3.js]
+function default_1() {
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = default_1;
+var C = (function () {
+    function C() {
+    }
+    return C;
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = C;
+//// [m4.js]
+function f() {
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = f;
+var default_1 = (function () {
+    function default_1() {
+    }
+    return default_1;
+})();
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = default_1;

--- a/tests/cases/conformance/es6/modules/multipleDefaultExports05.ts
+++ b/tests/cases/conformance/es6/modules/multipleDefaultExports05.ts
@@ -1,0 +1,38 @@
+// @module: commonjs
+// @target: ES5
+
+// @filename: m1.ts
+export default function () {
+
+}
+
+export default function () {
+
+}
+
+// @filename: m2.ts
+export default function () {
+
+}
+
+export default class {
+
+}
+
+// @filename: m3.ts
+export default function () {
+
+}
+
+export default class C {
+
+}
+
+// @filename: m4.ts
+export default function f() {
+
+}
+
+export default class {
+
+}


### PR DESCRIPTION
This is a follow up to @MartyIX's work on #5084.

With this change, instead of reporting `Duplicate function implementation.` for the following:

```TypeScript
export default function foo() { }
export default function bar() { }
```

We will report `A module cannot have multiple default exports.`

However, for

```TypeScript
export default function foo() { }
export default function foo() { }
```

we will report the original error message.

We also now correctly report on default-exported function declarations with *no names*.