### PR TITLE
Ambient class merges overloads with interface

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10992,7 +10992,13 @@ namespace ts {
 
         function getEffectiveDeclarationFlags(n: Node, flagsToCheck: NodeFlags): NodeFlags {
             let flags = getCombinedNodeFlags(n);
-            if (n.parent.kind !== SyntaxKind.InterfaceDeclaration && isInAmbientContext(n)) {
+            
+            // children of classes (even ambient classes) should not be marked as ambient or export
+            // because those flags have no useful semantics there.
+            if (n.parent.kind !== SyntaxKind.InterfaceDeclaration &&
+                n.parent.kind !== SyntaxKind.ClassDeclaration &&
+                n.parent.kind !== SyntaxKind.ClassExpression &&
+                isInAmbientContext(n)) {
                 if (!(flags & NodeFlags.Ambient)) {
                     // It is nested in an ambient context, which means it is automatically exported
                     flags |= NodeFlags.Export;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10992,7 +10992,7 @@ namespace ts {
 
         function getEffectiveDeclarationFlags(n: Node, flagsToCheck: NodeFlags): NodeFlags {
             let flags = getCombinedNodeFlags(n);
-            
+
             // children of classes (even ambient classes) should not be marked as ambient or export
             // because those flags have no useful semantics there.
             if (n.parent.kind !== SyntaxKind.InterfaceDeclaration &&

--- a/tests/baselines/reference/ambientClassMergesOverloadsWithInterface.js
+++ b/tests/baselines/reference/ambientClassMergesOverloadsWithInterface.js
@@ -1,0 +1,12 @@
+//// [ambientClassMergesOverloadsWithInterface.ts]
+declare class C {
+    baz(): any;
+    foo(n: number): any;
+}
+interface C {
+    foo(n: number): any;
+    bar(): any;
+}
+
+
+//// [ambientClassMergesOverloadsWithInterface.js]

--- a/tests/baselines/reference/ambientClassMergesOverloadsWithInterface.symbols
+++ b/tests/baselines/reference/ambientClassMergesOverloadsWithInterface.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/ambientClassMergesOverloadsWithInterface.ts ===
+declare class C {
+>C : Symbol(C, Decl(ambientClassMergesOverloadsWithInterface.ts, 0, 0), Decl(ambientClassMergesOverloadsWithInterface.ts, 3, 1))
+
+    baz(): any;
+>baz : Symbol(baz, Decl(ambientClassMergesOverloadsWithInterface.ts, 0, 17))
+
+    foo(n: number): any;
+>foo : Symbol(foo, Decl(ambientClassMergesOverloadsWithInterface.ts, 1, 15), Decl(ambientClassMergesOverloadsWithInterface.ts, 4, 13))
+>n : Symbol(n, Decl(ambientClassMergesOverloadsWithInterface.ts, 2, 8))
+}
+interface C {
+>C : Symbol(C, Decl(ambientClassMergesOverloadsWithInterface.ts, 0, 0), Decl(ambientClassMergesOverloadsWithInterface.ts, 3, 1))
+
+    foo(n: number): any;
+>foo : Symbol(foo, Decl(ambientClassMergesOverloadsWithInterface.ts, 1, 15), Decl(ambientClassMergesOverloadsWithInterface.ts, 4, 13))
+>n : Symbol(n, Decl(ambientClassMergesOverloadsWithInterface.ts, 5, 8))
+
+    bar(): any;
+>bar : Symbol(bar, Decl(ambientClassMergesOverloadsWithInterface.ts, 5, 24))
+}
+

--- a/tests/baselines/reference/ambientClassMergesOverloadsWithInterface.types
+++ b/tests/baselines/reference/ambientClassMergesOverloadsWithInterface.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/ambientClassMergesOverloadsWithInterface.ts ===
+declare class C {
+>C : C
+
+    baz(): any;
+>baz : () => any
+
+    foo(n: number): any;
+>foo : { (n: number): any; (n: number): any; }
+>n : number
+}
+interface C {
+>C : C
+
+    foo(n: number): any;
+>foo : { (n: number): any; (n: number): any; }
+>n : number
+
+    bar(): any;
+>bar : () => any
+}
+

--- a/tests/cases/compiler/ambientClassMergesOverloadsWithInterface.ts
+++ b/tests/cases/compiler/ambientClassMergesOverloadsWithInterface.ts
@@ -1,0 +1,8 @@
+﻿declare class C {
+    baz(): any;
+    foo(n: number): any;
+}
+interface C {
+    foo(n: number): any;
+    bar(): any;
+}


### PR DESCRIPTION
Even members of ambient classes. These flags have no useful semantics
there, and it prevents ambient classes from merging properly with
interfaces.

Fixes #4579 