### PR TITLE
Remove experimental async functions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11759,10 +11759,6 @@ namespace ts {
             checkSignatureDeclaration(node);
             let isAsync = isAsyncFunctionLike(node);
             if (isAsync) {
-                if (!compilerOptions.experimentalAsyncFunctions) {
-                    error(node, Diagnostics.Experimental_support_for_async_functions_is_a_feature_that_is_subject_to_change_in_a_future_release_Specify_experimentalAsyncFunctions_to_remove_this_warning);
-                }
-
                 emitAwaiter = true;
             }
 

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -223,11 +223,6 @@ namespace ts {
             description: Diagnostics.Watch_input_files,
         },
         {
-            name: "experimentalAsyncFunctions",
-            type: "boolean",
-            description: Diagnostics.Enables_experimental_support_for_ES7_async_functions
-        },
-        {
             name: "experimentalDecorators",
             type: "boolean",
             description: Diagnostics.Enables_experimental_support_for_ES7_decorators

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -783,10 +783,6 @@
         "category": "Error",
         "code": 1245
     },
-    "Experimental support for async functions is a feature that is subject to change in a future release. Specify '--experimentalAsyncFunctions' to remove this warning.": {
-        "category": "Error",
-        "code": 1246
-    },
 
     "'with' statements are not allowed in an async function block.": {
         "category": "Error",
@@ -2281,10 +2277,6 @@
     "Enables experimental support for emitting type metadata for decorators.": {
         "category": "Message",
         "code": 6066
-    },
-    "Option 'experimentalAsyncFunctions' cannot be specified when targeting ES5 or lower.": {
-        "category": "Message",
-        "code": 6067
     },
     "Enables experimental support for ES7 async functions.": {
         "category": "Message",

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1076,11 +1076,6 @@ namespace ts {
                 !options.experimentalDecorators) {
                 programDiagnostics.add(createCompilerDiagnostic(Diagnostics.Option_0_cannot_be_specified_without_specifying_option_1, "emitDecoratorMetadata", "experimentalDecorators"));
             }
-
-            if (options.experimentalAsyncFunctions &&
-                options.target !== ScriptTarget.ES6) {
-                programDiagnostics.add(createCompilerDiagnostic(Diagnostics.Option_experimentalAsyncFunctions_cannot_be_specified_when_targeting_ES5_or_lower));
-            }
         }
     }
 }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2080,7 +2080,6 @@ namespace ts {
         watch?: boolean;
         isolatedModules?: boolean;
         experimentalDecorators?: boolean;
-        experimentalAsyncFunctions?: boolean;
         emitDecoratorMetadata?: boolean;
         moduleResolution?: ModuleResolutionKind;
         /* @internal */ stripInternal?: boolean;

--- a/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction10_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction10_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 
 var foo = async foo(): Promise<void> => {
    // Legal to use 'await' in a type context.

--- a/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction1_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction1_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 
 var foo = async (): Promise<void> => {
 };

--- a/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction2_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction2_es6.ts
@@ -1,5 +1,4 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 var f = (await) => {
 }

--- a/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction3_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction3_es6.ts
@@ -1,5 +1,4 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 function f(await = await) {
 }

--- a/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction4_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction4_es6.ts
@@ -1,5 +1,4 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 var await = () => {
 }

--- a/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction5_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 
 var foo = async (await): Promise<void> => {
 }

--- a/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction6_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction6_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 
 var foo = async (a = await): Promise<void> => {
 }

--- a/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction7_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction7_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 
 var bar = async (): Promise<void> => {
   // 'await' here is an identifier, and not an await expression.

--- a/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction8_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction8_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 
 var foo = async (): Promise<void> => {
   var v = { [await]: foo }

--- a/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction9_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunction9_es6.ts
@@ -1,5 +1,4 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 var foo = async (a = await => await): Promise<void> => {
 }

--- a/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunctionCapturesArguments_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunctionCapturesArguments_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 class C {
    method() {
       function other() {}

--- a/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunctionCapturesThis_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncArrowFunction/asyncArrowFunctionCapturesThis_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 class C {
    method() {
       var fn = async () => await this;      

--- a/tests/cases/conformance/async/es6/asyncAwaitIsolatedModules_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncAwaitIsolatedModules_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @isolatedModules: true
-// @experimentalAsyncFunctions: true
 import { MyPromise } from "missing";
 
 declare var p: Promise<number>;

--- a/tests/cases/conformance/async/es6/asyncAwait_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncAwait_es6.ts
@@ -1,5 +1,4 @@
 // @target: ES6
-// @experimentalAsyncFunctions: true
 type MyPromise<T> = Promise<T>;
 declare var MyPromise: typeof Promise;
 declare var p: Promise<number>;

--- a/tests/cases/conformance/async/es6/asyncClass_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncClass_es6.ts
@@ -1,5 +1,4 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 async class C {  
 }

--- a/tests/cases/conformance/async/es6/asyncConstructor_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncConstructor_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 class C {  
   async constructor() {    
   }

--- a/tests/cases/conformance/async/es6/asyncDeclare_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncDeclare_es6.ts
@@ -1,4 +1,3 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 declare async function foo(): Promise<void>;

--- a/tests/cases/conformance/async/es6/asyncEnum_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncEnum_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 async enum E {  
   Value
 }

--- a/tests/cases/conformance/async/es6/asyncGetter_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncGetter_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 class C {
   async get foo() {
   }

--- a/tests/cases/conformance/async/es6/asyncInterface_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncInterface_es6.ts
@@ -1,5 +1,4 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 async interface I {  
 }

--- a/tests/cases/conformance/async/es6/asyncModule_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncModule_es6.ts
@@ -1,5 +1,4 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 async module M {   
 }

--- a/tests/cases/conformance/async/es6/asyncSetter_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncSetter_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 class C {
   async set foo(value) {
   }

--- a/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression1_es6.ts
+++ b/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression1_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 declare var a: boolean;
 declare var p: Promise<boolean>;
 async function func(): Promise<void> {

--- a/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression2_es6.ts
+++ b/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression2_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 declare var a: boolean;
 declare var p: Promise<boolean>;
 async function func(): Promise<void> {

--- a/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression3_es6.ts
+++ b/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression3_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 declare var a: number;
 declare var p: Promise<number>;
 async function func(): Promise<void> {

--- a/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression4_es6.ts
+++ b/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression4_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 declare var a: boolean;
 declare var p: Promise<boolean>;
 async function func(): Promise<void> {

--- a/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression5_es6.ts
+++ b/tests/cases/conformance/async/es6/awaitBinaryExpression/awaitBinaryExpression5_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 declare var a: boolean;
 declare var p: Promise<boolean>;
 async function func(): Promise<void> {

--- a/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression1_es6.ts
+++ b/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression1_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 declare var a: boolean;
 declare var p: Promise<boolean>;
 declare function fn(arg0: boolean, arg1: boolean, arg2: boolean): void;

--- a/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression2_es6.ts
+++ b/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression2_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 declare var a: boolean;
 declare var p: Promise<boolean>;
 declare function fn(arg0: boolean, arg1: boolean, arg2: boolean): void;

--- a/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression3_es6.ts
+++ b/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression3_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 declare var a: boolean;
 declare var p: Promise<boolean>;
 declare function fn(arg0: boolean, arg1: boolean, arg2: boolean): void;

--- a/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression4_es6.ts
+++ b/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression4_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 declare var a: boolean;
 declare var p: Promise<boolean>;
 declare function fn(arg0: boolean, arg1: boolean, arg2: boolean): void;

--- a/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression5_es6.ts
+++ b/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression5_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 declare var a: boolean;
 declare var p: Promise<boolean>;
 declare function fn(arg0: boolean, arg1: boolean, arg2: boolean): void;

--- a/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression6_es6.ts
+++ b/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression6_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 declare var a: boolean;
 declare var p: Promise<boolean>;
 declare function fn(arg0: boolean, arg1: boolean, arg2: boolean): void;

--- a/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression7_es6.ts
+++ b/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression7_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 declare var a: boolean;
 declare var p: Promise<boolean>;
 declare function fn(arg0: boolean, arg1: boolean, arg2: boolean): void;

--- a/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression8_es6.ts
+++ b/tests/cases/conformance/async/es6/awaitCallExpression/awaitCallExpression8_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 declare var a: boolean;
 declare var p: Promise<boolean>;
 declare function fn(arg0: boolean, arg1: boolean, arg2: boolean): void;

--- a/tests/cases/conformance/async/es6/awaitUnion_es6.ts
+++ b/tests/cases/conformance/async/es6/awaitUnion_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 declare let a: number | string;
 declare let b: PromiseLike<number> | PromiseLike<string>;
 declare let c: PromiseLike<number | string>;

--- a/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts
+++ b/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts
@@ -1,5 +1,4 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 async function foo(a = await => await): Promise<void> {
 }

--- a/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration11_es6.ts
+++ b/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration11_es6.ts
@@ -1,5 +1,4 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 async function await(): Promise<void> {
 }

--- a/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration12_es6.ts
+++ b/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration12_es6.ts
@@ -1,4 +1,3 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 var v = async function await(): Promise<void> { }

--- a/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration13_es6.ts
+++ b/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration13_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 async function foo(): Promise<void> {
    // Legal to use 'await' in a type context.
    var v: await;

--- a/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration14_es6.ts
+++ b/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration14_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 async function foo(): Promise<void> {
   return;
 }

--- a/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts
+++ b/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 declare class Thenable { then(): void; }
 declare let a: any;
 declare let obj: { then: string; };

--- a/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration1_es6.ts
+++ b/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration1_es6.ts
@@ -1,5 +1,4 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 async function foo(): Promise<void> {
 }

--- a/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration2_es6.ts
+++ b/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration2_es6.ts
@@ -1,5 +1,4 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 function f(await) {
 }

--- a/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration3_es6.ts
+++ b/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration3_es6.ts
@@ -1,5 +1,4 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 function f(await = await) {
 }

--- a/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration4_es6.ts
+++ b/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration4_es6.ts
@@ -1,5 +1,4 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 function await() {
 }

--- a/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts
+++ b/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts
@@ -1,5 +1,4 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 async function foo(await): Promise<void> {
 }

--- a/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration6_es6.ts
+++ b/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration6_es6.ts
@@ -1,5 +1,4 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 async function foo(a = await): Promise<void> {
 }

--- a/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration7_es6.ts
+++ b/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration7_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 async function bar(): Promise<void> {
   // 'await' here is an identifier, and not a yield expression.
   async function foo(a = await): Promise<void> {

--- a/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration8_es6.ts
+++ b/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration8_es6.ts
@@ -1,4 +1,3 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 var v = { [await]: foo }

--- a/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration9_es6.ts
+++ b/tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration9_es6.ts
@@ -1,6 +1,5 @@
 // @target: ES6
 // @noEmitHelpers: true
-// @experimentalAsyncFunctions: true
 async function foo(): Promise<void> {
   var v = { [await]: foo }
 }


### PR DESCRIPTION
Now that async/await support has reached stage 3 in the TC39 proposal process, time to remove the `--experimentalAsyncFunctions` flag