### PR TITLE
Improve error messages

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -923,3 +923,24 @@ task("lint-server", ["build-rules"], function() {
         lintWatchFile(lintTargets[i]);
     }
 });
+
+var builtScripts = path.join(builtLocalDirectory, 'scripts');
+var errorCheckTsFile = path.join('scripts/errorCheck.ts')
+var errorCheckJsFile = path.join(builtScripts, 'errorCheck.js')
+
+compileFile(errorCheckJsFile, [errorCheckTsFile], [tscFile, errorCheckTsFile], [], /*useBuiltCompiler*/false);
+
+desc("Runs the error validation script");
+task("error-check", [errorCheckJsFile], function() {
+    var cmd = host + " " + errorCheckJsFile;
+    console.log(cmd + "\n");
+
+    var ex = jake.createExec([cmd]);
+    ex.addListener("cmdEnd", function() {
+        complete();
+    });
+    ex.addListener("stdout", function(output) {
+        process.stdout.write(output);
+    });
+    ex.run();
+}, { async: true });    

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -820,7 +820,8 @@ var tslintRuleDir = "scripts/tslint";
 var tslintRules = ([
     "nextLineRule",
     "noNullRule",
-    "booleanTriviaRule"
+    "booleanTriviaRule",
+    "errorMessageArityRule"
 ]);
 var tslintRulesFiles = tslintRules.map(function(p) {
     return path.join(tslintRuleDir, p + ".ts");

--- a/scripts/errorCheck.ts
+++ b/scripts/errorCheck.ts
@@ -3,7 +3,7 @@ let fs = require('fs');
 let async = require('async');
 let glob = require('glob');
 
-fs.readFile('src/compiler/diagnosticMessages.json', 'utf-8', (err, data) => {
+fs.readFile('src/compiler/diagnosticMessages.json', 'utf-8', (err: any, data: string) => {
     if (err) {
         throw err;
     }
@@ -19,11 +19,11 @@ fs.readFile('src/compiler/diagnosticMessages.json', 'utf-8', (err, data) => {
     let errRegex = /\(\d+,\d+\): error TS([^:]+):/g;
 
     let baseDir = 'tests/baselines/reference/';
-    fs.readdir(baseDir, (err, files) => {
+    fs.readdir(baseDir, (err: any, files: string[]) => {
         files = files.filter(f => f.indexOf('.errors.txt') > 0);
         let tasks: Array<(callback: () => void) => void> = [];
         files.forEach(f => tasks.push(done => {
-            fs.readFile(baseDir + f, 'utf-8', (err, baseline) => {
+            fs.readFile(baseDir + f, 'utf-8', (err: any, baseline: string) => {
                 if (err) throw err;
 
                 let g: string[];
@@ -37,12 +37,12 @@ fs.readFile('src/compiler/diagnosticMessages.json', 'utf-8', (err, data) => {
             });
         }));
 
-        async.parallelLimit(tasks, 25, done => {
+        async.parallelLimit(tasks, 25, () => {
             console.log('== List of errors not present in baselines ==');
             let count = 0;
             for (let k of keys) {
-                if (messages[k]['seen'] !== true) {
-                    console.log(k);
+                if (messages[k]['seen'] !== true && messages[k].category === 'Error') {
+                    console.log(messages[k].code + ': ' + k);
                     count++;
                 }
             }
@@ -51,7 +51,7 @@ fs.readFile('src/compiler/diagnosticMessages.json', 'utf-8', (err, data) => {
     });
 });
 
-fs.readFile('src/compiler/diagnosticInformationMap.generated.ts', 'utf-8', (err, data) => {
+fs.readFile('src/compiler/diagnosticInformationMap.generated.ts', 'utf-8', (err: any, data: string) => {
     let errorRegexp = /\s(\w+): \{ code/g;
     let errorNames: string[] = [];
     let errMatch: string[];
@@ -60,7 +60,7 @@ fs.readFile('src/compiler/diagnosticInformationMap.generated.ts', 'utf-8', (err,
     }
 
     let allSrc: string = '';
-    glob('./src/**/*.ts', {}, (err, files) => {
+    glob('./src/**/*.ts', {}, (err: any, files: string[]) => {
         console.log('Reading ' + files.length + ' source files');
         for (let file of files) {
             if (file.indexOf('diagnosticInformationMap.generated.ts') > 0) {

--- a/scripts/processDiagnosticMessages.ts
+++ b/scripts/processDiagnosticMessages.ts
@@ -23,6 +23,8 @@ function main(): void {
     
     var diagnosticMessages: InputDiagnosticMessageTable = JSON.parse(inputStr);
 
+    Object.keys(diagnosticMessages).forEach(Utilities.styleCheck);
+
     var names = Utilities.getObjectKeys(diagnosticMessages);
     var nameMap = buildUniqueNameMap(names);
 
@@ -35,6 +37,14 @@ function main(): void {
     sys.writeFile(fileOutputPath, infoFileOutput);
 }
 
+function error(message: string) {
+    ts.sys.write("\x1b[91m"); // High intensity red.
+    ts.sys.write("Error");
+    ts.sys.write("\x1b[0m");  // Reset formatting.
+    ts.sys.write(': ' + message);
+    ts.sys.write(ts.sys.newLine + ts.sys.newLine);    
+}
+
 function checkForUniqueCodes(messages: string[], diagnosticTable: InputDiagnosticMessageTable) {
     const originalMessageForCode: string[] = [];
     let numConflicts = 0;
@@ -44,11 +54,7 @@ function checkForUniqueCodes(messages: string[], diagnosticTable: InputDiagnosti
 
         if (code in originalMessageForCode) {
             const originalMessage = originalMessageForCode[code];
-            ts.sys.write("\x1b[91m"); // High intensity red.
-            ts.sys.write("Error");
-            ts.sys.write("\x1b[0m");  // Reset formatting.
-            ts.sys.write(`: Diagnostic code '${code}' conflicts between "${originalMessage}" and "${currentMessage}".`);
-            ts.sys.write(ts.sys.newLine + ts.sys.newLine);
+            error(`Diagnostic code '${code}' conflicts between "${originalMessage}" and "${currentMessage}".`);
 
             numConflicts++;
         }
@@ -173,6 +179,12 @@ module NameGenerator {
 }
 
 module Utilities {
+    export function styleCheck(text: string) {
+        if (/\bmay\b/i.test(text)) {
+            error(`Diagnostic message '${text}' cannot use 'may'`);
+        }
+    }
+
     /// Return a list of all indices where a string occurs.
     export function collectMatchingIndices(name: string, proposedNames: string[], isCaseSensitive: boolean): number[] {
         var matchingIndices: number[] = [];

--- a/scripts/tslint/errorMessageArityRule.ts
+++ b/scripts/tslint/errorMessageArityRule.ts
@@ -1,0 +1,41 @@
+/// <reference path="../../node_modules/tslint/typings/typescriptServices.d.ts" />
+/// <reference path="../../node_modules/tslint/lib/tslint.d.ts" />
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static ARITY_FAILURE_STRING = "Provided argument count does not match the number of formatting holes";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new ErrorMessageWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class ErrorMessageWalker extends Lint.RuleWalker {
+    public visitCallExpression(node: ts.CallExpression) {
+        let rx = /(?:^|_)(\d)(?:_|$)/g;
+
+        if (node.expression.getText() === 'error' && node.arguments.length >= 2) {
+            const errorMessage = node.arguments[1];
+            if(errorMessage.kind === ts.SyntaxKind.PropertyAccessExpression) {
+                if ((<ts.PropertyAccessExpression>errorMessage).expression.getText() === 'Diagnostics') {
+                    const errorMessage = (<ts.PropertyAccessExpression>node.arguments[1]).name.getText();
+                    let arity = 0;
+                    let match = rx.exec(errorMessage);
+                    while (match) {
+                        let num = +match[1];
+                        if (num !== 5 && num !== 6) {
+                            arity = Math.max(arity, num + 1);
+                        }
+                        match = rx.exec(errorMessage);
+                    }
+                    if (node.arguments.length !== arity + 2) {
+                        console.log('Expected ' + arity + ' but saw ' + node.arguments.length + ' for ' + errorMessage);
+                        const failure = this.createFailure(node.getStart(), node.getWidth(), Rule.ARITY_FAILURE_STRING);
+                        this.addFailure(failure);
+                    }
+                }
+            }
+        }
+
+        super.visitCallExpression(node);
+    }
+}

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2891,7 +2891,7 @@ namespace ts {
                                 }
                             }
                             else {
-                                error(node, Diagnostics.An_interface_may_only_extend_a_class_or_another_interface);
+                                error(node, Diagnostics.An_interface_can_only_extend_a_class_or_another_interface);
                             }
                         }
                     }
@@ -4940,7 +4940,7 @@ namespace ts {
                             // Use this property as the error node as this will be more helpful in
                             // reasoning about what went wrong.
                             errorNode = prop.valueDeclaration;
-                            reportError(Diagnostics.Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1,
+                            reportError(Diagnostics.Object_literal_can_only_specify_known_properties_and_0_does_not_exist_in_type_1,
                                         symbolToString(prop),
                                         typeToString(target));
                         }
@@ -7363,7 +7363,7 @@ namespace ts {
                             prop.flags |= impliedProp.flags & SymbolFlags.Optional;
                         }
                         else if (!compilerOptions.suppressExcessPropertyErrors) {
-                            error(memberDecl.name, Diagnostics.Object_literal_may_only_specify_known_properties_and_0_does_not_exist_in_type_1,
+                            error(memberDecl.name, Diagnostics.Object_literal_can_only_specify_known_properties_and_0_does_not_exist_in_type_1,
                                 symbolToString(member), typeToString(contextualType));
                         }
                     }
@@ -7731,7 +7731,7 @@ namespace ts {
                 }
                 // More than one property on ElementAttributesProperty is an error
                 else {
-                    error(attribsPropTypeSym.declarations[0], Diagnostics.The_global_type_JSX_0_may_not_have_more_than_one_property, JsxNames.ElementAttributesPropertyNameContainer);
+                    error(attribsPropTypeSym.declarations[0], Diagnostics.The_global_type_JSX_0_cannot_have_more_than_one_property, JsxNames.ElementAttributesPropertyNameContainer);
                     return undefined;
                 }
             }
@@ -9099,7 +9099,7 @@ namespace ts {
                 // The unknownType indicates that an error already occured (and was reported).  No
                 // need to report another error in this case.
                 if (funcType !== unknownType && node.typeArguments) {
-                    error(node, Diagnostics.Untyped_function_calls_may_not_accept_type_arguments);
+                    error(node, Diagnostics.Untyped_function_calls_cannot_accept_type_arguments);
                 }
                 return resolveUntypedCall(node);
             }
@@ -9154,7 +9154,7 @@ namespace ts {
             // list and the result of the operation is of type Any.
             if (isTypeAny(expressionType)) {
                 if (node.typeArguments) {
-                    error(node, Diagnostics.Untyped_function_calls_may_not_accept_type_arguments);
+                    error(node, Diagnostics.Untyped_function_calls_cannot_accept_type_arguments);
                 }
                 return resolveUntypedCall(node);
             }
@@ -12918,7 +12918,7 @@ namespace ts {
                                 checkTypeAssignableTo(typeWithThis, getTypeWithThisArgument(t, type.thisType), node.name || node, Diagnostics.Class_0_incorrectly_implements_interface_1);
                             }
                             else {
-                                error(typeRefNode, Diagnostics.A_class_may_only_implement_another_class_or_interface);
+                                error(typeRefNode, Diagnostics.A_class_can_only_implement_another_class_or_interface);
                             }
                         }
                     }
@@ -15160,7 +15160,7 @@ namespace ts {
                 return grammarErrorOnNode(lastDeclare, Diagnostics.A_0_modifier_cannot_be_used_with_an_import_declaration, "declare");
             }
             else if (node.kind === SyntaxKind.Parameter && (flags & NodeFlags.AccessibilityModifier) && isBindingPattern((<ParameterDeclaration>node).name)) {
-                return grammarErrorOnNode(node, Diagnostics.A_parameter_property_may_not_be_a_binding_pattern);
+                return grammarErrorOnNode(node, Diagnostics.A_parameter_property_cannot_be_a_binding_pattern);
             }
             if (flags & NodeFlags.Async) {
                 return checkGrammarAsyncModifier(node, lastAsync);

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -107,25 +107,13 @@
         "category": "Error",
         "code": 1040
     },
-    "'{0}' modifier cannot be used with a class declaration.": {
-        "category": "Error",
-        "code": 1041
-    },
     "'{0}' modifier cannot be used here.": {
         "category": "Error",
         "code": 1042
     },
-    "'{0}' modifier cannot appear on a data property.": {
-        "category": "Error",
-        "code": 1043
-    },
     "'{0}' modifier cannot appear on a module element.": {
         "category": "Error",
         "code": 1044
-    },
-    "A '{0}' modifier cannot be used with an interface declaration.": {
-        "category": "Error",
-        "code": 1045
     },
     "A 'declare' modifier is required for a top level declaration in a .d.ts file.": {
         "category": "Error",
@@ -844,10 +832,6 @@
         "category": "Error",
         "code": 2310
     },
-    "A class may only extend another class.": {
-        "category": "Error",
-        "code": 2311
-    },
     "An interface may only extend a class or another interface.": {
         "category": "Error",
         "code": 2312
@@ -1244,10 +1228,6 @@
         "category": "Error",
         "code": 2417
     },
-    "Type name '{0}' in extends clause does not reference constructor function for '{0}'.": {
-        "category": "Error",
-        "code": 2419
-    },
     "Class '{0}' incorrectly implements interface '{1}'.": {
         "category": "Error",
         "code": 2420
@@ -1608,10 +1588,6 @@
         "category": "Error",
         "code": 2513
     },
-    "Classes containing abstract methods must be marked abstract.": {
-        "category": "Error",
-        "code": 2514
-    },
     "Non-abstract class '{0}' does not implement inherited abstract member '{1}' from class '{2}'.": {
         "category": "Error",
         "code": 2515
@@ -1631,14 +1607,6 @@
     "Duplicate identifier '{0}'. Compiler uses declaration '{1}' to support async functions.": {
         "category": "Error",
         "code": 2520
-    },
-    "Expression resolves to variable declaration '{0}' that compiler uses to support async functions.": {
-        "category": "Error",
-        "code": 2521
-    },
-    "The 'arguments' object cannot be referenced in an async arrow function. Consider using a standard async function expression.": {
-        "category": "Error",
-        "code": 2522
     },
     "'yield' expressions cannot be used in a parameter initializer.": {
         "category": "Error",
@@ -1668,17 +1636,9 @@
         "category": "Error",
         "code": 2600
     },
-    "The return type of a JSX element constructor must return an object type.": {
-        "category": "Error",
-        "code": 2601
-    },
     "JSX element implicitly has type 'any' because the global type 'JSX.Element' does not exist.": {
         "category": "Error",
         "code": 2602
-    },
-    "Property '{0}' in type '{1}' is not assignable to type '{2}'": {
-        "category": "Error",
-        "code": 2603
     },
     "JSX element type '{0}' does not have any construct or call signatures.": {
         "category": "Error",
@@ -1699,10 +1659,6 @@
     "The global type 'JSX.{0}' may not have more than one property": {
         "category": "Error",
         "code": 2608
-    },
-    "Cannot emit namespaced JSX elements in React": {
-        "category": "Error",
-        "code": 2650
     },
     "A member initializer in a enum declaration cannot reference members declared after it, including members defined in other enums.": {
         "category": "Error",
@@ -2445,15 +2401,6 @@
         "category": "Error",
         "code": 8017
     },
-
-    "Only identifiers/qualified-names with optional type arguments are currently supported in a class 'extends' clauses.": {
-        "category": "Error",
-        "code": 9002
-    },
-    "'class' expressions are not currently supported.": {
-        "category": "Error",
-        "code": 9003
-    },
     "JSX attributes must only be assigned a non-empty 'expression'.": {
         "category": "Error",
         "code": 17000
@@ -2465,10 +2412,6 @@
     "Expected corresponding JSX closing tag for '{0}'.": {
         "category": "Error",
         "code": 17002
-    },
-    "JSX attribute expected.": {
-        "category": "Error",
-        "code": 17003
     },
     "Cannot use JSX unless the '--jsx' flag is provided.": {
         "category": "Error",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -551,7 +551,7 @@
         "category": "Error",
         "code": 1186
     },
-    "A parameter property may not be a binding pattern.": {
+    "A parameter property cannot be a binding pattern.": {
         "category": "Error",
         "code": 1187
     },
@@ -832,7 +832,7 @@
         "category": "Error",
         "code": 2310
     },
-    "An interface may only extend a class or another interface.": {
+    "An interface can only extend a class or another interface.": {
         "category": "Error",
         "code": 2312
     },
@@ -964,7 +964,7 @@
         "category": "Error",
         "code": 2346
     },
-    "Untyped function calls may not accept type arguments.": {
+    "Untyped function calls cannot accept type arguments.": {
         "category": "Error",
         "code": 2347
     },
@@ -988,7 +988,7 @@
         "category": "Error",
         "code": 2352
     },
-    "Object literal may only specify known properties, and '{0}' does not exist in type '{1}'.": {
+    "Object literal can only specify known properties, and '{0}' does not exist in type '{1}'.": {
         "category": "Error",
         "code": 2353
     },
@@ -1232,7 +1232,7 @@
         "category": "Error",
         "code": 2420
     },
-    "A class may only implement another class or interface.": {
+    "A class can only implement another class or interface.": {
         "category": "Error",
         "code": 2422
     },
@@ -1656,7 +1656,7 @@
         "category": "Error",
         "code": 2607
     },
-    "The global type 'JSX.{0}' may not have more than one property": {
+    "The global type 'JSX.{0}' cannot have more than one property": {
         "category": "Error",
         "code": 2608
     },

--- a/tests/baselines/reference/anyAsConstructor.errors.txt
+++ b/tests/baselines/reference/anyAsConstructor.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/types/any/anyAsConstructor.ts(10,9): error TS2347: Untyped function calls may not accept type arguments.
+tests/cases/conformance/types/any/anyAsConstructor.ts(10,9): error TS2347: Untyped function calls cannot accept type arguments.
 
 
 ==== tests/cases/conformance/types/any/anyAsConstructor.ts (1 errors) ====
@@ -13,4 +13,4 @@ tests/cases/conformance/types/any/anyAsConstructor.ts(10,9): error TS2347: Untyp
     // grammar allows this for constructors
     var d = new x<any>(x); // no error
             ~~~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.

--- a/tests/baselines/reference/anyAsGenericFunctionCall.errors.txt
+++ b/tests/baselines/reference/anyAsGenericFunctionCall.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/types/any/anyAsGenericFunctionCall.ts(5,9): error TS2347: Untyped function calls may not accept type arguments.
-tests/cases/conformance/types/any/anyAsGenericFunctionCall.ts(6,9): error TS2347: Untyped function calls may not accept type arguments.
-tests/cases/conformance/types/any/anyAsGenericFunctionCall.ts(9,9): error TS2347: Untyped function calls may not accept type arguments.
-tests/cases/conformance/types/any/anyAsGenericFunctionCall.ts(10,9): error TS2347: Untyped function calls may not accept type arguments.
+tests/cases/conformance/types/any/anyAsGenericFunctionCall.ts(5,9): error TS2347: Untyped function calls cannot accept type arguments.
+tests/cases/conformance/types/any/anyAsGenericFunctionCall.ts(6,9): error TS2347: Untyped function calls cannot accept type arguments.
+tests/cases/conformance/types/any/anyAsGenericFunctionCall.ts(9,9): error TS2347: Untyped function calls cannot accept type arguments.
+tests/cases/conformance/types/any/anyAsGenericFunctionCall.ts(10,9): error TS2347: Untyped function calls cannot accept type arguments.
 
 
 ==== tests/cases/conformance/types/any/anyAsGenericFunctionCall.ts (4 errors) ====
@@ -11,15 +11,15 @@ tests/cases/conformance/types/any/anyAsGenericFunctionCall.ts(10,9): error TS234
     var x: any;
     var a = x<number>();
             ~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     var b = x<string>('hello');
             ~~~~~~~~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     
     class C { foo: string; }
     var c = x<C>(x);
             ~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     var d = x<any>(x);
             ~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.

--- a/tests/baselines/reference/arrayCast.errors.txt
+++ b/tests/baselines/reference/arrayCast.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/arrayCast.ts(3,23): error TS2352: Neither type '{ foo: string; }[]' nor type '{ id: number; }[]' is assignable to the other.
   Type '{ foo: string; }' is not assignable to type '{ id: number; }'.
-    Object literal may only specify known properties, and 'foo' does not exist in type '{ id: number; }'.
+    Object literal can only specify known properties, and 'foo' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/arrayCast.ts (1 errors) ====
@@ -10,7 +10,7 @@ tests/cases/compiler/arrayCast.ts(3,23): error TS2352: Neither type '{ foo: stri
                           ~~~~~~~~
 !!! error TS2352: Neither type '{ foo: string; }[]' nor type '{ id: number; }[]' is assignable to the other.
 !!! error TS2352:   Type '{ foo: string; }' is not assignable to type '{ id: number; }'.
-!!! error TS2352:     Object literal may only specify known properties, and 'foo' does not exist in type '{ id: number; }'.
+!!! error TS2352:     Object literal can only specify known properties, and 'foo' does not exist in type '{ id: number; }'.
     
     // Should succeed, as the {} element causes the type of the array to be {}[]
     <{ id: number; }[]>[{ foo: "s" }, {}]; 

--- a/tests/baselines/reference/arrayLiteralTypeInference.errors.txt
+++ b/tests/baselines/reference/arrayLiteralTypeInference.errors.txt
@@ -1,11 +1,11 @@
 tests/cases/compiler/arrayLiteralTypeInference.ts(14,14): error TS2322: Type '({ id: number; trueness: boolean; } | { id: number; name: string; })[]' is not assignable to type 'Action[]'.
   Type '{ id: number; trueness: boolean; } | { id: number; name: string; }' is not assignable to type 'Action'.
     Type '{ id: number; trueness: boolean; }' is not assignable to type 'Action'.
-      Object literal may only specify known properties, and 'trueness' does not exist in type 'Action'.
+      Object literal can only specify known properties, and 'trueness' does not exist in type 'Action'.
 tests/cases/compiler/arrayLiteralTypeInference.ts(31,18): error TS2322: Type '({ id: number; trueness: boolean; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
   Type '{ id: number; trueness: boolean; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
     Type '{ id: number; trueness: boolean; }' is not assignable to type '{ id: number; }'.
-      Object literal may only specify known properties, and 'trueness' does not exist in type '{ id: number; }'.
+      Object literal can only specify known properties, and 'trueness' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/arrayLiteralTypeInference.ts (2 errors) ====
@@ -27,7 +27,7 @@ tests/cases/compiler/arrayLiteralTypeInference.ts(31,18): error TS2322: Type '({
 !!! error TS2322: Type '({ id: number; trueness: boolean; } | { id: number; name: string; })[]' is not assignable to type 'Action[]'.
 !!! error TS2322:   Type '{ id: number; trueness: boolean; } | { id: number; name: string; }' is not assignable to type 'Action'.
 !!! error TS2322:     Type '{ id: number; trueness: boolean; }' is not assignable to type 'Action'.
-!!! error TS2322:       Object literal may only specify known properties, and 'trueness' does not exist in type 'Action'.
+!!! error TS2322:       Object literal can only specify known properties, and 'trueness' does not exist in type 'Action'.
         { id: 3, name: "three" }
     ]
     
@@ -49,7 +49,7 @@ tests/cases/compiler/arrayLiteralTypeInference.ts(31,18): error TS2322: Type '({
 !!! error TS2322: Type '({ id: number; trueness: boolean; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
 !!! error TS2322:   Type '{ id: number; trueness: boolean; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
 !!! error TS2322:     Type '{ id: number; trueness: boolean; }' is not assignable to type '{ id: number; }'.
-!!! error TS2322:       Object literal may only specify known properties, and 'trueness' does not exist in type '{ id: number; }'.
+!!! error TS2322:       Object literal can only specify known properties, and 'trueness' does not exist in type '{ id: number; }'.
             { id: 3, name: "three" }
         ]
     

--- a/tests/baselines/reference/arrayLiterals.errors.txt
+++ b/tests/baselines/reference/arrayLiterals.errors.txt
@@ -2,7 +2,7 @@ tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts(24,77): error
   Index signatures are incompatible.
     Type '{ a: string; b: number; c: string; } | { a: string; b: number; c: number; }' is not assignable to type '{ a: string; b: number; }'.
       Type '{ a: string; b: number; c: string; }' is not assignable to type '{ a: string; b: number; }'.
-        Object literal may only specify known properties, and 'c' does not exist in type '{ a: string; b: number; }'.
+        Object literal can only specify known properties, and 'c' does not exist in type '{ a: string; b: number; }'.
 
 
 ==== tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts (1 errors) ====
@@ -35,7 +35,7 @@ tests/cases/conformance/expressions/arrayLiterals/arrayLiterals.ts(24,77): error
 !!! error TS2322:   Index signatures are incompatible.
 !!! error TS2322:     Type '{ a: string; b: number; c: string; } | { a: string; b: number; c: number; }' is not assignable to type '{ a: string; b: number; }'.
 !!! error TS2322:       Type '{ a: string; b: number; c: string; }' is not assignable to type '{ a: string; b: number; }'.
-!!! error TS2322:         Object literal may only specify known properties, and 'c' does not exist in type '{ a: string; b: number; }'.
+!!! error TS2322:         Object literal can only specify known properties, and 'c' does not exist in type '{ a: string; b: number; }'.
     var context2 = [{ a: '', b: 0, c: '' }, { a: "", b: 3, c: 0 }];
     
     // Contextual type C with numeric index signature of type Base makes array literal of Derived have type Base[]

--- a/tests/baselines/reference/assignmentCompatBug2.errors.txt
+++ b/tests/baselines/reference/assignmentCompatBug2.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/compiler/assignmentCompatBug2.ts(1,27): error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
-  Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
+  Object literal can only specify known properties, and 'a' does not exist in type '{ b: number; }'.
 tests/cases/compiler/assignmentCompatBug2.ts(3,8): error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
-  Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
+  Object literal can only specify known properties, and 'a' does not exist in type '{ b: number; }'.
 tests/cases/compiler/assignmentCompatBug2.ts(5,13): error TS2322: Type '{ b: number; a: number; }' is not assignable to type '{ b: number; }'.
-  Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
+  Object literal can only specify known properties, and 'a' does not exist in type '{ b: number; }'.
 tests/cases/compiler/assignmentCompatBug2.ts(15,1): error TS2322: Type '{ f: (n: number) => number; g: (s: string) => number; }' is not assignable to type '{ f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; }'.
   Property 'm' is missing in type '{ f: (n: number) => number; g: (s: string) => number; }'.
 tests/cases/compiler/assignmentCompatBug2.ts(20,1): error TS2322: Type '{ f: (n: number) => number; m: number; }' is not assignable to type '{ f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; }'.
@@ -16,17 +16,17 @@ tests/cases/compiler/assignmentCompatBug2.ts(33,1): error TS2322: Type '{ f: (n:
     var b2: { b: number;} = { a: 0 }; // error
                               ~~~~
 !!! error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
+!!! error TS2322:   Object literal can only specify known properties, and 'a' does not exist in type '{ b: number; }'.
     
     b2 = { a: 0 }; // error
            ~~~~
 !!! error TS2322: Type '{ a: number; }' is not assignable to type '{ b: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
+!!! error TS2322:   Object literal can only specify known properties, and 'a' does not exist in type '{ b: number; }'.
     
     b2 = {b: 0, a: 0 };
                 ~~~~
 !!! error TS2322: Type '{ b: number; a: number; }' is not assignable to type '{ b: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'a' does not exist in type '{ b: number; }'.
+!!! error TS2322:   Object literal can only specify known properties, and 'a' does not exist in type '{ b: number; }'.
     
     var b3: { f(n: number): number; g(s: string): number; m: number; n?: number; k?(a: any): any; };
     

--- a/tests/baselines/reference/assignmentCompatBug5.errors.txt
+++ b/tests/baselines/reference/assignmentCompatBug5.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/assignmentCompatBug5.ts(2,8): error TS2345: Argument of type '{ b: number; }' is not assignable to parameter of type '{ a: number; }'.
-  Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
+  Object literal can only specify known properties, and 'b' does not exist in type '{ a: number; }'.
 tests/cases/compiler/assignmentCompatBug5.ts(5,6): error TS2345: Argument of type 'string[]' is not assignable to parameter of type 'number[]'.
   Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/assignmentCompatBug5.ts(8,6): error TS2345: Argument of type '(s: string) => void' is not assignable to parameter of type '(n: number) => number'.
@@ -14,7 +14,7 @@ tests/cases/compiler/assignmentCompatBug5.ts(9,6): error TS2345: Argument of typ
     foo1({ b: 5 });
            ~~~~
 !!! error TS2345: Argument of type '{ b: number; }' is not assignable to parameter of type '{ a: number; }'.
-!!! error TS2345:   Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
+!!! error TS2345:   Object literal can only specify known properties, and 'b' does not exist in type '{ a: number; }'.
     
     function foo2(x: number[]) { }
     foo2(["s", "t"]);

--- a/tests/baselines/reference/callNonGenericFunctionWithTypeArguments.errors.txt
+++ b/tests/baselines/reference/callNonGenericFunctionWithTypeArguments.errors.txt
@@ -5,8 +5,8 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFun
 tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(24,10): error TS2346: Supplied parameters do not match any signature of call target.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(31,10): error TS2346: Supplied parameters do not match any signature of call target.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(37,10): error TS2346: Supplied parameters do not match any signature of call target.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(40,10): error TS2347: Untyped function calls may not accept type arguments.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(43,10): error TS2347: Untyped function calls may not accept type arguments.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(40,10): error TS2347: Untyped function calls cannot accept type arguments.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts(43,10): error TS2347: Untyped function calls cannot accept type arguments.
 
 
 ==== tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFunctionWithTypeArguments.ts (9 errors) ====
@@ -65,9 +65,9 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/callNonGenericFun
     var a;
     var r8 = a<number>();
              ~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     
     var a2: any;
     var r8 = a2<number>();
              ~~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.

--- a/tests/baselines/reference/contextualTyping12.errors.txt
+++ b/tests/baselines/reference/contextualTyping12.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/contextualTyping12.ts(1,57): error TS2322: Type '({ id: number; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
   Type '{ id: number; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
     Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-      Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+      Object literal can only specify known properties, and 'name' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/contextualTyping12.ts (1 errors) ====
@@ -10,4 +10,4 @@ tests/cases/compiler/contextualTyping12.ts(1,57): error TS2322: Type '({ id: num
 !!! error TS2322: Type '({ id: number; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
 !!! error TS2322:   Type '{ id: number; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
 !!! error TS2322:     Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-!!! error TS2322:       Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+!!! error TS2322:       Object literal can only specify known properties, and 'name' does not exist in type '{ id: number; }'.

--- a/tests/baselines/reference/contextualTyping17.errors.txt
+++ b/tests/baselines/reference/contextualTyping17.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/compiler/contextualTyping17.ts(1,47): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-  Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+  Object literal can only specify known properties, and 'name' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/contextualTyping17.ts (1 errors) ====
     var foo: {id:number;} = {id:4}; foo = {id: 5, name:"foo"};
                                                   ~~~~~~~~~~
 !!! error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+!!! error TS2322:   Object literal can only specify known properties, and 'name' does not exist in type '{ id: number; }'.

--- a/tests/baselines/reference/contextualTyping2.errors.txt
+++ b/tests/baselines/reference/contextualTyping2.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/compiler/contextualTyping2.ts(1,32): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-  Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+  Object literal can only specify known properties, and 'name' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/contextualTyping2.ts (1 errors) ====
     var foo: {id:number;} = {id:4, name:"foo"};
                                    ~~~~~~~~~~
 !!! error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+!!! error TS2322:   Object literal can only specify known properties, and 'name' does not exist in type '{ id: number; }'.

--- a/tests/baselines/reference/contextualTyping20.errors.txt
+++ b/tests/baselines/reference/contextualTyping20.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/contextualTyping20.ts(1,58): error TS2322: Type '({ id: number; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
   Type '{ id: number; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
     Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-      Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+      Object literal can only specify known properties, and 'name' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/contextualTyping20.ts (1 errors) ====
@@ -10,4 +10,4 @@ tests/cases/compiler/contextualTyping20.ts(1,58): error TS2322: Type '({ id: num
 !!! error TS2322: Type '({ id: number; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
 !!! error TS2322:   Type '{ id: number; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
 !!! error TS2322:     Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-!!! error TS2322:       Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+!!! error TS2322:       Object literal can only specify known properties, and 'name' does not exist in type '{ id: number; }'.

--- a/tests/baselines/reference/contextualTyping4.errors.txt
+++ b/tests/baselines/reference/contextualTyping4.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/compiler/contextualTyping4.ts(1,46): error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-  Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+  Object literal can only specify known properties, and 'name' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/contextualTyping4.ts (1 errors) ====
     class foo { public bar:{id:number;} = {id:5, name:"foo"}; }
                                                  ~~~~~~~~~~
 !!! error TS2322: Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+!!! error TS2322:   Object literal can only specify known properties, and 'name' does not exist in type '{ id: number; }'.

--- a/tests/baselines/reference/contextualTyping9.errors.txt
+++ b/tests/baselines/reference/contextualTyping9.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/contextualTyping9.ts(1,42): error TS2322: Type '({ id: number; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
   Type '{ id: number; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
     Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-      Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+      Object literal can only specify known properties, and 'name' does not exist in type '{ id: number; }'.
 
 
 ==== tests/cases/compiler/contextualTyping9.ts (1 errors) ====
@@ -10,4 +10,4 @@ tests/cases/compiler/contextualTyping9.ts(1,42): error TS2322: Type '({ id: numb
 !!! error TS2322: Type '({ id: number; } | { id: number; name: string; })[]' is not assignable to type '{ id: number; }[]'.
 !!! error TS2322:   Type '{ id: number; } | { id: number; name: string; }' is not assignable to type '{ id: number; }'.
 !!! error TS2322:     Type '{ id: number; name: string; }' is not assignable to type '{ id: number; }'.
-!!! error TS2322:       Object literal may only specify known properties, and 'name' does not exist in type '{ id: number; }'.
+!!! error TS2322:       Object literal can only specify known properties, and 'name' does not exist in type '{ id: number; }'.

--- a/tests/baselines/reference/crashIntypeCheckInvocationExpression.errors.txt
+++ b/tests/baselines/reference/crashIntypeCheckInvocationExpression.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/crashIntypeCheckInvocationExpression.ts(6,28): error TS2304: Cannot find name 'task'.
 tests/cases/compiler/crashIntypeCheckInvocationExpression.ts(8,18): error TS2304: Cannot find name 'path'.
-tests/cases/compiler/crashIntypeCheckInvocationExpression.ts(9,19): error TS2347: Untyped function calls may not accept type arguments.
+tests/cases/compiler/crashIntypeCheckInvocationExpression.ts(9,19): error TS2347: Untyped function calls cannot accept type arguments.
 tests/cases/compiler/crashIntypeCheckInvocationExpression.ts(10,50): error TS2304: Cannot find name 'moduleType'.
 
 
@@ -19,7 +19,7 @@ tests/cases/compiler/crashIntypeCheckInvocationExpression.ts(10,50): error TS230
 !!! error TS2304: Cannot find name 'path'.
             fileset = nake.fileSetSync<number, number, any>(folder)
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
       return doCompile<number, number, any>(fileset, moduleType);
                                                      ~~~~~~~~~~
 !!! error TS2304: Cannot find name 'moduleType'.

--- a/tests/baselines/reference/declarationEmitDestructuring4.errors.txt
+++ b/tests/baselines/reference/declarationEmitDestructuring4.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/declarationEmitDestructuring4.ts(9,22): error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{}'.
+tests/cases/compiler/declarationEmitDestructuring4.ts(9,22): error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{}'.
 
 
 ==== tests/cases/compiler/declarationEmitDestructuring4.ts (1 errors) ====
@@ -12,6 +12,6 @@ tests/cases/compiler/declarationEmitDestructuring4.ts(9,22): error TS2353: Objec
     function baz3({}) { }
     function baz4({} = { x: 10 }) { }
                          ~
-!!! error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{}'.
+!!! error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{}'.
     
     

--- a/tests/baselines/reference/declarationEmitDestructuringObjectLiteralPattern.errors.txt
+++ b/tests/baselines/reference/declarationEmitDestructuringObjectLiteralPattern.errors.txt
@@ -1,31 +1,31 @@
-tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern.ts(2,13): error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{}'.
-tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern.ts(2,19): error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{}'.
-tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern.ts(3,23): error TS2353: Object literal may only specify known properties, and 'y4' does not exist in type '{ x4: any; }'.
-tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern.ts(4,16): error TS2353: Object literal may only specify known properties, and 'x5' does not exist in type '{ y5: any; }'.
-tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern.ts(6,27): error TS2353: Object literal may only specify known properties, and 'y7' does not exist in type '{ x7: any; }'.
-tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern.ts(7,20): error TS2353: Object literal may only specify known properties, and 'x8' does not exist in type '{ y8: any; }'.
+tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern.ts(2,13): error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{}'.
+tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern.ts(2,19): error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{}'.
+tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern.ts(3,23): error TS2353: Object literal can only specify known properties, and 'y4' does not exist in type '{ x4: any; }'.
+tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern.ts(4,16): error TS2353: Object literal can only specify known properties, and 'x5' does not exist in type '{ y5: any; }'.
+tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern.ts(6,27): error TS2353: Object literal can only specify known properties, and 'y7' does not exist in type '{ x7: any; }'.
+tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern.ts(7,20): error TS2353: Object literal can only specify known properties, and 'x8' does not exist in type '{ y8: any; }'.
 
 
 ==== tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern.ts (6 errors) ====
     
     var { } = { x: 5, y: "hello" };
                 ~
-!!! error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{}'.
+!!! error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{}'.
                       ~
-!!! error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{}'.
+!!! error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{}'.
     var { x4 } = { x4: 5, y4: "hello" };
                           ~~
-!!! error TS2353: Object literal may only specify known properties, and 'y4' does not exist in type '{ x4: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'y4' does not exist in type '{ x4: any; }'.
     var { y5 } = { x5: 5, y5: "hello" };
                    ~~
-!!! error TS2353: Object literal may only specify known properties, and 'x5' does not exist in type '{ y5: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'x5' does not exist in type '{ y5: any; }'.
     var { x6, y6 } = { x6: 5, y6: "hello" };
     var { x7: a1 } = { x7: 5, y7: "hello" };
                               ~~
-!!! error TS2353: Object literal may only specify known properties, and 'y7' does not exist in type '{ x7: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'y7' does not exist in type '{ x7: any; }'.
     var { y8: b1 } = { x8: 5, y8: "hello" };
                        ~~
-!!! error TS2353: Object literal may only specify known properties, and 'x8' does not exist in type '{ y8: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'x8' does not exist in type '{ y8: any; }'.
     var { x9: a2, y9: b2 } = { x9: 5, y9: "hello" };
     
     var { a: x11, b: { a: y11, b: { a: z11 }}} = { a: 1, b: { a: "hello", b: { a: true } } };

--- a/tests/baselines/reference/declarationEmitDestructuringObjectLiteralPattern1.errors.txt
+++ b/tests/baselines/reference/declarationEmitDestructuringObjectLiteralPattern1.errors.txt
@@ -1,29 +1,29 @@
-tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern1.ts(2,13): error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{}'.
-tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern1.ts(2,19): error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{}'.
-tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern1.ts(3,23): error TS2353: Object literal may only specify known properties, and 'y4' does not exist in type '{ x4: any; }'.
-tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern1.ts(4,16): error TS2353: Object literal may only specify known properties, and 'x5' does not exist in type '{ y5: any; }'.
-tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern1.ts(6,27): error TS2353: Object literal may only specify known properties, and 'y7' does not exist in type '{ x7: any; }'.
-tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern1.ts(7,20): error TS2353: Object literal may only specify known properties, and 'x8' does not exist in type '{ y8: any; }'.
+tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern1.ts(2,13): error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{}'.
+tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern1.ts(2,19): error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{}'.
+tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern1.ts(3,23): error TS2353: Object literal can only specify known properties, and 'y4' does not exist in type '{ x4: any; }'.
+tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern1.ts(4,16): error TS2353: Object literal can only specify known properties, and 'x5' does not exist in type '{ y5: any; }'.
+tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern1.ts(6,27): error TS2353: Object literal can only specify known properties, and 'y7' does not exist in type '{ x7: any; }'.
+tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern1.ts(7,20): error TS2353: Object literal can only specify known properties, and 'x8' does not exist in type '{ y8: any; }'.
 
 
 ==== tests/cases/compiler/declarationEmitDestructuringObjectLiteralPattern1.ts (6 errors) ====
     
     var { } = { x: 5, y: "hello" };
                 ~
-!!! error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{}'.
+!!! error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{}'.
                       ~
-!!! error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{}'.
+!!! error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{}'.
     var { x4 } = { x4: 5, y4: "hello" };
                           ~~
-!!! error TS2353: Object literal may only specify known properties, and 'y4' does not exist in type '{ x4: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'y4' does not exist in type '{ x4: any; }'.
     var { y5 } = { x5: 5, y5: "hello" };
                    ~~
-!!! error TS2353: Object literal may only specify known properties, and 'x5' does not exist in type '{ y5: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'x5' does not exist in type '{ y5: any; }'.
     var { x6, y6 } = { x6: 5, y6: "hello" };
     var { x7: a1 } = { x7: 5, y7: "hello" };
                               ~~
-!!! error TS2353: Object literal may only specify known properties, and 'y7' does not exist in type '{ x7: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'y7' does not exist in type '{ x7: any; }'.
     var { y8: b1 } = { x8: 5, y8: "hello" };
                        ~~
-!!! error TS2353: Object literal may only specify known properties, and 'x8' does not exist in type '{ y8: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'x8' does not exist in type '{ y8: any; }'.
     var { x9: a2, y9: b2 } = { x9: 5, y9: "hello" };

--- a/tests/baselines/reference/declarationEmitDestructuringParameterProperties.errors.txt
+++ b/tests/baselines/reference/declarationEmitDestructuringParameterProperties.errors.txt
@@ -1,13 +1,13 @@
-tests/cases/compiler/declarationEmitDestructuringParameterProperties.ts(2,17): error TS1187: A parameter property may not be a binding pattern.
-tests/cases/compiler/declarationEmitDestructuringParameterProperties.ts(8,17): error TS1187: A parameter property may not be a binding pattern.
-tests/cases/compiler/declarationEmitDestructuringParameterProperties.ts(14,17): error TS1187: A parameter property may not be a binding pattern.
+tests/cases/compiler/declarationEmitDestructuringParameterProperties.ts(2,17): error TS1187: A parameter property cannot be a binding pattern.
+tests/cases/compiler/declarationEmitDestructuringParameterProperties.ts(8,17): error TS1187: A parameter property cannot be a binding pattern.
+tests/cases/compiler/declarationEmitDestructuringParameterProperties.ts(14,17): error TS1187: A parameter property cannot be a binding pattern.
 
 
 ==== tests/cases/compiler/declarationEmitDestructuringParameterProperties.ts (3 errors) ====
     class C1 {
         constructor(public [x, y, z]: string[]) {
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1187: A parameter property may not be a binding pattern.
+!!! error TS1187: A parameter property cannot be a binding pattern.
         }
     }
     
@@ -15,7 +15,7 @@ tests/cases/compiler/declarationEmitDestructuringParameterProperties.ts(14,17): 
     class C2 {
         constructor(public [x, y, z]: TupleType1) {
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1187: A parameter property may not be a binding pattern.
+!!! error TS1187: A parameter property cannot be a binding pattern.
         }
     }
     
@@ -23,6 +23,6 @@ tests/cases/compiler/declarationEmitDestructuringParameterProperties.ts(14,17): 
     class C3 {
         constructor(public { x, y, z }: ObjType1) {
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1187: A parameter property may not be a binding pattern.
+!!! error TS1187: A parameter property cannot be a binding pattern.
         }
     }

--- a/tests/baselines/reference/declarationsAndAssignments.errors.txt
+++ b/tests/baselines/reference/declarationsAndAssignments.errors.txt
@@ -1,10 +1,10 @@
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(5,16): error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
-tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(22,17): error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{}'.
-tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(22,23): error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{}'.
-tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(23,25): error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{ x: any; }'.
-tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(24,19): error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{ y: any; }'.
-tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(28,28): error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{ x: any; }'.
-tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(29,22): error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{ y: any; }'.
+tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(22,17): error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{}'.
+tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(22,23): error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{}'.
+tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(23,25): error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{ x: any; }'.
+tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(24,19): error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{ y: any; }'.
+tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(28,28): error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{ x: any; }'.
+tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(29,22): error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{ y: any; }'.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(56,17): error TS2322: Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(62,10): error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(62,13): error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
@@ -53,24 +53,24 @@ tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(138,9): 
     function f2() {
         var { } = { x: 5, y: "hello" };       // Error, no x and y in target
                     ~
-!!! error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{}'.
+!!! error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{}'.
                           ~
-!!! error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{}'.
+!!! error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{}'.
         var { x } = { x: 5, y: "hello" };     // Error, no y in target
                             ~
-!!! error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{ x: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{ x: any; }'.
         var { y } = { x: 5, y: "hello" };     // Error, no x in target
                       ~
-!!! error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{ y: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{ y: any; }'.
         var { x, y } = { x: 5, y: "hello" };
         var x: number;
         var y: string;
         var { x: a } = { x: 5, y: "hello" };  // Error, no y in target
                                ~
-!!! error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{ x: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{ x: any; }'.
         var { y: b } = { x: 5, y: "hello" };  // Error, no x in target
                          ~
-!!! error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{ y: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{ y: any; }'.
         var { x: a, y: b } = { x: 5, y: "hello" };
         var a: number;
         var b: string;

--- a/tests/baselines/reference/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.errors.txt
+++ b/tests/baselines/reference/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.ts(14,36): error TS2345: Argument of type '{ a: number; b: number; }' is not assignable to parameter of type '{ a: number; }'.
-  Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
+  Object literal can only specify known properties, and 'b' does not exist in type '{ a: number; }'.
 
 
 ==== tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/derivedTypeAccessesHiddenBaseCallViaSuperPropertyAccess.ts (1 errors) ====
@@ -19,7 +19,7 @@ tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclara
             var r2 = super.foo({ a: 1, b: 2 }); // { a: number }
                                        ~~~~
 !!! error TS2345: Argument of type '{ a: number; b: number; }' is not assignable to parameter of type '{ a: number; }'.
-!!! error TS2345:   Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
+!!! error TS2345:   Object literal can only specify known properties, and 'b' does not exist in type '{ a: number; }'.
             var r3 = this.foo({ a: 1, b: 2 }); // { a: number; b: number; }
         }
     }

--- a/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment3.errors.txt
+++ b/tests/baselines/reference/destructuringObjectBindingPatternAndAssignment3.errors.txt
@@ -4,11 +4,11 @@ tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAs
 tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment3.ts(3,6): error TS2459: Type 'string | number' has no property 'i' and no string index signature.
 tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment3.ts(4,6): error TS2459: Type 'string | number | {}' has no property 'i1' and no string index signature.
 tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment3.ts(5,12): error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
-tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment3.ts(5,21): error TS2353: Object literal may only specify known properties, and 'f212' does not exist in type '{ f21: any; }'.
+tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment3.ts(5,21): error TS2353: Object literal can only specify known properties, and 'f212' does not exist in type '{ f21: any; }'.
 tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment3.ts(6,7): error TS1180: Property destructuring pattern expected.
-tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment3.ts(7,5): error TS2353: Object literal may only specify known properties, and 'a' does not exist in type '{ d1: any; }'.
-tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment3.ts(7,11): error TS2353: Object literal may only specify known properties, and 'b' does not exist in type '{ d1: any; }'.
-tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment3.ts(7,24): error TS2353: Object literal may only specify known properties, and 'e' does not exist in type '{ d1: any; }'.
+tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment3.ts(7,5): error TS2353: Object literal can only specify known properties, and 'a' does not exist in type '{ d1: any; }'.
+tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment3.ts(7,11): error TS2353: Object literal can only specify known properties, and 'b' does not exist in type '{ d1: any; }'.
+tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment3.ts(7,24): error TS2353: Object literal can only specify known properties, and 'e' does not exist in type '{ d1: any; }'.
 tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment3.ts(9,7): error TS1005: ':' expected.
 tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment3.ts(9,15): error TS1005: ':' expected.
 tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAssignment3.ts(10,12): error TS1005: ':' expected.
@@ -32,17 +32,17 @@ tests/cases/conformance/es6/destructuring/destructuringObjectBindingPatternAndAs
                ~~~
 !!! error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
                         ~~~~
-!!! error TS2353: Object literal may only specify known properties, and 'f212' does not exist in type '{ f21: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'f212' does not exist in type '{ f21: any; }'.
     var { ...d1 } = {
           ~~~
 !!! error TS1180: Property destructuring pattern expected.
         a: 1, b: 1, d1: 9, e: 10
         ~
-!!! error TS2353: Object literal may only specify known properties, and 'a' does not exist in type '{ d1: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'a' does not exist in type '{ d1: any; }'.
               ~
-!!! error TS2353: Object literal may only specify known properties, and 'b' does not exist in type '{ d1: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'b' does not exist in type '{ d1: any; }'.
                            ~
-!!! error TS2353: Object literal may only specify known properties, and 'e' does not exist in type '{ d1: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'e' does not exist in type '{ d1: any; }'.
     }
     var {1} = { 1 };
           ~

--- a/tests/baselines/reference/destructuringParameterProperties1.errors.txt
+++ b/tests/baselines/reference/destructuringParameterProperties1.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/es6/destructuring/destructuringParameterProperties1.ts(2,17): error TS1187: A parameter property may not be a binding pattern.
-tests/cases/conformance/es6/destructuring/destructuringParameterProperties1.ts(9,17): error TS1187: A parameter property may not be a binding pattern.
-tests/cases/conformance/es6/destructuring/destructuringParameterProperties1.ts(16,17): error TS1187: A parameter property may not be a binding pattern.
+tests/cases/conformance/es6/destructuring/destructuringParameterProperties1.ts(2,17): error TS1187: A parameter property cannot be a binding pattern.
+tests/cases/conformance/es6/destructuring/destructuringParameterProperties1.ts(9,17): error TS1187: A parameter property cannot be a binding pattern.
+tests/cases/conformance/es6/destructuring/destructuringParameterProperties1.ts(16,17): error TS1187: A parameter property cannot be a binding pattern.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties1.ts(22,26): error TS2339: Property 'x' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties1.ts(22,35): error TS2339: Property 'y' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties1.ts(22,43): error TS2339: Property 'y' does not exist on type 'C1'.
@@ -17,7 +17,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties1.ts(2
     class C1 {
         constructor(public [x, y, z]: string[]) {
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1187: A parameter property may not be a binding pattern.
+!!! error TS1187: A parameter property cannot be a binding pattern.
         }
     }
     
@@ -26,7 +26,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties1.ts(2
     class C2 {
         constructor(public [x, y, z]: TupleType1) {
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1187: A parameter property may not be a binding pattern.
+!!! error TS1187: A parameter property cannot be a binding pattern.
         }
     }
     
@@ -35,7 +35,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties1.ts(2
     class C3 {
         constructor(public { x, y, z }: ObjType1) {
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1187: A parameter property may not be a binding pattern.
+!!! error TS1187: A parameter property cannot be a binding pattern.
         }
     }
     

--- a/tests/baselines/reference/destructuringParameterProperties2.errors.txt
+++ b/tests/baselines/reference/destructuringParameterProperties2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(2,36): error TS1187: A parameter property may not be a binding pattern.
+tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(2,36): error TS1187: A parameter property cannot be a binding pattern.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(3,59): error TS2339: Property 'b' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(3,83): error TS2339: Property 'c' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(4,18): error TS2339: Property 'a' does not exist on type 'C1'.
@@ -14,7 +14,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(2
     class C1 {
         constructor(private k: number, private [a, b, c]: [number, string, boolean]) {
                                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1187: A parameter property may not be a binding pattern.
+!!! error TS1187: A parameter property cannot be a binding pattern.
             if ((b === undefined && c === undefined) || (this.b === undefined && this.c === undefined)) {
                                                               ~
 !!! error TS2339: Property 'b' does not exist on type 'C1'.

--- a/tests/baselines/reference/destructuringParameterProperties3.errors.txt
+++ b/tests/baselines/reference/destructuringParameterProperties3.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/destructuring/destructuringParameterProperties3.ts(2,31): error TS1187: A parameter property may not be a binding pattern.
+tests/cases/conformance/es6/destructuring/destructuringParameterProperties3.ts(2,31): error TS1187: A parameter property cannot be a binding pattern.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties3.ts(3,59): error TS2339: Property 'b' does not exist on type 'C1<T, U, V>'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties3.ts(3,83): error TS2339: Property 'c' does not exist on type 'C1<T, U, V>'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties3.ts(4,18): error TS2339: Property 'a' does not exist on type 'C1<T, U, V>'.
@@ -11,7 +11,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties3.ts(1
     class C1<T, U, V> {
         constructor(private k: T, private [a, b, c]: [T,U,V]) {
                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1187: A parameter property may not be a binding pattern.
+!!! error TS1187: A parameter property cannot be a binding pattern.
             if ((b === undefined && c === undefined) || (this.b === undefined && this.c === undefined)) {
                                                               ~
 !!! error TS2339: Property 'b' does not exist on type 'C1<T, U, V>'.

--- a/tests/baselines/reference/destructuringParameterProperties4.errors.txt
+++ b/tests/baselines/reference/destructuringParameterProperties4.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/destructuring/destructuringParameterProperties4.ts(3,31): error TS1187: A parameter property may not be a binding pattern.
+tests/cases/conformance/es6/destructuring/destructuringParameterProperties4.ts(3,31): error TS1187: A parameter property cannot be a binding pattern.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties4.ts(4,59): error TS2339: Property 'b' does not exist on type 'C1<T, U, V>'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties4.ts(4,83): error TS2339: Property 'c' does not exist on type 'C1<T, U, V>'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties4.ts(5,18): error TS2339: Property 'a' does not exist on type 'C1<T, U, V>'.
@@ -15,7 +15,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties4.ts(2
     class C1<T, U, V> {
         constructor(private k: T, protected [a, b, c]: [T,U,V]) {
                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1187: A parameter property may not be a binding pattern.
+!!! error TS1187: A parameter property cannot be a binding pattern.
             if ((b === undefined && c === undefined) || (this.b === undefined && this.c === undefined)) {
                                                               ~
 !!! error TS2339: Property 'b' does not exist on type 'C1<T, U, V>'.

--- a/tests/baselines/reference/destructuringParameterProperties5.errors.txt
+++ b/tests/baselines/reference/destructuringParameterProperties5.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(5,17): error TS1187: A parameter property may not be a binding pattern.
+tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(5,17): error TS1187: A parameter property cannot be a binding pattern.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(5,27): error TS2459: Type '{ x: number; y: string; z: boolean; }' has no property 'x1' and no string index signature.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(5,31): error TS2459: Type '{ x: number; y: string; z: boolean; }' has no property 'x2' and no string index signature.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(5,35): error TS2459: Type '{ x: number; y: string; z: boolean; }' has no property 'x3' and no string index signature.
@@ -10,7 +10,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(11,19): error TS2345: Argument of type '[{ x1: number; x2: string; x3: boolean; }, string, boolean]' is not assignable to parameter of type '[{ x: number; y: string; z: boolean; }, number, string]'.
   Types of property '0' are incompatible.
     Type '{ x1: number; x2: string; x3: boolean; }' is not assignable to type '{ x: number; y: string; z: boolean; }'.
-      Object literal may only specify known properties, and 'x1' does not exist in type '{ x: number; y: string; z: boolean; }'.
+      Object literal can only specify known properties, and 'x1' does not exist in type '{ x: number; y: string; z: boolean; }'.
 
 
 ==== tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts (10 errors) ====
@@ -20,7 +20,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(1
     class C1 {
         constructor(public [{ x1, x2, x3 }, y, z]: TupleType1) {
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS1187: A parameter property may not be a binding pattern.
+!!! error TS1187: A parameter property cannot be a binding pattern.
                               ~~
 !!! error TS2459: Type '{ x: number; y: string; z: boolean; }' has no property 'x1' and no string index signature.
                                   ~~
@@ -47,5 +47,5 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(1
 !!! error TS2345: Argument of type '[{ x1: number; x2: string; x3: boolean; }, string, boolean]' is not assignable to parameter of type '[{ x: number; y: string; z: boolean; }, number, string]'.
 !!! error TS2345:   Types of property '0' are incompatible.
 !!! error TS2345:     Type '{ x1: number; x2: string; x3: boolean; }' is not assignable to type '{ x: number; y: string; z: boolean; }'.
-!!! error TS2345:       Object literal may only specify known properties, and 'x1' does not exist in type '{ x: number; y: string; z: boolean; }'.
+!!! error TS2345:       Object literal can only specify known properties, and 'x1' does not exist in type '{ x: number; y: string; z: boolean; }'.
     var [a_x1, a_x2, a_x3, a_y, a_z] = [a.x1, a.x2, a.x3, a.y, a.z];

--- a/tests/baselines/reference/emptyObjectBindingPatternParameter04.errors.txt
+++ b/tests/baselines/reference/emptyObjectBindingPatternParameter04.errors.txt
@@ -1,16 +1,16 @@
-tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter04.ts(2,18): error TS2353: Object literal may only specify known properties, and 'a' does not exist in type '{}'.
-tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter04.ts(2,24): error TS2353: Object literal may only specify known properties, and 'b' does not exist in type '{}'.
-tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter04.ts(2,32): error TS2353: Object literal may only specify known properties, and 'c' does not exist in type '{}'.
+tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter04.ts(2,18): error TS2353: Object literal can only specify known properties, and 'a' does not exist in type '{}'.
+tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter04.ts(2,24): error TS2353: Object literal can only specify known properties, and 'b' does not exist in type '{}'.
+tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter04.ts(2,32): error TS2353: Object literal can only specify known properties, and 'c' does not exist in type '{}'.
 
 
 ==== tests/cases/conformance/es6/destructuring/emptyObjectBindingPatternParameter04.ts (3 errors) ====
     
     function f({} = {a: 1, b: "2", c: true}) {
                      ~
-!!! error TS2353: Object literal may only specify known properties, and 'a' does not exist in type '{}'.
+!!! error TS2353: Object literal can only specify known properties, and 'a' does not exist in type '{}'.
                            ~
-!!! error TS2353: Object literal may only specify known properties, and 'b' does not exist in type '{}'.
+!!! error TS2353: Object literal can only specify known properties, and 'b' does not exist in type '{}'.
                                    ~
-!!! error TS2353: Object literal may only specify known properties, and 'c' does not exist in type '{}'.
+!!! error TS2353: Object literal can only specify known properties, and 'c' does not exist in type '{}'.
         var x, y, z;
     }

--- a/tests/baselines/reference/functionCalls.errors.txt
+++ b/tests/baselines/reference/functionCalls.errors.txt
@@ -1,12 +1,12 @@
-tests/cases/conformance/expressions/functionCalls/functionCalls.ts(9,1): error TS2347: Untyped function calls may not accept type arguments.
-tests/cases/conformance/expressions/functionCalls/functionCalls.ts(10,1): error TS2347: Untyped function calls may not accept type arguments.
-tests/cases/conformance/expressions/functionCalls/functionCalls.ts(11,1): error TS2347: Untyped function calls may not accept type arguments.
-tests/cases/conformance/expressions/functionCalls/functionCalls.ts(26,1): error TS2347: Untyped function calls may not accept type arguments.
-tests/cases/conformance/expressions/functionCalls/functionCalls.ts(27,1): error TS2347: Untyped function calls may not accept type arguments.
-tests/cases/conformance/expressions/functionCalls/functionCalls.ts(28,1): error TS2347: Untyped function calls may not accept type arguments.
-tests/cases/conformance/expressions/functionCalls/functionCalls.ts(33,1): error TS2347: Untyped function calls may not accept type arguments.
-tests/cases/conformance/expressions/functionCalls/functionCalls.ts(34,1): error TS2347: Untyped function calls may not accept type arguments.
-tests/cases/conformance/expressions/functionCalls/functionCalls.ts(35,1): error TS2347: Untyped function calls may not accept type arguments.
+tests/cases/conformance/expressions/functionCalls/functionCalls.ts(9,1): error TS2347: Untyped function calls cannot accept type arguments.
+tests/cases/conformance/expressions/functionCalls/functionCalls.ts(10,1): error TS2347: Untyped function calls cannot accept type arguments.
+tests/cases/conformance/expressions/functionCalls/functionCalls.ts(11,1): error TS2347: Untyped function calls cannot accept type arguments.
+tests/cases/conformance/expressions/functionCalls/functionCalls.ts(26,1): error TS2347: Untyped function calls cannot accept type arguments.
+tests/cases/conformance/expressions/functionCalls/functionCalls.ts(27,1): error TS2347: Untyped function calls cannot accept type arguments.
+tests/cases/conformance/expressions/functionCalls/functionCalls.ts(28,1): error TS2347: Untyped function calls cannot accept type arguments.
+tests/cases/conformance/expressions/functionCalls/functionCalls.ts(33,1): error TS2347: Untyped function calls cannot accept type arguments.
+tests/cases/conformance/expressions/functionCalls/functionCalls.ts(34,1): error TS2347: Untyped function calls cannot accept type arguments.
+tests/cases/conformance/expressions/functionCalls/functionCalls.ts(35,1): error TS2347: Untyped function calls cannot accept type arguments.
 
 
 ==== tests/cases/conformance/expressions/functionCalls/functionCalls.ts (9 errors) ====
@@ -20,13 +20,13 @@ tests/cases/conformance/expressions/functionCalls/functionCalls.ts(35,1): error 
     // These should be errors
     anyVar<string>('hello');
     ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     anyVar<number>();
     ~~~~~~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     anyVar<Window>(undefined);
     ~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     
     
     // Invoke function call on value of a subtype of Function with no call signatures with no type arguments
@@ -43,24 +43,24 @@ tests/cases/conformance/expressions/functionCalls/functionCalls.ts(35,1): error 
     // These should be errors
     subFunc<number>(0);
     ~~~~~~~~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     subFunc<string>('');
     ~~~~~~~~~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     subFunc<any>();
     ~~~~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     
     // Invoke function call on value of type Function with no call signatures with type arguments
     // These should be errors
     var func: Function;
     func<number>(0);
     ~~~~~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     func<string>('');
     ~~~~~~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     func<any>();
     ~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     

--- a/tests/baselines/reference/incompatibleTypes.errors.txt
+++ b/tests/baselines/reference/incompatibleTypes.errors.txt
@@ -19,9 +19,9 @@ tests/cases/compiler/incompatibleTypes.ts(42,5): error TS2345: Argument of type 
     Type '() => string' is not assignable to type '(s: string) => number'.
       Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/incompatibleTypes.ts(49,7): error TS2345: Argument of type '{ e: number; f: number; }' is not assignable to parameter of type '{ c: { b: string; }; d: string; }'.
-  Object literal may only specify known properties, and 'e' does not exist in type '{ c: { b: string; }; d: string; }'.
+  Object literal can only specify known properties, and 'e' does not exist in type '{ c: { b: string; }; d: string; }'.
 tests/cases/compiler/incompatibleTypes.ts(66,47): error TS2322: Type '{ e: number; f: number; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
-  Object literal may only specify known properties, and 'e' does not exist in type '{ a: { a: string; }; b: string; }'.
+  Object literal can only specify known properties, and 'e' does not exist in type '{ a: { a: string; }; b: string; }'.
 tests/cases/compiler/incompatibleTypes.ts(72,5): error TS2322: Type 'number' is not assignable to type '() => string'.
 tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) => number' is not assignable to type '() => any'.
 
@@ -103,7 +103,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     of1({ e: 0, f: 0 });
           ~~~~
 !!! error TS2345: Argument of type '{ e: number; f: number; }' is not assignable to parameter of type '{ c: { b: string; }; d: string; }'.
-!!! error TS2345:   Object literal may only specify known properties, and 'e' does not exist in type '{ c: { b: string; }; d: string; }'.
+!!! error TS2345:   Object literal can only specify known properties, and 'e' does not exist in type '{ c: { b: string; }; d: string; }'.
     
     interface IMap {
      [key:string]:string;
@@ -123,7 +123,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
     var o1: { a: { a: string; }; b: string; } = { e: 0, f: 0 };
                                                   ~~~~
 !!! error TS2322: Type '{ e: number; f: number; }' is not assignable to type '{ a: { a: string; }; b: string; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'e' does not exist in type '{ a: { a: string; }; b: string; }'.
+!!! error TS2322:   Object literal can only specify known properties, and 'e' does not exist in type '{ a: { a: string; }; b: string; }'.
     
     var a1 = [{ e: 0, f: 0 }, { e: 0, f: 0 }, { e: 0, g: 0 }];
     

--- a/tests/baselines/reference/inheritFromGenericTypeParameter.errors.txt
+++ b/tests/baselines/reference/inheritFromGenericTypeParameter.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/inheritFromGenericTypeParameter.ts(1,20): error TS2304: Cannot find name 'T'.
-tests/cases/compiler/inheritFromGenericTypeParameter.ts(2,24): error TS2312: An interface may only extend a class or another interface.
+tests/cases/compiler/inheritFromGenericTypeParameter.ts(2,24): error TS2312: An interface can only extend a class or another interface.
 
 
 ==== tests/cases/compiler/inheritFromGenericTypeParameter.ts (2 errors) ====
@@ -8,4 +8,4 @@ tests/cases/compiler/inheritFromGenericTypeParameter.ts(2,24): error TS2312: An 
 !!! error TS2304: Cannot find name 'T'.
     interface I<T> extends T { }
                            ~
-!!! error TS2312: An interface may only extend a class or another interface.
+!!! error TS2312: An interface can only extend a class or another interface.

--- a/tests/baselines/reference/instantiateNonGenericTypeWithTypeArguments.errors.txt
+++ b/tests/baselines/reference/instantiateNonGenericTypeWithTypeArguments.errors.txt
@@ -3,7 +3,7 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGen
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(11,9): error TS2350: Only a void function can be called with the 'new' keyword.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(14,10): error TS2346: Supplied parameters do not match any signature of call target.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(14,10): error TS2350: Only a void function can be called with the 'new' keyword.
-tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(18,10): error TS2347: Untyped function calls may not accept type arguments.
+tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts(18,10): error TS2347: Untyped function calls cannot accept type arguments.
 
 
 ==== tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGenericTypeWithTypeArguments.ts (6 errors) ====
@@ -36,4 +36,4 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/instantiateNonGen
     // BUG 790977
     var r2 = new a<number>();
              ~~~~~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.

--- a/tests/baselines/reference/invokingNonGenericMethodWithTypeArguments2.errors.txt
+++ b/tests/baselines/reference/invokingNonGenericMethodWithTypeArguments2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/invokingNonGenericMethodWithTypeArguments2.ts(5,9): error TS2347: Untyped function calls may not accept type arguments.
+tests/cases/compiler/invokingNonGenericMethodWithTypeArguments2.ts(5,9): error TS2347: Untyped function calls cannot accept type arguments.
 
 
 ==== tests/cases/compiler/invokingNonGenericMethodWithTypeArguments2.ts (1 errors) ====
@@ -8,7 +8,7 @@ tests/cases/compiler/invokingNonGenericMethodWithTypeArguments2.ts(5,9): error T
         constructor() {
             this.foo<string>();
             ~~~~~~~~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
         }
     }
     

--- a/tests/baselines/reference/logicalOrExpressionIsContextuallyTyped.errors.txt
+++ b/tests/baselines/reference/logicalOrExpressionIsContextuallyTyped.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrExpressionIsContextuallyTyped.ts(6,33): error TS2322: Type '{ a: string; b: number; } | { a: string; b: boolean; }' is not assignable to type '{ a: string; }'.
   Type '{ a: string; b: number; }' is not assignable to type '{ a: string; }'.
-    Object literal may only specify known properties, and 'b' does not exist in type '{ a: string; }'.
+    Object literal can only specify known properties, and 'b' does not exist in type '{ a: string; }'.
 
 
 ==== tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrExpressionIsContextuallyTyped.ts (1 errors) ====
@@ -13,4 +13,4 @@ tests/cases/conformance/expressions/binaryOperators/logicalOrOperator/logicalOrE
                                     ~~~~~~
 !!! error TS2322: Type '{ a: string; b: number; } | { a: string; b: boolean; }' is not assignable to type '{ a: string; }'.
 !!! error TS2322:   Type '{ a: string; b: number; }' is not assignable to type '{ a: string; }'.
-!!! error TS2322:     Object literal may only specify known properties, and 'b' does not exist in type '{ a: string; }'.
+!!! error TS2322:     Object literal can only specify known properties, and 'b' does not exist in type '{ a: string; }'.

--- a/tests/baselines/reference/missingAndExcessProperties.errors.txt
+++ b/tests/baselines/reference/missingAndExcessProperties.errors.txt
@@ -10,14 +10,14 @@ tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(12,8): e
 tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(12,11): error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
 tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(13,18): error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
 tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(14,8): error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
-tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(20,17): error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{}'.
-tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(20,23): error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{}'.
-tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(21,25): error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{ x: any; }'.
-tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(22,19): error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{ y: any; }'.
-tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(29,14): error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{}'.
-tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(29,20): error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{}'.
-tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(30,22): error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; }'.
-tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(31,16): error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{ y: number; }'.
+tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(20,17): error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{}'.
+tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(20,23): error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{}'.
+tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(21,25): error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{ x: any; }'.
+tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(22,19): error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{ y: any; }'.
+tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(29,14): error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{}'.
+tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(29,20): error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{}'.
+tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(30,22): error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{ x: number; }'.
+tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(31,16): error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{ y: number; }'.
 
 
 ==== tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts (20 errors) ====
@@ -66,15 +66,15 @@ tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(31,16): 
     function f3() {
         var { } = { x: 0, y: 0 };
                     ~
-!!! error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{}'.
+!!! error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{}'.
                           ~
-!!! error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{}'.
+!!! error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{}'.
         var { x } = { x: 0, y: 0 };
                             ~
-!!! error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{ x: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{ x: any; }'.
         var { y } = { x: 0, y: 0 };
                       ~
-!!! error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{ y: any; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{ y: any; }'.
         var { x, y } = { x: 0, y: 0 };
     }
     
@@ -83,15 +83,15 @@ tests/cases/conformance/es6/destructuring/missingAndExcessProperties.ts(31,16): 
         var x: number, y: number;
         ({ } = { x: 0, y: 0 });
                  ~
-!!! error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{}'.
+!!! error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{}'.
                        ~
-!!! error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{}'.
+!!! error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{}'.
         ({ x } = { x: 0, y: 0 });
                          ~
-!!! error TS2353: Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'y' does not exist in type '{ x: number; }'.
         ({ y } = { x: 0, y: 0 });
                    ~
-!!! error TS2353: Object literal may only specify known properties, and 'x' does not exist in type '{ y: number; }'.
+!!! error TS2353: Object literal can only specify known properties, and 'x' does not exist in type '{ y: number; }'.
         ({ x, y } = { x: 0, y: 0 });
     }
     

--- a/tests/baselines/reference/objectLitStructuralTypeMismatch.errors.txt
+++ b/tests/baselines/reference/objectLitStructuralTypeMismatch.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/objectLitStructuralTypeMismatch.ts(2,27): error TS2322: Type '{ b: number; }' is not assignable to type '{ a: number; }'.
-  Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
+  Object literal can only specify known properties, and 'b' does not exist in type '{ a: number; }'.
 
 
 ==== tests/cases/compiler/objectLitStructuralTypeMismatch.ts (1 errors) ====
@@ -7,4 +7,4 @@ tests/cases/compiler/objectLitStructuralTypeMismatch.ts(2,27): error TS2322: Typ
     var x: { a: number; } = { b: 5 };
                               ~~~~
 !!! error TS2322: Type '{ b: number; }' is not assignable to type '{ a: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'b' does not exist in type '{ a: number; }'.
+!!! error TS2322:   Object literal can only specify known properties, and 'b' does not exist in type '{ a: number; }'.

--- a/tests/baselines/reference/objectLiteralFunctionArgContextualTyping.errors.txt
+++ b/tests/baselines/reference/objectLiteralFunctionArgContextualTyping.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(8,6): error TS2345: Argument of type '{ hello: number; }' is not assignable to parameter of type 'I'.
-  Object literal may only specify known properties, and 'hello' does not exist in type 'I'.
+  Object literal can only specify known properties, and 'hello' does not exist in type 'I'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(10,17): error TS2345: Argument of type '{ value: string; what: number; }' is not assignable to parameter of type 'I'.
-  Object literal may only specify known properties, and 'what' does not exist in type 'I'.
+  Object literal can only specify known properties, and 'what' does not exist in type 'I'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(11,4): error TS2345: Argument of type '{ toString: (s: string) => string; }' is not assignable to parameter of type 'I'.
   Property 'value' is missing in type '{ toString: (s: string) => string; }'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(12,4): error TS2345: Argument of type '{ toString: (s: string) => string; }' is not assignable to parameter of type 'I'.
@@ -20,12 +20,12 @@ tests/cases/compiler/objectLiteralFunctionArgContextualTyping.ts(13,36): error T
     f2({ hello: 1 }) // error 
          ~~~~~~~~
 !!! error TS2345: Argument of type '{ hello: number; }' is not assignable to parameter of type 'I'.
-!!! error TS2345:   Object literal may only specify known properties, and 'hello' does not exist in type 'I'.
+!!! error TS2345:   Object literal can only specify known properties, and 'hello' does not exist in type 'I'.
     f2({ value: '' }) // missing toString satisfied by Object's member
     f2({ value: '', what: 1 }) // missing toString satisfied by Object's member
                     ~~~~~~~
 !!! error TS2345: Argument of type '{ value: string; what: number; }' is not assignable to parameter of type 'I'.
-!!! error TS2345:   Object literal may only specify known properties, and 'what' does not exist in type 'I'.
+!!! error TS2345:   Object literal can only specify known properties, and 'what' does not exist in type 'I'.
     f2({ toString: (s) => s }) // error, missing property value from ArgsString
        ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ toString: (s: string) => string; }' is not assignable to parameter of type 'I'.

--- a/tests/baselines/reference/objectLiteralFunctionArgContextualTyping2.errors.txt
+++ b/tests/baselines/reference/objectLiteralFunctionArgContextualTyping2.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(8,6): error TS2345: Argument of type '{ hello: number; }' is not assignable to parameter of type 'I2'.
-  Object literal may only specify known properties, and 'hello' does not exist in type 'I2'.
+  Object literal can only specify known properties, and 'hello' does not exist in type 'I2'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(9,4): error TS2345: Argument of type '{ value: string; }' is not assignable to parameter of type 'I2'.
   Property 'doStuff' is missing in type '{ value: string; }'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(10,17): error TS2345: Argument of type '{ value: string; what: number; }' is not assignable to parameter of type 'I2'.
-  Object literal may only specify known properties, and 'what' does not exist in type 'I2'.
+  Object literal can only specify known properties, and 'what' does not exist in type 'I2'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(11,4): error TS2345: Argument of type '{ toString: (s: any) => any; }' is not assignable to parameter of type 'I2'.
   Property 'value' is missing in type '{ toString: (s: any) => any; }'.
 tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(12,4): error TS2345: Argument of type '{ toString: (s: string) => string; }' is not assignable to parameter of type 'I2'.
@@ -23,7 +23,7 @@ tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(13,4): error T
     f2({ hello: 1 }) 
          ~~~~~~~~
 !!! error TS2345: Argument of type '{ hello: number; }' is not assignable to parameter of type 'I2'.
-!!! error TS2345:   Object literal may only specify known properties, and 'hello' does not exist in type 'I2'.
+!!! error TS2345:   Object literal can only specify known properties, and 'hello' does not exist in type 'I2'.
     f2({ value: '' })
        ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ value: string; }' is not assignable to parameter of type 'I2'.
@@ -31,7 +31,7 @@ tests/cases/compiler/objectLiteralFunctionArgContextualTyping2.ts(13,4): error T
     f2({ value: '', what: 1 }) 
                     ~~~~~~~
 !!! error TS2345: Argument of type '{ value: string; what: number; }' is not assignable to parameter of type 'I2'.
-!!! error TS2345:   Object literal may only specify known properties, and 'what' does not exist in type 'I2'.
+!!! error TS2345:   Object literal can only specify known properties, and 'what' does not exist in type 'I2'.
     f2({ toString: (s) => s }) 
        ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ toString: (s: any) => any; }' is not assignable to parameter of type 'I2'.

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentError.errors.txt
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentError.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(4,43): error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ b: string; id: number; }'.
-  Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
+  Object literal can only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(5,16): error TS1131: Property or signature expected.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(5,22): error TS2403: Subsequent variable declarations must have the same type.  Variable 'id' must be of type 'number', but here has type 'any'.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(5,25): error TS1128: Declaration or statement expected.
@@ -18,7 +18,7 @@ tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPr
     var person: { b: string; id: number } = { name, id };  // error
                                               ~~~~
 !!! error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ b: string; id: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
+!!! error TS2322:   Object literal can only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
     var person1: { name, id };  // error: can't use short-hand property assignment in type position
                    ~~~~
 !!! error TS1131: Property or signature expected.

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.errors.txt
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts(4,43): error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ b: string; id: number; }'.
-  Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
+  Object literal can only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts(5,79): error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ name: number; id: string; }'.
   Types of property 'name' are incompatible.
     Type 'string' is not assignable to type 'number'.
@@ -18,7 +18,7 @@ tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPr
     var person: { b: string; id: number } = { name, id };  // error
                                               ~~~~
 !!! error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ b: string; id: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
+!!! error TS2322:   Object literal can only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
     function bar(name: string, id: number): { name: number, id: string } { return { name, id }; }  // error
                                                                                   ~~~~~~~~~~~~
 !!! error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ name: number; id: string; }'.

--- a/tests/baselines/reference/orderMattersForSignatureGroupIdentity.errors.txt
+++ b/tests/baselines/reference/orderMattersForSignatureGroupIdentity.errors.txt
@@ -1,8 +1,8 @@
 tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(19,5): error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
-  Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.
+  Object literal can only specify known properties, and 's' does not exist in type '{ n: number; }'.
 tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(22,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'w' must be of type 'A', but here has type 'C'.
 tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(24,5): error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
-  Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.
+  Object literal can only specify known properties, and 's' does not exist in type '{ n: number; }'.
 
 
 ==== tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts (3 errors) ====
@@ -27,7 +27,7 @@ tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(24,5): error TS234
     v({ s: "", n: 0 }).toLowerCase();
         ~~~~~
 !!! error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
-!!! error TS2345:   Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.
+!!! error TS2345:   Object literal can only specify known properties, and 's' does not exist in type '{ n: number; }'.
     
     var w: A;
     var w: C;
@@ -37,4 +37,4 @@ tests/cases/compiler/orderMattersForSignatureGroupIdentity.ts(24,5): error TS234
     w({ s: "", n: 0 }).toLowerCase();
         ~~~~~
 !!! error TS2345: Argument of type '{ s: string; n: number; }' is not assignable to parameter of type '{ n: number; }'.
-!!! error TS2345:   Object literal may only specify known properties, and 's' does not exist in type '{ n: number; }'.
+!!! error TS2345:   Object literal can only specify known properties, and 's' does not exist in type '{ n: number; }'.

--- a/tests/baselines/reference/parserAmbiguityWithBinaryOperator4.errors.txt
+++ b/tests/baselines/reference/parserAmbiguityWithBinaryOperator4.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts(3,9): error TS2347: Untyped function calls may not accept type arguments.
+tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts(3,9): error TS2347: Untyped function calls cannot accept type arguments.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts (1 errors) ====
@@ -6,5 +6,5 @@ tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOpe
         var a, b, c;
         if (a<b, b>(c + 1)) { }
             ~~~~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     }

--- a/tests/baselines/reference/switchStatements.errors.txt
+++ b/tests/baselines/reference/switchStatements.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/statements/switchStatements/switchStatements.ts(35,20): error TS2322: Type '{ id: number; name: string; }' is not assignable to type 'C'.
-  Object literal may only specify known properties, and 'name' does not exist in type 'C'.
+  Object literal can only specify known properties, and 'name' does not exist in type 'C'.
 
 
 ==== tests/cases/conformance/statements/switchStatements/switchStatements.ts (1 errors) ====
@@ -40,7 +40,7 @@ tests/cases/conformance/statements/switchStatements/switchStatements.ts(35,20): 
         case { id: 12, name: '' }:
                        ~~~~~~~~
 !!! error TS2322: Type '{ id: number; name: string; }' is not assignable to type 'C'.
-!!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type 'C'.
+!!! error TS2322:   Object literal can only specify known properties, and 'name' does not exist in type 'C'.
         case new C():
     }
     

--- a/tests/baselines/reference/symbolProperty21.errors.txt
+++ b/tests/baselines/reference/symbolProperty21.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: boolean; }' is not assignable to parameter of type 'I<boolean, string>'.
-  Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
+  Object literal can only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
 
 
 ==== tests/cases/conformance/es6/Symbols/symbolProperty21.ts (1 errors) ====
@@ -15,6 +15,6 @@ tests/cases/conformance/es6/Symbols/symbolProperty21.ts(10,5): error TS2345: Arg
         [Symbol.toPrimitive]: 0,
         ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ [Symbol.isConcatSpreadable]: string; [Symbol.toPrimitive]: number; [Symbol.unscopables]: boolean; }' is not assignable to parameter of type 'I<boolean, string>'.
-!!! error TS2345:   Object literal may only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
+!!! error TS2345:   Object literal can only specify known properties, and '[Symbol.toPrimitive]' does not exist in type 'I<boolean, string>'.
         [Symbol.unscopables]: true
     });

--- a/tests/baselines/reference/taggedTemplateStringsTypeArgumentInference.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsTypeArgumentInference.errors.txt
@@ -2,7 +2,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInference
   Type argument candidate 'string' is not a valid type argument because it is not a supertype of candidate 'number'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInference.ts(77,79): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate '{ x: number; z: Date; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
-    Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
+    Object literal can only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
 
 
 ==== tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInference.ts (2 errors) ====
@@ -89,7 +89,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInference
                                                                                   ~~~~~
 !!! error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
 !!! error TS2453:   Type argument candidate '{ x: number; z: Date; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
-!!! error TS2453:     Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
+!!! error TS2453:     Object literal can only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
     var a9e: {};
     
     // Generic tag with multiple parameters of generic type passed arguments with a single best common type

--- a/tests/baselines/reference/taggedTemplateStringsTypeArgumentInferenceES6.errors.txt
+++ b/tests/baselines/reference/taggedTemplateStringsTypeArgumentInferenceES6.errors.txt
@@ -2,7 +2,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInference
   Type argument candidate 'string' is not a valid type argument because it is not a supertype of candidate 'number'.
 tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInferenceES6.ts(76,79): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate '{ x: number; z: Date; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
-    Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
+    Object literal can only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
 
 
 ==== tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInferenceES6.ts (2 errors) ====
@@ -88,7 +88,7 @@ tests/cases/conformance/es6/templates/taggedTemplateStringsTypeArgumentInference
                                                                                   ~~~~~
 !!! error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
 !!! error TS2453:   Type argument candidate '{ x: number; z: Date; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
-!!! error TS2453:     Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
+!!! error TS2453:     Object literal can only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
     var a9e: {};
     
     // Generic tag with multiple parameters of generic type passed arguments with a single best common type

--- a/tests/baselines/reference/tsxElementResolution15.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution15.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/jsx/tsxElementResolution15.tsx(3,12): error TS2608: The global type 'JSX.ElementAttributesProperty' may not have more than one property
+tests/cases/conformance/jsx/tsxElementResolution15.tsx(3,12): error TS2608: The global type 'JSX.ElementAttributesProperty' cannot have more than one property
 
 
 ==== tests/cases/conformance/jsx/tsxElementResolution15.tsx (1 errors) ====
@@ -6,7 +6,7 @@ tests/cases/conformance/jsx/tsxElementResolution15.tsx(3,12): error TS2608: The 
     	interface Element { }
     	interface ElementAttributesProperty { pr1: any; pr2: any; }
     	          ~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2608: The global type 'JSX.ElementAttributesProperty' may not have more than one property
+!!! error TS2608: The global type 'JSX.ElementAttributesProperty' cannot have more than one property
     	interface IntrinsicElements { }
     }
     

--- a/tests/baselines/reference/typeAliasesForObjectTypes.errors.txt
+++ b/tests/baselines/reference/typeAliasesForObjectTypes.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/types/typeAliases/typeAliasesForObjectTypes.ts(4,22): error TS2312: An interface may only extend a class or another interface.
-tests/cases/conformance/types/typeAliases/typeAliasesForObjectTypes.ts(5,21): error TS2422: A class may only implement another class or interface.
+tests/cases/conformance/types/typeAliases/typeAliasesForObjectTypes.ts(4,22): error TS2312: An interface can only extend a class or another interface.
+tests/cases/conformance/types/typeAliases/typeAliasesForObjectTypes.ts(5,21): error TS2422: A class can only implement another class or interface.
 tests/cases/conformance/types/typeAliases/typeAliasesForObjectTypes.ts(10,6): error TS2300: Duplicate identifier 'T2'.
 tests/cases/conformance/types/typeAliases/typeAliasesForObjectTypes.ts(11,6): error TS2300: Duplicate identifier 'T2'.
 
@@ -10,10 +10,10 @@ tests/cases/conformance/types/typeAliases/typeAliasesForObjectTypes.ts(11,6): er
     // An interface can be named in an extends or implements clause, but a type alias for an object type literal cannot.
     interface I1 extends T1 { y: string }
                          ~~
-!!! error TS2312: An interface may only extend a class or another interface.
+!!! error TS2312: An interface can only extend a class or another interface.
     class C1 implements T1 {
                         ~~
-!!! error TS2422: A class may only implement another class or interface.
+!!! error TS2422: A class can only implement another class or interface.
         x: string;
     }
     

--- a/tests/baselines/reference/typeArgInference2.errors.txt
+++ b/tests/baselines/reference/typeArgInference2.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/typeArgInference2.ts(12,52): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate '{ name: string; a: number; }' is not a valid type argument because it is not a supertype of candidate '{ name: string; b: number; }'.
-    Object literal may only specify known properties, and 'b' does not exist in type '{ name: string; a: number; }'.
+    Object literal can only specify known properties, and 'b' does not exist in type '{ name: string; a: number; }'.
 
 
 ==== tests/cases/compiler/typeArgInference2.ts (1 errors) ====
@@ -19,4 +19,4 @@ tests/cases/compiler/typeArgInference2.ts(12,52): error TS2453: The type argumen
                                                        ~~~~
 !!! error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
 !!! error TS2453:   Type argument candidate '{ name: string; a: number; }' is not a valid type argument because it is not a supertype of candidate '{ name: string; b: number; }'.
-!!! error TS2453:     Object literal may only specify known properties, and 'b' does not exist in type '{ name: string; a: number; }'.
+!!! error TS2453:     Object literal can only specify known properties, and 'b' does not exist in type '{ name: string; a: number; }'.

--- a/tests/baselines/reference/typeArgumentInference.errors.txt
+++ b/tests/baselines/reference/typeArgumentInference.errors.txt
@@ -2,9 +2,9 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(68,11
   Type argument candidate 'string' is not a valid type argument because it is not a supertype of candidate 'number'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(82,69): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate '{ x: number; z: Date; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
-    Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
+    Object literal can only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(84,74): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
-  Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
+  Object literal can only specify known properties, and 'y' does not exist in type 'A92'.
 
 
 ==== tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts (3 errors) ====
@@ -96,12 +96,12 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInference.ts(84,74
                                                                         ~~~~~
 !!! error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
 !!! error TS2453:   Type argument candidate '{ x: number; z: Date; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
-!!! error TS2453:     Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
+!!! error TS2453:     Object literal can only specify known properties, and 'y' does not exist in type '{ x: number; z: Date; }'.
     var a9e: {};
     var a9f = someGenerics9<A92>(undefined, { x: 6, z: new Date() }, { x: 6, y: '' });
                                                                              ~~~~~
 !!! error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
-!!! error TS2345:   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
+!!! error TS2345:   Object literal can only specify known properties, and 'y' does not exist in type 'A92'.
     var a9f: A92;
     
     // Generic call with multiple parameters of generic type passed arguments with a single best common type

--- a/tests/baselines/reference/typeArgumentInferenceConstructSignatures.errors.txt
+++ b/tests/baselines/reference/typeArgumentInferenceConstructSignatures.errors.txt
@@ -15,10 +15,10 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstruct
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(120,51): error TS2304: Cannot find name 'window'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(120,69): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate '{ x: number; z: any; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
-    Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: any; }'.
+    Object literal can only specify known properties, and 'y' does not exist in type '{ x: number; z: any; }'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(122,56): error TS2304: Cannot find name 'window'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(122,74): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
-  Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
+  Object literal can only specify known properties, and 'y' does not exist in type 'A92'.
 
 
 ==== tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts (11 errors) ====
@@ -168,14 +168,14 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstruct
                                                                         ~~~~~
 !!! error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
 !!! error TS2453:   Type argument candidate '{ x: number; z: any; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
-!!! error TS2453:     Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: any; }'.
+!!! error TS2453:     Object literal can only specify known properties, and 'y' does not exist in type '{ x: number; z: any; }'.
     var a9e: {};
     var a9f = new someGenerics9<A92>(undefined, { x: 6, z: window }, { x: 6, y: '' });
                                                            ~~~~~~
 !!! error TS2304: Cannot find name 'window'.
                                                                              ~~~~~
 !!! error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
-!!! error TS2345:   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
+!!! error TS2345:   Object literal can only specify known properties, and 'y' does not exist in type 'A92'.
     var a9f: A92;
     
     // Generic call with multiple parameters of generic type passed arguments with a single best common type

--- a/tests/baselines/reference/typeArgumentInferenceWithConstraints.errors.txt
+++ b/tests/baselines/reference/typeArgumentInferenceWithConstraints.errors.txt
@@ -20,10 +20,10 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConst
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(87,47): error TS2304: Cannot find name 'window'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(87,65): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate '{ x: number; z: any; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
-    Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: any; }'.
+    Object literal can only specify known properties, and 'y' does not exist in type '{ x: number; z: any; }'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(89,52): error TS2304: Cannot find name 'window'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(89,70): error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
-  Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
+  Object literal can only specify known properties, and 'y' does not exist in type 'A92'.
 
 
 ==== tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts (16 errors) ====
@@ -150,14 +150,14 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConst
                                                                     ~~~~~
 !!! error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
 !!! error TS2453:   Type argument candidate '{ x: number; z: any; }' is not a valid type argument because it is not a supertype of candidate '{ x: number; y: string; }'.
-!!! error TS2453:     Object literal may only specify known properties, and 'y' does not exist in type '{ x: number; z: any; }'.
+!!! error TS2453:     Object literal can only specify known properties, and 'y' does not exist in type '{ x: number; z: any; }'.
     var a9e: {};
     var a9f = someGenerics9<A92>(undefined, { x: 6, z: window }, { x: 6, y: '' });
                                                        ~~~~~~
 !!! error TS2304: Cannot find name 'window'.
                                                                          ~~~~~
 !!! error TS2345: Argument of type '{ x: number; y: string; }' is not assignable to parameter of type 'A92'.
-!!! error TS2345:   Object literal may only specify known properties, and 'y' does not exist in type 'A92'.
+!!! error TS2345:   Object literal can only specify known properties, and 'y' does not exist in type 'A92'.
     var a9f: A92;
     
     // Generic call with multiple parameters of generic type passed arguments with a single best common type

--- a/tests/baselines/reference/typeInfer1.errors.txt
+++ b/tests/baselines/reference/typeInfer1.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/typeInfer1.ts(12,5): error TS2322: Type '{ Moo: () => string; }' is not assignable to type 'ITextWriter2'.
-  Object literal may only specify known properties, and 'Moo' does not exist in type 'ITextWriter2'.
+  Object literal can only specify known properties, and 'Moo' does not exist in type 'ITextWriter2'.
 
 
 ==== tests/cases/compiler/typeInfer1.ts (1 errors) ====
@@ -17,5 +17,5 @@ tests/cases/compiler/typeInfer1.ts(12,5): error TS2322: Type '{ Moo: () => strin
         Moo: function() { return "cow"; }
         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ Moo: () => string; }' is not assignable to type 'ITextWriter2'.
-!!! error TS2322:   Object literal may only specify known properties, and 'Moo' does not exist in type 'ITextWriter2'.
+!!! error TS2322:   Object literal can only specify known properties, and 'Moo' does not exist in type 'ITextWriter2'.
     }

--- a/tests/baselines/reference/typeMatch2.errors.txt
+++ b/tests/baselines/reference/typeMatch2.errors.txt
@@ -3,9 +3,9 @@ tests/cases/compiler/typeMatch2.ts(3,2): error TS2322: Type '{}' is not assignab
 tests/cases/compiler/typeMatch2.ts(4,5): error TS2322: Type '{ x: number; }' is not assignable to type '{ x: number; y: number; }'.
   Property 'y' is missing in type '{ x: number; }'.
 tests/cases/compiler/typeMatch2.ts(5,20): error TS2322: Type '{ x: number; y: number; z: number; }' is not assignable to type '{ x: number; y: number; }'.
-  Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
+  Object literal can only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
 tests/cases/compiler/typeMatch2.ts(6,17): error TS2322: Type '{ x: number; z: number; }' is not assignable to type '{ x: number; y: number; }'.
-  Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
+  Object literal can only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
 tests/cases/compiler/typeMatch2.ts(18,5): error TS2322: Type 'Animal[]' is not assignable to type 'Giraffe[]'.
   Type 'Animal' is not assignable to type 'Giraffe'.
     Property 'g' is missing in type 'Animal'.
@@ -14,7 +14,7 @@ tests/cases/compiler/typeMatch2.ts(22,5): error TS2322: Type '{ f1: number; f2: 
     Type 'Animal[]' is not assignable to type 'Giraffe[]'.
       Type 'Animal' is not assignable to type 'Giraffe'.
 tests/cases/compiler/typeMatch2.ts(34,26): error TS2322: Type '{ x: number; y: any; z: number; }' is not assignable to type '{ x: number; y: number; }'.
-  Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
+  Object literal can only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
 tests/cases/compiler/typeMatch2.ts(35,5): error TS2322: Type '{ x: number; }' is not assignable to type '{ x: number; y: number; }'.
   Property 'y' is missing in type '{ x: number; }'.
 
@@ -33,11 +33,11 @@ tests/cases/compiler/typeMatch2.ts(35,5): error TS2322: Type '{ x: number; }' is
     	a = { x: 1, y: 2, z: 3 };
     	                  ~~~~
 !!! error TS2322: Type '{ x: number; y: number; z: number; }' is not assignable to type '{ x: number; y: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
+!!! error TS2322:   Object literal can only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
         a = { x: 1, z: 3 };  // error
                     ~~~~
 !!! error TS2322: Type '{ x: number; z: number; }' is not assignable to type '{ x: number; y: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
+!!! error TS2322:   Object literal can only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
     }
     
     class Animal { private a; }
@@ -77,7 +77,7 @@ tests/cases/compiler/typeMatch2.ts(35,5): error TS2322: Type '{ x: number; }' is
         a = { x: 1, y: _any, z:1 }; 
                              ~~~
 !!! error TS2322: Type '{ x: number; y: any; z: number; }' is not assignable to type '{ x: number; y: number; }'.
-!!! error TS2322:   Object literal may only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
+!!! error TS2322:   Object literal can only specify known properties, and 'z' does not exist in type '{ x: number; y: number; }'.
         a = { x: 1 }; // error
         ~
 !!! error TS2322: Type '{ x: number; }' is not assignable to type '{ x: number; y: number; }'.

--- a/tests/baselines/reference/typeParameterAsBaseClass.errors.txt
+++ b/tests/baselines/reference/typeParameterAsBaseClass.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/typeParameterAsBaseClass.ts(1,20): error TS2304: Cannot find name 'T'.
-tests/cases/compiler/typeParameterAsBaseClass.ts(2,24): error TS2422: A class may only implement another class or interface.
+tests/cases/compiler/typeParameterAsBaseClass.ts(2,24): error TS2422: A class can only implement another class or interface.
 
 
 ==== tests/cases/compiler/typeParameterAsBaseClass.ts (2 errors) ====
@@ -8,4 +8,4 @@ tests/cases/compiler/typeParameterAsBaseClass.ts(2,24): error TS2422: A class ma
 !!! error TS2304: Cannot find name 'T'.
     class C2<T> implements T {}
                            ~
-!!! error TS2422: A class may only implement another class or interface.
+!!! error TS2422: A class can only implement another class or interface.

--- a/tests/baselines/reference/typeParameterAsBaseType.errors.txt
+++ b/tests/baselines/reference/typeParameterAsBaseType.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/types/typeParameters/typeParameterAsBaseType.ts(4,20): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/types/typeParameters/typeParameterAsBaseType.ts(5,24): error TS2304: Cannot find name 'U'.
-tests/cases/conformance/types/typeParameters/typeParameterAsBaseType.ts(7,24): error TS2312: An interface may only extend a class or another interface.
-tests/cases/conformance/types/typeParameters/typeParameterAsBaseType.ts(8,28): error TS2312: An interface may only extend a class or another interface.
+tests/cases/conformance/types/typeParameters/typeParameterAsBaseType.ts(7,24): error TS2312: An interface can only extend a class or another interface.
+tests/cases/conformance/types/typeParameters/typeParameterAsBaseType.ts(8,28): error TS2312: An interface can only extend a class or another interface.
 
 
 ==== tests/cases/conformance/types/typeParameters/typeParameterAsBaseType.ts (4 errors) ====
@@ -17,9 +17,9 @@ tests/cases/conformance/types/typeParameters/typeParameterAsBaseType.ts(8,28): e
     
     interface I<T> extends T { }
                            ~
-!!! error TS2312: An interface may only extend a class or another interface.
+!!! error TS2312: An interface can only extend a class or another interface.
     interface I2<T, U> extends U { }
                                ~
-!!! error TS2312: An interface may only extend a class or another interface.
+!!! error TS2312: An interface can only extend a class or another interface.
     
     

--- a/tests/baselines/reference/untypedFunctionCallsWithTypeParameters1.errors.txt
+++ b/tests/baselines/reference/untypedFunctionCallsWithTypeParameters1.errors.txt
@@ -1,10 +1,10 @@
 tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(3,10): error TS2346: Supplied parameters do not match any signature of call target.
-tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(5,10): error TS2347: Untyped function calls may not accept type arguments.
-tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(8,10): error TS2347: Untyped function calls may not accept type arguments.
+tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(5,10): error TS2347: Untyped function calls cannot accept type arguments.
+tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(8,10): error TS2347: Untyped function calls cannot accept type arguments.
 tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(10,7): error TS2420: Class 'C' incorrectly implements interface 'Function'.
   Property 'apply' is missing in type 'C'.
 tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(18,10): error TS2349: Cannot invoke an expression whose type lacks a call signature.
-tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(22,10): error TS2347: Untyped function calls may not accept type arguments.
+tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(22,10): error TS2347: Untyped function calls cannot accept type arguments.
 tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(28,10): error TS2346: Supplied parameters do not match any signature of call target.
 tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(35,1): error TS2346: Supplied parameters do not match any signature of call target.
 tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(41,1): error TS2346: Supplied parameters do not match any signature of call target.
@@ -19,12 +19,12 @@ tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(41,1): error TS2
     var y: any = x;
     var r2 = y<string>();
              ~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     
     var c: Function;
     var r3 = c<number>(); // should be an error
              ~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     
     class C implements Function {
           ~
@@ -45,7 +45,7 @@ tests/cases/compiler/untypedFunctionCallsWithTypeParameters1.ts(41,1): error TS2
     var c3: C2;
     var r5 = c3<number>(); // error
              ~~~~~~~~~~~~
-!!! error TS2347: Untyped function calls may not accept type arguments.
+!!! error TS2347: Untyped function calls cannot accept type arguments.
     
     interface I {
         (number): number;

--- a/tslint.json
+++ b/tslint.json
@@ -38,6 +38,7 @@
         "no-trailing-whitespace": true,
         "no-inferrable-types": true,
         "no-null": true,
+        "error-message-arity": true,
         "boolean-trivia": true
   }
 }


### PR DESCRIPTION
A few things here:
* Remove unused errors from diagnosticMessages.json
* Change instances of "may" to "can" in error messages
* Add a lint rule to enforce error message arity (e.g. it is an error to write `error(node, Diagnostics.Foo_0_is_bad);`)
* Add a `jake` task to run the error message validator script
* Add minimal phrasing checking to the error message validator (so far, the only rule is to disallow the word *"may"*)