### PR TITLE
Module merge with constructors

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3679,7 +3679,9 @@ namespace ts {
         function getSignatureFromDeclaration(declaration: SignatureDeclaration): Signature {
             let links = getNodeLinks(declaration);
             if (!links.resolvedSignature) {
-                let classType = declaration.kind === SyntaxKind.Constructor ? getDeclaredTypeOfClassOrInterface((<ClassDeclaration>declaration.parent).symbol) : undefined;
+                let classType = declaration.kind === SyntaxKind.Constructor ?
+                    getDeclaredTypeOfClassOrInterface(getMergedSymbol((<ClassDeclaration>declaration.parent).symbol))
+                    : undefined;
                 let typeParameters = classType ? classType.localTypeParameters :
                     declaration.typeParameters ? getTypeParametersFromDeclaration(declaration.typeParameters) : undefined;
                 let parameters: Symbol[] = [];

--- a/tests/baselines/reference/moduleMergeConstructor.js
+++ b/tests/baselines/reference/moduleMergeConstructor.js
@@ -4,7 +4,7 @@
 
 declare module "foo" {
     export class Foo {
-        // constructor(): Foo;
+        constructor();
         method1(): any;
     }
 }

--- a/tests/baselines/reference/moduleMergeConstructor.js
+++ b/tests/baselines/reference/moduleMergeConstructor.js
@@ -1,0 +1,38 @@
+//// [tests/cases/compiler/moduleMergeConstructor.ts] ////
+
+//// [foo.d.ts]
+
+declare module "foo" {
+    export class Foo {
+        // constructor(): Foo;
+        method1(): any;
+    }
+}
+
+//// [foo-ext.d.ts]
+declare module "foo" {
+    export interface Foo {
+        method2(): any;
+    }
+}
+
+//// [index.ts]
+import * as foo from "foo";
+
+class Test {
+    bar: foo.Foo;
+    constructor() {
+        this.bar = new foo.Foo();
+    }
+}
+
+
+//// [index.js]
+define(["require", "exports", "foo"], function (require, exports, foo) {
+    var Test = (function () {
+        function Test() {
+            this.bar = new foo.Foo();
+        }
+        return Test;
+    })();
+});

--- a/tests/baselines/reference/moduleMergeConstructor.symbols
+++ b/tests/baselines/reference/moduleMergeConstructor.symbols
@@ -4,9 +4,9 @@ declare module "foo" {
     export class Foo {
 >Foo : Symbol(Foo, Decl(foo.d.ts, 1, 22), Decl(foo-ext.d.ts, 0, 22))
 
-        // constructor(): Foo;
+        constructor();
         method1(): any;
->method1 : Symbol(method1, Decl(foo.d.ts, 2, 22))
+>method1 : Symbol(method1, Decl(foo.d.ts, 3, 22))
     }
 }
 

--- a/tests/baselines/reference/moduleMergeConstructor.symbols
+++ b/tests/baselines/reference/moduleMergeConstructor.symbols
@@ -1,0 +1,45 @@
+=== tests/cases/compiler/foo.d.ts ===
+
+declare module "foo" {
+    export class Foo {
+>Foo : Symbol(Foo, Decl(foo.d.ts, 1, 22), Decl(foo-ext.d.ts, 0, 22))
+
+        // constructor(): Foo;
+        method1(): any;
+>method1 : Symbol(method1, Decl(foo.d.ts, 2, 22))
+    }
+}
+
+=== tests/cases/compiler/foo-ext.d.ts ===
+declare module "foo" {
+    export interface Foo {
+>Foo : Symbol(Foo, Decl(foo.d.ts, 1, 22), Decl(foo-ext.d.ts, 0, 22))
+
+        method2(): any;
+>method2 : Symbol(method2, Decl(foo-ext.d.ts, 1, 26))
+    }
+}
+
+=== tests/cases/compiler/index.ts ===
+import * as foo from "foo";
+>foo : Symbol(foo, Decl(index.ts, 0, 6))
+
+class Test {
+>Test : Symbol(Test, Decl(index.ts, 0, 27))
+
+    bar: foo.Foo;
+>bar : Symbol(bar, Decl(index.ts, 2, 12))
+>foo : Symbol(foo, Decl(index.ts, 0, 6))
+>Foo : Symbol(foo.Foo, Decl(foo.d.ts, 1, 22), Decl(foo-ext.d.ts, 0, 22))
+
+    constructor() {
+        this.bar = new foo.Foo();
+>this.bar : Symbol(bar, Decl(index.ts, 2, 12))
+>this : Symbol(Test, Decl(index.ts, 0, 27))
+>bar : Symbol(bar, Decl(index.ts, 2, 12))
+>foo.Foo : Symbol(foo.Foo, Decl(foo.d.ts, 1, 22), Decl(foo-ext.d.ts, 0, 22))
+>foo : Symbol(foo, Decl(index.ts, 0, 6))
+>Foo : Symbol(foo.Foo, Decl(foo.d.ts, 1, 22), Decl(foo-ext.d.ts, 0, 22))
+    }
+}
+

--- a/tests/baselines/reference/moduleMergeConstructor.types
+++ b/tests/baselines/reference/moduleMergeConstructor.types
@@ -1,0 +1,47 @@
+=== tests/cases/compiler/foo.d.ts ===
+
+declare module "foo" {
+    export class Foo {
+>Foo : Foo
+
+        // constructor(): Foo;
+        method1(): any;
+>method1 : () => any
+    }
+}
+
+=== tests/cases/compiler/foo-ext.d.ts ===
+declare module "foo" {
+    export interface Foo {
+>Foo : Foo
+
+        method2(): any;
+>method2 : () => any
+    }
+}
+
+=== tests/cases/compiler/index.ts ===
+import * as foo from "foo";
+>foo : typeof foo
+
+class Test {
+>Test : Test
+
+    bar: foo.Foo;
+>bar : foo.Foo
+>foo : any
+>Foo : foo.Foo
+
+    constructor() {
+        this.bar = new foo.Foo();
+>this.bar = new foo.Foo() : foo.Foo
+>this.bar : foo.Foo
+>this : this
+>bar : foo.Foo
+>new foo.Foo() : foo.Foo
+>foo.Foo : typeof foo.Foo
+>foo : typeof foo
+>Foo : typeof foo.Foo
+    }
+}
+

--- a/tests/baselines/reference/moduleMergeConstructor.types
+++ b/tests/baselines/reference/moduleMergeConstructor.types
@@ -4,7 +4,7 @@ declare module "foo" {
     export class Foo {
 >Foo : Foo
 
-        // constructor(): Foo;
+        constructor();
         method1(): any;
 >method1 : () => any
     }

--- a/tests/cases/compiler/moduleMergeConstructor.ts
+++ b/tests/cases/compiler/moduleMergeConstructor.ts
@@ -3,7 +3,7 @@
 // @filename: foo.d.ts
 declare module "foo" {
     export class Foo {
-        // constructor(): Foo;
+        constructor();
         method1(): any;
     }
 }

--- a/tests/cases/compiler/moduleMergeConstructor.ts
+++ b/tests/cases/compiler/moduleMergeConstructor.ts
@@ -1,0 +1,26 @@
+// @module: amd 
+
+// @filename: foo.d.ts
+declare module "foo" {
+    export class Foo {
+        // constructor(): Foo;
+        method1(): any;
+    }
+}
+
+// @filename: foo-ext.d.ts
+declare module "foo" {
+    export interface Foo {
+        method2(): any;
+    }
+}
+
+// @filename: index.ts
+import * as foo from "foo";
+
+class Test {
+    bar: foo.Foo;
+    constructor() {
+        this.bar = new foo.Foo();
+    }
+}


### PR DESCRIPTION
Make constructor use merged parent symbol.

Previously in getSignatureFromDeclaration, it just used the parent symbol without checking whether it was merged.

Fixes #5130.