### PR TITLE
Add ES2015 as a synonym to ES6

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -77,6 +77,7 @@ namespace ts {
                 "system": ModuleKind.System,
                 "umd": ModuleKind.UMD,
                 "es6": ModuleKind.ES6,
+                "es2015": ModuleKind.ES2015,
             },
             description: Diagnostics.Specify_module_code_generation_Colon_commonjs_amd_system_umd_or_es6,
             paramType: Diagnostics.KIND,
@@ -205,7 +206,12 @@ namespace ts {
         {
             name: "target",
             shortName: "t",
-            type: { "es3": ScriptTarget.ES3, "es5": ScriptTarget.ES5, "es6": ScriptTarget.ES6 },
+            type: {
+                "es3": ScriptTarget.ES3,
+                "es5": ScriptTarget.ES5,
+                "es6": ScriptTarget.ES6,
+                "es2015": ScriptTarget.ES2015,
+            },
             description: Diagnostics.Specify_ECMAScript_target_version_Colon_ES3_default_ES5_or_ES6_experimental,
             paramType: Diagnostics.VERSION,
             error: Diagnostics.Argument_for_target_option_must_be_ES3_ES5_or_ES6

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2103,6 +2103,7 @@ namespace ts {
         UMD = 3,
         System = 4,
         ES6 = 5,
+        ES2015 = ES6,
     }
 
     export const enum JsxEmit {
@@ -2128,12 +2129,13 @@ namespace ts {
         ES3 = 0,
         ES5 = 1,
         ES6 = 2,
+        ES2015 = ES6,
         Latest = ES6,
     }
 
     export const enum LanguageVariant {
         Standard,
-        JSX
+        JSX,
     }
 
     export interface ParsedCommandLine {

--- a/tests/baselines/reference/es2015modulekind.js
+++ b/tests/baselines/reference/es2015modulekind.js
@@ -1,0 +1,23 @@
+//// [es2015modulekind.ts]
+
+export default class A
+{
+    constructor ()
+    {
+
+    }
+
+    public B()
+    {
+        return 42;
+    }
+}
+
+//// [es2015modulekind.js]
+export default class A {
+    constructor() {
+    }
+    B() {
+        return 42;
+    }
+}

--- a/tests/baselines/reference/es2015modulekind.symbols
+++ b/tests/baselines/reference/es2015modulekind.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/es2015modulekind.ts ===
+
+export default class A
+>A : Symbol(A, Decl(es2015modulekind.ts, 0, 0))
+{
+    constructor ()
+    {
+
+    }
+
+    public B()
+>B : Symbol(B, Decl(es2015modulekind.ts, 6, 5))
+    {
+        return 42;
+    }
+}

--- a/tests/baselines/reference/es2015modulekind.types
+++ b/tests/baselines/reference/es2015modulekind.types
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/es2015modulekind.ts ===
+
+export default class A
+>A : A
+{
+    constructor ()
+    {
+
+    }
+
+    public B()
+>B : () => number
+    {
+        return 42;
+>42 : number
+    }
+}

--- a/tests/baselines/reference/es2015modulekindWithES6Target.js
+++ b/tests/baselines/reference/es2015modulekindWithES6Target.js
@@ -1,0 +1,23 @@
+//// [es2015modulekindWithES6Target.ts]
+
+export default class A
+{
+    constructor ()
+    {
+
+    }
+
+    public B()
+    {
+        return 42;
+    }
+}
+
+//// [es2015modulekindWithES6Target.js]
+export default class A {
+    constructor() {
+    }
+    B() {
+        return 42;
+    }
+}

--- a/tests/baselines/reference/es2015modulekindWithES6Target.symbols
+++ b/tests/baselines/reference/es2015modulekindWithES6Target.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/es2015modulekindWithES6Target.ts ===
+
+export default class A
+>A : Symbol(A, Decl(es2015modulekindWithES6Target.ts, 0, 0))
+{
+    constructor ()
+    {
+
+    }
+
+    public B()
+>B : Symbol(B, Decl(es2015modulekindWithES6Target.ts, 6, 5))
+    {
+        return 42;
+    }
+}

--- a/tests/baselines/reference/es2015modulekindWithES6Target.types
+++ b/tests/baselines/reference/es2015modulekindWithES6Target.types
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/es2015modulekindWithES6Target.ts ===
+
+export default class A
+>A : A
+{
+    constructor ()
+    {
+
+    }
+
+    public B()
+>B : () => number
+    {
+        return 42;
+>42 : number
+    }
+}

--- a/tests/baselines/reference/es6modulekindWithES2015Target.js
+++ b/tests/baselines/reference/es6modulekindWithES2015Target.js
@@ -1,0 +1,23 @@
+//// [es6modulekindWithES2015Target.ts]
+
+export default class A
+{
+    constructor ()
+    {
+
+    }
+
+    public B()
+    {
+        return 42;
+    }
+}
+
+//// [es6modulekindWithES2015Target.js]
+export default class A {
+    constructor() {
+    }
+    B() {
+        return 42;
+    }
+}

--- a/tests/baselines/reference/es6modulekindWithES2015Target.symbols
+++ b/tests/baselines/reference/es6modulekindWithES2015Target.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/es6modulekindWithES2015Target.ts ===
+
+export default class A
+>A : Symbol(A, Decl(es6modulekindWithES2015Target.ts, 0, 0))
+{
+    constructor ()
+    {
+
+    }
+
+    public B()
+>B : Symbol(B, Decl(es6modulekindWithES2015Target.ts, 6, 5))
+    {
+        return 42;
+    }
+}

--- a/tests/baselines/reference/es6modulekindWithES2015Target.types
+++ b/tests/baselines/reference/es6modulekindWithES2015Target.types
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/es6modulekindWithES2015Target.ts ===
+
+export default class A
+>A : A
+{
+    constructor ()
+    {
+
+    }
+
+    public B()
+>B : () => number
+    {
+        return 42;
+>42 : number
+    }
+}

--- a/tests/cases/compiler/es2015modulekind.ts
+++ b/tests/cases/compiler/es2015modulekind.ts
@@ -1,0 +1,17 @@
+// @target: es2015
+// @sourcemap: false
+// @declaration: false
+// @module: es2015
+
+export default class A
+{
+    constructor ()
+    {
+
+    }
+
+    public B()
+    {
+        return 42;
+    }
+}

--- a/tests/cases/compiler/es2015modulekindWithES6Target.ts
+++ b/tests/cases/compiler/es2015modulekindWithES6Target.ts
@@ -1,0 +1,17 @@
+// @target: es6
+// @sourcemap: false
+// @declaration: false
+// @module: es2015
+
+export default class A
+{
+    constructor ()
+    {
+
+    }
+
+    public B()
+    {
+        return 42;
+    }
+}

--- a/tests/cases/compiler/es6modulekindWithES2015Target.ts
+++ b/tests/cases/compiler/es6modulekindWithES2015Target.ts
@@ -1,0 +1,17 @@
+// @target: es2015
+// @sourcemap: false
+// @declaration: false
+// @module: es6
+
+export default class A
+{
+    constructor ()
+    {
+
+    }
+
+    public B()
+    {
+        return 42;
+    }
+}


### PR DESCRIPTION
In ModuleKind, ScriptTarget and associated command line arguments. Fixes #5209.

Opinions are welcome on 
1. whether ModuleKind/ScriptTarget should have ES2015 variants, or just the command line parser.
2. whether ES2015 should be the default and ES6 the synonym.

I added tests, though I'm not certain they actually assert what it looks like.
