### PR TITLE
Add instructions on how to debug tests to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,11 @@ You can specify which browser to use for debugging. Currently Chrome and IE are 
 jake runtests-browser tests=2dArrays browser=chrome
 ```
 
+You can debug with VS Code or Node instead with `jake runtests debug=true`:
+
+```Shell
+jake runtests tests=2dArrays debug=true
+```
 ## Adding a Test
 To add a new testcase, simply place a `.ts` file in `tests\cases\compiler` containing code that exemplifies the bugfix or change you are making.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -73,6 +73,7 @@ You can debug with VS Code or Node instead with `jake runtests debug=true`:
 ```Shell
 jake runtests tests=2dArrays debug=true
 ```
+
 ## Adding a Test
 To add a new testcase, simply place a `.ts` file in `tests\cases\compiler` containing code that exemplifies the bugfix or change you are making.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,10 +47,25 @@ e.g. to run all compiler baseline tests:
 jake runtests tests=compiler
 ```
 
-or to run specifc test: `tests\cases\compiler\2dArrays.ts` 
+or to run a specific test: `tests\cases\compiler\2dArrays.ts` 
 
 ```Shell
 jake runtests tests=2dArrays
+```
+
+## Debugging the tests
+
+To debug the tests, invoke the runtests-browser using jake.
+You will probably only want to debug one test at a time:
+
+```Shell
+jake runtests-browser tests=2dArrays
+```
+
+You can specify which browser to use for debugging. Currently Chrome and IE are supported:
+
+```Shell
+jake runtests-browser tests=2dArrays browser=chrome
 ```
 
 ## Adding a Test


### PR DESCRIPTION
Using `jake runtests-browser`.

This step was hard for both me and @mikedon to discover when starting to contribute to TypeScript.