### PR TITLE
Change ArrayBuffer.isView declaration to type guard for ArrayBufferView.

### DIFF
--- a/src/lib/core.d.ts
+++ b/src/lib/core.d.ts
@@ -1210,7 +1210,7 @@ interface ArrayBuffer {
 interface ArrayBufferConstructor {
     prototype: ArrayBuffer;
     new (byteLength: number): ArrayBuffer;
-    isView(arg: any): boolean;
+    isView(arg: any): arg is ArrayBufferView;
 }
 declare var ArrayBuffer: ArrayBufferConstructor;
 

--- a/tests/baselines/reference/arrayBufferIsViewNarrowsType.js
+++ b/tests/baselines/reference/arrayBufferIsViewNarrowsType.js
@@ -1,0 +1,13 @@
+//// [arrayBufferIsViewNarrowsType.ts]
+var obj: Object;
+if (ArrayBuffer.isView(obj)) {
+    // isView should be a guard that narrows type to ArrayBufferView.
+    var ab: ArrayBufferView = obj;
+}
+
+//// [arrayBufferIsViewNarrowsType.js]
+var obj;
+if (ArrayBuffer.isView(obj)) {
+    // isView should be a guard that narrows type to ArrayBufferView.
+    var ab = obj;
+}

--- a/tests/baselines/reference/arrayBufferIsViewNarrowsType.symbols
+++ b/tests/baselines/reference/arrayBufferIsViewNarrowsType.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/arrayBufferIsViewNarrowsType.ts ===
+var obj: Object;
+>obj : Symbol(obj, Decl(arrayBufferIsViewNarrowsType.ts, 0, 3))
+>Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+if (ArrayBuffer.isView(obj)) {
+>ArrayBuffer.isView : Symbol(ArrayBufferConstructor.isView, Decl(lib.d.ts, --, --))
+>ArrayBuffer : Symbol(ArrayBuffer, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>isView : Symbol(ArrayBufferConstructor.isView, Decl(lib.d.ts, --, --))
+>obj : Symbol(obj, Decl(arrayBufferIsViewNarrowsType.ts, 0, 3))
+
+    // isView should be a guard that narrows type to ArrayBufferView.
+    var ab: ArrayBufferView = obj;
+>ab : Symbol(ab, Decl(arrayBufferIsViewNarrowsType.ts, 3, 7))
+>ArrayBufferView : Symbol(ArrayBufferView, Decl(lib.d.ts, --, --))
+>obj : Symbol(obj, Decl(arrayBufferIsViewNarrowsType.ts, 0, 3))
+}

--- a/tests/baselines/reference/arrayBufferIsViewNarrowsType.types
+++ b/tests/baselines/reference/arrayBufferIsViewNarrowsType.types
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/arrayBufferIsViewNarrowsType.ts ===
+var obj: Object;
+>obj : Object
+>Object : Object
+
+if (ArrayBuffer.isView(obj)) {
+>ArrayBuffer.isView(obj) : boolean
+>ArrayBuffer.isView : (arg: any) => arg is ArrayBufferView
+>ArrayBuffer : ArrayBufferConstructor
+>isView : (arg: any) => arg is ArrayBufferView
+>obj : Object
+
+    // isView should be a guard that narrows type to ArrayBufferView.
+    var ab: ArrayBufferView = obj;
+>ab : ArrayBufferView
+>ArrayBufferView : ArrayBufferView
+>obj : ArrayBufferView
+}

--- a/tests/cases/compiler/arrayBufferIsViewNarrowsType.ts
+++ b/tests/cases/compiler/arrayBufferIsViewNarrowsType.ts
@@ -1,0 +1,5 @@
+var obj: Object;
+if (ArrayBuffer.isView(obj)) {
+    // isView should be a guard that narrows type to ArrayBufferView.
+    var ab: ArrayBufferView = obj;
+}


### PR DESCRIPTION
Also adds a test that checks that `ArrayBuffer.isView` appropriately narrows its argument to `ArrayBufferView`.

Fixes #5308.