### PR TITLE
Issue fix for config file watcher callback

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1267,11 +1267,15 @@ namespace ts.server {
                             if (info.isOpen) {
                                 if (this.openFileRoots.indexOf(info) >= 0) {
                                     this.openFileRoots = copyListRemovingItem(info, this.openFileRoots);
+                                    if (info.defaultProject && !info.defaultProject.isConfiguredProject()) {
+                                        this.removeProject(info.defaultProject);
+                                    }
                                 }
                                 if (this.openFilesReferenced.indexOf(info) >= 0) {
                                     this.openFilesReferenced = copyListRemovingItem(info, this.openFilesReferenced);
                                 }
                                 this.openFileRootsConfigured.push(info);
+                                info.defaultProject = project;
                             }
                         }
                         project.addRoot(info);


### PR DESCRIPTION
Fix for the issue: can't add a file back to a configured project after being deleted from it once. 