### PR TITLE
Change sys.write to async in tsserver

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -370,20 +370,23 @@ namespace ts {
                 }
             }
 
+            function write(buffer: any, offset = 0) {
+                let toWrite = buffer.length - offset;
+                _fs.write(1, buffer, offset, toWrite, function(err: any, written: number, buffer: any){
+                    offset += written;
+                    if (toWrite > written) {
+                        write(buffer, offset);
+                    }
+                })
+            }
+
             return {
                 args: process.argv.slice(2),
                 newLine: _os.EOL,
                 useCaseSensitiveFileNames: useCaseSensitiveFileNames,
                 write(s: string): void {
                     const buffer = new Buffer(s, "utf8");
-                    let offset = 0;
-                    let toWrite: number = buffer.length;
-                    let written = 0;
-                    // 1 is a standard descriptor for stdout
-                    while ((written = _fs.writeSync(1, buffer, offset, toWrite)) < toWrite) {
-                        offset += written;
-                        toWrite -= written;
-                    }
+                    write(buffer);
                 },
                 readFile,
                 writeFile,

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -370,23 +370,20 @@ namespace ts {
                 }
             }
 
-            function write(buffer: any, offset = 0) {
-                let toWrite = buffer.length - offset;
-                _fs.write(1, buffer, offset, toWrite, function(err: any, written: number, buffer: any){
-                    offset += written;
-                    if (toWrite > written) {
-                        write(buffer, offset);
-                    }
-                })
-            }
-
             return {
                 args: process.argv.slice(2),
                 newLine: _os.EOL,
                 useCaseSensitiveFileNames: useCaseSensitiveFileNames,
                 write(s: string): void {
                     const buffer = new Buffer(s, "utf8");
-                    write(buffer);
+                    let offset = 0;
+                    let toWrite: number = buffer.length;
+                    let written = 0;
+                    // 1 is a standard descriptor for stdout
+                    while ((written = _fs.writeSync(1, buffer, offset, toWrite)) < toWrite) {
+                        offset += written;
+                        toWrite -= written;
+                    }
                 },
                 readFile,
                 writeFile,


### PR DESCRIPTION
This is related to 
https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/379
and 
https://github.com/Microsoft/TypeScript/issues/2758#issuecomment-149796636

`fs.writeSync` truncates a long line, and will throw an exception of `EAGAIN: Resource not available` if re trying right away. Changing the writing behavior to async solves the problem.