### PR TITLE
Add JS breakpoint into Debug.assert failure

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -832,7 +832,7 @@ namespace ts {
                 if (verboseDebugInfo) {
                     verboseDebugString = "\r\nVerbose Debug Information: " + verboseDebugInfo();
                 }
-
+                debugger;
                 throw new Error("Debug Failure. False expression: " + (message || "") + verboseDebugString);
             }
         }


### PR DESCRIPTION
I was talking to @DanielRosenwasser the other day and mentioned this - it's been a floating patch that I keep reapplying on top of my own changes locally. Turns out, it's pretty useful to have a preset breakpoint when an assertion is violated.