### PR TITLE
Merge inherits interface members

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2845,6 +2845,10 @@ namespace ts {
             return type.resolvedBaseConstructorType;
         }
 
+        function hasClassBaseType(type: InterfaceType): boolean {
+            return !!forEach(getBaseTypes(type), t => !!(t.symbol.flags & SymbolFlags.Class));
+        }
+
         function getBaseTypes(type: InterfaceType): ObjectType[] {
             let isClass = type.symbol.flags & SymbolFlags.Class;
             let isInterface = type.symbol.flags & SymbolFlags.Interface;
@@ -3254,7 +3258,7 @@ namespace ts {
         }
 
         function getDefaultConstructSignatures(classType: InterfaceType): Signature[] {
-            if (!getBaseTypes(classType).length) {
+            if (!hasClassBaseType(classType)) {
                 return [createSignature(undefined, classType.localTypeParameters, emptyArray, classType, undefined, 0, false, false)];
             }
             let baseConstructorType = getBaseConstructorTypeOfClass(classType);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2846,22 +2846,24 @@ namespace ts {
         }
 
         function getBaseTypes(type: InterfaceType): ObjectType[] {
+            let isClass = type.symbol.flags & SymbolFlags.Class;
+            let isInterface = type.symbol.flags & SymbolFlags.Interface;
             if (!type.resolvedBaseTypes) {
-                if (type.symbol.flags & SymbolFlags.Class) {
+                if (!isClass && !isInterface) {
+                    Debug.fail("type must be class or interface");
+                }
+                if (isClass) {
                     resolveBaseTypesOfClass(type);
                 }
-                else if (type.symbol.flags & SymbolFlags.Interface) {
+                if (isInterface) {
                     resolveBaseTypesOfInterface(type);
-                }
-                else {
-                    Debug.fail("type must be class or interface");
                 }
             }
             return type.resolvedBaseTypes;
         }
 
         function resolveBaseTypesOfClass(type: InterfaceType): void {
-            type.resolvedBaseTypes = emptyArray;
+            type.resolvedBaseTypes = type.resolvedBaseTypes || [];
             let baseContructorType = getBaseConstructorTypeOfClass(type);
             if (!(baseContructorType.flags & TypeFlags.ObjectType)) {
                 return;
@@ -2897,11 +2899,11 @@ namespace ts {
                     typeToString(type, /*enclosingDeclaration*/ undefined, TypeFormatFlags.WriteArrayAsGenericType));
                 return;
             }
-            type.resolvedBaseTypes = [baseType];
+            type.resolvedBaseTypes.push(baseType);
         }
 
         function resolveBaseTypesOfInterface(type: InterfaceType): void {
-            type.resolvedBaseTypes = [];
+            type.resolvedBaseTypes = type.resolvedBaseTypes || [];
             for (let declaration of type.symbol.declarations) {
                 if (declaration.kind === SyntaxKind.InterfaceDeclaration && getInterfaceBaseTypeNodes(<InterfaceDeclaration>declaration)) {
                     for (let node of getInterfaceBaseTypeNodes(<InterfaceDeclaration>declaration)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2867,7 +2867,7 @@ namespace ts {
         }
 
         function resolveBaseTypesOfClass(type: InterfaceType): void {
-            type.resolvedBaseTypes = type.resolvedBaseTypes || [];
+            type.resolvedBaseTypes = type.resolvedBaseTypes || emptyArray;
             let baseContructorType = getBaseConstructorTypeOfClass(type);
             if (!(baseContructorType.flags & TypeFlags.ObjectType)) {
                 return;
@@ -2903,11 +2903,16 @@ namespace ts {
                     typeToString(type, /*enclosingDeclaration*/ undefined, TypeFormatFlags.WriteArrayAsGenericType));
                 return;
             }
-            type.resolvedBaseTypes.push(baseType);
+            if (type.resolvedBaseTypes === emptyArray) {
+                type.resolvedBaseTypes = [baseType];
+            }
+            else {
+                type.resolvedBaseTypes.push(baseType);
+            }
         }
 
         function resolveBaseTypesOfInterface(type: InterfaceType): void {
-            type.resolvedBaseTypes = type.resolvedBaseTypes || [];
+            type.resolvedBaseTypes = type.resolvedBaseTypes || emptyArray;
             for (let declaration of type.symbol.declarations) {
                 if (declaration.kind === SyntaxKind.InterfaceDeclaration && getInterfaceBaseTypeNodes(<InterfaceDeclaration>declaration)) {
                     for (let node of getInterfaceBaseTypeNodes(<InterfaceDeclaration>declaration)) {
@@ -2915,7 +2920,12 @@ namespace ts {
                         if (baseType !== unknownType) {
                             if (getTargetType(baseType).flags & (TypeFlags.Class | TypeFlags.Interface)) {
                                 if (type !== baseType && !hasBaseType(<InterfaceType>baseType, type)) {
-                                    type.resolvedBaseTypes.push(baseType);
+                                    if (type.resolvedBaseTypes === emptyArray) {
+                                        type.resolvedBaseTypes = [baseType];
+                                    }
+                                    else {
+                                        type.resolvedBaseTypes.push(baseType);
+                                    }
                                 }
                                 else {
                                     error(declaration, Diagnostics.Type_0_recursively_references_itself_as_a_base_type, typeToString(type, /*enclosingDeclaration*/ undefined, TypeFormatFlags.WriteArrayAsGenericType));

--- a/tests/baselines/reference/mergedInheritedClassInterface.js
+++ b/tests/baselines/reference/mergedInheritedClassInterface.js
@@ -4,8 +4,8 @@ interface BaseInterface {
     optional?: number;
 }
 
-declare class BaseClass {
-    baseMethod();
+class BaseClass {
+    baseMethod() { }
     baseNumber: number;
 }
 
@@ -13,9 +13,19 @@ interface Child extends BaseInterface {
     additional: number;
 }
 
-declare class Child extends BaseClass {
+class Child extends BaseClass {
     classNumber: number;
-    method();
+    method() { }
+}
+
+interface ChildNoBaseClass extends BaseInterface {
+    additional2: string;
+}
+class ChildNoBaseClass {
+    classString: string;
+    method2() { }
+}
+class Grandchild extends ChildNoBaseClass {
 }
 
 // checks if properties actually were merged
@@ -28,8 +38,47 @@ child.classNumber;
 child.baseMethod();
 child.method();
 
+var grandchild: Grandchild;
+grandchild.required;
+grandchild.optional;
+grandchild.additional2;
+grandchild.classString;
+grandchild.method2();
+
 
 //// [mergedInheritedClassInterface.js]
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var BaseClass = (function () {
+    function BaseClass() {
+    }
+    BaseClass.prototype.baseMethod = function () { };
+    return BaseClass;
+})();
+var Child = (function (_super) {
+    __extends(Child, _super);
+    function Child() {
+        _super.apply(this, arguments);
+    }
+    Child.prototype.method = function () { };
+    return Child;
+})(BaseClass);
+var ChildNoBaseClass = (function () {
+    function ChildNoBaseClass() {
+    }
+    ChildNoBaseClass.prototype.method2 = function () { };
+    return ChildNoBaseClass;
+})();
+var Grandchild = (function (_super) {
+    __extends(Grandchild, _super);
+    function Grandchild() {
+        _super.apply(this, arguments);
+    }
+    return Grandchild;
+})(ChildNoBaseClass);
 // checks if properties actually were merged
 var child;
 child.required;
@@ -39,3 +88,9 @@ child.baseNumber;
 child.classNumber;
 child.baseMethod();
 child.method();
+var grandchild;
+grandchild.required;
+grandchild.optional;
+grandchild.additional2;
+grandchild.classString;
+grandchild.method2();

--- a/tests/baselines/reference/mergedInheritedClassInterface.js
+++ b/tests/baselines/reference/mergedInheritedClassInterface.js
@@ -1,0 +1,39 @@
+//// [mergedInheritedClassInterface.ts]
+interface BaseInterface {
+    required: number;
+    optional?: number;
+}
+
+declare class BaseClass {
+    baseMethod();
+    x2: number;
+}
+
+interface Child extends BaseInterface {
+    x3: number;
+}
+
+declare class Child extends BaseClass {
+    x4: number;
+    method();
+}
+
+// checks if properties actually were merged
+var child : Child;
+child.required;
+child.optional;
+child.x3;
+child.x4;
+child.baseMethod();
+child.method();
+
+
+//// [mergedInheritedClassInterface.js]
+// checks if properties actually were merged
+var child;
+child.required;
+child.optional;
+child.x3;
+child.x4;
+child.baseMethod();
+child.method();

--- a/tests/baselines/reference/mergedInheritedClassInterface.js
+++ b/tests/baselines/reference/mergedInheritedClassInterface.js
@@ -6,15 +6,15 @@ interface BaseInterface {
 
 declare class BaseClass {
     baseMethod();
-    x2: number;
+    baseNumber: number;
 }
 
 interface Child extends BaseInterface {
-    x3: number;
+    additional: number;
 }
 
 declare class Child extends BaseClass {
-    x4: number;
+    classNumber: number;
     method();
 }
 
@@ -22,8 +22,9 @@ declare class Child extends BaseClass {
 var child : Child;
 child.required;
 child.optional;
-child.x3;
-child.x4;
+child.additional;
+child.baseNumber;
+child.classNumber;
 child.baseMethod();
 child.method();
 
@@ -33,7 +34,8 @@ child.method();
 var child;
 child.required;
 child.optional;
-child.x3;
-child.x4;
+child.additional;
+child.baseNumber;
+child.classNumber;
 child.baseMethod();
 child.method();

--- a/tests/baselines/reference/mergedInheritedClassInterface.symbols
+++ b/tests/baselines/reference/mergedInheritedClassInterface.symbols
@@ -15,27 +15,27 @@ declare class BaseClass {
     baseMethod();
 >baseMethod : Symbol(baseMethod, Decl(mergedInheritedClassInterface.ts, 5, 25))
 
-    x2: number;
->x2 : Symbol(x2, Decl(mergedInheritedClassInterface.ts, 6, 17))
+    baseNumber: number;
+>baseNumber : Symbol(baseNumber, Decl(mergedInheritedClassInterface.ts, 6, 17))
 }
 
 interface Child extends BaseInterface {
 >Child : Symbol(Child, Decl(mergedInheritedClassInterface.ts, 8, 1), Decl(mergedInheritedClassInterface.ts, 12, 1))
 >BaseInterface : Symbol(BaseInterface, Decl(mergedInheritedClassInterface.ts, 0, 0))
 
-    x3: number;
->x3 : Symbol(x3, Decl(mergedInheritedClassInterface.ts, 10, 39))
+    additional: number;
+>additional : Symbol(additional, Decl(mergedInheritedClassInterface.ts, 10, 39))
 }
 
 declare class Child extends BaseClass {
 >Child : Symbol(Child, Decl(mergedInheritedClassInterface.ts, 8, 1), Decl(mergedInheritedClassInterface.ts, 12, 1))
 >BaseClass : Symbol(BaseClass, Decl(mergedInheritedClassInterface.ts, 3, 1))
 
-    x4: number;
->x4 : Symbol(x4, Decl(mergedInheritedClassInterface.ts, 14, 39))
+    classNumber: number;
+>classNumber : Symbol(classNumber, Decl(mergedInheritedClassInterface.ts, 14, 39))
 
     method();
->method : Symbol(method, Decl(mergedInheritedClassInterface.ts, 15, 15))
+>method : Symbol(method, Decl(mergedInheritedClassInterface.ts, 15, 24))
 }
 
 // checks if properties actually were merged
@@ -53,15 +53,20 @@ child.optional;
 >child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
 >optional : Symbol(BaseInterface.optional, Decl(mergedInheritedClassInterface.ts, 1, 21))
 
-child.x3;
->child.x3 : Symbol(Child.x3, Decl(mergedInheritedClassInterface.ts, 10, 39))
+child.additional;
+>child.additional : Symbol(Child.additional, Decl(mergedInheritedClassInterface.ts, 10, 39))
 >child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
->x3 : Symbol(Child.x3, Decl(mergedInheritedClassInterface.ts, 10, 39))
+>additional : Symbol(Child.additional, Decl(mergedInheritedClassInterface.ts, 10, 39))
 
-child.x4;
->child.x4 : Symbol(Child.x4, Decl(mergedInheritedClassInterface.ts, 14, 39))
+child.baseNumber;
+>child.baseNumber : Symbol(BaseClass.baseNumber, Decl(mergedInheritedClassInterface.ts, 6, 17))
 >child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
->x4 : Symbol(Child.x4, Decl(mergedInheritedClassInterface.ts, 14, 39))
+>baseNumber : Symbol(BaseClass.baseNumber, Decl(mergedInheritedClassInterface.ts, 6, 17))
+
+child.classNumber;
+>child.classNumber : Symbol(Child.classNumber, Decl(mergedInheritedClassInterface.ts, 14, 39))
+>child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
+>classNumber : Symbol(Child.classNumber, Decl(mergedInheritedClassInterface.ts, 14, 39))
 
 child.baseMethod();
 >child.baseMethod : Symbol(BaseClass.baseMethod, Decl(mergedInheritedClassInterface.ts, 5, 25))
@@ -69,7 +74,7 @@ child.baseMethod();
 >baseMethod : Symbol(BaseClass.baseMethod, Decl(mergedInheritedClassInterface.ts, 5, 25))
 
 child.method();
->child.method : Symbol(Child.method, Decl(mergedInheritedClassInterface.ts, 15, 15))
+>child.method : Symbol(Child.method, Decl(mergedInheritedClassInterface.ts, 15, 24))
 >child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
->method : Symbol(Child.method, Decl(mergedInheritedClassInterface.ts, 15, 15))
+>method : Symbol(Child.method, Decl(mergedInheritedClassInterface.ts, 15, 24))
 

--- a/tests/baselines/reference/mergedInheritedClassInterface.symbols
+++ b/tests/baselines/reference/mergedInheritedClassInterface.symbols
@@ -1,0 +1,75 @@
+=== tests/cases/conformance/classes/classDeclarations/mergedInheritedClassInterface.ts ===
+interface BaseInterface {
+>BaseInterface : Symbol(BaseInterface, Decl(mergedInheritedClassInterface.ts, 0, 0))
+
+    required: number;
+>required : Symbol(required, Decl(mergedInheritedClassInterface.ts, 0, 25))
+
+    optional?: number;
+>optional : Symbol(optional, Decl(mergedInheritedClassInterface.ts, 1, 21))
+}
+
+declare class BaseClass {
+>BaseClass : Symbol(BaseClass, Decl(mergedInheritedClassInterface.ts, 3, 1))
+
+    baseMethod();
+>baseMethod : Symbol(baseMethod, Decl(mergedInheritedClassInterface.ts, 5, 25))
+
+    x2: number;
+>x2 : Symbol(x2, Decl(mergedInheritedClassInterface.ts, 6, 17))
+}
+
+interface Child extends BaseInterface {
+>Child : Symbol(Child, Decl(mergedInheritedClassInterface.ts, 8, 1), Decl(mergedInheritedClassInterface.ts, 12, 1))
+>BaseInterface : Symbol(BaseInterface, Decl(mergedInheritedClassInterface.ts, 0, 0))
+
+    x3: number;
+>x3 : Symbol(x3, Decl(mergedInheritedClassInterface.ts, 10, 39))
+}
+
+declare class Child extends BaseClass {
+>Child : Symbol(Child, Decl(mergedInheritedClassInterface.ts, 8, 1), Decl(mergedInheritedClassInterface.ts, 12, 1))
+>BaseClass : Symbol(BaseClass, Decl(mergedInheritedClassInterface.ts, 3, 1))
+
+    x4: number;
+>x4 : Symbol(x4, Decl(mergedInheritedClassInterface.ts, 14, 39))
+
+    method();
+>method : Symbol(method, Decl(mergedInheritedClassInterface.ts, 15, 15))
+}
+
+// checks if properties actually were merged
+var child : Child;
+>child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
+>Child : Symbol(Child, Decl(mergedInheritedClassInterface.ts, 8, 1), Decl(mergedInheritedClassInterface.ts, 12, 1))
+
+child.required;
+>child.required : Symbol(BaseInterface.required, Decl(mergedInheritedClassInterface.ts, 0, 25))
+>child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
+>required : Symbol(BaseInterface.required, Decl(mergedInheritedClassInterface.ts, 0, 25))
+
+child.optional;
+>child.optional : Symbol(BaseInterface.optional, Decl(mergedInheritedClassInterface.ts, 1, 21))
+>child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
+>optional : Symbol(BaseInterface.optional, Decl(mergedInheritedClassInterface.ts, 1, 21))
+
+child.x3;
+>child.x3 : Symbol(Child.x3, Decl(mergedInheritedClassInterface.ts, 10, 39))
+>child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
+>x3 : Symbol(Child.x3, Decl(mergedInheritedClassInterface.ts, 10, 39))
+
+child.x4;
+>child.x4 : Symbol(Child.x4, Decl(mergedInheritedClassInterface.ts, 14, 39))
+>child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
+>x4 : Symbol(Child.x4, Decl(mergedInheritedClassInterface.ts, 14, 39))
+
+child.baseMethod();
+>child.baseMethod : Symbol(BaseClass.baseMethod, Decl(mergedInheritedClassInterface.ts, 5, 25))
+>child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
+>baseMethod : Symbol(BaseClass.baseMethod, Decl(mergedInheritedClassInterface.ts, 5, 25))
+
+child.method();
+>child.method : Symbol(Child.method, Decl(mergedInheritedClassInterface.ts, 15, 15))
+>child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
+>method : Symbol(Child.method, Decl(mergedInheritedClassInterface.ts, 15, 15))
+

--- a/tests/baselines/reference/mergedInheritedClassInterface.symbols
+++ b/tests/baselines/reference/mergedInheritedClassInterface.symbols
@@ -9,14 +9,14 @@ interface BaseInterface {
 >optional : Symbol(optional, Decl(mergedInheritedClassInterface.ts, 1, 21))
 }
 
-declare class BaseClass {
+class BaseClass {
 >BaseClass : Symbol(BaseClass, Decl(mergedInheritedClassInterface.ts, 3, 1))
 
-    baseMethod();
->baseMethod : Symbol(baseMethod, Decl(mergedInheritedClassInterface.ts, 5, 25))
+    baseMethod() { }
+>baseMethod : Symbol(baseMethod, Decl(mergedInheritedClassInterface.ts, 5, 17))
 
     baseNumber: number;
->baseNumber : Symbol(baseNumber, Decl(mergedInheritedClassInterface.ts, 6, 17))
+>baseNumber : Symbol(baseNumber, Decl(mergedInheritedClassInterface.ts, 6, 20))
 }
 
 interface Child extends BaseInterface {
@@ -27,54 +27,104 @@ interface Child extends BaseInterface {
 >additional : Symbol(additional, Decl(mergedInheritedClassInterface.ts, 10, 39))
 }
 
-declare class Child extends BaseClass {
+class Child extends BaseClass {
 >Child : Symbol(Child, Decl(mergedInheritedClassInterface.ts, 8, 1), Decl(mergedInheritedClassInterface.ts, 12, 1))
 >BaseClass : Symbol(BaseClass, Decl(mergedInheritedClassInterface.ts, 3, 1))
 
     classNumber: number;
->classNumber : Symbol(classNumber, Decl(mergedInheritedClassInterface.ts, 14, 39))
+>classNumber : Symbol(classNumber, Decl(mergedInheritedClassInterface.ts, 14, 31))
 
-    method();
+    method() { }
 >method : Symbol(method, Decl(mergedInheritedClassInterface.ts, 15, 24))
+}
+
+interface ChildNoBaseClass extends BaseInterface {
+>ChildNoBaseClass : Symbol(ChildNoBaseClass, Decl(mergedInheritedClassInterface.ts, 17, 1), Decl(mergedInheritedClassInterface.ts, 21, 1))
+>BaseInterface : Symbol(BaseInterface, Decl(mergedInheritedClassInterface.ts, 0, 0))
+
+    additional2: string;
+>additional2 : Symbol(additional2, Decl(mergedInheritedClassInterface.ts, 19, 50))
+}
+class ChildNoBaseClass {
+>ChildNoBaseClass : Symbol(ChildNoBaseClass, Decl(mergedInheritedClassInterface.ts, 17, 1), Decl(mergedInheritedClassInterface.ts, 21, 1))
+
+    classString: string;
+>classString : Symbol(classString, Decl(mergedInheritedClassInterface.ts, 22, 24))
+
+    method2() { }
+>method2 : Symbol(method2, Decl(mergedInheritedClassInterface.ts, 23, 24))
+}
+class Grandchild extends ChildNoBaseClass {
+>Grandchild : Symbol(Grandchild, Decl(mergedInheritedClassInterface.ts, 25, 1))
+>ChildNoBaseClass : Symbol(ChildNoBaseClass, Decl(mergedInheritedClassInterface.ts, 17, 1), Decl(mergedInheritedClassInterface.ts, 21, 1))
 }
 
 // checks if properties actually were merged
 var child : Child;
->child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
+>child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 30, 3))
 >Child : Symbol(Child, Decl(mergedInheritedClassInterface.ts, 8, 1), Decl(mergedInheritedClassInterface.ts, 12, 1))
 
 child.required;
 >child.required : Symbol(BaseInterface.required, Decl(mergedInheritedClassInterface.ts, 0, 25))
->child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
+>child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 30, 3))
 >required : Symbol(BaseInterface.required, Decl(mergedInheritedClassInterface.ts, 0, 25))
 
 child.optional;
 >child.optional : Symbol(BaseInterface.optional, Decl(mergedInheritedClassInterface.ts, 1, 21))
->child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
+>child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 30, 3))
 >optional : Symbol(BaseInterface.optional, Decl(mergedInheritedClassInterface.ts, 1, 21))
 
 child.additional;
 >child.additional : Symbol(Child.additional, Decl(mergedInheritedClassInterface.ts, 10, 39))
->child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
+>child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 30, 3))
 >additional : Symbol(Child.additional, Decl(mergedInheritedClassInterface.ts, 10, 39))
 
 child.baseNumber;
->child.baseNumber : Symbol(BaseClass.baseNumber, Decl(mergedInheritedClassInterface.ts, 6, 17))
->child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
->baseNumber : Symbol(BaseClass.baseNumber, Decl(mergedInheritedClassInterface.ts, 6, 17))
+>child.baseNumber : Symbol(BaseClass.baseNumber, Decl(mergedInheritedClassInterface.ts, 6, 20))
+>child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 30, 3))
+>baseNumber : Symbol(BaseClass.baseNumber, Decl(mergedInheritedClassInterface.ts, 6, 20))
 
 child.classNumber;
->child.classNumber : Symbol(Child.classNumber, Decl(mergedInheritedClassInterface.ts, 14, 39))
->child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
->classNumber : Symbol(Child.classNumber, Decl(mergedInheritedClassInterface.ts, 14, 39))
+>child.classNumber : Symbol(Child.classNumber, Decl(mergedInheritedClassInterface.ts, 14, 31))
+>child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 30, 3))
+>classNumber : Symbol(Child.classNumber, Decl(mergedInheritedClassInterface.ts, 14, 31))
 
 child.baseMethod();
->child.baseMethod : Symbol(BaseClass.baseMethod, Decl(mergedInheritedClassInterface.ts, 5, 25))
->child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
->baseMethod : Symbol(BaseClass.baseMethod, Decl(mergedInheritedClassInterface.ts, 5, 25))
+>child.baseMethod : Symbol(BaseClass.baseMethod, Decl(mergedInheritedClassInterface.ts, 5, 17))
+>child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 30, 3))
+>baseMethod : Symbol(BaseClass.baseMethod, Decl(mergedInheritedClassInterface.ts, 5, 17))
 
 child.method();
 >child.method : Symbol(Child.method, Decl(mergedInheritedClassInterface.ts, 15, 24))
->child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 20, 3))
+>child : Symbol(child, Decl(mergedInheritedClassInterface.ts, 30, 3))
 >method : Symbol(Child.method, Decl(mergedInheritedClassInterface.ts, 15, 24))
+
+var grandchild: Grandchild;
+>grandchild : Symbol(grandchild, Decl(mergedInheritedClassInterface.ts, 39, 3))
+>Grandchild : Symbol(Grandchild, Decl(mergedInheritedClassInterface.ts, 25, 1))
+
+grandchild.required;
+>grandchild.required : Symbol(BaseInterface.required, Decl(mergedInheritedClassInterface.ts, 0, 25))
+>grandchild : Symbol(grandchild, Decl(mergedInheritedClassInterface.ts, 39, 3))
+>required : Symbol(BaseInterface.required, Decl(mergedInheritedClassInterface.ts, 0, 25))
+
+grandchild.optional;
+>grandchild.optional : Symbol(BaseInterface.optional, Decl(mergedInheritedClassInterface.ts, 1, 21))
+>grandchild : Symbol(grandchild, Decl(mergedInheritedClassInterface.ts, 39, 3))
+>optional : Symbol(BaseInterface.optional, Decl(mergedInheritedClassInterface.ts, 1, 21))
+
+grandchild.additional2;
+>grandchild.additional2 : Symbol(ChildNoBaseClass.additional2, Decl(mergedInheritedClassInterface.ts, 19, 50))
+>grandchild : Symbol(grandchild, Decl(mergedInheritedClassInterface.ts, 39, 3))
+>additional2 : Symbol(ChildNoBaseClass.additional2, Decl(mergedInheritedClassInterface.ts, 19, 50))
+
+grandchild.classString;
+>grandchild.classString : Symbol(ChildNoBaseClass.classString, Decl(mergedInheritedClassInterface.ts, 22, 24))
+>grandchild : Symbol(grandchild, Decl(mergedInheritedClassInterface.ts, 39, 3))
+>classString : Symbol(ChildNoBaseClass.classString, Decl(mergedInheritedClassInterface.ts, 22, 24))
+
+grandchild.method2();
+>grandchild.method2 : Symbol(ChildNoBaseClass.method2, Decl(mergedInheritedClassInterface.ts, 23, 24))
+>grandchild : Symbol(grandchild, Decl(mergedInheritedClassInterface.ts, 39, 3))
+>method2 : Symbol(ChildNoBaseClass.method2, Decl(mergedInheritedClassInterface.ts, 23, 24))
 

--- a/tests/baselines/reference/mergedInheritedClassInterface.types
+++ b/tests/baselines/reference/mergedInheritedClassInterface.types
@@ -15,24 +15,24 @@ declare class BaseClass {
     baseMethod();
 >baseMethod : () => any
 
-    x2: number;
->x2 : number
+    baseNumber: number;
+>baseNumber : number
 }
 
 interface Child extends BaseInterface {
 >Child : Child
 >BaseInterface : BaseInterface
 
-    x3: number;
->x3 : number
+    additional: number;
+>additional : number
 }
 
 declare class Child extends BaseClass {
 >Child : Child
 >BaseClass : BaseClass
 
-    x4: number;
->x4 : number
+    classNumber: number;
+>classNumber : number
 
     method();
 >method : () => any
@@ -53,15 +53,20 @@ child.optional;
 >child : Child
 >optional : number
 
-child.x3;
->child.x3 : number
+child.additional;
+>child.additional : number
 >child : Child
->x3 : number
+>additional : number
 
-child.x4;
->child.x4 : number
+child.baseNumber;
+>child.baseNumber : number
 >child : Child
->x4 : number
+>baseNumber : number
+
+child.classNumber;
+>child.classNumber : number
+>child : Child
+>classNumber : number
 
 child.baseMethod();
 >child.baseMethod() : any

--- a/tests/baselines/reference/mergedInheritedClassInterface.types
+++ b/tests/baselines/reference/mergedInheritedClassInterface.types
@@ -1,0 +1,77 @@
+=== tests/cases/conformance/classes/classDeclarations/mergedInheritedClassInterface.ts ===
+interface BaseInterface {
+>BaseInterface : BaseInterface
+
+    required: number;
+>required : number
+
+    optional?: number;
+>optional : number
+}
+
+declare class BaseClass {
+>BaseClass : BaseClass
+
+    baseMethod();
+>baseMethod : () => any
+
+    x2: number;
+>x2 : number
+}
+
+interface Child extends BaseInterface {
+>Child : Child
+>BaseInterface : BaseInterface
+
+    x3: number;
+>x3 : number
+}
+
+declare class Child extends BaseClass {
+>Child : Child
+>BaseClass : BaseClass
+
+    x4: number;
+>x4 : number
+
+    method();
+>method : () => any
+}
+
+// checks if properties actually were merged
+var child : Child;
+>child : Child
+>Child : Child
+
+child.required;
+>child.required : number
+>child : Child
+>required : number
+
+child.optional;
+>child.optional : number
+>child : Child
+>optional : number
+
+child.x3;
+>child.x3 : number
+>child : Child
+>x3 : number
+
+child.x4;
+>child.x4 : number
+>child : Child
+>x4 : number
+
+child.baseMethod();
+>child.baseMethod() : any
+>child.baseMethod : () => any
+>child : Child
+>baseMethod : () => any
+
+child.method();
+>child.method() : any
+>child.method : () => any
+>child : Child
+>method : () => any
+

--- a/tests/baselines/reference/mergedInheritedClassInterface.types
+++ b/tests/baselines/reference/mergedInheritedClassInterface.types
@@ -9,11 +9,11 @@ interface BaseInterface {
 >optional : number
 }
 
-declare class BaseClass {
+class BaseClass {
 >BaseClass : BaseClass
 
-    baseMethod();
->baseMethod : () => any
+    baseMethod() { }
+>baseMethod : () => void
 
     baseNumber: number;
 >baseNumber : number
@@ -27,15 +27,36 @@ interface Child extends BaseInterface {
 >additional : number
 }
 
-declare class Child extends BaseClass {
+class Child extends BaseClass {
 >Child : Child
 >BaseClass : BaseClass
 
     classNumber: number;
 >classNumber : number
 
-    method();
->method : () => any
+    method() { }
+>method : () => void
+}
+
+interface ChildNoBaseClass extends BaseInterface {
+>ChildNoBaseClass : ChildNoBaseClass
+>BaseInterface : BaseInterface
+
+    additional2: string;
+>additional2 : string
+}
+class ChildNoBaseClass {
+>ChildNoBaseClass : ChildNoBaseClass
+
+    classString: string;
+>classString : string
+
+    method2() { }
+>method2 : () => void
+}
+class Grandchild extends ChildNoBaseClass {
+>Grandchild : Grandchild
+>ChildNoBaseClass : ChildNoBaseClass
 }
 
 // checks if properties actually were merged
@@ -69,14 +90,44 @@ child.classNumber;
 >classNumber : number
 
 child.baseMethod();
->child.baseMethod() : any
->child.baseMethod : () => any
+>child.baseMethod() : void
+>child.baseMethod : () => void
 >child : Child
->baseMethod : () => any
+>baseMethod : () => void
 
 child.method();
->child.method() : any
->child.method : () => any
+>child.method() : void
+>child.method : () => void
 >child : Child
->method : () => any
+>method : () => void
+
+var grandchild: Grandchild;
+>grandchild : Grandchild
+>Grandchild : Grandchild
+
+grandchild.required;
+>grandchild.required : number
+>grandchild : Grandchild
+>required : number
+
+grandchild.optional;
+>grandchild.optional : number
+>grandchild : Grandchild
+>optional : number
+
+grandchild.additional2;
+>grandchild.additional2 : string
+>grandchild : Grandchild
+>additional2 : string
+
+grandchild.classString;
+>grandchild.classString : string
+>grandchild : Grandchild
+>classString : string
+
+grandchild.method2();
+>grandchild.method2() : void
+>grandchild.method2 : () => void
+>grandchild : Grandchild
+>method2 : () => void
 

--- a/tests/baselines/reference/templateStringsArrayTypeDefinedInES5Mode.errors.txt
+++ b/tests/baselines/reference/templateStringsArrayTypeDefinedInES5Mode.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/templateStringsArrayTypeDefinedInES5Mode.ts(8,3): error TS2345: Argument of type '{}' is not assignable to parameter of type 'TemplateStringsArray'.
-  Property 'raw' is missing in type '{}'.
+tests/cases/compiler/templateStringsArrayTypeDefinedInES5Mode.ts(8,3): error TS2345: Argument of type '{ [x: number]: undefined; }' is not assignable to parameter of type 'TemplateStringsArray'.
+  Property 'raw' is missing in type '{ [x: number]: undefined; }'.
 
 
 ==== tests/cases/compiler/templateStringsArrayTypeDefinedInES5Mode.ts (1 errors) ====
@@ -12,7 +12,7 @@ tests/cases/compiler/templateStringsArrayTypeDefinedInES5Mode.ts(8,3): error TS2
     
     f({}, 10, 10);
       ~~
-!!! error TS2345: Argument of type '{}' is not assignable to parameter of type 'TemplateStringsArray'.
-!!! error TS2345:   Property 'raw' is missing in type '{}'.
+!!! error TS2345: Argument of type '{ [x: number]: undefined; }' is not assignable to parameter of type 'TemplateStringsArray'.
+!!! error TS2345:   Property 'raw' is missing in type '{ [x: number]: undefined; }'.
     
     f `abcdef${ 1234 }${ 5678 }ghijkl`;

--- a/tests/baselines/reference/templateStringsArrayTypeRedefinedInES6Mode.errors.txt
+++ b/tests/baselines/reference/templateStringsArrayTypeRedefinedInES6Mode.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/compiler/templateStringsArrayTypeRedefinedInES6Mode.ts(8,3): error TS2345: Argument of type '{}' is not assignable to parameter of type 'TemplateStringsArray'.
-  Property 'raw' is missing in type '{}'.
+tests/cases/compiler/templateStringsArrayTypeRedefinedInES6Mode.ts(8,3): error TS2345: Argument of type '{ [x: number]: undefined; }' is not assignable to parameter of type 'TemplateStringsArray'.
+  Property 'raw' is missing in type '{ [x: number]: undefined; }'.
 
 
 ==== tests/cases/compiler/templateStringsArrayTypeRedefinedInES6Mode.ts (1 errors) ====
@@ -12,7 +12,7 @@ tests/cases/compiler/templateStringsArrayTypeRedefinedInES6Mode.ts(8,3): error T
     
     f({}, 10, 10);
       ~~
-!!! error TS2345: Argument of type '{}' is not assignable to parameter of type 'TemplateStringsArray'.
-!!! error TS2345:   Property 'raw' is missing in type '{}'.
+!!! error TS2345: Argument of type '{ [x: number]: undefined; }' is not assignable to parameter of type 'TemplateStringsArray'.
+!!! error TS2345:   Property 'raw' is missing in type '{ [x: number]: undefined; }'.
     
     f `abcdef${ 1234 }${ 5678 }ghijkl`;

--- a/tests/cases/conformance/classes/classDeclarations/mergedInheritedClassInterface.ts
+++ b/tests/cases/conformance/classes/classDeclarations/mergedInheritedClassInterface.ts
@@ -1,0 +1,27 @@
+interface BaseInterface {
+    required: number;
+    optional?: number;
+}
+
+declare class BaseClass {
+    baseMethod();
+    x2: number;
+}
+
+interface Child extends BaseInterface {
+    x3: number;
+}
+
+declare class Child extends BaseClass {
+    x4: number;
+    method();
+}
+
+// checks if properties actually were merged
+var child : Child;
+child.required;
+child.optional;
+child.x3;
+child.x4;
+child.baseMethod();
+child.method();

--- a/tests/cases/conformance/classes/classDeclarations/mergedInheritedClassInterface.ts
+++ b/tests/cases/conformance/classes/classDeclarations/mergedInheritedClassInterface.ts
@@ -5,15 +5,15 @@ interface BaseInterface {
 
 declare class BaseClass {
     baseMethod();
-    x2: number;
+    baseNumber: number;
 }
 
 interface Child extends BaseInterface {
-    x3: number;
+    additional: number;
 }
 
 declare class Child extends BaseClass {
-    x4: number;
+    classNumber: number;
     method();
 }
 
@@ -21,7 +21,8 @@ declare class Child extends BaseClass {
 var child : Child;
 child.required;
 child.optional;
-child.x3;
-child.x4;
+child.additional;
+child.baseNumber;
+child.classNumber;
 child.baseMethod();
 child.method();

--- a/tests/cases/conformance/classes/classDeclarations/mergedInheritedClassInterface.ts
+++ b/tests/cases/conformance/classes/classDeclarations/mergedInheritedClassInterface.ts
@@ -3,8 +3,8 @@ interface BaseInterface {
     optional?: number;
 }
 
-declare class BaseClass {
-    baseMethod();
+class BaseClass {
+    baseMethod() { }
     baseNumber: number;
 }
 
@@ -12,9 +12,19 @@ interface Child extends BaseInterface {
     additional: number;
 }
 
-declare class Child extends BaseClass {
+class Child extends BaseClass {
     classNumber: number;
-    method();
+    method() { }
+}
+
+interface ChildNoBaseClass extends BaseInterface {
+    additional2: string;
+}
+class ChildNoBaseClass {
+    classString: string;
+    method2() { }
+}
+class Grandchild extends ChildNoBaseClass {
 }
 
 // checks if properties actually were merged
@@ -26,3 +36,10 @@ child.baseNumber;
 child.classNumber;
 child.baseMethod();
 child.method();
+
+var grandchild: Grandchild;
+grandchild.required;
+grandchild.optional;
+grandchild.additional2;
+grandchild.classString;
+grandchild.method2();


### PR DESCRIPTION
Fixes #5347 

This bug has been around since July but we didn't notice it until recently. `getBaseTypes` assumed that if a class was present in the merge, only the class base types needed to be used -- it skipped the interface base types entirely. This became false when [ambient] classes and interfaces could be merged.