### PR TITLE
Convert diagnostic text to es2015

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -79,9 +79,9 @@ namespace ts {
                 "es6": ModuleKind.ES6,
                 "es2015": ModuleKind.ES2015,
             },
-            description: Diagnostics.Specify_module_code_generation_Colon_commonjs_amd_system_umd_or_es6,
+            description: Diagnostics.Specify_module_code_generation_Colon_commonjs_amd_system_umd_or_es2015,
             paramType: Diagnostics.KIND,
-            error: Diagnostics.Argument_for_module_option_must_be_commonjs_amd_system_umd_or_es6
+            error: Diagnostics.Argument_for_module_option_must_be_commonjs_amd_system_umd_or_es2015
         },
         {
             name: "newLine",
@@ -212,9 +212,9 @@ namespace ts {
                 "es6": ScriptTarget.ES6,
                 "es2015": ScriptTarget.ES2015,
             },
-            description: Diagnostics.Specify_ECMAScript_target_version_Colon_ES3_default_ES5_or_ES6_experimental,
+            description: Diagnostics.Specify_ECMAScript_target_version_Colon_ES3_default_ES5_or_ES2015_experimental,
             paramType: Diagnostics.VERSION,
-            error: Diagnostics.Argument_for_target_option_must_be_ES3_ES5_or_ES6
+            error: Diagnostics.Argument_for_target_option_must_be_ES3_ES5_or_ES2015
         },
         {
             name: "version",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -627,7 +627,7 @@
         "category": "Error",
         "code": 1203
     },
-    "Cannot compile modules into 'es6' when targeting 'ES5' or lower.": {
+    "Cannot compile modules into 'es2015' when targeting 'ES5' or lower.": {
         "category": "Error",
         "code": 1204
     },
@@ -2044,7 +2044,7 @@
         "category": "Error",
         "code": 5042
     },
-    "Option 'isolatedModules' can only be used when either option'--module' is provided or option 'target' is 'ES6' or higher.": {
+    "Option 'isolatedModules' can only be used when either option '--module' is provided or option 'target' is 'ES2015' or higher.": {
         "category": "Error",
         "code": 5047
     },
@@ -2105,11 +2105,11 @@
         "category": "Message",
         "code": 6010
     },
-    "Specify ECMAScript target version: 'ES3' (default), 'ES5', or 'ES6' (experimental)": {
-        "category": "Message",
-        "code": 6015
-    },
-    "Specify module code generation: 'commonjs', 'amd', 'system', 'umd' or 'es6'": {
+  "Specify ECMAScript target version: 'ES3' (default), 'ES5', or 'ES2015' (experimental)": {
+    "category": "Message",
+    "code": 6015
+  },
+    "Specify module code generation: 'commonjs', 'amd', 'system', 'umd' or 'es2015'": {
         "category": "Message",
         "code": 6016
     },
@@ -2193,14 +2193,14 @@
         "category": "Error",
         "code": 6045
     },
-    "Argument for '--module' option must be 'commonjs', 'amd', 'system', 'umd', or 'es6'.": {
+    "Argument for '--module' option must be 'commonjs', 'amd', 'system', 'umd', or 'es2015'.": {
         "category": "Error",
         "code": 6046
     },
-    "Argument for '--target' option must be 'ES3', 'ES5', or 'ES6'.": {
-        "category": "Error",
-        "code": 6047
-    },
+  "Argument for '--target' option must be 'ES3', 'ES5', or 'ES2015'.": {
+    "category": "Error",
+    "code": 6047
+  },
     "Locale must be of the form <language> or <language>-<territory>. For example '{0}' or '{1}'.": {
         "category": "Error",
         "code": 6048

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1005,7 +1005,7 @@ namespace ts {
             let firstExternalModuleSourceFile = forEach(files, f => isExternalModule(f) ? f : undefined);
             if (options.isolatedModules) {
                 if (!options.module && languageVersion < ScriptTarget.ES6) {
-                    programDiagnostics.add(createCompilerDiagnostic(Diagnostics.Option_isolatedModules_can_only_be_used_when_either_option_module_is_provided_or_option_target_is_ES6_or_higher));
+                    programDiagnostics.add(createCompilerDiagnostic(Diagnostics.Option_isolatedModules_can_only_be_used_when_either_option_module_is_provided_or_option_target_is_ES2015_or_higher));
                 }
 
                 let firstNonExternalModuleSourceFile = forEach(files, f => !isExternalModule(f) && !isDeclarationFile(f) ? f : undefined);
@@ -1022,7 +1022,7 @@ namespace ts {
 
             // Cannot specify module gen target of es6 when below es6
             if (options.module === ModuleKind.ES6 && languageVersion < ScriptTarget.ES6) {
-                programDiagnostics.add(createCompilerDiagnostic(Diagnostics.Cannot_compile_modules_into_es6_when_targeting_ES5_or_lower));
+                programDiagnostics.add(createCompilerDiagnostic(Diagnostics.Cannot_compile_modules_into_es2015_when_targeting_ES5_or_lower));
             }
 
             // there has to be common source directory if user specified --outdir || --sourceRoot

--- a/tests/baselines/reference/es5andes6module.errors.txt
+++ b/tests/baselines/reference/es5andes6module.errors.txt
@@ -1,7 +1,7 @@
-error TS1204: Cannot compile modules into 'es6' when targeting 'ES5' or lower.
+error TS1204: Cannot compile modules into 'es2015' when targeting 'ES5' or lower.
 
 
-!!! error TS1204: Cannot compile modules into 'es6' when targeting 'ES5' or lower.
+!!! error TS1204: Cannot compile modules into 'es2015' when targeting 'ES5' or lower.
 ==== tests/cases/compiler/es5andes6module.ts (0 errors) ====
     
     export default class A

--- a/tests/baselines/reference/isolatedModulesUnspecifiedModule.errors.txt
+++ b/tests/baselines/reference/isolatedModulesUnspecifiedModule.errors.txt
@@ -1,6 +1,6 @@
-error TS5047: Option 'isolatedModules' can only be used when either option'--module' is provided or option 'target' is 'ES6' or higher.
+error TS5047: Option 'isolatedModules' can only be used when either option '--module' is provided or option 'target' is 'ES2015' or higher.
 
 
-!!! error TS5047: Option 'isolatedModules' can only be used when either option'--module' is provided or option 'target' is 'ES6' or higher.
+!!! error TS5047: Option 'isolatedModules' can only be used when either option '--module' is provided or option 'target' is 'ES2015' or higher.
 ==== tests/cases/compiler/isolatedModulesUnspecifiedModule.ts (0 errors) ====
     export var x;


### PR DESCRIPTION
Further improves the fix for #5209 by updating the diagnostics to use ES2015 instead of ES6.