### PR TITLE
Fix union of variadic functions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5620,11 +5620,10 @@ namespace ts {
             // M and N (the signatures) are instantiated using type Any as the type argument for all type parameters declared by M and N
             source = getErasedSignature(source);
             target = getErasedSignature(target);
-            let sourceLen = source.parameters.length;
             let targetLen = target.parameters.length;
             for (let i = 0; i < targetLen; i++) {
-                let s = source.hasRestParameter && i === sourceLen - 1 ? getRestTypeOfSignature(source) : getTypeOfSymbol(source.parameters[i]);
-                let t = target.hasRestParameter && i === targetLen - 1 ? getRestTypeOfSignature(target) : getTypeOfSymbol(target.parameters[i]);
+                let s = isRestParameterIndex(source, i) ? getRestTypeOfSignature(source) : getTypeOfSymbol(source.parameters[i]);
+                let t = isRestParameterIndex(target, i) ? getRestTypeOfSignature(target) : getTypeOfSymbol(target.parameters[i]);
                 let related = compareTypes(s, t);
                 if (!related) {
                     return Ternary.False;
@@ -5635,6 +5634,10 @@ namespace ts {
                 result &= compareTypes(getReturnTypeOfSignature(source), getReturnTypeOfSignature(target));
             }
             return result;
+        }
+
+        function isRestParameterIndex(signature: Signature, parameterIndex: number) {
+            return signature.hasRestParameter && parameterIndex >= signature.parameters.length - 1;
         }
 
         function isSupertypeOfEach(candidate: Type, types: Type[]): boolean {
@@ -6798,8 +6801,9 @@ namespace ts {
                         }
 
                         // If last parameter is contextually rest parameter get its type
-                        if (indexOfParameter === (func.parameters.length - 1) &&
-                            funcHasRestParameters && contextualSignature.hasRestParameter && func.parameters.length >= contextualSignature.parameters.length) {
+                        if (funcHasRestParameters &&
+                            indexOfParameter === (func.parameters.length - 1) &&
+                            isRestParameterIndex(contextualSignature, func.parameters.length - 1)) {
                             return getTypeOfSymbol(lastOrUndefined(contextualSignature.parameters));
                         }
                     }
@@ -8390,7 +8394,7 @@ namespace ts {
             // If spread arguments are present, check that they correspond to a rest parameter. If so, no
             // further checking is necessary.
             if (spreadArgIndex >= 0) {
-                return signature.hasRestParameter && spreadArgIndex >= signature.parameters.length - 1;
+                return isRestParameterIndex(signature, spreadArgIndex);
             }
 
             // Too many arguments implies incorrect arity.
@@ -9381,7 +9385,7 @@ namespace ts {
                 let contextualParameterType = getTypeAtPosition(context, i);
                 assignTypeToParameterAndFixTypeParameters(parameter, contextualParameterType, mapper);
             }
-            if (signature.hasRestParameter && context.hasRestParameter && signature.parameters.length >= context.parameters.length) {
+            if (signature.hasRestParameter && isRestParameterIndex(context, signature.parameters.length - 1)) {
                 let parameter = lastOrUndefined(signature.parameters);
                 let contextualParameterType = getTypeOfSymbol(lastOrUndefined(context.parameters));
                 assignTypeToParameterAndFixTypeParameters(parameter, contextualParameterType, mapper);

--- a/tests/baselines/reference/unionTypeCallSignatures.errors.txt
+++ b/tests/baselines/reference/unionTypeCallSignatures.errors.txt
@@ -28,9 +28,10 @@ tests/cases/conformance/types/union/unionTypeCallSignatures.ts(67,12): error TS2
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(68,12): error TS2346: Supplied parameters do not match any signature of call target.
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(69,12): error TS2346: Supplied parameters do not match any signature of call target.
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(70,12): error TS2346: Supplied parameters do not match any signature of call target.
+tests/cases/conformance/types/union/unionTypeCallSignatures.ts(73,12): error TS2346: Supplied parameters do not match any signature of call target.
 
 
-==== tests/cases/conformance/types/union/unionTypeCallSignatures.ts (30 errors) ====
+==== tests/cases/conformance/types/union/unionTypeCallSignatures.ts (31 errors) ====
     var numOrDate: number | Date;
     var strOrBoolean: string | boolean;
     var strOrNum: string | number;
@@ -162,4 +163,9 @@ tests/cases/conformance/types/union/unionTypeCallSignatures.ts(70,12): error TS2
                ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2346: Supplied parameters do not match any signature of call target.
     
+    var unionWithRestParameter4: { (...a: string[]): string; } | { (a: string, b: string): number; };
+    strOrNum = unionWithRestParameter4("hello"); // error supplied parameters do not match any call signature
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2346: Supplied parameters do not match any signature of call target.
+    strOrNum = unionWithRestParameter4("hello", "world");
     

--- a/tests/baselines/reference/unionTypeCallSignatures.js
+++ b/tests/baselines/reference/unionTypeCallSignatures.js
@@ -70,6 +70,9 @@ strOrNum = unionWithRestParameter3('hello', 10, 11); // error no call signature
 strOrNum = unionWithRestParameter3('hello', "hello"); // error no call signature
 strOrNum = unionWithRestParameter3(); // error no call signature
 
+var unionWithRestParameter4: { (...a: string[]): string; } | { (a: string, b: string): number; };
+strOrNum = unionWithRestParameter4("hello"); // error supplied parameters do not match any call signature
+strOrNum = unionWithRestParameter4("hello", "world");
 
 
 //// [unionTypeCallSignatures.js]
@@ -132,3 +135,6 @@ strOrNum = unionWithRestParameter3('hello', 10); // error no call signature
 strOrNum = unionWithRestParameter3('hello', 10, 11); // error no call signature
 strOrNum = unionWithRestParameter3('hello', "hello"); // error no call signature
 strOrNum = unionWithRestParameter3(); // error no call signature
+var unionWithRestParameter4;
+strOrNum = unionWithRestParameter4("hello"); // error supplied parameters do not match any call signature
+strOrNum = unionWithRestParameter4("hello", "world");

--- a/tests/cases/conformance/types/union/unionTypeCallSignatures.ts
+++ b/tests/cases/conformance/types/union/unionTypeCallSignatures.ts
@@ -69,3 +69,6 @@ strOrNum = unionWithRestParameter3('hello', 10, 11); // error no call signature
 strOrNum = unionWithRestParameter3('hello', "hello"); // error no call signature
 strOrNum = unionWithRestParameter3(); // error no call signature
 
+var unionWithRestParameter4: { (...a: string[]): string; } | { (a: string, b: string): number; };
+strOrNum = unionWithRestParameter4("hello"); // error supplied parameters do not match any call signature
+strOrNum = unionWithRestParameter4("hello", "world");


### PR DESCRIPTION
Fixes #5379.

The check used `=== len - 1` instead of `>= len - 1` to check whether a parameter index might be pointing to a rest argument.