### PR TITLE
Make undefined valid as a type name

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14885,7 +14885,9 @@ namespace ts {
             getSymbolLinks(undefinedSymbol).type = undefinedType;
             getSymbolLinks(argumentsSymbol).type = getGlobalType("IArguments");
             getSymbolLinks(unknownSymbol).type = unknownType;
-            globals[undefinedSymbol.name] = undefinedSymbol;
+            if (!globals[undefinedSymbol.name]) {
+                globals[undefinedSymbol.name] = undefinedSymbol;
+            }
             // Initialize special types
             globalArrayType = <GenericType>getGlobalType("Array", /*arity*/ 1);
             globalObjectType = getGlobalType("Object");

--- a/tests/baselines/reference/undefinedAsName.js
+++ b/tests/baselines/reference/undefinedAsName.js
@@ -1,0 +1,6 @@
+//// [undefinedAsName.ts]
+type undefined = string;
+var x: undefined;
+
+//// [undefinedAsName.js]
+var x;

--- a/tests/baselines/reference/undefinedAsName.symbols
+++ b/tests/baselines/reference/undefinedAsName.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/undefinedAsName.ts ===
+type undefined = string;
+>undefined : Symbol(undefined, Decl(undefinedAsName.ts, 0, 0))
+
+var x: undefined;
+>x : Symbol(x, Decl(undefinedAsName.ts, 1, 3))
+>undefined : Symbol(undefined, Decl(undefinedAsName.ts, 0, 0))
+

--- a/tests/baselines/reference/undefinedAsName.types
+++ b/tests/baselines/reference/undefinedAsName.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/undefinedAsName.ts ===
+type undefined = string;
+>undefined : string
+
+var x: undefined;
+>x : string
+>undefined : string
+

--- a/tests/cases/compiler/undefinedAsName.ts
+++ b/tests/cases/compiler/undefinedAsName.ts
@@ -1,0 +1,2 @@
+type undefined = string;
+var x: undefined;


### PR DESCRIPTION
Fixes #3087.

If the user introduces a global named `undefined` we no longer attempt to add the `undefined` builtin to the global table - the user's type overrides it.
