### PR TITLE
Allow type aliases to omit 'declare' keyword in '.d.ts' files

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15917,6 +15917,7 @@ namespace ts {
             //     export_opt   AmbientDeclaration
             //
             if (node.kind === SyntaxKind.InterfaceDeclaration ||
+                node.kind === SyntaxKind.TypeAliasDeclaration ||
                 node.kind === SyntaxKind.ImportDeclaration ||
                 node.kind === SyntaxKind.ImportEqualsDeclaration ||
                 node.kind === SyntaxKind.ExportDeclaration ||

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15912,10 +15912,12 @@ namespace ts {
             //  DeclarationElement:
             //     ExportAssignment
             //     export_opt   InterfaceDeclaration
+            //     export_opt   TypeAliasDeclaration
             //     export_opt   ImportDeclaration
             //     export_opt   ExternalImportDeclaration
             //     export_opt   AmbientDeclaration
             //
+            // TODO: The spec needs to be amended to reflect this grammar.
             if (node.kind === SyntaxKind.InterfaceDeclaration ||
                 node.kind === SyntaxKind.TypeAliasDeclaration ||
                 node.kind === SyntaxKind.ImportDeclaration ||

--- a/tests/baselines/reference/typeAliasDeclareKeyword01.d.errors.txt
+++ b/tests/baselines/reference/typeAliasDeclareKeyword01.d.errors.txt
@@ -1,0 +1,8 @@
+tests/cases/compiler/typeAliasDeclareKeyword01.d.ts(1,1): error TS1046: A 'declare' modifier is required for a top level declaration in a .d.ts file.
+
+
+==== tests/cases/compiler/typeAliasDeclareKeyword01.d.ts (1 errors) ====
+    type Foo = number;
+    ~~~~
+!!! error TS1046: A 'declare' modifier is required for a top level declaration in a .d.ts file.
+    declare type Bar = string;

--- a/tests/baselines/reference/typeAliasDeclareKeyword01.d.errors.txt
+++ b/tests/baselines/reference/typeAliasDeclareKeyword01.d.errors.txt
@@ -1,8 +1,0 @@
-tests/cases/compiler/typeAliasDeclareKeyword01.d.ts(1,1): error TS1046: A 'declare' modifier is required for a top level declaration in a .d.ts file.
-
-
-==== tests/cases/compiler/typeAliasDeclareKeyword01.d.ts (1 errors) ====
-    type Foo = number;
-    ~~~~
-!!! error TS1046: A 'declare' modifier is required for a top level declaration in a .d.ts file.
-    declare type Bar = string;

--- a/tests/baselines/reference/typeAliasDeclareKeyword01.d.symbols
+++ b/tests/baselines/reference/typeAliasDeclareKeyword01.d.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/typeAliasDeclareKeyword01.d.ts ===
+type Foo = number;
+>Foo : Symbol(Foo, Decl(typeAliasDeclareKeyword01.d.ts, 0, 0))
+
+declare type Bar = string;
+>Bar : Symbol(Bar, Decl(typeAliasDeclareKeyword01.d.ts, 0, 18))
+

--- a/tests/baselines/reference/typeAliasDeclareKeyword01.d.types
+++ b/tests/baselines/reference/typeAliasDeclareKeyword01.d.types
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/typeAliasDeclareKeyword01.d.ts ===
+type Foo = number;
+>Foo : number
+
+declare type Bar = string;
+>Bar : string
+

--- a/tests/cases/compiler/typeAliasDeclareKeyword01.d.ts
+++ b/tests/cases/compiler/typeAliasDeclareKeyword01.d.ts
@@ -1,0 +1,2 @@
+type Foo = number;
+declare type Bar = string;


### PR DESCRIPTION
Fixes #4487 