### PR TITLE
Fix nested parameter destructuring

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9414,7 +9414,9 @@ namespace ts {
             if (isBindingPattern(node.name)) {
                 for (let element of (<BindingPattern>node.name).elements) {
                     if (element.kind !== SyntaxKind.OmittedExpression) {
-                        getSymbolLinks(getSymbolOfNode(element)).type = getTypeForBindingElement(element);
+                        if (element.name.kind === SyntaxKind.Identifier) {
+                            getSymbolLinks(getSymbolOfNode(element)).type = getTypeForBindingElement(element);
+                        }
                         assignBindingElementTypes(element);
                     }
                 }

--- a/tests/baselines/reference/bindingPatternInParameter01.errors.txt
+++ b/tests/baselines/reference/bindingPatternInParameter01.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/bindingPatternInParameter01.ts(4,3): error TS2304: Cannot find name 'console'.
+
+
+==== tests/cases/compiler/bindingPatternInParameter01.ts (1 errors) ====
+    const nestedArray = [[[1, 2]], [[3, 4]]];
+    
+    nestedArray.forEach(([[a, b]]) => {
+      console.log(a, b);
+      ~~~~~~~
+!!! error TS2304: Cannot find name 'console'.
+    });
+    

--- a/tests/baselines/reference/bindingPatternInParameter01.js
+++ b/tests/baselines/reference/bindingPatternInParameter01.js
@@ -1,0 +1,14 @@
+//// [bindingPatternInParameter01.ts]
+const nestedArray = [[[1, 2]], [[3, 4]]];
+
+nestedArray.forEach(([[a, b]]) => {
+  console.log(a, b);
+});
+
+
+//// [bindingPatternInParameter01.js]
+var nestedArray = [[[1, 2]], [[3, 4]]];
+nestedArray.forEach(function (_a) {
+    var _b = _a[0], a = _b[0], b = _b[1];
+    console.log(a, b);
+});

--- a/tests/cases/compiler/bindingPatternInParameter01.ts
+++ b/tests/cases/compiler/bindingPatternInParameter01.ts
@@ -1,0 +1,5 @@
+const nestedArray = [[[1, 2]], [[3, 4]]];
+
+nestedArray.forEach(([[a, b]]) => {
+  console.log(a, b);
+});

--- a/tests/cases/fourslash/parameterWithNestedDestructuring.ts
+++ b/tests/cases/fourslash/parameterWithNestedDestructuring.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts'/>
+
+////[[{foo: 'hello', bar: [1]}]]
+////  .map(([{foo, bar: [baz]}]) => /*1*/foo + /*2*/baz);
+
+goTo.marker('1');
+verify.quickInfoIs('var foo: string');
+
+goTo.marker('2');
+verify.quickInfoIs('var baz: number');


### PR DESCRIPTION
This pull request fixes #5389 , by skipping assigning types for non-identifier binding patterns in `assignBindingElementTypes`.