### PR TITLE
use process.stdout.write on server instead of fs.write

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -163,12 +163,14 @@ namespace ts.server {
         }
         else {
             canWrite = false;
-            process.stdout.write(new Buffer(s, "utf8"), () => {
-                canWrite = true;
-                if (pending.length) {
-                    writeMessage(pending.shift());
-                }
-            })
+            process.stdout.write(new Buffer(s, "utf8"), setCanWriteFlagAndWriteMessageIfNecessary);
+        }
+    }
+
+    function setCanWriteFlagAndWriteMessageIfNecessary() {
+        canWrite = true;
+        if (pending.length) {
+            writeMessage(pending.shift());
         }
     }
 


### PR DESCRIPTION
fixes VSCode regression introduced in #5354.
pinging @zhengbli, can you check if this solution still solves #2758 and https://github.com/Microsoft/TypeScript-Sublime-Plugin/issues/379