### PR TITLE
Choose overload of unioned functions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9054,6 +9054,8 @@ namespace ts {
                         }
                         else {
                             if (originalCandidate.unionSignatures.some(sig => !hasCorrectArity(node, args, sig))) {
+                                // if at least one of the signatures fails to match arity, then give a generic
+                                // "no call signature" error instead of "string is not assignable to number"
                                 candidateForArgumentError = undefined;
                                 candidateForTypeArgumentError = undefined;
                             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9046,8 +9046,20 @@ namespace ts {
                 diagnostics.add(createDiagnosticForNodeFromMessageChain(node, errorInfo));
             }
 
-            function chooseOverload(candidates: Signature[], relation: Map<RelationComparisonResult>) {
+            function chooseOverload(candidates: Signature[], relation: Map<RelationComparisonResult>): Signature {
                 for (let originalCandidate of candidates) {
+                    if (originalCandidate.unionSignatures) {
+                        if (originalCandidate.unionSignatures.every(sig => !!chooseOverload([sig], relation))) {
+                            return originalCandidate;
+                        }
+                        else {
+                            if (originalCandidate.unionSignatures.some(sig => !hasCorrectArity(node, args, sig))) {
+                                candidateForArgumentError = undefined;
+                                candidateForTypeArgumentError = undefined;
+                            }
+                            continue;
+                        }
+                    }
                     if (!hasCorrectArity(node, args, originalCandidate)) {
                         continue;
                     }

--- a/tests/baselines/reference/unionTypeCallSignatures.errors.txt
+++ b/tests/baselines/reference/unionTypeCallSignatures.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(9,43): error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
-tests/cases/conformance/types/union/unionTypeCallSignatures.ts(10,29): error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'string'.
+tests/cases/conformance/types/union/unionTypeCallSignatures.ts(10,28): error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'number'.
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(15,29): error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'string'.
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(16,1): error TS2346: Supplied parameters do not match any signature of call target.
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(19,1): error TS2349: Cannot invoke an expression whose type lacks a call signature.
@@ -29,9 +29,11 @@ tests/cases/conformance/types/union/unionTypeCallSignatures.ts(68,12): error TS2
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(69,12): error TS2346: Supplied parameters do not match any signature of call target.
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(70,12): error TS2346: Supplied parameters do not match any signature of call target.
 tests/cases/conformance/types/union/unionTypeCallSignatures.ts(73,12): error TS2346: Supplied parameters do not match any signature of call target.
+tests/cases/conformance/types/union/unionTypeCallSignatures.ts(75,12): error TS2346: Supplied parameters do not match any signature of call target.
+tests/cases/conformance/types/union/unionTypeCallSignatures.ts(78,12): error TS2346: Supplied parameters do not match any signature of call target.
 
 
-==== tests/cases/conformance/types/union/unionTypeCallSignatures.ts (31 errors) ====
+==== tests/cases/conformance/types/union/unionTypeCallSignatures.ts (33 errors) ====
     var numOrDate: number | Date;
     var strOrBoolean: string | boolean;
     var strOrNum: string | number;
@@ -43,9 +45,9 @@ tests/cases/conformance/types/union/unionTypeCallSignatures.ts(73,12): error TS2
     strOrBoolean = unionOfDifferentReturnType("hello"); // error 
                                               ~~~~~~~
 !!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'number'.
-    unionOfDifferentReturnType1(true); // error in type of parameter
-                                ~~~~
-!!! error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'string'.
+    unionOfDifferentReturnType(true); // error in type of parameter
+                               ~~~~
+!!! error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'number'.
     
     var unionOfDifferentReturnType1: { (a: number): number; (a: string): string; } | { (a: number): Date; (a: string): boolean; };
     numOrDate = unionOfDifferentReturnType1(10);
@@ -168,4 +170,16 @@ tests/cases/conformance/types/union/unionTypeCallSignatures.ts(73,12): error TS2
                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2346: Supplied parameters do not match any signature of call target.
     strOrNum = unionWithRestParameter4("hello", "world");
+    strOrNum = unionWithRestParameter4("goodbye", "cruel", "world"); // error supplied parameters do not match any call signature
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2346: Supplied parameters do not match any signature of call target.
+    
+    var unionWithRestParameter5: { (b?: string, ...a: string[]): string; } | { (a?: string, b?: string): number; };
+    strOrNum = unionWithRestParameter5("goodbye", "cruel", "world"); // error supplied parameters do not match any call signature
+               ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2346: Supplied parameters do not match any signature of call target.
+    strOrNum = unionWithRestParameter5();
+    strOrNum = unionWithRestParameter5("hello");
+    strOrNum = unionWithRestParameter5("hello", "world");
+    
     

--- a/tests/baselines/reference/unionTypeCallSignatures.js
+++ b/tests/baselines/reference/unionTypeCallSignatures.js
@@ -8,7 +8,7 @@ var strOrNum: string | number;
 var unionOfDifferentReturnType: { (a: number): number; } | { (a: number): Date; };
 numOrDate = unionOfDifferentReturnType(10);
 strOrBoolean = unionOfDifferentReturnType("hello"); // error 
-unionOfDifferentReturnType1(true); // error in type of parameter
+unionOfDifferentReturnType(true); // error in type of parameter
 
 var unionOfDifferentReturnType1: { (a: number): number; (a: string): string; } | { (a: number): Date; (a: string): boolean; };
 numOrDate = unionOfDifferentReturnType1(10);
@@ -73,6 +73,14 @@ strOrNum = unionWithRestParameter3(); // error no call signature
 var unionWithRestParameter4: { (...a: string[]): string; } | { (a: string, b: string): number; };
 strOrNum = unionWithRestParameter4("hello"); // error supplied parameters do not match any call signature
 strOrNum = unionWithRestParameter4("hello", "world");
+strOrNum = unionWithRestParameter4("goodbye", "cruel", "world"); // error supplied parameters do not match any call signature
+
+var unionWithRestParameter5: { (b?: string, ...a: string[]): string; } | { (a?: string, b?: string): number; };
+strOrNum = unionWithRestParameter5("goodbye", "cruel", "world"); // error supplied parameters do not match any call signature
+strOrNum = unionWithRestParameter5();
+strOrNum = unionWithRestParameter5("hello");
+strOrNum = unionWithRestParameter5("hello", "world");
+
 
 
 //// [unionTypeCallSignatures.js]
@@ -84,7 +92,7 @@ var strOrNum;
 var unionOfDifferentReturnType;
 numOrDate = unionOfDifferentReturnType(10);
 strOrBoolean = unionOfDifferentReturnType("hello"); // error 
-unionOfDifferentReturnType1(true); // error in type of parameter
+unionOfDifferentReturnType(true); // error in type of parameter
 var unionOfDifferentReturnType1;
 numOrDate = unionOfDifferentReturnType1(10);
 strOrBoolean = unionOfDifferentReturnType1("hello");
@@ -138,3 +146,9 @@ strOrNum = unionWithRestParameter3(); // error no call signature
 var unionWithRestParameter4;
 strOrNum = unionWithRestParameter4("hello"); // error supplied parameters do not match any call signature
 strOrNum = unionWithRestParameter4("hello", "world");
+strOrNum = unionWithRestParameter4("goodbye", "cruel", "world"); // error supplied parameters do not match any call signature
+var unionWithRestParameter5;
+strOrNum = unionWithRestParameter5("goodbye", "cruel", "world"); // error supplied parameters do not match any call signature
+strOrNum = unionWithRestParameter5();
+strOrNum = unionWithRestParameter5("hello");
+strOrNum = unionWithRestParameter5("hello", "world");

--- a/tests/cases/conformance/types/union/unionTypeCallSignatures.ts
+++ b/tests/cases/conformance/types/union/unionTypeCallSignatures.ts
@@ -7,7 +7,7 @@ var strOrNum: string | number;
 var unionOfDifferentReturnType: { (a: number): number; } | { (a: number): Date; };
 numOrDate = unionOfDifferentReturnType(10);
 strOrBoolean = unionOfDifferentReturnType("hello"); // error 
-unionOfDifferentReturnType1(true); // error in type of parameter
+unionOfDifferentReturnType(true); // error in type of parameter
 
 var unionOfDifferentReturnType1: { (a: number): number; (a: string): string; } | { (a: number): Date; (a: string): boolean; };
 numOrDate = unionOfDifferentReturnType1(10);
@@ -72,3 +72,11 @@ strOrNum = unionWithRestParameter3(); // error no call signature
 var unionWithRestParameter4: { (...a: string[]): string; } | { (a: string, b: string): number; };
 strOrNum = unionWithRestParameter4("hello"); // error supplied parameters do not match any call signature
 strOrNum = unionWithRestParameter4("hello", "world");
+strOrNum = unionWithRestParameter4("goodbye", "cruel", "world"); // error supplied parameters do not match any call signature
+
+var unionWithRestParameter5: { (b?: string, ...a: string[]): string; } | { (a?: string, b?: string): number; };
+strOrNum = unionWithRestParameter5("goodbye", "cruel", "world"); // error supplied parameters do not match any call signature
+strOrNum = unionWithRestParameter5();
+strOrNum = unionWithRestParameter5("hello");
+strOrNum = unionWithRestParameter5("hello", "world");
+


### PR DESCRIPTION
Fixes #5401.

`chooseOverload` previously didn't check whether a signature was a union signature. It just used the first signature of the union. Calls to unions of functions are actually supposed to match only if all the arguments can be applied to all members of the union. See the linked bug for a good example.

The error case is tricky because `candidateForArgumentError` will be set if any of the members of the union matched arity but then failed to match types. So I have a redundant set of calls to `hasArity` to determine whether to reset it `candidateForArgumentError`. I haven't got a clean way to avoid this -- suggestions are welcome.