### PR TITLE
builtGeneratedDiagnosticMessagesJSON task probably shouldn't be async

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -352,7 +352,7 @@ file(diagnosticInfoMapTs, [processDiagnosticMessagesJs, diagnosticMessagesJson],
 
 file(builtGeneratedDiagnosticMessagesJSON, [generatedDiagnosticMessagesJSON], function() {
     jake.mkdirP(builtLocalDirectory);
-    jake.cpR(generatedDiagnosticMessagesJSON, builtGeneratedDiagnosticMessagesJSON):
+    jake.cpR(generatedDiagnosticMessagesJSON, builtGeneratedDiagnosticMessagesJSON);
 });
 
 desc("Generates a diagnostic file in TypeScript based on an input JSON file");

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -350,11 +350,10 @@ file(diagnosticInfoMapTs, [processDiagnosticMessagesJs, diagnosticMessagesJson],
     ex.run();
 }, {async: true});
 
-file(builtGeneratedDiagnosticMessagesJSON,[generatedDiagnosticMessagesJSON], function() {
-    if (fs.existsSync(builtLocalDirectory)) {
-        jake.cpR(generatedDiagnosticMessagesJSON, builtGeneratedDiagnosticMessagesJSON);
-    }
-}, {async: true});
+file(builtGeneratedDiagnosticMessagesJSON, [generatedDiagnosticMessagesJSON], function() {
+    jake.mkdirP(builtLocalDirectory);
+    jake.cpR(generatedDiagnosticMessagesJSON, builtGeneratedDiagnosticMessagesJSON):
+});
 
 desc("Generates a diagnostic file in TypeScript based on an input JSON file");
 task("generate-diagnostics", [diagnosticInfoMapTs]);


### PR DESCRIPTION
Additionally, use mkdirP to ensure directory existence, rather than only copying if present.