### PR TITLE
Fix type check for async function with alias return type.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5479,7 +5479,7 @@ namespace ts {
                 let targetType = getIndexTypeOfType(target, IndexKind.String);
                 if (targetType) {
                     if ((targetType.flags & TypeFlags.Any) && !(originalSource.flags & TypeFlags.Primitive)) {
-                        // non-primitive assignment to any is always allowed, eg 
+                        // non-primitive assignment to any is always allowed, eg
                         //   `var x: { [index: string]: any } = { property: 12 };`
                         return Ternary.True;
                     }
@@ -5509,7 +5509,7 @@ namespace ts {
                 let targetType = getIndexTypeOfType(target, IndexKind.Number);
                 if (targetType) {
                     if ((targetType.flags & TypeFlags.Any) && !(originalSource.flags & TypeFlags.Primitive)) {
-                        // non-primitive assignment to any is always allowed, eg 
+                        // non-primitive assignment to any is always allowed, eg
                         //   `var x: { [index: number]: any } = { property: 12 };`
                         return Ternary.True;
                     }
@@ -6586,9 +6586,9 @@ namespace ts {
                 return;
             }
 
-            // 1. walk from the use site up to the declaration and check 
+            // 1. walk from the use site up to the declaration and check
             // if there is anything function like between declaration and use-site (is binding/class is captured in function).
-            // 2. walk from the declaration up to the boundary of lexical environment and check 
+            // 2. walk from the declaration up to the boundary of lexical environment and check
             // if there is an iteration statement in between declaration and boundary (is binding/class declared inside iteration statement)
 
             let container: Node;
@@ -11631,14 +11631,14 @@ namespace ts {
             //
             // When we get the type of the `Promise` symbol here, we get the type of the static
             // side of the `Promise` class, which would be `{ new <T>(...): Promise<T> }`.
-            
+
             let promiseType = getTypeFromTypeNode(node.type);
             if (promiseType === unknownType && compilerOptions.isolatedModules) {
                 // If we are compiling with isolatedModules, we may not be able to resolve the
                 // type as a value. As such, we will just return unknownType;
                 return unknownType;
             }
-            
+
             let promiseConstructor = getNodeLinks(node.type).resolvedSymbol;
             if (!promiseConstructor || !symbolIsValue(promiseConstructor)) {
                 let typeName = promiseConstructor

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11631,17 +11631,20 @@ namespace ts {
             //
             // When we get the type of the `Promise` symbol here, we get the type of the static
             // side of the `Promise` class, which would be `{ new <T>(...): Promise<T> }`.
-
+            
             let promiseType = getTypeFromTypeNode(node.type);
             if (promiseType === unknownType && compilerOptions.isolatedModules) {
                 // If we are compiling with isolatedModules, we may not be able to resolve the
                 // type as a value. As such, we will just return unknownType;
                 return unknownType;
             }
-
-            let promiseConstructor = getMergedSymbol(promiseType.symbol);
+            
+            let promiseConstructor = getNodeLinks(node.type).resolvedSymbol;
             if (!promiseConstructor || !symbolIsValue(promiseConstructor)) {
-                error(node, Diagnostics.Type_0_is_not_a_valid_async_function_return_type, typeToString(promiseType));
+                let typeName = promiseConstructor
+                    ? symbolToString(promiseConstructor)
+                    : typeToString(promiseType);
+                error(node, Diagnostics.Type_0_is_not_a_valid_async_function_return_type, typeName);
                 return unknownType;
             }
 

--- a/tests/baselines/reference/asyncFunctionDeclaration15_es6.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration15_es6.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts(6,16): error TS1055: Type '{}' is not a valid async function return type.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts(7,16): error TS1055: Type 'any' is not a valid async function return type.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts(8,16): error TS1055: Type 'number' is not a valid async function return type.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts(9,16): error TS1055: Type 'PromiseLike<void>' is not a valid async function return type.
+tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts(9,16): error TS1055: Type 'PromiseLike' is not a valid async function return type.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts(10,16): error TS1055: Type 'typeof Thenable' is not a valid async function return type.
   Type 'Thenable' is not assignable to type 'PromiseLike<any>'.
     Types of property 'then' are incompatible.
@@ -28,7 +28,7 @@ tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration1
 !!! error TS1055: Type 'number' is not a valid async function return type.
     async function fn5(): PromiseLike<void> { } // error
                    ~~~
-!!! error TS1055: Type 'PromiseLike<void>' is not a valid async function return type.
+!!! error TS1055: Type 'PromiseLike' is not a valid async function return type.
     async function fn6(): Thenable { } // error
                    ~~~
 !!! error TS1055: Type 'typeof Thenable' is not a valid async function return type.


### PR DESCRIPTION
Switched to resolvedSymbol from NodeLinks instead of mergedSymbol from the type. When the return type is a type alias, we eagerly resolve the actual type. This resuls in a false positive for a type that exists as a value.

There is a minor change to the error reporting here, as I want to report the error using the name of the alias used in the return type, not the name of the resolved type of the alias. This is so you don't see an error like `"Type 'Promise' is not a valid async function return type"` when you use an alias for Promise.  This has the side effect of not including the type arguments in the error message, but I think that's acceptable.

Fixes #5333.