### PR TITLE
Support '/dev/stdout' as a valid '--out' parameter

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -336,7 +336,17 @@ namespace ts {
                     data = "\uFEFF" + data;
                 }
 
-                _fs.writeFileSync(fileName, data, "utf8");
+                let fd: number;
+
+                try {
+                    fd = _fs.openSync(fileName, "w");
+                    _fs.writeSync(fd, data, undefined, "utf8");
+                }
+                finally {
+                    if (fd !== undefined) {
+                        _fs.closeSync(fd);
+                    }
+                }
             }
 
             function getCanonicalPath(path: string): string {


### PR DESCRIPTION
Proposed fix for issue #4841.

I have updated `writeFile` function for Node system. Essentially, I've ended with the code that @mklement0 suggested in his [comment](https://github.com/Microsoft/TypeScript/issues/1226#issuecomment-141205171). The documentation [states](https://nodejs.org/api/process.html#process_process_stdout) that: 

> process.stderr and process.stdout are unlike other streams in Node.js in that they cannot be closed (end() will throw), they never emit the finish event and that writes are always **blocking** [added emphasis].

The new behavior can be tested this way:

```
node built/local/tsc.js --out /dev/stdout hello.ts
node built/local/tsc.js --out - hello.ts
```

Can you comment on a proper way of testing this feature?

Thanks!

____
<sup>I don't know how WScript system works and if the issue is present there too or not.</sup>