### PR TITLE
Add check for ./node_modules/typescript when tsc is run #5157

### DIFF
--- a/bin/tsc
+++ b/bin/tsc
@@ -1,2 +1,13 @@
 #!/usr/bin/env node
-require('../lib/tsc.js')
+var resolve = require('resolve').sync;
+var path = require('path');
+var basedir = process.cwd();
+var libdir = '../lib';
+var tsLocation;
+try {
+  tsLocation = resolve('typescript', {basedir: basedir});
+  libdir = path.dirname(tsLocation);
+} catch(e) {
+  // ignore, use global typescript
+}
+require(path.join(libdir, 'tsc.js'))

--- a/package.json
+++ b/package.json
@@ -28,6 +28,9 @@
     "engines": {
         "node": ">=0.8.0"
     },
+    "dependencies": {
+        "resolve": "^1.1.6"
+    },
     "devDependencies": {
         "jake": "latest",
         "mocha": "latest",
@@ -35,7 +38,6 @@
         "browserify": "latest",
         "istanbul": "latest",
         "mocha-fivemat-progress-reporter": "latest",
-        "resolve": "^1.1.6",
         "tslint": "latest",
         "tsd": "latest"
     },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "browserify": "latest",
         "istanbul": "latest",
         "mocha-fivemat-progress-reporter": "latest",
+        "resolve": "^1.1.6",
         "tslint": "latest",
         "tsd": "latest"
     },


### PR DESCRIPTION
@alexeagle Hello, I would like to work on this issue. I'm new to Typescript codebase and I'm not sure where to add a test for this. I changed the bin/tsc file directly so it doesn't load ../lib/tsc if is not needed. Would you rather have src/compiler/tsc.ts modified?

Let me know what do you think,
Thanks