### PR TITLE
Improve constructor object return error message

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12647,7 +12647,7 @@ namespace ts {
                         error(node.expression, Diagnostics.Setters_cannot_return_a_value);
                     }
                     else if (func.kind === SyntaxKind.Constructor) {
-                        if (!isTypeAssignableTo(exprType, returnType)) {
+                        if (!checkTypeAssignableTo(exprType, returnType, node.expression)) {
                             error(node.expression, Diagnostics.Return_type_of_constructor_signature_must_be_assignable_to_the_instance_type_of_the_class);
                         }
                     }

--- a/tests/baselines/reference/constructorReturnsInvalidType.errors.txt
+++ b/tests/baselines/reference/constructorReturnsInvalidType.errors.txt
@@ -1,10 +1,15 @@
+tests/cases/compiler/constructorReturnsInvalidType.ts(3,16): error TS2322: Type 'number' is not assignable to type 'X'.
+  Property 'foo' is missing in type 'Number'.
 tests/cases/compiler/constructorReturnsInvalidType.ts(3,16): error TS2409: Return type of constructor signature must be assignable to the instance type of the class
 
 
-==== tests/cases/compiler/constructorReturnsInvalidType.ts (1 errors) ====
+==== tests/cases/compiler/constructorReturnsInvalidType.ts (2 errors) ====
     class X {
         constructor() {
             return 1;
+                   ~
+!!! error TS2322: Type 'number' is not assignable to type 'X'.
+!!! error TS2322:   Property 'foo' is missing in type 'Number'.
                    ~
 !!! error TS2409: Return type of constructor signature must be assignable to the instance type of the class
         }

--- a/tests/baselines/reference/constructorWithAssignableReturnExpression.errors.txt
+++ b/tests/baselines/reference/constructorWithAssignableReturnExpression.errors.txt
@@ -1,8 +1,13 @@
+tests/cases/conformance/classes/constructorDeclarations/constructorWithAssignableReturnExpression.ts(12,16): error TS2322: Type 'number' is not assignable to type 'D'.
+  Property 'x' is missing in type 'Number'.
 tests/cases/conformance/classes/constructorDeclarations/constructorWithAssignableReturnExpression.ts(12,16): error TS2409: Return type of constructor signature must be assignable to the instance type of the class
+tests/cases/conformance/classes/constructorDeclarations/constructorWithAssignableReturnExpression.ts(26,16): error TS2322: Type '{ x: number; }' is not assignable to type 'F<T>'.
+  Types of property 'x' are incompatible.
+    Type 'number' is not assignable to type 'T'.
 tests/cases/conformance/classes/constructorDeclarations/constructorWithAssignableReturnExpression.ts(26,16): error TS2409: Return type of constructor signature must be assignable to the instance type of the class
 
 
-==== tests/cases/conformance/classes/constructorDeclarations/constructorWithAssignableReturnExpression.ts (2 errors) ====
+==== tests/cases/conformance/classes/constructorDeclarations/constructorWithAssignableReturnExpression.ts (4 errors) ====
     // a class constructor may return an expression, it must be assignable to the class instance type to be valid
     
     class C {
@@ -15,6 +20,9 @@ tests/cases/conformance/classes/constructorDeclarations/constructorWithAssignabl
         x: number;
         constructor() {
             return 1; // error
+                   ~
+!!! error TS2322: Type 'number' is not assignable to type 'D'.
+!!! error TS2322:   Property 'x' is missing in type 'Number'.
                    ~
 !!! error TS2409: Return type of constructor signature must be assignable to the instance type of the class
         }
@@ -31,6 +39,10 @@ tests/cases/conformance/classes/constructorDeclarations/constructorWithAssignabl
         x: T;
         constructor() {
             return { x: 1 }; // error
+                   ~~~~~~~~
+!!! error TS2322: Type '{ x: number; }' is not assignable to type 'F<T>'.
+!!! error TS2322:   Types of property 'x' are incompatible.
+!!! error TS2322:     Type 'number' is not assignable to type 'T'.
                    ~~~~~~~~
 !!! error TS2409: Return type of constructor signature must be assignable to the instance type of the class
         }

--- a/tests/baselines/reference/returnInConstructor1.errors.txt
+++ b/tests/baselines/reference/returnInConstructor1.errors.txt
@@ -1,10 +1,20 @@
+tests/cases/compiler/returnInConstructor1.ts(11,16): error TS2322: Type 'number' is not assignable to type 'B'.
+  Property 'foo' is missing in type 'Number'.
 tests/cases/compiler/returnInConstructor1.ts(11,16): error TS2409: Return type of constructor signature must be assignable to the instance type of the class
+tests/cases/compiler/returnInConstructor1.ts(25,16): error TS2322: Type 'string' is not assignable to type 'D'.
+  Property 'foo' is missing in type 'String'.
 tests/cases/compiler/returnInConstructor1.ts(25,16): error TS2409: Return type of constructor signature must be assignable to the instance type of the class
+tests/cases/compiler/returnInConstructor1.ts(39,16): error TS2322: Type '{ foo: number; }' is not assignable to type 'F'.
+  Types of property 'foo' are incompatible.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/returnInConstructor1.ts(39,16): error TS2409: Return type of constructor signature must be assignable to the instance type of the class
+tests/cases/compiler/returnInConstructor1.ts(55,16): error TS2322: Type 'G' is not assignable to type 'H'.
+  Types of property 'foo' are incompatible.
+    Type '() => void' is not assignable to type 'string'.
 tests/cases/compiler/returnInConstructor1.ts(55,16): error TS2409: Return type of constructor signature must be assignable to the instance type of the class
 
 
-==== tests/cases/compiler/returnInConstructor1.ts (4 errors) ====
+==== tests/cases/compiler/returnInConstructor1.ts (8 errors) ====
     class A {
         foo() { }
         constructor() {
@@ -16,6 +26,9 @@ tests/cases/compiler/returnInConstructor1.ts(55,16): error TS2409: Return type o
         foo() { }
         constructor() {
             return 1; // error
+                   ~
+!!! error TS2322: Type 'number' is not assignable to type 'B'.
+!!! error TS2322:   Property 'foo' is missing in type 'Number'.
                    ~
 !!! error TS2409: Return type of constructor signature must be assignable to the instance type of the class
         }
@@ -33,6 +46,9 @@ tests/cases/compiler/returnInConstructor1.ts(55,16): error TS2409: Return type o
         constructor() {
             return "test"; // error
                    ~~~~~~
+!!! error TS2322: Type 'string' is not assignable to type 'D'.
+!!! error TS2322:   Property 'foo' is missing in type 'String'.
+                   ~~~~~~
 !!! error TS2409: Return type of constructor signature must be assignable to the instance type of the class
         }
     }
@@ -48,6 +64,10 @@ tests/cases/compiler/returnInConstructor1.ts(55,16): error TS2409: Return type o
         public foo: string;
         constructor() {
             return { foo: 1 }; //error
+                   ~~~~~~~~~~
+!!! error TS2322: Type '{ foo: number; }' is not assignable to type 'F'.
+!!! error TS2322:   Types of property 'foo' are incompatible.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
                    ~~~~~~~~~~
 !!! error TS2409: Return type of constructor signature must be assignable to the instance type of the class
         }
@@ -66,6 +86,10 @@ tests/cases/compiler/returnInConstructor1.ts(55,16): error TS2409: Return type o
         constructor() {
             super();
             return new G(); //error
+                   ~~~~~~~
+!!! error TS2322: Type 'G' is not assignable to type 'H'.
+!!! error TS2322:   Types of property 'foo' are incompatible.
+!!! error TS2322:     Type '() => void' is not assignable to type 'string'.
                    ~~~~~~~
 !!! error TS2409: Return type of constructor signature must be assignable to the instance type of the class
         }

--- a/tests/baselines/reference/typeGuardFunctionErrors.errors.txt
+++ b/tests/baselines/reference/typeGuardFunctionErrors.errors.txt
@@ -25,6 +25,8 @@ tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(96,9):
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(97,16): error TS1228: A type predicate is only allowed in return type position for functions and methods.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(98,20): error TS1228: A type predicate is only allowed in return type position for functions and methods.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(104,25): error TS1228: A type predicate is only allowed in return type position for functions and methods.
+tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(105,16): error TS2322: Type 'boolean' is not assignable to type 'D'.
+  Property 'm1' is missing in type 'Boolean'.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(105,16): error TS2409: Return type of constructor signature must be assignable to the instance type of the class
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(107,20): error TS1228: A type predicate is only allowed in return type position for functions and methods.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(110,20): error TS1228: A type predicate is only allowed in return type position for functions and methods.
@@ -37,7 +39,7 @@ tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(133,34
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(137,39): error TS1230: A type predicate cannot reference element 'p1' in a binding pattern.
 
 
-==== tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts (31 errors) ====
+==== tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts (32 errors) ====
     
     class A {
         propA: number;
@@ -191,6 +193,9 @@ tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(137,39
                             ~~~~~~~
 !!! error TS1228: A type predicate is only allowed in return type position for functions and methods.
             return true;
+                   ~~~~
+!!! error TS2322: Type 'boolean' is not assignable to type 'D'.
+!!! error TS2322:   Property 'm1' is missing in type 'Boolean'.
                    ~~~~
 !!! error TS2409: Return type of constructor signature must be assignable to the instance type of the class
         }


### PR DESCRIPTION
Fixes #5372.

When an object literal, for example, is returned that does not match the type of the consturctor, add detail about a field that is required but missing.

Do this by passing `checkTypeAssignableTo` `node.expression` instead of `undefined` -- the rest of
the error reporting infrastructure is already in place.