### PR TITLE
This adds an option which lists the files emitted by the compiler

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -253,6 +253,10 @@ namespace ts {
             type: "boolean",
             description: Diagnostics.Disallow_inconsistently_cased_references_to_the_same_file
         },
+        {
+            name: "listEmittedFiles",
+            type: "boolean",
+        },
     ];
 
     /* @internal */

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -545,7 +545,7 @@ namespace ts {
             // immediately bail out.  Note that we pass 'undefined' for 'sourceFile' so that we
             // get any preEmit diagnostics, not just the ones
             if (options.noEmitOnError && getPreEmitDiagnostics(program, /*sourceFile:*/ undefined, cancellationToken).length > 0) {
-                return { diagnostics: [], sourceMaps: undefined, emitSkipped: true };
+                return { diagnostics: [], sourceMaps: undefined, emittedFiles: undefined, emitSkipped: true };
             }
 
             // Create the emit resolver outside of the "emitTime" tracking code below.  That way

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1427,6 +1427,7 @@ namespace ts {
     export interface EmitResult {
         emitSkipped: boolean;
         diagnostics: Diagnostic[];
+        emittedFiles: string[]; // Array of files the compiler wrote to disk
         /* @internal */ sourceMaps: SourceMapData[];  // Array of sourceMapData if compiler emitted sourcemaps
     }
 
@@ -2099,6 +2100,7 @@ namespace ts {
         emitDecoratorMetadata?: boolean;
         moduleResolution?: ModuleResolutionKind;
         forceConsistentCasingInFileNames?: boolean;
+        listEmittedFiles?: boolean;
         /* @internal */ stripInternal?: boolean;
 
         // Skip checking lib.d.ts to help speed up tests.


### PR DESCRIPTION
This adds an option which lists the files emitted by the compiler this is
usefull in various scenarios to make publishing the generated files easier.

This will reduce code duplicated in the MSBuild task used for publishing websites. e.g. to Azure.