### PR TITLE
do not report 'unreachable code' on empty statements

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1453,8 +1453,8 @@ namespace ts {
             switch (currentReachabilityState) {
                 case Reachability.Unreachable:
                     const reportError =
-                        // report error on all statements
-                        isStatement(node) ||
+                        // report error on all statements except empty ones
+                        (isStatement(node) && node.kind !== SyntaxKind.EmptyStatement) ||
                         // report error on class declarations
                         node.kind === SyntaxKind.ClassDeclaration ||
                         // report error on instantiated modules or const-enums only modules if preserveConstEnums is set

--- a/tests/baselines/reference/noReachabilityErrorsOnEmptyStatement.js
+++ b/tests/baselines/reference/noReachabilityErrorsOnEmptyStatement.js
@@ -1,0 +1,10 @@
+//// [noReachabilityErrorsOnEmptyStatement.ts]
+function foo() {
+    return 1;;
+}
+
+//// [noReachabilityErrorsOnEmptyStatement.js]
+function foo() {
+    return 1;
+    ;
+}

--- a/tests/baselines/reference/noReachabilityErrorsOnEmptyStatement.symbols
+++ b/tests/baselines/reference/noReachabilityErrorsOnEmptyStatement.symbols
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/noReachabilityErrorsOnEmptyStatement.ts ===
+function foo() {
+>foo : Symbol(foo, Decl(noReachabilityErrorsOnEmptyStatement.ts, 0, 0))
+
+    return 1;;
+}

--- a/tests/baselines/reference/noReachabilityErrorsOnEmptyStatement.types
+++ b/tests/baselines/reference/noReachabilityErrorsOnEmptyStatement.types
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/noReachabilityErrorsOnEmptyStatement.ts ===
+function foo() {
+>foo : () => number
+
+    return 1;;
+>1 : number
+}

--- a/tests/baselines/reference/privacyFunctionCannotNameReturnTypeDeclFile.errors.txt
+++ b/tests/baselines/reference/privacyFunctionCannotNameReturnTypeDeclFile.errors.txt
@@ -1,19 +1,7 @@
 tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(3,12): error TS4050: Return type of public static method from exported class has or is using name 'Widget1' from external module "tests/cases/compiler/privacyFunctionReturnTypeDeclFile_Widgets" but cannot be named.
-tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(7,49): error TS7027: Unreachable code detected.
 tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(9,5): error TS4053: Return type of public method from exported class has or is using name 'Widget1' from external module "tests/cases/compiler/privacyFunctionReturnTypeDeclFile_Widgets" but cannot be named.
-tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(10,49): error TS7027: Unreachable code detected.
-tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(13,49): error TS7027: Unreachable code detected.
 tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(15,12): error TS4050: Return type of public static method from exported class has or is using name 'Widget3' from external module "GlobalWidgets" but cannot be named.
-tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(19,49): error TS7027: Unreachable code detected.
 tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(21,5): error TS4053: Return type of public method from exported class has or is using name 'Widget3' from external module "GlobalWidgets" but cannot be named.
-tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(22,49): error TS7027: Unreachable code detected.
-tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(25,49): error TS7027: Unreachable code detected.
-tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(34,49): error TS7027: Unreachable code detected.
-tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(37,49): error TS7027: Unreachable code detected.
-tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(40,49): error TS7027: Unreachable code detected.
-tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(46,49): error TS7027: Unreachable code detected.
-tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(49,49): error TS7027: Unreachable code detected.
-tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(52,49): error TS7027: Unreachable code detected.
 tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(56,17): error TS4058: Return type of exported function has or is using name 'Widget1' from external module "tests/cases/compiler/privacyFunctionReturnTypeDeclFile_Widgets" but cannot be named.
 tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(62,17): error TS4058: Return type of exported function has or is using name 'Widget3' from external module "GlobalWidgets" but cannot be named.
 tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(70,12): error TS4050: Return type of public static method from exported class has or is using name 'SpecializedWidget.Widget2' from external module "tests/cases/compiler/privacyFunctionReturnTypeDeclFile_Widgets" but cannot be named.
@@ -24,7 +12,7 @@ tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(83,17): error
 tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(86,17): error TS4058: Return type of exported function has or is using name 'SpecializedGlobalWidget.Widget4' from external module "GlobalWidgets" but cannot be named.
 
 
-==== tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts (24 errors) ====
+==== tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts (12 errors) ====
     import exporter = require("./privacyFunctionReturnTypeDeclFile_exporter");
     export class publicClassWithWithPrivateParmeterTypes {
         static myPublicStaticMethod() { // Error
@@ -34,20 +22,14 @@ tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(86,17): error
         }
         private static myPrivateStaticMethod() {
             return exporter.createExportedWidget1();;
-                                                    ~
-!!! error TS7027: Unreachable code detected.
         }
         myPublicMethod() { // Error
         ~~~~~~~~~~~~~~
 !!! error TS4053: Return type of public method from exported class has or is using name 'Widget1' from external module "tests/cases/compiler/privacyFunctionReturnTypeDeclFile_Widgets" but cannot be named.
             return exporter.createExportedWidget1();;
-                                                    ~
-!!! error TS7027: Unreachable code detected.
         }
         private myPrivateMethod() {
             return exporter.createExportedWidget1();;
-                                                    ~
-!!! error TS7027: Unreachable code detected.
         }
         static myPublicStaticMethod1() { // Error
                ~~~~~~~~~~~~~~~~~~~~~
@@ -56,20 +38,14 @@ tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(86,17): error
         }
         private static myPrivateStaticMethod1() {
             return exporter.createExportedWidget3();;
-                                                    ~
-!!! error TS7027: Unreachable code detected.
         }
         myPublicMethod1() { // Error
         ~~~~~~~~~~~~~~~
 !!! error TS4053: Return type of public method from exported class has or is using name 'Widget3' from external module "GlobalWidgets" but cannot be named.
             return exporter.createExportedWidget3();;
-                                                    ~
-!!! error TS7027: Unreachable code detected.
         }
         private myPrivateMethod1() {
             return exporter.createExportedWidget3();;
-                                                    ~
-!!! error TS7027: Unreachable code detected.
         }
     }
     
@@ -79,36 +55,24 @@ tests/cases/compiler/privacyFunctionReturnTypeDeclFile_consumer.ts(86,17): error
         }
         private static myPrivateStaticMethod() {
             return exporter.createExportedWidget1();;
-                                                    ~
-!!! error TS7027: Unreachable code detected.
         }
         myPublicMethod() { 
             return exporter.createExportedWidget1();;
-                                                    ~
-!!! error TS7027: Unreachable code detected.
         }
         private myPrivateMethod() {
             return exporter.createExportedWidget1();;
-                                                    ~
-!!! error TS7027: Unreachable code detected.
         }
         static myPublicStaticMethod1() { 
             return exporter.createExportedWidget3();
         }
         private static myPrivateStaticMethod1() {
             return exporter.createExportedWidget3();;
-                                                    ~
-!!! error TS7027: Unreachable code detected.
         }
         myPublicMethod1() { 
             return exporter.createExportedWidget3();;
-                                                    ~
-!!! error TS7027: Unreachable code detected.
         }
         private myPrivateMethod1() {
             return exporter.createExportedWidget3();;
-                                                    ~
-!!! error TS7027: Unreachable code detected.
         }
     }
     

--- a/tests/cases/compiler/noReachabilityErrorsOnEmptyStatement.ts
+++ b/tests/cases/compiler/noReachabilityErrorsOnEmptyStatement.ts
@@ -1,0 +1,3 @@
+function foo() {
+    return 1;;
+}


### PR DESCRIPTION
technically this error is correct however I think it will be very annoying since people don't tend to think about empty statements as of executable code.