### PR TITLE
Update default configurations for --init

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -199,10 +199,8 @@ namespace ts {
     /* @internal */
     export const defaultInitCompilerOptions: CompilerOptions = {
         module: ModuleKind.CommonJS,
-        target: ScriptTarget.ES3,
+        target: ScriptTarget.ES5,
         noImplicitAny: false,
-        outDir: "built",
-        rootDir: ".",
         sourceMap: false,
     };
 


### PR DESCRIPTION
Make the default to ES5, ES3 is needlessly restrictive now
Remove --outDir (and subseqentlly --rootDir). These can be set on the command line, and will be included in the generated tsconfig.json, but if added by default, they can not be removed, which is annoying if you just want an output folder.