### PR TITLE
Have travis build against node 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 
 node_js:
+  - 'stable'
   - '4'
   - '0.10'
 


### PR DESCRIPTION
Since it is the latest stable release, but 4 is the latest LTS release, we should have CI against both.