### PR TITLE
Fix issue #5444

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11205,7 +11205,7 @@ namespace ts {
                         seen = c === node;
                     }
                 });
-                if (subsequentNode) {
+                if (subsequentNode && subsequentNode.pos === node.end) {
                     if (subsequentNode.kind === node.kind) {
                         const errorNode: Node = (<FunctionLikeDeclaration>subsequentNode).name || subsequentNode;
                         // TODO(jfreeman): These are methods, so handle computed name case

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11205,6 +11205,8 @@ namespace ts {
                         seen = c === node;
                     }
                 });
+                // We may be here because of some extra junk between overloads that could not be parsed into a valid node.
+                // In this case the subsequent node is not really consecutive (.pos !== node.end), and we must ignore it here.
                 if (subsequentNode && subsequentNode.pos === node.end) {
                     if (subsequentNode.kind === node.kind) {
                         const errorNode: Node = (<FunctionLikeDeclaration>subsequentNode).name || subsequentNode;

--- a/tests/baselines/reference/overloadConsecutiveness.errors.txt
+++ b/tests/baselines/reference/overloadConsecutiveness.errors.txt
@@ -1,0 +1,63 @@
+tests/cases/compiler/overloadConsecutiveness.ts(3,10): error TS2391: Function implementation is missing or not immediately following the declaration.
+tests/cases/compiler/overloadConsecutiveness.ts(3,14): error TS1144: '{' or ';' expected.
+tests/cases/compiler/overloadConsecutiveness.ts(3,25): error TS2391: Function implementation is missing or not immediately following the declaration.
+tests/cases/compiler/overloadConsecutiveness.ts(4,10): error TS2391: Function implementation is missing or not immediately following the declaration.
+tests/cases/compiler/overloadConsecutiveness.ts(4,14): error TS1144: '{' or ';' expected.
+tests/cases/compiler/overloadConsecutiveness.ts(5,10): error TS2391: Function implementation is missing or not immediately following the declaration.
+tests/cases/compiler/overloadConsecutiveness.ts(5,17): error TS1128: Declaration or statement expected.
+tests/cases/compiler/overloadConsecutiveness.ts(5,28): error TS2391: Function implementation is missing or not immediately following the declaration.
+tests/cases/compiler/overloadConsecutiveness.ts(8,2): error TS2391: Function implementation is missing or not immediately following the declaration.
+tests/cases/compiler/overloadConsecutiveness.ts(8,6): error TS1144: '{' or ';' expected.
+tests/cases/compiler/overloadConsecutiveness.ts(8,8): error TS2391: Function implementation is missing or not immediately following the declaration.
+tests/cases/compiler/overloadConsecutiveness.ts(9,2): error TS2391: Function implementation is missing or not immediately following the declaration.
+tests/cases/compiler/overloadConsecutiveness.ts(9,6): error TS1144: '{' or ';' expected.
+tests/cases/compiler/overloadConsecutiveness.ts(10,2): error TS2391: Function implementation is missing or not immediately following the declaration.
+tests/cases/compiler/overloadConsecutiveness.ts(10,9): error TS1068: Unexpected token. A constructor, method, accessor, or property was expected.
+tests/cases/compiler/overloadConsecutiveness.ts(10,11): error TS2391: Function implementation is missing or not immediately following the declaration.
+
+
+==== tests/cases/compiler/overloadConsecutiveness.ts (16 errors) ====
+    // Making sure compiler won't break with declarations that are consecutive in the AST but not consecutive in the source. Syntax errors intentional.
+    
+    function f1(), function f1();
+             ~~
+!!! error TS2391: Function implementation is missing or not immediately following the declaration.
+                 ~
+!!! error TS1144: '{' or ';' expected.
+                            ~~
+!!! error TS2391: Function implementation is missing or not immediately following the declaration.
+    function f2(), function f2() {}
+             ~~
+!!! error TS2391: Function implementation is missing or not immediately following the declaration.
+                 ~
+!!! error TS1144: '{' or ';' expected.
+    function f3() {}, function f3();
+             ~~
+!!! error TS2391: Function implementation is missing or not immediately following the declaration.
+                    ~
+!!! error TS1128: Declaration or statement expected.
+                               ~~
+!!! error TS2391: Function implementation is missing or not immediately following the declaration.
+    
+    class C {
+    	m1(), m1();
+    	~~
+!!! error TS2391: Function implementation is missing or not immediately following the declaration.
+    	    ~
+!!! error TS1144: '{' or ';' expected.
+    	      ~~
+!!! error TS2391: Function implementation is missing or not immediately following the declaration.
+    	m2(), m2() {}
+    	~~
+!!! error TS2391: Function implementation is missing or not immediately following the declaration.
+    	    ~
+!!! error TS1144: '{' or ';' expected.
+    	m3() {}, m3();
+    	~~
+!!! error TS2391: Function implementation is missing or not immediately following the declaration.
+    	       ~
+!!! error TS1068: Unexpected token. A constructor, method, accessor, or property was expected.
+    	         ~~
+!!! error TS2391: Function implementation is missing or not immediately following the declaration.
+    }
+    

--- a/tests/baselines/reference/overloadConsecutiveness.js
+++ b/tests/baselines/reference/overloadConsecutiveness.js
@@ -1,0 +1,27 @@
+//// [overloadConsecutiveness.ts]
+// Making sure compiler won't break with declarations that are consecutive in the AST but not consecutive in the source. Syntax errors intentional.
+
+function f1(), function f1();
+function f2(), function f2() {}
+function f3() {}, function f3();
+
+class C {
+	m1(), m1();
+	m2(), m2() {}
+	m3() {}, m3();
+}
+
+
+//// [overloadConsecutiveness.js]
+// Making sure compiler won't break with declarations that are consecutive in the AST but not consecutive in the source. Syntax errors intentional.
+function f2() { }
+function f3() { }
+var C = (function () {
+    function C() {
+    }
+    C.prototype.m1 = ;
+    C.prototype.m2 = ;
+    C.prototype.m2 = function () { };
+    C.prototype.m3 = function () { };
+    return C;
+})();

--- a/tests/cases/compiler/overloadConsecutiveness.ts
+++ b/tests/cases/compiler/overloadConsecutiveness.ts
@@ -1,0 +1,11 @@
+// Making sure compiler won't break with declarations that are consecutive in the AST but not consecutive in the source. Syntax errors intentional.
+
+function f1(), function f1();
+function f2(), function f2() {}
+function f3() {}, function f3();
+
+class C {
+	m1(), m1();
+	m2(), m2() {}
+	m3() {}, m3();
+}


### PR DESCRIPTION
reportImplementationExpectedError: The next node in the tree is not
necessarily consecutive. This happens due to syntax errors, e.g.

    class C { foo(), foo(); }

_____________
*Edit by @DanielRosenwasser: Fixes #5444*