### PR TITLE
Use ts.indexOf instead of Array.prototype.indexOf

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3731,7 +3731,7 @@ namespace ts {
             if (node.initializer) {
                 const signatureDeclaration = <SignatureDeclaration>node.parent;
                 const signature = getSignatureFromDeclaration(signatureDeclaration);
-                const parameterIndex = signatureDeclaration.parameters.indexOf(node);
+                const parameterIndex = ts.indexOf(signatureDeclaration.parameters, node);
                 Debug.assert(parameterIndex >= 0);
                 return parameterIndex >= signature.minArgumentCount;
             }

--- a/src/services/formatting/tokenRange.ts
+++ b/src/services/formatting/tokenRange.ts
@@ -14,7 +14,7 @@ namespace ts.formatting {
             constructor(from: SyntaxKind, to: SyntaxKind, except: SyntaxKind[]) {
                 this.tokens = [];
                 for (let token = from; token <= to; token++) {
-                    if (except.indexOf(token) < 0) {
+                    if (ts.indexOf(except, token) < 0) {
                         this.tokens.push(token);
                     }
                 }


### PR DESCRIPTION
`ts.indexOf` is employed instead of `Array.prototype.indexOf` consistently across tsc/services codebase for the sake of ES3-compatibility.

Once in a while somebody checks in code breaking that edge case, and in time I (or somebody else) pick on that and offer a patch.

This is one of those cases.

Please don't break ES3-compatibility *intentionally.* For occasional unintentional breaks I'll try to keep up.
Many thanks!