### PR TITLE
Reexport default export

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -677,12 +677,6 @@ namespace ts {
             return result;
         }
 
-        function doesNameResolveToLocalSymbolForExportDefault(exports: SymbolTable, meaning: SymbolFlags, name: string): boolean {
-            const defaultExport = exports["default"];
-            const localSymbol = getLocalSymbolForExportDefault(defaultExport);
-            return defaultExport && (defaultExport.flags & meaning) && localSymbol && localSymbol.name === name;
-        }
-
         function checkResolvedBlockScopedVariable(result: Symbol, errorLocation: Node): void {
             Debug.assert((result.flags & SymbolFlags.BlockScopedVariable) !== 0);
             // Block-scoped variables cannot be used before their definition

--- a/tests/baselines/reference/reExportDefaultExport.js
+++ b/tests/baselines/reference/reExportDefaultExport.js
@@ -1,0 +1,27 @@
+//// [tests/cases/conformance/es6/modules/reExportDefaultExport.ts] ////
+
+//// [m1.ts]
+
+export default function f() {
+}
+export {f};
+
+
+//// [m2.ts]
+import foo from "./m1";
+import {f} from "./m1";
+
+f();
+foo();
+
+//// [m1.js]
+function f() {
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = f;
+exports.f = f;
+//// [m2.js]
+var m1_1 = require("./m1");
+var m1_2 = require("./m1");
+m1_2.f();
+m1_1.default();

--- a/tests/baselines/reference/reExportDefaultExport.symbols
+++ b/tests/baselines/reference/reExportDefaultExport.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/conformance/es6/modules/m1.ts ===
+
+export default function f() {
+>f : Symbol(f, Decl(m1.ts, 0, 0))
+}
+export {f};
+>f : Symbol(f, Decl(m1.ts, 3, 8))
+
+
+=== tests/cases/conformance/es6/modules/m2.ts ===
+import foo from "./m1";
+>foo : Symbol(foo, Decl(m2.ts, 0, 6))
+
+import {f} from "./m1";
+>f : Symbol(f, Decl(m2.ts, 1, 8))
+
+f();
+>f : Symbol(f, Decl(m2.ts, 1, 8))
+
+foo();
+>foo : Symbol(foo, Decl(m2.ts, 0, 6))
+

--- a/tests/baselines/reference/reExportDefaultExport.types
+++ b/tests/baselines/reference/reExportDefaultExport.types
@@ -1,0 +1,24 @@
+=== tests/cases/conformance/es6/modules/m1.ts ===
+
+export default function f() {
+>f : () => void
+}
+export {f};
+>f : () => void
+
+
+=== tests/cases/conformance/es6/modules/m2.ts ===
+import foo from "./m1";
+>foo : () => void
+
+import {f} from "./m1";
+>f : () => void
+
+f();
+>f() : void
+>f : () => void
+
+foo();
+>foo() : void
+>foo : () => void
+

--- a/tests/cases/conformance/es6/modules/reExportDefaultExport.ts
+++ b/tests/cases/conformance/es6/modules/reExportDefaultExport.ts
@@ -1,0 +1,15 @@
+// @module: commonjs
+// @target: ES5
+
+// @filename: m1.ts
+export default function f() {
+}
+export {f};
+
+
+// @filename: m2.ts
+import foo from "./m1";
+import {f} from "./m1";
+
+f();
+foo();


### PR DESCRIPTION
Fixes #5447. 

A previous fix to `resolveName` assumed that export aliases should not be available locally, but this is not true for default exports, which also introduce a local name according to section 15.2.1.16 of ES2015 (June 2015 edition).