### PR TITLE
Add handling for json parse errors in tsconfig

### DIFF
--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -349,6 +349,11 @@ namespace ts {
 
             const result = parseConfigFileTextToJson(configFileName, cachedConfigFileText);
             const configObject = result.config;
+            if (!configObject) {
+                reportDiagnostics([result.error], /* compilerHost */ undefined);
+                sys.exit(ExitStatus.DiagnosticsPresent_OutputsSkipped);
+                return;
+            }
             const configParseResult = parseJsonConfigFileContent(configObject, sys, getDirectoryPath(configFileName));
             if (configParseResult.errors.length > 0) {
                 reportDiagnostics(configParseResult.errors, /* compilerHost */ undefined);

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -346,6 +346,12 @@ namespace ts {
                     return;
                 }
             }
+            if (!cachedConfigFileText) {
+                const error = createCompilerDiagnostic(Diagnostics.File_0_not_found, configFileName);
+                reportDiagnostics([error], /* compilerHost */ undefined);
+                sys.exit(ExitStatus.DiagnosticsPresent_OutputsSkipped);
+                return;
+            }
 
             const result = parseConfigFileTextToJson(configFileName, cachedConfigFileText);
             const configObject = result.config;


### PR DESCRIPTION
Previously we would error within `parseJsonConfigFileContent` on an attempt to index an `undefined` value whenever we returned an error from `parseConfigFileTextToJson` (Which occurs anytime a `tsconfig.json` file has malformed JSON).

Also fixes #4590