### PR TITLE
Do not get the apparent type for 'getContextualType' in the services layer

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -81,7 +81,7 @@ namespace ts {
             symbolToString,
             getAugmentedPropertiesOfType,
             getRootSymbols,
-            getContextualType: getApparentTypeOfContextualType,
+            getContextualType,
             getFullyQualifiedName,
             getResolvedSignature,
             getConstantValue,

--- a/tests/cases/fourslash/findAllRefsPropertyContextuallyTypedByTypeParam01.ts
+++ b/tests/cases/fourslash/findAllRefsPropertyContextuallyTypedByTypeParam01.ts
@@ -1,0 +1,28 @@
+/// <reference path="./fourslash.ts" />
+
+////interface IFoo {
+////    [|a|]: string;
+////}
+////class C<T extends IFoo> {
+////    method() {
+////        var x: T = {
+////            [|a|]: ""
+////        };
+////        x.[|a|];
+////    }
+////}
+////
+////
+////var x: IFoo = {
+////    [|a|]: "ss"
+////};
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.position(range.start);
+
+    verify.referencesCountIs(ranges.length);
+    for (let expectedReference of ranges) {
+        verify.referencesAtPositionContains(expectedReference);
+    }
+}


### PR DESCRIPTION
See relevant discussion starting from https://github.com/Microsoft/TypeScript/issues/5602#issuecomment-155861839

This doesn't seem to affect any of our tests in the services layer, so I don't think this is a major break.