### PR TITLE
Quote only names that need to be quoted, not the reverse

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1592,7 +1592,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 /// these emit into an object literal property name, we don't need to be worried
                 /// about keywords, just non-identifier characters
                 function emitAttributeName(name: Identifier) {
-                    if (/^[A-Za-z_]+[\w]*$/.test(name.text)) {
+                    if (/^[A-Za-z_]\w*$/.test(name.text)) {
                         emit(name);
                     }
                     else {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1592,13 +1592,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 /// these emit into an object literal property name, we don't need to be worried
                 /// about keywords, just non-identifier characters
                 function emitAttributeName(name: Identifier) {
-                    if (/[A-Za-z_]+[\w*]/.test(name.text)) {
-                        write("\"");
+                    if (/^[A-Za-z_]+[\w]*$/.test(name.text)) {
                         emit(name);
-                        write("\"");
                     }
                     else {
+                        write("\"");
                         emit(name);
+                        write("\"");
                     }
                 }
 

--- a/tests/baselines/reference/getEmitOutputTsxFile_React.baseline
+++ b/tests/baselines/reference/getEmitOutputTsxFile_React.baseline
@@ -17,9 +17,9 @@ declare class Bar {
 
 EmitSkipped: false
 FileName : tests/cases/fourslash/inputFile2.js.map
-{"version":3,"file":"inputFile2.js","sourceRoot":"","sources":["inputFile2.tsx"],"names":[],"mappings":"AAAA,IAAI,CAAC,GAAG,QAAQ,CAAC;AACjB,IAAI,CAAC,GAAG,qBAAC,GAAG,KAAC,IAAI,GAAG,CAAE,EAAG,CAAA"}FileName : tests/cases/fourslash/inputFile2.js
+{"version":3,"file":"inputFile2.js","sourceRoot":"","sources":["inputFile2.tsx"],"names":[],"mappings":"AAAA,IAAI,CAAC,GAAG,QAAQ,CAAC;AACjB,IAAI,CAAC,GAAG,qBAAC,GAAG,IAAC,IAAI,EAAG,CAAE,EAAG,CAAA"}FileName : tests/cases/fourslash/inputFile2.js
 var y = "my div";
-var x = React.createElement("div", {"name": y});
+var x = React.createElement("div", {name: y});
 //# sourceMappingURL=inputFile2.js.mapFileName : tests/cases/fourslash/inputFile2.d.ts
 declare var y: string;
 declare var x: any;

--- a/tests/baselines/reference/keywordInJsxIdentifier.js
+++ b/tests/baselines/reference/keywordInJsxIdentifier.js
@@ -9,6 +9,6 @@ declare var React: any;
 
 //// [keywordInJsxIdentifier.js]
 React.createElement("foo", {"class-id": true});
-React.createElement("foo", {"class": true});
+React.createElement("foo", {class: true});
 React.createElement("foo", {"class-id": "1"});
-React.createElement("foo", {"class": "1"});
+React.createElement("foo", {class: "1"});

--- a/tests/baselines/reference/tsxExternalModuleEmit2.js
+++ b/tests/baselines/reference/tsxExternalModuleEmit2.js
@@ -20,6 +20,6 @@ declare var Foo, React;
 //// [app.js]
 var mod_1 = require('mod');
 // Should see mod_1['default'] in emit here
-React.createElement(Foo, {"handler": mod_1["default"]});
+React.createElement(Foo, {handler: mod_1["default"]});
 // Should see mod_1['default'] in emit here
 React.createElement(Foo, React.__spread({}, mod_1["default"]));

--- a/tests/baselines/reference/tsxReactEmit7.errors.txt
+++ b/tests/baselines/reference/tsxReactEmit7.errors.txt
@@ -1,0 +1,50 @@
+tests/cases/conformance/jsx/tsxReactEmit7.tsx(9,10): error TS2304: Cannot find name 'React'.
+tests/cases/conformance/jsx/tsxReactEmit7.tsx(10,10): error TS2304: Cannot find name 'React'.
+tests/cases/conformance/jsx/tsxReactEmit7.tsx(11,10): error TS2304: Cannot find name 'React'.
+tests/cases/conformance/jsx/tsxReactEmit7.tsx(12,10): error TS2304: Cannot find name 'React'.
+tests/cases/conformance/jsx/tsxReactEmit7.tsx(15,10): error TS2304: Cannot find name 'React'.
+tests/cases/conformance/jsx/tsxReactEmit7.tsx(16,10): error TS2304: Cannot find name 'React'.
+tests/cases/conformance/jsx/tsxReactEmit7.tsx(17,10): error TS2304: Cannot find name 'React'.
+tests/cases/conformance/jsx/tsxReactEmit7.tsx(18,10): error TS2304: Cannot find name 'React'.
+tests/cases/conformance/jsx/tsxReactEmit7.tsx(19,10): error TS2304: Cannot find name 'React'.
+
+
+==== tests/cases/conformance/jsx/tsxReactEmit7.tsx (9 errors) ====
+    
+    declare module JSX {
+    	interface Element { }
+    	interface IntrinsicElements {
+    		[s: string]: any;
+    	}
+    }
+    
+    var m = <div x-y="val"></div>;
+             ~~~
+!!! error TS2304: Cannot find name 'React'.
+    var n = <div xx-y="val"></div>;
+             ~~~
+!!! error TS2304: Cannot find name 'React'.
+    var o = <div x-yy="val"></div>;
+             ~~~
+!!! error TS2304: Cannot find name 'React'.
+    var p = <div xx-yy="val"></div>;
+             ~~~
+!!! error TS2304: Cannot find name 'React'.
+    
+    // Investigation
+    var a = <div x="val"></div>;
+             ~~~
+!!! error TS2304: Cannot find name 'React'.
+    var b = <div xx="val"></div>;
+             ~~~
+!!! error TS2304: Cannot find name 'React'.
+    var c = <div xxx="val"></div>;
+             ~~~
+!!! error TS2304: Cannot find name 'React'.
+    var d = <div xxxx="val"></div>;
+             ~~~
+!!! error TS2304: Cannot find name 'React'.
+    var e = <div xxxxx="val"></div>;
+             ~~~
+!!! error TS2304: Cannot find name 'React'.
+    

--- a/tests/baselines/reference/tsxReactEmit7.js
+++ b/tests/baselines/reference/tsxReactEmit7.js
@@ -1,0 +1,33 @@
+//// [tsxReactEmit7.tsx]
+
+declare module JSX {
+	interface Element { }
+	interface IntrinsicElements {
+		[s: string]: any;
+	}
+}
+
+var m = <div x-y="val"></div>;
+var n = <div xx-y="val"></div>;
+var o = <div x-yy="val"></div>;
+var p = <div xx-yy="val"></div>;
+
+// Investigation
+var a = <div x="val"></div>;
+var b = <div xx="val"></div>;
+var c = <div xxx="val"></div>;
+var d = <div xxxx="val"></div>;
+var e = <div xxxxx="val"></div>;
+
+
+//// [tsxReactEmit7.js]
+var m = React.createElement("div", {"x-y": "val"});
+var n = React.createElement("div", {"xx-y": "val"});
+var o = React.createElement("div", {"x-yy": "val"});
+var p = React.createElement("div", {"xx-yy": "val"});
+// Investigation
+var a = React.createElement("div", {x: "val"});
+var b = React.createElement("div", {xx: "val"});
+var c = React.createElement("div", {xxx: "val"});
+var d = React.createElement("div", {xxxx: "val"});
+var e = React.createElement("div", {xxxxx: "val"});

--- a/tests/cases/conformance/jsx/tsxReactEmit7.tsx
+++ b/tests/cases/conformance/jsx/tsxReactEmit7.tsx
@@ -1,0 +1,22 @@
+//@jsx: react
+//@module: commonjs
+
+//@filename: file.tsx
+declare module JSX {
+	interface Element { }
+	interface IntrinsicElements {
+		[s: string]: any;
+	}
+}
+
+var m = <div x-y="val"></div>;
+var n = <div xx-y="val"></div>;
+var o = <div x-yy="val"></div>;
+var p = <div xx-yy="val"></div>;
+
+// Investigation
+var a = <div x="val"></div>;
+var b = <div xx="val"></div>;
+var c = <div xxx="val"></div>;
+var d = <div xxxx="val"></div>;
+var e = <div xxxxx="val"></div>;


### PR DESCRIPTION
Fixes #5634 

The code for detecting when to quote the property names in object literals when emitting React was spectacularly wrong. On account of being doubly wrong, this turned out to be mostly right, but it was still really bad:
 * The logic was backwards -- it quoted things that *didn't* need quoting
 * It didn't check the *entire* string, so it thought `x-y` didn't need quoting because it matched the substring `x`. 
 * The `*` character was inside the `[]`, which meant we were looking for a literal `*` instead of "0 or more" of the thing inside the `[]`