### PR TITLE
Handle default class exports when targeting es6 with non-es6 module kinds

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -5581,7 +5581,26 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 }
                 // If this is an exported class, but not on the top level (i.e. on an internal
                 // module), export it
-                if (node.parent.kind !== SyntaxKind.SourceFile) {
+                if (node.parent.kind === SyntaxKind.SourceFile && (node.flags & NodeFlags.Default)) {
+                    // if this is a top level default export of decorated class, write the export after the declaration.
+                    writeLine();
+                    if (thisNodeIsDecorated && modulekind === ModuleKind.ES6) {
+                        write("export default ");
+                        emitDeclarationName(node);
+                        write(";");
+                    }
+                    else if (modulekind === ModuleKind.System) {
+                        write(`${exportFunctionForFile}("default", `);
+                        emitDeclarationName(node);
+                        write(");");
+                    }
+                    else if (modulekind !== ModuleKind.ES6) {
+                        write(`exports.default = `);
+                        emitDeclarationName(node);
+                        write(";");
+                    }
+                }
+                else if (node.parent.kind !== SyntaxKind.SourceFile || (modulekind !== ModuleKind.ES6 && !(node.flags & NodeFlags.Default))) {
                     writeLine();
                     emitStart(node);
                     emitModuleMemberName(node);
@@ -5589,32 +5608,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     emitDeclarationName(node);
                     emitEnd(node);
                     write(";");
-                }
-                else if (node.parent.kind === SyntaxKind.SourceFile && (node.flags & NodeFlags.Default) && thisNodeIsDecorated) {
-                    // if this is a top level default export of decorated class, write the export after the declaration.
-                    if (modulekind === ModuleKind.ES6) {
-                        writeLine();
-                        write("export default ");
-                        emitDeclarationName(node);
-                        write(";");
-                    }
-                    else if (modulekind === ModuleKind.System) {
-                        writeLine();
-                        write(`${exportFunctionForFile}("default", `);
-                        emitDeclarationName(node);
-                        write(");");
-                    }
-                    else {
-                        writeLine();
-                        if (languageVersion === ScriptTarget.ES3) {
-                            write(`exports["default"] = `);
-                        }
-                        else {
-                            write(`exports.default = `);
-                        }
-                        emitDeclarationName(node);
-                        write(";");
-                    }
                 }
             }
 

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -5583,7 +5583,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 }
                 // If this is an exported class, but not on the top level (i.e. on an internal
                 // module), export it
-                if (node.parent.kind === SyntaxKind.SourceFile && (node.flags & NodeFlags.Default)) {
+                if (node.flags & NodeFlags.Default) {
                     // if this is a top level default export of decorated class, write the export after the declaration.
                     writeLine();
                     if (thisNodeIsDecorated && modulekind === ModuleKind.ES6) {

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedAmd.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedAmd.js
@@ -1,0 +1,24 @@
+//// [decoratedDefaultExportsGetExportedAmd.ts]
+
+var decorator: ClassDecorator;
+
+@decorator
+export default class Foo {}
+
+
+//// [decoratedDefaultExportsGetExportedAmd.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+define(["require", "exports"], function (require, exports) {
+    var decorator;
+    let Foo = class {
+    };
+    Foo = __decorate([
+        decorator
+    ], Foo);
+    exports.default = Foo;
+});

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedAmd.symbols
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedAmd.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/es6/moduleExportsAmd/decoratedDefaultExportsGetExportedAmd.ts ===
+
+var decorator: ClassDecorator;
+>decorator : Symbol(decorator, Decl(decoratedDefaultExportsGetExportedAmd.ts, 1, 3))
+>ClassDecorator : Symbol(ClassDecorator, Decl(lib.d.ts, --, --))
+
+@decorator
+>decorator : Symbol(decorator, Decl(decoratedDefaultExportsGetExportedAmd.ts, 1, 3))
+
+export default class Foo {}
+>Foo : Symbol(Foo, Decl(decoratedDefaultExportsGetExportedAmd.ts, 1, 30))
+

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedAmd.types
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedAmd.types
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/es6/moduleExportsAmd/decoratedDefaultExportsGetExportedAmd.ts ===
+
+var decorator: ClassDecorator;
+>decorator : <TFunction extends Function>(target: TFunction) => TFunction | void
+>ClassDecorator : <TFunction extends Function>(target: TFunction) => TFunction | void
+
+@decorator
+>decorator : <TFunction extends Function>(target: TFunction) => TFunction | void
+
+export default class Foo {}
+>Foo : Foo
+

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedCommonjs.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedCommonjs.js
@@ -1,0 +1,22 @@
+//// [decoratedDefaultExportsGetExportedCommonjs.ts]
+
+var decorator: ClassDecorator;
+
+@decorator
+export default class Foo {}
+
+
+//// [decoratedDefaultExportsGetExportedCommonjs.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var decorator;
+let Foo = class {
+};
+Foo = __decorate([
+    decorator
+], Foo);
+exports.default = Foo;

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedCommonjs.symbols
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedCommonjs.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/es6/moduleExportsCommonjs/decoratedDefaultExportsGetExportedCommonjs.ts ===
+
+var decorator: ClassDecorator;
+>decorator : Symbol(decorator, Decl(decoratedDefaultExportsGetExportedCommonjs.ts, 1, 3))
+>ClassDecorator : Symbol(ClassDecorator, Decl(lib.d.ts, --, --))
+
+@decorator
+>decorator : Symbol(decorator, Decl(decoratedDefaultExportsGetExportedCommonjs.ts, 1, 3))
+
+export default class Foo {}
+>Foo : Symbol(Foo, Decl(decoratedDefaultExportsGetExportedCommonjs.ts, 1, 30))
+

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedCommonjs.types
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedCommonjs.types
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/es6/moduleExportsCommonjs/decoratedDefaultExportsGetExportedCommonjs.ts ===
+
+var decorator: ClassDecorator;
+>decorator : <TFunction extends Function>(target: TFunction) => TFunction | void
+>ClassDecorator : <TFunction extends Function>(target: TFunction) => TFunction | void
+
+@decorator
+>decorator : <TFunction extends Function>(target: TFunction) => TFunction | void
+
+export default class Foo {}
+>Foo : Foo
+

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedSystem.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedSystem.js
@@ -1,0 +1,29 @@
+//// [decoratedDefaultExportsGetExportedSystem.ts]
+
+var decorator: ClassDecorator;
+
+@decorator
+export default class Foo {}
+
+
+//// [decoratedDefaultExportsGetExportedSystem.js]
+System.register([], function(exports_1) {
+    var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+        var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+        if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+        else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+        return c > 3 && r && Object.defineProperty(target, key, r), r;
+    };
+    var decorator, Foo;
+    return {
+        setters:[],
+        execute: function() {
+            let Foo = class {
+            };
+            Foo = __decorate([
+                decorator
+            ], Foo);
+            exports_1("default", Foo);
+        }
+    }
+});

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedSystem.symbols
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedSystem.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/es6/moduleExportsSystem/decoratedDefaultExportsGetExportedSystem.ts ===
+
+var decorator: ClassDecorator;
+>decorator : Symbol(decorator, Decl(decoratedDefaultExportsGetExportedSystem.ts, 1, 3))
+>ClassDecorator : Symbol(ClassDecorator, Decl(lib.d.ts, --, --))
+
+@decorator
+>decorator : Symbol(decorator, Decl(decoratedDefaultExportsGetExportedSystem.ts, 1, 3))
+
+export default class Foo {}
+>Foo : Symbol(Foo, Decl(decoratedDefaultExportsGetExportedSystem.ts, 1, 30))
+

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedSystem.types
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedSystem.types
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/es6/moduleExportsSystem/decoratedDefaultExportsGetExportedSystem.ts ===
+
+var decorator: ClassDecorator;
+>decorator : <TFunction extends Function>(target: TFunction) => TFunction | void
+>ClassDecorator : <TFunction extends Function>(target: TFunction) => TFunction | void
+
+@decorator
+>decorator : <TFunction extends Function>(target: TFunction) => TFunction | void
+
+export default class Foo {}
+>Foo : Foo
+

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedUmd.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedUmd.js
@@ -1,0 +1,31 @@
+//// [decoratedDefaultExportsGetExportedUmd.ts]
+
+var decorator: ClassDecorator;
+
+@decorator
+export default class Foo {}
+
+
+//// [decoratedDefaultExportsGetExportedUmd.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+(function (factory) {
+    if (typeof module === 'object' && typeof module.exports === 'object') {
+        var v = factory(require, exports); if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === 'function' && define.amd) {
+        define(["require", "exports"], factory);
+    }
+})(function (require, exports) {
+    var decorator;
+    let Foo = class {
+    };
+    Foo = __decorate([
+        decorator
+    ], Foo);
+    exports.default = Foo;
+});

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedUmd.symbols
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedUmd.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/es6/moduleExportsUmd/decoratedDefaultExportsGetExportedUmd.ts ===
+
+var decorator: ClassDecorator;
+>decorator : Symbol(decorator, Decl(decoratedDefaultExportsGetExportedUmd.ts, 1, 3))
+>ClassDecorator : Symbol(ClassDecorator, Decl(lib.d.ts, --, --))
+
+@decorator
+>decorator : Symbol(decorator, Decl(decoratedDefaultExportsGetExportedUmd.ts, 1, 3))
+
+export default class Foo {}
+>Foo : Symbol(Foo, Decl(decoratedDefaultExportsGetExportedUmd.ts, 1, 30))
+

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedUmd.types
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedUmd.types
@@ -1,0 +1,12 @@
+=== tests/cases/conformance/es6/moduleExportsUmd/decoratedDefaultExportsGetExportedUmd.ts ===
+
+var decorator: ClassDecorator;
+>decorator : <TFunction extends Function>(target: TFunction) => TFunction | void
+>ClassDecorator : <TFunction extends Function>(target: TFunction) => TFunction | void
+
+@decorator
+>decorator : <TFunction extends Function>(target: TFunction) => TFunction | void
+
+export default class Foo {}
+>Foo : Foo
+

--- a/tests/baselines/reference/defaultExportsGetExportedAmd.js
+++ b/tests/baselines/reference/defaultExportsGetExportedAmd.js
@@ -1,0 +1,10 @@
+//// [defaultExportsGetExportedAmd.ts]
+export default class Foo {}
+
+
+//// [defaultExportsGetExportedAmd.js]
+define(["require", "exports"], function (require, exports) {
+    class Foo {
+    }
+    exports.default = Foo;
+});

--- a/tests/baselines/reference/defaultExportsGetExportedAmd.symbols
+++ b/tests/baselines/reference/defaultExportsGetExportedAmd.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/es6/moduleExportsAmd/defaultExportsGetExportedAmd.ts ===
+export default class Foo {}
+>Foo : Symbol(Foo, Decl(defaultExportsGetExportedAmd.ts, 0, 0))
+

--- a/tests/baselines/reference/defaultExportsGetExportedAmd.types
+++ b/tests/baselines/reference/defaultExportsGetExportedAmd.types
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/es6/moduleExportsAmd/defaultExportsGetExportedAmd.ts ===
+export default class Foo {}
+>Foo : Foo
+

--- a/tests/baselines/reference/defaultExportsGetExportedCommonjs.js
+++ b/tests/baselines/reference/defaultExportsGetExportedCommonjs.js
@@ -1,0 +1,8 @@
+//// [defaultExportsGetExportedCommonjs.ts]
+export default class Foo {}
+
+
+//// [defaultExportsGetExportedCommonjs.js]
+class Foo {
+}
+exports.default = Foo;

--- a/tests/baselines/reference/defaultExportsGetExportedCommonjs.symbols
+++ b/tests/baselines/reference/defaultExportsGetExportedCommonjs.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/es6/moduleExportsCommonjs/defaultExportsGetExportedCommonjs.ts ===
+export default class Foo {}
+>Foo : Symbol(Foo, Decl(defaultExportsGetExportedCommonjs.ts, 0, 0))
+

--- a/tests/baselines/reference/defaultExportsGetExportedCommonjs.types
+++ b/tests/baselines/reference/defaultExportsGetExportedCommonjs.types
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/es6/moduleExportsCommonjs/defaultExportsGetExportedCommonjs.ts ===
+export default class Foo {}
+>Foo : Foo
+

--- a/tests/baselines/reference/defaultExportsGetExportedSystem.js
+++ b/tests/baselines/reference/defaultExportsGetExportedSystem.js
@@ -1,0 +1,16 @@
+//// [defaultExportsGetExportedSystem.ts]
+export default class Foo {}
+
+
+//// [defaultExportsGetExportedSystem.js]
+System.register([], function(exports_1) {
+    var Foo;
+    return {
+        setters:[],
+        execute: function() {
+            class Foo {
+            }
+            exports_1("default", Foo);
+        }
+    }
+});

--- a/tests/baselines/reference/defaultExportsGetExportedSystem.symbols
+++ b/tests/baselines/reference/defaultExportsGetExportedSystem.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/es6/moduleExportsSystem/defaultExportsGetExportedSystem.ts ===
+export default class Foo {}
+>Foo : Symbol(Foo, Decl(defaultExportsGetExportedSystem.ts, 0, 0))
+

--- a/tests/baselines/reference/defaultExportsGetExportedSystem.types
+++ b/tests/baselines/reference/defaultExportsGetExportedSystem.types
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/es6/moduleExportsSystem/defaultExportsGetExportedSystem.ts ===
+export default class Foo {}
+>Foo : Foo
+

--- a/tests/baselines/reference/defaultExportsGetExportedUmd.js
+++ b/tests/baselines/reference/defaultExportsGetExportedUmd.js
@@ -1,0 +1,17 @@
+//// [defaultExportsGetExportedUmd.ts]
+export default class Foo {}
+
+
+//// [defaultExportsGetExportedUmd.js]
+(function (factory) {
+    if (typeof module === 'object' && typeof module.exports === 'object') {
+        var v = factory(require, exports); if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === 'function' && define.amd) {
+        define(["require", "exports"], factory);
+    }
+})(function (require, exports) {
+    class Foo {
+    }
+    exports.default = Foo;
+});

--- a/tests/baselines/reference/defaultExportsGetExportedUmd.symbols
+++ b/tests/baselines/reference/defaultExportsGetExportedUmd.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/es6/moduleExportsUmd/defaultExportsGetExportedUmd.ts ===
+export default class Foo {}
+>Foo : Symbol(Foo, Decl(defaultExportsGetExportedUmd.ts, 0, 0))
+

--- a/tests/baselines/reference/defaultExportsGetExportedUmd.types
+++ b/tests/baselines/reference/defaultExportsGetExportedUmd.types
@@ -1,0 +1,4 @@
+=== tests/cases/conformance/es6/moduleExportsUmd/defaultExportsGetExportedUmd.ts ===
+export default class Foo {}
+>Foo : Foo
+

--- a/tests/cases/conformance/es6/moduleExportsAmd/decoratedDefaultExportsGetExportedAmd.ts
+++ b/tests/cases/conformance/es6/moduleExportsAmd/decoratedDefaultExportsGetExportedAmd.ts
@@ -1,0 +1,7 @@
+// @target: ES6
+// @module: amd
+
+var decorator: ClassDecorator;
+
+@decorator
+export default class Foo {}

--- a/tests/cases/conformance/es6/moduleExportsAmd/decoratedDefaultExportsGetExportedAmd.ts
+++ b/tests/cases/conformance/es6/moduleExportsAmd/decoratedDefaultExportsGetExportedAmd.ts
@@ -1,4 +1,5 @@
 // @target: ES6
+// @experimentalDecorators: true
 // @module: amd
 
 var decorator: ClassDecorator;

--- a/tests/cases/conformance/es6/moduleExportsAmd/defaultExportsGetExportedAmd.ts
+++ b/tests/cases/conformance/es6/moduleExportsAmd/defaultExportsGetExportedAmd.ts
@@ -1,0 +1,3 @@
+// @target: ES6
+// @module: amd
+export default class Foo {}

--- a/tests/cases/conformance/es6/moduleExportsCommonjs/decoratedDefaultExportsGetExportedCommonjs.ts
+++ b/tests/cases/conformance/es6/moduleExportsCommonjs/decoratedDefaultExportsGetExportedCommonjs.ts
@@ -1,0 +1,7 @@
+// @target: ES6
+// @module: commonjs
+
+var decorator: ClassDecorator;
+
+@decorator
+export default class Foo {}

--- a/tests/cases/conformance/es6/moduleExportsCommonjs/decoratedDefaultExportsGetExportedCommonjs.ts
+++ b/tests/cases/conformance/es6/moduleExportsCommonjs/decoratedDefaultExportsGetExportedCommonjs.ts
@@ -1,4 +1,5 @@
 // @target: ES6
+// @experimentalDecorators: true
 // @module: commonjs
 
 var decorator: ClassDecorator;

--- a/tests/cases/conformance/es6/moduleExportsCommonjs/defaultExportsGetExportedCommonjs.ts
+++ b/tests/cases/conformance/es6/moduleExportsCommonjs/defaultExportsGetExportedCommonjs.ts
@@ -1,0 +1,3 @@
+// @target: ES6
+// @module: commonjs
+export default class Foo {}

--- a/tests/cases/conformance/es6/moduleExportsSystem/decoratedDefaultExportsGetExportedSystem.ts
+++ b/tests/cases/conformance/es6/moduleExportsSystem/decoratedDefaultExportsGetExportedSystem.ts
@@ -1,4 +1,5 @@
 // @target: ES6
+// @experimentalDecorators: true
 // @module: system
 
 var decorator: ClassDecorator;

--- a/tests/cases/conformance/es6/moduleExportsSystem/decoratedDefaultExportsGetExportedSystem.ts
+++ b/tests/cases/conformance/es6/moduleExportsSystem/decoratedDefaultExportsGetExportedSystem.ts
@@ -1,0 +1,7 @@
+// @target: ES6
+// @module: system
+
+var decorator: ClassDecorator;
+
+@decorator
+export default class Foo {}

--- a/tests/cases/conformance/es6/moduleExportsSystem/defaultExportsGetExportedSystem.ts
+++ b/tests/cases/conformance/es6/moduleExportsSystem/defaultExportsGetExportedSystem.ts
@@ -1,0 +1,3 @@
+// @target: ES6
+// @module: system
+export default class Foo {}

--- a/tests/cases/conformance/es6/moduleExportsUmd/decoratedDefaultExportsGetExportedUmd.ts
+++ b/tests/cases/conformance/es6/moduleExportsUmd/decoratedDefaultExportsGetExportedUmd.ts
@@ -1,0 +1,7 @@
+// @target: ES6
+// @module: umd
+
+var decorator: ClassDecorator;
+
+@decorator
+export default class Foo {}

--- a/tests/cases/conformance/es6/moduleExportsUmd/decoratedDefaultExportsGetExportedUmd.ts
+++ b/tests/cases/conformance/es6/moduleExportsUmd/decoratedDefaultExportsGetExportedUmd.ts
@@ -1,4 +1,5 @@
 // @target: ES6
+// @experimentalDecorators: true
 // @module: umd
 
 var decorator: ClassDecorator;

--- a/tests/cases/conformance/es6/moduleExportsUmd/defaultExportsGetExportedUmd.ts
+++ b/tests/cases/conformance/es6/moduleExportsUmd/defaultExportsGetExportedUmd.ts
@@ -1,0 +1,3 @@
+// @target: ES6
+// @module: umd
+export default class Foo {}


### PR DESCRIPTION
Fixes #5594.