### PR TITLE
Ignore typeof x === "undefined" type guards when narrowing

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -200,6 +200,10 @@ namespace ts {
             "symbol": {
                 type: esSymbolType,
                 flags: TypeFlags.ESSymbol
+            },
+            "undefined": {
+                type: undefinedType,
+                flags: TypeFlags.ContainsUndefinedOrNull
             }
         };
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6479,6 +6479,10 @@ namespace ts {
                     assumeTrue = !assumeTrue;
                 }
                 const typeInfo = primitiveTypeInfo[right.text];
+                // Don't narrow `undefined`
+                if (typeInfo && typeInfo.type === undefinedType) {
+                    return type;
+                }
                 // If the type to be narrowed is any and we're checking a primitive with assumeTrue=true, return the primitive
                 if (!!(type.flags & TypeFlags.Any) && typeInfo && assumeTrue) {
                     return typeInfo.type;

--- a/tests/baselines/reference/typeGuardTypeOfUndefined.js
+++ b/tests/baselines/reference/typeGuardTypeOfUndefined.js
@@ -1,0 +1,357 @@
+//// [typeGuardTypeOfUndefined.ts]
+// undefined type guard adds no new type information
+function test1(a: any) {
+    if (typeof a !== "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+
+function test2(a: any) {
+    if (typeof a === "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+
+function test3(a: any) {
+    if (typeof a === "undefined" || typeof a === "boolean") {
+		a;
+    }
+    else {
+        a;
+    }
+}
+
+function test4(a: any) {
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+		a;
+    }
+    else {
+        a;
+    }
+}
+
+function test5(a: boolean | void) {
+    if (typeof a !== "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+
+function test6(a: boolean | void) {
+    if (typeof a === "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+
+function test7(a: boolean | void) {
+    if (typeof a === "undefined" || typeof a === "boolean") {
+		a;
+    }
+    else {
+        a;
+    }
+}
+
+function test8(a: boolean | void) {
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+		a;
+    }
+    else {
+        a;
+    }
+}
+
+function test9(a: boolean | number) {
+    if (typeof a !== "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+
+function test10(a: boolean | number) {
+    if (typeof a === "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+
+function test11(a: boolean | number) {
+    if (typeof a === "undefined" || typeof a === "boolean") {
+		a;
+    }
+    else {
+        a;
+    }
+}
+
+function test12(a: boolean | number) {
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+		a;
+    }
+    else {
+        a;
+    }
+}
+
+function test13(a: boolean | number | void) {
+    if (typeof a !== "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+
+function test14(a: boolean | number | void) {
+    if (typeof a === "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+
+function test15(a: boolean | number | void) {
+    if (typeof a === "undefined" || typeof a === "boolean") {
+		a;
+    }
+    else {
+        a;
+    }
+}
+
+function test16(a: boolean | number | void) {
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+		a;
+    }
+    else {
+        a;
+    }
+}
+
+
+//// [typeGuardTypeOfUndefined.js]
+// undefined type guard adds no new type information
+function test1(a) {
+    if (typeof a !== "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+function test2(a) {
+    if (typeof a === "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+function test3(a) {
+    if (typeof a === "undefined" || typeof a === "boolean") {
+        a;
+    }
+    else {
+        a;
+    }
+}
+function test4(a) {
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+        a;
+    }
+    else {
+        a;
+    }
+}
+function test5(a) {
+    if (typeof a !== "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+function test6(a) {
+    if (typeof a === "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+function test7(a) {
+    if (typeof a === "undefined" || typeof a === "boolean") {
+        a;
+    }
+    else {
+        a;
+    }
+}
+function test8(a) {
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+        a;
+    }
+    else {
+        a;
+    }
+}
+function test9(a) {
+    if (typeof a !== "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+function test10(a) {
+    if (typeof a === "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+function test11(a) {
+    if (typeof a === "undefined" || typeof a === "boolean") {
+        a;
+    }
+    else {
+        a;
+    }
+}
+function test12(a) {
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+        a;
+    }
+    else {
+        a;
+    }
+}
+function test13(a) {
+    if (typeof a !== "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+function test14(a) {
+    if (typeof a === "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+function test15(a) {
+    if (typeof a === "undefined" || typeof a === "boolean") {
+        a;
+    }
+    else {
+        a;
+    }
+}
+function test16(a) {
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+        a;
+    }
+    else {
+        a;
+    }
+}

--- a/tests/baselines/reference/typeGuardTypeOfUndefined.symbols
+++ b/tests/baselines/reference/typeGuardTypeOfUndefined.symbols
@@ -1,0 +1,330 @@
+=== tests/cases/conformance/expressions/typeGuards/typeGuardTypeOfUndefined.ts ===
+// undefined type guard adds no new type information
+function test1(a: any) {
+>test1 : Symbol(test1, Decl(typeGuardTypeOfUndefined.ts, 0, 0))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 1, 15))
+
+    if (typeof a !== "undefined") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 1, 15))
+
+        if (typeof a === "boolean") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 1, 15))
+
+            a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 1, 15))
+        }
+        else {
+            a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 1, 15))
+        }
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 1, 15))
+    }
+}
+
+function test2(a: any) {
+>test2 : Symbol(test2, Decl(typeGuardTypeOfUndefined.ts, 13, 1))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 15, 15))
+
+    if (typeof a === "undefined") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 15, 15))
+
+        if (typeof a === "boolean") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 15, 15))
+
+            a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 15, 15))
+        }
+        else {
+            a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 15, 15))
+        }
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 15, 15))
+    }
+}
+
+function test3(a: any) {
+>test3 : Symbol(test3, Decl(typeGuardTypeOfUndefined.ts, 27, 1))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 29, 15))
+
+    if (typeof a === "undefined" || typeof a === "boolean") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 29, 15))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 29, 15))
+
+		a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 29, 15))
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 29, 15))
+    }
+}
+
+function test4(a: any) {
+>test4 : Symbol(test4, Decl(typeGuardTypeOfUndefined.ts, 36, 1))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 38, 15))
+
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 38, 15))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 38, 15))
+
+		a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 38, 15))
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 38, 15))
+    }
+}
+
+function test5(a: boolean | void) {
+>test5 : Symbol(test5, Decl(typeGuardTypeOfUndefined.ts, 45, 1))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 47, 15))
+
+    if (typeof a !== "undefined") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 47, 15))
+
+        if (typeof a === "boolean") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 47, 15))
+
+            a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 47, 15))
+        }
+        else {
+            a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 47, 15))
+        }
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 47, 15))
+    }
+}
+
+function test6(a: boolean | void) {
+>test6 : Symbol(test6, Decl(typeGuardTypeOfUndefined.ts, 59, 1))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 61, 15))
+
+    if (typeof a === "undefined") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 61, 15))
+
+        if (typeof a === "boolean") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 61, 15))
+
+            a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 61, 15))
+        }
+        else {
+            a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 61, 15))
+        }
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 61, 15))
+    }
+}
+
+function test7(a: boolean | void) {
+>test7 : Symbol(test7, Decl(typeGuardTypeOfUndefined.ts, 73, 1))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 75, 15))
+
+    if (typeof a === "undefined" || typeof a === "boolean") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 75, 15))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 75, 15))
+
+		a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 75, 15))
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 75, 15))
+    }
+}
+
+function test8(a: boolean | void) {
+>test8 : Symbol(test8, Decl(typeGuardTypeOfUndefined.ts, 82, 1))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 84, 15))
+
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 84, 15))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 84, 15))
+
+		a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 84, 15))
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 84, 15))
+    }
+}
+
+function test9(a: boolean | number) {
+>test9 : Symbol(test9, Decl(typeGuardTypeOfUndefined.ts, 91, 1))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 93, 15))
+
+    if (typeof a !== "undefined") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 93, 15))
+
+        if (typeof a === "boolean") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 93, 15))
+
+            a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 93, 15))
+        }
+        else {
+            a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 93, 15))
+        }
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 93, 15))
+    }
+}
+
+function test10(a: boolean | number) {
+>test10 : Symbol(test10, Decl(typeGuardTypeOfUndefined.ts, 105, 1))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 107, 16))
+
+    if (typeof a === "undefined") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 107, 16))
+
+        if (typeof a === "boolean") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 107, 16))
+
+            a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 107, 16))
+        }
+        else {
+            a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 107, 16))
+        }
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 107, 16))
+    }
+}
+
+function test11(a: boolean | number) {
+>test11 : Symbol(test11, Decl(typeGuardTypeOfUndefined.ts, 119, 1))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 121, 16))
+
+    if (typeof a === "undefined" || typeof a === "boolean") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 121, 16))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 121, 16))
+
+		a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 121, 16))
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 121, 16))
+    }
+}
+
+function test12(a: boolean | number) {
+>test12 : Symbol(test12, Decl(typeGuardTypeOfUndefined.ts, 128, 1))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 130, 16))
+
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 130, 16))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 130, 16))
+
+		a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 130, 16))
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 130, 16))
+    }
+}
+
+function test13(a: boolean | number | void) {
+>test13 : Symbol(test13, Decl(typeGuardTypeOfUndefined.ts, 137, 1))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 139, 16))
+
+    if (typeof a !== "undefined") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 139, 16))
+
+        if (typeof a === "boolean") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 139, 16))
+
+            a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 139, 16))
+        }
+        else {
+            a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 139, 16))
+        }
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 139, 16))
+    }
+}
+
+function test14(a: boolean | number | void) {
+>test14 : Symbol(test14, Decl(typeGuardTypeOfUndefined.ts, 151, 1))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 153, 16))
+
+    if (typeof a === "undefined") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 153, 16))
+
+        if (typeof a === "boolean") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 153, 16))
+
+            a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 153, 16))
+        }
+        else {
+            a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 153, 16))
+        }
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 153, 16))
+    }
+}
+
+function test15(a: boolean | number | void) {
+>test15 : Symbol(test15, Decl(typeGuardTypeOfUndefined.ts, 165, 1))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 167, 16))
+
+    if (typeof a === "undefined" || typeof a === "boolean") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 167, 16))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 167, 16))
+
+		a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 167, 16))
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 167, 16))
+    }
+}
+
+function test16(a: boolean | number | void) {
+>test16 : Symbol(test16, Decl(typeGuardTypeOfUndefined.ts, 174, 1))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 176, 16))
+
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 176, 16))
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 176, 16))
+
+		a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 176, 16))
+    }
+    else {
+        a;
+>a : Symbol(a, Decl(typeGuardTypeOfUndefined.ts, 176, 16))
+    }
+}
+

--- a/tests/baselines/reference/typeGuardTypeOfUndefined.types
+++ b/tests/baselines/reference/typeGuardTypeOfUndefined.types
@@ -1,0 +1,434 @@
+=== tests/cases/conformance/expressions/typeGuards/typeGuardTypeOfUndefined.ts ===
+// undefined type guard adds no new type information
+function test1(a: any) {
+>test1 : (a: any) => void
+>a : any
+
+    if (typeof a !== "undefined") {
+>typeof a !== "undefined" : boolean
+>typeof a : string
+>a : any
+>"undefined" : string
+
+        if (typeof a === "boolean") {
+>typeof a === "boolean" : boolean
+>typeof a : string
+>a : any
+>"boolean" : string
+
+            a;
+>a : boolean
+        }
+        else {
+            a;
+>a : any
+        }
+    }
+    else {
+        a;
+>a : any
+    }
+}
+
+function test2(a: any) {
+>test2 : (a: any) => void
+>a : any
+
+    if (typeof a === "undefined") {
+>typeof a === "undefined" : boolean
+>typeof a : string
+>a : any
+>"undefined" : string
+
+        if (typeof a === "boolean") {
+>typeof a === "boolean" : boolean
+>typeof a : string
+>a : any
+>"boolean" : string
+
+            a;
+>a : boolean
+        }
+        else {
+            a;
+>a : any
+        }
+    }
+    else {
+        a;
+>a : any
+    }
+}
+
+function test3(a: any) {
+>test3 : (a: any) => void
+>a : any
+
+    if (typeof a === "undefined" || typeof a === "boolean") {
+>typeof a === "undefined" || typeof a === "boolean" : boolean
+>typeof a === "undefined" : boolean
+>typeof a : string
+>a : any
+>"undefined" : string
+>typeof a === "boolean" : boolean
+>typeof a : string
+>a : any
+>"boolean" : string
+
+		a;
+>a : any
+    }
+    else {
+        a;
+>a : any
+    }
+}
+
+function test4(a: any) {
+>test4 : (a: any) => void
+>a : any
+
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+>typeof a !== "undefined" && typeof a === "boolean" : boolean
+>typeof a !== "undefined" : boolean
+>typeof a : string
+>a : any
+>"undefined" : string
+>typeof a === "boolean" : boolean
+>typeof a : string
+>a : any
+>"boolean" : string
+
+		a;
+>a : boolean
+    }
+    else {
+        a;
+>a : any
+    }
+}
+
+function test5(a: boolean | void) {
+>test5 : (a: boolean | void) => void
+>a : boolean | void
+
+    if (typeof a !== "undefined") {
+>typeof a !== "undefined" : boolean
+>typeof a : string
+>a : boolean | void
+>"undefined" : string
+
+        if (typeof a === "boolean") {
+>typeof a === "boolean" : boolean
+>typeof a : string
+>a : boolean | void
+>"boolean" : string
+
+            a;
+>a : boolean
+        }
+        else {
+            a;
+>a : void
+        }
+    }
+    else {
+        a;
+>a : boolean | void
+    }
+}
+
+function test6(a: boolean | void) {
+>test6 : (a: boolean | void) => void
+>a : boolean | void
+
+    if (typeof a === "undefined") {
+>typeof a === "undefined" : boolean
+>typeof a : string
+>a : boolean | void
+>"undefined" : string
+
+        if (typeof a === "boolean") {
+>typeof a === "boolean" : boolean
+>typeof a : string
+>a : boolean | void
+>"boolean" : string
+
+            a;
+>a : boolean
+        }
+        else {
+            a;
+>a : void
+        }
+    }
+    else {
+        a;
+>a : boolean | void
+    }
+}
+
+function test7(a: boolean | void) {
+>test7 : (a: boolean | void) => void
+>a : boolean | void
+
+    if (typeof a === "undefined" || typeof a === "boolean") {
+>typeof a === "undefined" || typeof a === "boolean" : boolean
+>typeof a === "undefined" : boolean
+>typeof a : string
+>a : boolean | void
+>"undefined" : string
+>typeof a === "boolean" : boolean
+>typeof a : string
+>a : boolean | void
+>"boolean" : string
+
+		a;
+>a : boolean | void
+    }
+    else {
+        a;
+>a : void
+    }
+}
+
+function test8(a: boolean | void) {
+>test8 : (a: boolean | void) => void
+>a : boolean | void
+
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+>typeof a !== "undefined" && typeof a === "boolean" : boolean
+>typeof a !== "undefined" : boolean
+>typeof a : string
+>a : boolean | void
+>"undefined" : string
+>typeof a === "boolean" : boolean
+>typeof a : string
+>a : boolean | void
+>"boolean" : string
+
+		a;
+>a : boolean
+    }
+    else {
+        a;
+>a : boolean | void
+    }
+}
+
+function test9(a: boolean | number) {
+>test9 : (a: boolean | number) => void
+>a : boolean | number
+
+    if (typeof a !== "undefined") {
+>typeof a !== "undefined" : boolean
+>typeof a : string
+>a : boolean | number
+>"undefined" : string
+
+        if (typeof a === "boolean") {
+>typeof a === "boolean" : boolean
+>typeof a : string
+>a : boolean | number
+>"boolean" : string
+
+            a;
+>a : boolean
+        }
+        else {
+            a;
+>a : number
+        }
+    }
+    else {
+        a;
+>a : boolean | number
+    }
+}
+
+function test10(a: boolean | number) {
+>test10 : (a: boolean | number) => void
+>a : boolean | number
+
+    if (typeof a === "undefined") {
+>typeof a === "undefined" : boolean
+>typeof a : string
+>a : boolean | number
+>"undefined" : string
+
+        if (typeof a === "boolean") {
+>typeof a === "boolean" : boolean
+>typeof a : string
+>a : boolean | number
+>"boolean" : string
+
+            a;
+>a : boolean
+        }
+        else {
+            a;
+>a : number
+        }
+    }
+    else {
+        a;
+>a : boolean | number
+    }
+}
+
+function test11(a: boolean | number) {
+>test11 : (a: boolean | number) => void
+>a : boolean | number
+
+    if (typeof a === "undefined" || typeof a === "boolean") {
+>typeof a === "undefined" || typeof a === "boolean" : boolean
+>typeof a === "undefined" : boolean
+>typeof a : string
+>a : boolean | number
+>"undefined" : string
+>typeof a === "boolean" : boolean
+>typeof a : string
+>a : boolean | number
+>"boolean" : string
+
+		a;
+>a : boolean | number
+    }
+    else {
+        a;
+>a : number
+    }
+}
+
+function test12(a: boolean | number) {
+>test12 : (a: boolean | number) => void
+>a : boolean | number
+
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+>typeof a !== "undefined" && typeof a === "boolean" : boolean
+>typeof a !== "undefined" : boolean
+>typeof a : string
+>a : boolean | number
+>"undefined" : string
+>typeof a === "boolean" : boolean
+>typeof a : string
+>a : boolean | number
+>"boolean" : string
+
+		a;
+>a : boolean
+    }
+    else {
+        a;
+>a : boolean | number
+    }
+}
+
+function test13(a: boolean | number | void) {
+>test13 : (a: boolean | number | void) => void
+>a : boolean | number | void
+
+    if (typeof a !== "undefined") {
+>typeof a !== "undefined" : boolean
+>typeof a : string
+>a : boolean | number | void
+>"undefined" : string
+
+        if (typeof a === "boolean") {
+>typeof a === "boolean" : boolean
+>typeof a : string
+>a : boolean | number | void
+>"boolean" : string
+
+            a;
+>a : boolean
+        }
+        else {
+            a;
+>a : number | void
+        }
+    }
+    else {
+        a;
+>a : boolean | number | void
+    }
+}
+
+function test14(a: boolean | number | void) {
+>test14 : (a: boolean | number | void) => void
+>a : boolean | number | void
+
+    if (typeof a === "undefined") {
+>typeof a === "undefined" : boolean
+>typeof a : string
+>a : boolean | number | void
+>"undefined" : string
+
+        if (typeof a === "boolean") {
+>typeof a === "boolean" : boolean
+>typeof a : string
+>a : boolean | number | void
+>"boolean" : string
+
+            a;
+>a : boolean
+        }
+        else {
+            a;
+>a : number | void
+        }
+    }
+    else {
+        a;
+>a : boolean | number | void
+    }
+}
+
+function test15(a: boolean | number | void) {
+>test15 : (a: boolean | number | void) => void
+>a : boolean | number | void
+
+    if (typeof a === "undefined" || typeof a === "boolean") {
+>typeof a === "undefined" || typeof a === "boolean" : boolean
+>typeof a === "undefined" : boolean
+>typeof a : string
+>a : boolean | number | void
+>"undefined" : string
+>typeof a === "boolean" : boolean
+>typeof a : string
+>a : boolean | number | void
+>"boolean" : string
+
+		a;
+>a : boolean | number | void
+    }
+    else {
+        a;
+>a : number | void
+    }
+}
+
+function test16(a: boolean | number | void) {
+>test16 : (a: boolean | number | void) => void
+>a : boolean | number | void
+
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+>typeof a !== "undefined" && typeof a === "boolean" : boolean
+>typeof a !== "undefined" : boolean
+>typeof a : string
+>a : boolean | number | void
+>"undefined" : string
+>typeof a === "boolean" : boolean
+>typeof a : string
+>a : boolean | number | void
+>"boolean" : string
+
+		a;
+>a : boolean
+    }
+    else {
+        a;
+>a : boolean | number | void
+    }
+}
+

--- a/tests/cases/conformance/expressions/typeGuards/typeGuardTypeOfUndefined.ts
+++ b/tests/cases/conformance/expressions/typeGuards/typeGuardTypeOfUndefined.ts
@@ -1,0 +1,28 @@
+// undefined type guard adds no new type information
+function test1(a: any) {
+    if (typeof a !== "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+    }
+}
+
+function test2(a: any) {
+    if (typeof a === "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+    }
+}
+
+function test3(a: any) {
+    if (typeof a === "undefined" || typeof a === "boolean") {
+		a;
+    }
+}
+
+function test4(a: any) {
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+		a;
+    }
+}

--- a/tests/cases/conformance/expressions/typeGuards/typeGuardTypeOfUndefined.ts
+++ b/tests/cases/conformance/expressions/typeGuards/typeGuardTypeOfUndefined.ts
@@ -4,6 +4,12 @@ function test1(a: any) {
         if (typeof a === "boolean") {
             a;
         }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
     }
 }
 
@@ -12,6 +18,12 @@ function test2(a: any) {
         if (typeof a === "boolean") {
             a;
         }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
     }
 }
 
@@ -19,10 +31,154 @@ function test3(a: any) {
     if (typeof a === "undefined" || typeof a === "boolean") {
 		a;
     }
+    else {
+        a;
+    }
 }
 
 function test4(a: any) {
     if (typeof a !== "undefined" && typeof a === "boolean") {
 		a;
+    }
+    else {
+        a;
+    }
+}
+
+function test5(a: boolean | void) {
+    if (typeof a !== "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+
+function test6(a: boolean | void) {
+    if (typeof a === "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+
+function test7(a: boolean | void) {
+    if (typeof a === "undefined" || typeof a === "boolean") {
+		a;
+    }
+    else {
+        a;
+    }
+}
+
+function test8(a: boolean | void) {
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+		a;
+    }
+    else {
+        a;
+    }
+}
+
+function test9(a: boolean | number) {
+    if (typeof a !== "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+
+function test10(a: boolean | number) {
+    if (typeof a === "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+
+function test11(a: boolean | number) {
+    if (typeof a === "undefined" || typeof a === "boolean") {
+		a;
+    }
+    else {
+        a;
+    }
+}
+
+function test12(a: boolean | number) {
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+		a;
+    }
+    else {
+        a;
+    }
+}
+
+function test13(a: boolean | number | void) {
+    if (typeof a !== "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+
+function test14(a: boolean | number | void) {
+    if (typeof a === "undefined") {
+        if (typeof a === "boolean") {
+            a;
+        }
+        else {
+            a;
+        }
+    }
+    else {
+        a;
+    }
+}
+
+function test15(a: boolean | number | void) {
+    if (typeof a === "undefined" || typeof a === "boolean") {
+		a;
+    }
+    else {
+        a;
+    }
+}
+
+function test16(a: boolean | number | void) {
+    if (typeof a !== "undefined" && typeof a === "boolean") {
+		a;
+    }
+    else {
+        a;
     }
 }


### PR DESCRIPTION
Fixes #5654.

Theoretically we could use this type guard to narrow `void` types out of unions, but our stance on #1806 was that that was undesirable.