### PR TITLE
Fix for doc comment for parameter-property not shown correctly when invoking constructor

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3829,7 +3829,13 @@ namespace ts {
                 let minArgumentCount = -1;
                 for (let i = 0, n = declaration.parameters.length; i < n; i++) {
                     const param = declaration.parameters[i];
-                    parameters.push(param.symbol);
+                    let paramSymbol = param.symbol;
+                    // Include parameter symbol instead of property symbol in the signature
+                    if (paramSymbol && !!(paramSymbol.flags & SymbolFlags.Property) && !isBindingPattern(param.name)) {
+                        const resolvedSymbol = resolveName(param, paramSymbol.name, SymbolFlags.Value, undefined, undefined);
+                        paramSymbol = resolvedSymbol;
+                    }
+                    parameters.push(paramSymbol);
                     if (param.type && param.type.kind === SyntaxKind.StringLiteral) {
                         hasStringLiterals = true;
                     }

--- a/tests/cases/fourslash/signatureHelpConstructorCallParamProperties.ts
+++ b/tests/cases/fourslash/signatureHelpConstructorCallParamProperties.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts' />
+
+////class Circle {
+////    /**
+////      * Initialize a circle.
+////      * @param  radius The radius of the circle.
+////      */
+////    constructor(private radius: number) {
+////    }
+////}
+////var a = new Circle(/**/
+
+goTo.marker('');
+verify.signatureHelpCountIs(1);
+verify.currentSignatureHelpIs("Circle(radius: number): Circle");
+verify.currentParameterHelpArgumentNameIs("radius");
+verify.currentParameterSpanIs("radius: number");
+verify.currentParameterHelpArgumentDocCommentIs("The radius of the circle.");


### PR DESCRIPTION
When constructing signature from declaration include parameter symbol instead of property symbol of parameter-property declaration.
Fixes #4566