### PR TITLE
restrict the scope of parameters\type parameters

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -492,12 +492,16 @@ namespace ts {
                                     : false;
                             }
                             if (meaning & SymbolFlags.Value && result.flags & SymbolFlags.FunctionScopedVariable) {
-                                // function scoped variables are visible only inside function body and parameter list
-                                // technically here we might mix parameters and variables declared in function,
-                                // however this case is detected separately when checking initializers of parameters
+                                // parameters are visible only inside function body, parameter list and return type
+                                // technically for parameter list case here we might mix parameters and variables declared in function,
+                                // however it is detected separately when checking initializers of parameters
                                 // to make sure that they reference no variables declared after them.
-                                useResult = lastLocation === (<FunctionLikeDeclaration>location).type ||
-                                    lastLocation.kind === SyntaxKind.Parameter;
+                                useResult =
+                                    lastLocation.kind === SyntaxKind.Parameter ||
+                                    (
+                                        lastLocation === (<FunctionLikeDeclaration>location).type &&
+                                        result.valueDeclaration.kind === SyntaxKind.Parameter
+                                    );
                             }
                         }
 

--- a/tests/baselines/reference/functionVariableInReturnTypeAnnotation.errors.txt
+++ b/tests/baselines/reference/functionVariableInReturnTypeAnnotation.errors.txt
@@ -1,0 +1,10 @@
+tests/cases/compiler/functionVariableInReturnTypeAnnotation.ts(1,24): error TS2304: Cannot find name 'b'.
+
+
+==== tests/cases/compiler/functionVariableInReturnTypeAnnotation.ts (1 errors) ====
+    function bar(): typeof b {
+                           ~
+!!! error TS2304: Cannot find name 'b'.
+        var b = 1;
+        return undefined;
+    }

--- a/tests/baselines/reference/functionVariableInReturnTypeAnnotation.js
+++ b/tests/baselines/reference/functionVariableInReturnTypeAnnotation.js
@@ -1,0 +1,11 @@
+//// [functionVariableInReturnTypeAnnotation.ts]
+function bar(): typeof b {
+    var b = 1;
+    return undefined;
+}
+
+//// [functionVariableInReturnTypeAnnotation.js]
+function bar() {
+    var b = 1;
+    return undefined;
+}

--- a/tests/baselines/reference/parameterNamesInTypeParameterList.errors.txt
+++ b/tests/baselines/reference/parameterNamesInTypeParameterList.errors.txt
@@ -1,0 +1,44 @@
+tests/cases/compiler/parameterNamesInTypeParameterList.ts(1,30): error TS2304: Cannot find name 'a'.
+tests/cases/compiler/parameterNamesInTypeParameterList.ts(5,30): error TS2304: Cannot find name 'a'.
+tests/cases/compiler/parameterNamesInTypeParameterList.ts(9,30): error TS2304: Cannot find name 'a'.
+tests/cases/compiler/parameterNamesInTypeParameterList.ts(14,22): error TS2304: Cannot find name 'a'.
+tests/cases/compiler/parameterNamesInTypeParameterList.ts(17,22): error TS2304: Cannot find name 'a'.
+tests/cases/compiler/parameterNamesInTypeParameterList.ts(20,22): error TS2304: Cannot find name 'a'.
+
+
+==== tests/cases/compiler/parameterNamesInTypeParameterList.ts (6 errors) ====
+    function f0<T extends typeof a>(a: T) {
+                                 ~
+!!! error TS2304: Cannot find name 'a'.
+    	a.b;
+    }
+    
+    function f1<T extends typeof a>({a}: {a:T}) {
+                                 ~
+!!! error TS2304: Cannot find name 'a'.
+    	a.b;
+    }
+    
+    function f2<T extends typeof a>([a]: T[]) {
+                                 ~
+!!! error TS2304: Cannot find name 'a'.
+    	a.b;
+    }
+    
+    class A {
+    	m0<T extends typeof a>(a: T) {
+    	                    ~
+!!! error TS2304: Cannot find name 'a'.
+    		a.b
+    	}
+    	m1<T extends typeof a>({a}: {a:T}) {
+    	                    ~
+!!! error TS2304: Cannot find name 'a'.
+    		a.b
+    	}
+    	m2<T extends typeof a>([a]: T[]) {
+    	                    ~
+!!! error TS2304: Cannot find name 'a'.
+    		a.b
+    	}
+    }

--- a/tests/baselines/reference/parameterNamesInTypeParameterList.js
+++ b/tests/baselines/reference/parameterNamesInTypeParameterList.js
@@ -1,0 +1,53 @@
+//// [parameterNamesInTypeParameterList.ts]
+function f0<T extends typeof a>(a: T) {
+	a.b;
+}
+
+function f1<T extends typeof a>({a}: {a:T}) {
+	a.b;
+}
+
+function f2<T extends typeof a>([a]: T[]) {
+	a.b;
+}
+
+class A {
+	m0<T extends typeof a>(a: T) {
+		a.b
+	}
+	m1<T extends typeof a>({a}: {a:T}) {
+		a.b
+	}
+	m2<T extends typeof a>([a]: T[]) {
+		a.b
+	}
+}
+
+//// [parameterNamesInTypeParameterList.js]
+function f0(a) {
+    a.b;
+}
+function f1(_a) {
+    var a = _a.a;
+    a.b;
+}
+function f2(_a) {
+    var a = _a[0];
+    a.b;
+}
+var A = (function () {
+    function A() {
+    }
+    A.prototype.m0 = function (a) {
+        a.b;
+    };
+    A.prototype.m1 = function (_a) {
+        var a = _a.a;
+        a.b;
+    };
+    A.prototype.m2 = function (_a) {
+        var a = _a[0];
+        a.b;
+    };
+    return A;
+})();

--- a/tests/baselines/reference/typeParametersAndParametersInComputedNames.errors.txt
+++ b/tests/baselines/reference/typeParametersAndParametersInComputedNames.errors.txt
@@ -1,0 +1,17 @@
+tests/cases/compiler/typeParametersAndParametersInComputedNames.ts(6,10): error TS2304: Cannot find name 'T'.
+tests/cases/compiler/typeParametersAndParametersInComputedNames.ts(6,13): error TS2304: Cannot find name 'a'.
+
+
+==== tests/cases/compiler/typeParametersAndParametersInComputedNames.ts (2 errors) ====
+    function foo<T>(a: T) : string {
+        return "";
+    }
+    
+    class A {
+        [foo<T>(a)]<T>(a: T) {  
+             ~
+!!! error TS2304: Cannot find name 'T'.
+                ~
+!!! error TS2304: Cannot find name 'a'.
+        }
+    }

--- a/tests/baselines/reference/typeParametersAndParametersInComputedNames.js
+++ b/tests/baselines/reference/typeParametersAndParametersInComputedNames.js
@@ -1,0 +1,21 @@
+//// [typeParametersAndParametersInComputedNames.ts]
+function foo<T>(a: T) : string {
+    return "";
+}
+
+class A {
+    [foo<T>(a)]<T>(a: T) {  
+    }
+}
+
+//// [typeParametersAndParametersInComputedNames.js]
+function foo(a) {
+    return "";
+}
+var A = (function () {
+    function A() {
+    }
+    A.prototype[foo(a)] = function (a) {
+    };
+    return A;
+})();

--- a/tests/cases/compiler/functionVariableInReturnTypeAnnotation.ts
+++ b/tests/cases/compiler/functionVariableInReturnTypeAnnotation.ts
@@ -1,0 +1,4 @@
+function bar(): typeof b {
+    var b = 1;
+    return undefined;
+}

--- a/tests/cases/compiler/parameterNamesInTypeParameterList.ts
+++ b/tests/cases/compiler/parameterNamesInTypeParameterList.ts
@@ -1,0 +1,23 @@
+function f0<T extends typeof a>(a: T) {
+	a.b;
+}
+
+function f1<T extends typeof a>({a}: {a:T}) {
+	a.b;
+}
+
+function f2<T extends typeof a>([a]: T[]) {
+	a.b;
+}
+
+class A {
+	m0<T extends typeof a>(a: T) {
+		a.b
+	}
+	m1<T extends typeof a>({a}: {a:T}) {
+		a.b
+	}
+	m2<T extends typeof a>([a]: T[]) {
+		a.b
+	}
+}

--- a/tests/cases/compiler/typeParametersAndParametersInComputedNames.ts
+++ b/tests/cases/compiler/typeParametersAndParametersInComputedNames.ts
@@ -1,0 +1,8 @@
+function foo<T>(a: T) : string {
+    return "";
+}
+
+class A {
+    [foo<T>(a)]<T>(a: T) {  
+    }
+}


### PR DESCRIPTION
- Parameters are only visible in parameter list, return type annotation (via type query)
- Type parameters are only visible in parameter list, return type annotation and type parameter list

Fixes #5699, #5704 and #5707 (thanks to @sandersn for catching this)