### PR TITLE
Enable await in ES5 and ES2015 script mode

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2978,7 +2978,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     }
                     else {
                         // this is top level converted loop so we need to create an alias for 'this' here
-                        // NOTE:
+                        // NOTE: 
                         // if converted loops were all nested in arrow function then we'll always emit '_this' so convertedLoopState.thisName will not be set.
                         // If it is set this means that all nested loops are not nested in arrow function and it is safe to capture 'this'.
                         write(`var ${convertedLoopState.thisName} = this;`);

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2978,7 +2978,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     }
                     else {
                         // this is top level converted loop so we need to create an alias for 'this' here
-                        // NOTE: 
+                        // NOTE:
                         // if converted loops were all nested in arrow function then we'll always emit '_this' so convertedLoopState.thisName will not be set.
                         // If it is set this means that all nested loops are not nested in arrow function and it is safe to capture 'this'.
                         write(`var ${convertedLoopState.thisName} = this;`);
@@ -4526,10 +4526,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     emitSignatureParameters(node);
                 }
 
-                // Even though generators are a ES6 only feature, the functionality is wiedely supported
-                // in current browsers and latest node, therefore showing some tolerance
                 const isAsync = isAsyncFunctionLike(node);
-                if (isAsync && (languageVersion === ScriptTarget.ES6 || languageVersion === ScriptTarget.ES2015 || languageVersion === ScriptTarget.ES5)) {
+                if (isAsync) {
                     emitAsyncFunctionBodyForES6(node);
                 }
                 else {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4526,8 +4526,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     emitSignatureParameters(node);
                 }
 
+                // Even though generators are a ES6 only feature, the functionality is wiedely supported
+                // in current browsers and latest node, therefore showing some tolerance
                 const isAsync = isAsyncFunctionLike(node);
-                if (isAsync && languageVersion === ScriptTarget.ES6) {
+                if (isAsync && (languageVersion === ScriptTarget.ES6 || languageVersion === ScriptTarget.ES2015 || languageVersion === ScriptTarget.ES5)) {
                     emitAsyncFunctionBodyForES6(node);
                 }
                 else {


### PR DESCRIPTION
Even though strictly generators are an ES6 feature the real world support is large enough to use the feature in well known environments like node.js or Electron app. 

Since the previous output was not working at all anyway it feels like a good compromise to at least emit working code while still having the warning in place.