### PR TITLE
lint: Forbid ++ and -- operators in many positions

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -108,17 +108,6 @@ var serverCoreSources = [
     return path.join(serverDirectory, f);
 });
 
-var scriptSources = [
-    "tslint/booleanTriviaRule.ts",
-    "tslint/nextLineRule.ts",
-    "tslint/noNullRule.ts",
-    "tslint/preferConstRule.ts",
-    "tslint/typeOperatorSpacingRule.ts",
-    "tslint/noInOperatorRule.ts"
-].map(function (f) {
-    return path.join(scriptsDirectory, f);
-});
-
 var serverSources = serverCoreSources.concat(servicesSources);
 
 var languageServiceLibrarySources = [
@@ -877,7 +866,8 @@ var tslintRules = ([
     "preferConstRule",
     "booleanTriviaRule",
     "typeOperatorSpacingRule",
-    "noInOperatorRule"
+    "noInOperatorRule",
+    "noIncrementDecrementRule"
 ]);
 var tslintRulesFiles = tslintRules.map(function(p) {
     return path.join(tslintRuleDir, p + ".ts");
@@ -923,7 +913,7 @@ function lintFileAsync(options, path, cb) {
 var lintTargets = compilerSources
     .concat(harnessCoreSources)
     .concat(serverCoreSources)
-    .concat(scriptSources);
+    .concat(tslintRulesFiles);
 
 desc("Runs tslint on the compiler sources");
 task("lint", ["build-rules"], function() {

--- a/scripts/tslint/noIncrementDecrementRule.ts
+++ b/scripts/tslint/noIncrementDecrementRule.ts
@@ -3,7 +3,7 @@ import * as ts from "typescript";
 
 
 export class Rule extends Lint.Rules.AbstractRule {
-    public static FAILURE_STRING = "Don't use '++' or '--' operators outside for for loops or statements - prefer '+= 1' and '-= 1'.";
+    public static FAILURE_STRING = "Don't use '++' or '--' operators outside for loops or statements - prefer '+= 1' and '-= 1'.";
 
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
         return this.applyWithWalker(new IncrementDecrementWalker(sourceFile, this.getOptions()));

--- a/scripts/tslint/noIncrementDecrementRule.ts
+++ b/scripts/tslint/noIncrementDecrementRule.ts
@@ -1,0 +1,35 @@
+import * as Lint from "tslint/lib/lint";
+import * as ts from "typescript";
+
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public static FAILURE_STRING = "Don't use '++' or '--' operators outside for for loops or statements - prefer '+= 1' and '-= 1'.";
+
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new IncrementDecrementWalker(sourceFile, this.getOptions()));
+    }
+}
+
+class IncrementDecrementWalker extends Lint.RuleWalker {
+
+    visitPostfixUnaryExpression(node: ts.PostfixUnaryExpression) {
+        super.visitPostfixUnaryExpression(node);
+        if (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator == ts.SyntaxKind.MinusMinusToken) {
+            this.visitIncrementDecrement(node);
+        }
+    }
+
+    visitPrefixUnaryExpression(node: ts.PrefixUnaryExpression) {
+        super.visitPrefixUnaryExpression(node);
+        if (node.operator === ts.SyntaxKind.PlusPlusToken || node.operator == ts.SyntaxKind.MinusMinusToken) {
+            this.visitIncrementDecrement(node);
+        }
+    }
+
+    visitIncrementDecrement(node: ts.UnaryExpression) {
+        if (node.parent && (node.parent.kind === ts.SyntaxKind.ExpressionStatement || node.parent.kind === ts.SyntaxKind.ForStatement)) {
+            return;
+        }
+        this.addFailure(this.createFailure(node.getStart(), node.getWidth(), Rule.FAILURE_STRING));
+    }
+}

--- a/tslint.json
+++ b/tslint.json
@@ -41,6 +41,7 @@
         "boolean-trivia": true,
         "type-operator-spacing": true,
         "prefer-const": true,
-        "no-in-operator": true
+        "no-in-operator": true,
+        "no-increment-decrement": true
   }
 }


### PR DESCRIPTION
Always forbid prefix versions, forbid postfix versions when not used in a for statement, an expression statement, or an element access expression.

@DanielRosenwasser is still on the fence about this rule, since we violate it so many times already and isn't sure if its the right call to add it.