### PR TITLE
Respect root dir/common src dir when generating module names

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1891,7 +1891,7 @@ namespace ts {
     export function getExternalModuleNameFromPath(host: EmitHost, fileName: string): string {
         const getCanonicalFileName = (f: string) => host.getCanonicalFileName(f);
         const dir = toPath(host.getCommonSourceDirectory(), host.getCurrentDirectory(), getCanonicalFileName);
-        const filePath = toPath(fileName, host.getCurrentDirectory(), getCanonicalFileName);
+        const filePath = getNormalizedAbsolutePath(fileName, host.getCurrentDirectory());
         const relativePath = getRelativePathToDirectoryOrUrl(dir, filePath, dir, getCanonicalFileName, /*isAbsolutePathAnUrl*/ false);
         return removeFileExtension(relativePath);
     }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1889,8 +1889,10 @@ namespace ts {
      * Resolves a local path to a path which is absolute to the base of the emit
      */
     export function getExternalModuleNameFromPath(host: EmitHost, fileName: string): string {
-        const dir = toPath(host.getCommonSourceDirectory(), host.getCurrentDirectory(), f => host.getCanonicalFileName(f));
-        const relativePath = getRelativePathToDirectoryOrUrl(dir, fileName, dir, f => host.getCanonicalFileName(f), /*isAbsolutePathAnUrl*/ false);
+        const getCanonicalFileName = (f: string) => host.getCanonicalFileName(f);
+        const dir = toPath(host.getCommonSourceDirectory(), host.getCurrentDirectory(), getCanonicalFileName);
+        const filePath = toPath(fileName, host.getCurrentDirectory(), getCanonicalFileName);
+        const relativePath = getRelativePathToDirectoryOrUrl(dir, filePath, dir, getCanonicalFileName, /*isAbsolutePathAnUrl*/ false);
         return removeFileExtension(relativePath);
     }
 

--- a/tests/baselines/reference/commonSourceDir5.js
+++ b/tests/baselines/reference/commonSourceDir5.js
@@ -16,17 +16,17 @@ export var pi = Math.PI;
 export var y = x * i;
 
 //// [concat.js]
-define("B:/baz", ["require", "exports", "A:/bar", "A:/foo"], function (require, exports, bar_1, foo_1) {
+define("b:/baz", ["require", "exports", "a:/bar", "a:/foo"], function (require, exports, bar_1, foo_1) {
     "use strict";
     exports.pi = Math.PI;
     exports.y = bar_1.x * foo_1.i;
 });
-define("A:/foo", ["require", "exports", "B:/baz"], function (require, exports, baz_1) {
+define("a:/foo", ["require", "exports", "b:/baz"], function (require, exports, baz_1) {
     "use strict";
     exports.i = Math.sqrt(-1);
     exports.z = baz_1.pi * baz_1.pi;
 });
-define("A:/bar", ["require", "exports", "A:/foo"], function (require, exports, foo_2) {
+define("a:/bar", ["require", "exports", "a:/foo"], function (require, exports, foo_2) {
     "use strict";
     exports.x = foo_2.z + foo_2.z;
 });

--- a/tests/baselines/reference/commonSourceDir5.js
+++ b/tests/baselines/reference/commonSourceDir5.js
@@ -16,17 +16,17 @@ export var pi = Math.PI;
 export var y = x * i;
 
 //// [concat.js]
-define("b:/baz", ["require", "exports", "a:/bar", "a:/foo"], function (require, exports, bar_1, foo_1) {
+define("B:/baz", ["require", "exports", "A:/bar", "A:/foo"], function (require, exports, bar_1, foo_1) {
     "use strict";
     exports.pi = Math.PI;
     exports.y = bar_1.x * foo_1.i;
 });
-define("a:/foo", ["require", "exports", "b:/baz"], function (require, exports, baz_1) {
+define("A:/foo", ["require", "exports", "B:/baz"], function (require, exports, baz_1) {
     "use strict";
     exports.i = Math.sqrt(-1);
     exports.z = baz_1.pi * baz_1.pi;
 });
-define("a:/bar", ["require", "exports", "a:/foo"], function (require, exports, foo_2) {
+define("A:/bar", ["require", "exports", "A:/foo"], function (require, exports, foo_2) {
     "use strict";
     exports.x = foo_2.z + foo_2.z;
 });

--- a/tests/baselines/reference/commonSourceDir6.js
+++ b/tests/baselines/reference/commonSourceDir6.js
@@ -16,17 +16,17 @@ export var pi = Math.PI;
 export var y = x * i;
 
 //// [concat.js]
-define("tests/cases/compiler/baz", ["require", "exports", "tests/cases/compiler/a/bar", "tests/cases/compiler/a/foo"], function (require, exports, bar_1, foo_1) {
+define("baz", ["require", "exports", "a/bar", "a/foo"], function (require, exports, bar_1, foo_1) {
     "use strict";
     exports.pi = Math.PI;
     exports.y = bar_1.x * foo_1.i;
 });
-define("tests/cases/compiler/a/foo", ["require", "exports", "tests/cases/compiler/baz"], function (require, exports, baz_1) {
+define("a/foo", ["require", "exports", "baz"], function (require, exports, baz_1) {
     "use strict";
     exports.i = Math.sqrt(-1);
     exports.z = baz_1.pi * baz_1.pi;
 });
-define("tests/cases/compiler/a/bar", ["require", "exports", "tests/cases/compiler/a/foo"], function (require, exports, foo_2) {
+define("a/bar", ["require", "exports", "a/foo"], function (require, exports, foo_2) {
     "use strict";
     exports.x = foo_2.z + foo_2.z;
 });

--- a/tests/baselines/reference/filesEmittingIntoSameOutputWithOutOption.js
+++ b/tests/baselines/reference/filesEmittingIntoSameOutputWithOutOption.js
@@ -10,7 +10,7 @@ function foo() {
 
 
 //// [a.js]
-define("tests/cases/compiler/a", ["require", "exports"], function (require, exports) {
+define("a", ["require", "exports"], function (require, exports) {
     "use strict";
     var c = (function () {
         function c() {

--- a/tests/baselines/reference/getEmitOutputSingleFile2.baseline
+++ b/tests/baselines/reference/getEmitOutputSingleFile2.baseline
@@ -23,7 +23,7 @@ declare class Foo {
     x: string;
     y: number;
 }
-declare module "inputfile3" {
+declare module "inputFile3" {
     export var foo: number;
     export var bar: string;
 }

--- a/tests/baselines/reference/getEmitOutputSingleFile2.baseline
+++ b/tests/baselines/reference/getEmitOutputSingleFile2.baseline
@@ -23,7 +23,7 @@ declare class Foo {
     x: string;
     y: number;
 }
-declare module "inputFile3" {
+declare module "inputfile3" {
     export var foo: number;
     export var bar: string;
 }

--- a/tests/baselines/reference/outFilerootDirModuleNamesAmd.js
+++ b/tests/baselines/reference/outFilerootDirModuleNamesAmd.js
@@ -1,0 +1,25 @@
+//// [tests/cases/conformance/es6/moduleExportsAmd/outFilerootDirModuleNamesAmd.ts] ////
+
+//// [a.ts]
+import foo from "./b";
+export default class Foo {}
+foo();
+
+//// [b.ts]
+import Foo from "./a";
+export default function foo() { new Foo(); }
+
+
+//// [output.js]
+define("b", ["require", "exports", "a"], function (require, exports, a_1) {
+    "use strict";
+    function foo() { new a_1.default(); }
+    exports.default = foo;
+});
+define("a", ["require", "exports", "b"], function (require, exports, b_1) {
+    "use strict";
+    class Foo {
+    }
+    exports.default = Foo;
+    b_1.default();
+});

--- a/tests/baselines/reference/outFilerootDirModuleNamesAmd.symbols
+++ b/tests/baselines/reference/outFilerootDirModuleNamesAmd.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/es6/moduleExportsAmd/src/a.ts ===
+import foo from "./b";
+>foo : Symbol(foo, Decl(a.ts, 0, 6))
+
+export default class Foo {}
+>Foo : Symbol(Foo, Decl(a.ts, 0, 22))
+
+foo();
+>foo : Symbol(foo, Decl(a.ts, 0, 6))
+
+=== tests/cases/conformance/es6/moduleExportsAmd/src/b.ts ===
+import Foo from "./a";
+>Foo : Symbol(Foo, Decl(b.ts, 0, 6))
+
+export default function foo() { new Foo(); }
+>foo : Symbol(foo, Decl(b.ts, 0, 22))
+>Foo : Symbol(Foo, Decl(b.ts, 0, 6))
+

--- a/tests/baselines/reference/outFilerootDirModuleNamesAmd.types
+++ b/tests/baselines/reference/outFilerootDirModuleNamesAmd.types
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/es6/moduleExportsAmd/src/a.ts ===
+import foo from "./b";
+>foo : () => void
+
+export default class Foo {}
+>Foo : Foo
+
+foo();
+>foo() : void
+>foo : () => void
+
+=== tests/cases/conformance/es6/moduleExportsAmd/src/b.ts ===
+import Foo from "./a";
+>Foo : typeof Foo
+
+export default function foo() { new Foo(); }
+>foo : () => void
+>new Foo() : Foo
+>Foo : typeof Foo
+

--- a/tests/baselines/reference/outFilerootDirModuleNamesSystem.js
+++ b/tests/baselines/reference/outFilerootDirModuleNamesSystem.js
@@ -1,0 +1,44 @@
+//// [tests/cases/conformance/es6/moduleExportsSystem/outFilerootDirModuleNamesSystem.ts] ////
+
+//// [a.ts]
+import foo from "./b";
+export default class Foo {}
+foo();
+
+//// [b.ts]
+import Foo from "./a";
+export default function foo() { new Foo(); }
+
+
+//// [output.js]
+System.register("b", ["a"], function(exports_1) {
+    "use strict";
+    var a_1;
+    function foo() { new a_1.default(); }
+    exports_1("default", foo);
+    return {
+        setters:[
+            function (a_1_1) {
+                a_1 = a_1_1;
+            }],
+        execute: function() {
+        }
+    }
+});
+System.register("a", ["b"], function(exports_2) {
+    "use strict";
+    var b_1;
+    var Foo;
+    return {
+        setters:[
+            function (b_1_1) {
+                b_1 = b_1_1;
+            }],
+        execute: function() {
+            class Foo {
+            }
+            exports_2("default", Foo);
+            b_1.default();
+        }
+    }
+});

--- a/tests/baselines/reference/outFilerootDirModuleNamesSystem.symbols
+++ b/tests/baselines/reference/outFilerootDirModuleNamesSystem.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/es6/moduleExportsSystem/src/a.ts ===
+import foo from "./b";
+>foo : Symbol(foo, Decl(a.ts, 0, 6))
+
+export default class Foo {}
+>Foo : Symbol(Foo, Decl(a.ts, 0, 22))
+
+foo();
+>foo : Symbol(foo, Decl(a.ts, 0, 6))
+
+=== tests/cases/conformance/es6/moduleExportsSystem/src/b.ts ===
+import Foo from "./a";
+>Foo : Symbol(Foo, Decl(b.ts, 0, 6))
+
+export default function foo() { new Foo(); }
+>foo : Symbol(foo, Decl(b.ts, 0, 22))
+>Foo : Symbol(Foo, Decl(b.ts, 0, 6))
+

--- a/tests/baselines/reference/outFilerootDirModuleNamesSystem.types
+++ b/tests/baselines/reference/outFilerootDirModuleNamesSystem.types
@@ -1,0 +1,20 @@
+=== tests/cases/conformance/es6/moduleExportsSystem/src/a.ts ===
+import foo from "./b";
+>foo : () => void
+
+export default class Foo {}
+>Foo : Foo
+
+foo();
+>foo() : void
+>foo : () => void
+
+=== tests/cases/conformance/es6/moduleExportsSystem/src/b.ts ===
+import Foo from "./a";
+>Foo : typeof Foo
+
+export default function foo() { new Foo(); }
+>foo : () => void
+>new Foo() : Foo
+>Foo : typeof Foo
+

--- a/tests/baselines/reference/outModuleConcatAmd.js
+++ b/tests/baselines/reference/outModuleConcatAmd.js
@@ -14,7 +14,7 @@ var __extends = (this && this.__extends) || function (d, b) {
     function __() { this.constructor = d; }
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
-define("tests/cases/compiler/ref/a", ["require", "exports"], function (require, exports) {
+define("ref/a", ["require", "exports"], function (require, exports) {
     "use strict";
     var A = (function () {
         function A() {
@@ -23,7 +23,7 @@ define("tests/cases/compiler/ref/a", ["require", "exports"], function (require, 
     })();
     exports.A = A;
 });
-define("tests/cases/compiler/b", ["require", "exports", "tests/cases/compiler/ref/a"], function (require, exports, a_1) {
+define("b", ["require", "exports", "ref/a"], function (require, exports, a_1) {
     "use strict";
     var B = (function (_super) {
         __extends(B, _super);
@@ -37,12 +37,12 @@ define("tests/cases/compiler/b", ["require", "exports", "tests/cases/compiler/re
 //# sourceMappingURL=all.js.map
 
 //// [all.d.ts]
-declare module "tests/cases/compiler/ref/a" {
+declare module "ref/a" {
     export class A {
     }
 }
-declare module "tests/cases/compiler/b" {
-    import { A } from "tests/cases/compiler/ref/a";
+declare module "b" {
+    import { A } from "ref/a";
     export class B extends A {
     }
 }

--- a/tests/baselines/reference/outModuleConcatAmd.sourcemap.txt
+++ b/tests/baselines/reference/outModuleConcatAmd.sourcemap.txt
@@ -13,7 +13,7 @@ sourceFile:tests/cases/compiler/ref/a.ts
 >>>    function __() { this.constructor = d; }
 >>>    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 >>>};
->>>define("tests/cases/compiler/ref/a", ["require", "exports"], function (require, exports) {
+>>>define("ref/a", ["require", "exports"], function (require, exports) {
 >>>    "use strict";
 >>>    var A = (function () {
 1 >^^^^
@@ -79,7 +79,7 @@ emittedFile:all.js
 sourceFile:tests/cases/compiler/b.ts
 -------------------------------------------------------------------
 >>>});
->>>define("tests/cases/compiler/b", ["require", "exports", "tests/cases/compiler/ref/a"], function (require, exports, a_1) {
+>>>define("b", ["require", "exports", "ref/a"], function (require, exports, a_1) {
 >>>    "use strict";
 >>>    var B = (function (_super) {
 1 >^^^^

--- a/tests/baselines/reference/outModuleConcatCommonjs.js
+++ b/tests/baselines/reference/outModuleConcatCommonjs.js
@@ -20,12 +20,12 @@ var __extends = (this && this.__extends) || function (d, b) {
 //# sourceMappingURL=all.js.map
 
 //// [all.d.ts]
-declare module "tests/cases/compiler/ref/a" {
+declare module "ref/a" {
     export class A {
     }
 }
-declare module "tests/cases/compiler/b" {
-    import { A } from "tests/cases/compiler/ref/a";
+declare module "b" {
+    import { A } from "ref/a";
     export class B extends A {
     }
 }

--- a/tests/baselines/reference/outModuleConcatES6.js
+++ b/tests/baselines/reference/outModuleConcatES6.js
@@ -15,12 +15,12 @@ export class B extends A { }
 //# sourceMappingURL=all.js.map
 
 //// [all.d.ts]
-declare module "tests/cases/compiler/ref/a" {
+declare module "ref/a" {
     export class A {
     }
 }
-declare module "tests/cases/compiler/b" {
-    import { A } from "tests/cases/compiler/ref/a";
+declare module "b" {
+    import { A } from "ref/a";
     export class B extends A {
     }
 }

--- a/tests/baselines/reference/outModuleConcatSystem.js
+++ b/tests/baselines/reference/outModuleConcatSystem.js
@@ -14,7 +14,7 @@ var __extends = (this && this.__extends) || function (d, b) {
     function __() { this.constructor = d; }
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
-System.register("tests/cases/compiler/ref/a", [], function(exports_1) {
+System.register("ref/a", [], function(exports_1) {
     "use strict";
     var A;
     return {
@@ -29,7 +29,7 @@ System.register("tests/cases/compiler/ref/a", [], function(exports_1) {
         }
     }
 });
-System.register("tests/cases/compiler/b", ["tests/cases/compiler/ref/a"], function(exports_2) {
+System.register("b", ["ref/a"], function(exports_2) {
     "use strict";
     var a_1;
     var B;
@@ -53,12 +53,12 @@ System.register("tests/cases/compiler/b", ["tests/cases/compiler/ref/a"], functi
 //# sourceMappingURL=all.js.map
 
 //// [all.d.ts]
-declare module "tests/cases/compiler/ref/a" {
+declare module "ref/a" {
     export class A {
     }
 }
-declare module "tests/cases/compiler/b" {
-    import { A } from "tests/cases/compiler/ref/a";
+declare module "b" {
+    import { A } from "ref/a";
     export class B extends A {
     }
 }

--- a/tests/baselines/reference/outModuleConcatSystem.sourcemap.txt
+++ b/tests/baselines/reference/outModuleConcatSystem.sourcemap.txt
@@ -13,7 +13,7 @@ sourceFile:tests/cases/compiler/ref/a.ts
 >>>    function __() { this.constructor = d; }
 >>>    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 >>>};
->>>System.register("tests/cases/compiler/ref/a", [], function(exports_1) {
+>>>System.register("ref/a", [], function(exports_1) {
 >>>    "use strict";
 >>>    var A;
 >>>    return {
@@ -82,7 +82,7 @@ sourceFile:tests/cases/compiler/b.ts
 >>>        }
 >>>    }
 >>>});
->>>System.register("tests/cases/compiler/b", ["tests/cases/compiler/ref/a"], function(exports_2) {
+>>>System.register("b", ["ref/a"], function(exports_2) {
 >>>    "use strict";
 >>>    var a_1;
 >>>    var B;

--- a/tests/baselines/reference/outModuleConcatUmd.js
+++ b/tests/baselines/reference/outModuleConcatUmd.js
@@ -20,12 +20,12 @@ var __extends = (this && this.__extends) || function (d, b) {
 //# sourceMappingURL=all.js.map
 
 //// [all.d.ts]
-declare module "tests/cases/compiler/ref/a" {
+declare module "ref/a" {
     export class A {
     }
 }
-declare module "tests/cases/compiler/b" {
-    import { A } from "tests/cases/compiler/ref/a";
+declare module "b" {
+    import { A } from "ref/a";
     export class B extends A {
     }
 }

--- a/tests/baselines/reference/outModuleTripleSlashRefs.js
+++ b/tests/baselines/reference/outModuleTripleSlashRefs.js
@@ -42,7 +42,7 @@ var Foo = (function () {
     }
     return Foo;
 })();
-define("tests/cases/compiler/ref/a", ["require", "exports"], function (require, exports) {
+define("ref/a", ["require", "exports"], function (require, exports) {
     "use strict";
     /// <reference path="./b.ts" />
     var A = (function () {
@@ -52,7 +52,7 @@ define("tests/cases/compiler/ref/a", ["require", "exports"], function (require, 
     })();
     exports.A = A;
 });
-define("tests/cases/compiler/b", ["require", "exports", "tests/cases/compiler/ref/a"], function (require, exports, a_1) {
+define("b", ["require", "exports", "ref/a"], function (require, exports, a_1) {
     "use strict";
     var B = (function (_super) {
         __extends(B, _super);
@@ -71,13 +71,13 @@ declare class Foo {
     member: Bar;
 }
 declare var GlobalFoo: Foo;
-declare module "tests/cases/compiler/ref/a" {
+declare module "ref/a" {
     export class A {
         member: typeof GlobalFoo;
     }
 }
-declare module "tests/cases/compiler/b" {
-    import { A } from "tests/cases/compiler/ref/a";
+declare module "b" {
+    import { A } from "ref/a";
     export class B extends A {
     }
 }

--- a/tests/baselines/reference/outModuleTripleSlashRefs.sourcemap.txt
+++ b/tests/baselines/reference/outModuleTripleSlashRefs.sourcemap.txt
@@ -58,7 +58,7 @@ sourceFile:tests/cases/compiler/ref/b.ts
 2 >^
 3 > 
 4 > ^^^^
-5 >     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
+5 >     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >
 2 >}
 3 > 
@@ -74,7 +74,7 @@ sourceFile:tests/cases/compiler/ref/b.ts
 emittedFile:all.js
 sourceFile:tests/cases/compiler/ref/a.ts
 -------------------------------------------------------------------
->>>define("tests/cases/compiler/ref/a", ["require", "exports"], function (require, exports) {
+>>>define("ref/a", ["require", "exports"], function (require, exports) {
 >>>    "use strict";
 >>>    /// <reference path="./b.ts" />
 1->^^^^
@@ -155,7 +155,7 @@ emittedFile:all.js
 sourceFile:tests/cases/compiler/b.ts
 -------------------------------------------------------------------
 >>>});
->>>define("tests/cases/compiler/b", ["require", "exports", "tests/cases/compiler/ref/a"], function (require, exports, a_1) {
+>>>define("b", ["require", "exports", "ref/a"], function (require, exports, a_1) {
 >>>    "use strict";
 >>>    var B = (function (_super) {
 1 >^^^^

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/bin/test.js
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/bin/test.js
@@ -28,7 +28,7 @@ define("outputdir_module_multifolder_ref/m2", ["require", "exports"], function (
     }
     exports.m2_f1 = m2_f1;
 });
-define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
     "use strict";
     exports.a1 = 10;
     var c1 = (function () {

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile.sourcemap.txt
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile.sourcemap.txt
@@ -342,7 +342,7 @@ emittedFile:bin/test.js
 sourceFile:../test.ts
 -------------------------------------------------------------------
 >>>});
->>>define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+>>>define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
 >>>    "use strict";
 >>>    exports.a1 = 10;
 1 >^^^^

--- a/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
+++ b/tests/baselines/reference/project/mapRootAbsolutePathModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile/amd/bin/test.js
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile/amd/bin/test.js
@@ -28,7 +28,7 @@ define("outputdir_module_multifolder_ref/m2", ["require", "exports"], function (
     }
     exports.m2_f1 = m2_f1;
 });
-define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
     "use strict";
     exports.a1 = 10;
     var c1 = (function () {

--- a/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile/amd/mapRootRelativePathModuleMultifolderSpecifyOutputFile.sourcemap.txt
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile/amd/mapRootRelativePathModuleMultifolderSpecifyOutputFile.sourcemap.txt
@@ -342,7 +342,7 @@ emittedFile:bin/test.js
 sourceFile:../projects/outputdir_module_multifolder/test.ts
 -------------------------------------------------------------------
 >>>});
->>>define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+>>>define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
 >>>    "use strict";
 >>>    exports.a1 = 10;
 1 >^^^^

--- a/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
+++ b/tests/baselines/reference/project/mapRootRelativePathModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
+++ b/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputFile/amd/bin/test.js
+++ b/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputFile/amd/bin/test.js
@@ -28,7 +28,7 @@ define("outputdir_module_multifolder_ref/m2", ["require", "exports"], function (
     }
     exports.m2_f1 = m2_f1;
 });
-define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
     "use strict";
     exports.a1 = 10;
     var c1 = (function () {

--- a/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputFile/amd/maprootUrlModuleMultifolderSpecifyOutputFile.sourcemap.txt
+++ b/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputFile/amd/maprootUrlModuleMultifolderSpecifyOutputFile.sourcemap.txt
@@ -342,7 +342,7 @@ emittedFile:bin/test.js
 sourceFile:file:///tests/cases/projects/outputdir_module_multifolder/test.ts
 -------------------------------------------------------------------
 >>>});
->>>define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+>>>define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
 >>>    "use strict";
 >>>    exports.a1 = 10;
 1 >^^^^

--- a/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
+++ b/tests/baselines/reference/project/maprootUrlModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile/amd/bin/test.js
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile/amd/bin/test.js
@@ -28,7 +28,7 @@ define("outputdir_module_multifolder_ref/m2", ["require", "exports"], function (
     }
     exports.m2_f1 = m2_f1;
 });
-define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
     "use strict";
     exports.a1 = 10;
     var c1 = (function () {

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile/amd/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile.sourcemap.txt
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile/amd/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile.sourcemap.txt
@@ -342,7 +342,7 @@ emittedFile:bin/test.js
 sourceFile:outputdir_module_multifolder/test.ts
 -------------------------------------------------------------------
 >>>});
->>>define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+>>>define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
 >>>    "use strict";
 >>>    exports.a1 = 10;
 1 >^^^^

--- a/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
+++ b/tests/baselines/reference/project/maprootUrlsourcerootUrlModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
+++ b/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputFile/amd/bin/test.js
+++ b/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputFile/amd/bin/test.js
@@ -28,7 +28,7 @@ define("outputdir_module_multifolder_ref/m2", ["require", "exports"], function (
     }
     exports.m2_f1 = m2_f1;
 });
-define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
     "use strict";
     exports.a1 = 10;
     var c1 = (function () {

--- a/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
+++ b/tests/baselines/reference/project/outModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/bin/test.js
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/bin/test.js
@@ -28,7 +28,7 @@ define("outputdir_module_multifolder_ref/m2", ["require", "exports"], function (
     }
     exports.m2_f1 = m2_f1;
 });
-define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
     "use strict";
     exports.a1 = 10;
     var c1 = (function () {

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile.sourcemap.txt
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile/amd/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile.sourcemap.txt
@@ -342,7 +342,7 @@ emittedFile:bin/test.js
 sourceFile:outputdir_module_multifolder/test.ts
 -------------------------------------------------------------------
 >>>});
->>>define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+>>>define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
 >>>    "use strict";
 >>>    exports.a1 = 10;
 1 >^^^^

--- a/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
+++ b/tests/baselines/reference/project/sourceRootAbsolutePathModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile/amd/bin/test.js
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile/amd/bin/test.js
@@ -28,7 +28,7 @@ define("outputdir_module_multifolder_ref/m2", ["require", "exports"], function (
     }
     exports.m2_f1 = m2_f1;
 });
-define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
     "use strict";
     exports.a1 = 10;
     var c1 = (function () {

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile/amd/sourceRootRelativePathModuleMultifolderSpecifyOutputFile.sourcemap.txt
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile/amd/sourceRootRelativePathModuleMultifolderSpecifyOutputFile.sourcemap.txt
@@ -342,7 +342,7 @@ emittedFile:bin/test.js
 sourceFile:outputdir_module_multifolder/test.ts
 -------------------------------------------------------------------
 >>>});
->>>define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+>>>define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
 >>>    "use strict";
 >>>    exports.a1 = 10;
 1 >^^^^

--- a/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
+++ b/tests/baselines/reference/project/sourceRootRelativePathModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
+++ b/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputFile/amd/bin/test.js
+++ b/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputFile/amd/bin/test.js
@@ -28,7 +28,7 @@ define("outputdir_module_multifolder_ref/m2", ["require", "exports"], function (
     }
     exports.m2_f1 = m2_f1;
 });
-define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
     "use strict";
     exports.a1 = 10;
     var c1 = (function () {

--- a/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputFile/amd/sourcemapModuleMultifolderSpecifyOutputFile.sourcemap.txt
+++ b/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputFile/amd/sourcemapModuleMultifolderSpecifyOutputFile.sourcemap.txt
@@ -342,7 +342,7 @@ emittedFile:bin/test.js
 sourceFile:../test.ts
 -------------------------------------------------------------------
 >>>});
->>>define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+>>>define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
 >>>    "use strict";
 >>>    exports.a1 = 10;
 1 >^^^^

--- a/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
+++ b/tests/baselines/reference/project/sourcemapModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
+++ b/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputFile/amd/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputFile/amd/bin/test.js
+++ b/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputFile/amd/bin/test.js
@@ -28,7 +28,7 @@ define("outputdir_module_multifolder_ref/m2", ["require", "exports"], function (
     }
     exports.m2_f1 = m2_f1;
 });
-define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
     "use strict";
     exports.a1 = 10;
     var c1 = (function () {

--- a/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputFile/amd/sourcerootUrlModuleMultifolderSpecifyOutputFile.sourcemap.txt
+++ b/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputFile/amd/sourcerootUrlModuleMultifolderSpecifyOutputFile.sourcemap.txt
@@ -342,7 +342,7 @@ emittedFile:bin/test.js
 sourceFile:outputdir_module_multifolder/test.ts
 -------------------------------------------------------------------
 >>>});
->>>define("test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
+>>>define("outputdir_module_multifolder/test", ["require", "exports", "outputdir_module_multifolder/ref/m1", "outputdir_module_multifolder_ref/m2"], function (require, exports, m1, m2) {
 >>>    "use strict";
 >>>    exports.a1 = 10;
 1 >^^^^

--- a/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
+++ b/tests/baselines/reference/project/sourcerootUrlModuleMultifolderSpecifyOutputFile/node/bin/test.d.ts
@@ -14,7 +14,7 @@ declare module "outputdir_module_multifolder_ref/m2" {
     export var m2_instance1: m2_c1;
     export function m2_f1(): m2_c1;
 }
-declare module "test" {
+declare module "outputdir_module_multifolder/test" {
     import m1 = require("outputdir_module_multifolder/ref/m1");
     import m2 = require("outputdir_module_multifolder_ref/m2");
     export var a1: number;

--- a/tests/cases/conformance/es6/moduleExportsAmd/outFilerootDirModuleNamesAmd.ts
+++ b/tests/cases/conformance/es6/moduleExportsAmd/outFilerootDirModuleNamesAmd.ts
@@ -1,0 +1,12 @@
+// @target: ES6
+// @module: amd
+// @rootDir: tests/cases/conformance/es6/moduleExportsAmd/src
+// @outFile: output.js
+// @filename: src/a.ts
+import foo from "./b";
+export default class Foo {}
+foo();
+
+// @filename: src/b.ts
+import Foo from "./a";
+export default function foo() { new Foo(); }

--- a/tests/cases/conformance/es6/moduleExportsSystem/outFilerootDirModuleNamesSystem.ts
+++ b/tests/cases/conformance/es6/moduleExportsSystem/outFilerootDirModuleNamesSystem.ts
@@ -1,0 +1,12 @@
+// @target: ES6
+// @module: system
+// @rootDir: tests/cases/conformance/es6/moduleExportsSystem/src
+// @outFile: output.js
+// @filename: src/a.ts
+import foo from "./b";
+export default class Foo {}
+foo();
+
+// @filename: src/b.ts
+import Foo from "./a";
+export default function foo() { new Foo(); }


### PR DESCRIPTION
Fixes #5819.

The root of the issue was that we weren't combining/separating paths correctly when joining/splitting the common source directory with the filename to generate the module name.