### PR TITLE
Format false branch of ternary operation

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -376,7 +376,7 @@ namespace FourSlash {
                 insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: false,
                 insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: false,
                 insertSpaceAfterTypeAssertion: false,
-                indentInsideTernaryOperator: false,
+                indentConditionalExpressionFalseBranch: false,
                 placeOpenBraceOnNewLineForFunctions: false,
                 placeOpenBraceOnNewLineForControlBlocks: false,
             };

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -376,6 +376,7 @@ namespace FourSlash {
                 insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: false,
                 insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: false,
                 insertSpaceAfterTypeAssertion: false,
+                indentInsideTernaryOperator: false,
                 placeOpenBraceOnNewLineForFunctions: false,
                 placeOpenBraceOnNewLineForControlBlocks: false,
             };

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2321,6 +2321,7 @@ namespace ts.server.protocol {
         insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces?: boolean;
         insertSpaceAfterTypeAssertion?: boolean;
         insertSpaceBeforeFunctionParenthesis?: boolean;
+        indentConditionalExpressionFalseBranch?: boolean;
         placeOpenBraceOnNewLineForFunctions?: boolean;
         placeOpenBraceOnNewLineForControlBlocks?: boolean;
     }

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -90,7 +90,7 @@ namespace ts.server {
             insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: false,
             insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: false,
             insertSpaceBeforeFunctionParenthesis: false,
-            indentInsideTernaryOperator: false,
+            indentConditionalExpressionFalseBranch: false,
             placeOpenBraceOnNewLineForFunctions: false,
             placeOpenBraceOnNewLineForControlBlocks: false,
         };

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -90,6 +90,7 @@ namespace ts.server {
             insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: false,
             insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: false,
             insertSpaceBeforeFunctionParenthesis: false,
+            indentInsideTernaryOperator: false,
             placeOpenBraceOnNewLineForFunctions: false,
             placeOpenBraceOnNewLineForControlBlocks: false,
         };

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -303,7 +303,7 @@ namespace ts.formatting {
                 break;
             }
 
-            if (SmartIndenter.shouldIndentChildNode(n, child)) {
+            if (SmartIndenter.shouldIndentChildNode(n, options, child)) {
                 return options.indentSize;
             }
 
@@ -443,7 +443,7 @@ namespace ts.formatting {
             effectiveParentStartLine: number): Indentation {
 
             let indentation = inheritedIndentation;
-            let delta = SmartIndenter.shouldIndentChildNode(node) ? options.indentSize : 0;
+            let delta = SmartIndenter.shouldIndentChildNode(node, options) ? options.indentSize : 0;
 
             if (effectiveParentStartLine === startLine) {
                 // if node is located on the same line with the parent
@@ -547,7 +547,7 @@ namespace ts.formatting {
                 getIndentation: () => indentation,
                 getDelta: child => getEffectiveDelta(delta, child),
                 recomputeIndentation: lineAdded => {
-                    if (node.parent && SmartIndenter.shouldIndentChildNode(node.parent, node)) {
+                    if (node.parent && SmartIndenter.shouldIndentChildNode(node.parent, options, node)) {
                         if (lineAdded) {
                             indentation += options.indentSize;
                         }
@@ -555,7 +555,7 @@ namespace ts.formatting {
                             indentation -= options.indentSize;
                         }
 
-                        if (SmartIndenter.shouldIndentChildNode(node)) {
+                        if (SmartIndenter.shouldIndentChildNode(node, options)) {
                             delta = options.indentSize;
                         }
                         else {
@@ -567,7 +567,7 @@ namespace ts.formatting {
 
             function getEffectiveDelta(delta: number, child: TextRangeWithKind) {
                 // Delta value should be zero when the node explicitly prevents indentation of the child node
-                return SmartIndenter.nodeWillIndentChild(node, child, /*indentByDefault*/ true) ? delta : 0;
+                return SmartIndenter.nodeWillIndentChild(node, child, /*indentByDefault*/ true, options) ? delta : 0;
             }
         }
 

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -463,7 +463,6 @@ namespace ts.formatting {
                 case SyntaxKind.VariableDeclaration:
                 case SyntaxKind.ExportAssignment:
                 case SyntaxKind.ReturnStatement:
-                case SyntaxKind.ConditionalExpression:
                 case SyntaxKind.ArrayBindingPattern:
                 case SyntaxKind.ObjectBindingPattern:
                 case SyntaxKind.JsxOpeningElement:
@@ -512,6 +511,8 @@ namespace ts.formatting {
                         ((<ImportClause>child).namedBindings && (<ImportClause>child).namedBindings.kind !== SyntaxKind.NamedImports);
                 case SyntaxKind.JsxElement:
                     return childKind !== SyntaxKind.JsxClosingElement;
+                case SyntaxKind.ConditionalExpression:
+                    return (parent as ConditionalExpression).whenFalse !== child;
             }
             // No explicit rule for given nodes so the result will follow the default value argument
             return indentByDefault;

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -512,7 +512,7 @@ namespace ts.formatting {
                 case SyntaxKind.JsxElement:
                     return childKind !== SyntaxKind.JsxClosingElement;
                 case SyntaxKind.ConditionalExpression:
-                    return options.indentInsideTernaryOperator || (parent as ConditionalExpression).whenFalse !== child;
+                    return options.indentConditionalExpressionFalseBranch || (parent as ConditionalExpression).whenFalse !== child;
             }
             // No explicit rule for given nodes so the result will follow the default value argument
             return indentByDefault;

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -470,7 +470,7 @@ namespace ts.textChanges {
             const delta =
                 change.options.delta !== undefined
                     ? change.options.delta
-                    : formatting.SmartIndenter.shouldIndentChildNode(change.node)
+                    : formatting.SmartIndenter.shouldIndentChildNode(change.node, formatOptions)
                         ? formatOptions.indentSize
                         : 0;
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -472,7 +472,7 @@ namespace ts {
         insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces?: boolean;
         insertSpaceAfterTypeAssertion?: boolean;
         insertSpaceBeforeFunctionParenthesis?: boolean;
-        indentInsideTernaryOperator?: boolean;
+        indentConditionalExpressionFalseBranch?: boolean;
         placeOpenBraceOnNewLineForFunctions?: boolean;
         placeOpenBraceOnNewLineForControlBlocks?: boolean;
     }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -250,7 +250,7 @@ namespace ts {
         getOutliningSpans(fileName: string): OutliningSpan[];
         getTodoComments(fileName: string, descriptors: TodoCommentDescriptor[]): TodoComment[];
         getBraceMatchingAtPosition(fileName: string, position: number): TextSpan[];
-        getIndentationAtPosition(fileName: string, position: number, options: EditorOptions | EditorSettings): number;
+        getIndentationAtPosition(fileName: string, position: number, options: EditorOptions | FormatCodeSettings): number;
 
         getFormattingEditsForRange(fileName: string, start: number, end: number, options: FormatCodeOptions | FormatCodeSettings): TextChange[];
         getFormattingEditsForDocument(fileName: string, options: FormatCodeOptions | FormatCodeSettings): TextChange[];
@@ -472,6 +472,7 @@ namespace ts {
         insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces?: boolean;
         insertSpaceAfterTypeAssertion?: boolean;
         insertSpaceBeforeFunctionParenthesis?: boolean;
+        indentInsideTernaryOperator?: boolean;
         placeOpenBraceOnNewLineForFunctions?: boolean;
         placeOpenBraceOnNewLineForControlBlocks?: boolean;
     }

--- a/tests/cases/fourslash/formatConditionalExpressions.ts
+++ b/tests/cases/fourslash/formatConditionalExpressions.ts
@@ -1,0 +1,18 @@
+/// <reference path="fourslash.ts"/>
+
+////let v =
+////    0 ? 1 :
+////    //
+/////*falseBranchExpression*/    2 ? 3 :
+/////*indent*/
+////    //
+/////*falseBranchToken*/    2;
+
+format.document();
+
+goTo.marker("falseBranchExpression");
+verify.currentLineContentIs("    2 ? 3 :");
+goTo.marker("indent");
+verify.indentationIs(8);
+goTo.marker("falseBranchToken");
+verify.currentLineContentIs("    2;");

--- a/tests/cases/fourslash/formattingOptionsChangeTernary.ts
+++ b/tests/cases/fourslash/formattingOptionsChangeTernary.ts
@@ -13,7 +13,7 @@
 ////    ? ScanAction.RescanJsxText
 ////    : ScanAction.Scan;
 
-format.setOption("indentInsideTernaryOperator", false);
+format.setOption("indentConditionalExpressionFalseBranch", false);
 format.document();
 verify.currentFileContentIs(`const expectedScanAction =
     shouldRescanGreaterThanToken(n)
@@ -28,7 +28,7 @@ verify.currentFileContentIs(`const expectedScanAction =
         ? ScanAction.RescanJsxText
         : ScanAction.Scan;`)
 
-format.setOption("indentInsideTernaryOperator", true);
+format.setOption("indentConditionalExpressionFalseBranch", true);
 format.document();
 verify.currentFileContentIs(`const expectedScanAction =
     shouldRescanGreaterThanToken(n)

--- a/tests/cases/fourslash/formattingOptionsChangeTernary.ts
+++ b/tests/cases/fourslash/formattingOptionsChangeTernary.ts
@@ -1,0 +1,44 @@
+///<reference path="fourslash.ts"/>
+
+////const expectedScanAction =
+////    shouldRescanGreaterThanToken(n)
+////    ? ScanAction.RescanGreaterThanToken
+////    : shouldRescanSlashToken(n)
+////    ? ScanAction.RescanSlashToken
+////    : shouldRescanTemplateToken(n)
+////    ? ScanAction.RescanTemplateToken
+////    : shouldRescanJsxIdentifier(n)
+////    ? ScanAction.RescanJsxIdentifier
+////    : shouldRescanJsxText(n)
+////    ? ScanAction.RescanJsxText
+////    : ScanAction.Scan;
+
+format.setOption("indentInsideTernaryOperator", false);
+format.document();
+verify.currentFileContentIs(`const expectedScanAction =
+    shouldRescanGreaterThanToken(n)
+        ? ScanAction.RescanGreaterThanToken
+        : shouldRescanSlashToken(n)
+        ? ScanAction.RescanSlashToken
+        : shouldRescanTemplateToken(n)
+        ? ScanAction.RescanTemplateToken
+        : shouldRescanJsxIdentifier(n)
+        ? ScanAction.RescanJsxIdentifier
+        : shouldRescanJsxText(n)
+        ? ScanAction.RescanJsxText
+        : ScanAction.Scan;`)
+
+format.setOption("indentInsideTernaryOperator", true);
+format.document();
+verify.currentFileContentIs(`const expectedScanAction =
+    shouldRescanGreaterThanToken(n)
+        ? ScanAction.RescanGreaterThanToken
+        : shouldRescanSlashToken(n)
+            ? ScanAction.RescanSlashToken
+            : shouldRescanTemplateToken(n)
+                ? ScanAction.RescanTemplateToken
+                : shouldRescanJsxIdentifier(n)
+                    ? ScanAction.RescanJsxIdentifier
+                    : shouldRescanJsxText(n)
+                        ? ScanAction.RescanJsxText
+                        : ScanAction.Scan;`)


### PR DESCRIPTION
~~**This PR includes #4757**~~ (#4757 is now merged :+1:)

Fixes #3676.

Current:

``` typescript
var v =
    0 ? 1 :
        2 ? 3 :
            4;
```

Fixed:

``` typescript
var v =
    0 ? 1 :
    2 ? 3 :
    4;
```
