### PR TITLE
Emit __esModule in when target == es6

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -3628,13 +3628,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     // only allow export default at a source file level
                     if (modulekind === ModuleKind.CommonJS || modulekind === ModuleKind.AMD || modulekind === ModuleKind.UMD) {
                         if (!isEs6Module) {
-                            if (languageVersion === ScriptTarget.ES5) {
-                                // default value of configurable, enumerable, writable are `false`.
-                                write("Object.defineProperty(exports, \"__esModule\", { value: true });");
+                            if (languageVersion === ScriptTarget.ES3) {
+                                write("exports.__esModule = true;");
                                 writeLine();
                             }
-                            else if (languageVersion === ScriptTarget.ES3) {
-                                write("exports.__esModule = true;");
+                            else {
+                                // default value of configurable, enumerable, writable are `false`.
+                                write("Object.defineProperty(exports, \"__esModule\", { value: true });");
                                 writeLine();
                             }
                         }

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -5190,6 +5190,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                         write(`exports.default = `);
                         emitDeclarationName(node);
                         write(";");
+                        writeLine();
+                        emitEs6ExportDefaultCompat(node);
                     }
                 }
                 else if (node.parent.kind !== SyntaxKind.SourceFile || (modulekind !== ModuleKind.ES6 && !(node.flags & NodeFlags.Default))) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2400,7 +2400,7 @@ namespace ts {
      * Serialize an object graph into a JSON string. This is intended only for use on an acyclic graph
      * as the fallback implementation does not check for circular references by default.
      */
-    export const stringify: (value: any) => string = JSON && JSON.stringify
+    export const stringify: (value: any) => string = typeof JSON !== "undefined" && JSON.stringify
         ? JSON.stringify
         : stringifyFallback;
 

--- a/tests/baselines/reference/anonymousDefaultExportsAmd.js
+++ b/tests/baselines/reference/anonymousDefaultExportsAmd.js
@@ -17,5 +17,6 @@ define(["require", "exports"], function (require, exports) {
 define(["require", "exports"], function (require, exports) {
     "use strict";
     function default_1() { }
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = default_1;
 });

--- a/tests/baselines/reference/anonymousDefaultExportsAmd.js
+++ b/tests/baselines/reference/anonymousDefaultExportsAmd.js
@@ -12,6 +12,7 @@ define(["require", "exports"], function (require, exports) {
     class default_1 {
     }
     exports.default = default_1;
+    Object.defineProperty(exports, "__esModule", { value: true });
 });
 //// [b.js]
 define(["require", "exports"], function (require, exports) {

--- a/tests/baselines/reference/anonymousDefaultExportsCommonjs.js
+++ b/tests/baselines/reference/anonymousDefaultExportsCommonjs.js
@@ -14,4 +14,5 @@ exports.default = default_1;
 //// [b.js]
 "use strict";
 function default_1() { }
+Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = default_1;

--- a/tests/baselines/reference/anonymousDefaultExportsCommonjs.js
+++ b/tests/baselines/reference/anonymousDefaultExportsCommonjs.js
@@ -11,6 +11,7 @@ export default function() {}
 class default_1 {
 }
 exports.default = default_1;
+Object.defineProperty(exports, "__esModule", { value: true });
 //// [b.js]
 "use strict";
 function default_1() { }

--- a/tests/baselines/reference/anonymousDefaultExportsUmd.js
+++ b/tests/baselines/reference/anonymousDefaultExportsUmd.js
@@ -19,6 +19,7 @@ export default function() {}
     class default_1 {
     }
     exports.default = default_1;
+    Object.defineProperty(exports, "__esModule", { value: true });
 });
 //// [b.js]
 (function (factory) {

--- a/tests/baselines/reference/anonymousDefaultExportsUmd.js
+++ b/tests/baselines/reference/anonymousDefaultExportsUmd.js
@@ -31,5 +31,6 @@ export default function() {}
 })(function (require, exports) {
     "use strict";
     function default_1() { }
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = default_1;
 });

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedAmd.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedAmd.js
@@ -29,6 +29,7 @@ define(["require", "exports"], function (require, exports) {
         decorator
     ], Foo);
     exports.default = Foo;
+    Object.defineProperty(exports, "__esModule", { value: true });
 });
 //// [b.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
@@ -46,4 +47,5 @@ define(["require", "exports"], function (require, exports) {
         decorator
     ], default_1);
     exports.default = default_1;
+    Object.defineProperty(exports, "__esModule", { value: true });
 });

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedCommonjs.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedCommonjs.js
@@ -28,6 +28,7 @@ Foo = __decorate([
     decorator
 ], Foo);
 exports.default = Foo;
+Object.defineProperty(exports, "__esModule", { value: true });
 //// [b.js]
 "use strict";
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
@@ -43,3 +44,4 @@ default_1 = __decorate([
     decorator
 ], default_1);
 exports.default = default_1;
+Object.defineProperty(exports, "__esModule", { value: true });

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedUmd.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedUmd.js
@@ -36,6 +36,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
         decorator
     ], Foo);
     exports.default = Foo;
+    Object.defineProperty(exports, "__esModule", { value: true });
 });
 //// [b.js]
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
@@ -60,4 +61,5 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
         decorator
     ], default_1);
     exports.default = default_1;
+    Object.defineProperty(exports, "__esModule", { value: true });
 });

--- a/tests/baselines/reference/defaultExportsGetExportedAmd.js
+++ b/tests/baselines/reference/defaultExportsGetExportedAmd.js
@@ -18,5 +18,6 @@ define(["require", "exports"], function (require, exports) {
 define(["require", "exports"], function (require, exports) {
     "use strict";
     function foo() { }
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = foo;
 });

--- a/tests/baselines/reference/defaultExportsGetExportedAmd.js
+++ b/tests/baselines/reference/defaultExportsGetExportedAmd.js
@@ -13,6 +13,7 @@ define(["require", "exports"], function (require, exports) {
     class Foo {
     }
     exports.default = Foo;
+    Object.defineProperty(exports, "__esModule", { value: true });
 });
 //// [b.js]
 define(["require", "exports"], function (require, exports) {

--- a/tests/baselines/reference/defaultExportsGetExportedCommonjs.js
+++ b/tests/baselines/reference/defaultExportsGetExportedCommonjs.js
@@ -12,6 +12,7 @@ export default function foo() {}
 class Foo {
 }
 exports.default = Foo;
+Object.defineProperty(exports, "__esModule", { value: true });
 //// [b.js]
 "use strict";
 function foo() { }

--- a/tests/baselines/reference/defaultExportsGetExportedCommonjs.js
+++ b/tests/baselines/reference/defaultExportsGetExportedCommonjs.js
@@ -15,4 +15,5 @@ exports.default = Foo;
 //// [b.js]
 "use strict";
 function foo() { }
+Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = foo;

--- a/tests/baselines/reference/defaultExportsGetExportedUmd.js
+++ b/tests/baselines/reference/defaultExportsGetExportedUmd.js
@@ -20,6 +20,7 @@ export default function foo() {}
     class Foo {
     }
     exports.default = Foo;
+    Object.defineProperty(exports, "__esModule", { value: true });
 });
 //// [b.js]
 (function (factory) {

--- a/tests/baselines/reference/defaultExportsGetExportedUmd.js
+++ b/tests/baselines/reference/defaultExportsGetExportedUmd.js
@@ -32,5 +32,6 @@ export default function foo() {}
 })(function (require, exports) {
     "use strict";
     function foo() { }
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = foo;
 });

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImport.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImport.js
@@ -27,6 +27,7 @@ var x1: number = m;
 exports.a = 10;
 exports.x = exports.a;
 exports.m = exports.a;
+Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = {};
 //// [es6ImportDefaultBindingFollowedWithNamedImport_1.js]
 "use strict";

--- a/tests/baselines/reference/esModuleEmitForDefaultExport.js
+++ b/tests/baselines/reference/esModuleEmitForDefaultExport.js
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/esModuleEmitForDefaultExport.ts] ////
+
+//// [a.ts]
+
+class C { }
+export default C;
+
+//// [b.ts]
+var x = 0;
+export default x;
+
+//// [c.ts]
+function f() { }
+export default f;
+
+
+//// [a.js]
+"use strict";
+class C {
+}
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = C;
+//// [b.js]
+"use strict";
+var x = 0;
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = x;
+//// [c.js]
+"use strict";
+function f() { }
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = f;

--- a/tests/baselines/reference/esModuleEmitForDefaultExport.symbols
+++ b/tests/baselines/reference/esModuleEmitForDefaultExport.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/a.ts ===
+
+class C { }
+>C : Symbol(C, Decl(a.ts, 0, 0))
+
+export default C;
+>C : Symbol(C, Decl(a.ts, 0, 0))
+
+=== tests/cases/compiler/b.ts ===
+var x = 0;
+>x : Symbol(x, Decl(b.ts, 0, 3))
+
+export default x;
+>x : Symbol(x, Decl(b.ts, 0, 3))
+
+=== tests/cases/compiler/c.ts ===
+function f() { }
+>f : Symbol(f, Decl(c.ts, 0, 0))
+
+export default f;
+>f : Symbol(f, Decl(c.ts, 0, 0))
+

--- a/tests/baselines/reference/esModuleEmitForDefaultExport.types
+++ b/tests/baselines/reference/esModuleEmitForDefaultExport.types
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/a.ts ===
+
+class C { }
+>C : C
+
+export default C;
+>C : C
+
+=== tests/cases/compiler/b.ts ===
+var x = 0;
+>x : number
+>0 : number
+
+export default x;
+>x : number
+
+=== tests/cases/compiler/c.ts ===
+function f() { }
+>f : () => void
+
+export default f;
+>f : () => void
+

--- a/tests/baselines/reference/exportsAndImports4-es6.js
+++ b/tests/baselines/reference/exportsAndImports4-es6.js
@@ -41,6 +41,7 @@ export { a, b, c, d, e1, e2, f1, f2 };
 
 //// [t1.js]
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = "hello";
 //// [t3.js]
 "use strict";

--- a/tests/baselines/reference/outFilerootDirModuleNamesAmd.js
+++ b/tests/baselines/reference/outFilerootDirModuleNamesAmd.js
@@ -22,5 +22,6 @@ define("a", ["require", "exports", "b"], function (require, exports, b_1) {
     class Foo {
     }
     exports.default = Foo;
+    Object.defineProperty(exports, "__esModule", { value: true });
     b_1.default();
 });

--- a/tests/baselines/reference/outFilerootDirModuleNamesAmd.js
+++ b/tests/baselines/reference/outFilerootDirModuleNamesAmd.js
@@ -14,6 +14,7 @@ export default function foo() { new Foo(); }
 define("b", ["require", "exports", "a"], function (require, exports, a_1) {
     "use strict";
     function foo() { new a_1.default(); }
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = foo;
 });
 define("a", ["require", "exports", "b"], function (require, exports, b_1) {

--- a/tests/cases/compiler/esModuleEmitForDefaultExport.ts
+++ b/tests/cases/compiler/esModuleEmitForDefaultExport.ts
@@ -1,0 +1,14 @@
+// @target: ES6
+// @module: commonjs
+
+// @filename: a.ts
+class C { }
+export default C;
+
+// @filename: b.ts
+var x = 0;
+export default x;
+
+// @filename: c.ts
+function f() { }
+export default f;


### PR DESCRIPTION
Emits `__esModule` if target == ES6 and module != ES6. also add emitting __esModule to export default class, which we missed before. 

More details about this can be found in https://github.com/Microsoft/TypeScript/issues/5844#issuecomment-161499771