### PR TITLE
Fix esmodule bug, unify export emit between es6/pre-es6

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -3628,12 +3628,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     // only allow export default at a source file level
                     if (modulekind === ModuleKind.CommonJS || modulekind === ModuleKind.AMD || modulekind === ModuleKind.UMD) {
                         if (!isEs6Module) {
-                            if (languageVersion === ScriptTarget.ES5) {
+                            if (languageVersion !== ScriptTarget.ES3) {
                                 // default value of configurable, enumerable, writable are `false`.
                                 write("Object.defineProperty(exports, \"__esModule\", { value: true });");
                                 writeLine();
                             }
-                            else if (languageVersion === ScriptTarget.ES3) {
+                            else {
                                 write("exports.__esModule = true;");
                                 writeLine();
                             }
@@ -5171,35 +5171,30 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                 if (!(node.flags & NodeFlags.Export)) {
                     return;
                 }
-                // If this is an exported class, but not on the top level (i.e. on an internal
-                // module), export it
-                if (node.flags & NodeFlags.Default) {
-                    // if this is a top level default export of decorated class, write the export after the declaration.
-                    writeLine();
-                    if (thisNodeIsDecorated && modulekind === ModuleKind.ES6) {
-                        write("export default ");
-                        emitDeclarationName(node);
-                        write(";");
-                    }
-                    else if (modulekind === ModuleKind.System) {
-                        write(`${exportFunctionForFile}("default", `);
-                        emitDeclarationName(node);
-                        write(");");
-                    }
-                    else if (modulekind !== ModuleKind.ES6) {
-                        write(`exports.default = `);
-                        emitDeclarationName(node);
-                        write(";");
-                    }
+                if (modulekind !== ModuleKind.ES6) {
+                    emitExportMemberAssignment(node as ClassDeclaration);
                 }
-                else if (node.parent.kind !== SyntaxKind.SourceFile || (modulekind !== ModuleKind.ES6 && !(node.flags & NodeFlags.Default))) {
-                    writeLine();
-                    emitStart(node);
-                    emitModuleMemberName(node);
-                    write(" = ");
-                    emitDeclarationName(node);
-                    emitEnd(node);
-                    write(";");
+                else {
+                    // If this is an exported class, but not on the top level (i.e. on an internal
+                    // module), export it
+                    if (node.flags & NodeFlags.Default) {
+                        // if this is a top level default export of decorated class, write the export after the declaration.
+                        if (thisNodeIsDecorated) {
+                            writeLine();
+                            write("export default ");
+                            emitDeclarationName(node);
+                            write(";");
+                        }
+                    }
+                    else if (node.parent.kind !== SyntaxKind.SourceFile) {
+                        writeLine();
+                        emitStart(node);
+                        emitModuleMemberName(node);
+                        write(" = ");
+                        emitDeclarationName(node);
+                        emitEnd(node);
+                        write(";");
+                    }
                 }
             }
 

--- a/tests/baselines/reference/anonymousDefaultExportsAmd.js
+++ b/tests/baselines/reference/anonymousDefaultExportsAmd.js
@@ -11,11 +11,13 @@ define(["require", "exports"], function (require, exports) {
     "use strict";
     class default_1 {
     }
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = default_1;
 });
 //// [b.js]
 define(["require", "exports"], function (require, exports) {
     "use strict";
     function default_1() { }
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = default_1;
 });

--- a/tests/baselines/reference/anonymousDefaultExportsCommonjs.js
+++ b/tests/baselines/reference/anonymousDefaultExportsCommonjs.js
@@ -10,8 +10,10 @@ export default function() {}
 "use strict";
 class default_1 {
 }
+Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = default_1;
 //// [b.js]
 "use strict";
 function default_1() { }
+Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = default_1;

--- a/tests/baselines/reference/anonymousDefaultExportsUmd.js
+++ b/tests/baselines/reference/anonymousDefaultExportsUmd.js
@@ -18,6 +18,7 @@ export default function() {}
     "use strict";
     class default_1 {
     }
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = default_1;
 });
 //// [b.js]
@@ -31,5 +32,6 @@ export default function() {}
 })(function (require, exports) {
     "use strict";
     function default_1() { }
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = default_1;
 });

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedAmd.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedAmd.js
@@ -28,6 +28,7 @@ define(["require", "exports"], function (require, exports) {
     Foo = __decorate([
         decorator
     ], Foo);
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = Foo;
 });
 //// [b.js]
@@ -45,5 +46,6 @@ define(["require", "exports"], function (require, exports) {
     default_1 = __decorate([
         decorator
     ], default_1);
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = default_1;
 });

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedCommonjs.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedCommonjs.js
@@ -27,6 +27,7 @@ let Foo = class {
 Foo = __decorate([
     decorator
 ], Foo);
+Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = Foo;
 //// [b.js]
 "use strict";
@@ -42,4 +43,5 @@ let default_1 = class {
 default_1 = __decorate([
     decorator
 ], default_1);
+Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = default_1;

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedUmd.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedUmd.js
@@ -35,6 +35,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     Foo = __decorate([
         decorator
     ], Foo);
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = Foo;
 });
 //// [b.js]
@@ -59,5 +60,6 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     default_1 = __decorate([
         decorator
     ], default_1);
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = default_1;
 });

--- a/tests/baselines/reference/defaultExportsGetExportedAmd.js
+++ b/tests/baselines/reference/defaultExportsGetExportedAmd.js
@@ -12,11 +12,13 @@ define(["require", "exports"], function (require, exports) {
     "use strict";
     class Foo {
     }
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = Foo;
 });
 //// [b.js]
 define(["require", "exports"], function (require, exports) {
     "use strict";
     function foo() { }
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = foo;
 });

--- a/tests/baselines/reference/defaultExportsGetExportedCommonjs.js
+++ b/tests/baselines/reference/defaultExportsGetExportedCommonjs.js
@@ -11,8 +11,10 @@ export default function foo() {}
 "use strict";
 class Foo {
 }
+Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = Foo;
 //// [b.js]
 "use strict";
 function foo() { }
+Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = foo;

--- a/tests/baselines/reference/defaultExportsGetExportedUmd.js
+++ b/tests/baselines/reference/defaultExportsGetExportedUmd.js
@@ -19,6 +19,7 @@ export default function foo() {}
     "use strict";
     class Foo {
     }
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = Foo;
 });
 //// [b.js]
@@ -32,5 +33,6 @@ export default function foo() {}
 })(function (require, exports) {
     "use strict";
     function foo() { }
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = foo;
 });

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImport.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamedImport.js
@@ -27,6 +27,7 @@ var x1: number = m;
 exports.a = 10;
 exports.x = exports.a;
 exports.m = exports.a;
+Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = {};
 //// [es6ImportDefaultBindingFollowedWithNamedImport_1.js]
 "use strict";

--- a/tests/baselines/reference/exportsAndImports4-es6.js
+++ b/tests/baselines/reference/exportsAndImports4-es6.js
@@ -41,6 +41,7 @@ export { a, b, c, d, e1, e2, f1, f2 };
 
 //// [t1.js]
 "use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = "hello";
 //// [t3.js]
 "use strict";

--- a/tests/baselines/reference/outFilerootDirModuleNamesAmd.js
+++ b/tests/baselines/reference/outFilerootDirModuleNamesAmd.js
@@ -14,12 +14,14 @@ export default function foo() { new Foo(); }
 define("b", ["require", "exports", "a"], function (require, exports, a_1) {
     "use strict";
     function foo() { new a_1.default(); }
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = foo;
 });
 define("a", ["require", "exports", "b"], function (require, exports, b_1) {
     "use strict";
     class Foo {
     }
+    Object.defineProperty(exports, "__esModule", { value: true });
     exports.default = Foo;
     b_1.default();
 });


### PR DESCRIPTION
I realized I had been duplicating work the `emitExportMemberAssignment` method was already doing - and that was pretty much the root cause of many prior issues.

Discussed the issue in [#5844](https://github.com/Microsoft/TypeScript/issues/5844#issuecomment-161499771).