### PR TITLE
Use typeof to check for presence of `JSON` global

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2400,7 +2400,7 @@ namespace ts {
      * Serialize an object graph into a JSON string. This is intended only for use on an acyclic graph
      * as the fallback implementation does not check for circular references by default.
      */
-    export const stringify: (value: any) => string = JSON && JSON.stringify
+    export const stringify: (value: any) => string = typeof JSON !== "undefined" && JSON.stringify
         ? JSON.stringify
         : stringifyFallback;
 


### PR DESCRIPTION
Conceivably under strict mode in an environment without a global JSON object this would error before. I have no idea if such an environment exists. Picked from #5907.