### PR TITLE
parse module specifier as string

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5310,16 +5310,17 @@ namespace ts {
         }
 
         function parseModuleSpecifier(): Expression {
-            // We allow arbitrary expressions here, even though the grammar only allows string
-            // literals.  We check to ensure that it is only a string literal later in the grammar
-            // walker.
-            const result = parseExpression();
-            // Ensure the string being required is in our 'identifier' table.  This will ensure
-            // that features like 'find refs' will look inside this file when search for its name.
-            if (result.kind === SyntaxKind.StringLiteral) {
+            if (token === SyntaxKind.StringLiteral) {
+                const result = parseLiteralNode();
                 internIdentifier((<LiteralExpression>result).text);
+                return result;
             }
-            return result;
+            else {
+                // We allow arbitrary expressions here, even though the grammar only allows string
+                // literals.  We check to ensure that it is only a string literal later in the grammar
+                // check pass.
+                return parseExpression();
+            }
         }
 
         function parseNamespaceImport(): NamespaceImport {

--- a/tests/baselines/reference/missingSemicolonInModuleSpecifier.js
+++ b/tests/baselines/reference/missingSemicolonInModuleSpecifier.js
@@ -1,0 +1,16 @@
+//// [tests/cases/compiler/missingSemicolonInModuleSpecifier.ts] ////
+
+//// [a.ts]
+
+export const x = 1;
+
+//// [b.ts]
+import {x} from "./a"
+(function() { return 1; }())
+
+//// [a.js]
+"use strict";
+exports.x = 1;
+//// [b.js]
+"use strict";
+(function () { return 1; }());

--- a/tests/baselines/reference/missingSemicolonInModuleSpecifier.symbols
+++ b/tests/baselines/reference/missingSemicolonInModuleSpecifier.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/a.ts ===
+
+export const x = 1;
+>x : Symbol(x, Decl(a.ts, 1, 12))
+
+=== tests/cases/compiler/b.ts ===
+import {x} from "./a"
+>x : Symbol(x, Decl(b.ts, 0, 8))
+
+(function() { return 1; }())

--- a/tests/baselines/reference/missingSemicolonInModuleSpecifier.types
+++ b/tests/baselines/reference/missingSemicolonInModuleSpecifier.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/a.ts ===
+
+export const x = 1;
+>x : number
+>1 : number
+
+=== tests/cases/compiler/b.ts ===
+import {x} from "./a"
+>x : number
+
+(function() { return 1; }())
+>(function() { return 1; }()) : number
+>function() { return 1; }() : number
+>function() { return 1; } : () => number
+>1 : number
+

--- a/tests/cases/compiler/missingSemicolonInModuleSpecifier.ts
+++ b/tests/cases/compiler/missingSemicolonInModuleSpecifier.ts
@@ -1,0 +1,8 @@
+// @module: commonjs
+
+// @filename: a.ts
+export const x = 1;
+
+// @filename: b.ts
+import {x} from "./a"
+(function() { return 1; }())


### PR DESCRIPTION
 Old logic (when module specifier is parsed as expression)  is kept for better error recovery. Fixes #5931 