### PR TITLE
Gracefully handle errors where 'typings' is not a string (fixes #4828)

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -99,7 +99,7 @@ namespace ts {
                 jsonContent = { typings: undefined };
             }
 
-            if (jsonContent.typings) {
+            if (typeof jsonContent.typings === "string") {
                 const result = loadNodeModuleFromFile(extensions, normalizePath(combinePaths(candidate, jsonContent.typings)), failedLookupLocation, host);
                 if (result) {
                     return result;

--- a/tests/cases/unittests/moduleResolution.ts
+++ b/tests/cases/unittests/moduleResolution.ts
@@ -99,11 +99,32 @@ module ts {
             assert.equal(resolution.failedLookupLocations.length, supportedTypeScriptExtensions.length);
         }
 
-        it("module name as directory - load from typings", () => {
+        it("module name as directory - load from 'typings'", () => {
             testLoadingFromPackageJson("/a/b/c/d.ts", "/a/b/c/bar/package.json", "c/d/e.d.ts", "/a/b/c/bar/c/d/e.d.ts", "./bar");
             testLoadingFromPackageJson("/a/b/c/d.ts", "/a/bar/package.json", "e.d.ts", "/a/bar/e.d.ts", "../../bar");
             testLoadingFromPackageJson("/a/b/c/d.ts", "/bar/package.json", "e.d.ts", "/bar/e.d.ts", "/bar");
             testLoadingFromPackageJson("c:/a/b/c/d.ts", "c:/bar/package.json", "e.d.ts", "c:/bar/e.d.ts", "c:/bar");
+        });
+
+        function testTypingsIgnored(typings: any): void {
+            let containingFile = { name: "/a/b.ts" };
+            let packageJson = { name: "/node_modules/b/package.json", content: JSON.stringify({ "typings": typings }) };
+            let moduleFile = { name: "/a/b.d.ts" };
+
+            let indexPath = "/node_modules/b/index.d.ts";
+            let indexFile = { name: indexPath }
+
+            let resolution = nodeModuleNameResolver("b", containingFile.name, {}, createModuleResolutionHost(containingFile, packageJson, moduleFile, indexFile));
+
+            assert.equal(resolution.resolvedModule.resolvedFileName, indexPath);
+        }
+
+        it("module name as directory - handle invalid 'typings'", () => {
+            testTypingsIgnored(["a", "b"]);
+            testTypingsIgnored({ "a": "b" });
+            testTypingsIgnored(true);
+            testTypingsIgnored(null);
+            testTypingsIgnored(undefined);
         });
 
         it("module name as directory - load index.d.ts", () => {


### PR DESCRIPTION
Rather than blindly assuming 'typings' is a string (and exploding when it's not), we now check, and gracefully move on it not.

I've avoided throwing exceptions if the type of this is incorrect, and instead quietly ignoring it. I'm a bit hesitant about that, but it's consistent with what we do in various other cases for this. If the package.json is unreadable or doesn't contain JSON, for example, we currently silently ignore that and move on too.