### PR TITLE
Identify JSX closing tags as identifiers so they emit correctly

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1453,6 +1453,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
                     case SyntaxKind.ForInStatement:
                     case SyntaxKind.ForOfStatement:
                     case SyntaxKind.IfStatement:
+                    case SyntaxKind.JsxClosingElement:
                     case SyntaxKind.JsxSelfClosingElement:
                     case SyntaxKind.JsxOpeningElement:
                     case SyntaxKind.JsxSpreadAttribute:

--- a/tests/baselines/reference/tsxPreserveEmit1.js
+++ b/tests/baselines/reference/tsxPreserveEmit1.js
@@ -22,12 +22,28 @@ import ReactRouter = require('react-router');
 
 import Route = ReactRouter.Route;
 
-var routes = <Route />;
+var routes1 = <Route />;
+
+module M {
+	export var X: any;
+}
+module M {
+	// Should emit 'M.X' in both opening and closing tags
+	var y = <X></X>;
+}
 
 
 //// [test.jsx]
 define(["require", "exports", 'react-router'], function (require, exports, ReactRouter) {
     "use strict";
     var Route = ReactRouter.Route;
-    var routes = <Route />;
+    var routes1 = <Route />;
+    var M;
+    (function (M) {
+    })(M || (M = {}));
+    var M;
+    (function (M) {
+        // Should emit 'M.X' in both opening and closing tags
+        var y = <M.X></M.X>;
+    })(M || (M = {}));
 });

--- a/tests/baselines/reference/tsxPreserveEmit1.symbols
+++ b/tests/baselines/reference/tsxPreserveEmit1.symbols
@@ -11,9 +11,25 @@ import Route = ReactRouter.Route;
 >ReactRouter : Symbol(ReactRouter, Decl(react.d.ts, 4, 1))
 >Route : Symbol(ReactRouter.Route, Decl(react.d.ts, 7, 4))
 
-var routes = <Route />;
->routes : Symbol(routes, Decl(test.tsx, 6, 3))
+var routes1 = <Route />;
+>routes1 : Symbol(routes1, Decl(test.tsx, 6, 3))
 >Route : Symbol(Route, Decl(test.tsx, 2, 45))
+
+module M {
+>M : Symbol(M, Decl(test.tsx, 6, 24), Decl(test.tsx, 10, 1))
+
+	export var X: any;
+>X : Symbol(X, Decl(test.tsx, 9, 11))
+}
+module M {
+>M : Symbol(M, Decl(test.tsx, 6, 24), Decl(test.tsx, 10, 1))
+
+	// Should emit 'M.X' in both opening and closing tags
+	var y = <X></X>;
+>y : Symbol(y, Decl(test.tsx, 13, 4))
+>X : Symbol(X, Decl(test.tsx, 9, 11))
+>X : Symbol(X, Decl(test.tsx, 9, 11))
+}
 
 === tests/cases/conformance/jsx/react.d.ts ===
 

--- a/tests/baselines/reference/tsxPreserveEmit1.types
+++ b/tests/baselines/reference/tsxPreserveEmit1.types
@@ -11,10 +11,27 @@ import Route = ReactRouter.Route;
 >ReactRouter : typeof ReactRouter
 >Route : any
 
-var routes = <Route />;
->routes : any
+var routes1 = <Route />;
+>routes1 : any
 ><Route /> : any
 >Route : any
+
+module M {
+>M : typeof M
+
+	export var X: any;
+>X : any
+}
+module M {
+>M : typeof M
+
+	// Should emit 'M.X' in both opening and closing tags
+	var y = <X></X>;
+>y : any
+><X></X> : any
+>X : any
+>X : any
+}
 
 === tests/cases/conformance/jsx/react.d.ts ===
 

--- a/tests/cases/conformance/jsx/tsxPreserveEmit1.tsx
+++ b/tests/cases/conformance/jsx/tsxPreserveEmit1.tsx
@@ -23,4 +23,12 @@ import ReactRouter = require('react-router');
 
 import Route = ReactRouter.Route;
 
-var routes = <Route />;
+var routes1 = <Route />;
+
+module M {
+	export var X: any;
+}
+module M {
+	// Should emit 'M.X' in both opening and closing tags
+	var y = <X></X>;
+}


### PR DESCRIPTION
Fixes bug #5955