### PR TITLE
Type predicates cannot be unions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11037,7 +11037,7 @@ namespace ts {
                 case SyntaxKind.MethodDeclaration:
                 case SyntaxKind.MethodSignature:
                     const parent = <SignatureDeclaration>node.parent;
-                    if(node === parent.type) {
+                    if (node === parent.type) {
                         return parent;
                     }
             }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10963,6 +10963,87 @@ namespace ts {
             return -1;
         }
 
+        function checkTypePredicate(node: TypePredicateNode) {
+            const parent = getTypePredicateParent(node);
+            if (!parent) {
+                error(node, Diagnostics.A_type_predicate_is_only_allowed_in_return_type_position_for_functions_and_methods);
+                return;
+            }
+
+            const typePredicate = getSignatureFromDeclaration(parent).typePredicate;
+            if (typePredicate.parameterIndex >= 0) {
+                if (parent.parameters[typePredicate.parameterIndex].dotDotDotToken) {
+                    error(node.parameterName,
+                        Diagnostics.A_type_predicate_cannot_reference_a_rest_parameter);
+                }
+                else {
+                    checkTypeAssignableTo(typePredicate.type,
+                        getTypeOfNode(parent.parameters[typePredicate.parameterIndex]),
+                        node.type);
+                }
+            }
+            else if (node.parameterName) {
+                let hasReportedError = false;
+                for (var param of parent.parameters) {
+                    if (hasReportedError) {
+                        break;
+                    }
+                    if (param.name.kind === SyntaxKind.ObjectBindingPattern ||
+                        param.name.kind === SyntaxKind.ArrayBindingPattern) {
+
+                        (function checkBindingPattern(pattern: BindingPattern) {
+                            for (const element of pattern.elements) {
+                                if (element.name.kind === SyntaxKind.Identifier &&
+                                    (<Identifier>element.name).text === typePredicate.parameterName) {
+
+                                    error(node.parameterName,
+                                        Diagnostics.A_type_predicate_cannot_reference_element_0_in_a_binding_pattern,
+                                        typePredicate.parameterName);
+                                    hasReportedError = true;
+                                    break;
+                                }
+                                else if (element.name.kind === SyntaxKind.ArrayBindingPattern ||
+                                    element.name.kind === SyntaxKind.ObjectBindingPattern) {
+
+                                    checkBindingPattern(<BindingPattern>element.name);
+                                }
+                            }
+                        })(<BindingPattern>param.name);
+                    }
+                }
+                if (!hasReportedError) {
+                    error(node.parameterName,
+                        Diagnostics.Cannot_find_parameter_0,
+                        typePredicate.parameterName);
+                }
+            }
+
+            if (node.type && node.type.kind === SyntaxKind.UnionType) {
+                for (const type of (<UnionTypeNode>node.type).types) {
+                    if (type.kind === SyntaxKind.TypePredicate) {
+                        checkTypePredicate(<TypePredicateNode>type);
+                    }
+                }
+            }
+        }
+
+        function getTypePredicateParent(node: Node): SignatureDeclaration {
+            switch (node.parent.kind) {
+                case SyntaxKind.ArrowFunction:
+                case SyntaxKind.CallSignature:
+                case SyntaxKind.FunctionDeclaration:
+                case SyntaxKind.FunctionExpression:
+                case SyntaxKind.FunctionType:
+                case SyntaxKind.MethodDeclaration:
+                case SyntaxKind.MethodSignature:
+                    const parent = <SignatureDeclaration>node.parent;
+                    if(node === parent.type) {
+                        return parent;
+                    }
+            }
+            return undefined;
+        }
+
         function isInLegalTypePredicatePosition(node: Node): boolean {
             switch (node.parent.kind) {
                 case SyntaxKind.ArrowFunction:
@@ -10993,66 +11074,9 @@ namespace ts {
 
             forEach(node.parameters, checkParameter);
 
-            if (node.type) {
-                if (node.type.kind === SyntaxKind.TypePredicate) {
-                    const typePredicate = getSignatureFromDeclaration(node).typePredicate;
-                    const typePredicateNode = <TypePredicateNode>node.type;
-                    if (isInLegalTypePredicatePosition(typePredicateNode)) {
-                        if (typePredicate.parameterIndex >= 0) {
-                            if (node.parameters[typePredicate.parameterIndex].dotDotDotToken) {
-                                error(typePredicateNode.parameterName,
-                                    Diagnostics.A_type_predicate_cannot_reference_a_rest_parameter);
-                            }
-                            else {
-                                checkTypeAssignableTo(typePredicate.type,
-                                    getTypeOfNode(node.parameters[typePredicate.parameterIndex]),
-                                    typePredicateNode.type);
-                            }
-                        }
-                        else if (typePredicateNode.parameterName) {
-                            let hasReportedError = false;
-                            for (var param of node.parameters) {
-                                if (hasReportedError) {
-                                    break;
-                                }
-                                if (param.name.kind === SyntaxKind.ObjectBindingPattern ||
-                                    param.name.kind === SyntaxKind.ArrayBindingPattern) {
+            checkSourceElement(node.type);
+            if (node.type && node.type.kind === SyntaxKind.TypePredicate) {
 
-                                    (function checkBindingPattern(pattern: BindingPattern) {
-                                        for (const element of pattern.elements) {
-                                            if (element.name.kind === SyntaxKind.Identifier &&
-                                                (<Identifier>element.name).text === typePredicate.parameterName) {
-
-                                                error(typePredicateNode.parameterName,
-                                                    Diagnostics.A_type_predicate_cannot_reference_element_0_in_a_binding_pattern,
-                                                    typePredicate.parameterName);
-                                                hasReportedError = true;
-                                                break;
-                                            }
-                                            else if (element.name.kind === SyntaxKind.ArrayBindingPattern ||
-                                                element.name.kind === SyntaxKind.ObjectBindingPattern) {
-
-                                                checkBindingPattern(<BindingPattern>element.name);
-                                            }
-                                        }
-                                    })(<BindingPattern>param.name);
-                                }
-                            }
-                            if (!hasReportedError) {
-                                error(typePredicateNode.parameterName,
-                                    Diagnostics.Cannot_find_parameter_0,
-                                    typePredicate.parameterName);
-                            }
-                        }
-                    }
-                    else {
-                        error(typePredicateNode,
-                            Diagnostics.A_type_predicate_is_only_allowed_in_return_type_position_for_functions_and_methods);
-                    }
-                }
-                else {
-                    checkSourceElement(node.type);
-                }
             }
 
             if (produceDiagnostics) {
@@ -14192,12 +14216,6 @@ namespace ts {
 
             function isNotOverload(declaration: Declaration): boolean {
                 return declaration.kind !== SyntaxKind.FunctionDeclaration || !!(declaration as FunctionDeclaration).body;
-            }
-        }
-
-        function checkTypePredicate(node: TypePredicateNode) {
-            if (!isInLegalTypePredicatePosition(node)) {
-                error(node, Diagnostics.A_type_predicate_is_only_allowed_in_return_type_position_for_functions_and_methods);
             }
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11075,9 +11075,6 @@ namespace ts {
             forEach(node.parameters, checkParameter);
 
             checkSourceElement(node.type);
-            if (node.type && node.type.kind === SyntaxKind.TypePredicate) {
-
-            }
 
             if (produceDiagnostics) {
                 checkCollisionWithArgumentsInGeneratedCode(node);

--- a/tests/baselines/reference/typePredicateUnions.errors.txt
+++ b/tests/baselines/reference/typePredicateUnions.errors.txt
@@ -1,0 +1,24 @@
+tests/cases/conformance/expressions/typeGuards/typePredicateUnions.ts(1,43): error TS1228: A type predicate is only allowed in return type position for functions and methods.
+
+
+==== tests/cases/conformance/expressions/typeGuards/typePredicateUnions.ts (1 errors) ====
+    function isA<A>(x: any, y: any): x is A | y is B {
+                                              ~~~~~~
+!!! error TS1228: A type predicate is only allowed in return type position for functions and methods.
+        return false;
+    }
+    
+    var x: number | number[];
+    var y: string | string[];
+    var num: number;
+    var nums: number[];
+    var strOrStrs: string | string[];
+    
+    if (isA<number>(x, y)) {
+        num = x;
+        strOrStrs = y;
+    }
+    else {
+        nums = x;
+        strOrStrs = y;
+    }

--- a/tests/baselines/reference/typePredicateUnions.js
+++ b/tests/baselines/reference/typePredicateUnions.js
@@ -1,0 +1,37 @@
+//// [typePredicateUnions.ts]
+function isA<A>(x: any, y: any): x is A | y is B {
+    return false;
+}
+
+var x: number | number[];
+var y: string | string[];
+var num: number;
+var nums: number[];
+var strOrStrs: string | string[];
+
+if (isA<number>(x, y)) {
+    num = x;
+    strOrStrs = y;
+}
+else {
+    nums = x;
+    strOrStrs = y;
+}
+
+//// [typePredicateUnions.js]
+function isA(x, y) {
+    return false;
+}
+var x;
+var y;
+var num;
+var nums;
+var strOrStrs;
+if (isA(x, y)) {
+    num = x;
+    strOrStrs = y;
+}
+else {
+    nums = x;
+    strOrStrs = y;
+}

--- a/tests/cases/conformance/expressions/typeGuards/typePredicateUnions.ts
+++ b/tests/cases/conformance/expressions/typeGuards/typePredicateUnions.ts
@@ -1,0 +1,18 @@
+function isA<A>(x: any, y: any): x is A | y is B {
+    return false;
+}
+
+var x: number | number[];
+var y: string | string[];
+var num: number;
+var nums: number[];
+var strOrStrs: string | string[];
+
+if (isA<number>(x, y)) {
+    num = x;
+    strOrStrs = y;
+}
+else {
+    nums = x;
+    strOrStrs = y;
+}


### PR DESCRIPTION
Add union type checking to checkTypePredicate and refactor `checkSignatureDeclaration` to call `checkTypePredicate` via `checkSourceElement`.

The new code is at the end of `checkTypePredicate`. I forgot to change the branch name -- what this really does is disallow the type of the type predicate from being a union that itself contains type predicates.

Fixes #5903.