### PR TITLE
Parse JSX attributes as AssignmentExpressions

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3639,7 +3639,7 @@ namespace ts {
 
             parseExpected(SyntaxKind.OpenBraceToken);
             if (token !== SyntaxKind.CloseBraceToken) {
-                node.expression = parseExpression();
+                node.expression = parseAssignmentExpressionOrHigher();
             }
             if (inExpressionContext) {
                 parseExpected(SyntaxKind.CloseBraceToken);

--- a/tests/baselines/reference/jsxParsingError1.errors.txt
+++ b/tests/baselines/reference/jsxParsingError1.errors.txt
@@ -1,0 +1,25 @@
+tests/cases/conformance/jsx/file.tsx(12,36): error TS1005: '}' expected.
+tests/cases/conformance/jsx/file.tsx(12,44): error TS1003: Identifier expected.
+tests/cases/conformance/jsx/file.tsx(12,46): error TS1161: Unterminated regular expression literal.
+
+
+==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
+    
+    declare module JSX {
+    	interface Element { }
+    	interface IntrinsicElements {
+    		[s: string]: any;
+    	}
+    }
+    
+    // This should be a parse error
+    const class1 = "foo";
+    const class2 = "bar";
+    const elem = <div className={class1, class2}/>;
+                                       ~
+!!! error TS1005: '}' expected.
+                                               ~
+!!! error TS1003: Identifier expected.
+                                                 
+!!! error TS1161: Unterminated regular expression literal.
+    

--- a/tests/baselines/reference/jsxParsingError1.js
+++ b/tests/baselines/reference/jsxParsingError1.js
@@ -1,0 +1,21 @@
+//// [file.tsx]
+
+declare module JSX {
+	interface Element { }
+	interface IntrinsicElements {
+		[s: string]: any;
+	}
+}
+
+// This should be a parse error
+const class1 = "foo";
+const class2 = "bar";
+const elem = <div className={class1, class2}/>;
+
+
+//// [file.jsx]
+// This should be a parse error
+var class1 = "foo";
+var class2 = "bar";
+var elem = <div className={class1} class2/>;
+/>;;

--- a/tests/cases/conformance/jsx/jsxParsingError1.tsx
+++ b/tests/cases/conformance/jsx/jsxParsingError1.tsx
@@ -1,0 +1,14 @@
+//@jsx: preserve
+
+//@filename: file.tsx
+declare module JSX {
+	interface Element { }
+	interface IntrinsicElements {
+		[s: string]: any;
+	}
+}
+
+// This should be a parse error
+const class1 = "foo";
+const class2 = "bar";
+const elem = <div className={class1, class2}/>;


### PR DESCRIPTION
We should issue an error when parsing `<div x={1, 2} />` as the comma operator is not a legal production in a JSX Expression

Fixes (mitigates?) bug #5991