### PR TITLE
Suggested solution to #5730 [tsserver] custom command

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -179,10 +179,13 @@ namespace ts.server {
     // Override sys.write because fs.writeSync is not reliable on Node 4
     ts.sys.write = (s: string) => writeMessage(s);
 
-    const ioSession = new IOSession(ts.sys, logger);
-    process.on("uncaughtException", function(err: Error) {
-        ioSession.logError(err, "unknown");
+    process.nextTick(() => { // allow extension to Session prototype to happen by external hosting code
+
+        const ioSession = new IOSession(ts.sys, logger);
+        process.on("uncaughtException", function(err: Error) {
+            ioSession.logError(err, "unknown");
+        });
+        // Start listening
+        ioSession.listen();
     });
-    // Start listening
-    ioSession.listen();
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -189,5 +189,5 @@ namespace ts.server {
         ioSession.listen();
     });
 
-    module.export = ts;
+    module.exports = ts;
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -179,15 +179,15 @@ namespace ts.server {
     // Override sys.write because fs.writeSync is not reliable on Node 4
     ts.sys.write = (s: string) => writeMessage(s);
 
-    process.nextTick(() => { // allow extension to Session prototype to happen by external hosting code
+    const ioSession = new IOSession(ts.sys, logger);
+    process.on("uncaughtException", function(err: Error) {
+        ioSession.logError(err, "unknown");
+    });
 
-        const ioSession = new IOSession(ts.sys, logger);
-        process.on("uncaughtException", function(err: Error) {
-            ioSession.logError(err, "unknown");
-        });
-        // Start listening
+    process.nextTick(() => {
+        // Start listening, but leave potential for extensions
         ioSession.listen();
     });
 
-    module.exports = ts;
+    module.exports = ioSession;
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -188,4 +188,6 @@ namespace ts.server {
         // Start listening
         ioSession.listen();
     });
+
+    module.export = ts;
 }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -5,7 +5,6 @@
 
 namespace ts.server {
     const spaceCache: string[] = [];
-ha
     interface StackTraceError extends Error {
         stack?: string;
     }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -5,7 +5,7 @@
 
 namespace ts.server {
     const spaceCache: string[] = [];
-
+ha
     interface StackTraceError extends Error {
         stack?: string;
     }
@@ -949,7 +949,7 @@ namespace ts.server {
         exit() {
         }
 
-        private handlers: Map<(request: protocol.Request) => {response?: any, responseRequired?: boolean}> = {
+        handlers: Map<(request: protocol.Request) => {response?: any, responseRequired?: boolean}> = {
             [CommandNames.Exit]: () => {
                 this.exit();
                 return { responseRequired: false};

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -5,6 +5,7 @@
 
 namespace ts.server {
     const spaceCache: string[] = [];
+
     interface StackTraceError extends Error {
         stack?: string;
     }


### PR DESCRIPTION
See discussion (specifically [my comment](https://github.com/Microsoft/TypeScript/issues/5730#issuecomment-163164083)) in #5730 .

To summarise here, the idea is to allow complex hosts (such as Angular-aware editors) to inject extra commands into `tsserver`, without recompiling `tsserver.js`.

Instead of all the complexity of a plugin hosting model, I suggest we turn the table and put the burden of hosting on the actual *host* interested in running `tsserver`.

The Angular-editing enrichment will load `tsserver.js` script content, eval() it, then it has a window to update `ts.server.Session.prototype` to its liking before the server starts up proper.