### PR TITLE
Compare enums semi-structurally.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5757,15 +5757,17 @@ namespace ts {
             }
 
             function enumRelatedTo(source: Type, target: Type) {
-                if (source.symbol.name !== target.symbol.name) {
+                if (source.symbol.name !== target.symbol.name ||
+                    source.symbol.flags & SymbolFlags.ConstEnum ||
+                    target.symbol.flags & SymbolFlags.ConstEnum) {
                     return Ternary.False;
                 }
-                const sourceDecl = <EnumDeclaration>getMergedSymbol(source.symbol).valueDeclaration;
-                const targetDecl = <EnumDeclaration>getMergedSymbol(target.symbol).valueDeclaration;
+                const sourceDecl = <EnumDeclaration>getDeclarationOfKind(source.symbol, SyntaxKind.EnumDeclaration);
+                const targetDecl = <EnumDeclaration>getDeclarationOfKind(target.symbol, SyntaxKind.EnumDeclaration);
                 const targetMembers = arrayToMap(targetDecl.members, member => getTextOfPropertyName(<PropertyName>member.name));
                 for (const member of sourceDecl.members) {
                     const name = getTextOfPropertyName(<PropertyName>member.name);
-                    if (!targetMembers[name]) {
+                    if (!hasProperty(targetMembers, name)) {
                         reportError(Diagnostics.Property_0_is_missing_in_type_1,
                                     name,
                                     typeToString(target, /*enclosingDeclaration*/ undefined, TypeFormatFlags.UseFullyQualifiedType));

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5762,9 +5762,10 @@ namespace ts {
                     target.symbol.flags & SymbolFlags.ConstEnum) {
                     return Ternary.False;
                 }
+                const targetEnumType = getTypeOfSymbol(target.symbol);
                 for (const property of getPropertiesOfType(getTypeOfSymbol(source.symbol))) {
                     if (property.flags & SymbolFlags.EnumMember) {
-                        const targetProperty = getPropertyOfType(getTypeOfSymbol(target.symbol), property.name);
+                        const targetProperty = getPropertyOfType(targetEnumType, property.name);
                         if (!targetProperty || !(targetProperty.flags & SymbolFlags.EnumMember)) {
                             reportError(Diagnostics.Property_0_is_missing_in_type_1,
                                 property.name,

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5762,12 +5762,11 @@ namespace ts {
                     target.symbol.flags & SymbolFlags.ConstEnum) {
                     return Ternary.False;
                 }
-                const sourceDecl = <EnumDeclaration>getDeclarationOfKind(source.symbol, SyntaxKind.EnumDeclaration);
-                const targetDecl = <EnumDeclaration>getDeclarationOfKind(target.symbol, SyntaxKind.EnumDeclaration);
-                const targetMembers = arrayToMap(targetDecl.members, member => getTextOfPropertyName(<PropertyName>member.name));
-                for (const member of sourceDecl.members) {
+                const targetMembers = getEnumMembers(target.symbol);
+                const targetNames = arrayToMap(targetMembers, member => getTextOfPropertyName(<PropertyName>member.name));
+                for (const member of getEnumMembers(source.symbol)) {
                     const name = getTextOfPropertyName(<PropertyName>member.name);
-                    if (!hasProperty(targetMembers, name)) {
+                    if (!hasProperty(targetNames, name)) {
                         reportError(Diagnostics.Property_0_is_missing_in_type_1,
                                     name,
                                     typeToString(target, /*enclosingDeclaration*/ undefined, TypeFormatFlags.UseFullyQualifiedType));
@@ -5776,6 +5775,20 @@ namespace ts {
                 }
                 return Ternary.True;
             }
+        }
+
+        function getEnumMembers(symbol: Symbol): EnumMember[] {
+            const declarations = getDeclarationsOfKind(symbol, SyntaxKind.EnumDeclaration);
+            if (!declarations) {
+                return emptyArray;
+            }
+            const members: EnumMember[] = [];
+            for (const declaration of declarations) {
+                for (const member of (<EnumDeclaration>declaration).members) {
+                    members.push(member);
+                }
+            }
+            return members;
         }
 
         // Return true if the given type is part of a deeply nested chain of generic instantiations. We consider this to be the case

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5762,33 +5762,19 @@ namespace ts {
                     target.symbol.flags & SymbolFlags.ConstEnum) {
                     return Ternary.False;
                 }
-                const targetMembers = getEnumMembers(target.symbol);
-                const targetNames = arrayToMap(targetMembers, member => getTextOfPropertyName(<PropertyName>member.name));
-                for (const member of getEnumMembers(source.symbol)) {
-                    const name = getTextOfPropertyName(<PropertyName>member.name);
-                    if (!hasProperty(targetNames, name)) {
+                const sourceMembers = resolveStructuredTypeMembers(getTypeOfSymbol(source.symbol)).properties;
+                const targetMembers = resolveStructuredTypeMembers(getTypeOfSymbol(target.symbol)).properties;
+                const targetNames = arrayToMap(targetMembers, member => member.name);
+                for (const member of sourceMembers) {
+                    if (!hasProperty(targetNames, member.name)) {
                         reportError(Diagnostics.Property_0_is_missing_in_type_1,
-                                    name,
+                                    member.name,
                                     typeToString(target, /*enclosingDeclaration*/ undefined, TypeFormatFlags.UseFullyQualifiedType));
                         return Ternary.False;
                     }
                 }
                 return Ternary.True;
             }
-        }
-
-        function getEnumMembers(symbol: Symbol): EnumMember[] {
-            const declarations = getDeclarationsOfKind(symbol, SyntaxKind.EnumDeclaration);
-            if (!declarations) {
-                return emptyArray;
-            }
-            const members: EnumMember[] = [];
-            for (const declaration of declarations) {
-                for (const member of (<EnumDeclaration>declaration).members) {
-                    members.push(member);
-                }
-            }
-            return members;
         }
 
         // Return true if the given type is part of a deeply nested chain of generic instantiations. We consider this to be the case

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5762,21 +5762,18 @@ namespace ts {
                     target.symbol.flags & SymbolFlags.ConstEnum) {
                     return Ternary.False;
                 }
-                const targetNames = arrayToMap(getEnumMembersOfEnumType(target), member => member.name);
-                for (const member of getEnumMembersOfEnumType(source)) {
-                    if (!hasProperty(targetNames, member.name)) {
-                        reportError(Diagnostics.Property_0_is_missing_in_type_1,
-                                    member.name,
-                                    typeToString(target, /*enclosingDeclaration*/ undefined, TypeFormatFlags.UseFullyQualifiedType));
-                        return Ternary.False;
+                for (const property of getPropertiesOfType(getTypeOfSymbol(source.symbol))) {
+                    if (property.flags & SymbolFlags.EnumMember) {
+                        const targetProperty = getPropertyOfType(getTypeOfSymbol(target.symbol), property.name);
+                        if (!targetProperty || !(targetProperty.flags & SymbolFlags.EnumMember)) {
+                            reportError(Diagnostics.Property_0_is_missing_in_type_1,
+                                property.name,
+                                typeToString(target, /*enclosingDeclaration*/ undefined, TypeFormatFlags.UseFullyQualifiedType));
+                            return Ternary.False;
+                        }
                     }
                 }
                 return Ternary.True;
-            }
-
-            function getEnumMembersOfEnumType(type: Type) {
-                return filter(resolveStructuredTypeMembers(getTypeOfSymbol(type.symbol)).properties,
-                              property => !!(property.flags & SymbolFlags.EnumMember));
             }
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5775,7 +5775,7 @@ namespace ts {
             }
 
             function getEnumMembersOfEnumType(type: Type) {
-                return filter(resolveStructuredTypeMembers(getTypeOfSymbol(type.symbol)).properties, 
+                return filter(resolveStructuredTypeMembers(getTypeOfSymbol(type.symbol)).properties,
                               property => !!(property.flags & SymbolFlags.EnumMember));
             }
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5762,10 +5762,8 @@ namespace ts {
                     target.symbol.flags & SymbolFlags.ConstEnum) {
                     return Ternary.False;
                 }
-                const sourceMembers = resolveStructuredTypeMembers(getTypeOfSymbol(source.symbol)).properties;
-                const targetMembers = resolveStructuredTypeMembers(getTypeOfSymbol(target.symbol)).properties;
-                const targetNames = arrayToMap(targetMembers, member => member.name);
-                for (const member of sourceMembers) {
+                const targetNames = arrayToMap(getEnumMembersOfEnumType(target), member => member.name);
+                for (const member of getEnumMembersOfEnumType(source)) {
                     if (!hasProperty(targetNames, member.name)) {
                         reportError(Diagnostics.Property_0_is_missing_in_type_1,
                                     member.name,
@@ -5774,6 +5772,11 @@ namespace ts {
                     }
                 }
                 return Ternary.True;
+            }
+
+            function getEnumMembersOfEnumType(type: Type) {
+                return filter(resolveStructuredTypeMembers(getTypeOfSymbol(type.symbol)).properties, 
+                              property => !!(property.flags & SymbolFlags.EnumMember));
             }
         }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -27,6 +27,21 @@ namespace ts {
         return undefined;
     }
 
+    export function getDeclarationsOfKind(symbol: Symbol, kind: SyntaxKind): Declaration[] {
+        const declarations = symbol.declarations;
+        if (declarations) {
+            const declarationsOfKind: Declaration[] = [];
+            for (const declaration of declarations) {
+                if (declaration.kind === kind) {
+                    declarationsOfKind.push(declaration);
+                }
+            }
+            return declarationsOfKind;
+        }
+
+        return undefined;
+    }
+
     export interface StringSymbolWriter extends SymbolWriter {
         string(): string;
     }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -27,21 +27,6 @@ namespace ts {
         return undefined;
     }
 
-    export function getDeclarationsOfKind(symbol: Symbol, kind: SyntaxKind): Declaration[] {
-        const declarations = symbol.declarations;
-        if (declarations) {
-            const declarationsOfKind: Declaration[] = [];
-            for (const declaration of declarations) {
-                if (declaration.kind === kind) {
-                    declarationsOfKind.push(declaration);
-                }
-            }
-            return declarationsOfKind;
-        }
-
-        return undefined;
-    }
-
     export interface StringSymbolWriter extends SymbolWriter {
         string(): string;
     }

--- a/tests/baselines/reference/enumAssignmentCompat3.errors.txt
+++ b/tests/baselines/reference/enumAssignmentCompat3.errors.txt
@@ -1,18 +1,20 @@
-tests/cases/compiler/enumAssignmentCompat3.ts(49,1): error TS2322: Type 'Abcd.E' is not assignable to type 'First.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(58,1): error TS2322: Type 'Abcd.E' is not assignable to type 'First.E'.
   Property 'd' is missing in type 'First.E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(51,1): error TS2322: Type 'Cd.E' is not assignable to type 'First.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(60,1): error TS2322: Type 'Cd.E' is not assignable to type 'First.E'.
   Property 'd' is missing in type 'First.E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(52,1): error TS2322: Type 'Nope' is not assignable to type 'E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(56,1): error TS2322: Type 'First.E' is not assignable to type 'Ab.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(61,1): error TS2322: Type 'Nope' is not assignable to type 'E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(65,1): error TS2322: Type 'First.E' is not assignable to type 'Ab.E'.
   Property 'c' is missing in type 'Ab.E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(57,1): error TS2322: Type 'First.E' is not assignable to type 'Cd.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(66,1): error TS2322: Type 'First.E' is not assignable to type 'Cd.E'.
   Property 'a' is missing in type 'Cd.E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(58,1): error TS2322: Type 'E' is not assignable to type 'Nope'.
-tests/cases/compiler/enumAssignmentCompat3.ts(62,1): error TS2322: Type 'Const.E' is not assignable to type 'First.E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(63,1): error TS2322: Type 'First.E' is not assignable to type 'Const.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(67,1): error TS2322: Type 'E' is not assignable to type 'Nope'.
+tests/cases/compiler/enumAssignmentCompat3.ts(72,1): error TS2322: Type 'Const.E' is not assignable to type 'First.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(73,1): error TS2322: Type 'First.E' is not assignable to type 'Const.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(76,1): error TS2322: Type 'Merged.E' is not assignable to type 'First.E'.
+  Property 'd' is missing in type 'First.E'.
 
 
-==== tests/cases/compiler/enumAssignmentCompat3.ts (8 errors) ====
+==== tests/cases/compiler/enumAssignmentCompat3.ts (9 errors) ====
     namespace First {
         export enum E {
             a, b, c,
@@ -51,6 +53,14 @@ tests/cases/compiler/enumAssignmentCompat3.ts(63,1): error TS2322: Type 'First.E
             a, b, c = 3,
         }
     }
+    namespace Merged {
+        export enum E {
+            a, b, 
+        }
+        export enum E {
+            c = 3, d,
+        }
+    }
     
     var abc: First.E;
     var secondAbc: Abc.E;
@@ -60,6 +70,7 @@ tests/cases/compiler/enumAssignmentCompat3.ts(63,1): error TS2322: Type 'First.E
     var nope: Abc.Nope;
     var k: Const.E;
     var decl: Decl.E;
+    var merged: Merged.E;
     abc = secondAbc; // ok
     abc = secondAbcd; // missing 'd'
     ~~~
@@ -89,7 +100,8 @@ tests/cases/compiler/enumAssignmentCompat3.ts(63,1): error TS2322: Type 'First.E
 !!! error TS2322: Type 'E' is not assignable to type 'Nope'.
     decl = abc; // ok
     
-    k = k; // const is only assignable to itself
+    // const is only assignable to itself
+    k = k;
     abc = k; // error
     ~~~
 !!! error TS2322: Type 'Const.E' is not assignable to type 'First.E'.
@@ -97,3 +109,9 @@ tests/cases/compiler/enumAssignmentCompat3.ts(63,1): error TS2322: Type 'First.E
     ~
 !!! error TS2322: Type 'First.E' is not assignable to type 'Const.E'.
     
+    // merged enums compare all their members
+    abc = merged; // missing 'd'
+    ~~~
+!!! error TS2322: Type 'Merged.E' is not assignable to type 'First.E'.
+!!! error TS2322:   Property 'd' is missing in type 'First.E'.
+    merged = abc; // ok

--- a/tests/baselines/reference/enumAssignmentCompat3.errors.txt
+++ b/tests/baselines/reference/enumAssignmentCompat3.errors.txt
@@ -1,16 +1,16 @@
-tests/cases/compiler/enumAssignmentCompat3.ts(58,1): error TS2322: Type 'Abcd.E' is not assignable to type 'First.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(68,1): error TS2322: Type 'Abcd.E' is not assignable to type 'First.E'.
   Property 'd' is missing in type 'First.E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(60,1): error TS2322: Type 'Cd.E' is not assignable to type 'First.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(70,1): error TS2322: Type 'Cd.E' is not assignable to type 'First.E'.
   Property 'd' is missing in type 'First.E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(61,1): error TS2322: Type 'Nope' is not assignable to type 'E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(65,1): error TS2322: Type 'First.E' is not assignable to type 'Ab.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(71,1): error TS2322: Type 'Nope' is not assignable to type 'E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(75,1): error TS2322: Type 'First.E' is not assignable to type 'Ab.E'.
   Property 'c' is missing in type 'Ab.E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(66,1): error TS2322: Type 'First.E' is not assignable to type 'Cd.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(76,1): error TS2322: Type 'First.E' is not assignable to type 'Cd.E'.
   Property 'a' is missing in type 'Cd.E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(67,1): error TS2322: Type 'E' is not assignable to type 'Nope'.
-tests/cases/compiler/enumAssignmentCompat3.ts(72,1): error TS2322: Type 'Const.E' is not assignable to type 'First.E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(73,1): error TS2322: Type 'First.E' is not assignable to type 'Const.E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(76,1): error TS2322: Type 'Merged.E' is not assignable to type 'First.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(77,1): error TS2322: Type 'E' is not assignable to type 'Nope'.
+tests/cases/compiler/enumAssignmentCompat3.ts(82,1): error TS2322: Type 'Const.E' is not assignable to type 'First.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(83,1): error TS2322: Type 'First.E' is not assignable to type 'Const.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(86,1): error TS2322: Type 'Merged.E' is not assignable to type 'First.E'.
   Property 'd' is missing in type 'First.E'.
 
 
@@ -62,6 +62,15 @@ tests/cases/compiler/enumAssignmentCompat3.ts(76,1): error TS2322: Type 'Merged.
         }
     }
     
+    namespace Merged2 {
+        export enum E {
+            a, b, c
+        }
+        export module E {
+            export let d = 5;
+        }
+    }
+    
     var abc: First.E;
     var secondAbc: Abc.E;
     var secondAbcd: Abcd.E;
@@ -71,6 +80,7 @@ tests/cases/compiler/enumAssignmentCompat3.ts(76,1): error TS2322: Type 'Merged.
     var k: Const.E;
     var decl: Decl.E;
     var merged: Merged.E;
+    var merged2: Merged2.E;
     abc = secondAbc; // ok
     abc = secondAbcd; // missing 'd'
     ~~~
@@ -115,3 +125,5 @@ tests/cases/compiler/enumAssignmentCompat3.ts(76,1): error TS2322: Type 'Merged.
 !!! error TS2322: Type 'Merged.E' is not assignable to type 'First.E'.
 !!! error TS2322:   Property 'd' is missing in type 'First.E'.
     merged = abc; // ok
+    abc = merged2; // ok
+    merged2 = abc; // ok

--- a/tests/baselines/reference/enumAssignmentCompat3.errors.txt
+++ b/tests/baselines/reference/enumAssignmentCompat3.errors.txt
@@ -1,16 +1,18 @@
-tests/cases/compiler/enumAssignmentCompat3.ts(37,1): error TS2322: Type 'Abcd.E' is not assignable to type 'First.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(49,1): error TS2322: Type 'Abcd.E' is not assignable to type 'First.E'.
   Property 'd' is missing in type 'First.E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(39,1): error TS2322: Type 'Cd.E' is not assignable to type 'First.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(51,1): error TS2322: Type 'Cd.E' is not assignable to type 'First.E'.
   Property 'd' is missing in type 'First.E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(40,1): error TS2322: Type 'Nope' is not assignable to type 'E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(43,1): error TS2322: Type 'First.E' is not assignable to type 'Ab.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(52,1): error TS2322: Type 'Nope' is not assignable to type 'E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(56,1): error TS2322: Type 'First.E' is not assignable to type 'Ab.E'.
   Property 'c' is missing in type 'Ab.E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(44,1): error TS2322: Type 'First.E' is not assignable to type 'Cd.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(57,1): error TS2322: Type 'First.E' is not assignable to type 'Cd.E'.
   Property 'a' is missing in type 'Cd.E'.
-tests/cases/compiler/enumAssignmentCompat3.ts(45,1): error TS2322: Type 'E' is not assignable to type 'Nope'.
+tests/cases/compiler/enumAssignmentCompat3.ts(58,1): error TS2322: Type 'E' is not assignable to type 'Nope'.
+tests/cases/compiler/enumAssignmentCompat3.ts(62,1): error TS2322: Type 'Const.E' is not assignable to type 'First.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(63,1): error TS2322: Type 'First.E' is not assignable to type 'Const.E'.
 
 
-==== tests/cases/compiler/enumAssignmentCompat3.ts (6 errors) ====
+==== tests/cases/compiler/enumAssignmentCompat3.ts (8 errors) ====
     namespace First {
         export enum E {
             a, b, c,
@@ -39,6 +41,16 @@ tests/cases/compiler/enumAssignmentCompat3.ts(45,1): error TS2322: Type 'E' is n
             c, d,
         }
     }
+    namespace Const {
+        export const enum E {
+            a, b, c,
+        }
+    }
+    namespace Decl {
+        export declare enum E {
+            a, b, c = 3,
+        }
+    }
     
     var abc: First.E;
     var secondAbc: Abc.E;
@@ -46,6 +58,8 @@ tests/cases/compiler/enumAssignmentCompat3.ts(45,1): error TS2322: Type 'E' is n
     var secondAb: Ab.E;
     var secondCd: Cd.E;
     var nope: Abc.Nope;
+    var k: Const.E;
+    var decl: Decl.E;
     abc = secondAbc; // ok
     abc = secondAbcd; // missing 'd'
     ~~~
@@ -59,6 +73,7 @@ tests/cases/compiler/enumAssignmentCompat3.ts(45,1): error TS2322: Type 'E' is n
     abc = nope; // nope!
     ~~~
 !!! error TS2322: Type 'Nope' is not assignable to type 'E'.
+    abc = decl; // ok
     secondAbc = abc; // ok
     secondAbcd = abc; // ok
     secondAb = abc; // missing 'c'
@@ -72,4 +87,13 @@ tests/cases/compiler/enumAssignmentCompat3.ts(45,1): error TS2322: Type 'E' is n
     nope = abc; // nope!
     ~~~~
 !!! error TS2322: Type 'E' is not assignable to type 'Nope'.
+    decl = abc; // ok
+    
+    k = k; // const is only assignable to itself
+    abc = k; // error
+    ~~~
+!!! error TS2322: Type 'Const.E' is not assignable to type 'First.E'.
+    k = abc;
+    ~
+!!! error TS2322: Type 'First.E' is not assignable to type 'Const.E'.
     

--- a/tests/baselines/reference/enumAssignmentCompat3.errors.txt
+++ b/tests/baselines/reference/enumAssignmentCompat3.errors.txt
@@ -1,0 +1,75 @@
+tests/cases/compiler/enumAssignmentCompat3.ts(37,1): error TS2322: Type 'Abcd.E' is not assignable to type 'First.E'.
+  Property 'd' is missing in type 'First.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(39,1): error TS2322: Type 'Cd.E' is not assignable to type 'First.E'.
+  Property 'd' is missing in type 'First.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(40,1): error TS2322: Type 'Nope' is not assignable to type 'E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(43,1): error TS2322: Type 'First.E' is not assignable to type 'Ab.E'.
+  Property 'c' is missing in type 'Ab.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(44,1): error TS2322: Type 'First.E' is not assignable to type 'Cd.E'.
+  Property 'a' is missing in type 'Cd.E'.
+tests/cases/compiler/enumAssignmentCompat3.ts(45,1): error TS2322: Type 'E' is not assignable to type 'Nope'.
+
+
+==== tests/cases/compiler/enumAssignmentCompat3.ts (6 errors) ====
+    namespace First {
+        export enum E {
+            a, b, c,
+        }
+    }
+    namespace Abc {
+        export enum E {
+            a, b, c,
+        }
+        export enum Nope {
+            a, b, c,
+        }
+    }
+    namespace Abcd {
+        export enum E {
+            a, b, c, d,
+        }
+    }
+    namespace Ab {
+        export enum E {
+            a, b,
+        }
+    }
+    namespace Cd {
+        export enum E {
+            c, d,
+        }
+    }
+    
+    var abc: First.E;
+    var secondAbc: Abc.E;
+    var secondAbcd: Abcd.E;
+    var secondAb: Ab.E;
+    var secondCd: Cd.E;
+    var nope: Abc.Nope;
+    abc = secondAbc; // ok
+    abc = secondAbcd; // missing 'd'
+    ~~~
+!!! error TS2322: Type 'Abcd.E' is not assignable to type 'First.E'.
+!!! error TS2322:   Property 'd' is missing in type 'First.E'.
+    abc = secondAb; // ok
+    abc = secondCd; // missing 'd'
+    ~~~
+!!! error TS2322: Type 'Cd.E' is not assignable to type 'First.E'.
+!!! error TS2322:   Property 'd' is missing in type 'First.E'.
+    abc = nope; // nope!
+    ~~~
+!!! error TS2322: Type 'Nope' is not assignable to type 'E'.
+    secondAbc = abc; // ok
+    secondAbcd = abc; // ok
+    secondAb = abc; // missing 'c'
+    ~~~~~~~~
+!!! error TS2322: Type 'First.E' is not assignable to type 'Ab.E'.
+!!! error TS2322:   Property 'c' is missing in type 'Ab.E'.
+    secondCd = abc; // missing 'a' and 'b'
+    ~~~~~~~~
+!!! error TS2322: Type 'First.E' is not assignable to type 'Cd.E'.
+!!! error TS2322:   Property 'a' is missing in type 'Cd.E'.
+    nope = abc; // nope!
+    ~~~~
+!!! error TS2322: Type 'E' is not assignable to type 'Nope'.
+    

--- a/tests/baselines/reference/enumAssignmentCompat3.js
+++ b/tests/baselines/reference/enumAssignmentCompat3.js
@@ -1,0 +1,115 @@
+//// [enumAssignmentCompat3.ts]
+namespace First {
+    export enum E {
+        a, b, c,
+    }
+}
+namespace Abc {
+    export enum E {
+        a, b, c,
+    }
+    export enum Nope {
+        a, b, c,
+    }
+}
+namespace Abcd {
+    export enum E {
+        a, b, c, d,
+    }
+}
+namespace Ab {
+    export enum E {
+        a, b,
+    }
+}
+namespace Cd {
+    export enum E {
+        c, d,
+    }
+}
+
+var abc: First.E;
+var secondAbc: Abc.E;
+var secondAbcd: Abcd.E;
+var secondAb: Ab.E;
+var secondCd: Cd.E;
+var nope: Abc.Nope;
+abc = secondAbc; // ok
+abc = secondAbcd; // missing 'd'
+abc = secondAb; // ok
+abc = secondCd; // missing 'd'
+abc = nope; // nope!
+secondAbc = abc; // ok
+secondAbcd = abc; // ok
+secondAb = abc; // missing 'c'
+secondCd = abc; // missing 'a' and 'b'
+nope = abc; // nope!
+
+
+//// [enumAssignmentCompat3.js]
+var First;
+(function (First) {
+    (function (E) {
+        E[E["a"] = 0] = "a";
+        E[E["b"] = 1] = "b";
+        E[E["c"] = 2] = "c";
+    })(First.E || (First.E = {}));
+    var E = First.E;
+})(First || (First = {}));
+var Abc;
+(function (Abc) {
+    (function (E) {
+        E[E["a"] = 0] = "a";
+        E[E["b"] = 1] = "b";
+        E[E["c"] = 2] = "c";
+    })(Abc.E || (Abc.E = {}));
+    var E = Abc.E;
+    (function (Nope) {
+        Nope[Nope["a"] = 0] = "a";
+        Nope[Nope["b"] = 1] = "b";
+        Nope[Nope["c"] = 2] = "c";
+    })(Abc.Nope || (Abc.Nope = {}));
+    var Nope = Abc.Nope;
+})(Abc || (Abc = {}));
+var Abcd;
+(function (Abcd) {
+    (function (E) {
+        E[E["a"] = 0] = "a";
+        E[E["b"] = 1] = "b";
+        E[E["c"] = 2] = "c";
+        E[E["d"] = 3] = "d";
+    })(Abcd.E || (Abcd.E = {}));
+    var E = Abcd.E;
+})(Abcd || (Abcd = {}));
+var Ab;
+(function (Ab) {
+    (function (E) {
+        E[E["a"] = 0] = "a";
+        E[E["b"] = 1] = "b";
+    })(Ab.E || (Ab.E = {}));
+    var E = Ab.E;
+})(Ab || (Ab = {}));
+var Cd;
+(function (Cd) {
+    (function (E) {
+        E[E["c"] = 0] = "c";
+        E[E["d"] = 1] = "d";
+    })(Cd.E || (Cd.E = {}));
+    var E = Cd.E;
+})(Cd || (Cd = {}));
+var abc;
+var secondAbc;
+var secondAbcd;
+var secondAb;
+var secondCd;
+var nope;
+abc = secondAbc; // ok
+abc = secondAbcd; // missing 'd'
+abc = secondAb; // ok
+abc = secondCd; // missing 'd'
+abc = nope; // nope!
+secondAbc = abc; // ok
+secondAbcd = abc; // ok
+secondAb = abc; // missing 'c'
+secondCd = abc; // missing 'a' and 'b'
+nope = abc; // nope!

--- a/tests/baselines/reference/enumAssignmentCompat3.js
+++ b/tests/baselines/reference/enumAssignmentCompat3.js
@@ -27,6 +27,16 @@ namespace Cd {
         c, d,
     }
 }
+namespace Const {
+    export const enum E {
+        a, b, c,
+    }
+}
+namespace Decl {
+    export declare enum E {
+        a, b, c = 3,
+    }
+}
 
 var abc: First.E;
 var secondAbc: Abc.E;
@@ -34,16 +44,24 @@ var secondAbcd: Abcd.E;
 var secondAb: Ab.E;
 var secondCd: Cd.E;
 var nope: Abc.Nope;
+var k: Const.E;
+var decl: Decl.E;
 abc = secondAbc; // ok
 abc = secondAbcd; // missing 'd'
 abc = secondAb; // ok
 abc = secondCd; // missing 'd'
 abc = nope; // nope!
+abc = decl; // ok
 secondAbc = abc; // ok
 secondAbcd = abc; // ok
 secondAb = abc; // missing 'c'
 secondCd = abc; // missing 'a' and 'b'
 nope = abc; // nope!
+decl = abc; // ok
+
+k = k; // const is only assignable to itself
+abc = k; // error
+k = abc;
 
 
 //// [enumAssignmentCompat3.js]
@@ -97,19 +115,29 @@ var Cd;
     })(Cd.E || (Cd.E = {}));
     var E = Cd.E;
 })(Cd || (Cd = {}));
+var Decl;
+(function (Decl) {
+})(Decl || (Decl = {}));
 var abc;
 var secondAbc;
 var secondAbcd;
 var secondAb;
 var secondCd;
 var nope;
+var k;
+var decl;
 abc = secondAbc; // ok
 abc = secondAbcd; // missing 'd'
 abc = secondAb; // ok
 abc = secondCd; // missing 'd'
 abc = nope; // nope!
+abc = decl; // ok
 secondAbc = abc; // ok
 secondAbcd = abc; // ok
 secondAb = abc; // missing 'c'
 secondCd = abc; // missing 'a' and 'b'
 nope = abc; // nope!
+decl = abc; // ok
+k = k; // const is only assignable to itself
+abc = k; // error
+k = abc;

--- a/tests/baselines/reference/enumAssignmentCompat3.js
+++ b/tests/baselines/reference/enumAssignmentCompat3.js
@@ -46,6 +46,15 @@ namespace Merged {
     }
 }
 
+namespace Merged2 {
+    export enum E {
+        a, b, c
+    }
+    export module E {
+        export let d = 5;
+    }
+}
+
 var abc: First.E;
 var secondAbc: Abc.E;
 var secondAbcd: Abcd.E;
@@ -55,6 +64,7 @@ var nope: Abc.Nope;
 var k: Const.E;
 var decl: Decl.E;
 var merged: Merged.E;
+var merged2: Merged2.E;
 abc = secondAbc; // ok
 abc = secondAbcd; // missing 'd'
 abc = secondAb; // ok
@@ -76,6 +86,8 @@ k = abc;
 // merged enums compare all their members
 abc = merged; // missing 'd'
 merged = abc; // ok
+abc = merged2; // ok
+merged2 = abc; // ok
 
 //// [enumAssignmentCompat3.js]
 var First;
@@ -144,6 +156,19 @@ var Merged;
     })(Merged.E || (Merged.E = {}));
     var E = Merged.E;
 })(Merged || (Merged = {}));
+var Merged2;
+(function (Merged2) {
+    (function (E) {
+        E[E["a"] = 0] = "a";
+        E[E["b"] = 1] = "b";
+        E[E["c"] = 2] = "c";
+    })(Merged2.E || (Merged2.E = {}));
+    var E = Merged2.E;
+    var E;
+    (function (E) {
+        E.d = 5;
+    })(E = Merged2.E || (Merged2.E = {}));
+})(Merged2 || (Merged2 = {}));
 var abc;
 var secondAbc;
 var secondAbcd;
@@ -153,6 +178,7 @@ var nope;
 var k;
 var decl;
 var merged;
+var merged2;
 abc = secondAbc; // ok
 abc = secondAbcd; // missing 'd'
 abc = secondAb; // ok
@@ -172,3 +198,5 @@ k = abc;
 // merged enums compare all their members
 abc = merged; // missing 'd'
 merged = abc; // ok
+abc = merged2; // ok
+merged2 = abc; // ok

--- a/tests/baselines/reference/enumAssignmentCompat3.js
+++ b/tests/baselines/reference/enumAssignmentCompat3.js
@@ -37,6 +37,14 @@ namespace Decl {
         a, b, c = 3,
     }
 }
+namespace Merged {
+    export enum E {
+        a, b, 
+    }
+    export enum E {
+        c = 3, d,
+    }
+}
 
 var abc: First.E;
 var secondAbc: Abc.E;
@@ -46,6 +54,7 @@ var secondCd: Cd.E;
 var nope: Abc.Nope;
 var k: Const.E;
 var decl: Decl.E;
+var merged: Merged.E;
 abc = secondAbc; // ok
 abc = secondAbcd; // missing 'd'
 abc = secondAb; // ok
@@ -59,10 +68,14 @@ secondCd = abc; // missing 'a' and 'b'
 nope = abc; // nope!
 decl = abc; // ok
 
-k = k; // const is only assignable to itself
+// const is only assignable to itself
+k = k;
 abc = k; // error
 k = abc;
 
+// merged enums compare all their members
+abc = merged; // missing 'd'
+merged = abc; // ok
 
 //// [enumAssignmentCompat3.js]
 var First;
@@ -118,6 +131,19 @@ var Cd;
 var Decl;
 (function (Decl) {
 })(Decl || (Decl = {}));
+var Merged;
+(function (Merged) {
+    (function (E) {
+        E[E["a"] = 0] = "a";
+        E[E["b"] = 1] = "b";
+    })(Merged.E || (Merged.E = {}));
+    var E = Merged.E;
+    (function (E) {
+        E[E["c"] = 3] = "c";
+        E[E["d"] = 4] = "d";
+    })(Merged.E || (Merged.E = {}));
+    var E = Merged.E;
+})(Merged || (Merged = {}));
 var abc;
 var secondAbc;
 var secondAbcd;
@@ -126,6 +152,7 @@ var secondCd;
 var nope;
 var k;
 var decl;
+var merged;
 abc = secondAbc; // ok
 abc = secondAbcd; // missing 'd'
 abc = secondAb; // ok
@@ -138,6 +165,10 @@ secondAb = abc; // missing 'c'
 secondCd = abc; // missing 'a' and 'b'
 nope = abc; // nope!
 decl = abc; // ok
-k = k; // const is only assignable to itself
+// const is only assignable to itself
+k = k;
 abc = k; // error
 k = abc;
+// merged enums compare all their members
+abc = merged; // missing 'd'
+merged = abc; // ok

--- a/tests/cases/compiler/enumAssignmentCompat3.ts
+++ b/tests/cases/compiler/enumAssignmentCompat3.ts
@@ -1,0 +1,45 @@
+namespace First {
+    export enum E {
+        a, b, c,
+    }
+}
+namespace Abc {
+    export enum E {
+        a, b, c,
+    }
+    export enum Nope {
+        a, b, c,
+    }
+}
+namespace Abcd {
+    export enum E {
+        a, b, c, d,
+    }
+}
+namespace Ab {
+    export enum E {
+        a, b,
+    }
+}
+namespace Cd {
+    export enum E {
+        c, d,
+    }
+}
+
+var abc: First.E;
+var secondAbc: Abc.E;
+var secondAbcd: Abcd.E;
+var secondAb: Ab.E;
+var secondCd: Cd.E;
+var nope: Abc.Nope;
+abc = secondAbc; // ok
+abc = secondAbcd; // missing 'd'
+abc = secondAb; // ok
+abc = secondCd; // missing 'd'
+abc = nope; // nope!
+secondAbc = abc; // ok
+secondAbcd = abc; // ok
+secondAb = abc; // missing 'c'
+secondCd = abc; // missing 'a' and 'b'
+nope = abc; // nope!

--- a/tests/cases/compiler/enumAssignmentCompat3.ts
+++ b/tests/cases/compiler/enumAssignmentCompat3.ts
@@ -36,6 +36,14 @@ namespace Decl {
         a, b, c = 3,
     }
 }
+namespace Merged {
+    export enum E {
+        a, b, 
+    }
+    export enum E {
+        c = 3, d,
+    }
+}
 
 var abc: First.E;
 var secondAbc: Abc.E;
@@ -45,6 +53,7 @@ var secondCd: Cd.E;
 var nope: Abc.Nope;
 var k: Const.E;
 var decl: Decl.E;
+var merged: Merged.E;
 abc = secondAbc; // ok
 abc = secondAbcd; // missing 'd'
 abc = secondAb; // ok
@@ -58,6 +67,11 @@ secondCd = abc; // missing 'a' and 'b'
 nope = abc; // nope!
 decl = abc; // ok
 
-k = k; // const is only assignable to itself
+// const is only assignable to itself
+k = k;
 abc = k; // error
 k = abc;
+
+// merged enums compare all their members
+abc = merged; // missing 'd'
+merged = abc; // ok

--- a/tests/cases/compiler/enumAssignmentCompat3.ts
+++ b/tests/cases/compiler/enumAssignmentCompat3.ts
@@ -45,6 +45,15 @@ namespace Merged {
     }
 }
 
+namespace Merged2 {
+    export enum E {
+        a, b, c
+    }
+    export module E {
+        export let d = 5;
+    }
+}
+
 var abc: First.E;
 var secondAbc: Abc.E;
 var secondAbcd: Abcd.E;
@@ -54,6 +63,7 @@ var nope: Abc.Nope;
 var k: Const.E;
 var decl: Decl.E;
 var merged: Merged.E;
+var merged2: Merged2.E;
 abc = secondAbc; // ok
 abc = secondAbcd; // missing 'd'
 abc = secondAb; // ok
@@ -75,3 +85,5 @@ k = abc;
 // merged enums compare all their members
 abc = merged; // missing 'd'
 merged = abc; // ok
+abc = merged2; // ok
+merged2 = abc; // ok

--- a/tests/cases/compiler/enumAssignmentCompat3.ts
+++ b/tests/cases/compiler/enumAssignmentCompat3.ts
@@ -26,6 +26,16 @@ namespace Cd {
         c, d,
     }
 }
+namespace Const {
+    export const enum E {
+        a, b, c,
+    }
+}
+namespace Decl {
+    export declare enum E {
+        a, b, c = 3,
+    }
+}
 
 var abc: First.E;
 var secondAbc: Abc.E;
@@ -33,13 +43,21 @@ var secondAbcd: Abcd.E;
 var secondAb: Ab.E;
 var secondCd: Cd.E;
 var nope: Abc.Nope;
+var k: Const.E;
+var decl: Decl.E;
 abc = secondAbc; // ok
 abc = secondAbcd; // missing 'd'
 abc = secondAb; // ok
 abc = secondCd; // missing 'd'
 abc = nope; // nope!
+abc = decl; // ok
 secondAbc = abc; // ok
 secondAbcd = abc; // ok
 secondAb = abc; // missing 'c'
 secondCd = abc; // missing 'a' and 'b'
 nope = abc; // nope!
+decl = abc; // ok
+
+k = k; // const is only assignable to itself
+abc = k; // error
+k = abc;


### PR DESCRIPTION
Fixes #1748.

1. Unqualified names must match.
2. Target contains members with same names as all source members.