### PR TITLE
Roll back to polling file watching for 1.7

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -411,11 +411,6 @@ namespace ts {
                     // and is more efficient than `fs.watchFile` (ref: https://github.com/nodejs/node/pull/2649
                     // and https://github.com/Microsoft/TypeScript/issues/4643), therefore
                     // if the current node.js version is newer than 4, use `fs.watch` instead.
-                    if (isNode4OrLater()) {
-                        // Note: in node the callback of fs.watch is given only the relative file name as a parameter
-                        return _fs.watch(fileName, (eventName: string, relativeFileName: string) => callback(fileName));
-                    }
-
                     const watchedFile = watchedFileSet.addFile(fileName, callback);
                     return {
                         close: () => watchedFileSet.removeFile(watchedFile)


### PR DESCRIPTION
This is a fix for #6016 that reverts to polling file watching for the approaching release 1.7.5
The non-polling fix is located at #6026, and will be updated later. 