### PR TITLE
Naive implementation for #6097

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -6992,7 +6992,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
 
                     write(text);
                 }
-                write(`], function(${exportFunctionForFile}) {`);
+                write(`], function(${exportFunctionForFile}, __moduleName) {`);
                 writeLine();
                 increaseIndent();
                 const startIndex = emitDirectivePrologues(node.statements, /*startWithNewLine*/ true, /*ensureUseStrict*/ true);

--- a/tests/baselines/reference/aliasesInSystemModule1.js
+++ b/tests/baselines/reference/aliasesInSystemModule1.js
@@ -17,7 +17,7 @@ module M {
   
 
 //// [aliasesInSystemModule1.js]
-System.register(['foo'], function(exports_1) {
+System.register(['foo'], function(exports_1, __moduleName) {
     "use strict";
     var alias;
     var cls, cls2, x, y, z, M;

--- a/tests/baselines/reference/aliasesInSystemModule2.js
+++ b/tests/baselines/reference/aliasesInSystemModule2.js
@@ -16,7 +16,7 @@ module M {
 }
 
 //// [aliasesInSystemModule2.js]
-System.register(["foo"], function(exports_1) {
+System.register(["foo"], function(exports_1, __moduleName) {
     "use strict";
     var foo_1;
     var cls, cls2, x, y, z, M;

--- a/tests/baselines/reference/allowSyntheticDefaultImports2.js
+++ b/tests/baselines/reference/allowSyntheticDefaultImports2.js
@@ -10,7 +10,7 @@ export class Foo {
 }
 
 //// [b.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var Foo;
     return {
@@ -26,7 +26,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [a.js]
-System.register(["./b"], function(exports_1) {
+System.register(["./b"], function(exports_1, __moduleName) {
     "use strict";
     var b_1;
     var x;

--- a/tests/baselines/reference/allowSyntheticDefaultImports3.js
+++ b/tests/baselines/reference/allowSyntheticDefaultImports3.js
@@ -11,7 +11,7 @@ export class Foo {
 
 
 //// [b.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var Foo;
     return {
@@ -27,7 +27,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [a.js]
-System.register(["./b"], function(exports_1) {
+System.register(["./b"], function(exports_1, __moduleName) {
     "use strict";
     var b_1;
     var x;

--- a/tests/baselines/reference/allowSyntheticDefaultImports5.js
+++ b/tests/baselines/reference/allowSyntheticDefaultImports5.js
@@ -12,7 +12,7 @@ export var x = new Foo();
 
 
 //// [a.js]
-System.register(["./b"], function(exports_1) {
+System.register(["./b"], function(exports_1, __moduleName) {
     "use strict";
     var b_1;
     var x;

--- a/tests/baselines/reference/allowSyntheticDefaultImports6.js
+++ b/tests/baselines/reference/allowSyntheticDefaultImports6.js
@@ -12,7 +12,7 @@ export var x = new Foo();
 
 
 //// [a.js]
-System.register(["./b"], function(exports_1) {
+System.register(["./b"], function(exports_1, __moduleName) {
     "use strict";
     var b_1;
     var x;

--- a/tests/baselines/reference/anonymousDefaultExportsSystem.js
+++ b/tests/baselines/reference/anonymousDefaultExportsSystem.js
@@ -7,7 +7,7 @@ export default class {}
 export default function() {}
 
 //// [a.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var default_1;
     return {
@@ -20,7 +20,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [b.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     function default_1() { }
     exports_1("default", default_1);

--- a/tests/baselines/reference/capturedLetConstInLoop4.js
+++ b/tests/baselines/reference/capturedLetConstInLoop4.js
@@ -144,7 +144,7 @@ for (const y = 0; y < 1;) {
 
 
 //// [capturedLetConstInLoop4.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var v0, v00, v1, v2, v3, v4, v5, v6, v7, v8, v0_c, v00_c, v1_c, v2_c, v3_c, v4_c, v5_c, v6_c, v7_c, v8_c;
     //======let

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedSystem.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedSystem.js
@@ -13,7 +13,7 @@ var decorator: ClassDecorator;
 export default class {}
 
 //// [a.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
         var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
@@ -35,7 +35,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [b.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
         var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;

--- a/tests/baselines/reference/defaultExportsGetExportedSystem.js
+++ b/tests/baselines/reference/defaultExportsGetExportedSystem.js
@@ -8,7 +8,7 @@ export default function foo() {}
 
 
 //// [a.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var Foo;
     return {
@@ -21,7 +21,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [b.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     function foo() { }
     exports_1("default", foo);

--- a/tests/baselines/reference/es5-system.js
+++ b/tests/baselines/reference/es5-system.js
@@ -15,7 +15,7 @@ export default class A
 
 
 //// [es5-system.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var A;
     return {

--- a/tests/baselines/reference/exportNonInitializedVariablesSystem.js
+++ b/tests/baselines/reference/exportNonInitializedVariablesSystem.js
@@ -35,7 +35,7 @@ export let h1: D = new D;
 
 
 //// [exportNonInitializedVariablesSystem.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var a, b, c, d, A, e, f, B, C, a1, b1, c1, d1, D, e1, f1, g1, h1;
     return {

--- a/tests/baselines/reference/exportStarForValues10.js
+++ b/tests/baselines/reference/exportStarForValues10.js
@@ -13,7 +13,7 @@ export * from "file1";
 var x = 1;
 
 //// [file0.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var v;
     return {
@@ -24,7 +24,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file1.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     return {
         setters:[],
@@ -33,7 +33,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file2.js]
-System.register(["file0"], function(exports_1) {
+System.register(["file0"], function(exports_1, __moduleName) {
     "use strict";
     var x;
     function exportStar_1(m) {

--- a/tests/baselines/reference/exportStarForValues6.js
+++ b/tests/baselines/reference/exportStarForValues6.js
@@ -9,7 +9,7 @@ export * from "file1"
 export var x = 1;
 
 //// [file1.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     return {
         setters:[],
@@ -18,7 +18,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file2.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var x;
     return {

--- a/tests/baselines/reference/exportStarForValuesInSystem.js
+++ b/tests/baselines/reference/exportStarForValuesInSystem.js
@@ -9,7 +9,7 @@ export * from "file1"
 var x = 1;
 
 //// [file1.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     return {
         setters:[],
@@ -18,7 +18,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file2.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var x;
     return {

--- a/tests/baselines/reference/isolatedModulesPlainFile-System.js
+++ b/tests/baselines/reference/isolatedModulesPlainFile-System.js
@@ -5,7 +5,7 @@ run(1);
 
 
 //// [isolatedModulesPlainFile-System.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     return {
         setters:[],

--- a/tests/baselines/reference/modulePrologueSystem.js
+++ b/tests/baselines/reference/modulePrologueSystem.js
@@ -4,7 +4,7 @@
 export class Foo {}
 
 //// [modulePrologueSystem.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var Foo;
     return {

--- a/tests/baselines/reference/outFilerootDirModuleNamesSystem.js
+++ b/tests/baselines/reference/outFilerootDirModuleNamesSystem.js
@@ -11,7 +11,7 @@ export default function foo() { new Foo(); }
 
 
 //// [output.js]
-System.register("b", ["a"], function(exports_1) {
+System.register("b", ["a"], function(exports_1, __moduleName) {
     "use strict";
     var a_1;
     function foo() { new a_1.default(); }
@@ -25,7 +25,7 @@ System.register("b", ["a"], function(exports_1) {
         }
     }
 });
-System.register("a", ["b"], function(exports_2) {
+System.register("a", ["b"], function(exports_2, __moduleName) {
     "use strict";
     var b_1;
     var Foo;

--- a/tests/baselines/reference/outModuleConcatSystem.js
+++ b/tests/baselines/reference/outModuleConcatSystem.js
@@ -14,7 +14,7 @@ var __extends = (this && this.__extends) || function (d, b) {
     function __() { this.constructor = d; }
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
-System.register("ref/a", [], function(exports_1) {
+System.register("ref/a", [], function(exports_1, __moduleName) {
     "use strict";
     var A;
     return {
@@ -29,7 +29,7 @@ System.register("ref/a", [], function(exports_1) {
         }
     }
 });
-System.register("b", ["ref/a"], function(exports_2) {
+System.register("b", ["ref/a"], function(exports_2, __moduleName) {
     "use strict";
     var a_1;
     var B;

--- a/tests/baselines/reference/outModuleConcatSystem.sourcemap.txt
+++ b/tests/baselines/reference/outModuleConcatSystem.sourcemap.txt
@@ -13,7 +13,7 @@ sourceFile:tests/cases/compiler/ref/a.ts
 >>>    function __() { this.constructor = d; }
 >>>    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 >>>};
->>>System.register("ref/a", [], function(exports_1) {
+>>>System.register("ref/a", [], function(exports_1, __moduleName) {
 >>>    "use strict";
 >>>    var A;
 >>>    return {
@@ -82,7 +82,7 @@ sourceFile:tests/cases/compiler/b.ts
 >>>        }
 >>>    }
 >>>});
->>>System.register("b", ["ref/a"], function(exports_2) {
+>>>System.register("b", ["ref/a"], function(exports_2, __moduleName) {
 >>>    "use strict";
 >>>    var a_1;
 >>>    var B;

--- a/tests/baselines/reference/systemExportAssignment.js
+++ b/tests/baselines/reference/systemExportAssignment.js
@@ -10,7 +10,7 @@ import * as a from "a";
 
 
 //// [b.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     return {
         setters:[],

--- a/tests/baselines/reference/systemExportAssignment2.js
+++ b/tests/baselines/reference/systemExportAssignment2.js
@@ -10,7 +10,7 @@ import * as a from "a";
 
 
 //// [a.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var a;
     return {
@@ -21,7 +21,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [b.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     return {
         setters:[],

--- a/tests/baselines/reference/systemExportAssignment3.js
+++ b/tests/baselines/reference/systemExportAssignment3.js
@@ -12,7 +12,7 @@ import * as a from "a";
 
 
 //// [b.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     return {
         setters:[],

--- a/tests/baselines/reference/systemModule1.js
+++ b/tests/baselines/reference/systemModule1.js
@@ -3,7 +3,7 @@
 export var x = 1;
 
 //// [systemModule1.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var x;
     return {

--- a/tests/baselines/reference/systemModule10.js
+++ b/tests/baselines/reference/systemModule10.js
@@ -10,7 +10,7 @@ export {n2}
 export {n2 as n3}
 
 //// [systemModule10.js]
-System.register(['file1', 'file2'], function(exports_1) {
+System.register(['file1', 'file2'], function(exports_1, __moduleName) {
     "use strict";
     var file1_1, n2;
     return {

--- a/tests/baselines/reference/systemModule10_ES5.js
+++ b/tests/baselines/reference/systemModule10_ES5.js
@@ -10,7 +10,7 @@ export {n2}
 export {n2 as n3}
 
 //// [systemModule10_ES5.js]
-System.register(['file1', 'file2'], function(exports_1) {
+System.register(['file1', 'file2'], function(exports_1, __moduleName) {
     "use strict";
     var file1_1, n2;
     return {

--- a/tests/baselines/reference/systemModule11.js
+++ b/tests/baselines/reference/systemModule11.js
@@ -42,7 +42,7 @@ export * from 'a';
 
 //// [file1.js]
 // set of tests cases that checks generation of local storage for exported names
-System.register(['bar'], function(exports_1) {
+System.register(['bar'], function(exports_1, __moduleName) {
     "use strict";
     var x;
     function foo() { }
@@ -68,7 +68,7 @@ System.register(['bar'], function(exports_1) {
     }
 });
 //// [file2.js]
-System.register(['bar'], function(exports_1) {
+System.register(['bar'], function(exports_1, __moduleName) {
     "use strict";
     var x, y;
     var exportedNames_1 = {
@@ -94,7 +94,7 @@ System.register(['bar'], function(exports_1) {
     }
 });
 //// [file3.js]
-System.register(['a', 'bar'], function(exports_1) {
+System.register(['a', 'bar'], function(exports_1, __moduleName) {
     "use strict";
     function foo() { }
     exports_1("default", foo);
@@ -125,7 +125,7 @@ System.register(['a', 'bar'], function(exports_1) {
     }
 });
 //// [file4.js]
-System.register(['a'], function(exports_1) {
+System.register(['a'], function(exports_1, __moduleName) {
     "use strict";
     var x, z, z1;
     function foo() { }
@@ -147,7 +147,7 @@ System.register(['a'], function(exports_1) {
     }
 });
 //// [file5.js]
-System.register(['a'], function(exports_1) {
+System.register(['a'], function(exports_1, __moduleName) {
     "use strict";
     function foo() { }
     function exportStar_1(m) {

--- a/tests/baselines/reference/systemModule12.js
+++ b/tests/baselines/reference/systemModule12.js
@@ -5,7 +5,7 @@ import n from 'file1'
 
 
 //// [systemModule12.js]
-System.register("NamedModule", [], function(exports_1) {
+System.register("NamedModule", [], function(exports_1, __moduleName) {
     "use strict";
     return {
         setters:[],

--- a/tests/baselines/reference/systemModule13.js
+++ b/tests/baselines/reference/systemModule13.js
@@ -5,7 +5,7 @@ export const {a: z0, b: {c: z1}} = {a: true, b: {c: "123"}};
 for ([x] of [[1]]) {}
 
 //// [systemModule13.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var x, y, z, z0, z1;
     return {

--- a/tests/baselines/reference/systemModule14.js
+++ b/tests/baselines/reference/systemModule14.js
@@ -11,7 +11,7 @@ var x = 1;
 export {foo as b}
 
 //// [systemModule14.js]
-System.register(["foo"], function(exports_1) {
+System.register(["foo"], function(exports_1, __moduleName) {
     "use strict";
     var foo_1;
     var x;

--- a/tests/baselines/reference/systemModule15.js
+++ b/tests/baselines/reference/systemModule15.js
@@ -34,7 +34,7 @@ export default value;
 export var value2 = "v";
 
 //// [file3.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var value;
     return {
@@ -46,7 +46,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file4.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var value2;
     return {
@@ -57,7 +57,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file2.js]
-System.register(["./file3"], function(exports_1) {
+System.register(["./file3"], function(exports_1, __moduleName) {
     "use strict";
     var moduleCStar, file3_1, file3_2;
     return {
@@ -75,7 +75,7 @@ System.register(["./file3"], function(exports_1) {
     }
 });
 //// [file1.js]
-System.register(["./file2"], function(exports_1) {
+System.register(["./file2"], function(exports_1, __moduleName) {
     "use strict";
     var moduleB;
     return {

--- a/tests/baselines/reference/systemModule16.js
+++ b/tests/baselines/reference/systemModule16.js
@@ -13,7 +13,7 @@ x,y,a1,b1,d1;
 
 
 //// [systemModule16.js]
-System.register(["foo", "bar"], function(exports_1) {
+System.register(["foo", "bar"], function(exports_1, __moduleName) {
     "use strict";
     var x, y, foo_1;
     var exportedNames_1 = {

--- a/tests/baselines/reference/systemModule17.js
+++ b/tests/baselines/reference/systemModule17.js
@@ -42,7 +42,7 @@ export {II};
 export {II as II1};
 
 //// [f1.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var A;
     return {
@@ -58,7 +58,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [f2.js]
-System.register(["f1"], function(exports_1) {
+System.register(["f1"], function(exports_1, __moduleName) {
     "use strict";
     var f1_1;
     var x, N, IX;

--- a/tests/baselines/reference/systemModule2.js
+++ b/tests/baselines/reference/systemModule2.js
@@ -4,7 +4,7 @@ var x = 1;
 export = x;
 
 //// [systemModule2.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var x;
     return {

--- a/tests/baselines/reference/systemModule3.js
+++ b/tests/baselines/reference/systemModule3.js
@@ -18,7 +18,7 @@ export default class C {}
 export default class {}
 
 //// [file1.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     function default_1() { }
     exports_1("default", default_1);
@@ -29,7 +29,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file2.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     function f() { }
     exports_1("default", f);
@@ -40,7 +40,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file3.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var C;
     return {
@@ -56,7 +56,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file4.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var default_1;
     return {

--- a/tests/baselines/reference/systemModule4.js
+++ b/tests/baselines/reference/systemModule4.js
@@ -4,7 +4,7 @@ export var x = 1;
 export var y;
 
 //// [systemModule4.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var x, y;
     return {

--- a/tests/baselines/reference/systemModule5.js
+++ b/tests/baselines/reference/systemModule5.js
@@ -4,7 +4,7 @@ export function foo() {}
 
 
 //// [systemModule5.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     function foo() { }
     exports_1("foo", foo);

--- a/tests/baselines/reference/systemModule6.js
+++ b/tests/baselines/reference/systemModule6.js
@@ -7,7 +7,7 @@ function foo() {
 
 
 //// [systemModule6.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var C;
     function foo() {

--- a/tests/baselines/reference/systemModule7.js
+++ b/tests/baselines/reference/systemModule7.js
@@ -11,7 +11,7 @@ export module M {
 }
 
 //// [systemModule7.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var M;
     return {

--- a/tests/baselines/reference/systemModule8.js
+++ b/tests/baselines/reference/systemModule8.js
@@ -31,7 +31,7 @@ export const {a: z0, b: {c: z1}} = {a: true, b: {c: "123"}};
 for ([x] of [[1]]) {}
 
 //// [systemModule8.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var x, y, z0, z1;
     function foo() {

--- a/tests/baselines/reference/systemModule9.js
+++ b/tests/baselines/reference/systemModule9.js
@@ -22,7 +22,7 @@ export {x};
 export {y as z};
 
 //// [systemModule9.js]
-System.register(['file1', 'file2', 'file3', 'file4', 'file5', 'file6', 'file7'], function(exports_1) {
+System.register(['file1', 'file2', 'file3', 'file4', 'file5', 'file6', 'file7'], function(exports_1, __moduleName) {
     "use strict";
     var ns, file2_1, file3_1, file5_1, ns3;
     var x, y;

--- a/tests/baselines/reference/systemModuleAmbientDeclarations.js
+++ b/tests/baselines/reference/systemModuleAmbientDeclarations.js
@@ -29,7 +29,7 @@ export declare module M { var v: number; }
 
 
 //// [file1.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var promise, foo, c, e;
     return {
@@ -44,7 +44,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file2.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     return {
         setters:[],
@@ -53,7 +53,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file3.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     return {
         setters:[],
@@ -62,7 +62,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file4.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     return {
         setters:[],
@@ -71,7 +71,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file5.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     return {
         setters:[],
@@ -80,7 +80,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file6.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     return {
         setters:[],

--- a/tests/baselines/reference/systemModuleConstEnums.js
+++ b/tests/baselines/reference/systemModuleConstEnums.js
@@ -13,7 +13,7 @@ module M {
 }
 
 //// [systemModuleConstEnums.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     function foo() {
         use(0 /* X */);

--- a/tests/baselines/reference/systemModuleConstEnumsSeparateCompilation.js
+++ b/tests/baselines/reference/systemModuleConstEnumsSeparateCompilation.js
@@ -13,7 +13,7 @@ module M {
 }
 
 //// [systemModuleConstEnumsSeparateCompilation.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var TopLevelConstEnum, M;
     function foo() {

--- a/tests/baselines/reference/systemModuleDeclarationMerging.js
+++ b/tests/baselines/reference/systemModuleDeclarationMerging.js
@@ -10,7 +10,7 @@ export enum E {}
 export module E { var x; }
 
 //// [systemModuleDeclarationMerging.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var F, C, E;
     function F() { }

--- a/tests/baselines/reference/systemModuleExportDefault.js
+++ b/tests/baselines/reference/systemModuleExportDefault.js
@@ -16,7 +16,7 @@ export default class C {}
 
 
 //// [file1.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     function default_1() { }
     exports_1("default", default_1);
@@ -27,7 +27,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file2.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     function foo() { }
     exports_1("default", foo);
@@ -38,7 +38,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file3.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var default_1;
     return {
@@ -54,7 +54,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [file4.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var C;
     return {

--- a/tests/baselines/reference/systemModuleNonTopLevelModuleMembers.js
+++ b/tests/baselines/reference/systemModuleNonTopLevelModuleMembers.js
@@ -13,7 +13,7 @@ export module TopLevelModule2 {
 }
 
 //// [systemModuleNonTopLevelModuleMembers.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var TopLevelClass, TopLevelModule, TopLevelEnum, TopLevelModule2;
     function TopLevelFunction() { }

--- a/tests/baselines/reference/systemModuleWithSuperClass.js
+++ b/tests/baselines/reference/systemModuleWithSuperClass.js
@@ -13,7 +13,7 @@ export class Bar extends Foo {
 }
 
 //// [foo.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, __moduleName) {
     "use strict";
     var Foo;
     return {
@@ -29,7 +29,7 @@ System.register([], function(exports_1) {
     }
 });
 //// [bar.js]
-System.register(['./foo'], function(exports_1) {
+System.register(['./foo'], function(exports_1, __moduleName) {
     "use strict";
     var __extends = (this && this.__extends) || function (d, b) {
         for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];

--- a/tests/cases/unittests/transpile.ts
+++ b/tests/cases/unittests/transpile.ts
@@ -134,7 +134,7 @@ var x = 0;`,
 
         it("Sets module name", () => {
             let output =
-                `System.register("NamedModule", [], function(exports_1) {\n    "use strict";\n    var x;\n` +
+                `System.register("NamedModule", [], function(exports_1, __moduleName) {\n    "use strict";\n    var x;\n` +
                 `    return {\n` +
                 `        setters:[],\n` +
                 `        execute: function() {\n` +
@@ -159,7 +159,7 @@ var x = 0;`,
                 `declare function use(a: any);\n` +
                 `use(foo);`
             let output =
-                `System.register(["SomeOtherName"], function(exports_1) {\n` +
+                `System.register(["SomeOtherName"], function(exports_1, __moduleName) {\n` +
                 `    "use strict";\n` +
                 `    var SomeName_1;\n` +
                 `    return {\n` +


### PR DESCRIPTION
As in https://github.com/Microsoft/TypeScript/issues/6097 this adds System.register `__moduleName` reference support.

An optimization that can be included is to only add this argument when it is explicitly used in the code, making the output cleaner, but it would be removed by minification anyway if it is always output.