### PR TITLE
Update the file watching intervals and chunk size

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -290,7 +290,7 @@ namespace ts {
             // changes for large reference sets? If so, do we want
             // to increase the chunk size or decrease the interval
             // time dynamically to match the large reference set?
-            let watchedFileSet = createWatchedFileSet(1500, 100);
+            let watchedFileSet = createWatchedFileSet(/*interval*/ 1500,/*chunkSize*/ 100);
 
             function isNode4OrLater(): Boolean {
                 return parseInt(process.version.charAt(1)) >= 4;

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -290,7 +290,7 @@ namespace ts {
             // changes for large reference sets? If so, do we want
             // to increase the chunk size or decrease the interval
             // time dynamically to match the large reference set?
-            let watchedFileSet = createWatchedFileSet();
+            let watchedFileSet = createWatchedFileSet(1500, 100);
 
             function isNode4OrLater(): Boolean {
                 return parseInt(process.version.charAt(1)) >= 4;


### PR DESCRIPTION
Issue: the current polling file watching can result in long wait time for large watched file set. For example, for >120 watched files it takes ~10s to get the changes. 

The new parameters would wait 1.5s each time, and process at most 100 files. It takes at most 3s to detect changes for a project of 200 files. As an average async stat takes about 30 microsecond, the overhead of each polling is 100*(30 microsecond) = 3 millisecond. However for a smaller project size, the overhead is determined by the numebr of files in the project.