### PR TITLE
Properly handle multiply-declared optional properties in JSX attr. type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3766,13 +3766,14 @@ namespace ts {
         function createUnionOrIntersectionProperty(containingType: UnionOrIntersectionType, name: string): Symbol {
             const types = containingType.types;
             let props: Symbol[];
-            let isOptional = !!(containingType.flags & TypeFlags.Intersection);
+            // Flags we want to propagate to the result if they exist in all source symbols
+            let commonFlags = (containingType.flags & TypeFlags.Intersection) ? SymbolFlags.Optional : SymbolFlags.None;
             for (const current of types) {
                 const type = getApparentType(current);
                 if (type !== unknownType) {
                     const prop = getPropertyOfType(type, name);
                     if (prop && !(getDeclarationFlagsFromSymbol(prop) & (NodeFlags.Private | NodeFlags.Protected))) {
-                        isOptional = isOptional && !!(prop.flags & SymbolFlags.Optional);
+                        commonFlags &= prop.flags;
                         if (!props) {
                             props = [prop];
                         }
@@ -3804,7 +3805,7 @@ namespace ts {
                 SymbolFlags.Property |
                 SymbolFlags.Transient |
                 SymbolFlags.SyntheticProperty |
-                (isOptional ? SymbolFlags.Optional : SymbolFlags.None),
+                commonFlags,
                 name);
             result.containingType = containingType;
             result.declarations = declarations;

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1691,7 +1691,7 @@
         "category": "Error",
         "code": 2528
     },
-    "JSX element attributes type '{0}' must be an object type.": {
+    "JSX element attributes type '{0}' may not be a union type.": {
         "category": "Error",
         "code": 2600
     },

--- a/tests/baselines/reference/tsxAttributeResolution11.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution11.errors.txt
@@ -1,0 +1,33 @@
+tests/cases/conformance/jsx/file.tsx(11,22): error TS2339: Property 'bar' does not exist on type 'IntrinsicAttributes & { ref?: string; }'.
+
+
+==== tests/cases/conformance/jsx/react.d.ts (0 errors) ====
+    
+    declare module JSX {
+    	interface Element { }
+    	interface IntrinsicElements {
+    	}
+    	interface ElementAttributesProperty {
+    		props;
+    	}
+    	interface IntrinsicAttributes {
+    		ref?: string;
+    	}
+    }
+    
+==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
+    class MyComponent {  
+      render() {
+      }
+    
+      props: {
+    	  ref?: string;
+      }
+    }
+    
+    // Should be an OK
+    var x = <MyComponent bar='world' />;
+                         ~~~
+!!! error TS2339: Property 'bar' does not exist on type 'IntrinsicAttributes & { ref?: string; }'.
+    
+    

--- a/tests/baselines/reference/tsxAttributeResolution11.js
+++ b/tests/baselines/reference/tsxAttributeResolution11.js
@@ -1,0 +1,41 @@
+//// [tests/cases/conformance/jsx/tsxAttributeResolution11.tsx] ////
+
+//// [react.d.ts]
+
+declare module JSX {
+	interface Element { }
+	interface IntrinsicElements {
+	}
+	interface ElementAttributesProperty {
+		props;
+	}
+	interface IntrinsicAttributes {
+		ref?: string;
+	}
+}
+
+//// [file.tsx]
+class MyComponent {  
+  render() {
+  }
+
+  props: {
+	  ref?: string;
+  }
+}
+
+// Should be an OK
+var x = <MyComponent bar='world' />;
+
+
+
+//// [file.jsx]
+var MyComponent = (function () {
+    function MyComponent() {
+    }
+    MyComponent.prototype.render = function () {
+    };
+    return MyComponent;
+}());
+// Should be an OK
+var x = <MyComponent bar='world'/>;

--- a/tests/cases/conformance/jsx/tsxAttributeResolution11.tsx
+++ b/tests/cases/conformance/jsx/tsxAttributeResolution11.tsx
@@ -1,0 +1,29 @@
+//@jsx: preserve
+//@module: amd
+
+//@filename: react.d.ts
+declare module JSX {
+	interface Element { }
+	interface IntrinsicElements {
+	}
+	interface ElementAttributesProperty {
+		props;
+	}
+	interface IntrinsicAttributes {
+		ref?: string;
+	}
+}
+
+//@filename: file.tsx
+class MyComponent {  
+  render() {
+  }
+
+  props: {
+	  ref?: string;
+  }
+}
+
+// Should be an OK
+var x = <MyComponent bar='world' />;
+


### PR DESCRIPTION
Fixes #6029 and removes the bogus restriction on non-intersection prop types (#4362)