### PR TITLE
Improve decorator on overload error message

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15544,7 +15544,12 @@ namespace ts {
                 return false;
             }
             if (!nodeCanBeDecorated(node)) {
-                return grammarErrorOnFirstToken(node, Diagnostics.Decorators_are_not_valid_here);
+                if (node.kind === SyntaxKind.MethodDeclaration && !ts.nodeIsPresent((<MethodDeclaration>node).body)) {
+                    return grammarErrorOnFirstToken(node, Diagnostics.A_decorator_can_only_decorate_a_method_implementation_not_an_overload);
+                }
+                else {
+                    return grammarErrorOnFirstToken(node, Diagnostics.Decorators_are_not_valid_here);
+                }
             }
             else if (node.kind === SyntaxKind.GetAccessor || node.kind === SyntaxKind.SetAccessor) {
                 const accessors = getAllAccessorDeclarations((<ClassDeclaration>node.parent).members, <AccessorDeclaration>node);

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -795,6 +795,10 @@
         "category": "Error",
         "code": 1248
     },
+    "A decorator can only decorate a method implementation, not an overload.": {
+        "category": "Error",
+        "code": 1249
+    }, 
     "'with' statements are not allowed in an async function block.": {
         "category": "Error",
         "code": 1300

--- a/tests/baselines/reference/decoratorOnClassMethodOverload1.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassMethodOverload1.errors.txt
@@ -1,0 +1,13 @@
+tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload1.ts(4,5): error TS1249: A decorator can only decorate a method implementation, not an overload.
+
+
+==== tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload1.ts (1 errors) ====
+    declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+    
+    class C {
+        @dec
+        ~
+!!! error TS1249: A decorator can only decorate a method implementation, not an overload.
+        method()
+        method() { }
+    }

--- a/tests/baselines/reference/decoratorOnClassMethodOverload1.js
+++ b/tests/baselines/reference/decoratorOnClassMethodOverload1.js
@@ -1,0 +1,16 @@
+//// [decoratorOnClassMethodOverload1.ts]
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    @dec
+    method()
+    method() { }
+}
+
+//// [decoratorOnClassMethodOverload1.js]
+var C = (function () {
+    function C() {
+    }
+    C.prototype.method = function () { };
+    return C;
+}());

--- a/tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload1.ts
+++ b/tests/cases/conformance/decorators/class/method/decoratorOnClassMethodOverload1.ts
@@ -1,0 +1,9 @@
+// @target: ES5
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class C {
+    @dec
+    method()
+    method() { }
+}


### PR DESCRIPTION
This fixes #6064, by improving the error message in the case when a decorator is rejected for being on a method overload, not an implementation.

I'm happy this works, but I'm not super happy with the detection of whether it's a method overload (currently: it's a method declaration without a body, which can't be decorated). I'm not familiar with the structure of the TypeScript codebase yet though, and I can't find any existing methods that define exactly how to check whether a node is an overload declaration.

I've opened this PR regardless for now, to check I'm on the right track, and because it is working and mergeable if you're happy with the approach.

Any suggestions on tidying that check up, or if that's required at all? If there's nothing already existing for this then should I be refactoring this check out somewhere? (and if so where?)