### PR TITLE
Support for other JSX factories

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8491,13 +8491,14 @@ namespace ts {
             checkGrammarJsxElement(node);
             checkJsxPreconditions(node);
 
-            // If we're compiling under --jsx react, the symbol 'React' should
+            // If we're compiling under --jsx react, the JSX namespace symbol should
             // be marked as 'used' so we don't incorrectly elide its import. And if there
-            // is no 'React' symbol in scope, we should issue an error.
+            // is no JSX namespace symbol in scope, we should issue an error.
             if (compilerOptions.jsx === JsxEmit.React) {
-                const reactSym = resolveName(node.tagName, "React", SymbolFlags.Value, Diagnostics.Cannot_find_name_0, "React");
-                if (reactSym) {
-                    getSymbolLinks(reactSym).referenced = true;
+                const jsxNamespace = compilerOptions.jsxNamespace ? compilerOptions.jsxNamespace : "React";
+                const jsxSym = resolveName(node.tagName, jsxNamespace, SymbolFlags.Value, Diagnostics.Cannot_find_name_0, jsxNamespace);
+                if (jsxSym) {
+                    getSymbolLinks(jsxSym).referenced = true;
                 }
             }
 

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -55,6 +55,11 @@ namespace ts {
             error: Diagnostics.Argument_for_jsx_must_be_preserve_or_react
         },
         {
+            name: "jsxNamespace",
+            type: "string",
+            description: Diagnostics.Specify_JSX_emit_namespace_when_JSX_code_generation_mode_is_react
+        },
+        {
             name: "listFiles",
             type: "boolean",
         },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2389,6 +2389,10 @@
         "category": "Message",
         "code": 6083
     },
+    "Specify JSX emit namespace when JSX code generation mode is 'react'": {
+        "category": "Message",
+        "code": 6084    
+    },
 
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1192,7 +1192,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, Promi
 
                 function emitJsxElement(openingNode: JsxOpeningLikeElement, children?: JsxChild[]) {
                     const syntheticReactRef = <Identifier>createSynthesizedNode(SyntaxKind.Identifier);
-                    syntheticReactRef.text = "React";
+                    syntheticReactRef.text = compilerOptions.jsxNamespace ? compilerOptions.jsxNamespace : "React";
                     syntheticReactRef.parent = openingNode;
 
                     // Call React.createElement(tag, ...

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2382,7 +2382,7 @@ namespace ts {
         inlineSourceMap?: boolean;
         inlineSources?: boolean;
         jsx?: JsxEmit;
-        jsxNamespace? : string;        
+        jsxNamespace? : string;
         listFiles?: boolean;
         locale?: string;
         mapRoot?: string;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2382,6 +2382,7 @@ namespace ts {
         inlineSourceMap?: boolean;
         inlineSources?: boolean;
         jsx?: JsxEmit;
+        jsxNamespace? : string;        
         listFiles?: boolean;
         locale?: string;
         mapRoot?: string;


### PR DESCRIPTION
PR for Issue #3788

Current implementation adds a new jsxNamespace compile option that can specify the JSX namespace (factory) when jsx mode is react.

--jsx react --jsxNamespace MyDOMLib

results in emits being MyDOMLib.createElement

I was thinking an alternative would be to just use the existing --jsx option where "preserve" and "react" are special reserved values. In this setup the above would be achieved by just doing

-- jsx MyDOMLib