### PR TITLE
Made 'expression' non-optional in 'CaseClause'.

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1195,7 +1195,7 @@ namespace ts {
 
     // @kind(SyntaxKind.CaseClause)
     export interface CaseClause extends Node {
-        expression?: Expression;
+        expression: Expression;
         statements: NodeArray<Statement>;
     }
 


### PR DESCRIPTION
Fixes #6159