### PR TITLE
Fix #6311

### DIFF
--- a/tests/baselines/reference/typeGuardOfFormFunctionEquality.js
+++ b/tests/baselines/reference/typeGuardOfFormFunctionEquality.js
@@ -1,0 +1,26 @@
+//// [typeGuardOfFormFunctionEquality.ts]
+declare function isString1(a: number, b: Object): b is string;
+
+declare function isString2(a: Object): a is string;
+
+switch (isString1(0, "")) {
+    case isString2(""):
+    default:
+}
+
+var x = isString1(0, "") === isString2("");
+
+function isString3(a: number, b: number, c: Object): c is string {
+    return isString1(0, c);
+}
+
+
+//// [typeGuardOfFormFunctionEquality.js]
+switch (isString1(0, "")) {
+    case isString2(""):
+    default:
+}
+var x = isString1(0, "") === isString2("");
+function isString3(a, b, c) {
+    return isString1(0, c);
+}

--- a/tests/baselines/reference/typeGuardOfFormFunctionEquality.symbols
+++ b/tests/baselines/reference/typeGuardOfFormFunctionEquality.symbols
@@ -1,0 +1,41 @@
+=== tests/cases/conformance/expressions/typeGuards/typeGuardOfFormFunctionEquality.ts ===
+declare function isString1(a: number, b: Object): b is string;
+>isString1 : Symbol(isString1, Decl(typeGuardOfFormFunctionEquality.ts, 0, 0))
+>a : Symbol(a, Decl(typeGuardOfFormFunctionEquality.ts, 0, 27))
+>b : Symbol(b, Decl(typeGuardOfFormFunctionEquality.ts, 0, 37))
+>Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>b : Symbol(b, Decl(typeGuardOfFormFunctionEquality.ts, 0, 37))
+
+declare function isString2(a: Object): a is string;
+>isString2 : Symbol(isString2, Decl(typeGuardOfFormFunctionEquality.ts, 0, 62))
+>a : Symbol(a, Decl(typeGuardOfFormFunctionEquality.ts, 2, 27))
+>Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>a : Symbol(a, Decl(typeGuardOfFormFunctionEquality.ts, 2, 27))
+
+switch (isString1(0, "")) {
+>isString1 : Symbol(isString1, Decl(typeGuardOfFormFunctionEquality.ts, 0, 0))
+
+    case isString2(""):
+>isString2 : Symbol(isString2, Decl(typeGuardOfFormFunctionEquality.ts, 0, 62))
+
+    default:
+}
+
+var x = isString1(0, "") === isString2("");
+>x : Symbol(x, Decl(typeGuardOfFormFunctionEquality.ts, 9, 3))
+>isString1 : Symbol(isString1, Decl(typeGuardOfFormFunctionEquality.ts, 0, 0))
+>isString2 : Symbol(isString2, Decl(typeGuardOfFormFunctionEquality.ts, 0, 62))
+
+function isString3(a: number, b: number, c: Object): c is string {
+>isString3 : Symbol(isString3, Decl(typeGuardOfFormFunctionEquality.ts, 9, 43))
+>a : Symbol(a, Decl(typeGuardOfFormFunctionEquality.ts, 11, 19))
+>b : Symbol(b, Decl(typeGuardOfFormFunctionEquality.ts, 11, 29))
+>c : Symbol(c, Decl(typeGuardOfFormFunctionEquality.ts, 11, 40))
+>Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>c : Symbol(c, Decl(typeGuardOfFormFunctionEquality.ts, 11, 40))
+
+    return isString1(0, c);
+>isString1 : Symbol(isString1, Decl(typeGuardOfFormFunctionEquality.ts, 0, 0))
+>c : Symbol(c, Decl(typeGuardOfFormFunctionEquality.ts, 11, 40))
+}
+

--- a/tests/baselines/reference/typeGuardOfFormFunctionEquality.types
+++ b/tests/baselines/reference/typeGuardOfFormFunctionEquality.types
@@ -1,0 +1,54 @@
+=== tests/cases/conformance/expressions/typeGuards/typeGuardOfFormFunctionEquality.ts ===
+declare function isString1(a: number, b: Object): b is string;
+>isString1 : (a: number, b: Object) => b is string
+>a : number
+>b : Object
+>Object : Object
+>b : any
+
+declare function isString2(a: Object): a is string;
+>isString2 : (a: Object) => a is string
+>a : Object
+>Object : Object
+>a : any
+
+switch (isString1(0, "")) {
+>isString1(0, "") : b is string
+>isString1 : (a: number, b: Object) => b is string
+>0 : number
+>"" : string
+
+    case isString2(""):
+>isString2("") : a is string
+>isString2 : (a: Object) => a is string
+>"" : string
+
+    default:
+}
+
+var x = isString1(0, "") === isString2("");
+>x : boolean
+>isString1(0, "") === isString2("") : boolean
+>isString1(0, "") : b is string
+>isString1 : (a: number, b: Object) => b is string
+>0 : number
+>"" : string
+>isString2("") : a is string
+>isString2 : (a: Object) => a is string
+>"" : string
+
+function isString3(a: number, b: number, c: Object): c is string {
+>isString3 : (a: number, b: number, c: Object) => c is string
+>a : number
+>b : number
+>c : Object
+>Object : Object
+>c : any
+
+    return isString1(0, c);
+>isString1(0, c) : b is string
+>isString1 : (a: number, b: Object) => b is string
+>0 : number
+>c : Object
+}
+

--- a/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormFunctionEquality.ts
+++ b/tests/cases/conformance/expressions/typeGuards/typeGuardOfFormFunctionEquality.ts
@@ -1,0 +1,14 @@
+declare function isString1(a: number, b: Object): b is string;
+
+declare function isString2(a: Object): a is string;
+
+switch (isString1(0, "")) {
+    case isString2(""):
+    default:
+}
+
+var x = isString1(0, "") === isString2("");
+
+function isString3(a: number, b: number, c: Object): c is string {
+    return isString1(0, c);
+}


### PR DESCRIPTION
By moving predicate argument position comparison to signature comparison, since the compatibility of isolated predicate comparisons never hinges on argument position equality.

Thoughts? @JsonFreeman @DanielRosenwasser 

______________
*Edit by @DanielRosenwasser: Fixes #6311*