### PR TITLE
Use string literal types for '[Symbol.toStringTag]' properties

### DIFF
--- a/src/lib/es6.d.ts
+++ b/src/lib/es6.d.ts
@@ -7,7 +7,7 @@ interface Symbol {
     /** Returns the primitive value of the specified object. */
     valueOf(): Object;
 
-    [Symbol.toStringTag]: string;
+    [Symbol.toStringTag]: "Symbol";
 }
 
 interface SymbolConstructor {
@@ -565,7 +565,7 @@ interface IterableIterator<T> extends Iterator<T> {
 }
 
 interface GeneratorFunction extends Function {
-    [Symbol.toStringTag]: string;
+    [Symbol.toStringTag]: "GeneratorFunction";
 }
 
 interface GeneratorFunctionConstructor {
@@ -690,7 +690,7 @@ interface Math {
       */
     cbrt(x: number): number;
 
-    [Symbol.toStringTag]: string;
+    [Symbol.toStringTag]: "Math";
 }
 
 interface Date {
@@ -807,7 +807,7 @@ interface Map<K, V> {
     size: number;
     values(): IterableIterator<V>;
     [Symbol.iterator]():IterableIterator<[K,V]>;
-    [Symbol.toStringTag]: string;
+    [Symbol.toStringTag]: "Map";
 }
 
 interface MapConstructor {
@@ -824,7 +824,7 @@ interface WeakMap<K, V> {
     get(key: K): V;
     has(key: K): boolean;
     set(key: K, value?: V): WeakMap<K, V>;
-    [Symbol.toStringTag]: string;
+    [Symbol.toStringTag]: "WeakMap";
 }
 
 interface WeakMapConstructor {
@@ -846,7 +846,7 @@ interface Set<T> {
     size: number;
     values(): IterableIterator<T>;
     [Symbol.iterator]():IterableIterator<T>;
-    [Symbol.toStringTag]: string;
+    [Symbol.toStringTag]: "Set";
 }
 
 interface SetConstructor {
@@ -862,7 +862,7 @@ interface WeakSet<T> {
     clear(): void;
     delete(value: T): boolean;
     has(value: T): boolean;
-    [Symbol.toStringTag]: string;
+    [Symbol.toStringTag]: "WeakSet";
 }
 
 interface WeakSetConstructor {
@@ -874,7 +874,7 @@ interface WeakSetConstructor {
 declare var WeakSet: WeakSetConstructor;
 
 interface JSON {
-    [Symbol.toStringTag]: string;
+    [Symbol.toStringTag]: "JSON";
 }
 
 /**
@@ -884,11 +884,11 @@ interface JSON {
   * buffer as needed. 
   */
 interface ArrayBuffer {
-    [Symbol.toStringTag]: string;
+    [Symbol.toStringTag]: "ArrayBuffer";
 }
 
 interface DataView {
-    [Symbol.toStringTag]: string;
+    [Symbol.toStringTag]: "DataView";
 }
 
 /**
@@ -1258,7 +1258,7 @@ interface Promise<T> {
     catch(onrejected?: (reason: any) => T | PromiseLike<T>): Promise<T>;
     catch(onrejected?: (reason: any) => void): Promise<T>;
 
-    [Symbol.toStringTag]: string;
+    [Symbol.toStringTag]: "Promise";
 }
 
 interface PromiseConstructor {

--- a/src/lib/es6.d.ts
+++ b/src/lib/es6.d.ts
@@ -909,6 +909,7 @@ interface Int8Array {
       */
     values(): IterableIterator<number>;
     [Symbol.iterator](): IterableIterator<number>;
+    [Symbol.toStringTag]: "Int8Array";
 }
 
 interface Int8ArrayConstructor {
@@ -941,6 +942,7 @@ interface Uint8Array {
       */
     values(): IterableIterator<number>;
     [Symbol.iterator](): IterableIterator<number>;
+    [Symbol.toStringTag]: "UInt8Array";
 }
 
 interface Uint8ArrayConstructor {
@@ -976,6 +978,7 @@ interface Uint8ClampedArray {
     values(): IterableIterator<number>;
 
     [Symbol.iterator](): IterableIterator<number>;
+    [Symbol.toStringTag]: "Uint8ClampedArray";
 }
 
 interface Uint8ClampedArrayConstructor {
@@ -1013,6 +1016,7 @@ interface Int16Array {
 
 
     [Symbol.iterator](): IterableIterator<number>;
+    [Symbol.toStringTag]: "Int16Array";
 }
 
 interface Int16ArrayConstructor {
@@ -1045,6 +1049,7 @@ interface Uint16Array {
       */
     values(): IterableIterator<number>;
     [Symbol.iterator](): IterableIterator<number>;
+    [Symbol.toStringTag]: "Uint16Array";
 }
 
 interface Uint16ArrayConstructor {
@@ -1077,6 +1082,7 @@ interface Int32Array {
       */
     values(): IterableIterator<number>;
     [Symbol.iterator](): IterableIterator<number>;
+    [Symbol.toStringTag]: "Int32Array";
 }
 
 interface Int32ArrayConstructor {
@@ -1109,6 +1115,7 @@ interface Uint32Array {
       */
     values(): IterableIterator<number>;
     [Symbol.iterator](): IterableIterator<number>;
+    [Symbol.toStringTag]: "Uint32Array";
 }
 
 interface Uint32ArrayConstructor {
@@ -1141,6 +1148,7 @@ interface Float32Array {
       */
     values(): IterableIterator<number>;
     [Symbol.iterator](): IterableIterator<number>;
+    [Symbol.toStringTag]: "Float32Array";
 }
 
 interface Float32ArrayConstructor {
@@ -1173,6 +1181,7 @@ interface Float64Array {
       */
     values(): IterableIterator<number>;
     [Symbol.iterator](): IterableIterator<number>;
+    [Symbol.toStringTag]: "Float64Array";
 }
 
 interface Float64ArrayConstructor {

--- a/src/lib/es6.d.ts
+++ b/src/lib/es6.d.ts
@@ -565,7 +565,7 @@ interface IterableIterator<T> extends Iterator<T> {
 }
 
 interface GeneratorFunction extends Function {
-
+    [Symbol.toStringTag]: string;
 }
 
 interface GeneratorFunctionConstructor {

--- a/tests/baselines/reference/typedArrays.js
+++ b/tests/baselines/reference/typedArrays.js
@@ -75,7 +75,6 @@ function CreateIntegerTypedArraysFromArrayLike(obj:ArrayLike<number>) {
     return typedArrays;
 }
 
-/*
 function CreateTypedArraysOf(obj) {
     var typedArrays = [];
     typedArrays[0] = Int8Array.of(...obj);
@@ -90,7 +89,6 @@ function CreateTypedArraysOf(obj) {
 
     return typedArrays;
 }
-*/
 
 function CreateTypedArraysOf2() {
     var typedArrays = [];
@@ -203,7 +201,6 @@ function CreateIntegerTypedArraysFromArrayLike(obj) {
     typedArrays[8] = Uint8ClampedArray.from(obj);
     return typedArrays;
 }
-/*
 function CreateTypedArraysOf(obj) {
     var typedArrays = [];
     typedArrays[0] = Int8Array.of(...obj);
@@ -215,10 +212,8 @@ function CreateTypedArraysOf(obj) {
     typedArrays[6] = Float32Array.of(...obj);
     typedArrays[7] = Float64Array.of(...obj);
     typedArrays[8] = Uint8ClampedArray.of(...obj);
-
     return typedArrays;
 }
-*/
 function CreateTypedArraysOf2() {
     var typedArrays = [];
     typedArrays[0] = Int8Array.of(1, 2, 3, 4);

--- a/tests/baselines/reference/typedArrays.symbols
+++ b/tests/baselines/reference/typedArrays.symbols
@@ -307,267 +307,324 @@ function CreateIntegerTypedArraysFromArrayLike(obj:ArrayLike<number>) {
 >typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 62, 7))
 }
 
-/*
 function CreateTypedArraysOf(obj) {
+>CreateTypedArraysOf : Symbol(CreateTypedArraysOf, Decl(typedArrays.ts, 74, 1))
+>obj : Symbol(obj, Decl(typedArrays.ts, 76, 29))
+
     var typedArrays = [];
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 77, 7))
+
     typedArrays[0] = Int8Array.of(...obj);
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 77, 7))
+>Int8Array.of : Symbol(Int8ArrayConstructor.of, Decl(lib.d.ts, --, --))
+>Int8Array : Symbol(Int8Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>of : Symbol(Int8ArrayConstructor.of, Decl(lib.d.ts, --, --))
+>obj : Symbol(obj, Decl(typedArrays.ts, 76, 29))
+
     typedArrays[1] = Uint8Array.of(...obj);
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 77, 7))
+>Uint8Array.of : Symbol(Uint8ArrayConstructor.of, Decl(lib.d.ts, --, --))
+>Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>of : Symbol(Uint8ArrayConstructor.of, Decl(lib.d.ts, --, --))
+>obj : Symbol(obj, Decl(typedArrays.ts, 76, 29))
+
     typedArrays[2] = Int16Array.of(...obj);
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 77, 7))
+>Int16Array.of : Symbol(Int16ArrayConstructor.of, Decl(lib.d.ts, --, --))
+>Int16Array : Symbol(Int16Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>of : Symbol(Int16ArrayConstructor.of, Decl(lib.d.ts, --, --))
+>obj : Symbol(obj, Decl(typedArrays.ts, 76, 29))
+
     typedArrays[3] = Uint16Array.of(...obj);
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 77, 7))
+>Uint16Array.of : Symbol(Uint16ArrayConstructor.of, Decl(lib.d.ts, --, --))
+>Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>of : Symbol(Uint16ArrayConstructor.of, Decl(lib.d.ts, --, --))
+>obj : Symbol(obj, Decl(typedArrays.ts, 76, 29))
+
     typedArrays[4] = Int32Array.of(...obj);
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 77, 7))
+>Int32Array.of : Symbol(Int32ArrayConstructor.of, Decl(lib.d.ts, --, --))
+>Int32Array : Symbol(Int32Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>of : Symbol(Int32ArrayConstructor.of, Decl(lib.d.ts, --, --))
+>obj : Symbol(obj, Decl(typedArrays.ts, 76, 29))
+
     typedArrays[5] = Uint32Array.of(...obj);
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 77, 7))
+>Uint32Array.of : Symbol(Uint32ArrayConstructor.of, Decl(lib.d.ts, --, --))
+>Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>of : Symbol(Uint32ArrayConstructor.of, Decl(lib.d.ts, --, --))
+>obj : Symbol(obj, Decl(typedArrays.ts, 76, 29))
+
     typedArrays[6] = Float32Array.of(...obj);
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 77, 7))
+>Float32Array.of : Symbol(Float32ArrayConstructor.of, Decl(lib.d.ts, --, --))
+>Float32Array : Symbol(Float32Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>of : Symbol(Float32ArrayConstructor.of, Decl(lib.d.ts, --, --))
+>obj : Symbol(obj, Decl(typedArrays.ts, 76, 29))
+
     typedArrays[7] = Float64Array.of(...obj);
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 77, 7))
+>Float64Array.of : Symbol(Float64ArrayConstructor.of, Decl(lib.d.ts, --, --))
+>Float64Array : Symbol(Float64Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>of : Symbol(Float64ArrayConstructor.of, Decl(lib.d.ts, --, --))
+>obj : Symbol(obj, Decl(typedArrays.ts, 76, 29))
+
     typedArrays[8] = Uint8ClampedArray.of(...obj);
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 77, 7))
+>Uint8ClampedArray.of : Symbol(Uint8ClampedArrayConstructor.of, Decl(lib.d.ts, --, --))
+>Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>of : Symbol(Uint8ClampedArrayConstructor.of, Decl(lib.d.ts, --, --))
+>obj : Symbol(obj, Decl(typedArrays.ts, 76, 29))
 
     return typedArrays;
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 77, 7))
 }
-*/
 
 function CreateTypedArraysOf2() {
->CreateTypedArraysOf2 : Symbol(CreateTypedArraysOf2, Decl(typedArrays.ts, 74, 1))
+>CreateTypedArraysOf2 : Symbol(CreateTypedArraysOf2, Decl(typedArrays.ts, 89, 1))
 
     var typedArrays = [];
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 92, 7))
 
     typedArrays[0] = Int8Array.of(1,2,3,4);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 92, 7))
 >Int8Array.of : Symbol(Int8ArrayConstructor.of, Decl(lib.d.ts, --, --))
 >Int8Array : Symbol(Int8Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >of : Symbol(Int8ArrayConstructor.of, Decl(lib.d.ts, --, --))
 
     typedArrays[1] = Uint8Array.of(1,2,3,4);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 92, 7))
 >Uint8Array.of : Symbol(Uint8ArrayConstructor.of, Decl(lib.d.ts, --, --))
 >Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >of : Symbol(Uint8ArrayConstructor.of, Decl(lib.d.ts, --, --))
 
     typedArrays[2] = Int16Array.of(1,2,3,4);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 92, 7))
 >Int16Array.of : Symbol(Int16ArrayConstructor.of, Decl(lib.d.ts, --, --))
 >Int16Array : Symbol(Int16Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >of : Symbol(Int16ArrayConstructor.of, Decl(lib.d.ts, --, --))
 
     typedArrays[3] = Uint16Array.of(1,2,3,4);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 92, 7))
 >Uint16Array.of : Symbol(Uint16ArrayConstructor.of, Decl(lib.d.ts, --, --))
 >Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >of : Symbol(Uint16ArrayConstructor.of, Decl(lib.d.ts, --, --))
 
     typedArrays[4] = Int32Array.of(1,2,3,4);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 92, 7))
 >Int32Array.of : Symbol(Int32ArrayConstructor.of, Decl(lib.d.ts, --, --))
 >Int32Array : Symbol(Int32Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >of : Symbol(Int32ArrayConstructor.of, Decl(lib.d.ts, --, --))
 
     typedArrays[5] = Uint32Array.of(1,2,3,4);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 92, 7))
 >Uint32Array.of : Symbol(Uint32ArrayConstructor.of, Decl(lib.d.ts, --, --))
 >Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >of : Symbol(Uint32ArrayConstructor.of, Decl(lib.d.ts, --, --))
 
     typedArrays[6] = Float32Array.of(1,2,3,4);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 92, 7))
 >Float32Array.of : Symbol(Float32ArrayConstructor.of, Decl(lib.d.ts, --, --))
 >Float32Array : Symbol(Float32Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >of : Symbol(Float32ArrayConstructor.of, Decl(lib.d.ts, --, --))
 
     typedArrays[7] = Float64Array.of(1,2,3,4);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 92, 7))
 >Float64Array.of : Symbol(Float64ArrayConstructor.of, Decl(lib.d.ts, --, --))
 >Float64Array : Symbol(Float64Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >of : Symbol(Float64ArrayConstructor.of, Decl(lib.d.ts, --, --))
 
     typedArrays[8] = Uint8ClampedArray.of(1,2,3,4);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 92, 7))
 >Uint8ClampedArray.of : Symbol(Uint8ClampedArrayConstructor.of, Decl(lib.d.ts, --, --))
 >Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >of : Symbol(Uint8ClampedArrayConstructor.of, Decl(lib.d.ts, --, --))
 
     return typedArrays;
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 94, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 92, 7))
 }
 
 function CreateTypedArraysFromMapFn(obj:ArrayLike<number>, mapFn: (n:number, v:number)=> number) {
->CreateTypedArraysFromMapFn : Symbol(CreateTypedArraysFromMapFn, Decl(typedArrays.ts, 106, 1))
->obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
+>CreateTypedArraysFromMapFn : Symbol(CreateTypedArraysFromMapFn, Decl(typedArrays.ts, 104, 1))
+>obj : Symbol(obj, Decl(typedArrays.ts, 106, 36))
 >ArrayLike : Symbol(ArrayLike, Decl(lib.d.ts, --, --))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
->n : Symbol(n, Decl(typedArrays.ts, 108, 67))
->v : Symbol(v, Decl(typedArrays.ts, 108, 76))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 106, 58))
+>n : Symbol(n, Decl(typedArrays.ts, 106, 67))
+>v : Symbol(v, Decl(typedArrays.ts, 106, 76))
 
     var typedArrays = [];
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 107, 7))
 
     typedArrays[0] = Int8Array.from(obj, mapFn);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 107, 7))
 >Int8Array.from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Int8Array : Symbol(Int8Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
+>obj : Symbol(obj, Decl(typedArrays.ts, 106, 36))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 106, 58))
 
     typedArrays[1] = Uint8Array.from(obj, mapFn);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 107, 7))
 >Uint8Array.from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
+>obj : Symbol(obj, Decl(typedArrays.ts, 106, 36))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 106, 58))
 
     typedArrays[2] = Int16Array.from(obj, mapFn);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 107, 7))
 >Int16Array.from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Int16Array : Symbol(Int16Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
+>obj : Symbol(obj, Decl(typedArrays.ts, 106, 36))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 106, 58))
 
     typedArrays[3] = Uint16Array.from(obj, mapFn);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 107, 7))
 >Uint16Array.from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
+>obj : Symbol(obj, Decl(typedArrays.ts, 106, 36))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 106, 58))
 
     typedArrays[4] = Int32Array.from(obj, mapFn);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 107, 7))
 >Int32Array.from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Int32Array : Symbol(Int32Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
+>obj : Symbol(obj, Decl(typedArrays.ts, 106, 36))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 106, 58))
 
     typedArrays[5] = Uint32Array.from(obj, mapFn);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 107, 7))
 >Uint32Array.from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
+>obj : Symbol(obj, Decl(typedArrays.ts, 106, 36))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 106, 58))
 
     typedArrays[6] = Float32Array.from(obj, mapFn);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 107, 7))
 >Float32Array.from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Float32Array : Symbol(Float32Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
+>obj : Symbol(obj, Decl(typedArrays.ts, 106, 36))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 106, 58))
 
     typedArrays[7] = Float64Array.from(obj, mapFn);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 107, 7))
 >Float64Array.from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Float64Array : Symbol(Float64Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
+>obj : Symbol(obj, Decl(typedArrays.ts, 106, 36))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 106, 58))
 
     typedArrays[8] = Uint8ClampedArray.from(obj, mapFn);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 107, 7))
 >Uint8ClampedArray.from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 108, 36))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 108, 58))
+>obj : Symbol(obj, Decl(typedArrays.ts, 106, 36))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 106, 58))
 
     return typedArrays;
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 109, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 107, 7))
 }
 
 function CreateTypedArraysFromThisObj(obj:ArrayLike<number>, mapFn: (n:number, v:number)=> number, thisArg: {}) {
->CreateTypedArraysFromThisObj : Symbol(CreateTypedArraysFromThisObj, Decl(typedArrays.ts, 121, 1))
->obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
+>CreateTypedArraysFromThisObj : Symbol(CreateTypedArraysFromThisObj, Decl(typedArrays.ts, 119, 1))
+>obj : Symbol(obj, Decl(typedArrays.ts, 121, 38))
 >ArrayLike : Symbol(ArrayLike, Decl(lib.d.ts, --, --))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
->n : Symbol(n, Decl(typedArrays.ts, 123, 69))
->v : Symbol(v, Decl(typedArrays.ts, 123, 78))
->thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 121, 60))
+>n : Symbol(n, Decl(typedArrays.ts, 121, 69))
+>v : Symbol(v, Decl(typedArrays.ts, 121, 78))
+>thisArg : Symbol(thisArg, Decl(typedArrays.ts, 121, 98))
 
     var typedArrays = [];
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 122, 7))
 
     typedArrays[0] = Int8Array.from(obj, mapFn, thisArg);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 122, 7))
 >Int8Array.from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Int8Array : Symbol(Int8Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Int8ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
->thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
+>obj : Symbol(obj, Decl(typedArrays.ts, 121, 38))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 121, 60))
+>thisArg : Symbol(thisArg, Decl(typedArrays.ts, 121, 98))
 
     typedArrays[1] = Uint8Array.from(obj, mapFn, thisArg);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 122, 7))
 >Uint8Array.from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Uint8Array : Symbol(Uint8Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Uint8ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
->thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
+>obj : Symbol(obj, Decl(typedArrays.ts, 121, 38))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 121, 60))
+>thisArg : Symbol(thisArg, Decl(typedArrays.ts, 121, 98))
 
     typedArrays[2] = Int16Array.from(obj, mapFn, thisArg);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 122, 7))
 >Int16Array.from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Int16Array : Symbol(Int16Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Int16ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
->thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
+>obj : Symbol(obj, Decl(typedArrays.ts, 121, 38))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 121, 60))
+>thisArg : Symbol(thisArg, Decl(typedArrays.ts, 121, 98))
 
     typedArrays[3] = Uint16Array.from(obj, mapFn, thisArg);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 122, 7))
 >Uint16Array.from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Uint16Array : Symbol(Uint16Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Uint16ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
->thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
+>obj : Symbol(obj, Decl(typedArrays.ts, 121, 38))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 121, 60))
+>thisArg : Symbol(thisArg, Decl(typedArrays.ts, 121, 98))
 
     typedArrays[4] = Int32Array.from(obj, mapFn, thisArg);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 122, 7))
 >Int32Array.from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Int32Array : Symbol(Int32Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Int32ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
->thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
+>obj : Symbol(obj, Decl(typedArrays.ts, 121, 38))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 121, 60))
+>thisArg : Symbol(thisArg, Decl(typedArrays.ts, 121, 98))
 
     typedArrays[5] = Uint32Array.from(obj, mapFn, thisArg);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 122, 7))
 >Uint32Array.from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Uint32Array : Symbol(Uint32Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Uint32ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
->thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
+>obj : Symbol(obj, Decl(typedArrays.ts, 121, 38))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 121, 60))
+>thisArg : Symbol(thisArg, Decl(typedArrays.ts, 121, 98))
 
     typedArrays[6] = Float32Array.from(obj, mapFn, thisArg);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 122, 7))
 >Float32Array.from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Float32Array : Symbol(Float32Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Float32ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
->thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
+>obj : Symbol(obj, Decl(typedArrays.ts, 121, 38))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 121, 60))
+>thisArg : Symbol(thisArg, Decl(typedArrays.ts, 121, 98))
 
     typedArrays[7] = Float64Array.from(obj, mapFn, thisArg);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 122, 7))
 >Float64Array.from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Float64Array : Symbol(Float64Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Float64ArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
->thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
+>obj : Symbol(obj, Decl(typedArrays.ts, 121, 38))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 121, 60))
+>thisArg : Symbol(thisArg, Decl(typedArrays.ts, 121, 98))
 
     typedArrays[8] = Uint8ClampedArray.from(obj, mapFn, thisArg);
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 122, 7))
 >Uint8ClampedArray.from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Uint8ClampedArray : Symbol(Uint8ClampedArray, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >from : Symbol(Uint8ClampedArrayConstructor.from, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->obj : Symbol(obj, Decl(typedArrays.ts, 123, 38))
->mapFn : Symbol(mapFn, Decl(typedArrays.ts, 123, 60))
->thisArg : Symbol(thisArg, Decl(typedArrays.ts, 123, 98))
+>obj : Symbol(obj, Decl(typedArrays.ts, 121, 38))
+>mapFn : Symbol(mapFn, Decl(typedArrays.ts, 121, 60))
+>thisArg : Symbol(thisArg, Decl(typedArrays.ts, 121, 98))
 
     return typedArrays;
->typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 124, 7))
+>typedArrays : Symbol(typedArrays, Decl(typedArrays.ts, 122, 7))
 }

--- a/tests/baselines/reference/typedArrays.types
+++ b/tests/baselines/reference/typedArrays.types
@@ -483,22 +483,125 @@ function CreateIntegerTypedArraysFromArrayLike(obj:ArrayLike<number>) {
 >typedArrays : any[]
 }
 
-/*
 function CreateTypedArraysOf(obj) {
+>CreateTypedArraysOf : (obj: any) => any[]
+>obj : any
+
     var typedArrays = [];
+>typedArrays : any[]
+>[] : undefined[]
+
     typedArrays[0] = Int8Array.of(...obj);
+>typedArrays[0] = Int8Array.of(...obj) : Int8Array
+>typedArrays[0] : any
+>typedArrays : any[]
+>0 : number
+>Int8Array.of(...obj) : Int8Array
+>Int8Array.of : (...items: number[]) => Int8Array
+>Int8Array : Int8ArrayConstructor
+>of : (...items: number[]) => Int8Array
+>...obj : any
+>obj : any
+
     typedArrays[1] = Uint8Array.of(...obj);
+>typedArrays[1] = Uint8Array.of(...obj) : Uint8Array
+>typedArrays[1] : any
+>typedArrays : any[]
+>1 : number
+>Uint8Array.of(...obj) : Uint8Array
+>Uint8Array.of : (...items: number[]) => Uint8Array
+>Uint8Array : Uint8ArrayConstructor
+>of : (...items: number[]) => Uint8Array
+>...obj : any
+>obj : any
+
     typedArrays[2] = Int16Array.of(...obj);
+>typedArrays[2] = Int16Array.of(...obj) : Int16Array
+>typedArrays[2] : any
+>typedArrays : any[]
+>2 : number
+>Int16Array.of(...obj) : Int16Array
+>Int16Array.of : (...items: number[]) => Int16Array
+>Int16Array : Int16ArrayConstructor
+>of : (...items: number[]) => Int16Array
+>...obj : any
+>obj : any
+
     typedArrays[3] = Uint16Array.of(...obj);
+>typedArrays[3] = Uint16Array.of(...obj) : Uint16Array
+>typedArrays[3] : any
+>typedArrays : any[]
+>3 : number
+>Uint16Array.of(...obj) : Uint16Array
+>Uint16Array.of : (...items: number[]) => Uint16Array
+>Uint16Array : Uint16ArrayConstructor
+>of : (...items: number[]) => Uint16Array
+>...obj : any
+>obj : any
+
     typedArrays[4] = Int32Array.of(...obj);
+>typedArrays[4] = Int32Array.of(...obj) : Int32Array
+>typedArrays[4] : any
+>typedArrays : any[]
+>4 : number
+>Int32Array.of(...obj) : Int32Array
+>Int32Array.of : (...items: number[]) => Int32Array
+>Int32Array : Int32ArrayConstructor
+>of : (...items: number[]) => Int32Array
+>...obj : any
+>obj : any
+
     typedArrays[5] = Uint32Array.of(...obj);
+>typedArrays[5] = Uint32Array.of(...obj) : Uint32Array
+>typedArrays[5] : any
+>typedArrays : any[]
+>5 : number
+>Uint32Array.of(...obj) : Uint32Array
+>Uint32Array.of : (...items: number[]) => Uint32Array
+>Uint32Array : Uint32ArrayConstructor
+>of : (...items: number[]) => Uint32Array
+>...obj : any
+>obj : any
+
     typedArrays[6] = Float32Array.of(...obj);
+>typedArrays[6] = Float32Array.of(...obj) : Float32Array
+>typedArrays[6] : any
+>typedArrays : any[]
+>6 : number
+>Float32Array.of(...obj) : Float32Array
+>Float32Array.of : (...items: number[]) => Float32Array
+>Float32Array : Float32ArrayConstructor
+>of : (...items: number[]) => Float32Array
+>...obj : any
+>obj : any
+
     typedArrays[7] = Float64Array.of(...obj);
+>typedArrays[7] = Float64Array.of(...obj) : Float64Array
+>typedArrays[7] : any
+>typedArrays : any[]
+>7 : number
+>Float64Array.of(...obj) : Float64Array
+>Float64Array.of : (...items: number[]) => Float64Array
+>Float64Array : Float64ArrayConstructor
+>of : (...items: number[]) => Float64Array
+>...obj : any
+>obj : any
+
     typedArrays[8] = Uint8ClampedArray.of(...obj);
+>typedArrays[8] = Uint8ClampedArray.of(...obj) : Uint8ClampedArray
+>typedArrays[8] : any
+>typedArrays : any[]
+>8 : number
+>Uint8ClampedArray.of(...obj) : Uint8ClampedArray
+>Uint8ClampedArray.of : (...items: number[]) => Uint8ClampedArray
+>Uint8ClampedArray : Uint8ClampedArrayConstructor
+>of : (...items: number[]) => Uint8ClampedArray
+>...obj : any
+>obj : any
 
     return typedArrays;
+>typedArrays : any[]
 }
-*/
 
 function CreateTypedArraysOf2() {
 >CreateTypedArraysOf2 : () => any[]

--- a/tests/baselines/reference/typedArraysCrossAssignability01.errors.txt
+++ b/tests/baselines/reference/typedArraysCrossAssignability01.errors.txt
@@ -1,0 +1,545 @@
+tests/cases/compiler/typedArraysCrossAssignability01.ts(14,5): error TS2322: Type 'Uint8Array' is not assignable to type 'Int8Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"UInt8Array"' is not assignable to type '"Int8Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(15,5): error TS2322: Type 'Int16Array' is not assignable to type 'Int8Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int16Array"' is not assignable to type '"Int8Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(16,5): error TS2322: Type 'Uint16Array' is not assignable to type 'Int8Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint16Array"' is not assignable to type '"Int8Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(17,5): error TS2322: Type 'Int32Array' is not assignable to type 'Int8Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int32Array"' is not assignable to type '"Int8Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(18,5): error TS2322: Type 'Uint32Array' is not assignable to type 'Int8Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint32Array"' is not assignable to type '"Int8Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(19,5): error TS2322: Type 'Float32Array' is not assignable to type 'Int8Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Float32Array"' is not assignable to type '"Int8Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(20,5): error TS2322: Type 'Float64Array' is not assignable to type 'Int8Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Float64Array"' is not assignable to type '"Int8Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(21,5): error TS2322: Type 'Uint8ClampedArray' is not assignable to type 'Int8Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint8ClampedArray"' is not assignable to type '"Int8Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(23,5): error TS2322: Type 'Int8Array' is not assignable to type 'Uint8Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int8Array"' is not assignable to type '"UInt8Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(25,5): error TS2322: Type 'Int16Array' is not assignable to type 'Uint8Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int16Array"' is not assignable to type '"UInt8Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(26,5): error TS2322: Type 'Uint16Array' is not assignable to type 'Uint8Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint16Array"' is not assignable to type '"UInt8Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(27,5): error TS2322: Type 'Int32Array' is not assignable to type 'Uint8Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int32Array"' is not assignable to type '"UInt8Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(28,5): error TS2322: Type 'Uint32Array' is not assignable to type 'Uint8Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint32Array"' is not assignable to type '"UInt8Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(29,5): error TS2322: Type 'Float32Array' is not assignable to type 'Uint8Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Float32Array"' is not assignable to type '"UInt8Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(30,5): error TS2322: Type 'Float64Array' is not assignable to type 'Uint8Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Float64Array"' is not assignable to type '"UInt8Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(31,5): error TS2322: Type 'Uint8ClampedArray' is not assignable to type 'Uint8Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint8ClampedArray"' is not assignable to type '"UInt8Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(33,5): error TS2322: Type 'Int8Array' is not assignable to type 'Int16Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int8Array"' is not assignable to type '"Int16Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(34,5): error TS2322: Type 'Uint8Array' is not assignable to type 'Int16Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"UInt8Array"' is not assignable to type '"Int16Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(36,5): error TS2322: Type 'Uint16Array' is not assignable to type 'Int16Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint16Array"' is not assignable to type '"Int16Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(37,5): error TS2322: Type 'Int32Array' is not assignable to type 'Int16Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int32Array"' is not assignable to type '"Int16Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(38,5): error TS2322: Type 'Uint32Array' is not assignable to type 'Int16Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint32Array"' is not assignable to type '"Int16Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(39,5): error TS2322: Type 'Float32Array' is not assignable to type 'Int16Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Float32Array"' is not assignable to type '"Int16Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(40,5): error TS2322: Type 'Float64Array' is not assignable to type 'Int16Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Float64Array"' is not assignable to type '"Int16Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(41,5): error TS2322: Type 'Uint8ClampedArray' is not assignable to type 'Int16Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint8ClampedArray"' is not assignable to type '"Int16Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(43,5): error TS2322: Type 'Int8Array' is not assignable to type 'Uint16Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int8Array"' is not assignable to type '"Uint16Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(44,5): error TS2322: Type 'Uint8Array' is not assignable to type 'Uint16Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"UInt8Array"' is not assignable to type '"Uint16Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(45,5): error TS2322: Type 'Int16Array' is not assignable to type 'Uint16Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int16Array"' is not assignable to type '"Uint16Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(47,5): error TS2322: Type 'Int32Array' is not assignable to type 'Uint16Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int32Array"' is not assignable to type '"Uint16Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(48,5): error TS2322: Type 'Uint32Array' is not assignable to type 'Uint16Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint32Array"' is not assignable to type '"Uint16Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(49,5): error TS2322: Type 'Float32Array' is not assignable to type 'Uint16Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Float32Array"' is not assignable to type '"Uint16Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(50,5): error TS2322: Type 'Float64Array' is not assignable to type 'Uint16Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Float64Array"' is not assignable to type '"Uint16Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(51,5): error TS2322: Type 'Uint8ClampedArray' is not assignable to type 'Uint16Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint8ClampedArray"' is not assignable to type '"Uint16Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(53,5): error TS2322: Type 'Int8Array' is not assignable to type 'Int32Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int8Array"' is not assignable to type '"Int32Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(54,5): error TS2322: Type 'Uint8Array' is not assignable to type 'Int32Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"UInt8Array"' is not assignable to type '"Int32Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(55,5): error TS2322: Type 'Int16Array' is not assignable to type 'Int32Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int16Array"' is not assignable to type '"Int32Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(56,5): error TS2322: Type 'Uint16Array' is not assignable to type 'Int32Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint16Array"' is not assignable to type '"Int32Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(58,5): error TS2322: Type 'Uint32Array' is not assignable to type 'Int32Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint32Array"' is not assignable to type '"Int32Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(59,5): error TS2322: Type 'Float32Array' is not assignable to type 'Int32Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Float32Array"' is not assignable to type '"Int32Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(60,5): error TS2322: Type 'Float64Array' is not assignable to type 'Int32Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Float64Array"' is not assignable to type '"Int32Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(61,5): error TS2322: Type 'Uint8ClampedArray' is not assignable to type 'Int32Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint8ClampedArray"' is not assignable to type '"Int32Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(63,5): error TS2322: Type 'Int8Array' is not assignable to type 'Float32Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int8Array"' is not assignable to type '"Float32Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(64,5): error TS2322: Type 'Uint8Array' is not assignable to type 'Float32Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"UInt8Array"' is not assignable to type '"Float32Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(65,5): error TS2322: Type 'Int16Array' is not assignable to type 'Float32Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int16Array"' is not assignable to type '"Float32Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(66,5): error TS2322: Type 'Uint16Array' is not assignable to type 'Float32Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint16Array"' is not assignable to type '"Float32Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(67,5): error TS2322: Type 'Int32Array' is not assignable to type 'Float32Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int32Array"' is not assignable to type '"Float32Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(68,5): error TS2322: Type 'Uint32Array' is not assignable to type 'Float32Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint32Array"' is not assignable to type '"Float32Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(70,5): error TS2322: Type 'Float64Array' is not assignable to type 'Float32Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Float64Array"' is not assignable to type '"Float32Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(71,5): error TS2322: Type 'Uint8ClampedArray' is not assignable to type 'Float32Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint8ClampedArray"' is not assignable to type '"Float32Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(73,5): error TS2322: Type 'Int8Array' is not assignable to type 'Float64Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int8Array"' is not assignable to type '"Float64Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(74,5): error TS2322: Type 'Uint8Array' is not assignable to type 'Float64Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"UInt8Array"' is not assignable to type '"Float64Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(75,5): error TS2322: Type 'Int16Array' is not assignable to type 'Float64Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int16Array"' is not assignable to type '"Float64Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(76,5): error TS2322: Type 'Uint16Array' is not assignable to type 'Float64Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint16Array"' is not assignable to type '"Float64Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(77,5): error TS2322: Type 'Int32Array' is not assignable to type 'Float64Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int32Array"' is not assignable to type '"Float64Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(78,5): error TS2322: Type 'Uint32Array' is not assignable to type 'Float64Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint32Array"' is not assignable to type '"Float64Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(79,5): error TS2322: Type 'Float32Array' is not assignable to type 'Float64Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Float32Array"' is not assignable to type '"Float64Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(81,5): error TS2322: Type 'Uint8ClampedArray' is not assignable to type 'Float64Array'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint8ClampedArray"' is not assignable to type '"Float64Array"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(83,5): error TS2322: Type 'Int8Array' is not assignable to type 'Uint8ClampedArray'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int8Array"' is not assignable to type '"Uint8ClampedArray"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(84,5): error TS2322: Type 'Uint8Array' is not assignable to type 'Uint8ClampedArray'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"UInt8Array"' is not assignable to type '"Uint8ClampedArray"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(85,5): error TS2322: Type 'Int16Array' is not assignable to type 'Uint8ClampedArray'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int16Array"' is not assignable to type '"Uint8ClampedArray"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(86,5): error TS2322: Type 'Uint16Array' is not assignable to type 'Uint8ClampedArray'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint16Array"' is not assignable to type '"Uint8ClampedArray"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(87,5): error TS2322: Type 'Int32Array' is not assignable to type 'Uint8ClampedArray'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Int32Array"' is not assignable to type '"Uint8ClampedArray"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(88,5): error TS2322: Type 'Uint32Array' is not assignable to type 'Uint8ClampedArray'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Uint32Array"' is not assignable to type '"Uint8ClampedArray"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(89,5): error TS2322: Type 'Float32Array' is not assignable to type 'Uint8ClampedArray'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Float32Array"' is not assignable to type '"Uint8ClampedArray"'.
+tests/cases/compiler/typedArraysCrossAssignability01.ts(90,5): error TS2322: Type 'Float64Array' is not assignable to type 'Uint8ClampedArray'.
+  Types of property '[Symbol.toStringTag]' are incompatible.
+    Type '"Float64Array"' is not assignable to type '"Uint8ClampedArray"'.
+
+
+==== tests/cases/compiler/typedArraysCrossAssignability01.ts (64 errors) ====
+    
+    function CheckAssignability() {
+        let arr_Int8Array           = new Int8Array(1);
+        let arr_Uint8Array          = new Uint8Array(1);
+        let arr_Int16Array          = new Int16Array(1);
+        let arr_Uint16Array         = new Uint16Array(1);
+        let arr_Int32Array          = new Int32Array(1);
+        let arr_Uint32Array         = new Uint32Array(1);
+        let arr_Float32Array        = new Float32Array(1);
+        let arr_Float64Array        = new Float64Array(1);
+        let arr_Uint8ClampedArray   = new Uint8ClampedArray(1);
+    
+        arr_Int8Array = arr_Int8Array;
+        arr_Int8Array = arr_Uint8Array;
+        ~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint8Array' is not assignable to type 'Int8Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"UInt8Array"' is not assignable to type '"Int8Array"'.
+        arr_Int8Array = arr_Int16Array;
+        ~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int16Array' is not assignable to type 'Int8Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int16Array"' is not assignable to type '"Int8Array"'.
+        arr_Int8Array = arr_Uint16Array;
+        ~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint16Array' is not assignable to type 'Int8Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint16Array"' is not assignable to type '"Int8Array"'.
+        arr_Int8Array = arr_Int32Array;
+        ~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int32Array' is not assignable to type 'Int8Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int32Array"' is not assignable to type '"Int8Array"'.
+        arr_Int8Array = arr_Uint32Array;
+        ~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint32Array' is not assignable to type 'Int8Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint32Array"' is not assignable to type '"Int8Array"'.
+        arr_Int8Array = arr_Float32Array;
+        ~~~~~~~~~~~~~
+!!! error TS2322: Type 'Float32Array' is not assignable to type 'Int8Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Float32Array"' is not assignable to type '"Int8Array"'.
+        arr_Int8Array = arr_Float64Array;
+        ~~~~~~~~~~~~~
+!!! error TS2322: Type 'Float64Array' is not assignable to type 'Int8Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Float64Array"' is not assignable to type '"Int8Array"'.
+        arr_Int8Array = arr_Uint8ClampedArray;
+        ~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint8ClampedArray' is not assignable to type 'Int8Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint8ClampedArray"' is not assignable to type '"Int8Array"'.
+    
+        arr_Uint8Array = arr_Int8Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int8Array' is not assignable to type 'Uint8Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int8Array"' is not assignable to type '"UInt8Array"'.
+        arr_Uint8Array = arr_Uint8Array;
+        arr_Uint8Array = arr_Int16Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int16Array' is not assignable to type 'Uint8Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int16Array"' is not assignable to type '"UInt8Array"'.
+        arr_Uint8Array = arr_Uint16Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint16Array' is not assignable to type 'Uint8Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint16Array"' is not assignable to type '"UInt8Array"'.
+        arr_Uint8Array = arr_Int32Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int32Array' is not assignable to type 'Uint8Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int32Array"' is not assignable to type '"UInt8Array"'.
+        arr_Uint8Array = arr_Uint32Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint32Array' is not assignable to type 'Uint8Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint32Array"' is not assignable to type '"UInt8Array"'.
+        arr_Uint8Array = arr_Float32Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Float32Array' is not assignable to type 'Uint8Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Float32Array"' is not assignable to type '"UInt8Array"'.
+        arr_Uint8Array = arr_Float64Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Float64Array' is not assignable to type 'Uint8Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Float64Array"' is not assignable to type '"UInt8Array"'.
+        arr_Uint8Array = arr_Uint8ClampedArray;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint8ClampedArray' is not assignable to type 'Uint8Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint8ClampedArray"' is not assignable to type '"UInt8Array"'.
+    
+        arr_Int16Array = arr_Int8Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int8Array' is not assignable to type 'Int16Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int8Array"' is not assignable to type '"Int16Array"'.
+        arr_Int16Array = arr_Uint8Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint8Array' is not assignable to type 'Int16Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"UInt8Array"' is not assignable to type '"Int16Array"'.
+        arr_Int16Array = arr_Int16Array;
+        arr_Int16Array = arr_Uint16Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint16Array' is not assignable to type 'Int16Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint16Array"' is not assignable to type '"Int16Array"'.
+        arr_Int16Array = arr_Int32Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int32Array' is not assignable to type 'Int16Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int32Array"' is not assignable to type '"Int16Array"'.
+        arr_Int16Array = arr_Uint32Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint32Array' is not assignable to type 'Int16Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint32Array"' is not assignable to type '"Int16Array"'.
+        arr_Int16Array = arr_Float32Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Float32Array' is not assignable to type 'Int16Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Float32Array"' is not assignable to type '"Int16Array"'.
+        arr_Int16Array = arr_Float64Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Float64Array' is not assignable to type 'Int16Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Float64Array"' is not assignable to type '"Int16Array"'.
+        arr_Int16Array = arr_Uint8ClampedArray;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint8ClampedArray' is not assignable to type 'Int16Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint8ClampedArray"' is not assignable to type '"Int16Array"'.
+    
+        arr_Uint16Array = arr_Int8Array;
+        ~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int8Array' is not assignable to type 'Uint16Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int8Array"' is not assignable to type '"Uint16Array"'.
+        arr_Uint16Array = arr_Uint8Array;
+        ~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint8Array' is not assignable to type 'Uint16Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"UInt8Array"' is not assignable to type '"Uint16Array"'.
+        arr_Uint16Array = arr_Int16Array;
+        ~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int16Array' is not assignable to type 'Uint16Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int16Array"' is not assignable to type '"Uint16Array"'.
+        arr_Uint16Array = arr_Uint16Array;
+        arr_Uint16Array = arr_Int32Array;
+        ~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int32Array' is not assignable to type 'Uint16Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int32Array"' is not assignable to type '"Uint16Array"'.
+        arr_Uint16Array = arr_Uint32Array;
+        ~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint32Array' is not assignable to type 'Uint16Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint32Array"' is not assignable to type '"Uint16Array"'.
+        arr_Uint16Array = arr_Float32Array;
+        ~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Float32Array' is not assignable to type 'Uint16Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Float32Array"' is not assignable to type '"Uint16Array"'.
+        arr_Uint16Array = arr_Float64Array;
+        ~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Float64Array' is not assignable to type 'Uint16Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Float64Array"' is not assignable to type '"Uint16Array"'.
+        arr_Uint16Array = arr_Uint8ClampedArray;
+        ~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint8ClampedArray' is not assignable to type 'Uint16Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint8ClampedArray"' is not assignable to type '"Uint16Array"'.
+    
+        arr_Int32Array = arr_Int8Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int8Array' is not assignable to type 'Int32Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int8Array"' is not assignable to type '"Int32Array"'.
+        arr_Int32Array = arr_Uint8Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint8Array' is not assignable to type 'Int32Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"UInt8Array"' is not assignable to type '"Int32Array"'.
+        arr_Int32Array = arr_Int16Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int16Array' is not assignable to type 'Int32Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int16Array"' is not assignable to type '"Int32Array"'.
+        arr_Int32Array = arr_Uint16Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint16Array' is not assignable to type 'Int32Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint16Array"' is not assignable to type '"Int32Array"'.
+        arr_Int32Array = arr_Int32Array;
+        arr_Int32Array = arr_Uint32Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint32Array' is not assignable to type 'Int32Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint32Array"' is not assignable to type '"Int32Array"'.
+        arr_Int32Array = arr_Float32Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Float32Array' is not assignable to type 'Int32Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Float32Array"' is not assignable to type '"Int32Array"'.
+        arr_Int32Array = arr_Float64Array;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Float64Array' is not assignable to type 'Int32Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Float64Array"' is not assignable to type '"Int32Array"'.
+        arr_Int32Array = arr_Uint8ClampedArray;
+        ~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint8ClampedArray' is not assignable to type 'Int32Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint8ClampedArray"' is not assignable to type '"Int32Array"'.
+    
+        arr_Float32Array = arr_Int8Array;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int8Array' is not assignable to type 'Float32Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int8Array"' is not assignable to type '"Float32Array"'.
+        arr_Float32Array = arr_Uint8Array;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint8Array' is not assignable to type 'Float32Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"UInt8Array"' is not assignable to type '"Float32Array"'.
+        arr_Float32Array = arr_Int16Array;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int16Array' is not assignable to type 'Float32Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int16Array"' is not assignable to type '"Float32Array"'.
+        arr_Float32Array = arr_Uint16Array;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint16Array' is not assignable to type 'Float32Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint16Array"' is not assignable to type '"Float32Array"'.
+        arr_Float32Array = arr_Int32Array;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int32Array' is not assignable to type 'Float32Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int32Array"' is not assignable to type '"Float32Array"'.
+        arr_Float32Array = arr_Uint32Array;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint32Array' is not assignable to type 'Float32Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint32Array"' is not assignable to type '"Float32Array"'.
+        arr_Float32Array = arr_Float32Array;
+        arr_Float32Array = arr_Float64Array;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Float64Array' is not assignable to type 'Float32Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Float64Array"' is not assignable to type '"Float32Array"'.
+        arr_Float32Array = arr_Uint8ClampedArray;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint8ClampedArray' is not assignable to type 'Float32Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint8ClampedArray"' is not assignable to type '"Float32Array"'.
+    
+        arr_Float64Array = arr_Int8Array;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int8Array' is not assignable to type 'Float64Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int8Array"' is not assignable to type '"Float64Array"'.
+        arr_Float64Array = arr_Uint8Array;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint8Array' is not assignable to type 'Float64Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"UInt8Array"' is not assignable to type '"Float64Array"'.
+        arr_Float64Array = arr_Int16Array;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int16Array' is not assignable to type 'Float64Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int16Array"' is not assignable to type '"Float64Array"'.
+        arr_Float64Array = arr_Uint16Array;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint16Array' is not assignable to type 'Float64Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint16Array"' is not assignable to type '"Float64Array"'.
+        arr_Float64Array = arr_Int32Array;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int32Array' is not assignable to type 'Float64Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int32Array"' is not assignable to type '"Float64Array"'.
+        arr_Float64Array = arr_Uint32Array;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint32Array' is not assignable to type 'Float64Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint32Array"' is not assignable to type '"Float64Array"'.
+        arr_Float64Array = arr_Float32Array;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Float32Array' is not assignable to type 'Float64Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Float32Array"' is not assignable to type '"Float64Array"'.
+        arr_Float64Array = arr_Float64Array;
+        arr_Float64Array = arr_Uint8ClampedArray;
+        ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint8ClampedArray' is not assignable to type 'Float64Array'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint8ClampedArray"' is not assignable to type '"Float64Array"'.
+    
+        arr_Uint8ClampedArray = arr_Int8Array;
+        ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int8Array' is not assignable to type 'Uint8ClampedArray'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int8Array"' is not assignable to type '"Uint8ClampedArray"'.
+        arr_Uint8ClampedArray = arr_Uint8Array;
+        ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint8Array' is not assignable to type 'Uint8ClampedArray'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"UInt8Array"' is not assignable to type '"Uint8ClampedArray"'.
+        arr_Uint8ClampedArray = arr_Int16Array;
+        ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int16Array' is not assignable to type 'Uint8ClampedArray'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int16Array"' is not assignable to type '"Uint8ClampedArray"'.
+        arr_Uint8ClampedArray = arr_Uint16Array;
+        ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint16Array' is not assignable to type 'Uint8ClampedArray'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint16Array"' is not assignable to type '"Uint8ClampedArray"'.
+        arr_Uint8ClampedArray = arr_Int32Array;
+        ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Int32Array' is not assignable to type 'Uint8ClampedArray'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Int32Array"' is not assignable to type '"Uint8ClampedArray"'.
+        arr_Uint8ClampedArray = arr_Uint32Array;
+        ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Uint32Array' is not assignable to type 'Uint8ClampedArray'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Uint32Array"' is not assignable to type '"Uint8ClampedArray"'.
+        arr_Uint8ClampedArray = arr_Float32Array;
+        ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Float32Array' is not assignable to type 'Uint8ClampedArray'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Float32Array"' is not assignable to type '"Uint8ClampedArray"'.
+        arr_Uint8ClampedArray = arr_Float64Array;
+        ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type 'Float64Array' is not assignable to type 'Uint8ClampedArray'.
+!!! error TS2322:   Types of property '[Symbol.toStringTag]' are incompatible.
+!!! error TS2322:     Type '"Float64Array"' is not assignable to type '"Uint8ClampedArray"'.
+        arr_Uint8ClampedArray = arr_Uint8ClampedArray;
+        
+    }
+    

--- a/tests/baselines/reference/typedArraysCrossAssignability01.js
+++ b/tests/baselines/reference/typedArraysCrossAssignability01.js
@@ -1,0 +1,180 @@
+//// [typedArraysCrossAssignability01.ts]
+
+function CheckAssignability() {
+    let arr_Int8Array           = new Int8Array(1);
+    let arr_Uint8Array          = new Uint8Array(1);
+    let arr_Int16Array          = new Int16Array(1);
+    let arr_Uint16Array         = new Uint16Array(1);
+    let arr_Int32Array          = new Int32Array(1);
+    let arr_Uint32Array         = new Uint32Array(1);
+    let arr_Float32Array        = new Float32Array(1);
+    let arr_Float64Array        = new Float64Array(1);
+    let arr_Uint8ClampedArray   = new Uint8ClampedArray(1);
+
+    arr_Int8Array = arr_Int8Array;
+    arr_Int8Array = arr_Uint8Array;
+    arr_Int8Array = arr_Int16Array;
+    arr_Int8Array = arr_Uint16Array;
+    arr_Int8Array = arr_Int32Array;
+    arr_Int8Array = arr_Uint32Array;
+    arr_Int8Array = arr_Float32Array;
+    arr_Int8Array = arr_Float64Array;
+    arr_Int8Array = arr_Uint8ClampedArray;
+
+    arr_Uint8Array = arr_Int8Array;
+    arr_Uint8Array = arr_Uint8Array;
+    arr_Uint8Array = arr_Int16Array;
+    arr_Uint8Array = arr_Uint16Array;
+    arr_Uint8Array = arr_Int32Array;
+    arr_Uint8Array = arr_Uint32Array;
+    arr_Uint8Array = arr_Float32Array;
+    arr_Uint8Array = arr_Float64Array;
+    arr_Uint8Array = arr_Uint8ClampedArray;
+
+    arr_Int16Array = arr_Int8Array;
+    arr_Int16Array = arr_Uint8Array;
+    arr_Int16Array = arr_Int16Array;
+    arr_Int16Array = arr_Uint16Array;
+    arr_Int16Array = arr_Int32Array;
+    arr_Int16Array = arr_Uint32Array;
+    arr_Int16Array = arr_Float32Array;
+    arr_Int16Array = arr_Float64Array;
+    arr_Int16Array = arr_Uint8ClampedArray;
+
+    arr_Uint16Array = arr_Int8Array;
+    arr_Uint16Array = arr_Uint8Array;
+    arr_Uint16Array = arr_Int16Array;
+    arr_Uint16Array = arr_Uint16Array;
+    arr_Uint16Array = arr_Int32Array;
+    arr_Uint16Array = arr_Uint32Array;
+    arr_Uint16Array = arr_Float32Array;
+    arr_Uint16Array = arr_Float64Array;
+    arr_Uint16Array = arr_Uint8ClampedArray;
+
+    arr_Int32Array = arr_Int8Array;
+    arr_Int32Array = arr_Uint8Array;
+    arr_Int32Array = arr_Int16Array;
+    arr_Int32Array = arr_Uint16Array;
+    arr_Int32Array = arr_Int32Array;
+    arr_Int32Array = arr_Uint32Array;
+    arr_Int32Array = arr_Float32Array;
+    arr_Int32Array = arr_Float64Array;
+    arr_Int32Array = arr_Uint8ClampedArray;
+
+    arr_Float32Array = arr_Int8Array;
+    arr_Float32Array = arr_Uint8Array;
+    arr_Float32Array = arr_Int16Array;
+    arr_Float32Array = arr_Uint16Array;
+    arr_Float32Array = arr_Int32Array;
+    arr_Float32Array = arr_Uint32Array;
+    arr_Float32Array = arr_Float32Array;
+    arr_Float32Array = arr_Float64Array;
+    arr_Float32Array = arr_Uint8ClampedArray;
+
+    arr_Float64Array = arr_Int8Array;
+    arr_Float64Array = arr_Uint8Array;
+    arr_Float64Array = arr_Int16Array;
+    arr_Float64Array = arr_Uint16Array;
+    arr_Float64Array = arr_Int32Array;
+    arr_Float64Array = arr_Uint32Array;
+    arr_Float64Array = arr_Float32Array;
+    arr_Float64Array = arr_Float64Array;
+    arr_Float64Array = arr_Uint8ClampedArray;
+
+    arr_Uint8ClampedArray = arr_Int8Array;
+    arr_Uint8ClampedArray = arr_Uint8Array;
+    arr_Uint8ClampedArray = arr_Int16Array;
+    arr_Uint8ClampedArray = arr_Uint16Array;
+    arr_Uint8ClampedArray = arr_Int32Array;
+    arr_Uint8ClampedArray = arr_Uint32Array;
+    arr_Uint8ClampedArray = arr_Float32Array;
+    arr_Uint8ClampedArray = arr_Float64Array;
+    arr_Uint8ClampedArray = arr_Uint8ClampedArray;
+    
+}
+
+
+//// [typedArraysCrossAssignability01.js]
+function CheckAssignability() {
+    let arr_Int8Array = new Int8Array(1);
+    let arr_Uint8Array = new Uint8Array(1);
+    let arr_Int16Array = new Int16Array(1);
+    let arr_Uint16Array = new Uint16Array(1);
+    let arr_Int32Array = new Int32Array(1);
+    let arr_Uint32Array = new Uint32Array(1);
+    let arr_Float32Array = new Float32Array(1);
+    let arr_Float64Array = new Float64Array(1);
+    let arr_Uint8ClampedArray = new Uint8ClampedArray(1);
+    arr_Int8Array = arr_Int8Array;
+    arr_Int8Array = arr_Uint8Array;
+    arr_Int8Array = arr_Int16Array;
+    arr_Int8Array = arr_Uint16Array;
+    arr_Int8Array = arr_Int32Array;
+    arr_Int8Array = arr_Uint32Array;
+    arr_Int8Array = arr_Float32Array;
+    arr_Int8Array = arr_Float64Array;
+    arr_Int8Array = arr_Uint8ClampedArray;
+    arr_Uint8Array = arr_Int8Array;
+    arr_Uint8Array = arr_Uint8Array;
+    arr_Uint8Array = arr_Int16Array;
+    arr_Uint8Array = arr_Uint16Array;
+    arr_Uint8Array = arr_Int32Array;
+    arr_Uint8Array = arr_Uint32Array;
+    arr_Uint8Array = arr_Float32Array;
+    arr_Uint8Array = arr_Float64Array;
+    arr_Uint8Array = arr_Uint8ClampedArray;
+    arr_Int16Array = arr_Int8Array;
+    arr_Int16Array = arr_Uint8Array;
+    arr_Int16Array = arr_Int16Array;
+    arr_Int16Array = arr_Uint16Array;
+    arr_Int16Array = arr_Int32Array;
+    arr_Int16Array = arr_Uint32Array;
+    arr_Int16Array = arr_Float32Array;
+    arr_Int16Array = arr_Float64Array;
+    arr_Int16Array = arr_Uint8ClampedArray;
+    arr_Uint16Array = arr_Int8Array;
+    arr_Uint16Array = arr_Uint8Array;
+    arr_Uint16Array = arr_Int16Array;
+    arr_Uint16Array = arr_Uint16Array;
+    arr_Uint16Array = arr_Int32Array;
+    arr_Uint16Array = arr_Uint32Array;
+    arr_Uint16Array = arr_Float32Array;
+    arr_Uint16Array = arr_Float64Array;
+    arr_Uint16Array = arr_Uint8ClampedArray;
+    arr_Int32Array = arr_Int8Array;
+    arr_Int32Array = arr_Uint8Array;
+    arr_Int32Array = arr_Int16Array;
+    arr_Int32Array = arr_Uint16Array;
+    arr_Int32Array = arr_Int32Array;
+    arr_Int32Array = arr_Uint32Array;
+    arr_Int32Array = arr_Float32Array;
+    arr_Int32Array = arr_Float64Array;
+    arr_Int32Array = arr_Uint8ClampedArray;
+    arr_Float32Array = arr_Int8Array;
+    arr_Float32Array = arr_Uint8Array;
+    arr_Float32Array = arr_Int16Array;
+    arr_Float32Array = arr_Uint16Array;
+    arr_Float32Array = arr_Int32Array;
+    arr_Float32Array = arr_Uint32Array;
+    arr_Float32Array = arr_Float32Array;
+    arr_Float32Array = arr_Float64Array;
+    arr_Float32Array = arr_Uint8ClampedArray;
+    arr_Float64Array = arr_Int8Array;
+    arr_Float64Array = arr_Uint8Array;
+    arr_Float64Array = arr_Int16Array;
+    arr_Float64Array = arr_Uint16Array;
+    arr_Float64Array = arr_Int32Array;
+    arr_Float64Array = arr_Uint32Array;
+    arr_Float64Array = arr_Float32Array;
+    arr_Float64Array = arr_Float64Array;
+    arr_Float64Array = arr_Uint8ClampedArray;
+    arr_Uint8ClampedArray = arr_Int8Array;
+    arr_Uint8ClampedArray = arr_Uint8Array;
+    arr_Uint8ClampedArray = arr_Int16Array;
+    arr_Uint8ClampedArray = arr_Uint16Array;
+    arr_Uint8ClampedArray = arr_Int32Array;
+    arr_Uint8ClampedArray = arr_Uint32Array;
+    arr_Uint8ClampedArray = arr_Float32Array;
+    arr_Uint8ClampedArray = arr_Float64Array;
+    arr_Uint8ClampedArray = arr_Uint8ClampedArray;
+}

--- a/tests/cases/compiler/typedArrays.ts
+++ b/tests/cases/compiler/typedArrays.ts
@@ -75,7 +75,6 @@ function CreateIntegerTypedArraysFromArrayLike(obj:ArrayLike<number>) {
     return typedArrays;
 }
 
-/*
 function CreateTypedArraysOf(obj) {
     var typedArrays = [];
     typedArrays[0] = Int8Array.of(...obj);
@@ -90,7 +89,6 @@ function CreateTypedArraysOf(obj) {
 
     return typedArrays;
 }
-*/
 
 function CreateTypedArraysOf2() {
     var typedArrays = [];

--- a/tests/cases/compiler/typedArraysCrossAssignability01.ts
+++ b/tests/cases/compiler/typedArraysCrossAssignability01.ts
@@ -1,0 +1,94 @@
+﻿// @target: ES6
+
+function CheckAssignability() {
+    let arr_Int8Array           = new Int8Array(1);
+    let arr_Uint8Array          = new Uint8Array(1);
+    let arr_Int16Array          = new Int16Array(1);
+    let arr_Uint16Array         = new Uint16Array(1);
+    let arr_Int32Array          = new Int32Array(1);
+    let arr_Uint32Array         = new Uint32Array(1);
+    let arr_Float32Array        = new Float32Array(1);
+    let arr_Float64Array        = new Float64Array(1);
+    let arr_Uint8ClampedArray   = new Uint8ClampedArray(1);
+
+    arr_Int8Array = arr_Int8Array;
+    arr_Int8Array = arr_Uint8Array;
+    arr_Int8Array = arr_Int16Array;
+    arr_Int8Array = arr_Uint16Array;
+    arr_Int8Array = arr_Int32Array;
+    arr_Int8Array = arr_Uint32Array;
+    arr_Int8Array = arr_Float32Array;
+    arr_Int8Array = arr_Float64Array;
+    arr_Int8Array = arr_Uint8ClampedArray;
+
+    arr_Uint8Array = arr_Int8Array;
+    arr_Uint8Array = arr_Uint8Array;
+    arr_Uint8Array = arr_Int16Array;
+    arr_Uint8Array = arr_Uint16Array;
+    arr_Uint8Array = arr_Int32Array;
+    arr_Uint8Array = arr_Uint32Array;
+    arr_Uint8Array = arr_Float32Array;
+    arr_Uint8Array = arr_Float64Array;
+    arr_Uint8Array = arr_Uint8ClampedArray;
+
+    arr_Int16Array = arr_Int8Array;
+    arr_Int16Array = arr_Uint8Array;
+    arr_Int16Array = arr_Int16Array;
+    arr_Int16Array = arr_Uint16Array;
+    arr_Int16Array = arr_Int32Array;
+    arr_Int16Array = arr_Uint32Array;
+    arr_Int16Array = arr_Float32Array;
+    arr_Int16Array = arr_Float64Array;
+    arr_Int16Array = arr_Uint8ClampedArray;
+
+    arr_Uint16Array = arr_Int8Array;
+    arr_Uint16Array = arr_Uint8Array;
+    arr_Uint16Array = arr_Int16Array;
+    arr_Uint16Array = arr_Uint16Array;
+    arr_Uint16Array = arr_Int32Array;
+    arr_Uint16Array = arr_Uint32Array;
+    arr_Uint16Array = arr_Float32Array;
+    arr_Uint16Array = arr_Float64Array;
+    arr_Uint16Array = arr_Uint8ClampedArray;
+
+    arr_Int32Array = arr_Int8Array;
+    arr_Int32Array = arr_Uint8Array;
+    arr_Int32Array = arr_Int16Array;
+    arr_Int32Array = arr_Uint16Array;
+    arr_Int32Array = arr_Int32Array;
+    arr_Int32Array = arr_Uint32Array;
+    arr_Int32Array = arr_Float32Array;
+    arr_Int32Array = arr_Float64Array;
+    arr_Int32Array = arr_Uint8ClampedArray;
+
+    arr_Float32Array = arr_Int8Array;
+    arr_Float32Array = arr_Uint8Array;
+    arr_Float32Array = arr_Int16Array;
+    arr_Float32Array = arr_Uint16Array;
+    arr_Float32Array = arr_Int32Array;
+    arr_Float32Array = arr_Uint32Array;
+    arr_Float32Array = arr_Float32Array;
+    arr_Float32Array = arr_Float64Array;
+    arr_Float32Array = arr_Uint8ClampedArray;
+
+    arr_Float64Array = arr_Int8Array;
+    arr_Float64Array = arr_Uint8Array;
+    arr_Float64Array = arr_Int16Array;
+    arr_Float64Array = arr_Uint16Array;
+    arr_Float64Array = arr_Int32Array;
+    arr_Float64Array = arr_Uint32Array;
+    arr_Float64Array = arr_Float32Array;
+    arr_Float64Array = arr_Float64Array;
+    arr_Float64Array = arr_Uint8ClampedArray;
+
+    arr_Uint8ClampedArray = arr_Int8Array;
+    arr_Uint8ClampedArray = arr_Uint8Array;
+    arr_Uint8ClampedArray = arr_Int16Array;
+    arr_Uint8ClampedArray = arr_Uint16Array;
+    arr_Uint8ClampedArray = arr_Int32Array;
+    arr_Uint8ClampedArray = arr_Uint32Array;
+    arr_Uint8ClampedArray = arr_Float32Array;
+    arr_Uint8ClampedArray = arr_Float64Array;
+    arr_Uint8ClampedArray = arr_Uint8ClampedArray;
+    
+}


### PR DESCRIPTION
This PR fixes #5388 by using string literal types to brand all `[Symbol.toStringTag]` properties.

This PR also adds missing `[Symbol.toStringTag]` properties listed in #2881.