### PR TITLE
Improve reference finding for imported variables

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -5490,9 +5490,11 @@ namespace ts {
                 };
             }
 
-            function isImportOrExportSpecifierImportSymbol(symbol: Symbol) {
+            function isES6StyleImportSymbol(symbol: Symbol) {
                 return (symbol.flags & SymbolFlags.Alias) && forEach(symbol.declarations, declaration => {
-                    return declaration.kind === SyntaxKind.ImportSpecifier || declaration.kind === SyntaxKind.ExportSpecifier;
+                    const { kind } = declaration;
+                    return kind === SyntaxKind.ImportSpecifier || kind === SyntaxKind.ExportSpecifier
+                        || kind === SyntaxKind.ImportClause || kind === SyntaxKind.NamespaceImport;
                 });
             }
 
@@ -5936,8 +5938,8 @@ namespace ts {
                 // The search set contains at least the current symbol
                 let result = [symbol];
 
-                // If the symbol is an alias, add what it alaises to the list
-                if (isImportOrExportSpecifierImportSymbol(symbol)) {
+                // If the symbol is an alias, add what it aliases to the list
+                if (isES6StyleImportSymbol(symbol)) {
                     result.push(typeChecker.getAliasedSymbol(symbol));
                 }
 
@@ -6028,7 +6030,7 @@ namespace ts {
 
                 // If the reference symbol is an alias, check if what it is aliasing is one of the search
                 // symbols.
-                if (isImportOrExportSpecifierImportSymbol(referenceSymbol)) {
+                if (isES6StyleImportSymbol(referenceSymbol)) {
                     const aliasedSymbol = typeChecker.getAliasedSymbol(referenceSymbol);
                     if (searchSymbols.indexOf(aliasedSymbol) >= 0) {
                         return aliasedSymbol;

--- a/tests/cases/fourslash/renameImportAndExport.ts
+++ b/tests/cases/fourslash/renameImportAndExport.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts' />
+
+////import [|a|] from "module";
+////export { [|a|] };
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}

--- a/tests/cases/fourslash/renameImportAndShorthand.ts
+++ b/tests/cases/fourslash/renameImportAndShorthand.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts' />
+
+////import [|foo|] from 'bar';
+////const bar = { [|foo|] };
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}

--- a/tests/cases/fourslash/renameImportNamespaceAndShorthand.ts
+++ b/tests/cases/fourslash/renameImportNamespaceAndShorthand.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts' />
+
+////import * as [|foo|] from 'bar';
+////const bar = { [|foo|] };
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}


### PR DESCRIPTION
We ran into a [TSLint issue](https://github.com/palantir/tslint/issues/684) where used, imported, variables were being marked as unused because the TS language services weren't finding all references correctly. In the example below, `b` is marked as used but not `c` or `d`.

```ts
let a;

import {b} from "mod1";
a = {b};

import c from "mod2";
a = {c};

import * as d from "mod3";
a = {d};
```

I spent a little bit debugging the issue a little, and it seemed to be that for some ES6 style imports, [the symbol the import aliases is added to the search set](https://github.com/Microsoft/TypeScript/blob/ba0f7f52abc0ab93f573b9faf3c8c8ce29161181/src/services/services.ts#L5940) and thus a match is found. But for every other kind of import, it is not and this sometimes causes problems.

This PR seems to fix the issue for ES6-style imports. I think this is all related to the work @mhegazy did at https://github.com/Microsoft/TypeScript/pull/2126. I don't have full confidence that this PR is doing things the right way, but wanted to put it out here for discussion.

A similar issue still persists for `import e = require("mod4");` type imports, but when I expanded my changes to include them, it broke the `referencesForAmbients` and `referencesForImports` tests.