### PR TITLE
Improved checking of for-in statements

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2422,6 +2422,10 @@
         "category": "Error",
         "code": 7013
     },
+    "Element implicitly has an 'any' type because index expression is not of type 'number'.": {
+        "category": "Error",
+        "code": 7015
+    },
     "Property '{0}' implicitly has type 'any', because its 'set' accessor lacks a type annotation.": {
         "category": "Error",
         "code": 7016

--- a/tests/baselines/reference/capturedLetConstInLoop1.types
+++ b/tests/baselines/reference/capturedLetConstInLoop1.types
@@ -1,18 +1,18 @@
 === tests/cases/compiler/capturedLetConstInLoop1.ts ===
 //==== let
 for (let x in {}) {
->x : any
+>x : string
 >{} : {}
 
     (function() { return x});
->(function() { return x}) : () => any
->function() { return x} : () => any
->x : any
+>(function() { return x}) : () => string
+>function() { return x} : () => string
+>x : string
 
     (() => x);
->(() => x) : () => any
->() => x : () => any
->x : any
+>(() => x) : () => string
+>() => x : () => string
+>x : string
 }
 
 for (let x of []) {
@@ -216,18 +216,18 @@ for (let y = 0; y < 1; ++y) {
 
 //=========const
 for (const x in {}) {
->x : any
+>x : string
 >{} : {}
 
     (function() { return x});
->(function() { return x}) : () => any
->function() { return x} : () => any
->x : any
+>(function() { return x}) : () => string
+>function() { return x} : () => string
+>x : string
 
     (() => x);
->(() => x) : () => any
->() => x : () => any
->x : any
+>(() => x) : () => string
+>() => x : () => string
+>x : string
 }
 
 for (const x of []) {

--- a/tests/baselines/reference/capturedLetConstInLoop1_ES6.types
+++ b/tests/baselines/reference/capturedLetConstInLoop1_ES6.types
@@ -1,18 +1,18 @@
 === tests/cases/compiler/capturedLetConstInLoop1_ES6.ts ===
 //==== let
 for (let x in {}) {
->x : any
+>x : string
 >{} : {}
 
     (function() { return x});
->(function() { return x}) : () => any
->function() { return x} : () => any
->x : any
+>(function() { return x}) : () => string
+>function() { return x} : () => string
+>x : string
 
     (() => x);
->(() => x) : () => any
->() => x : () => any
->x : any
+>(() => x) : () => string
+>() => x : () => string
+>x : string
 }
 
 for (let x of []) {
@@ -216,18 +216,18 @@ for (let y = 0; y < 1; ++y) {
 
 //=========const
 for (const x in {}) {
->x : any
+>x : string
 >{} : {}
 
     (function() { return x});
->(function() { return x}) : () => any
->function() { return x} : () => any
->x : any
+>(function() { return x}) : () => string
+>function() { return x} : () => string
+>x : string
 
     (() => x);
->(() => x) : () => any
->() => x : () => any
->x : any
+>(() => x) : () => string
+>() => x : () => string
+>x : string
 }
 
 for (const x of []) {

--- a/tests/baselines/reference/capturedLetConstInLoop2.types
+++ b/tests/baselines/reference/capturedLetConstInLoop2.types
@@ -37,7 +37,7 @@ function foo0_1(x) {
 >x : any
 
     for (let x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
         let a = arguments.length;
@@ -47,17 +47,17 @@ function foo0_1(x) {
 >length : number
 
         (function() { return x + a });
->(function() { return x + a }) : () => any
->function() { return x + a } : () => any
->x + a : any
->x : any
+>(function() { return x + a }) : () => string
+>function() { return x + a } : () => string
+>x + a : string
+>x : string
 >a : number
 
         (() => x + a);
->(() => x + a) : () => any
->() => x + a : () => any
->x + a : any
->x : any
+>(() => x + a) : () => string
+>() => x + a : () => string
+>x + a : string
+>x : string
 >a : number
     }
 }
@@ -400,7 +400,7 @@ function foo0_1_c(x) {
 >x : any
 
     for (const x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
         const a = arguments.length;
@@ -410,17 +410,17 @@ function foo0_1_c(x) {
 >length : number
 
         (function() { return x + a });
->(function() { return x + a }) : () => any
->function() { return x + a } : () => any
->x + a : any
->x : any
+>(function() { return x + a }) : () => string
+>function() { return x + a } : () => string
+>x + a : string
+>x : string
 >a : number
 
         (() => x + a);
->(() => x + a) : () => any
->() => x + a : () => any
->x + a : any
->x : any
+>(() => x + a) : () => string
+>() => x + a : () => string
+>x + a : string
+>x : string
 >a : number
     }
 }

--- a/tests/baselines/reference/capturedLetConstInLoop2_ES6.types
+++ b/tests/baselines/reference/capturedLetConstInLoop2_ES6.types
@@ -36,7 +36,7 @@ function foo0_1(x) {
 >x : any
 
     for (let x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
         let a = arguments.length;
@@ -46,17 +46,17 @@ function foo0_1(x) {
 >length : number
 
         (function() { return x + a });
->(function() { return x + a }) : () => any
->function() { return x + a } : () => any
->x + a : any
->x : any
+>(function() { return x + a }) : () => string
+>function() { return x + a } : () => string
+>x + a : string
+>x : string
 >a : number
 
         (() => x + a);
->(() => x + a) : () => any
->() => x + a : () => any
->x + a : any
->x : any
+>(() => x + a) : () => string
+>() => x + a : () => string
+>x + a : string
+>x : string
 >a : number
     }
 }
@@ -399,7 +399,7 @@ function foo0_1_c(x) {
 >x : any
 
     for (const x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
         const a = arguments.length;
@@ -409,17 +409,17 @@ function foo0_1_c(x) {
 >length : number
 
         (function() { return x + a });
->(function() { return x + a }) : () => any
->function() { return x + a } : () => any
->x + a : any
->x : any
+>(function() { return x + a }) : () => string
+>function() { return x + a } : () => string
+>x + a : string
+>x : string
 >a : number
 
         (() => x + a);
->(() => x + a) : () => any
->() => x + a : () => any
->x + a : any
->x : any
+>(() => x + a) : () => string
+>() => x + a : () => string
+>x + a : string
+>x : string
 >a : number
     }
 }

--- a/tests/baselines/reference/capturedLetConstInLoop3.types
+++ b/tests/baselines/reference/capturedLetConstInLoop3.types
@@ -42,32 +42,32 @@ function foo0_1(x) {
 >x : any
 
     for (let x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
         var v = x;
->v : any
->x : any
+>v : string
+>x : string
 
         (function() { return x + v });
->(function() { return x + v }) : () => any
->function() { return x + v } : () => any
->x + v : any
->x : any
->v : any
+>(function() { return x + v }) : () => string
+>function() { return x + v } : () => string
+>x + v : string
+>x : string
+>v : string
 
         (() => x + v);
->(() => x + v) : () => any
->() => x + v : () => any
->x + v : any
->x : any
->v : any
+>(() => x + v) : () => string
+>() => x + v : () => string
+>x + v : string
+>x : string
+>v : string
     }
 
     use(v);
 >use(v) : any
 >use : (a: any) => any
->v : any
+>v : string
 }
 
 function foo1(x) {
@@ -438,32 +438,32 @@ function foo0_1_c(x) {
 >x : any
 
     for (const x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
         var v = x;
->v : any
->x : any
+>v : string
+>x : string
 
         (function() { return x + v });
->(function() { return x + v }) : () => any
->function() { return x + v } : () => any
->x + v : any
->x : any
->v : any
+>(function() { return x + v }) : () => string
+>function() { return x + v } : () => string
+>x + v : string
+>x : string
+>v : string
 
         (() => x + v);
->(() => x + v) : () => any
->() => x + v : () => any
->x + v : any
->x : any
->v : any
+>(() => x + v) : () => string
+>() => x + v : () => string
+>x + v : string
+>x : string
+>v : string
     }
 
     use(v);
 >use(v) : any
 >use : (a: any) => any
->v : any
+>v : string
 }
 
 function foo1_c(x) {

--- a/tests/baselines/reference/capturedLetConstInLoop3_ES6.types
+++ b/tests/baselines/reference/capturedLetConstInLoop3_ES6.types
@@ -43,32 +43,32 @@ function foo0_1(x) {
 >x : any
 
     for (let x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
         var v = x;
->v : any
->x : any
+>v : string
+>x : string
 
         (function() { return x + v });
->(function() { return x + v }) : () => any
->function() { return x + v } : () => any
->x + v : any
->x : any
->v : any
+>(function() { return x + v }) : () => string
+>function() { return x + v } : () => string
+>x + v : string
+>x : string
+>v : string
 
         (() => x + v);
->(() => x + v) : () => any
->() => x + v : () => any
->x + v : any
->x : any
->v : any
+>(() => x + v) : () => string
+>() => x + v : () => string
+>x + v : string
+>x : string
+>v : string
     }
 
     use(v);
 >use(v) : any
 >use : (a: any) => any
->v : any
+>v : string
 }
 
 function foo1(x) {
@@ -439,32 +439,32 @@ function foo0_1_c(x) {
 >x : any
 
     for (const x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
         var v = x;
->v : any
->x : any
+>v : string
+>x : string
 
         (function() { return x + v });
->(function() { return x + v }) : () => any
->function() { return x + v } : () => any
->x + v : any
->x : any
->v : any
+>(function() { return x + v }) : () => string
+>function() { return x + v } : () => string
+>x + v : string
+>x : string
+>v : string
 
         (() => x + v);
->(() => x + v) : () => any
->() => x + v : () => any
->x + v : any
->x : any
->v : any
+>(() => x + v) : () => string
+>() => x + v : () => string
+>x + v : string
+>x : string
+>v : string
     }
 
     use(v);
 >use(v) : any
 >use : (a: any) => any
->v : any
+>v : string
 }
 
 function foo1_c(x) {

--- a/tests/baselines/reference/capturedLetConstInLoop4.types
+++ b/tests/baselines/reference/capturedLetConstInLoop4.types
@@ -2,20 +2,20 @@
 
 //======let
 export function exportedFoo() {
->exportedFoo : () => any
+>exportedFoo : () => string
 
     return v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8;
->v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 : any
->v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 + v7 : any
->v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 : any
->v0 + v00 + v1 + v2 + v3 + v4 + v5 : any
->v0 + v00 + v1 + v2 + v3 + v4 : any
->v0 + v00 + v1 + v2 + v3 : any
->v0 + v00 + v1 + v2 : any
->v0 + v00 + v1 : any
->v0 + v00 : any
+>v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 : string
+>v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 + v7 : string
+>v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 : string
+>v0 + v00 + v1 + v2 + v3 + v4 + v5 : string
+>v0 + v00 + v1 + v2 + v3 + v4 : string
+>v0 + v00 + v1 + v2 + v3 : string
+>v0 + v00 + v1 + v2 : string
+>v0 + v00 + v1 : string
+>v0 + v00 : string
 >v0 : any
->v00 : any
+>v00 : string
 >v1 : number
 >v2 : any
 >v3 : any
@@ -48,24 +48,24 @@ for (let x of []) {
 }
 
 for (let x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
     var v00 = x;
->v00 : any
->x : any
+>v00 : string
+>x : string
 
     (function() { return x + v00});
->(function() { return x + v00}) : () => any
->function() { return x + v00} : () => any
->x + v00 : any
->x : any
->v00 : any
+>(function() { return x + v00}) : () => string
+>function() { return x + v00} : () => string
+>x + v00 : string
+>x : string
+>v00 : string
 
     (() => x);    
->(() => x) : () => any
->() => x : () => any
->x : any
+>(() => x) : () => string
+>() => x : () => string
+>x : string
 }
 
 for (let x = 0; x < 1; ++x) {
@@ -302,20 +302,20 @@ for (let y = 0; y < 1; ++y) {
 
 //======const
 export function exportedFoo2() {
->exportedFoo2 : () => any
+>exportedFoo2 : () => string
 
     return v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c + v6_c + v7_c + v8_c;
->v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c + v6_c + v7_c + v8_c : any
->v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c + v6_c + v7_c : any
->v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c + v6_c : any
->v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c : any
->v0_c + v00_c + v1_c + v2_c + v3_c + v4_c : any
->v0_c + v00_c + v1_c + v2_c + v3_c : any
->v0_c + v00_c + v1_c + v2_c : any
->v0_c + v00_c + v1_c : any
->v0_c + v00_c : any
+>v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c + v6_c + v7_c + v8_c : string
+>v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c + v6_c + v7_c : string
+>v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c + v6_c : string
+>v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c : string
+>v0_c + v00_c + v1_c + v2_c + v3_c + v4_c : string
+>v0_c + v00_c + v1_c + v2_c + v3_c : string
+>v0_c + v00_c + v1_c + v2_c : string
+>v0_c + v00_c + v1_c : string
+>v0_c + v00_c : string
 >v0_c : any
->v00_c : any
+>v00_c : string
 >v1_c : number
 >v2_c : number
 >v3_c : number
@@ -348,24 +348,24 @@ for (const x of []) {
 }
 
 for (const x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
     var v00_c = x;
->v00_c : any
->x : any
+>v00_c : string
+>x : string
 
     (function() { return x + v00});
->(function() { return x + v00}) : () => any
->function() { return x + v00} : () => any
->x + v00 : any
->x : any
->v00 : any
+>(function() { return x + v00}) : () => string
+>function() { return x + v00} : () => string
+>x + v00 : string
+>x : string
+>v00 : string
 
     (() => x);    
->(() => x) : () => any
->() => x : () => any
->x : any
+>(() => x) : () => string
+>() => x : () => string
+>x : string
 }
 
 for (const x = 0; x < 1;) {

--- a/tests/baselines/reference/capturedLetConstInLoop4_ES6.types
+++ b/tests/baselines/reference/capturedLetConstInLoop4_ES6.types
@@ -2,20 +2,20 @@
 
 //======let
 export function exportedFoo() {
->exportedFoo : () => any
+>exportedFoo : () => string
 
     return v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8;
->v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 : any
->v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 + v7 : any
->v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 : any
->v0 + v00 + v1 + v2 + v3 + v4 + v5 : any
->v0 + v00 + v1 + v2 + v3 + v4 : any
->v0 + v00 + v1 + v2 + v3 : any
->v0 + v00 + v1 + v2 : any
->v0 + v00 + v1 : any
->v0 + v00 : any
+>v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8 : string
+>v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 + v7 : string
+>v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 : string
+>v0 + v00 + v1 + v2 + v3 + v4 + v5 : string
+>v0 + v00 + v1 + v2 + v3 + v4 : string
+>v0 + v00 + v1 + v2 + v3 : string
+>v0 + v00 + v1 + v2 : string
+>v0 + v00 + v1 : string
+>v0 + v00 : string
 >v0 : any
->v00 : any
+>v00 : string
 >v1 : number
 >v2 : any
 >v3 : any
@@ -48,24 +48,24 @@ for (let x of []) {
 }
 
 for (let x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
     var v00 = x;
->v00 : any
->x : any
+>v00 : string
+>x : string
 
     (function() { return x + v00});
->(function() { return x + v00}) : () => any
->function() { return x + v00} : () => any
->x + v00 : any
->x : any
->v00 : any
+>(function() { return x + v00}) : () => string
+>function() { return x + v00} : () => string
+>x + v00 : string
+>x : string
+>v00 : string
 
     (() => x);    
->(() => x) : () => any
->() => x : () => any
->x : any
+>(() => x) : () => string
+>() => x : () => string
+>x : string
 }
 
 for (let x = 0; x < 1; ++x) {
@@ -302,20 +302,20 @@ for (let y = 0; y < 1; ++y) {
 
 //======const
 export function exportedFoo2() {
->exportedFoo2 : () => any
+>exportedFoo2 : () => string
 
     return v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c + v6_c + v7_c + v8_c;
->v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c + v6_c + v7_c + v8_c : any
->v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c + v6_c + v7_c : any
->v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c + v6_c : any
->v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c : any
->v0_c + v00_c + v1_c + v2_c + v3_c + v4_c : any
->v0_c + v00_c + v1_c + v2_c + v3_c : any
->v0_c + v00_c + v1_c + v2_c : any
->v0_c + v00_c + v1_c : any
->v0_c + v00_c : any
+>v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c + v6_c + v7_c + v8_c : string
+>v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c + v6_c + v7_c : string
+>v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c + v6_c : string
+>v0_c + v00_c + v1_c + v2_c + v3_c + v4_c + v5_c : string
+>v0_c + v00_c + v1_c + v2_c + v3_c + v4_c : string
+>v0_c + v00_c + v1_c + v2_c + v3_c : string
+>v0_c + v00_c + v1_c + v2_c : string
+>v0_c + v00_c + v1_c : string
+>v0_c + v00_c : string
 >v0_c : any
->v00_c : any
+>v00_c : string
 >v1_c : number
 >v2_c : number
 >v3_c : number
@@ -348,24 +348,24 @@ for (const x of []) {
 }
 
 for (const x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
     var v00_c = x;
->v00_c : any
->x : any
+>v00_c : string
+>x : string
 
     (function() { return x + v00});
->(function() { return x + v00}) : () => any
->function() { return x + v00} : () => any
->x + v00 : any
->x : any
->v00 : any
+>(function() { return x + v00}) : () => string
+>function() { return x + v00} : () => string
+>x + v00 : string
+>x : string
+>v00 : string
 
     (() => x);    
->(() => x) : () => any
->() => x : () => any
->x : any
+>(() => x) : () => string
+>() => x : () => string
+>x : string
 }
 
 for (const x = 0; x < 1;) {

--- a/tests/baselines/reference/capturedLetConstInLoop5.js
+++ b/tests/baselines/reference/capturedLetConstInLoop5.js
@@ -20,7 +20,7 @@ function foo00(x) {
         var v = x;
         (function() { return x + v });
         (() => x + v);
-        if (x == 1) {
+        if (x == "1") {
             return;
         }
     }
@@ -159,7 +159,7 @@ function foo00_c(x) {
         var v = x;
         (function() { return x + v });
         (() => x + v);
-        if (x == 1) {
+        if (x == "1") {
             return;
         }
     }
@@ -303,7 +303,7 @@ function foo00(x) {
         v = x_2;
         (function () { return x_2 + v; });
         (function () { return x_2 + v; });
-        if (x_2 == 1) {
+        if (x_2 == "1") {
             return { value: void 0 };
         }
     };
@@ -471,7 +471,7 @@ function foo00_c(x) {
         v = x_12;
         (function () { return x_12 + v; });
         (function () { return x_12 + v; });
-        if (x_12 == 1) {
+        if (x_12 == "1") {
             return { value: void 0 };
         }
     };

--- a/tests/baselines/reference/capturedLetConstInLoop5.symbols
+++ b/tests/baselines/reference/capturedLetConstInLoop5.symbols
@@ -54,7 +54,7 @@ function foo00(x) {
 >x : Symbol(x, Decl(capturedLetConstInLoop5.ts, 17, 12))
 >v : Symbol(v, Decl(capturedLetConstInLoop5.ts, 18, 11))
 
-        if (x == 1) {
+        if (x == "1") {
 >x : Symbol(x, Decl(capturedLetConstInLoop5.ts, 17, 12))
 
             return;
@@ -395,7 +395,7 @@ function foo00_c(x) {
 >x : Symbol(x, Decl(capturedLetConstInLoop5.ts, 156, 14))
 >v : Symbol(v, Decl(capturedLetConstInLoop5.ts, 157, 11))
 
-        if (x == 1) {
+        if (x == "1") {
 >x : Symbol(x, Decl(capturedLetConstInLoop5.ts, 156, 14))
 
             return;

--- a/tests/baselines/reference/capturedLetConstInLoop5.types
+++ b/tests/baselines/reference/capturedLetConstInLoop5.types
@@ -50,31 +50,31 @@ function foo00(x) {
 >x : any
 
     for (let x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
         var v = x;
->v : any
->x : any
+>v : string
+>x : string
 
         (function() { return x + v });
->(function() { return x + v }) : () => any
->function() { return x + v } : () => any
->x + v : any
->x : any
->v : any
+>(function() { return x + v }) : () => string
+>function() { return x + v } : () => string
+>x + v : string
+>x : string
+>v : string
 
         (() => x + v);
->(() => x + v) : () => any
->() => x + v : () => any
->x + v : any
->x : any
->v : any
+>(() => x + v) : () => string
+>() => x + v : () => string
+>x + v : string
+>x : string
+>v : string
 
-        if (x == 1) {
->x == 1 : boolean
->x : any
->1 : number
+        if (x == "1") {
+>x == "1" : boolean
+>x : string
+>"1" : string
 
             return;
         }
@@ -83,7 +83,7 @@ function foo00(x) {
     use(v);
 >use(v) : any
 >use : (a: any) => any
->v : any
+>v : string
 }
 
 function foo1(x) {
@@ -525,31 +525,31 @@ function foo00_c(x) {
 >x : any
 
     for (const x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
         var v = x;
->v : any
->x : any
+>v : string
+>x : string
 
         (function() { return x + v });
->(function() { return x + v }) : () => any
->function() { return x + v } : () => any
->x + v : any
->x : any
->v : any
+>(function() { return x + v }) : () => string
+>function() { return x + v } : () => string
+>x + v : string
+>x : string
+>v : string
 
         (() => x + v);
->(() => x + v) : () => any
->() => x + v : () => any
->x + v : any
->x : any
->v : any
+>(() => x + v) : () => string
+>() => x + v : () => string
+>x + v : string
+>x : string
+>v : string
 
-        if (x == 1) {
->x == 1 : boolean
->x : any
->1 : number
+        if (x == "1") {
+>x == "1" : boolean
+>x : string
+>"1" : string
 
             return;
         }
@@ -558,7 +558,7 @@ function foo00_c(x) {
     use(v);
 >use(v) : any
 >use : (a: any) => any
->v : any
+>v : string
 }
 
 function foo1_c(x) {

--- a/tests/baselines/reference/capturedLetConstInLoop5_ES6.js
+++ b/tests/baselines/reference/capturedLetConstInLoop5_ES6.js
@@ -21,7 +21,7 @@ function foo00(x) {
         var v = x;
         (function() { return x + v });
         (() => x + v);
-        if (x == 1) {
+        if (x == "1") {
             return;
         }
     }
@@ -160,7 +160,7 @@ function foo00_c(x) {
         var v = x;
         (function() { return x + v });
         (() => x + v);
-        if (x == 1) {
+        if (x == "1") {
             return;
         }
     }
@@ -298,7 +298,7 @@ function foo00(x) {
         var v = x;
         (function () { return x + v; });
         (() => x + v);
-        if (x == 1) {
+        if (x == "1") {
             return;
         }
     }
@@ -416,7 +416,7 @@ function foo00_c(x) {
         var v = x;
         (function () { return x + v; });
         (() => x + v);
-        if (x == 1) {
+        if (x == "1") {
             return;
         }
     }

--- a/tests/baselines/reference/capturedLetConstInLoop5_ES6.symbols
+++ b/tests/baselines/reference/capturedLetConstInLoop5_ES6.symbols
@@ -55,7 +55,7 @@ function foo00(x) {
 >x : Symbol(x, Decl(capturedLetConstInLoop5_ES6.ts, 18, 12))
 >v : Symbol(v, Decl(capturedLetConstInLoop5_ES6.ts, 19, 11))
 
-        if (x == 1) {
+        if (x == "1") {
 >x : Symbol(x, Decl(capturedLetConstInLoop5_ES6.ts, 18, 12))
 
             return;
@@ -396,7 +396,7 @@ function foo00_c(x) {
 >x : Symbol(x, Decl(capturedLetConstInLoop5_ES6.ts, 157, 14))
 >v : Symbol(v, Decl(capturedLetConstInLoop5_ES6.ts, 158, 11))
 
-        if (x == 1) {
+        if (x == "1") {
 >x : Symbol(x, Decl(capturedLetConstInLoop5_ES6.ts, 157, 14))
 
             return;

--- a/tests/baselines/reference/capturedLetConstInLoop5_ES6.types
+++ b/tests/baselines/reference/capturedLetConstInLoop5_ES6.types
@@ -51,31 +51,31 @@ function foo00(x) {
 >x : any
 
     for (let x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
         var v = x;
->v : any
->x : any
+>v : string
+>x : string
 
         (function() { return x + v });
->(function() { return x + v }) : () => any
->function() { return x + v } : () => any
->x + v : any
->x : any
->v : any
+>(function() { return x + v }) : () => string
+>function() { return x + v } : () => string
+>x + v : string
+>x : string
+>v : string
 
         (() => x + v);
->(() => x + v) : () => any
->() => x + v : () => any
->x + v : any
->x : any
->v : any
+>(() => x + v) : () => string
+>() => x + v : () => string
+>x + v : string
+>x : string
+>v : string
 
-        if (x == 1) {
->x == 1 : boolean
->x : any
->1 : number
+        if (x == "1") {
+>x == "1" : boolean
+>x : string
+>"1" : string
 
             return;
         }
@@ -84,7 +84,7 @@ function foo00(x) {
     use(v);
 >use(v) : any
 >use : (a: any) => any
->v : any
+>v : string
 }
 
 function foo1(x) {
@@ -526,31 +526,31 @@ function foo00_c(x) {
 >x : any
 
     for (const x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
         var v = x;
->v : any
->x : any
+>v : string
+>x : string
 
         (function() { return x + v });
->(function() { return x + v }) : () => any
->function() { return x + v } : () => any
->x + v : any
->x : any
->v : any
+>(function() { return x + v }) : () => string
+>function() { return x + v } : () => string
+>x + v : string
+>x : string
+>v : string
 
         (() => x + v);
->(() => x + v) : () => any
->() => x + v : () => any
->x + v : any
->x : any
->v : any
+>(() => x + v) : () => string
+>() => x + v : () => string
+>x + v : string
+>x : string
+>v : string
 
-        if (x == 1) {
->x == 1 : boolean
->x : any
->1 : number
+        if (x == "1") {
+>x == "1" : boolean
+>x : string
+>"1" : string
 
             return;
         }
@@ -559,7 +559,7 @@ function foo00_c(x) {
     use(v);
 >use(v) : any
 >use : (a: any) => any
->v : any
+>v : string
 }
 
 function foo1_c(x) {

--- a/tests/baselines/reference/capturedLetConstInLoop6.js
+++ b/tests/baselines/reference/capturedLetConstInLoop6.js
@@ -14,10 +14,10 @@ for (let x of []) {
 for (let x in []) {
     (function() { return x});
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
 }
@@ -133,10 +133,10 @@ for (const x of []) {
 for (const x in []) {
     (function() { return x});
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
 }
@@ -259,10 +259,10 @@ for (var _i = 0, _a = []; _i < _a.length; _i++) {
 var _loop_2 = function(x) {
     (function () { return x; });
     (function () { return x; });
-    if (x == 1) {
+    if (x == "1") {
         return "break";
     }
-    if (x == 2) {
+    if (x == "2") {
         return "continue";
     }
 };
@@ -417,10 +417,10 @@ for (var _b = 0, _c = []; _b < _c.length; _b++) {
 var _loop_12 = function(x) {
     (function () { return x; });
     (function () { return x; });
-    if (x == 1) {
+    if (x == "1") {
         return "break";
     }
-    if (x == 2) {
+    if (x == "2") {
         return "continue";
     }
 };

--- a/tests/baselines/reference/capturedLetConstInLoop6.symbols
+++ b/tests/baselines/reference/capturedLetConstInLoop6.symbols
@@ -30,12 +30,12 @@ for (let x in []) {
     (() => x);
 >x : Symbol(x, Decl(capturedLetConstInLoop6.ts, 12, 8))
 
-    if (x == 1) {
+    if (x == "1") {
 >x : Symbol(x, Decl(capturedLetConstInLoop6.ts, 12, 8))
 
         break;
     }
-    if (x == 2) {
+    if (x == "2") {
 >x : Symbol(x, Decl(capturedLetConstInLoop6.ts, 12, 8))
 
         continue;
@@ -272,12 +272,12 @@ for (const x in []) {
     (() => x);
 >x : Symbol(x, Decl(capturedLetConstInLoop6.ts, 131, 10))
 
-    if (x == 1) {
+    if (x == "1") {
 >x : Symbol(x, Decl(capturedLetConstInLoop6.ts, 131, 10))
 
         break;
     }
-    if (x == 2) {
+    if (x == "2") {
 >x : Symbol(x, Decl(capturedLetConstInLoop6.ts, 131, 10))
 
         continue;

--- a/tests/baselines/reference/capturedLetConstInLoop6.types
+++ b/tests/baselines/reference/capturedLetConstInLoop6.types
@@ -31,30 +31,30 @@ for (let x of []) {
 }
 
 for (let x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
     (function() { return x});
->(function() { return x}) : () => any
->function() { return x} : () => any
->x : any
+>(function() { return x}) : () => string
+>function() { return x} : () => string
+>x : string
 
     (() => x);
->(() => x) : () => any
->() => x : () => any
->x : any
+>(() => x) : () => string
+>() => x : () => string
+>x : string
 
-    if (x == 1) {
->x == 1 : boolean
->x : any
->1 : number
+    if (x == "1") {
+>x == "1" : boolean
+>x : string
+>"1" : string
 
         break;
     }
-    if (x == 2) {
->x == 2 : boolean
->x : any
->2 : number
+    if (x == "2") {
+>x == "2" : boolean
+>x : string
+>"2" : string
 
         continue;
     }
@@ -396,30 +396,30 @@ for (const x of []) {
 }
 
 for (const x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
     (function() { return x});
->(function() { return x}) : () => any
->function() { return x} : () => any
->x : any
+>(function() { return x}) : () => string
+>function() { return x} : () => string
+>x : string
 
     (() => x);
->(() => x) : () => any
->() => x : () => any
->x : any
+>(() => x) : () => string
+>() => x : () => string
+>x : string
 
-    if (x == 1) {
->x == 1 : boolean
->x : any
->1 : number
+    if (x == "1") {
+>x == "1" : boolean
+>x : string
+>"1" : string
 
         break;
     }
-    if (x == 2) {
->x == 2 : boolean
->x : any
->2 : number
+    if (x == "2") {
+>x == "2" : boolean
+>x : string
+>"2" : string
 
         continue;
     }

--- a/tests/baselines/reference/capturedLetConstInLoop6_ES6.js
+++ b/tests/baselines/reference/capturedLetConstInLoop6_ES6.js
@@ -14,10 +14,10 @@ for (let x of []) {
 for (let x in []) {
     (function() { return x});
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
 }
@@ -133,10 +133,10 @@ for (const x of []) {
 for (const x in []) {
     (function() { return x});
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
 }
@@ -253,10 +253,10 @@ for (let x of []) {
 for (let x in []) {
     (function () { return x; });
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
 }
@@ -360,10 +360,10 @@ for (const x of []) {
 for (const x in []) {
     (function () { return x; });
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
 }

--- a/tests/baselines/reference/capturedLetConstInLoop6_ES6.symbols
+++ b/tests/baselines/reference/capturedLetConstInLoop6_ES6.symbols
@@ -30,12 +30,12 @@ for (let x in []) {
     (() => x);
 >x : Symbol(x, Decl(capturedLetConstInLoop6_ES6.ts, 12, 8))
 
-    if (x == 1) {
+    if (x == "1") {
 >x : Symbol(x, Decl(capturedLetConstInLoop6_ES6.ts, 12, 8))
 
         break;
     }
-    if (x == 2) {
+    if (x == "2") {
 >x : Symbol(x, Decl(capturedLetConstInLoop6_ES6.ts, 12, 8))
 
         continue;
@@ -272,12 +272,12 @@ for (const x in []) {
     (() => x);
 >x : Symbol(x, Decl(capturedLetConstInLoop6_ES6.ts, 131, 10))
 
-    if (x == 1) {
+    if (x == "1") {
 >x : Symbol(x, Decl(capturedLetConstInLoop6_ES6.ts, 131, 10))
 
         break;
     }
-    if (x == 2) {
+    if (x == "2") {
 >x : Symbol(x, Decl(capturedLetConstInLoop6_ES6.ts, 131, 10))
 
         continue;

--- a/tests/baselines/reference/capturedLetConstInLoop6_ES6.types
+++ b/tests/baselines/reference/capturedLetConstInLoop6_ES6.types
@@ -31,30 +31,30 @@ for (let x of []) {
 }
 
 for (let x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
     (function() { return x});
->(function() { return x}) : () => any
->function() { return x} : () => any
->x : any
+>(function() { return x}) : () => string
+>function() { return x} : () => string
+>x : string
 
     (() => x);
->(() => x) : () => any
->() => x : () => any
->x : any
+>(() => x) : () => string
+>() => x : () => string
+>x : string
 
-    if (x == 1) {
->x == 1 : boolean
->x : any
->1 : number
+    if (x == "1") {
+>x == "1" : boolean
+>x : string
+>"1" : string
 
         break;
     }
-    if (x == 2) {
->x == 2 : boolean
->x : any
->2 : number
+    if (x == "2") {
+>x == "2" : boolean
+>x : string
+>"2" : string
 
         continue;
     }
@@ -396,30 +396,30 @@ for (const x of []) {
 }
 
 for (const x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
     (function() { return x});
->(function() { return x}) : () => any
->function() { return x} : () => any
->x : any
+>(function() { return x}) : () => string
+>function() { return x} : () => string
+>x : string
 
     (() => x);
->(() => x) : () => any
->() => x : () => any
->x : any
+>(() => x) : () => string
+>() => x : () => string
+>x : string
 
-    if (x == 1) {
->x == 1 : boolean
->x : any
->1 : number
+    if (x == "1") {
+>x == "1" : boolean
+>x : string
+>"1" : string
 
         break;
     }
-    if (x == 2) {
->x == 2 : boolean
->x : any
->2 : number
+    if (x == "2") {
+>x == "2" : boolean
+>x : string
+>"2" : string
 
         continue;
     }

--- a/tests/baselines/reference/capturedLetConstInLoop7.js
+++ b/tests/baselines/reference/capturedLetConstInLoop7.js
@@ -22,16 +22,16 @@ l00:
 for (let x in []) {
     (function() { return x});
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 1) {
+    if (x == "1") {
         break l00;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue l00;
     }
 }
@@ -210,16 +210,16 @@ l00_c:
 for (const x in []) {
     (function() { return x});
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 1) {
+    if (x == "1") {
         break l00_c;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue l00_c;
     }
 }
@@ -406,16 +406,16 @@ l0: for (var _i = 0, _a = []; _i < _a.length; _i++) {
 var _loop_2 = function(x) {
     (function () { return x; });
     (function () { return x; });
-    if (x == 1) {
+    if (x == "1") {
         return "break";
     }
-    if (x == 1) {
+    if (x == "1") {
         return "break-l00";
     }
-    if (x == 2) {
+    if (x == "2") {
         return "continue";
     }
-    if (x == 2) {
+    if (x == "2") {
         return "continue-l00";
     }
 };
@@ -664,16 +664,16 @@ l0_c: for (var _b = 0, _c = []; _b < _c.length; _b++) {
 var _loop_12 = function(x) {
     (function () { return x; });
     (function () { return x; });
-    if (x == 1) {
+    if (x == "1") {
         return "break";
     }
-    if (x == 1) {
+    if (x == "1") {
         return "break-l00_c";
     }
-    if (x == 2) {
+    if (x == "2") {
         return "continue";
     }
-    if (x == 2) {
+    if (x == "2") {
         return "continue-l00_c";
     }
 };

--- a/tests/baselines/reference/capturedLetConstInLoop7.symbols
+++ b/tests/baselines/reference/capturedLetConstInLoop7.symbols
@@ -42,22 +42,22 @@ for (let x in []) {
     (() => x);
 >x : Symbol(x, Decl(capturedLetConstInLoop7.ts, 20, 8))
 
-    if (x == 1) {
+    if (x == "1") {
 >x : Symbol(x, Decl(capturedLetConstInLoop7.ts, 20, 8))
 
         break;
     }
-    if (x == 1) {
+    if (x == "1") {
 >x : Symbol(x, Decl(capturedLetConstInLoop7.ts, 20, 8))
 
         break l00;
     }
-    if (x == 2) {
+    if (x == "2") {
 >x : Symbol(x, Decl(capturedLetConstInLoop7.ts, 20, 8))
 
         continue;
     }
-    if (x == 2) {
+    if (x == "2") {
 >x : Symbol(x, Decl(capturedLetConstInLoop7.ts, 20, 8))
 
         continue l00;
@@ -393,22 +393,22 @@ for (const x in []) {
     (() => x);
 >x : Symbol(x, Decl(capturedLetConstInLoop7.ts, 208, 10))
 
-    if (x == 1) {
+    if (x == "1") {
 >x : Symbol(x, Decl(capturedLetConstInLoop7.ts, 208, 10))
 
         break;
     }
-    if (x == 1) {
+    if (x == "1") {
 >x : Symbol(x, Decl(capturedLetConstInLoop7.ts, 208, 10))
 
         break l00_c;
     }
-    if (x == 2) {
+    if (x == "2") {
 >x : Symbol(x, Decl(capturedLetConstInLoop7.ts, 208, 10))
 
         continue;
     }
-    if (x == 2) {
+    if (x == "2") {
 >x : Symbol(x, Decl(capturedLetConstInLoop7.ts, 208, 10))
 
         continue l00_c;

--- a/tests/baselines/reference/capturedLetConstInLoop7.types
+++ b/tests/baselines/reference/capturedLetConstInLoop7.types
@@ -53,45 +53,45 @@ l00:
 >l00 : any
 
 for (let x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
     (function() { return x});
->(function() { return x}) : () => any
->function() { return x} : () => any
->x : any
+>(function() { return x}) : () => string
+>function() { return x} : () => string
+>x : string
 
     (() => x);
->(() => x) : () => any
->() => x : () => any
->x : any
+>(() => x) : () => string
+>() => x : () => string
+>x : string
 
-    if (x == 1) {
->x == 1 : boolean
->x : any
->1 : number
+    if (x == "1") {
+>x == "1" : boolean
+>x : string
+>"1" : string
 
         break;
     }
-    if (x == 1) {
->x == 1 : boolean
->x : any
->1 : number
+    if (x == "1") {
+>x == "1" : boolean
+>x : string
+>"1" : string
 
         break l00;
 >l00 : any
     }
-    if (x == 2) {
->x == 2 : boolean
->x : any
->2 : number
+    if (x == "2") {
+>x == "2" : boolean
+>x : string
+>"2" : string
 
         continue;
     }
-    if (x == 2) {
->x == 2 : boolean
->x : any
->2 : number
+    if (x == "2") {
+>x == "2" : boolean
+>x : string
+>"2" : string
 
         continue l00;
 >l00 : any
@@ -607,45 +607,45 @@ l00_c:
 >l00_c : any
 
 for (const x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
     (function() { return x});
->(function() { return x}) : () => any
->function() { return x} : () => any
->x : any
+>(function() { return x}) : () => string
+>function() { return x} : () => string
+>x : string
 
     (() => x);
->(() => x) : () => any
->() => x : () => any
->x : any
+>(() => x) : () => string
+>() => x : () => string
+>x : string
 
-    if (x == 1) {
->x == 1 : boolean
->x : any
->1 : number
+    if (x == "1") {
+>x == "1" : boolean
+>x : string
+>"1" : string
 
         break;
     }
-    if (x == 1) {
->x == 1 : boolean
->x : any
->1 : number
+    if (x == "1") {
+>x == "1" : boolean
+>x : string
+>"1" : string
 
         break l00_c;
 >l00_c : any
     }
-    if (x == 2) {
->x == 2 : boolean
->x : any
->2 : number
+    if (x == "2") {
+>x == "2" : boolean
+>x : string
+>"2" : string
 
         continue;
     }
-    if (x == 2) {
->x == 2 : boolean
->x : any
->2 : number
+    if (x == "2") {
+>x == "2" : boolean
+>x : string
+>"2" : string
 
         continue l00_c;
 >l00_c : any

--- a/tests/baselines/reference/capturedLetConstInLoop7_ES6.js
+++ b/tests/baselines/reference/capturedLetConstInLoop7_ES6.js
@@ -22,16 +22,16 @@ l00:
 for (let x in []) {
     (function() { return x});
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 1) {
+    if (x == "1") {
         break l00;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue l00;
     }
 }
@@ -210,16 +210,16 @@ l00_c:
 for (const x in []) {
     (function() { return x});
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 1) {
+    if (x == "1") {
         break l00_c;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue l00_c;
     }
 }
@@ -396,16 +396,16 @@ l0: for (let x of []) {
 l00: for (let x in []) {
     (function () { return x; });
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 1) {
+    if (x == "1") {
         break l00;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue l00;
     }
 }
@@ -563,16 +563,16 @@ l0_c: for (const x of []) {
 l00_c: for (const x in []) {
     (function () { return x; });
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 1) {
+    if (x == "1") {
         break l00_c;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue l00_c;
     }
 }

--- a/tests/baselines/reference/capturedLetConstInLoop7_ES6.symbols
+++ b/tests/baselines/reference/capturedLetConstInLoop7_ES6.symbols
@@ -42,22 +42,22 @@ for (let x in []) {
     (() => x);
 >x : Symbol(x, Decl(capturedLetConstInLoop7_ES6.ts, 20, 8))
 
-    if (x == 1) {
+    if (x == "1") {
 >x : Symbol(x, Decl(capturedLetConstInLoop7_ES6.ts, 20, 8))
 
         break;
     }
-    if (x == 1) {
+    if (x == "1") {
 >x : Symbol(x, Decl(capturedLetConstInLoop7_ES6.ts, 20, 8))
 
         break l00;
     }
-    if (x == 2) {
+    if (x == "2") {
 >x : Symbol(x, Decl(capturedLetConstInLoop7_ES6.ts, 20, 8))
 
         continue;
     }
-    if (x == 2) {
+    if (x == "2") {
 >x : Symbol(x, Decl(capturedLetConstInLoop7_ES6.ts, 20, 8))
 
         continue l00;
@@ -393,22 +393,22 @@ for (const x in []) {
     (() => x);
 >x : Symbol(x, Decl(capturedLetConstInLoop7_ES6.ts, 208, 10))
 
-    if (x == 1) {
+    if (x == "1") {
 >x : Symbol(x, Decl(capturedLetConstInLoop7_ES6.ts, 208, 10))
 
         break;
     }
-    if (x == 1) {
+    if (x == "1") {
 >x : Symbol(x, Decl(capturedLetConstInLoop7_ES6.ts, 208, 10))
 
         break l00_c;
     }
-    if (x == 2) {
+    if (x == "2") {
 >x : Symbol(x, Decl(capturedLetConstInLoop7_ES6.ts, 208, 10))
 
         continue;
     }
-    if (x == 2) {
+    if (x == "2") {
 >x : Symbol(x, Decl(capturedLetConstInLoop7_ES6.ts, 208, 10))
 
         continue l00_c;

--- a/tests/baselines/reference/capturedLetConstInLoop7_ES6.types
+++ b/tests/baselines/reference/capturedLetConstInLoop7_ES6.types
@@ -53,45 +53,45 @@ l00:
 >l00 : any
 
 for (let x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
     (function() { return x});
->(function() { return x}) : () => any
->function() { return x} : () => any
->x : any
+>(function() { return x}) : () => string
+>function() { return x} : () => string
+>x : string
 
     (() => x);
->(() => x) : () => any
->() => x : () => any
->x : any
+>(() => x) : () => string
+>() => x : () => string
+>x : string
 
-    if (x == 1) {
->x == 1 : boolean
->x : any
->1 : number
+    if (x == "1") {
+>x == "1" : boolean
+>x : string
+>"1" : string
 
         break;
     }
-    if (x == 1) {
->x == 1 : boolean
->x : any
->1 : number
+    if (x == "1") {
+>x == "1" : boolean
+>x : string
+>"1" : string
 
         break l00;
 >l00 : any
     }
-    if (x == 2) {
->x == 2 : boolean
->x : any
->2 : number
+    if (x == "2") {
+>x == "2" : boolean
+>x : string
+>"2" : string
 
         continue;
     }
-    if (x == 2) {
->x == 2 : boolean
->x : any
->2 : number
+    if (x == "2") {
+>x == "2" : boolean
+>x : string
+>"2" : string
 
         continue l00;
 >l00 : any
@@ -607,45 +607,45 @@ l00_c:
 >l00_c : any
 
 for (const x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
     (function() { return x});
->(function() { return x}) : () => any
->function() { return x} : () => any
->x : any
+>(function() { return x}) : () => string
+>function() { return x} : () => string
+>x : string
 
     (() => x);
->(() => x) : () => any
->() => x : () => any
->x : any
+>(() => x) : () => string
+>() => x : () => string
+>x : string
 
-    if (x == 1) {
->x == 1 : boolean
->x : any
->1 : number
+    if (x == "1") {
+>x == "1" : boolean
+>x : string
+>"1" : string
 
         break;
     }
-    if (x == 1) {
->x == 1 : boolean
->x : any
->1 : number
+    if (x == "1") {
+>x == "1" : boolean
+>x : string
+>"1" : string
 
         break l00_c;
 >l00_c : any
     }
-    if (x == 2) {
->x == 2 : boolean
->x : any
->2 : number
+    if (x == "2") {
+>x == "2" : boolean
+>x : string
+>"2" : string
 
         continue;
     }
-    if (x == 2) {
->x == 2 : boolean
->x : any
->2 : number
+    if (x == "2") {
+>x == "2" : boolean
+>x : string
+>"2" : string
 
         continue l00_c;
 >l00_c : any

--- a/tests/baselines/reference/downlevelLetConst17.types
+++ b/tests/baselines/reference/downlevelLetConst17.types
@@ -139,23 +139,23 @@ do {
 >true : boolean
 
 for (let x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
     use(x);
 >use(x) : any
 >use : (a: any) => any
->x : any
+>x : string
 }
 
 for (const x in []) {
->x : any
+>x : string
 >[] : undefined[]
 
     use(x);
 >use(x) : any
 >use : (a: any) => any
->x : any
+>x : string
 }
 
 for (const x of []) {

--- a/tests/baselines/reference/duplicateLocalVariable1.errors.txt
+++ b/tests/baselines/reference/duplicateLocalVariable1.errors.txt
@@ -2,10 +2,12 @@ tests/cases/compiler/duplicateLocalVariable1.ts(2,4): error TS1005: ';' expected
 tests/cases/compiler/duplicateLocalVariable1.ts(2,11): error TS1146: Declaration expected.
 tests/cases/compiler/duplicateLocalVariable1.ts(2,13): error TS2304: Cannot find name 'commonjs'.
 tests/cases/compiler/duplicateLocalVariable1.ts(12,14): error TS1148: Cannot compile modules unless the '--module' flag is provided. Consider setting the 'module' compiler option in a 'tsconfig.json' file.
-tests/cases/compiler/duplicateLocalVariable1.ts(187,22): error TS2403: Subsequent variable declarations must have the same type.  Variable 'i' must be of type 'any', but here has type 'number'.
+tests/cases/compiler/duplicateLocalVariable1.ts(187,22): error TS2403: Subsequent variable declarations must have the same type.  Variable 'i' must be of type 'string', but here has type 'number'.
+tests/cases/compiler/duplicateLocalVariable1.ts(187,29): error TS2365: Operator '<' cannot be applied to types 'string' and 'number'.
+tests/cases/compiler/duplicateLocalVariable1.ts(187,37): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 
 
-==== tests/cases/compiler/duplicateLocalVariable1.ts (5 errors) ====
+==== tests/cases/compiler/duplicateLocalVariable1.ts (7 errors) ====
     
     / /@module: commonjs
        ~
@@ -202,7 +204,11 @@ tests/cases/compiler/duplicateLocalVariable1.ts(187,22): error TS2403: Subsequen
                 var bytes = [];
                 for (var i = 0; i < 14; i++) {
                          ~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'i' must be of type 'any', but here has type 'number'.
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'i' must be of type 'string', but here has type 'number'.
+                                ~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'number'.
+                                        ~
+!!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
                     bytes.push(fb.readByte());
                 }
                 var expected = [0xEF, 0xBB, 0xBF, 0x54, 0xC3, 0xA8, 0xE1, 0xB4, 0xA3, 0xE2, 0x80, 0xA0, 0x0D, 0x0A];

--- a/tests/baselines/reference/duplicateLocalVariable2.errors.txt
+++ b/tests/baselines/reference/duplicateLocalVariable2.errors.txt
@@ -1,7 +1,9 @@
-tests/cases/compiler/duplicateLocalVariable2.ts(27,22): error TS2403: Subsequent variable declarations must have the same type.  Variable 'i' must be of type 'any', but here has type 'number'.
+tests/cases/compiler/duplicateLocalVariable2.ts(27,22): error TS2403: Subsequent variable declarations must have the same type.  Variable 'i' must be of type 'string', but here has type 'number'.
+tests/cases/compiler/duplicateLocalVariable2.ts(27,29): error TS2365: Operator '<' cannot be applied to types 'string' and 'number'.
+tests/cases/compiler/duplicateLocalVariable2.ts(27,37): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 
 
-==== tests/cases/compiler/duplicateLocalVariable2.ts (1 errors) ====
+==== tests/cases/compiler/duplicateLocalVariable2.ts (3 errors) ====
     export class TestCase {
         constructor (public name: string, public test: ()=>boolean, public errorMessageRegEx?: string) {
         }
@@ -30,7 +32,11 @@ tests/cases/compiler/duplicateLocalVariable2.ts(27,22): error TS2403: Subsequent
                 var bytes = [];
                 for (var i = 0; i < 14; i++) {
                          ~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'i' must be of type 'any', but here has type 'number'.
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'i' must be of type 'string', but here has type 'number'.
+                                ~~~~~~
+!!! error TS2365: Operator '<' cannot be applied to types 'string' and 'number'.
+                                        ~
+!!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
                     bytes.push(fb.readByte());
                 }
                 var expected = [0xEF];

--- a/tests/baselines/reference/for-inStatementsArray.js
+++ b/tests/baselines/reference/for-inStatementsArray.js
@@ -1,0 +1,25 @@
+//// [for-inStatementsArray.ts]
+let a: Date[];
+let b: boolean[];
+
+for (let x in a) {
+    let a1 = a[x];
+    let a2 = a[(x)];
+    let a3 = a[+x];
+    let b1 = b[x];
+    let b2 = b[(x)];
+    let b3 = b[+x];
+}
+
+
+//// [for-inStatementsArray.js]
+var a;
+var b;
+for (var x in a) {
+    var a1 = a[x];
+    var a2 = a[(x)];
+    var a3 = a[+x];
+    var b1 = b[x];
+    var b2 = b[(x)];
+    var b3 = b[+x];
+}

--- a/tests/baselines/reference/for-inStatementsArray.js
+++ b/tests/baselines/reference/for-inStatementsArray.js
@@ -11,6 +11,33 @@ for (let x in a) {
     let b3 = b[+x];
 }
 
+for (let x in a) {
+    for (let y in a) {
+        for (let z in a) {
+            let a1 = a[x];
+            let a2 = a[y];
+            let a3 = a[z];
+        }
+    }
+}
+
+let i: string;
+let j: string;
+for (i in a) {
+    for (j in b) {
+        let a1 = a[i];
+        let a2 = a[j];
+    }
+}
+
+var s: string;
+for (var s in a) {
+    let a1 = a[s];
+}
+for (s in a) {
+    let a1 = a[s];
+}
+
 
 //// [for-inStatementsArray.js]
 var a;
@@ -22,4 +49,28 @@ for (var x in a) {
     var b1 = b[x];
     var b2 = b[(x)];
     var b3 = b[+x];
+}
+for (var x in a) {
+    for (var y in a) {
+        for (var z in a) {
+            var a1 = a[x];
+            var a2 = a[y];
+            var a3 = a[z];
+        }
+    }
+}
+var i;
+var j;
+for (i in a) {
+    for (j in b) {
+        var a1 = a[i];
+        var a2 = a[j];
+    }
+}
+var s;
+for (var s in a) {
+    var a1 = a[s];
+}
+for (s in a) {
+    var a1 = a[s];
 }

--- a/tests/baselines/reference/for-inStatementsArray.symbols
+++ b/tests/baselines/reference/for-inStatementsArray.symbols
@@ -41,3 +41,81 @@ for (let x in a) {
 >x : Symbol(x, Decl(for-inStatementsArray.ts, 3, 8))
 }
 
+for (let x in a) {
+>x : Symbol(x, Decl(for-inStatementsArray.ts, 12, 8))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+
+    for (let y in a) {
+>y : Symbol(y, Decl(for-inStatementsArray.ts, 13, 12))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+
+        for (let z in a) {
+>z : Symbol(z, Decl(for-inStatementsArray.ts, 14, 16))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+
+            let a1 = a[x];
+>a1 : Symbol(a1, Decl(for-inStatementsArray.ts, 15, 15))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+>x : Symbol(x, Decl(for-inStatementsArray.ts, 12, 8))
+
+            let a2 = a[y];
+>a2 : Symbol(a2, Decl(for-inStatementsArray.ts, 16, 15))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+>y : Symbol(y, Decl(for-inStatementsArray.ts, 13, 12))
+
+            let a3 = a[z];
+>a3 : Symbol(a3, Decl(for-inStatementsArray.ts, 17, 15))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+>z : Symbol(z, Decl(for-inStatementsArray.ts, 14, 16))
+        }
+    }
+}
+
+let i: string;
+>i : Symbol(i, Decl(for-inStatementsArray.ts, 22, 3))
+
+let j: string;
+>j : Symbol(j, Decl(for-inStatementsArray.ts, 23, 3))
+
+for (i in a) {
+>i : Symbol(i, Decl(for-inStatementsArray.ts, 22, 3))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+
+    for (j in b) {
+>j : Symbol(j, Decl(for-inStatementsArray.ts, 23, 3))
+>b : Symbol(b, Decl(for-inStatementsArray.ts, 1, 3))
+
+        let a1 = a[i];
+>a1 : Symbol(a1, Decl(for-inStatementsArray.ts, 26, 11))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+>i : Symbol(i, Decl(for-inStatementsArray.ts, 22, 3))
+
+        let a2 = a[j];
+>a2 : Symbol(a2, Decl(for-inStatementsArray.ts, 27, 11))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+>j : Symbol(j, Decl(for-inStatementsArray.ts, 23, 3))
+    }
+}
+
+var s: string;
+>s : Symbol(s, Decl(for-inStatementsArray.ts, 31, 3), Decl(for-inStatementsArray.ts, 32, 8))
+
+for (var s in a) {
+>s : Symbol(s, Decl(for-inStatementsArray.ts, 31, 3), Decl(for-inStatementsArray.ts, 32, 8))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+
+    let a1 = a[s];
+>a1 : Symbol(a1, Decl(for-inStatementsArray.ts, 33, 7))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+>s : Symbol(s, Decl(for-inStatementsArray.ts, 31, 3), Decl(for-inStatementsArray.ts, 32, 8))
+}
+for (s in a) {
+>s : Symbol(s, Decl(for-inStatementsArray.ts, 31, 3), Decl(for-inStatementsArray.ts, 32, 8))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+
+    let a1 = a[s];
+>a1 : Symbol(a1, Decl(for-inStatementsArray.ts, 36, 7))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+>s : Symbol(s, Decl(for-inStatementsArray.ts, 31, 3), Decl(for-inStatementsArray.ts, 32, 8))
+}
+

--- a/tests/baselines/reference/for-inStatementsArray.symbols
+++ b/tests/baselines/reference/for-inStatementsArray.symbols
@@ -1,0 +1,43 @@
+=== tests/cases/conformance/statements/for-inStatements/for-inStatementsArray.ts ===
+let a: Date[];
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+>Date : Symbol(Date, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+let b: boolean[];
+>b : Symbol(b, Decl(for-inStatementsArray.ts, 1, 3))
+
+for (let x in a) {
+>x : Symbol(x, Decl(for-inStatementsArray.ts, 3, 8))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+
+    let a1 = a[x];
+>a1 : Symbol(a1, Decl(for-inStatementsArray.ts, 4, 7))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+>x : Symbol(x, Decl(for-inStatementsArray.ts, 3, 8))
+
+    let a2 = a[(x)];
+>a2 : Symbol(a2, Decl(for-inStatementsArray.ts, 5, 7))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+>x : Symbol(x, Decl(for-inStatementsArray.ts, 3, 8))
+
+    let a3 = a[+x];
+>a3 : Symbol(a3, Decl(for-inStatementsArray.ts, 6, 7))
+>a : Symbol(a, Decl(for-inStatementsArray.ts, 0, 3))
+>x : Symbol(x, Decl(for-inStatementsArray.ts, 3, 8))
+
+    let b1 = b[x];
+>b1 : Symbol(b1, Decl(for-inStatementsArray.ts, 7, 7))
+>b : Symbol(b, Decl(for-inStatementsArray.ts, 1, 3))
+>x : Symbol(x, Decl(for-inStatementsArray.ts, 3, 8))
+
+    let b2 = b[(x)];
+>b2 : Symbol(b2, Decl(for-inStatementsArray.ts, 8, 7))
+>b : Symbol(b, Decl(for-inStatementsArray.ts, 1, 3))
+>x : Symbol(x, Decl(for-inStatementsArray.ts, 3, 8))
+
+    let b3 = b[+x];
+>b3 : Symbol(b3, Decl(for-inStatementsArray.ts, 9, 7))
+>b : Symbol(b, Decl(for-inStatementsArray.ts, 1, 3))
+>x : Symbol(x, Decl(for-inStatementsArray.ts, 3, 8))
+}
+

--- a/tests/baselines/reference/for-inStatementsArray.types
+++ b/tests/baselines/reference/for-inStatementsArray.types
@@ -51,3 +51,88 @@ for (let x in a) {
 >x : string
 }
 
+for (let x in a) {
+>x : string
+>a : Date[]
+
+    for (let y in a) {
+>y : string
+>a : Date[]
+
+        for (let z in a) {
+>z : string
+>a : Date[]
+
+            let a1 = a[x];
+>a1 : Date
+>a[x] : Date
+>a : Date[]
+>x : string
+
+            let a2 = a[y];
+>a2 : Date
+>a[y] : Date
+>a : Date[]
+>y : string
+
+            let a3 = a[z];
+>a3 : Date
+>a[z] : Date
+>a : Date[]
+>z : string
+        }
+    }
+}
+
+let i: string;
+>i : string
+
+let j: string;
+>j : string
+
+for (i in a) {
+>i : string
+>a : Date[]
+
+    for (j in b) {
+>j : string
+>b : boolean[]
+
+        let a1 = a[i];
+>a1 : Date
+>a[i] : Date
+>a : Date[]
+>i : string
+
+        let a2 = a[j];
+>a2 : Date
+>a[j] : Date
+>a : Date[]
+>j : string
+    }
+}
+
+var s: string;
+>s : string
+
+for (var s in a) {
+>s : string
+>a : Date[]
+
+    let a1 = a[s];
+>a1 : Date
+>a[s] : Date
+>a : Date[]
+>s : string
+}
+for (s in a) {
+>s : string
+>a : Date[]
+
+    let a1 = a[s];
+>a1 : Date
+>a[s] : Date
+>a : Date[]
+>s : string
+}
+

--- a/tests/baselines/reference/for-inStatementsArray.types
+++ b/tests/baselines/reference/for-inStatementsArray.types
@@ -1,0 +1,53 @@
+=== tests/cases/conformance/statements/for-inStatements/for-inStatementsArray.ts ===
+let a: Date[];
+>a : Date[]
+>Date : Date
+
+let b: boolean[];
+>b : boolean[]
+
+for (let x in a) {
+>x : string
+>a : Date[]
+
+    let a1 = a[x];
+>a1 : Date
+>a[x] : Date
+>a : Date[]
+>x : string
+
+    let a2 = a[(x)];
+>a2 : Date
+>a[(x)] : Date
+>a : Date[]
+>(x) : string
+>x : string
+
+    let a3 = a[+x];
+>a3 : Date
+>a[+x] : Date
+>a : Date[]
+>+x : number
+>x : string
+
+    let b1 = b[x];
+>b1 : boolean
+>b[x] : boolean
+>b : boolean[]
+>x : string
+
+    let b2 = b[(x)];
+>b2 : boolean
+>b[(x)] : boolean
+>b : boolean[]
+>(x) : string
+>x : string
+
+    let b3 = b[+x];
+>b3 : boolean
+>b[+x] : boolean
+>b : boolean[]
+>+x : number
+>x : string
+}
+

--- a/tests/baselines/reference/for-inStatementsArrayErrors.errors.txt
+++ b/tests/baselines/reference/for-inStatementsArrayErrors.errors.txt
@@ -1,0 +1,40 @@
+tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.ts(5,14): error TS7017: Index signature of object type implicitly has an 'any' type.
+tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.ts(6,16): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.ts(7,9): error TS2365: Operator '===' cannot be applied to types 'string' and 'number'.
+tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.ts(9,16): error TS2339: Property 'unknownProperty' does not exist on type 'string'.
+tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.ts(13,10): error TS2403: Subsequent variable declarations must have the same type.  Variable 'i' must be of type 'number', but here has type 'string'.
+tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.ts(17,10): error TS2403: Subsequent variable declarations must have the same type.  Variable 'j' must be of type 'any', but here has type 'string'.
+
+
+==== tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.ts (6 errors) ====
+    
+    let a: Date[];
+    
+    for (let x in a) {
+        let a1 = a[x + 1];
+                 ~~~~~~~~
+!!! error TS7017: Index signature of object type implicitly has an 'any' type.
+        let a2 = a[x - 1];
+                   ~
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+        if (x === 1) {
+            ~~~~~~~
+!!! error TS2365: Operator '===' cannot be applied to types 'string' and 'number'.
+        }
+        let a3 = x.unknownProperty;
+                   ~~~~~~~~~~~~~~~
+!!! error TS2339: Property 'unknownProperty' does not exist on type 'string'.
+    }
+    
+    var i: number;
+    for (var i in a ) {
+             ~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'i' must be of type 'number', but here has type 'string'.
+    }
+    
+    var j: any;
+    for (var j in a ) {
+             ~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'j' must be of type 'any', but here has type 'string'.
+    }
+    

--- a/tests/baselines/reference/for-inStatementsArrayErrors.errors.txt
+++ b/tests/baselines/reference/for-inStatementsArrayErrors.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.ts(5,14): error TS7017: Index signature of object type implicitly has an 'any' type.
+tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.ts(5,14): error TS7015: Element implicitly has an 'any' type because index expression is not of type 'number'.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.ts(6,16): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.ts(7,9): error TS2365: Operator '===' cannot be applied to types 'string' and 'number'.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.ts(9,16): error TS2339: Property 'unknownProperty' does not exist on type 'string'.
@@ -13,7 +13,7 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.
     for (let x in a) {
         let a1 = a[x + 1];
                  ~~~~~~~~
-!!! error TS7017: Index signature of object type implicitly has an 'any' type.
+!!! error TS7015: Element implicitly has an 'any' type because index expression is not of type 'number'.
         let a2 = a[x - 1];
                    ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.

--- a/tests/baselines/reference/for-inStatementsArrayErrors.js
+++ b/tests/baselines/reference/for-inStatementsArrayErrors.js
@@ -1,0 +1,36 @@
+//// [for-inStatementsArrayErrors.ts]
+
+let a: Date[];
+
+for (let x in a) {
+    let a1 = a[x + 1];
+    let a2 = a[x - 1];
+    if (x === 1) {
+    }
+    let a3 = x.unknownProperty;
+}
+
+var i: number;
+for (var i in a ) {
+}
+
+var j: any;
+for (var j in a ) {
+}
+
+
+//// [for-inStatementsArrayErrors.js]
+var a;
+for (var x in a) {
+    var a1 = a[x + 1];
+    var a2 = a[x - 1];
+    if (x === 1) {
+    }
+    var a3 = x.unknownProperty;
+}
+var i;
+for (var i in a) {
+}
+var j;
+for (var j in a) {
+}

--- a/tests/baselines/reference/for-inStatementsDestructuring.errors.txt
+++ b/tests/baselines/reference/for-inStatementsDestructuring.errors.txt
@@ -1,7 +1,10 @@
+tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring.ts(1,10): error TS2461: Type 'string' is not an array type.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring.ts(1,10): error TS2491: The left-hand side of a 'for...in' statement cannot be a destructuring pattern.
 
 
-==== tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring.ts (1 errors) ====
+==== tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring.ts (2 errors) ====
     for (var [a, b] in []) {}
+             ~~~~~~
+!!! error TS2461: Type 'string' is not an array type.
              ~~~~~~
 !!! error TS2491: The left-hand side of a 'for...in' statement cannot be a destructuring pattern.

--- a/tests/baselines/reference/for-inStatementsDestructuring2.errors.txt
+++ b/tests/baselines/reference/for-inStatementsDestructuring2.errors.txt
@@ -1,7 +1,13 @@
 tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring2.ts(1,10): error TS2491: The left-hand side of a 'for...in' statement cannot be a destructuring pattern.
+tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring2.ts(1,11): error TS2459: Type 'string' has no property 'a' and no string index signature.
+tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring2.ts(1,14): error TS2459: Type 'string' has no property 'b' and no string index signature.
 
 
-==== tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring2.ts (1 errors) ====
+==== tests/cases/conformance/statements/for-inStatements/for-inStatementsDestructuring2.ts (3 errors) ====
     for (var {a, b} in []) {}
              ~~~~~~
 !!! error TS2491: The left-hand side of a 'for...in' statement cannot be a destructuring pattern.
+              ~
+!!! error TS2459: Type 'string' has no property 'a' and no string index signature.
+                 ~
+!!! error TS2459: Type 'string' has no property 'b' and no string index signature.

--- a/tests/baselines/reference/for-inStatementsInvalid.errors.txt
+++ b/tests/baselines/reference/for-inStatementsInvalid.errors.txt
@@ -7,7 +7,6 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(1
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(18,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(19,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(20,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
-tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(21,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(22,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(29,23): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(38,23): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
@@ -16,7 +15,7 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(5
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(62,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 
 
-==== tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts (16 errors) ====
+==== tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts (15 errors) ====
     var aNumber: number;
     for (aNumber in {}) { }
          ~~~~~~~
@@ -56,8 +55,6 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(6
                   ~~~~~~~~~~
 !!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
     for (var x in 42 ? d[x] : c[x]) { }
-                  ~~~~~~~~~~~~~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
     for (var x in c[23]) { }
                   ~~~~~
 !!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.

--- a/tests/baselines/reference/forInBreakStatements.types
+++ b/tests/baselines/reference/forInBreakStatements.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/statements/breakStatements/forInBreakStatements.ts ===
 
 for(var x in {}) {
->x : any
+>x : string
 >{} : {}
 
     break;
@@ -11,7 +11,7 @@ ONE:
 >ONE : any
 
 for(var x in {}) {
->x : any
+>x : string
 >{} : {}
 
     break ONE;
@@ -25,7 +25,7 @@ THREE:
 >THREE : any
 
 for(var x in {}) {
->x : any
+>x : string
 >{} : {}
 
     break THREE;
@@ -36,14 +36,14 @@ FOUR:
 >FOUR : any
 
 for(var x in {}) {
->x : any
+>x : string
 >{} : {}
 
     FIVE:
 >FIVE : any
 
     for(var x in {}) {
->x : any
+>x : string
 >{} : {}
 
         break FOUR;
@@ -52,14 +52,14 @@ for(var x in {}) {
 }
 
 for(var x in {}) {
->x : any
+>x : string
 >{} : {}
 
     SIX:
 >SIX : any
 
     for(var x in {}) break SIX;
->x : any
+>x : string
 >{} : {}
 >SIX : any
 }
@@ -68,11 +68,11 @@ SEVEN:
 >SEVEN : any
 
 for (var x in {}) for (var x in {}) for (var x in {}) break SEVEN;
->x : any
+>x : string
 >{} : {}
->x : any
+>x : string
 >{} : {}
->x : any
+>x : string
 >{} : {}
 >SEVEN : any
 
@@ -80,7 +80,7 @@ EIGHT:
 >EIGHT : any
 
 for (var x in {}){
->x : any
+>x : string
 >{} : {}
 
     var fn = function () { }

--- a/tests/baselines/reference/forInContinueStatements.types
+++ b/tests/baselines/reference/forInContinueStatements.types
@@ -1,7 +1,7 @@
 === tests/cases/conformance/statements/continueStatements/forInContinueStatements.ts ===
 
 for(var x in {}) {
->x : any
+>x : string
 >{} : {}
 
     continue;
@@ -11,7 +11,7 @@ ONE:
 >ONE : any
 
 for(var x in {}) {
->x : any
+>x : string
 >{} : {}
 
     continue ONE;
@@ -25,7 +25,7 @@ THREE:
 >THREE : any
 
 for(var x in {}) {
->x : any
+>x : string
 >{} : {}
 
     continue THREE;
@@ -36,14 +36,14 @@ FOUR:
 >FOUR : any
 
 for(var x in {}) {
->x : any
+>x : string
 >{} : {}
 
     FIVE:
 >FIVE : any
 
     for(var x in {}) {
->x : any
+>x : string
 >{} : {}
 
         continue FOUR;
@@ -52,14 +52,14 @@ for(var x in {}) {
 }
 
 for(var x in {}) {
->x : any
+>x : string
 >{} : {}
 
     SIX:
 >SIX : any
 
     for(var x in {}) continue SIX;
->x : any
+>x : string
 >{} : {}
 >SIX : any
 }
@@ -68,11 +68,11 @@ SEVEN:
 >SEVEN : any
 
 for (var x in {}) for (var x in {}) for (var x in {}) continue SEVEN;
->x : any
+>x : string
 >{} : {}
->x : any
+>x : string
 >{} : {}
->x : any
+>x : string
 >{} : {}
 >SEVEN : any
 
@@ -80,7 +80,7 @@ EIGHT:
 >EIGHT : any
 
 for (var x in {}){
->x : any
+>x : string
 >{} : {}
 
     var fn = function () { }

--- a/tests/baselines/reference/forInStatement1.types
+++ b/tests/baselines/reference/forInStatement1.types
@@ -3,6 +3,6 @@ var expr: any;
 >expr : any
 
 for (var a in expr) {
->a : any
+>a : string
 >expr : any
 }

--- a/tests/baselines/reference/forInStatement3.types
+++ b/tests/baselines/reference/forInStatement3.types
@@ -8,7 +8,7 @@ function F<T>() {
 >T : T
 
   for (var a in expr) {
->a : any
+>a : string
 >expr : T
   }
 }

--- a/tests/baselines/reference/implicitAnyInCatch.types
+++ b/tests/baselines/reference/implicitAnyInCatch.types
@@ -12,7 +12,7 @@ try { } catch (error) {
 >2147024809 : number
 }
 for (var key in this) { }
->key : any
+>key : string
 >this : any
 
 class C {
@@ -22,7 +22,7 @@ class C {
 >temp : () => void
 
         for (var x in this) {
->x : any
+>x : string
 >this : this
         }
     }

--- a/tests/baselines/reference/inOperatorWithGeneric.types
+++ b/tests/baselines/reference/inOperatorWithGeneric.types
@@ -9,7 +9,7 @@ class C<T> {
 >T : T
 
         for (var p in x) {
->p : any
+>p : string
 >x : T
         }
     }

--- a/tests/baselines/reference/letDeclarations-es5.types
+++ b/tests/baselines/reference/letDeclarations-es5.types
@@ -29,7 +29,7 @@ let l9 = 0, l10 :string = "", l11 = null;
 >null : null
 
 for(let l11 in {}) { }
->l11 : any
+>l11 : string
 >{} : {}
 
 for(let l12 = 0; l12 < 9; l12++) { }

--- a/tests/baselines/reference/letDeclarations.types
+++ b/tests/baselines/reference/letDeclarations.types
@@ -29,7 +29,7 @@ let l9 = 0, l10 :string = "", l11 = null;
 >null : null
 
 for(let l11 in {}) { }
->l11 : any
+>l11 : string
 >{} : {}
 
 for(let l12 = 0; l12 < 9; l12++) { }

--- a/tests/baselines/reference/letInVarDeclOfForIn_ES5.types
+++ b/tests/baselines/reference/letInVarDeclOfForIn_ES5.types
@@ -2,7 +2,7 @@
 
 // should not be an error
 for (var let in [1,2,3]) {}
->let : any
+>let : string
 >[1,2,3] : number[]
 >1 : number
 >2 : number
@@ -10,7 +10,7 @@ for (var let in [1,2,3]) {}
 
 {
 	for (var let in [1,2,3]) {}
->let : any
+>let : string
 >[1,2,3] : number[]
 >1 : number
 >2 : number

--- a/tests/baselines/reference/letInVarDeclOfForIn_ES6.types
+++ b/tests/baselines/reference/letInVarDeclOfForIn_ES6.types
@@ -2,7 +2,7 @@
 
 // should not be an error
 for (var let in [1,2,3]) {}
->let : any
+>let : string
 >[1,2,3] : number[]
 >1 : number
 >2 : number
@@ -10,7 +10,7 @@ for (var let in [1,2,3]) {}
 
 {
 	for (var let in [1,2,3]) {}
->let : any
+>let : string
 >[1,2,3] : number[]
 >1 : number
 >2 : number

--- a/tests/baselines/reference/noImplicitAnyIndexing.errors.txt
+++ b/tests/baselines/reference/noImplicitAnyIndexing.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/noImplicitAnyIndexing.ts(13,26): error TS7017: Index signature of object type implicitly has an 'any' type.
+tests/cases/compiler/noImplicitAnyIndexing.ts(13,26): error TS7015: Element implicitly has an 'any' type because index expression is not of type 'number'.
 tests/cases/compiler/noImplicitAnyIndexing.ts(20,9): error TS7017: Index signature of object type implicitly has an 'any' type.
 tests/cases/compiler/noImplicitAnyIndexing.ts(23,9): error TS7017: Index signature of object type implicitly has an 'any' type.
 tests/cases/compiler/noImplicitAnyIndexing.ts(31,10): error TS7017: Index signature of object type implicitly has an 'any' type.
@@ -19,7 +19,7 @@ tests/cases/compiler/noImplicitAnyIndexing.ts(31,10): error TS7017: Index signat
     // Should be implicit 'any' ; property access fails, no string indexer.
     var strRepresentation3 = MyEmusEnum["monehh"];
                              ~~~~~~~~~~~~~~~~~~~~
-!!! error TS7017: Index signature of object type implicitly has an 'any' type.
+!!! error TS7015: Element implicitly has an 'any' type because index expression is not of type 'number'.
     
     // Should be okay; should be a MyEmusEnum
     var strRepresentation4 = MyEmusEnum["emu"];

--- a/tests/baselines/reference/parserES5ForOfStatement19.errors.txt
+++ b/tests/baselines/reference/parserES5ForOfStatement19.errors.txt
@@ -1,0 +1,7 @@
+tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement19.ts(1,16): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
+
+
+==== tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement19.ts (1 errors) ====
+    for (var of in of) { }
+                   ~~
+!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.

--- a/tests/baselines/reference/parserES5ForOfStatement19.symbols
+++ b/tests/baselines/reference/parserES5ForOfStatement19.symbols
@@ -1,5 +1,0 @@
-=== tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement19.ts ===
-for (var of in of) { }
->of : Symbol(of, Decl(parserES5ForOfStatement19.ts, 0, 8))
->of : Symbol(of, Decl(parserES5ForOfStatement19.ts, 0, 8))
-

--- a/tests/baselines/reference/parserES5ForOfStatement19.types
+++ b/tests/baselines/reference/parserES5ForOfStatement19.types
@@ -1,5 +1,0 @@
-=== tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement19.ts ===
-for (var of in of) { }
->of : any
->of : any
-

--- a/tests/baselines/reference/parserES5ForOfStatement20.errors.txt
+++ b/tests/baselines/reference/parserES5ForOfStatement20.errors.txt
@@ -1,7 +1,10 @@
 tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement20.ts(1,10): error TS1189: The variable declaration of a 'for...in' statement cannot have an initializer.
+tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement20.ts(1,20): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 
 
-==== tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement20.ts (1 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement20.ts (2 errors) ====
     for (var of = 0 in of) { }
              ~~
 !!! error TS1189: The variable declaration of a 'for...in' statement cannot have an initializer.
+                       ~~
+!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.

--- a/tests/baselines/reference/parserForOfStatement19.errors.txt
+++ b/tests/baselines/reference/parserForOfStatement19.errors.txt
@@ -1,0 +1,7 @@
+tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement19.ts(1,16): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
+
+
+==== tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement19.ts (1 errors) ====
+    for (var of in of) { }
+                   ~~
+!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.

--- a/tests/baselines/reference/parserForOfStatement19.symbols
+++ b/tests/baselines/reference/parserForOfStatement19.symbols
@@ -1,5 +1,0 @@
-=== tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement19.ts ===
-for (var of in of) { }
->of : Symbol(of, Decl(parserForOfStatement19.ts, 0, 8))
->of : Symbol(of, Decl(parserForOfStatement19.ts, 0, 8))
-

--- a/tests/baselines/reference/parserForOfStatement19.types
+++ b/tests/baselines/reference/parserForOfStatement19.types
@@ -1,5 +1,0 @@
-=== tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement19.ts ===
-for (var of in of) { }
->of : any
->of : any
-

--- a/tests/baselines/reference/parserForOfStatement20.errors.txt
+++ b/tests/baselines/reference/parserForOfStatement20.errors.txt
@@ -1,7 +1,10 @@
 tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement20.ts(1,10): error TS1189: The variable declaration of a 'for...in' statement cannot have an initializer.
+tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement20.ts(1,20): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 
 
-==== tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement20.ts (1 errors) ====
+==== tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement20.ts (2 errors) ====
     for (var of = 0 in of) { }
              ~~
 !!! error TS1189: The variable declaration of a 'for...in' statement cannot have an initializer.
+                       ~~
+!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.

--- a/tests/baselines/reference/recursiveLetConst.errors.txt
+++ b/tests/baselines/reference/recursiveLetConst.errors.txt
@@ -5,13 +5,14 @@ tests/cases/compiler/recursiveLetConst.ts(5,14): error TS2448: Block-scoped vari
 tests/cases/compiler/recursiveLetConst.ts(6,14): error TS2448: Block-scoped variable 'v' used before its declaration.
 tests/cases/compiler/recursiveLetConst.ts(7,1): error TS7027: Unreachable code detected.
 tests/cases/compiler/recursiveLetConst.ts(7,16): error TS2448: Block-scoped variable 'v' used before its declaration.
+tests/cases/compiler/recursiveLetConst.ts(8,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 tests/cases/compiler/recursiveLetConst.ts(8,15): error TS2448: Block-scoped variable 'v' used before its declaration.
 tests/cases/compiler/recursiveLetConst.ts(9,15): error TS2448: Block-scoped variable 'v' used before its declaration.
 tests/cases/compiler/recursiveLetConst.ts(10,17): error TS2448: Block-scoped variable 'v' used before its declaration.
 tests/cases/compiler/recursiveLetConst.ts(11,11): error TS2448: Block-scoped variable 'x2' used before its declaration.
 
 
-==== tests/cases/compiler/recursiveLetConst.ts (11 errors) ====
+==== tests/cases/compiler/recursiveLetConst.ts (12 errors) ====
     'use strict'
     let x = x + 1;
             ~
@@ -34,6 +35,8 @@ tests/cases/compiler/recursiveLetConst.ts(11,11): error TS2448: Block-scoped var
                    ~
 !!! error TS2448: Block-scoped variable 'v' used before its declaration.
     for (let v in v) { }
+                  ~
+!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
                   ~
 !!! error TS2448: Block-scoped variable 'v' used before its declaration.
     for (let v of v) { }

--- a/tests/baselines/reference/throwInEnclosingStatements.types
+++ b/tests/baselines/reference/throwInEnclosingStatements.types
@@ -51,9 +51,9 @@ for (var i = 0; ;) { throw i; }
 >i : number
 
 for (var idx in {}) { throw idx; }
->idx : any
+>idx : string
 >{} : {}
->idx : any
+>idx : string
 
 do { throw null; }while(true)
 >null : null

--- a/tests/cases/compiler/capturedLetConstInLoop5.ts
+++ b/tests/cases/compiler/capturedLetConstInLoop5.ts
@@ -19,7 +19,7 @@ function foo00(x) {
         var v = x;
         (function() { return x + v });
         (() => x + v);
-        if (x == 1) {
+        if (x == "1") {
             return;
         }
     }
@@ -158,7 +158,7 @@ function foo00_c(x) {
         var v = x;
         (function() { return x + v });
         (() => x + v);
-        if (x == 1) {
+        if (x == "1") {
             return;
         }
     }

--- a/tests/cases/compiler/capturedLetConstInLoop5_ES6.ts
+++ b/tests/cases/compiler/capturedLetConstInLoop5_ES6.ts
@@ -21,7 +21,7 @@ function foo00(x) {
         var v = x;
         (function() { return x + v });
         (() => x + v);
-        if (x == 1) {
+        if (x == "1") {
             return;
         }
     }
@@ -160,7 +160,7 @@ function foo00_c(x) {
         var v = x;
         (function() { return x + v });
         (() => x + v);
-        if (x == 1) {
+        if (x == "1") {
             return;
         }
     }

--- a/tests/cases/compiler/capturedLetConstInLoop6.ts
+++ b/tests/cases/compiler/capturedLetConstInLoop6.ts
@@ -13,10 +13,10 @@ for (let x of []) {
 for (let x in []) {
     (function() { return x});
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
 }
@@ -132,10 +132,10 @@ for (const x of []) {
 for (const x in []) {
     (function() { return x});
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
 }

--- a/tests/cases/compiler/capturedLetConstInLoop6_ES6.ts
+++ b/tests/cases/compiler/capturedLetConstInLoop6_ES6.ts
@@ -14,10 +14,10 @@ for (let x of []) {
 for (let x in []) {
     (function() { return x});
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
 }
@@ -133,10 +133,10 @@ for (const x of []) {
 for (const x in []) {
     (function() { return x});
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
 }

--- a/tests/cases/compiler/capturedLetConstInLoop7.ts
+++ b/tests/cases/compiler/capturedLetConstInLoop7.ts
@@ -21,16 +21,16 @@ l00:
 for (let x in []) {
     (function() { return x});
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 1) {
+    if (x == "1") {
         break l00;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue l00;
     }
 }
@@ -209,16 +209,16 @@ l00_c:
 for (const x in []) {
     (function() { return x});
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 1) {
+    if (x == "1") {
         break l00_c;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue l00_c;
     }
 }

--- a/tests/cases/compiler/capturedLetConstInLoop7_ES6.ts
+++ b/tests/cases/compiler/capturedLetConstInLoop7_ES6.ts
@@ -22,16 +22,16 @@ l00:
 for (let x in []) {
     (function() { return x});
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 1) {
+    if (x == "1") {
         break l00;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue l00;
     }
 }
@@ -210,16 +210,16 @@ l00_c:
 for (const x in []) {
     (function() { return x});
     (() => x);
-    if (x == 1) {
+    if (x == "1") {
         break;
     }
-    if (x == 1) {
+    if (x == "1") {
         break l00_c;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue;
     }
-    if (x == 2) {
+    if (x == "2") {
         continue l00_c;
     }
 }

--- a/tests/cases/conformance/statements/for-inStatements/for-inStatementsArray.ts
+++ b/tests/cases/conformance/statements/for-inStatements/for-inStatementsArray.ts
@@ -9,3 +9,30 @@ for (let x in a) {
     let b2 = b[(x)];
     let b3 = b[+x];
 }
+
+for (let x in a) {
+    for (let y in a) {
+        for (let z in a) {
+            let a1 = a[x];
+            let a2 = a[y];
+            let a3 = a[z];
+        }
+    }
+}
+
+let i: string;
+let j: string;
+for (i in a) {
+    for (j in b) {
+        let a1 = a[i];
+        let a2 = a[j];
+    }
+}
+
+var s: string;
+for (var s in a) {
+    let a1 = a[s];
+}
+for (s in a) {
+    let a1 = a[s];
+}

--- a/tests/cases/conformance/statements/for-inStatements/for-inStatementsArray.ts
+++ b/tests/cases/conformance/statements/for-inStatements/for-inStatementsArray.ts
@@ -1,0 +1,11 @@
+let a: Date[];
+let b: boolean[];
+
+for (let x in a) {
+    let a1 = a[x];
+    let a2 = a[(x)];
+    let a3 = a[+x];
+    let b1 = b[x];
+    let b2 = b[(x)];
+    let b3 = b[+x];
+}

--- a/tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.ts
+++ b/tests/cases/conformance/statements/for-inStatements/for-inStatementsArrayErrors.ts
@@ -1,0 +1,19 @@
+// @noImplicitAny: true
+
+let a: Date[];
+
+for (let x in a) {
+    let a1 = a[x + 1];
+    let a2 = a[x - 1];
+    if (x === 1) {
+    }
+    let a3 = x.unknownProperty;
+}
+
+var i: number;
+for (var i in a ) {
+}
+
+var j: any;
+for (var j in a ) {
+}

--- a/tests/cases/fourslash/forIn.ts
+++ b/tests/cases/fourslash/forIn.ts
@@ -5,4 +5,4 @@
 
 goTo.marker();
 
-verify.quickInfoIs('var p: any', "");
+verify.quickInfoIs('var p: string', "");


### PR DESCRIPTION
This PR fixes #6346 by implementing two changes:

* The type of a variable declared in a for-in statement is implicitly `string` (previously it was `any`).
* When an object with a numeric index signature of type T (such as an array) is indexed by a for-in variable of a containing for-in statement for an object *with* a numeric index signature and *without* a string index signature (again such as an array), the value produced is of type T.

An example:

```typescript
var a: MyObject[];
for (var x in a) {   // Type of x is implicitly string
    var obj = a[x];  // Type of obj is MyObject
}
```

With this PR, the type of `x` is now `string` and the type of `obj` is `MyObject` because the array is indexed with a for-in variable for an array (and thus the for-in variable is known to contain a numeric string). Had the array been indexed with any other string expression, the type of obj would be `any` because the string could be the name of a property or method (e.g. "length" or "push").

For historical reasons we have used type `any` for for-in variables even though the iterated values are always strings. The reason we used type `any` is that when an array is indexed with an expression of type `any` or `number` we produce a value of the array element type, and thus the example above produces the correct type for `obj`. However, with the second new rule above, indexing with an expression of type `string` can now also produce a value of the array element type if the expression is a for-in variable for an array.

The use of type `any` was never a great solution, in particular because the `any` is "silent" and not caught by the `-noImplicitAny` flag. Furthermore, with the introduction of the new for-of statement in ES2015 it got worse. Consider:

```typescript
var a: MyObject[];
for (var x in a) {       // Accidentally used for-in instead of for-of
    x.myObjectMethod();  // Reports an error now, but didn't before
}
```

This PR is a breaking change for certain (suspicious) constructs. For example:

```typescript
var a: MyObject[];
for (var x in a) {
    if (x == 1) {  // Previously ok, now an error
        // ...
    }
}
```

Previously, the static type of `x` was of type `any`. Thus, even though `x` contains a string it could be compared to a numeric literal (at run-time this coerces the string operand to a number and then compares that to the numeric operand). This is one of the not so good parts of JavaScript. Mixing of strings and numbers only work for some operators and are a source of many a surprising bug (for example, it doesn't work with the `===` operator, and `+` concatenates string values instead of adding the numeric values).