### PR TITLE
handle gracefully if symbol for opening tag cannot be obtained

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -3124,8 +3124,12 @@ namespace ts {
                 isNewIdentifierLocation = false;
             }
             else if (isStartingCloseTag) {
+                symbols = [];
                 const tagName = (<JsxElement>contextToken.parent.parent).openingElement.tagName;
-                symbols = [typeChecker.getSymbolAtLocation(tagName)];
+                const symbol = typeChecker.getSymbolAtLocation(tagName);
+                if (symbol) {
+                    symbols.push(symbol);
+                }
 
                 isMemberCompletion = true;
                 isNewIdentifierLocation = false;

--- a/tests/cases/fourslash/completionOnInvalidClosingTagInJsx.ts
+++ b/tests/cases/fourslash/completionOnInvalidClosingTagInJsx.ts
@@ -1,0 +1,8 @@
+/// <reference path="fourslash.ts"/>
+
+// @Filename: file.tsx
+////let React: any;
+////let x = <someName text="123"><//*1*/>
+
+goTo.marker("1");
+verify.completionListIsEmpty();


### PR DESCRIPTION
currently attempt to get completion at position `/*1*/` leads to exception,
```ts
let React: any;
let x = <someName text="123"><//*1*/>
```