### PR TITLE
Fix issue #6478 (bug in the language services)

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -6028,6 +6028,10 @@ namespace ts {
              */
             function getPropertySymbolsFromBaseTypes(symbol: Symbol, propertyName: string, result: Symbol[],
                 previousIterationSymbolsCache: SymbolTable): void {
+                if (!symbol) {
+                    return;
+                }
+
                 // If the current symbol is the same as the previous-iteration symbol, we can just return the symbol that has already been visited
                 // This is particularly important for the following cases, so that we do not infinitely visit the same symbol.
                 // For example:
@@ -6043,7 +6047,7 @@ namespace ts {
                     return;
                 }
 
-                if (symbol && symbol.flags & (SymbolFlags.Class | SymbolFlags.Interface)) {
+                if (symbol.flags & (SymbolFlags.Class | SymbolFlags.Interface)) {
                     forEach(symbol.getDeclarations(), declaration => {
                         if (declaration.kind === SyntaxKind.ClassDeclaration) {
                             getPropertySymbolFromTypeReference(getClassExtendsHeritageClauseElement(<ClassDeclaration>declaration));

--- a/tests/cases/fourslash/getPropertySymbolsFromBaseTypesDoesntCrash.ts
+++ b/tests/cases/fourslash/getPropertySymbolsFromBaseTypesDoesntCrash.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts'/>
+
+// @Filename: file1.ts
+//// class ClassA implements IInterface {
+////     private /*1*/value: number;
+//// }
+
+goTo.marker("1");
+verify.documentHighlightsAtPositionCount(1, ["file1.ts"]);


### PR DESCRIPTION
I made the changes suggested in #6478 (check that `symbol` is not undefined right away) and found a fairly minimal repro which I added as a fourslash test case.

Edit: The paragraph below is out of date now :)
The last commit, which reverts `package.json` to use the latest nightly instead of a fixed version, causes this build to break since the latest nightly still has bugs in it. Most likely that revert should be done tomorrow, after this PR is in and a new, working nightly is released. I'll remove the revert from here so that can be done later if requested