### PR TITLE
Fix the getCanonicalFileName in sys.ts and also check null value in f…

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -376,13 +376,11 @@ namespace ts {
                 /**
                  * @param watcherPath is the path from which the watcher is triggered.
                  */
-                function fileEventHandler(eventName: string, relativefileName: string, baseDirPath: Path) {
+                function fileEventHandler(eventName: string, relativeFileName: string, baseDirPath: Path) {
                     // When files are deleted from disk, the triggered "rename" event would have a relativefileName of "undefined"
-                    /* tslint:disable:no-null */
-                    const filePath = relativefileName === undefined || relativefileName === null
+                    const filePath = typeof relativeFileName !== "string"
                         ? undefined
-                        : toPath(relativefileName, baseDirPath, createGetCanonicalFileName(sys.useCaseSensitiveFileNames));
-                    /* tslint:enable:no-null */
+                        : toPath(relativeFileName, baseDirPath, createGetCanonicalFileName(sys.useCaseSensitiveFileNames));
                     if (eventName === "change" && fileWatcherCallbacks.contains(filePath)) {
                         for (const fileCallback of fileWatcherCallbacks.get(filePath)) {
                             fileCallback(filePath);

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -378,7 +378,11 @@ namespace ts {
                  */
                 function fileEventHandler(eventName: string, relativefileName: string, baseDirPath: Path) {
                     // When files are deleted from disk, the triggered "rename" event would have a relativefileName of "undefined"
-                    const filePath = relativefileName === undefined ? undefined : toPath(relativefileName, baseDirPath, getCanonicalPath);
+                    /* tslint:disable:no-null */
+                    const filePath = relativefileName === undefined || relativefileName === null
+                        ? undefined
+                        : toPath(relativefileName, baseDirPath, createGetCanonicalFileName(sys.useCaseSensitiveFileNames));
+                    /* tslint:enable:no-null */
                     if (eventName === "change" && fileWatcherCallbacks.contains(filePath)) {
                         for (const fileCallback of fileWatcherCallbacks.get(filePath)) {
                             fileCallback(filePath);
@@ -460,7 +464,7 @@ namespace ts {
             }
 
             function getCanonicalPath(path: string): string {
-                return useCaseSensitiveFileNames ? path.toLowerCase() : path;
+                return useCaseSensitiveFileNames ? path : path.toLowerCase();
             }
 
             function readDirectory(path: string, extension?: string, exclude?: string[]): string[] {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1002,7 +1002,9 @@ namespace ts.server {
                     info.setFormatOptions(this.getFormatCodeOptions());
                     this.filenameToScriptInfo[fileName] = info;
                     if (!info.isOpen) {
-                        info.fileWatcher = this.host.watchFile(<Path>fileName, _ => { this.watchedFileChanged(fileName); });
+                        info.fileWatcher = this.host.watchFile(
+                            toPath(fileName, fileName, createGetCanonicalFileName(sys.useCaseSensitiveFileNames)),
+                            _ => { this.watchedFileChanged(fileName); });
                     }
                 }
             }
@@ -1215,7 +1217,9 @@ namespace ts.server {
                     }
                 }
                 project.finishGraph();
-                project.projectFileWatcher = this.host.watchFile(<Path>configFilename, _ => this.watchedProjectConfigFileChanged(project));
+                project.projectFileWatcher = this.host.watchFile(
+                    toPath(configFilename, configFilename, createGetCanonicalFileName(sys.useCaseSensitiveFileNames)),
+                    _ => this.watchedProjectConfigFileChanged(project));
                 this.log("Add recursive watcher for: " + ts.getDirectoryPath(configFilename));
                 project.directoryWatcher = this.host.watchDirectory(
                     ts.getDirectoryPath(configFilename),


### PR DESCRIPTION
…ile watcher call back

This PR fixes the `getCanonicalFileName` function used in `sys.ts` for file systems using case sensitive file names. Also added checking for `null` for file watcher callbacks as node sometimes will pass `null` as a parameter value. 