### PR TITLE
Rename moduleResolutionKind.NodeJs to Node for consistency with command line value

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -254,7 +254,7 @@ namespace ts {
         {
             name: "moduleResolution",
             type: {
-                "node": ModuleResolutionKind.NodeJs,
+                "node": ModuleResolutionKind.Node,
                 "classic": ModuleResolutionKind.Classic
             },
             description: Diagnostics.Specifies_module_resolution_strategy_Colon_node_Node_js_or_classic_TypeScript_pre_1_6,

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -39,10 +39,10 @@ namespace ts {
     export function resolveModuleName(moduleName: string, containingFile: string, compilerOptions: CompilerOptions, host: ModuleResolutionHost): ResolvedModuleWithFailedLookupLocations {
         const moduleResolution = compilerOptions.moduleResolution !== undefined
             ? compilerOptions.moduleResolution
-            : compilerOptions.module === ModuleKind.CommonJS ? ModuleResolutionKind.NodeJs : ModuleResolutionKind.Classic;
+            : compilerOptions.module === ModuleKind.CommonJS ? ModuleResolutionKind.Node : ModuleResolutionKind.Classic;
 
         switch (moduleResolution) {
-            case ModuleResolutionKind.NodeJs: return nodeModuleNameResolver(moduleName, containingFile, compilerOptions, host);
+            case ModuleResolutionKind.Node: return nodeModuleNameResolver(moduleName, containingFile, compilerOptions, host);
             case ModuleResolutionKind.Classic: return classicNameResolver(moduleName, containingFile, compilerOptions, host);
         }
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2376,7 +2376,7 @@ namespace ts {
 
     export const enum ModuleResolutionKind {
         Classic  = 1,
-        NodeJs  = 2
+        Node  = 2
     }
 
     export interface CompilerOptions {

--- a/tests/cases/unittests/moduleResolution.ts
+++ b/tests/cases/unittests/moduleResolution.ts
@@ -5,7 +5,7 @@ declare namespace chai.assert {
     function deepEqual(actual: any, expected: any): void;
 }
 
-module ts {
+namespace ts {
     function diagnosticToString(diagnostic: Diagnostic) {
         let output = "";
 
@@ -471,7 +471,7 @@ import b = require("./moduleB.ts");
                 directoryExists: _ => false
             };
 
-            const result = resolveModuleName("someName", "/a/b/c/d", { moduleResolution: ModuleResolutionKind.NodeJs }, host);
+            const result = resolveModuleName("someName", "/a/b/c/d", { moduleResolution: ModuleResolutionKind.Node }, host);
             assert(!result.resolvedModule);
         });
     });


### PR DESCRIPTION
uncovered by https://github.com/Microsoft/TypeScript/issues/6625. the enum value is `NodeJS` the command-line value is `node`; in VS we map the enum name to the value, resulting in an invalid value for the compiler. unifying both.
//CC @vladima and @paulvanbrenk 