### PR TITLE
Update Array.concat type signature to fix #6594

### DIFF
--- a/src/lib/core.d.ts
+++ b/src/lib/core.d.ts
@@ -1011,12 +1011,7 @@ interface Array<T> {
       * Combines two or more arrays.
       * @param items Additional items to add to the end of array1.
       */
-    concat<U extends T[]>(...items: U[]): T[];
-    /**
-      * Combines two or more arrays.
-      * @param items Additional items to add to the end of array1.
-      */
-    concat(...items: T[]): T[];
+    concat(...items: (T | T[])[]): T[];
     /**
       * Adds all the elements of an array separated by the specified separator string.
       * @param separator A string used to separate one element of an array from the next in the resulting String. If omitted, the array elements are separated with a comma.


### PR DESCRIPTION
I wasn't sure whether I should commit the LKG changes with the source lib changes; there was another change that hasn't propagated to LKG yet (removal of WeakMap/WeakSet.clear) but I didn't commit it.

This should fix #6594.