### PR TITLE
Patch fivemat progress to use chalk

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "chai": "latest",
         "browserify": "latest",
         "istanbul": "latest",
-        "mocha-fivemat-progress-reporter": "latest",
+        "mocha-fivemat-progress-reporter": "vladima/mocha-fivemat-progress-reporter#fix_progress",
         "tslint": "next",
         "typescript": "next",
         "tsd": "latest"


### PR DESCRIPTION
mocha has switched to use 'chalk' for colors instead of color codes however our project reporter was not updated meaning that our test execution was interrupted by internal errors somewhere at the very beginning (which explains why test execution time on the CI server suddenly dropped from 10 to 2 minutes). PR to 'fivemat-progress-reporter' is already [submitted](https://github.com/danquirk/mocha-fivemat-progress-reporter/pull/4) however as a temporary measure we can apply this PR