### PR TITLE
pin mocha version to 2.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     },
     "devDependencies": {
         "jake": "latest",
-        "mocha": "latest",
+        "mocha": "2.3.4",
         "chai": "latest",
         "browserify": "latest",
         "istanbul": "latest",


### PR DESCRIPTION
mocha 2.4* started to used `chalk` and fivemat-progress-reporter was not updated for it. Temporary rollback mocha until new version of progress reporter is published