### PR TITLE
Set __moduleName from context.id argument

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -477,6 +477,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
             // =>
             // var x;... exporter("x", x = 1)
             let exportFunctionForFile: string;
+            let contextObjectForFile: string;
 
             let generatedNameSet: Map<string>;
             let nodeToGeneratedName: string[];
@@ -557,6 +558,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 currentText = undefined;
                 currentLineMap = undefined;
                 exportFunctionForFile = undefined;
+                contextObjectForFile = undefined;
                 generatedNameSet = undefined;
                 nodeToGeneratedName = undefined;
                 computedPropertyNamesToGeneratedNames = undefined;
@@ -585,6 +587,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 currentText = sourceFile.text;
                 currentLineMap = getLineStarts(sourceFile);
                 exportFunctionForFile = undefined;
+                contextObjectForFile = undefined;
                 isEs6Module = sourceFile.symbol && sourceFile.symbol.exports && !!sourceFile.symbol.exports["___esModule"];
                 renamedDependencies = sourceFile.renamedDependencies;
                 currentFileIdentifiers = sourceFile.identifiers;
@@ -7058,6 +7061,7 @@ const _super = (function (geti, seti) {
                 Debug.assert(!exportFunctionForFile);
                 // make sure that  name of 'exports' function does not conflict with existing identifiers
                 exportFunctionForFile = makeUniqueName("exports");
+                contextObjectForFile = makeUniqueName("context");
                 writeLine();
                 write("System.register(");
                 writeModuleName(node, emitRelativePathAsModuleName);
@@ -7093,10 +7097,13 @@ const _super = (function (geti, seti) {
 
                     write(text);
                 }
-                write(`], function(${exportFunctionForFile}) {`);
+                write(`], function(${exportFunctionForFile}, ${contextObjectForFile}) {`);
                 writeLine();
                 increaseIndent();
                 const startIndex = emitDirectivePrologues(node.statements, /*startWithNewLine*/ true, /*ensureUseStrict*/ true);
+                writeLine();
+                write(`var __moduleName = ${contextObjectForFile} && ${contextObjectForFile}.id;`);
+                writeLine();
                 emitEmitHelpers(node);
                 emitCaptureThisForNodeIfNecessary(node);
                 emitSystemModuleBody(node, dependencyGroups, startIndex);

--- a/tests/baselines/reference/aliasesInSystemModule1.js
+++ b/tests/baselines/reference/aliasesInSystemModule1.js
@@ -17,8 +17,9 @@ module M {
   
 
 //// [aliasesInSystemModule1.js]
-System.register(['foo'], function(exports_1) {
+System.register(['foo'], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var alias;
     var cls, cls2, x, y, z, M;
     return {

--- a/tests/baselines/reference/aliasesInSystemModule2.js
+++ b/tests/baselines/reference/aliasesInSystemModule2.js
@@ -16,8 +16,9 @@ module M {
 }
 
 //// [aliasesInSystemModule2.js]
-System.register(["foo"], function(exports_1) {
+System.register(["foo"], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var foo_1;
     var cls, cls2, x, y, z, M;
     return {

--- a/tests/baselines/reference/allowSyntheticDefaultImports2.js
+++ b/tests/baselines/reference/allowSyntheticDefaultImports2.js
@@ -10,8 +10,9 @@ export class Foo {
 }
 
 //// [b.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var Foo;
     return {
         setters:[],
@@ -26,8 +27,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [a.js]
-System.register(["./b"], function(exports_1) {
+System.register(["./b"], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var b_1;
     var x;
     return {

--- a/tests/baselines/reference/allowSyntheticDefaultImports3.js
+++ b/tests/baselines/reference/allowSyntheticDefaultImports3.js
@@ -11,8 +11,9 @@ export class Foo {
 
 
 //// [b.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var Foo;
     return {
         setters:[],
@@ -27,8 +28,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [a.js]
-System.register(["./b"], function(exports_1) {
+System.register(["./b"], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var b_1;
     var x;
     return {

--- a/tests/baselines/reference/allowSyntheticDefaultImports5.js
+++ b/tests/baselines/reference/allowSyntheticDefaultImports5.js
@@ -12,8 +12,9 @@ export var x = new Foo();
 
 
 //// [a.js]
-System.register(["./b"], function(exports_1) {
+System.register(["./b"], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var b_1;
     var x;
     return {

--- a/tests/baselines/reference/allowSyntheticDefaultImports6.js
+++ b/tests/baselines/reference/allowSyntheticDefaultImports6.js
@@ -12,8 +12,9 @@ export var x = new Foo();
 
 
 //// [a.js]
-System.register(["./b"], function(exports_1) {
+System.register(["./b"], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var b_1;
     var x;
     return {

--- a/tests/baselines/reference/anonymousDefaultExportsSystem.js
+++ b/tests/baselines/reference/anonymousDefaultExportsSystem.js
@@ -7,8 +7,9 @@ export default class {}
 export default function() {}
 
 //// [a.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var default_1;
     return {
         setters:[],
@@ -20,8 +21,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [b.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     function default_1() { }
     exports_1("default", default_1);
     return {

--- a/tests/baselines/reference/capturedLetConstInLoop4.js
+++ b/tests/baselines/reference/capturedLetConstInLoop4.js
@@ -144,8 +144,9 @@ for (const y = 0; y < 1;) {
 
 
 //// [capturedLetConstInLoop4.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var v0, v00, v1, v2, v3, v4, v5, v6, v7, v8, v0_c, v00_c, v1_c, v2_c, v3_c, v4_c, v5_c, v6_c, v7_c, v8_c;
     //======let
     function exportedFoo() {

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedSystem.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedSystem.js
@@ -13,8 +13,9 @@ var decorator: ClassDecorator;
 export default class {}
 
 //// [a.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
         var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
         if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
@@ -35,8 +36,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [b.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
         var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
         if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);

--- a/tests/baselines/reference/deduplicateImportsInSystem.js
+++ b/tests/baselines/reference/deduplicateImportsInSystem.js
@@ -9,8 +9,9 @@ import {F} from 'f1';
 console.log(A + B + C + D + E + F)
 
 //// [deduplicateImportsInSystem.js]
-System.register(["f1", "f2", "f3"], function(exports_1) {
+System.register(["f1", "f2", "f3"], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var f1_1, f2_1, f3_1, f2_2, f2_3, f1_2;
     return {
         setters:[

--- a/tests/baselines/reference/defaultExportsGetExportedSystem.js
+++ b/tests/baselines/reference/defaultExportsGetExportedSystem.js
@@ -8,8 +8,9 @@ export default function foo() {}
 
 
 //// [a.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var Foo;
     return {
         setters:[],
@@ -21,8 +22,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [b.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     function foo() { }
     exports_1("default", foo);
     return {

--- a/tests/baselines/reference/es5-system.js
+++ b/tests/baselines/reference/es5-system.js
@@ -15,8 +15,9 @@ export default class A
 
 
 //// [es5-system.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var A;
     return {
         setters:[],

--- a/tests/baselines/reference/exportNonInitializedVariablesSystem.js
+++ b/tests/baselines/reference/exportNonInitializedVariablesSystem.js
@@ -35,8 +35,9 @@ export let h1: D = new D;
 
 
 //// [exportNonInitializedVariablesSystem.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var a, b, c, d, A, e, f, B, C, a1, b1, c1, d1, D, e1, f1, g1, h1;
     return {
         setters:[],

--- a/tests/baselines/reference/exportStarForValues10.js
+++ b/tests/baselines/reference/exportStarForValues10.js
@@ -13,8 +13,9 @@ export * from "file1";
 var x = 1;
 
 //// [file0.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var v;
     return {
         setters:[],
@@ -24,8 +25,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file1.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     return {
         setters:[],
         execute: function() {
@@ -33,8 +35,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file2.js]
-System.register(["file0"], function(exports_1) {
+System.register(["file0"], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var x;
     function exportStar_1(m) {
         var exports = {};

--- a/tests/baselines/reference/exportStarForValues6.js
+++ b/tests/baselines/reference/exportStarForValues6.js
@@ -9,8 +9,9 @@ export * from "file1"
 export var x = 1;
 
 //// [file1.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     return {
         setters:[],
         execute: function() {
@@ -18,8 +19,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file2.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var x;
     return {
         setters:[],

--- a/tests/baselines/reference/exportStarForValuesInSystem.js
+++ b/tests/baselines/reference/exportStarForValuesInSystem.js
@@ -9,8 +9,9 @@ export * from "file1"
 var x = 1;
 
 //// [file1.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     return {
         setters:[],
         execute: function() {
@@ -18,8 +19,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file2.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var x;
     return {
         setters:[],

--- a/tests/baselines/reference/isolatedModulesPlainFile-System.js
+++ b/tests/baselines/reference/isolatedModulesPlainFile-System.js
@@ -5,8 +5,9 @@ run(1);
 
 
 //// [isolatedModulesPlainFile-System.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     return {
         setters:[],
         execute: function() {

--- a/tests/baselines/reference/modulePrologueSystem.js
+++ b/tests/baselines/reference/modulePrologueSystem.js
@@ -4,8 +4,9 @@
 export class Foo {}
 
 //// [modulePrologueSystem.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var Foo;
     return {
         setters:[],

--- a/tests/baselines/reference/outFilerootDirModuleNamesSystem.js
+++ b/tests/baselines/reference/outFilerootDirModuleNamesSystem.js
@@ -11,8 +11,9 @@ export default function foo() { new Foo(); }
 
 
 //// [output.js]
-System.register("b", ["a"], function(exports_1) {
+System.register("b", ["a"], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var a_1;
     function foo() { new a_1.default(); }
     exports_1("default", foo);
@@ -25,8 +26,9 @@ System.register("b", ["a"], function(exports_1) {
         }
     }
 });
-System.register("a", ["b"], function(exports_2) {
+System.register("a", ["b"], function(exports_2, context_2) {
     "use strict";
+    var __moduleName = context_2 && context_2.id;
     var b_1;
     var Foo;
     return {

--- a/tests/baselines/reference/outModuleConcatSystem.js
+++ b/tests/baselines/reference/outModuleConcatSystem.js
@@ -14,8 +14,9 @@ var __extends = (this && this.__extends) || function (d, b) {
     function __() { this.constructor = d; }
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
-System.register("ref/a", [], function(exports_1) {
+System.register("ref/a", [], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var A;
     return {
         setters:[],
@@ -29,8 +30,9 @@ System.register("ref/a", [], function(exports_1) {
         }
     }
 });
-System.register("b", ["ref/a"], function(exports_2) {
+System.register("b", ["ref/a"], function(exports_2, context_2) {
     "use strict";
+    var __moduleName = context_2 && context_2.id;
     var a_1;
     var B;
     return {

--- a/tests/baselines/reference/outModuleConcatSystem.js.map
+++ b/tests/baselines/reference/outModuleConcatSystem.js.map
@@ -1,2 +1,2 @@
 //// [all.js.map]
-{"version":3,"file":"all.js","sourceRoot":"","sources":["tests/cases/compiler/ref/a.ts","tests/cases/compiler/b.ts"],"names":[],"mappings":";;;;;;;;;;;YACA;gBAAA;gBAAiB,CAAC;gBAAD,QAAC;YAAD,CAAC,AAAlB,IAAkB;YAAlB,iBAAkB,CAAA;;;;;;;;;;;;;;YCAlB;gBAAuB,qBAAC;gBAAxB;oBAAuB,8BAAC;gBAAG,CAAC;gBAAD,QAAC;YAAD,CAAC,AAA5B,CAAuB,KAAC,GAAI;YAA5B,iBAA4B,CAAA"}
+{"version":3,"file":"all.js","sourceRoot":"","sources":["tests/cases/compiler/ref/a.ts","tests/cases/compiler/b.ts"],"names":[],"mappings":";;;;;;;;;;;;YACA;gBAAA;gBAAiB,CAAC;gBAAD,QAAC;YAAD,CAAC,AAAlB,IAAkB;YAAlB,iBAAkB,CAAA;;;;;;;;;;;;;;;YCAlB;gBAAuB,qBAAC;gBAAxB;oBAAuB,8BAAC;gBAAG,CAAC;gBAAD,QAAC;YAAD,CAAC,AAA5B,CAAuB,KAAC,GAAI;YAA5B,iBAA4B,CAAA"}

--- a/tests/baselines/reference/outModuleConcatSystem.sourcemap.txt
+++ b/tests/baselines/reference/outModuleConcatSystem.sourcemap.txt
@@ -13,8 +13,9 @@ sourceFile:tests/cases/compiler/ref/a.ts
 >>>    function __() { this.constructor = d; }
 >>>    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 >>>};
->>>System.register("ref/a", [], function(exports_1) {
+>>>System.register("ref/a", [], function(exports_1, context_1) {
 >>>    "use strict";
+>>>    var __moduleName = context_1 && context_1.id;
 >>>    var A;
 >>>    return {
 >>>        setters:[],
@@ -24,13 +25,13 @@ sourceFile:tests/cases/compiler/ref/a.ts
 2 >            ^^^^^^^^^^^^^^^^^^^->
 1 >
   >
-1 >Emitted(12, 13) Source(2, 1) + SourceIndex(0)
+1 >Emitted(13, 13) Source(2, 1) + SourceIndex(0)
 ---
 >>>                function A() {
 1->^^^^^^^^^^^^^^^^
 2 >                ^^->
 1->
-1->Emitted(13, 17) Source(2, 1) + SourceIndex(0)
+1->Emitted(14, 17) Source(2, 1) + SourceIndex(0)
 ---
 >>>                }
 1->^^^^^^^^^^^^^^^^
@@ -38,16 +39,16 @@ sourceFile:tests/cases/compiler/ref/a.ts
 3 >                 ^^^^^^^^^->
 1->export class A { 
 2 >                }
-1->Emitted(14, 17) Source(2, 18) + SourceIndex(0)
-2 >Emitted(14, 18) Source(2, 19) + SourceIndex(0)
+1->Emitted(15, 17) Source(2, 18) + SourceIndex(0)
+2 >Emitted(15, 18) Source(2, 19) + SourceIndex(0)
 ---
 >>>                return A;
 1->^^^^^^^^^^^^^^^^
 2 >                ^^^^^^^^
 1->
 2 >                }
-1->Emitted(15, 17) Source(2, 18) + SourceIndex(0)
-2 >Emitted(15, 25) Source(2, 19) + SourceIndex(0)
+1->Emitted(16, 17) Source(2, 18) + SourceIndex(0)
+2 >Emitted(16, 25) Source(2, 19) + SourceIndex(0)
 ---
 >>>            }());
 1 >^^^^^^^^^^^^
@@ -59,10 +60,10 @@ sourceFile:tests/cases/compiler/ref/a.ts
 2 >            }
 3 >             
 4 >             export class A { }
-1 >Emitted(16, 13) Source(2, 18) + SourceIndex(0)
-2 >Emitted(16, 14) Source(2, 19) + SourceIndex(0)
-3 >Emitted(16, 14) Source(2, 1) + SourceIndex(0)
-4 >Emitted(16, 18) Source(2, 19) + SourceIndex(0)
+1 >Emitted(17, 13) Source(2, 18) + SourceIndex(0)
+2 >Emitted(17, 14) Source(2, 19) + SourceIndex(0)
+3 >Emitted(17, 14) Source(2, 1) + SourceIndex(0)
+4 >Emitted(17, 18) Source(2, 19) + SourceIndex(0)
 ---
 >>>            exports_1("A", A);
 1->^^^^^^^^^^^^
@@ -71,9 +72,9 @@ sourceFile:tests/cases/compiler/ref/a.ts
 1->
 2 >            export class A { }
 3 >                             
-1->Emitted(17, 13) Source(2, 1) + SourceIndex(0)
-2 >Emitted(17, 30) Source(2, 19) + SourceIndex(0)
-3 >Emitted(17, 31) Source(2, 19) + SourceIndex(0)
+1->Emitted(18, 13) Source(2, 1) + SourceIndex(0)
+2 >Emitted(18, 30) Source(2, 19) + SourceIndex(0)
+3 >Emitted(18, 31) Source(2, 19) + SourceIndex(0)
 ---
 -------------------------------------------------------------------
 emittedFile:all.js
@@ -82,8 +83,9 @@ sourceFile:tests/cases/compiler/b.ts
 >>>        }
 >>>    }
 >>>});
->>>System.register("b", ["ref/a"], function(exports_2) {
+>>>System.register("b", ["ref/a"], function(exports_2, context_2) {
 >>>    "use strict";
+>>>    var __moduleName = context_2 && context_2.id;
 >>>    var a_1;
 >>>    var B;
 >>>    return {
@@ -97,29 +99,29 @@ sourceFile:tests/cases/compiler/b.ts
 2 >            ^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >import {A} from "./ref/a";
   >
-1 >Emitted(31, 13) Source(2, 1) + SourceIndex(1)
+1 >Emitted(33, 13) Source(2, 1) + SourceIndex(1)
 ---
 >>>                __extends(B, _super);
 1->^^^^^^^^^^^^^^^^
 2 >                ^^^^^^^^^^^^^^^^^^^^^
 1->export class B extends 
 2 >                A
-1->Emitted(32, 17) Source(2, 24) + SourceIndex(1)
-2 >Emitted(32, 38) Source(2, 25) + SourceIndex(1)
+1->Emitted(34, 17) Source(2, 24) + SourceIndex(1)
+2 >Emitted(34, 38) Source(2, 25) + SourceIndex(1)
 ---
 >>>                function B() {
 1 >^^^^^^^^^^^^^^^^
 2 >                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^->
 1 >
-1 >Emitted(33, 17) Source(2, 1) + SourceIndex(1)
+1 >Emitted(35, 17) Source(2, 1) + SourceIndex(1)
 ---
 >>>                    _super.apply(this, arguments);
 1->^^^^^^^^^^^^^^^^^^^^
 2 >                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 1->export class B extends 
 2 >                    A
-1->Emitted(34, 21) Source(2, 24) + SourceIndex(1)
-2 >Emitted(34, 51) Source(2, 25) + SourceIndex(1)
+1->Emitted(36, 21) Source(2, 24) + SourceIndex(1)
+2 >Emitted(36, 51) Source(2, 25) + SourceIndex(1)
 ---
 >>>                }
 1 >^^^^^^^^^^^^^^^^
@@ -127,16 +129,16 @@ sourceFile:tests/cases/compiler/b.ts
 3 >                 ^^^^^^^^^->
 1 > { 
 2 >                }
-1 >Emitted(35, 17) Source(2, 28) + SourceIndex(1)
-2 >Emitted(35, 18) Source(2, 29) + SourceIndex(1)
+1 >Emitted(37, 17) Source(2, 28) + SourceIndex(1)
+2 >Emitted(37, 18) Source(2, 29) + SourceIndex(1)
 ---
 >>>                return B;
 1->^^^^^^^^^^^^^^^^
 2 >                ^^^^^^^^
 1->
 2 >                }
-1->Emitted(36, 17) Source(2, 28) + SourceIndex(1)
-2 >Emitted(36, 25) Source(2, 29) + SourceIndex(1)
+1->Emitted(38, 17) Source(2, 28) + SourceIndex(1)
+2 >Emitted(38, 25) Source(2, 29) + SourceIndex(1)
 ---
 >>>            }(a_1.A));
 1 >^^^^^^^^^^^^
@@ -152,12 +154,12 @@ sourceFile:tests/cases/compiler/b.ts
 4 >             export class B extends 
 5 >              A
 6 >                    { }
-1 >Emitted(37, 13) Source(2, 28) + SourceIndex(1)
-2 >Emitted(37, 14) Source(2, 29) + SourceIndex(1)
-3 >Emitted(37, 14) Source(2, 1) + SourceIndex(1)
-4 >Emitted(37, 15) Source(2, 24) + SourceIndex(1)
-5 >Emitted(37, 20) Source(2, 25) + SourceIndex(1)
-6 >Emitted(37, 23) Source(2, 29) + SourceIndex(1)
+1 >Emitted(39, 13) Source(2, 28) + SourceIndex(1)
+2 >Emitted(39, 14) Source(2, 29) + SourceIndex(1)
+3 >Emitted(39, 14) Source(2, 1) + SourceIndex(1)
+4 >Emitted(39, 15) Source(2, 24) + SourceIndex(1)
+5 >Emitted(39, 20) Source(2, 25) + SourceIndex(1)
+6 >Emitted(39, 23) Source(2, 29) + SourceIndex(1)
 ---
 >>>            exports_2("B", B);
 1->^^^^^^^^^^^^
@@ -166,9 +168,9 @@ sourceFile:tests/cases/compiler/b.ts
 1->
 2 >            export class B extends A { }
 3 >                             
-1->Emitted(38, 13) Source(2, 1) + SourceIndex(1)
-2 >Emitted(38, 30) Source(2, 29) + SourceIndex(1)
-3 >Emitted(38, 31) Source(2, 29) + SourceIndex(1)
+1->Emitted(40, 13) Source(2, 1) + SourceIndex(1)
+2 >Emitted(40, 30) Source(2, 29) + SourceIndex(1)
+3 >Emitted(40, 31) Source(2, 29) + SourceIndex(1)
 ---
 >>>        }
 >>>    }

--- a/tests/baselines/reference/prefixUnaryOperatorsOnExportedVariables.js
+++ b/tests/baselines/reference/prefixUnaryOperatorsOnExportedVariables.js
@@ -31,8 +31,9 @@ if (++y) {
 }
 
 //// [prefixUnaryOperatorsOnExportedVariables.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var x, y;
     return {
         setters:[],

--- a/tests/baselines/reference/systemExportAssignment.js
+++ b/tests/baselines/reference/systemExportAssignment.js
@@ -10,8 +10,9 @@ import * as a from "a";
 
 
 //// [b.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     return {
         setters:[],
         execute: function() {

--- a/tests/baselines/reference/systemExportAssignment2.js
+++ b/tests/baselines/reference/systemExportAssignment2.js
@@ -10,8 +10,9 @@ import * as a from "a";
 
 
 //// [a.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var a;
     return {
         setters:[],
@@ -21,8 +22,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [b.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     return {
         setters:[],
         execute: function() {

--- a/tests/baselines/reference/systemExportAssignment3.js
+++ b/tests/baselines/reference/systemExportAssignment3.js
@@ -12,8 +12,9 @@ import * as a from "a";
 
 
 //// [b.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     return {
         setters:[],
         execute: function() {

--- a/tests/baselines/reference/systemModule1.js
+++ b/tests/baselines/reference/systemModule1.js
@@ -3,8 +3,9 @@
 export var x = 1;
 
 //// [systemModule1.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var x;
     return {
         setters:[],

--- a/tests/baselines/reference/systemModule10.js
+++ b/tests/baselines/reference/systemModule10.js
@@ -10,8 +10,9 @@ export {n2}
 export {n2 as n3}
 
 //// [systemModule10.js]
-System.register(['file1', 'file2'], function(exports_1) {
+System.register(['file1', 'file2'], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var file1_1, n2;
     return {
         setters:[

--- a/tests/baselines/reference/systemModule10_ES5.js
+++ b/tests/baselines/reference/systemModule10_ES5.js
@@ -10,8 +10,9 @@ export {n2}
 export {n2 as n3}
 
 //// [systemModule10_ES5.js]
-System.register(['file1', 'file2'], function(exports_1) {
+System.register(['file1', 'file2'], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var file1_1, n2;
     return {
         setters:[

--- a/tests/baselines/reference/systemModule11.js
+++ b/tests/baselines/reference/systemModule11.js
@@ -42,8 +42,9 @@ export * from 'a';
 
 //// [file1.js]
 // set of tests cases that checks generation of local storage for exported names
-System.register(['bar'], function(exports_1) {
+System.register(['bar'], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var x;
     function foo() { }
     exports_1("foo", foo);
@@ -68,8 +69,9 @@ System.register(['bar'], function(exports_1) {
     }
 });
 //// [file2.js]
-System.register(['bar'], function(exports_1) {
+System.register(['bar'], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var x, y;
     var exportedNames_1 = {
         'x': true,
@@ -94,8 +96,9 @@ System.register(['bar'], function(exports_1) {
     }
 });
 //// [file3.js]
-System.register(['a', 'bar'], function(exports_1) {
+System.register(['a', 'bar'], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     function foo() { }
     exports_1("default", foo);
     var exportedNames_1 = {
@@ -125,8 +128,9 @@ System.register(['a', 'bar'], function(exports_1) {
     }
 });
 //// [file4.js]
-System.register(['a'], function(exports_1) {
+System.register(['a'], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var x, z, z1;
     function foo() { }
     exports_1("foo", foo);
@@ -147,8 +151,9 @@ System.register(['a'], function(exports_1) {
     }
 });
 //// [file5.js]
-System.register(['a'], function(exports_1) {
+System.register(['a'], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     function foo() { }
     function exportStar_1(m) {
         var exports = {};

--- a/tests/baselines/reference/systemModule12.js
+++ b/tests/baselines/reference/systemModule12.js
@@ -5,8 +5,9 @@ import n from 'file1'
 
 
 //// [systemModule12.js]
-System.register("NamedModule", [], function(exports_1) {
+System.register("NamedModule", [], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     return {
         setters:[],
         execute: function() {

--- a/tests/baselines/reference/systemModule13.js
+++ b/tests/baselines/reference/systemModule13.js
@@ -5,8 +5,9 @@ export const {a: z0, b: {c: z1}} = {a: true, b: {c: "123"}};
 for ([x] of [[1]]) {}
 
 //// [systemModule13.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var x, y, z, z0, z1;
     return {
         setters:[],

--- a/tests/baselines/reference/systemModule14.js
+++ b/tests/baselines/reference/systemModule14.js
@@ -11,8 +11,9 @@ var x = 1;
 export {foo as b}
 
 //// [systemModule14.js]
-System.register(["foo"], function(exports_1) {
+System.register(["foo"], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var foo_1;
     var x;
     function foo() {

--- a/tests/baselines/reference/systemModule15.js
+++ b/tests/baselines/reference/systemModule15.js
@@ -34,8 +34,9 @@ export default value;
 export var value2 = "v";
 
 //// [file3.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var value;
     return {
         setters:[],
@@ -46,8 +47,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file4.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var value2;
     return {
         setters:[],
@@ -57,8 +59,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file2.js]
-System.register(["./file3"], function(exports_1) {
+System.register(["./file3"], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var moduleCStar, file3_1, file3_2;
     return {
         setters:[
@@ -75,8 +78,9 @@ System.register(["./file3"], function(exports_1) {
     }
 });
 //// [file1.js]
-System.register(["./file2"], function(exports_1) {
+System.register(["./file2"], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var moduleB;
     return {
         setters:[

--- a/tests/baselines/reference/systemModule16.js
+++ b/tests/baselines/reference/systemModule16.js
@@ -13,8 +13,9 @@ x,y,a1,b1,d1;
 
 
 //// [systemModule16.js]
-System.register(["foo", "bar"], function(exports_1) {
+System.register(["foo", "bar"], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var x, y, foo_1;
     var exportedNames_1 = {
         'x': true,

--- a/tests/baselines/reference/systemModule17.js
+++ b/tests/baselines/reference/systemModule17.js
@@ -42,8 +42,9 @@ export {II};
 export {II as II1};
 
 //// [f1.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var A;
     return {
         setters:[],
@@ -58,8 +59,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [f2.js]
-System.register(["f1"], function(exports_1) {
+System.register(["f1"], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var f1_1;
     var x, N, IX;
     return {

--- a/tests/baselines/reference/systemModule2.js
+++ b/tests/baselines/reference/systemModule2.js
@@ -4,8 +4,9 @@ var x = 1;
 export = x;
 
 //// [systemModule2.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var x;
     return {
         setters:[],

--- a/tests/baselines/reference/systemModule3.js
+++ b/tests/baselines/reference/systemModule3.js
@@ -18,8 +18,9 @@ export default class C {}
 export default class {}
 
 //// [file1.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     function default_1() { }
     exports_1("default", default_1);
     return {
@@ -29,8 +30,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file2.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     function f() { }
     exports_1("default", f);
     return {
@@ -40,8 +42,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file3.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var C;
     return {
         setters:[],
@@ -56,8 +59,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file4.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var default_1;
     return {
         setters:[],

--- a/tests/baselines/reference/systemModule4.js
+++ b/tests/baselines/reference/systemModule4.js
@@ -4,8 +4,9 @@ export var x = 1;
 export var y;
 
 //// [systemModule4.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var x, y;
     return {
         setters:[],

--- a/tests/baselines/reference/systemModule5.js
+++ b/tests/baselines/reference/systemModule5.js
@@ -4,8 +4,9 @@ export function foo() {}
 
 
 //// [systemModule5.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     function foo() { }
     exports_1("foo", foo);
     return {

--- a/tests/baselines/reference/systemModule6.js
+++ b/tests/baselines/reference/systemModule6.js
@@ -7,8 +7,9 @@ function foo() {
 
 
 //// [systemModule6.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var C;
     function foo() {
         new C();

--- a/tests/baselines/reference/systemModule7.js
+++ b/tests/baselines/reference/systemModule7.js
@@ -11,8 +11,9 @@ export module M {
 }
 
 //// [systemModule7.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var M;
     return {
         setters:[],

--- a/tests/baselines/reference/systemModule8.js
+++ b/tests/baselines/reference/systemModule8.js
@@ -31,8 +31,9 @@ export const {a: z0, b: {c: z1}} = {a: true, b: {c: "123"}};
 for ([x] of [[1]]) {}
 
 //// [systemModule8.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var x, y, z0, z1;
     function foo() {
         exports_1("x", x = 100);

--- a/tests/baselines/reference/systemModule9.js
+++ b/tests/baselines/reference/systemModule9.js
@@ -22,8 +22,9 @@ export {x};
 export {y as z};
 
 //// [systemModule9.js]
-System.register(['file1', 'file2', 'file3', 'file4', 'file5', 'file6', 'file7'], function(exports_1) {
+System.register(['file1', 'file2', 'file3', 'file4', 'file5', 'file6', 'file7'], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var ns, file2_1, file3_1, file5_1, ns3;
     var x, y;
     var exportedNames_1 = {

--- a/tests/baselines/reference/systemModuleAmbientDeclarations.js
+++ b/tests/baselines/reference/systemModuleAmbientDeclarations.js
@@ -29,8 +29,9 @@ export declare module M { var v: number; }
 
 
 //// [file1.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var promise, foo, c, e;
     return {
         setters:[],
@@ -44,8 +45,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file2.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     return {
         setters:[],
         execute: function() {
@@ -53,8 +55,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file3.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     return {
         setters:[],
         execute: function() {
@@ -62,8 +65,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file4.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     return {
         setters:[],
         execute: function() {
@@ -71,8 +75,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file5.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     return {
         setters:[],
         execute: function() {
@@ -80,8 +85,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file6.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     return {
         setters:[],
         execute: function() {

--- a/tests/baselines/reference/systemModuleConstEnums.js
+++ b/tests/baselines/reference/systemModuleConstEnums.js
@@ -13,8 +13,9 @@ module M {
 }
 
 //// [systemModuleConstEnums.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     function foo() {
         use(0 /* X */);
         use(0 /* X */);

--- a/tests/baselines/reference/systemModuleConstEnumsSeparateCompilation.js
+++ b/tests/baselines/reference/systemModuleConstEnumsSeparateCompilation.js
@@ -13,8 +13,9 @@ module M {
 }
 
 //// [systemModuleConstEnumsSeparateCompilation.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var TopLevelConstEnum, M;
     function foo() {
         use(TopLevelConstEnum.X);

--- a/tests/baselines/reference/systemModuleDeclarationMerging.js
+++ b/tests/baselines/reference/systemModuleDeclarationMerging.js
@@ -10,8 +10,9 @@ export enum E {}
 export module E { var x; }
 
 //// [systemModuleDeclarationMerging.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var F, C, E;
     function F() { }
     exports_1("F", F);

--- a/tests/baselines/reference/systemModuleExportDefault.js
+++ b/tests/baselines/reference/systemModuleExportDefault.js
@@ -16,8 +16,9 @@ export default class C {}
 
 
 //// [file1.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     function default_1() { }
     exports_1("default", default_1);
     return {
@@ -27,8 +28,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file2.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     function foo() { }
     exports_1("default", foo);
     return {
@@ -38,8 +40,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file3.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var default_1;
     return {
         setters:[],
@@ -54,8 +57,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [file4.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var C;
     return {
         setters:[],

--- a/tests/baselines/reference/systemModuleNonTopLevelModuleMembers.js
+++ b/tests/baselines/reference/systemModuleNonTopLevelModuleMembers.js
@@ -13,8 +13,9 @@ export module TopLevelModule2 {
 }
 
 //// [systemModuleNonTopLevelModuleMembers.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var TopLevelClass, TopLevelModule, TopLevelEnum, TopLevelModule2;
     function TopLevelFunction() { }
     exports_1("TopLevelFunction", TopLevelFunction);

--- a/tests/baselines/reference/systemModuleWithSuperClass.js
+++ b/tests/baselines/reference/systemModuleWithSuperClass.js
@@ -13,8 +13,9 @@ export class Bar extends Foo {
 }
 
 //// [foo.js]
-System.register([], function(exports_1) {
+System.register([], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var Foo;
     return {
         setters:[],
@@ -29,8 +30,9 @@ System.register([], function(exports_1) {
     }
 });
 //// [bar.js]
-System.register(['./foo'], function(exports_1) {
+System.register(['./foo'], function(exports_1, context_1) {
     "use strict";
+    var __moduleName = context_1 && context_1.id;
     var __extends = (this && this.__extends) || function (d, b) {
         for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
         function __() { this.constructor = d; }

--- a/tests/cases/unittests/transpile.ts
+++ b/tests/cases/unittests/transpile.ts
@@ -134,7 +134,10 @@ var x = 0;`,
 
         it("Sets module name", () => {
             let output =
-                `System.register("NamedModule", [], function(exports_1) {\n    "use strict";\n    var x;\n` +
+                `System.register("NamedModule", [], function(exports_1, context_1) {\n` +
+                `    "use strict";\n` +
+                `    var __moduleName = context_1 && context_1.id;\n` +
+                `    var x;\n` +
                 `    return {\n` +
                 `        setters:[],\n` +
                 `        execute: function() {\n` +
@@ -159,8 +162,9 @@ var x = 0;`,
                 `declare function use(a: any);\n` +
                 `use(foo);`
             let output =
-                `System.register(["SomeOtherName"], function(exports_1) {\n` +
+                `System.register(["SomeOtherName"], function(exports_1, context_1) {\n` +
                 `    "use strict";\n` +
+                `    var __moduleName = context_1 && context_1.id;\n` +
                 `    var SomeName_1;\n` +
                 `    return {\n` +
                 `        setters:[\n` +


### PR DESCRIPTION
This resolves #6359 using the method suggested by @vladima as the replacement to the original PR at https://github.com/Microsoft/TypeScript/pull/6098.

This context object is described at https://github.com/ModuleLoader/es6-module-loader/wiki/System.register-Explained#how-it-works, and was considered more extensible for future spec changes than a string second argument directly.