### PR TITLE
Readonly in declaration files (part 2)

### DIFF
--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -637,21 +637,21 @@ namespace ts {
             }
         }
 
-        function emitClassMemberDeclarationFlags(node: Declaration) {
-            if (node.flags & NodeFlags.Private) {
+        function emitClassMemberDeclarationFlags(flags: NodeFlags) {
+            if (flags & NodeFlags.Private) {
                 write("private ");
             }
-            else if (node.flags & NodeFlags.Protected) {
+            else if (flags & NodeFlags.Protected) {
                 write("protected ");
             }
 
-            if (node.flags & NodeFlags.Static) {
+            if (flags & NodeFlags.Static) {
                 write("static ");
             }
-            if (node.flags & NodeFlags.Readonly) {
+            if (flags & NodeFlags.Readonly) {
                 write("readonly ");
             }
-            if (node.flags & NodeFlags.Abstract) {
+            if (flags & NodeFlags.Abstract) {
                 write("abstract ");
             }
         }
@@ -1077,7 +1077,7 @@ namespace ts {
             }
 
             emitJsDocComments(node);
-            emitClassMemberDeclarationFlags(node);
+            emitClassMemberDeclarationFlags(node.flags);
             emitVariableDeclaration(<VariableDeclaration>node);
             write(";");
             writeLine();
@@ -1230,7 +1230,7 @@ namespace ts {
             if (node === accessors.firstAccessor) {
                 emitJsDocComments(accessors.getAccessor);
                 emitJsDocComments(accessors.setAccessor);
-                emitClassMemberDeclarationFlags(node);
+                emitClassMemberDeclarationFlags(node.flags | (accessors.setAccessor ? 0 : NodeFlags.Readonly));
                 writeTextOfNode(currentText, node.name);
                 if (!(node.flags & NodeFlags.Private)) {
                     accessorWithTypeAnnotation = node;
@@ -1317,7 +1317,7 @@ namespace ts {
                     emitModuleElementDeclarationFlags(node);
                 }
                 else if (node.kind === SyntaxKind.MethodDeclaration) {
-                    emitClassMemberDeclarationFlags(node);
+                    emitClassMemberDeclarationFlags(node.flags);
                 }
                 if (node.kind === SyntaxKind.FunctionDeclaration) {
                     write("function ");
@@ -1347,7 +1347,7 @@ namespace ts {
 
             if (node.kind === SyntaxKind.IndexSignature) {
                 // Index signature can have readonly modifier
-                emitClassMemberDeclarationFlags(node);
+                emitClassMemberDeclarationFlags(node.flags);
                 write("[");
             }
             else {

--- a/tests/baselines/reference/classdecl.js
+++ b/tests/baselines/reference/classdecl.js
@@ -211,12 +211,12 @@ declare class a {
     pgF(): void;
     pv: any;
     d: number;
-    static p2: {
+    static readonly p2: {
         x: number;
         y: number;
     };
     private static d2();
-    private static p3;
+    private static readonly p3;
     private pv3;
     private foo(n);
     private foo(s);

--- a/tests/baselines/reference/commentsClassMembers.js
+++ b/tests/baselines/reference/commentsClassMembers.js
@@ -568,8 +568,8 @@ declare var i1_c: typeof c1;
 declare class cProperties {
     private val;
     /** getter only property*/
-    p1: number;
-    nc_p1: number;
+    readonly p1: number;
+    readonly nc_p1: number;
     /**setter only property*/
     p2: number;
     nc_p2: number;

--- a/tests/baselines/reference/commentsInheritance.js
+++ b/tests/baselines/reference/commentsInheritance.js
@@ -316,19 +316,19 @@ declare class c2 {
     /** c2 c2_f1*/
     c2_f1(): void;
     /** c2 c2_prop*/
-    c2_prop: number;
+    readonly c2_prop: number;
     c2_nc_p1: number;
     c2_nc_f1(): void;
-    c2_nc_prop: number;
+    readonly c2_nc_prop: number;
     /** c2 p1*/
     p1: number;
     /** c2 f1*/
     f1(): void;
     /** c2 prop*/
-    prop: number;
+    readonly prop: number;
     nc_p1: number;
     nc_f1(): void;
-    nc_prop: number;
+    readonly nc_prop: number;
     /** c2 constructor*/
     constructor(a: number);
 }
@@ -339,10 +339,10 @@ declare class c3 extends c2 {
     /** c3 f1*/
     f1(): void;
     /** c3 prop*/
-    prop: number;
+    readonly prop: number;
     nc_p1: number;
     nc_f1(): void;
-    nc_prop: number;
+    readonly nc_prop: number;
 }
 declare var c2_i: c2;
 declare var c3_i: c3;

--- a/tests/baselines/reference/declFileAccessors.js
+++ b/tests/baselines/reference/declFileAccessors.js
@@ -284,7 +284,7 @@ export declare class c1 {
     nc_p3: number;
     private nc_pp3;
     static nc_s3: string;
-    onlyGetter: number;
+    readonly onlyGetter: number;
     onlySetter: number;
 }
 //// [declFileAccessors_1.d.ts]
@@ -302,6 +302,6 @@ declare class c2 {
     nc_p3: number;
     private nc_pp3;
     static nc_s3: string;
-    onlyGetter: number;
+    readonly onlyGetter: number;
     onlySetter: number;
 }

--- a/tests/baselines/reference/declFilePrivateStatic.js
+++ b/tests/baselines/reference/declFilePrivateStatic.js
@@ -52,8 +52,8 @@ declare class C {
     static y: number;
     private static a();
     static b(): void;
-    private static c;
-    static d: number;
+    private static readonly c;
+    static readonly d: number;
     private static e;
     static f: any;
 }

--- a/tests/baselines/reference/declarationEmit_protectedMembers.js
+++ b/tests/baselines/reference/declarationEmit_protectedMembers.js
@@ -135,7 +135,7 @@ declare class C1 {
     protected static sx: number;
     protected static sf(): number;
     protected static staticSetter: number;
-    protected static staticGetter: number;
+    protected static readonly staticGetter: number;
 }
 declare class C2 extends C1 {
     protected f(): number;
@@ -146,7 +146,7 @@ declare class C3 extends C2 {
     static sx: number;
     f(): number;
     static sf(): number;
-    static staticGetter: number;
+    static readonly staticGetter: number;
 }
 declare class C4 {
     protected a: number;

--- a/tests/baselines/reference/giant.js
+++ b/tests/baselines/reference/giant.js
@@ -1120,11 +1120,11 @@ export declare class eC {
     pF(): void;
     private rF();
     pgF(): void;
-    pgF: any;
+    readonly pgF: any;
     psF(param: any): void;
     psF: any;
     private rgF();
-    private rgF;
+    private readonly rgF;
     private rsF(param);
     private rsF;
     static tV: any;
@@ -1132,7 +1132,7 @@ export declare class eC {
     static tsF(param: any): void;
     static tsF: any;
     static tgF(): void;
-    static tgF: any;
+    static readonly tgF: any;
 }
 export interface eI {
     (): any;
@@ -1172,11 +1172,11 @@ export declare module eM {
         pF(): void;
         private rF();
         pgF(): void;
-        pgF: any;
+        readonly pgF: any;
         psF(param: any): void;
         psF: any;
         private rgF();
-        private rgF;
+        private readonly rgF;
         private rsF(param);
         private rsF;
         static tV: any;
@@ -1184,7 +1184,7 @@ export declare module eM {
         static tsF(param: any): void;
         static tsF: any;
         static tgF(): void;
-        static tgF: any;
+        static readonly tgF: any;
     }
     interface eI {
         (): any;
@@ -1239,11 +1239,11 @@ export declare module eM {
         pF(): void;
         private rF();
         pgF(): void;
-        pgF: any;
+        readonly pgF: any;
         psF(param: any): void;
         psF: any;
         private rgF();
-        private rgF;
+        private readonly rgF;
         private rsF(param);
         private rsF;
         static tV: any;
@@ -1251,7 +1251,7 @@ export declare module eM {
         static tsF(param: any): void;
         static tsF: any;
         static tgF(): void;
-        static tgF: any;
+        static readonly tgF: any;
     }
     module eaM {
         var V: any;
@@ -1281,11 +1281,11 @@ export declare class eaC {
     pF(): void;
     private rF();
     pgF(): void;
-    pgF: any;
+    readonly pgF: any;
     psF(param: any): void;
     psF: any;
     private rgF();
-    private rgF;
+    private readonly rgF;
     private rsF(param);
     private rsF;
     static tV: any;
@@ -1293,7 +1293,7 @@ export declare class eaC {
     static tsF(param: any): void;
     static tsF: any;
     static tgF(): void;
-    static tgF: any;
+    static readonly tgF: any;
 }
 export declare module eaM {
     var V: any;

--- a/tests/baselines/reference/isDeclarationVisibleNodeKinds.js
+++ b/tests/baselines/reference/isDeclarationVisibleNodeKinds.js
@@ -193,7 +193,7 @@ declare module schema {
 }
 declare module schema {
     class T {
-        createValidator9: <T>(data: T) => T;
+        readonly createValidator9: <T>(data: T) => T;
         createValidator10: <T>(data: T) => T;
     }
 }

--- a/tests/baselines/reference/moduledecl.js
+++ b/tests/baselines/reference/moduledecl.js
@@ -459,10 +459,10 @@ declare module exportTests {
     class C3_public {
         private getC2_private();
         private setC2_private(arg);
-        private c2;
+        private readonly c2;
         getC1_public(): C1_public;
         setC1_public(arg: C1_public): void;
-        c1: C1_public;
+        readonly c1: C1_public;
     }
 }
 declare module mAmbient {

--- a/tests/baselines/reference/readonlyInDeclarationFile.js
+++ b/tests/baselines/reference/readonlyInDeclarationFile.js
@@ -6,11 +6,31 @@ interface Foo {
 }
 
 class C {
-    protected readonly y: number;
     readonly [x: string]: Object;
-    private static readonly a = "foo"; 
-    protected static readonly b = "foo"; 
-    public static readonly c = "foo"; 
+    private readonly a1: number;
+    protected readonly a2: number;
+    public readonly a3: number;
+    private get b1() { return 1 }
+    protected get b2() { return 1 }
+    public get b3() { return 1 }
+    private get c1() { return 1 }
+    private set c1(value) { }
+    protected get c2() { return 1 }
+    protected set c2(value) { }
+    public get c3() { return 1 }
+    public set c3(value) { }
+    private static readonly s1: number;
+    protected static readonly s2: number;
+    public static readonly s3: number;
+    private static get t1() { return 1 }
+    protected static get t2() { return 1 }
+    public static get t3() { return 1 }
+    private static get u1() { return 1 }
+    private static set u1(value) { }
+    protected static get u2() { return 1 }
+    protected static set u2(value) { }
+    public static get u3() { return 1 }
+    public static set u3(value) { }
 }
 
 var z: {
@@ -38,9 +58,72 @@ function g() {
 var C = (function () {
     function C() {
     }
-    C.a = "foo";
-    C.b = "foo";
-    C.c = "foo";
+    Object.defineProperty(C.prototype, "b1", {
+        get: function () { return 1; },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(C.prototype, "b2", {
+        get: function () { return 1; },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(C.prototype, "b3", {
+        get: function () { return 1; },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(C.prototype, "c1", {
+        get: function () { return 1; },
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(C.prototype, "c2", {
+        get: function () { return 1; },
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(C.prototype, "c3", {
+        get: function () { return 1; },
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(C, "t1", {
+        get: function () { return 1; },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(C, "t2", {
+        get: function () { return 1; },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(C, "t3", {
+        get: function () { return 1; },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(C, "u1", {
+        get: function () { return 1; },
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(C, "u2", {
+        get: function () { return 1; },
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(C, "u3", {
+        get: function () { return 1; },
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
     return C;
 }());
 var z;
@@ -63,11 +146,25 @@ interface Foo {
     readonly [x: string]: Object;
 }
 declare class C {
-    protected readonly y: number;
     readonly [x: string]: Object;
-    private static readonly a;
-    protected static readonly b: string;
-    static readonly c: string;
+    private readonly a1;
+    protected readonly a2: number;
+    readonly a3: number;
+    private readonly b1;
+    protected readonly b2: number;
+    readonly b3: number;
+    private c1;
+    protected c2: number;
+    c3: number;
+    private static readonly s1;
+    protected static readonly s2: number;
+    static readonly s3: number;
+    private static readonly t1;
+    protected static readonly t2: number;
+    static readonly t3: number;
+    private static u1;
+    protected static u2: number;
+    static u3: number;
 }
 declare var z: {
     readonly a: string;

--- a/tests/baselines/reference/readonlyInDeclarationFile.symbols
+++ b/tests/baselines/reference/readonlyInDeclarationFile.symbols
@@ -14,63 +14,129 @@ interface Foo {
 class C {
 >C : Symbol(C, Decl(readonlyInDeclarationFile.ts, 4, 1))
 
-    protected readonly y: number;
->y : Symbol(y, Decl(readonlyInDeclarationFile.ts, 6, 9))
-
     readonly [x: string]: Object;
->x : Symbol(x, Decl(readonlyInDeclarationFile.ts, 8, 14))
+>x : Symbol(x, Decl(readonlyInDeclarationFile.ts, 7, 14))
 >Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
-    private static readonly a = "foo"; 
->a : Symbol(C.a, Decl(readonlyInDeclarationFile.ts, 8, 33))
+    private readonly a1: number;
+>a1 : Symbol(a1, Decl(readonlyInDeclarationFile.ts, 7, 33))
 
-    protected static readonly b = "foo"; 
->b : Symbol(C.b, Decl(readonlyInDeclarationFile.ts, 9, 38))
+    protected readonly a2: number;
+>a2 : Symbol(a2, Decl(readonlyInDeclarationFile.ts, 8, 32))
 
-    public static readonly c = "foo"; 
->c : Symbol(C.c, Decl(readonlyInDeclarationFile.ts, 10, 40))
+    public readonly a3: number;
+>a3 : Symbol(a3, Decl(readonlyInDeclarationFile.ts, 9, 34))
+
+    private get b1() { return 1 }
+>b1 : Symbol(b1, Decl(readonlyInDeclarationFile.ts, 10, 31))
+
+    protected get b2() { return 1 }
+>b2 : Symbol(b2, Decl(readonlyInDeclarationFile.ts, 11, 33))
+
+    public get b3() { return 1 }
+>b3 : Symbol(b3, Decl(readonlyInDeclarationFile.ts, 12, 35))
+
+    private get c1() { return 1 }
+>c1 : Symbol(c1, Decl(readonlyInDeclarationFile.ts, 13, 32), Decl(readonlyInDeclarationFile.ts, 14, 33))
+
+    private set c1(value) { }
+>c1 : Symbol(c1, Decl(readonlyInDeclarationFile.ts, 13, 32), Decl(readonlyInDeclarationFile.ts, 14, 33))
+>value : Symbol(value, Decl(readonlyInDeclarationFile.ts, 15, 19))
+
+    protected get c2() { return 1 }
+>c2 : Symbol(c2, Decl(readonlyInDeclarationFile.ts, 15, 29), Decl(readonlyInDeclarationFile.ts, 16, 35))
+
+    protected set c2(value) { }
+>c2 : Symbol(c2, Decl(readonlyInDeclarationFile.ts, 15, 29), Decl(readonlyInDeclarationFile.ts, 16, 35))
+>value : Symbol(value, Decl(readonlyInDeclarationFile.ts, 17, 21))
+
+    public get c3() { return 1 }
+>c3 : Symbol(c3, Decl(readonlyInDeclarationFile.ts, 17, 31), Decl(readonlyInDeclarationFile.ts, 18, 32))
+
+    public set c3(value) { }
+>c3 : Symbol(c3, Decl(readonlyInDeclarationFile.ts, 17, 31), Decl(readonlyInDeclarationFile.ts, 18, 32))
+>value : Symbol(value, Decl(readonlyInDeclarationFile.ts, 19, 18))
+
+    private static readonly s1: number;
+>s1 : Symbol(C.s1, Decl(readonlyInDeclarationFile.ts, 19, 28))
+
+    protected static readonly s2: number;
+>s2 : Symbol(C.s2, Decl(readonlyInDeclarationFile.ts, 20, 39))
+
+    public static readonly s3: number;
+>s3 : Symbol(C.s3, Decl(readonlyInDeclarationFile.ts, 21, 41))
+
+    private static get t1() { return 1 }
+>t1 : Symbol(C.t1, Decl(readonlyInDeclarationFile.ts, 22, 38))
+
+    protected static get t2() { return 1 }
+>t2 : Symbol(C.t2, Decl(readonlyInDeclarationFile.ts, 23, 40))
+
+    public static get t3() { return 1 }
+>t3 : Symbol(C.t3, Decl(readonlyInDeclarationFile.ts, 24, 42))
+
+    private static get u1() { return 1 }
+>u1 : Symbol(C.u1, Decl(readonlyInDeclarationFile.ts, 25, 39), Decl(readonlyInDeclarationFile.ts, 26, 40))
+
+    private static set u1(value) { }
+>u1 : Symbol(C.u1, Decl(readonlyInDeclarationFile.ts, 25, 39), Decl(readonlyInDeclarationFile.ts, 26, 40))
+>value : Symbol(value, Decl(readonlyInDeclarationFile.ts, 27, 26))
+
+    protected static get u2() { return 1 }
+>u2 : Symbol(C.u2, Decl(readonlyInDeclarationFile.ts, 27, 36), Decl(readonlyInDeclarationFile.ts, 28, 42))
+
+    protected static set u2(value) { }
+>u2 : Symbol(C.u2, Decl(readonlyInDeclarationFile.ts, 27, 36), Decl(readonlyInDeclarationFile.ts, 28, 42))
+>value : Symbol(value, Decl(readonlyInDeclarationFile.ts, 29, 28))
+
+    public static get u3() { return 1 }
+>u3 : Symbol(C.u3, Decl(readonlyInDeclarationFile.ts, 29, 38), Decl(readonlyInDeclarationFile.ts, 30, 39))
+
+    public static set u3(value) { }
+>u3 : Symbol(C.u3, Decl(readonlyInDeclarationFile.ts, 29, 38), Decl(readonlyInDeclarationFile.ts, 30, 39))
+>value : Symbol(value, Decl(readonlyInDeclarationFile.ts, 31, 25))
 }
 
 var z: {
->z : Symbol(z, Decl(readonlyInDeclarationFile.ts, 14, 3))
+>z : Symbol(z, Decl(readonlyInDeclarationFile.ts, 34, 3))
 
     readonly a: string;
->a : Symbol(a, Decl(readonlyInDeclarationFile.ts, 14, 8))
+>a : Symbol(a, Decl(readonlyInDeclarationFile.ts, 34, 8))
 
     readonly [x: string]: Object;
->x : Symbol(x, Decl(readonlyInDeclarationFile.ts, 16, 14))
+>x : Symbol(x, Decl(readonlyInDeclarationFile.ts, 36, 14))
 >Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 }
 
 function f() {
->f : Symbol(f, Decl(readonlyInDeclarationFile.ts, 17, 1))
+>f : Symbol(f, Decl(readonlyInDeclarationFile.ts, 37, 1))
 
     return {
         get x() { return 1; },
->x : Symbol(x, Decl(readonlyInDeclarationFile.ts, 20, 12))
+>x : Symbol(x, Decl(readonlyInDeclarationFile.ts, 40, 12))
 
         get y() { return 1; },
->y : Symbol(y, Decl(readonlyInDeclarationFile.ts, 21, 30), Decl(readonlyInDeclarationFile.ts, 22, 30))
+>y : Symbol(y, Decl(readonlyInDeclarationFile.ts, 41, 30), Decl(readonlyInDeclarationFile.ts, 42, 30))
 
         set y(value) { }
->y : Symbol(y, Decl(readonlyInDeclarationFile.ts, 21, 30), Decl(readonlyInDeclarationFile.ts, 22, 30))
->value : Symbol(value, Decl(readonlyInDeclarationFile.ts, 23, 14))
+>y : Symbol(y, Decl(readonlyInDeclarationFile.ts, 41, 30), Decl(readonlyInDeclarationFile.ts, 42, 30))
+>value : Symbol(value, Decl(readonlyInDeclarationFile.ts, 43, 14))
     }
 }
 
 function g() {
->g : Symbol(g, Decl(readonlyInDeclarationFile.ts, 25, 1))
+>g : Symbol(g, Decl(readonlyInDeclarationFile.ts, 45, 1))
 
     var x: {
->x : Symbol(x, Decl(readonlyInDeclarationFile.ts, 28, 7))
+>x : Symbol(x, Decl(readonlyInDeclarationFile.ts, 48, 7))
 
         readonly a: string;
->a : Symbol(a, Decl(readonlyInDeclarationFile.ts, 28, 12))
+>a : Symbol(a, Decl(readonlyInDeclarationFile.ts, 48, 12))
 
         readonly [x: string]: Object;
->x : Symbol(x, Decl(readonlyInDeclarationFile.ts, 30, 18))
+>x : Symbol(x, Decl(readonlyInDeclarationFile.ts, 50, 18))
 >Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
     }
     return x;
->x : Symbol(x, Decl(readonlyInDeclarationFile.ts, 28, 7))
+>x : Symbol(x, Decl(readonlyInDeclarationFile.ts, 48, 7))
 }

--- a/tests/baselines/reference/readonlyInDeclarationFile.types
+++ b/tests/baselines/reference/readonlyInDeclarationFile.types
@@ -14,24 +14,99 @@ interface Foo {
 class C {
 >C : C
 
-    protected readonly y: number;
->y : number
-
     readonly [x: string]: Object;
 >x : string
 >Object : Object
 
-    private static readonly a = "foo"; 
->a : string
->"foo" : string
+    private readonly a1: number;
+>a1 : number
 
-    protected static readonly b = "foo"; 
->b : string
->"foo" : string
+    protected readonly a2: number;
+>a2 : number
 
-    public static readonly c = "foo"; 
->c : string
->"foo" : string
+    public readonly a3: number;
+>a3 : number
+
+    private get b1() { return 1 }
+>b1 : number
+>1 : number
+
+    protected get b2() { return 1 }
+>b2 : number
+>1 : number
+
+    public get b3() { return 1 }
+>b3 : number
+>1 : number
+
+    private get c1() { return 1 }
+>c1 : number
+>1 : number
+
+    private set c1(value) { }
+>c1 : number
+>value : number
+
+    protected get c2() { return 1 }
+>c2 : number
+>1 : number
+
+    protected set c2(value) { }
+>c2 : number
+>value : number
+
+    public get c3() { return 1 }
+>c3 : number
+>1 : number
+
+    public set c3(value) { }
+>c3 : number
+>value : number
+
+    private static readonly s1: number;
+>s1 : number
+
+    protected static readonly s2: number;
+>s2 : number
+
+    public static readonly s3: number;
+>s3 : number
+
+    private static get t1() { return 1 }
+>t1 : number
+>1 : number
+
+    protected static get t2() { return 1 }
+>t2 : number
+>1 : number
+
+    public static get t3() { return 1 }
+>t3 : number
+>1 : number
+
+    private static get u1() { return 1 }
+>u1 : number
+>1 : number
+
+    private static set u1(value) { }
+>u1 : number
+>value : number
+
+    protected static get u2() { return 1 }
+>u2 : number
+>1 : number
+
+    protected static set u2(value) { }
+>u2 : number
+>value : number
+
+    public static get u3() { return 1 }
+>u3 : number
+>1 : number
+
+    public static set u3(value) { }
+>u3 : number
+>value : number
 }
 
 var z: {

--- a/tests/baselines/reference/symbolDeclarationEmit13.js
+++ b/tests/baselines/reference/symbolDeclarationEmit13.js
@@ -13,6 +13,6 @@ class C {
 
 //// [symbolDeclarationEmit13.d.ts]
 declare class C {
-    [Symbol.toPrimitive]: string;
+    readonly [Symbol.toPrimitive]: string;
     [Symbol.toStringTag]: any;
 }

--- a/tests/baselines/reference/symbolDeclarationEmit14.js
+++ b/tests/baselines/reference/symbolDeclarationEmit14.js
@@ -13,6 +13,6 @@ class C {
 
 //// [symbolDeclarationEmit14.d.ts]
 declare class C {
-    [Symbol.toPrimitive]: string;
-    [Symbol.toStringTag]: string;
+    readonly [Symbol.toPrimitive]: string;
+    readonly [Symbol.toStringTag]: string;
 }

--- a/tests/baselines/reference/typeGuardOfFormThisMember.js
+++ b/tests/baselines/reference/typeGuardOfFormThisMember.js
@@ -170,7 +170,7 @@ declare namespace Test {
         path: string;
         isFSO: this is FileSystemObject;
         isFile: this is File;
-        isDirectory: this is Directory;
+        readonly isDirectory: this is Directory;
         isNetworked: this is (Networked & this);
         constructor(path: string);
     }

--- a/tests/baselines/reference/typeGuardOfFormThisMemberErrors.js
+++ b/tests/baselines/reference/typeGuardOfFormThisMemberErrors.js
@@ -95,7 +95,7 @@ declare namespace Test {
         path: string;
         isFSO: this is FileSystemObject;
         isFile: this is File;
-        isDirectory: this is Directory;
+        readonly isDirectory: this is Directory;
         isNetworked: this is (Networked & this);
         constructor(path: string);
     }

--- a/tests/cases/compiler/readonlyInDeclarationFile.ts
+++ b/tests/cases/compiler/readonlyInDeclarationFile.ts
@@ -7,11 +7,31 @@ interface Foo {
 }
 
 class C {
-    protected readonly y: number;
     readonly [x: string]: Object;
-    private static readonly a = "foo"; 
-    protected static readonly b = "foo"; 
-    public static readonly c = "foo"; 
+    private readonly a1: number;
+    protected readonly a2: number;
+    public readonly a3: number;
+    private get b1() { return 1 }
+    protected get b2() { return 1 }
+    public get b3() { return 1 }
+    private get c1() { return 1 }
+    private set c1(value) { }
+    protected get c2() { return 1 }
+    protected set c2(value) { }
+    public get c3() { return 1 }
+    public set c3(value) { }
+    private static readonly s1: number;
+    protected static readonly s2: number;
+    public static readonly s3: number;
+    private static get t1() { return 1 }
+    protected static get t2() { return 1 }
+    public static get t3() { return 1 }
+    private static get u1() { return 1 }
+    private static set u1(value) { }
+    protected static get u2() { return 1 }
+    protected static set u2(value) { }
+    public static get u3() { return 1 }
+    public static set u3(value) { }
 }
 
 var z: {


### PR DESCRIPTION
Augments #6697 to emit `readonly` modifier in declaration file for get-only accessors in classes.