### PR TITLE
unpin mocha version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     },
     "devDependencies": {
         "jake": "latest",
-        "mocha": "2.3.4",
+        "mocha": "latest",
         "chai": "latest",
         "browserify": "latest",
         "istanbul": "latest",


### PR DESCRIPTION
mocha reverted its 'chalk' usage so we can keep using the latest bits