### PR TITLE
Allow parsing TS-style generics in JSDoc

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5734,15 +5734,21 @@ namespace ts {
                 const result = <JSDocTypeReference>createNode(SyntaxKind.JSDocTypeReference);
                 result.name = parseSimplePropertyName();
 
-                while (parseOptional(SyntaxKind.DotToken)) {
-                    if (token === SyntaxKind.LessThanToken) {
-                        result.typeArguments = parseTypeArguments();
-                        break;
-                    }
-                    else {
-                        result.name = parseQualifiedName(result.name);
+                if (token === SyntaxKind.LessThanToken) {
+                    result.typeArguments = parseTypeArguments();
+                }
+                else {
+                    while (parseOptional(SyntaxKind.DotToken)) {
+                        if (token === SyntaxKind.LessThanToken) {
+                            result.typeArguments = parseTypeArguments();
+                            break;
+                        }
+                        else {
+                            result.name = parseQualifiedName(result.name);
+                        }
                     }
                 }
+
 
                 return finishNode(result);
             }

--- a/tests/cases/fourslash/jsDocGenerics1.ts
+++ b/tests/cases/fourslash/jsDocGenerics1.ts
@@ -1,0 +1,10 @@
+///<reference path="fourslash.ts" />
+
+// @allowNonTsExtensions: true
+// @Filename: Foo.js
+//// /** @type {Array<number>} */
+//// var v;
+//// v[0]./**/
+
+goTo.marker();
+verify.memberListContains("toFixed", /*displayText:*/ undefined, /*documentation*/ undefined, "method");

--- a/tests/cases/fourslash/jsDocGenerics1.ts
+++ b/tests/cases/fourslash/jsDocGenerics1.ts
@@ -1,10 +1,34 @@
 ///<reference path="fourslash.ts" />
 
 // @allowNonTsExtensions: true
+// @Filename: ref.d.ts
+//// namespace Thing {
+////     export interface Thung {
+////         a: number;
+////     ]
+//// ]
+
+
 // @Filename: Foo.js
+////
 //// /** @type {Array<number>} */
 //// var v;
-//// v[0]./**/
+//// v[0]./*1*/
+////
+//// /** @type {{x: Array<Array<number>>}} */
+//// var w;
+//// w.x[0][0]./*2*/
+////
+//// /** @type {Array<Thing.Thung>} */
+//// var x;
+//// x[0].a./*3*/
 
-goTo.marker();
+
+goTo.marker('1');
+verify.memberListContains("toFixed", /*displayText:*/ undefined, /*documentation*/ undefined, "method");
+
+goTo.marker('2');
+verify.memberListContains("toFixed", /*displayText:*/ undefined, /*documentation*/ undefined, "method");
+
+goTo.marker('3');
 verify.memberListContains("toFixed", /*displayText:*/ undefined, /*documentation*/ undefined, "method");


### PR DESCRIPTION
Fixes #6814