### PR TITLE
Recognize `=` as equivalent to `?` in JSDoc signatures

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5728,7 +5728,7 @@ namespace ts {
                 const parameter = <ParameterDeclaration>createNode(SyntaxKind.Parameter);
                 parameter.type = parseJSDocType();
                 if (parseOptional(SyntaxKind.EqualsToken)) {
-                    parameter.questionToken = createNode(SyntaxKind.QuestionToken);
+                    parameter.questionToken = createNode(SyntaxKind.EqualsToken);
                 }
                 return finishNode(parameter);
             }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5727,6 +5727,9 @@ namespace ts {
             function parseJSDocParameter(): ParameterDeclaration {
                 const parameter = <ParameterDeclaration>createNode(SyntaxKind.Parameter);
                 parameter.type = parseJSDocType();
+                if (parseOptional(SyntaxKind.EqualsToken)) {
+                    parameter.questionToken = createNode(SyntaxKind.QuestionToken);
+                }
                 return finishNode(parameter);
             }
 

--- a/tests/cases/fourslash/jsDocFunctionSignatures2.ts
+++ b/tests/cases/fourslash/jsDocFunctionSignatures2.ts
@@ -1,0 +1,12 @@
+///<reference path="fourslash.ts" />
+
+// @allowNonTsExtensions: true
+// @Filename: Foo.js
+
+//// /** @type {function(string, boolean=): number} */
+//// var f6;
+//// 
+//// f6('', /**/false)
+
+goTo.marker();
+verify.currentSignatureHelpIs('f6(p0: string, p1?: boolean): number')


### PR DESCRIPTION
Fixes #6811