### PR TITLE
fix issue #6861, ignore hidden files by default

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -523,6 +523,11 @@ namespace ts {
                 for (const extension of supportedExtensions) {
                     const filesInDirWithExtension = host.readDirectory(basePath, extension, exclude);
                     for (const fileName of filesInDirWithExtension) {
+                        // skip hidden file on unixy platform
+                        if (isHiddenFile(fileName)) {
+                            continue;
+                        }
+
                         // .ts extension would read the .d.ts extension files too but since .d.ts is lower priority extension,
                         // lets pick them when its turn comes up
                         if (extension === ".ts" && fileExtensionIs(fileName, ".d.ts")) {

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -769,6 +769,10 @@ namespace ts {
         return pathLen > extLen && path.substr(pathLen - extLen, extLen) === extension;
     }
 
+    export function isHiddenFile(path: string): boolean {
+        return getBaseFileName(path)[0] === ".";
+    }
+
     /**
      *  List of supported extensions in order of file resolution precedence.
      */
@@ -781,7 +785,7 @@ namespace ts {
     }
 
     export function isSupportedSourceFileName(fileName: string, compilerOptions?: CompilerOptions) {
-        if (!fileName) { return false; }
+        if (!fileName || isHiddenFile(fileName)) { return false; }
 
         for (const extension of getSupportedExtensions(compilerOptions)) {
             if (fileExtensionIs(fileName, extension)) {


### PR DESCRIPTION
Fix #6861 

I'm new to TypeScript compiler, please forgive my ignorance.

There are two places I modified: finding files when tsc start and detecting file changes.

`isHiddenFile` is currently unixy only. I don't think the same logic applies on windows.