### PR TITLE
propagate back assignments to block scoped binding from the loop body

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -287,6 +287,54 @@ namespace ts {
         _i        = 0x10000000,  // Use/preference flag for '_i'
     }
 
+    const enum CopyDirection {
+        ToOriginal,
+        ToOutParameter
+    }
+
+    /**
+     * If loop contains block scoped binding captured in some function then loop body is converted to a function.
+     * Lexical bindings declared in loop initializer will be passed into the loop body function as parameters,
+     * however if this binding is modified inside the body - this new value should be propagated back to the original binding.
+     * This is done by declaring new variable (out parameter holder) outside of the loop for every binding that is reassigned inside the body. 
+     * On every iteration this variable is initialized with value of corresponding binding.
+     * At every point where control flow leaves the loop either explicitly (break/continue) or implicitly (at the end of loop body)
+     * we copy the value inside the loop to the out parameter holder.
+     * 
+     * for (let x;;) {
+     *     let a = 1;
+     *     let b = () => a;
+     *     x++
+     *     if (...) break;
+     *     ...
+     * }
+     * 
+     * will be converted to
+     * 
+     * var out_x;
+     * var loop = function(x) {
+     *     var a = 1;
+     *     var b = function() { return a; }
+     *     x++;
+     *     if (...) return out_x = x, "break";
+     *     ...
+     *     out_x = x;
+     * }
+     * for (var x;;) {
+     *     out_x = x;
+     *     var state = loop(x);
+     *     x = out_x;
+     *     if (state === "break") break;
+     * }
+     * 
+     * NOTE: values to out parameters are not copies if loop is abrupted with 'return' - in this case this will end the entire enclosing function
+     * so nobody can observe this new value.
+     */
+    interface LoopOutParameter {
+        originalName: Identifier;
+        outParamName: string;
+    }
+
     // targetSourceFile is when users only want one file in entire project to be emitted. This is used in compileOnSave feature
     export function emitFiles(resolver: EmitResolver, host: EmitHost, targetSourceFile: SourceFile): EmitResult {
         // emit output for the __extends helper function
@@ -419,6 +467,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
              * for (var x;;) loop(x);
              */
             hoistedLocalVariables?: Identifier[];
+
+            /**
+             * List of loop out parameters - detailed descripion can be found in the comment to LoopOutParameter
+             */
+            loopOutParameters?: LoopOutParameter[];
         }
 
         function setLabeledJump(state: ConvertedLoopState, isBreak: boolean, labelText: string, labelMarker: string): void {
@@ -2968,11 +3021,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 }
 
                 let loopParameters: string[];
+                let loopOutParameters: LoopOutParameter[];
                 if (loopInitializer && (getCombinedNodeFlags(loopInitializer) & NodeFlags.BlockScoped)) {
                     // if loop initializer contains block scoped variables - they should be passed to converted loop body as parameters
                     loopParameters = [];
                     for (const varDeclaration of loopInitializer.declarations) {
-                        collectNames(varDeclaration.name);
+                        processVariableDeclaration(varDeclaration.name);
                     }
                 }
 
@@ -2982,14 +3036,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 writeLine();
                 write(`var ${functionName} = function(${paramList})`);
 
-                if (!bodyIsBlock) {
-                    write(" {");
-                    writeLine();
-                    increaseIndent();
-                }
-
                 const convertedOuterLoopState = convertedLoopState;
-                convertedLoopState = {};
+                convertedLoopState = { loopOutParameters };
 
                 if (convertedOuterLoopState) {
                     // convertedOuterLoopState !== undefined means that this converted loop is nested in another converted loop.
@@ -3013,16 +3061,38 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     }
                 }
 
-                emitEmbeddedStatement(node.statement);
+                write(" {");
+                writeLine();
+                increaseIndent();
 
-                if (!bodyIsBlock) {
-                    decreaseIndent();
-                    writeLine();
-                    write("}");
+                if (bodyIsBlock) {
+                    emitLines((<Block>node.statement).statements);
                 }
-                write(";");
+                else {
+                    emit(node.statement);
+                }
+
+                writeLine();
+                // end of loop body -> copy out parameter 
+                copyLoopOutParameters(convertedLoopState, CopyDirection.ToOutParameter, /*emitAsStatements*/true);
+
+                decreaseIndent();
+                writeLine();
+                write("};");
                 writeLine();
 
+                if (loopOutParameters) {
+                    // declare variables to hold out params for loop body
+                    write(`var `);
+                    for (let i = 0; i < loopOutParameters.length; i++) {
+                        if (i !== 0) {
+                            write(", ");
+                        }
+                        write(loopOutParameters[i].outParamName);
+                    }
+                    write(";");
+                    writeLine();
+                }
                 if (convertedLoopState.argumentsName) {
                     // if alias for arguments is set
                     if (convertedOuterLoopState) {
@@ -3086,14 +3156,21 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 
                 return { functionName, paramList, state: currentLoopState };
 
-                function collectNames(name: Identifier | BindingPattern): void {
+                function processVariableDeclaration(name: Identifier | BindingPattern): void {
                     if (name.kind === SyntaxKind.Identifier) {
-                        const nameText = isNameOfNestedBlockScopedRedeclarationOrCapturedBinding(<Identifier>name) ? getGeneratedNameForNode(name) : (<Identifier>name).text;
+                        const nameText = isNameOfNestedBlockScopedRedeclarationOrCapturedBinding(<Identifier>name)
+                            ? getGeneratedNameForNode(name)
+                            : (<Identifier>name).text;
+
                         loopParameters.push(nameText);
+                        if (resolver.getNodeCheckFlags(name.parent) & NodeCheckFlags.NeedsLoopOutParameter) {
+                            const reassignedVariable = { originalName: <Identifier>name, outParamName: makeUniqueName(`out_${nameText}`) };
+                            (loopOutParameters || (loopOutParameters = [])).push(reassignedVariable);
+                        }
                     }
                     else {
                         for (const element of (<BindingPattern>name).elements) {
-                            collectNames(element.name);
+                            processVariableDeclaration(element.name);
                         }
                     }
                 }
@@ -3124,6 +3201,28 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 }
             }
 
+            function copyLoopOutParameters(state: ConvertedLoopState, copyDirection: CopyDirection, emitAsStatements: boolean) {
+                if (state.loopOutParameters) {
+                    for (const outParam of state.loopOutParameters) {
+                        if (copyDirection === CopyDirection.ToOriginal) {
+                            emitIdentifier(outParam.originalName);
+                            write(` = ${outParam.outParamName}`);
+                        }
+                        else {
+                            write(`${outParam.outParamName} = `);
+                            emitIdentifier(outParam.originalName);
+                        }
+                        if (emitAsStatements) {
+                            write(";");
+                            writeLine();
+                        }
+                        else {
+                            write(", ");
+                        }
+                    }
+                }
+            }
+
             function emitConvertedLoopCall(loop: ConvertedLoop, emitAsBlock: boolean): void {
                 if (emitAsBlock) {
                     write(" {");
@@ -3138,12 +3237,18 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     !loop.state.labeledNonLocalBreaks &&
                     !loop.state.labeledNonLocalContinues;
 
+                copyLoopOutParameters(loop.state, CopyDirection.ToOutParameter, /*emitAsStatements*/ true);
+                writeLine();
+
                 const loopResult = makeUniqueName("state");
                 if (!isSimpleLoop) {
                     write(`var ${loopResult} = `);
                 }
 
                 write(`${loop.functionName}(${loop.paramList});`);
+                writeLine();
+
+                copyLoopOutParameters(loop.state, CopyDirection.ToOriginal, /*emitAsStatements*/ true);
 
                 if (!isSimpleLoop) {
                     // for non simple loops we need to store result returned from converted loop function and use it to do dispatching
@@ -3463,14 +3568,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                         (!node.label && (convertedLoopState.allowedNonLabeledJumps & jump));
 
                     if (!canUseBreakOrContinue) {
+                        write ("return ");
+                        // explicit exit from loop -> copy out parameters
+                        copyLoopOutParameters(convertedLoopState, CopyDirection.ToOutParameter, /*emitAsStatements*/ false);
                         if (!node.label) {
                             if (node.kind === SyntaxKind.BreakStatement) {
                                 convertedLoopState.nonLocalJumps |= Jump.Break;
-                                write(`return "break";`);
+                                write(`"break";`);
                             }
                             else {
                                 convertedLoopState.nonLocalJumps |= Jump.Continue;
-                                write(`return "continue";`);
+                                write(`"continue";`);
                             }
                         }
                         else {
@@ -3483,7 +3591,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                                 labelMarker = `continue-${node.label.text}`;
                                 setLabeledJump(convertedLoopState, /*isBreak*/ false, node.label.text, labelMarker);
                             }
-                            write(`return "${labelMarker}";`);
+                            write(`"${labelMarker}";`);
                         }
 
                         return;

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -3237,9 +3237,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     !loop.state.labeledNonLocalBreaks &&
                     !loop.state.labeledNonLocalContinues;
 
-                copyLoopOutParameters(loop.state, CopyDirection.ToOutParameter, /*emitAsStatements*/ true);
-                writeLine();
-
                 const loopResult = makeUniqueName("state");
                 if (!isSimpleLoop) {
                     write(`var ${loopResult} = `);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2044,6 +2044,7 @@ namespace ts {
         HasSeenSuperCall                    = 0x00080000, // Set during the binding when encounter 'super'
         ClassWithBodyScopedClassBinding     = 0x00100000, // Decorated class that contains a binding to itself inside of the class body.
         BodyScopedClassBinding              = 0x00200000, // Binding to a decorated class inside of the class's body.
+        NeedsLoopOutParameter               = 0x00400000, // Block scoped binding whose value should be explicitly copied outside of the converted loop
     }
 
     /* @internal */

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop1.js
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop1.js
@@ -1,0 +1,23 @@
+//// [blockScopedBindingsReassignedInLoop1.ts]
+declare function use(n: number): void;
+(function () {
+  'use strict'
+  for (let i = 0; i < 9; ++i) {
+    (() => use(++i))();
+  }
+})();
+
+//// [blockScopedBindingsReassignedInLoop1.js]
+(function () {
+    'use strict';
+    var _loop_1 = function(i) {
+        (function () { return use(++i); })();
+        out_i_1 = i;
+    };
+    var out_i_1;
+    for (var i = 0; i < 9; ++i) {
+        out_i_1 = i;
+        _loop_1(i);
+        i = out_i_1;
+    }
+})();

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop1.js
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop1.js
@@ -16,7 +16,6 @@ declare function use(n: number): void;
     };
     var out_i_1;
     for (var i = 0; i < 9; ++i) {
-        out_i_1 = i;
         _loop_1(i);
         i = out_i_1;
     }

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop1.symbols
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop1.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/blockScopedBindingsReassignedInLoop1.ts ===
+declare function use(n: number): void;
+>use : Symbol(use, Decl(blockScopedBindingsReassignedInLoop1.ts, 0, 0))
+>n : Symbol(n, Decl(blockScopedBindingsReassignedInLoop1.ts, 0, 21))
+
+(function () {
+  'use strict'
+  for (let i = 0; i < 9; ++i) {
+>i : Symbol(i, Decl(blockScopedBindingsReassignedInLoop1.ts, 3, 10))
+>i : Symbol(i, Decl(blockScopedBindingsReassignedInLoop1.ts, 3, 10))
+>i : Symbol(i, Decl(blockScopedBindingsReassignedInLoop1.ts, 3, 10))
+
+    (() => use(++i))();
+>use : Symbol(use, Decl(blockScopedBindingsReassignedInLoop1.ts, 0, 0))
+>i : Symbol(i, Decl(blockScopedBindingsReassignedInLoop1.ts, 3, 10))
+  }
+})();

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop1.types
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop1.types
@@ -1,0 +1,32 @@
+=== tests/cases/compiler/blockScopedBindingsReassignedInLoop1.ts ===
+declare function use(n: number): void;
+>use : (n: number) => void
+>n : number
+
+(function () {
+>(function () {  'use strict'  for (let i = 0; i < 9; ++i) {    (() => use(++i))();  }})() : void
+>(function () {  'use strict'  for (let i = 0; i < 9; ++i) {    (() => use(++i))();  }}) : () => void
+>function () {  'use strict'  for (let i = 0; i < 9; ++i) {    (() => use(++i))();  }} : () => void
+
+  'use strict'
+>'use strict' : string
+
+  for (let i = 0; i < 9; ++i) {
+>i : number
+>0 : number
+>i < 9 : boolean
+>i : number
+>9 : number
+>++i : number
+>i : number
+
+    (() => use(++i))();
+>(() => use(++i))() : void
+>(() => use(++i)) : () => void
+>() => use(++i) : () => void
+>use(++i) : void
+>use : (n: number) => void
+>++i : number
+>i : number
+  }
+})();

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop2.js
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop2.js
@@ -55,8 +55,6 @@ var _loop_1 = function(x, y) {
 };
 var out_x_1, out_y_1;
 for (var x = 1, y = 2; x < y; ++x, --y) {
-    out_x_1 = x;
-    out_y_1 = y;
     var state_1 = _loop_1(x, y);
     x = out_x_1;
     y = out_y_1;
@@ -75,8 +73,6 @@ var _loop_2 = function(x, y) {
 };
 var out_x_2, out_y_2;
 for (var x = 1, y = 2; x < y; ++x, --y) {
-    out_x_2 = x;
-    out_y_2 = y;
     var state_2 = _loop_2(x, y);
     x = out_x_2;
     y = out_y_2;
@@ -95,8 +91,6 @@ var _loop_3 = function(x, y) {
 };
 var out_x_3, out_y_3;
 loop: for (var x = 1, y = 2; x < y; ++x, --y) {
-    out_x_3 = x;
-    out_y_3 = y;
     var state_3 = _loop_3(x, y);
     x = out_x_3;
     y = out_y_3;
@@ -117,8 +111,6 @@ var _loop_4 = function(x, y) {
 };
 var out_x_4, out_y_4;
 loop: for (var x = 1, y = 2; x < y; ++x, --y) {
-    out_x_4 = x;
-    out_y_4 = y;
     var state_4 = _loop_4(x, y);
     x = out_x_4;
     y = out_y_4;

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop2.js
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop2.js
@@ -1,0 +1,128 @@
+//// [blockScopedBindingsReassignedInLoop2.ts]
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) {
+        break;
+    }
+    else {
+        y = 5;
+    }
+}
+
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) {
+        continue;
+    }
+    else {
+        y = 5;
+    }
+}
+
+loop:
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) {
+        break loop;
+    }
+    else {
+        y = 5;
+    }
+}
+
+loop:
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) {
+        continue loop;
+    }
+    else {
+        y = 5;
+    }
+}
+
+//// [blockScopedBindingsReassignedInLoop2.js]
+var _loop_1 = function(x, y) {
+    var a = function () { return x++ + y++; };
+    if (x == 1) {
+        return out_x_1 = x, out_y_1 = y, "break";
+    }
+    else {
+        y = 5;
+    }
+    out_x_1 = x;
+    out_y_1 = y;
+};
+var out_x_1, out_y_1;
+for (var x = 1, y = 2; x < y; ++x, --y) {
+    out_x_1 = x;
+    out_y_1 = y;
+    var state_1 = _loop_1(x, y);
+    x = out_x_1;
+    y = out_y_1;
+    if (state_1 === "break") break;
+}
+var _loop_2 = function(x, y) {
+    var a = function () { return x++ + y++; };
+    if (x == 1) {
+        return out_x_2 = x, out_y_2 = y, "continue";
+    }
+    else {
+        y = 5;
+    }
+    out_x_2 = x;
+    out_y_2 = y;
+};
+var out_x_2, out_y_2;
+for (var x = 1, y = 2; x < y; ++x, --y) {
+    out_x_2 = x;
+    out_y_2 = y;
+    var state_2 = _loop_2(x, y);
+    x = out_x_2;
+    y = out_y_2;
+    if (state_2 === "continue") continue;
+}
+var _loop_3 = function(x, y) {
+    var a = function () { return x++ + y++; };
+    if (x == 1) {
+        return out_x_3 = x, out_y_3 = y, "break-loop";
+    }
+    else {
+        y = 5;
+    }
+    out_x_3 = x;
+    out_y_3 = y;
+};
+var out_x_3, out_y_3;
+loop: for (var x = 1, y = 2; x < y; ++x, --y) {
+    out_x_3 = x;
+    out_y_3 = y;
+    var state_3 = _loop_3(x, y);
+    x = out_x_3;
+    y = out_y_3;
+    switch(state_3) {
+        case "break-loop": break loop;
+    }
+}
+var _loop_4 = function(x, y) {
+    var a = function () { return x++ + y++; };
+    if (x == 1) {
+        return out_x_4 = x, out_y_4 = y, "continue-loop";
+    }
+    else {
+        y = 5;
+    }
+    out_x_4 = x;
+    out_y_4 = y;
+};
+var out_x_4, out_y_4;
+loop: for (var x = 1, y = 2; x < y; ++x, --y) {
+    out_x_4 = x;
+    out_y_4 = y;
+    var state_4 = _loop_4(x, y);
+    x = out_x_4;
+    y = out_y_4;
+    switch(state_4) {
+        case "continue-loop": continue loop;
+    }
+}

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop2.symbols
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop2.symbols
@@ -1,0 +1,98 @@
+=== tests/cases/compiler/blockScopedBindingsReassignedInLoop2.ts ===
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 0, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 0, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 0, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 0, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 0, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 0, 15))
+
+    let a = () => x++ + y++;
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop2.ts, 1, 7))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 0, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 0, 15))
+
+    if (x == 1) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 0, 8))
+
+        break;
+    }
+    else {
+        y = 5;
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 0, 15))
+    }
+}
+
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 10, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 10, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 10, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 10, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 10, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 10, 15))
+
+    let a = () => x++ + y++;
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop2.ts, 11, 7))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 10, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 10, 15))
+
+    if (x == 1) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 10, 8))
+
+        continue;
+    }
+    else {
+        y = 5;
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 10, 15))
+    }
+}
+
+loop:
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 21, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 21, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 21, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 21, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 21, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 21, 15))
+
+    let a = () => x++ + y++;
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop2.ts, 22, 7))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 21, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 21, 15))
+
+    if (x == 1) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 21, 8))
+
+        break loop;
+    }
+    else {
+        y = 5;
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 21, 15))
+    }
+}
+
+loop:
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 32, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 32, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 32, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 32, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 32, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 32, 15))
+
+    let a = () => x++ + y++;
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop2.ts, 33, 7))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 32, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 32, 15))
+
+    if (x == 1) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop2.ts, 32, 8))
+
+        continue loop;
+    }
+    else {
+        y = 5;
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop2.ts, 32, 15))
+    }
+}

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop2.types
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop2.types
@@ -1,0 +1,160 @@
+=== tests/cases/compiler/blockScopedBindingsReassignedInLoop2.ts ===
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : number
+>1 : number
+>y : number
+>2 : number
+>x < y : boolean
+>x : number
+>y : number
+>++x, --y : number
+>++x : number
+>x : number
+>--y : number
+>y : number
+
+    let a = () => x++ + y++;
+>a : () => number
+>() => x++ + y++ : () => number
+>x++ + y++ : number
+>x++ : number
+>x : number
+>y++ : number
+>y : number
+
+    if (x == 1) {
+>x == 1 : boolean
+>x : number
+>1 : number
+
+        break;
+    }
+    else {
+        y = 5;
+>y = 5 : number
+>y : number
+>5 : number
+    }
+}
+
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : number
+>1 : number
+>y : number
+>2 : number
+>x < y : boolean
+>x : number
+>y : number
+>++x, --y : number
+>++x : number
+>x : number
+>--y : number
+>y : number
+
+    let a = () => x++ + y++;
+>a : () => number
+>() => x++ + y++ : () => number
+>x++ + y++ : number
+>x++ : number
+>x : number
+>y++ : number
+>y : number
+
+    if (x == 1) {
+>x == 1 : boolean
+>x : number
+>1 : number
+
+        continue;
+    }
+    else {
+        y = 5;
+>y = 5 : number
+>y : number
+>5 : number
+    }
+}
+
+loop:
+>loop : any
+
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : number
+>1 : number
+>y : number
+>2 : number
+>x < y : boolean
+>x : number
+>y : number
+>++x, --y : number
+>++x : number
+>x : number
+>--y : number
+>y : number
+
+    let a = () => x++ + y++;
+>a : () => number
+>() => x++ + y++ : () => number
+>x++ + y++ : number
+>x++ : number
+>x : number
+>y++ : number
+>y : number
+
+    if (x == 1) {
+>x == 1 : boolean
+>x : number
+>1 : number
+
+        break loop;
+>loop : any
+    }
+    else {
+        y = 5;
+>y = 5 : number
+>y : number
+>5 : number
+    }
+}
+
+loop:
+>loop : any
+
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : number
+>1 : number
+>y : number
+>2 : number
+>x < y : boolean
+>x : number
+>y : number
+>++x, --y : number
+>++x : number
+>x : number
+>--y : number
+>y : number
+
+    let a = () => x++ + y++;
+>a : () => number
+>() => x++ + y++ : () => number
+>x++ + y++ : number
+>x++ : number
+>x : number
+>y++ : number
+>y : number
+
+    if (x == 1) {
+>x == 1 : boolean
+>x : number
+>1 : number
+
+        continue loop;
+>loop : any
+    }
+    else {
+        y = 5;
+>y = 5 : number
+>y : number
+>5 : number
+    }
+}

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop3.js
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop3.js
@@ -112,7 +112,6 @@ var _loop_1 = function(x, y) {
         };
         var out_a_1_1;
         for (var a_1 = 1; a_1 < 5; --a_1) {
-            out_a_1_1 = a_1;
             var state_1 = _loop_2(a_1);
             a_1 = out_a_1_1;
             if (state_1 === "break") break;
@@ -124,8 +123,6 @@ var _loop_1 = function(x, y) {
 };
 var out_x_1, out_y_1;
 for (var x = 1, y = 2; x < y; ++x, --y) {
-    out_x_1 = x;
-    out_y_1 = y;
     var state_2 = _loop_1(x, y);
     x = out_x_1;
     y = out_y_1;
@@ -150,7 +147,6 @@ var _loop_3 = function(x, y) {
         };
         var out_a_2_1;
         for (var a_2 = 1; a_2 < 5; --a_2) {
-            out_a_2_1 = a_2;
             var state_3 = _loop_4(a_2);
             a_2 = out_a_2_1;
             if (state_3 === "continue") continue;
@@ -162,8 +158,6 @@ var _loop_3 = function(x, y) {
 };
 var out_x_2, out_y_2;
 for (var x = 1, y = 2; x < y; ++x, --y) {
-    out_x_2 = x;
-    out_y_2 = y;
     var state_4 = _loop_3(x, y);
     x = out_x_2;
     y = out_y_2;
@@ -189,7 +183,6 @@ var _loop_5 = function(x, y) {
         };
         var out_a_3_1;
         loop1: for (var a_3 = 1; a_3 < 5; --a_3) {
-            out_a_3_1 = a_3;
             var state_5 = _loop_6(a_3);
             a_3 = out_a_3_1;
             switch(state_5) {
@@ -204,8 +197,6 @@ var _loop_5 = function(x, y) {
 };
 var out_x_3, out_y_3;
 loop2: for (var x = 1, y = 2; x < y; ++x, --y) {
-    out_x_3 = x;
-    out_y_3 = y;
     var state_6 = _loop_5(x, y);
     x = out_x_3;
     y = out_y_3;
@@ -233,7 +224,6 @@ var _loop_7 = function(x, y) {
         };
         var out_a_4_1;
         loop1: for (var a_4 = 1; a_4 < 5; --a_4) {
-            out_a_4_1 = a_4;
             var state_7 = _loop_8(a_4);
             a_4 = out_a_4_1;
             switch(state_7) {
@@ -248,8 +238,6 @@ var _loop_7 = function(x, y) {
 };
 var out_x_4, out_y_4;
 loop2: for (var x = 1, y = 2; x < y; ++x, --y) {
-    out_x_4 = x;
-    out_y_4 = y;
     var state_8 = _loop_7(x, y);
     x = out_x_4;
     y = out_y_4;

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop3.js
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop3.js
@@ -1,0 +1,259 @@
+//// [blockScopedBindingsReassignedInLoop3.ts]
+
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) {
+        break;
+    }
+    else {
+        for (let a = 1; a < 5; --a) {
+            let f = () => a;
+            if (a) {
+                a = x;
+                break;
+            }
+            else {
+                y++;
+            }
+        }
+        
+        y = 5;
+    }
+}
+
+
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) {
+        continue;
+    }
+    else {
+        for (let a = 1; a < 5; --a) {
+            let f = () => a;
+            if (a) {
+                a = x;
+                continue;
+            }
+            else {
+                y++;
+            }
+        }
+        
+        y = 5;
+    }
+}
+
+loop2:
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) {
+        break loop2;
+    }
+    else {
+        loop1:
+        for (let a = 1; a < 5; --a) {
+            let f = () => a;
+            if (a) {
+                a = x;
+                break loop1;
+            }
+            else {
+                y++;
+                break loop2
+            }
+        }
+        
+        y = 5;
+    }
+}
+
+loop2:
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) {
+        continue loop2;
+    }
+    else {
+        loop1:
+        for (let a = 1; a < 5; --a) {
+            let f = () => a;
+            if (a) {
+                a = x;
+                continue loop1;
+            }
+            else {
+                y++;
+                continue loop2
+            }
+        }
+        
+        y = 5;
+    }
+}
+
+
+//// [blockScopedBindingsReassignedInLoop3.js]
+var _loop_1 = function(x, y) {
+    var a = function () { return x++ + y++; };
+    if (x == 1) {
+        return out_x_1 = x, out_y_1 = y, "break";
+    }
+    else {
+        var _loop_2 = function(a_1) {
+            var f = function () { return a_1; };
+            if (a_1) {
+                a_1 = x;
+                return out_a_1_1 = a_1, "break";
+            }
+            else {
+                y++;
+            }
+            out_a_1_1 = a_1;
+        };
+        var out_a_1_1;
+        for (var a_1 = 1; a_1 < 5; --a_1) {
+            out_a_1_1 = a_1;
+            var state_1 = _loop_2(a_1);
+            a_1 = out_a_1_1;
+            if (state_1 === "break") break;
+        }
+        y = 5;
+    }
+    out_x_1 = x;
+    out_y_1 = y;
+};
+var out_x_1, out_y_1;
+for (var x = 1, y = 2; x < y; ++x, --y) {
+    out_x_1 = x;
+    out_y_1 = y;
+    var state_2 = _loop_1(x, y);
+    x = out_x_1;
+    y = out_y_1;
+    if (state_2 === "break") break;
+}
+var _loop_3 = function(x, y) {
+    var a = function () { return x++ + y++; };
+    if (x == 1) {
+        return out_x_2 = x, out_y_2 = y, "continue";
+    }
+    else {
+        var _loop_4 = function(a_2) {
+            var f = function () { return a_2; };
+            if (a_2) {
+                a_2 = x;
+                return out_a_2_1 = a_2, "continue";
+            }
+            else {
+                y++;
+            }
+            out_a_2_1 = a_2;
+        };
+        var out_a_2_1;
+        for (var a_2 = 1; a_2 < 5; --a_2) {
+            out_a_2_1 = a_2;
+            var state_3 = _loop_4(a_2);
+            a_2 = out_a_2_1;
+            if (state_3 === "continue") continue;
+        }
+        y = 5;
+    }
+    out_x_2 = x;
+    out_y_2 = y;
+};
+var out_x_2, out_y_2;
+for (var x = 1, y = 2; x < y; ++x, --y) {
+    out_x_2 = x;
+    out_y_2 = y;
+    var state_4 = _loop_3(x, y);
+    x = out_x_2;
+    y = out_y_2;
+    if (state_4 === "continue") continue;
+}
+var _loop_5 = function(x, y) {
+    var a = function () { return x++ + y++; };
+    if (x == 1) {
+        return out_x_3 = x, out_y_3 = y, "break-loop2";
+    }
+    else {
+        var _loop_6 = function(a_3) {
+            var f = function () { return a_3; };
+            if (a_3) {
+                a_3 = x;
+                return out_a_3_1 = a_3, "break-loop1";
+            }
+            else {
+                y++;
+                return out_a_3_1 = a_3, "break-loop2";
+            }
+            out_a_3_1 = a_3;
+        };
+        var out_a_3_1;
+        loop1: for (var a_3 = 1; a_3 < 5; --a_3) {
+            out_a_3_1 = a_3;
+            var state_5 = _loop_6(a_3);
+            a_3 = out_a_3_1;
+            switch(state_5) {
+                case "break-loop1": break loop1;
+                case "break-loop2": return state_5;
+            }
+        }
+        y = 5;
+    }
+    out_x_3 = x;
+    out_y_3 = y;
+};
+var out_x_3, out_y_3;
+loop2: for (var x = 1, y = 2; x < y; ++x, --y) {
+    out_x_3 = x;
+    out_y_3 = y;
+    var state_6 = _loop_5(x, y);
+    x = out_x_3;
+    y = out_y_3;
+    switch(state_6) {
+        case "break-loop2": break loop2;
+    }
+}
+var _loop_7 = function(x, y) {
+    var a = function () { return x++ + y++; };
+    if (x == 1) {
+        return out_x_4 = x, out_y_4 = y, "continue-loop2";
+    }
+    else {
+        var _loop_8 = function(a_4) {
+            var f = function () { return a_4; };
+            if (a_4) {
+                a_4 = x;
+                return out_a_4_1 = a_4, "continue-loop1";
+            }
+            else {
+                y++;
+                return out_a_4_1 = a_4, "continue-loop2";
+            }
+            out_a_4_1 = a_4;
+        };
+        var out_a_4_1;
+        loop1: for (var a_4 = 1; a_4 < 5; --a_4) {
+            out_a_4_1 = a_4;
+            var state_7 = _loop_8(a_4);
+            a_4 = out_a_4_1;
+            switch(state_7) {
+                case "continue-loop1": continue loop1;
+                case "continue-loop2": return state_7;
+            }
+        }
+        y = 5;
+    }
+    out_x_4 = x;
+    out_y_4 = y;
+};
+var out_x_4, out_y_4;
+loop2: for (var x = 1, y = 2; x < y; ++x, --y) {
+    out_x_4 = x;
+    out_y_4 = y;
+    var state_8 = _loop_7(x, y);
+    x = out_x_4;
+    y = out_y_4;
+    switch(state_8) {
+        case "continue-loop2": continue loop2;
+    }
+}

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop3.symbols
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop3.symbols
@@ -1,0 +1,203 @@
+=== tests/cases/compiler/blockScopedBindingsReassignedInLoop3.ts ===
+
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 1, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 1, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 1, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 1, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 1, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 1, 15))
+
+    let a = () => x++ + y++;
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 2, 7))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 1, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 1, 15))
+
+    if (x == 1) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 1, 8))
+
+        break;
+    }
+    else {
+        for (let a = 1; a < 5; --a) {
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 7, 16))
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 7, 16))
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 7, 16))
+
+            let f = () => a;
+>f : Symbol(f, Decl(blockScopedBindingsReassignedInLoop3.ts, 8, 15))
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 7, 16))
+
+            if (a) {
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 7, 16))
+
+                a = x;
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 7, 16))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 1, 8))
+
+                break;
+            }
+            else {
+                y++;
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 1, 15))
+            }
+        }
+        
+        y = 5;
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 1, 15))
+    }
+}
+
+
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 23, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 23, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 23, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 23, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 23, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 23, 15))
+
+    let a = () => x++ + y++;
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 24, 7))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 23, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 23, 15))
+
+    if (x == 1) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 23, 8))
+
+        continue;
+    }
+    else {
+        for (let a = 1; a < 5; --a) {
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 29, 16))
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 29, 16))
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 29, 16))
+
+            let f = () => a;
+>f : Symbol(f, Decl(blockScopedBindingsReassignedInLoop3.ts, 30, 15))
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 29, 16))
+
+            if (a) {
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 29, 16))
+
+                a = x;
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 29, 16))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 23, 8))
+
+                continue;
+            }
+            else {
+                y++;
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 23, 15))
+            }
+        }
+        
+        y = 5;
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 23, 15))
+    }
+}
+
+loop2:
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 45, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 45, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 45, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 45, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 45, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 45, 15))
+
+    let a = () => x++ + y++;
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 46, 7))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 45, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 45, 15))
+
+    if (x == 1) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 45, 8))
+
+        break loop2;
+    }
+    else {
+        loop1:
+        for (let a = 1; a < 5; --a) {
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 52, 16))
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 52, 16))
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 52, 16))
+
+            let f = () => a;
+>f : Symbol(f, Decl(blockScopedBindingsReassignedInLoop3.ts, 53, 15))
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 52, 16))
+
+            if (a) {
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 52, 16))
+
+                a = x;
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 52, 16))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 45, 8))
+
+                break loop1;
+            }
+            else {
+                y++;
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 45, 15))
+
+                break loop2
+            }
+        }
+        
+        y = 5;
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 45, 15))
+    }
+}
+
+loop2:
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 69, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 69, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 69, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 69, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 69, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 69, 15))
+
+    let a = () => x++ + y++;
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 70, 7))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 69, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 69, 15))
+
+    if (x == 1) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 69, 8))
+
+        continue loop2;
+    }
+    else {
+        loop1:
+        for (let a = 1; a < 5; --a) {
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 76, 16))
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 76, 16))
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 76, 16))
+
+            let f = () => a;
+>f : Symbol(f, Decl(blockScopedBindingsReassignedInLoop3.ts, 77, 15))
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 76, 16))
+
+            if (a) {
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 76, 16))
+
+                a = x;
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop3.ts, 76, 16))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop3.ts, 69, 8))
+
+                continue loop1;
+            }
+            else {
+                y++;
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 69, 15))
+
+                continue loop2
+            }
+        }
+        
+        y = 5;
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop3.ts, 69, 15))
+    }
+}
+

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop3.types
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop3.types
@@ -1,0 +1,301 @@
+=== tests/cases/compiler/blockScopedBindingsReassignedInLoop3.ts ===
+
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : number
+>1 : number
+>y : number
+>2 : number
+>x < y : boolean
+>x : number
+>y : number
+>++x, --y : number
+>++x : number
+>x : number
+>--y : number
+>y : number
+
+    let a = () => x++ + y++;
+>a : () => number
+>() => x++ + y++ : () => number
+>x++ + y++ : number
+>x++ : number
+>x : number
+>y++ : number
+>y : number
+
+    if (x == 1) {
+>x == 1 : boolean
+>x : number
+>1 : number
+
+        break;
+    }
+    else {
+        for (let a = 1; a < 5; --a) {
+>a : number
+>1 : number
+>a < 5 : boolean
+>a : number
+>5 : number
+>--a : number
+>a : number
+
+            let f = () => a;
+>f : () => number
+>() => a : () => number
+>a : number
+
+            if (a) {
+>a : number
+
+                a = x;
+>a = x : number
+>a : number
+>x : number
+
+                break;
+            }
+            else {
+                y++;
+>y++ : number
+>y : number
+            }
+        }
+        
+        y = 5;
+>y = 5 : number
+>y : number
+>5 : number
+    }
+}
+
+
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : number
+>1 : number
+>y : number
+>2 : number
+>x < y : boolean
+>x : number
+>y : number
+>++x, --y : number
+>++x : number
+>x : number
+>--y : number
+>y : number
+
+    let a = () => x++ + y++;
+>a : () => number
+>() => x++ + y++ : () => number
+>x++ + y++ : number
+>x++ : number
+>x : number
+>y++ : number
+>y : number
+
+    if (x == 1) {
+>x == 1 : boolean
+>x : number
+>1 : number
+
+        continue;
+    }
+    else {
+        for (let a = 1; a < 5; --a) {
+>a : number
+>1 : number
+>a < 5 : boolean
+>a : number
+>5 : number
+>--a : number
+>a : number
+
+            let f = () => a;
+>f : () => number
+>() => a : () => number
+>a : number
+
+            if (a) {
+>a : number
+
+                a = x;
+>a = x : number
+>a : number
+>x : number
+
+                continue;
+            }
+            else {
+                y++;
+>y++ : number
+>y : number
+            }
+        }
+        
+        y = 5;
+>y = 5 : number
+>y : number
+>5 : number
+    }
+}
+
+loop2:
+>loop2 : any
+
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : number
+>1 : number
+>y : number
+>2 : number
+>x < y : boolean
+>x : number
+>y : number
+>++x, --y : number
+>++x : number
+>x : number
+>--y : number
+>y : number
+
+    let a = () => x++ + y++;
+>a : () => number
+>() => x++ + y++ : () => number
+>x++ + y++ : number
+>x++ : number
+>x : number
+>y++ : number
+>y : number
+
+    if (x == 1) {
+>x == 1 : boolean
+>x : number
+>1 : number
+
+        break loop2;
+>loop2 : any
+    }
+    else {
+        loop1:
+>loop1 : any
+
+        for (let a = 1; a < 5; --a) {
+>a : number
+>1 : number
+>a < 5 : boolean
+>a : number
+>5 : number
+>--a : number
+>a : number
+
+            let f = () => a;
+>f : () => number
+>() => a : () => number
+>a : number
+
+            if (a) {
+>a : number
+
+                a = x;
+>a = x : number
+>a : number
+>x : number
+
+                break loop1;
+>loop1 : any
+            }
+            else {
+                y++;
+>y++ : number
+>y : number
+
+                break loop2
+>loop2 : any
+            }
+        }
+        
+        y = 5;
+>y = 5 : number
+>y : number
+>5 : number
+    }
+}
+
+loop2:
+>loop2 : any
+
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : number
+>1 : number
+>y : number
+>2 : number
+>x < y : boolean
+>x : number
+>y : number
+>++x, --y : number
+>++x : number
+>x : number
+>--y : number
+>y : number
+
+    let a = () => x++ + y++;
+>a : () => number
+>() => x++ + y++ : () => number
+>x++ + y++ : number
+>x++ : number
+>x : number
+>y++ : number
+>y : number
+
+    if (x == 1) {
+>x == 1 : boolean
+>x : number
+>1 : number
+
+        continue loop2;
+>loop2 : any
+    }
+    else {
+        loop1:
+>loop1 : any
+
+        for (let a = 1; a < 5; --a) {
+>a : number
+>1 : number
+>a < 5 : boolean
+>a : number
+>5 : number
+>--a : number
+>a : number
+
+            let f = () => a;
+>f : () => number
+>() => a : () => number
+>a : number
+
+            if (a) {
+>a : number
+
+                a = x;
+>a = x : number
+>a : number
+>x : number
+
+                continue loop1;
+>loop1 : any
+            }
+            else {
+                y++;
+>y++ : number
+>y : number
+
+                continue loop2
+>loop2 : any
+            }
+        }
+        
+        y = 5;
+>y = 5 : number
+>y : number
+>5 : number
+    }
+}
+

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop4.js
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop4.js
@@ -1,0 +1,36 @@
+//// [blockScopedBindingsReassignedInLoop4.ts]
+function f1() {
+    for (let x = 1, y = 2; x < y; ++x, --y) {
+        let a = () => x++ + y++;
+        if (x == 1) {
+            return 1;
+        }
+        else {
+            y = 5;
+        }
+    }
+}
+
+//// [blockScopedBindingsReassignedInLoop4.js]
+function f1() {
+    var _loop_1 = function(x, y) {
+        var a = function () { return x++ + y++; };
+        if (x == 1) {
+            return { value: 1 };
+        }
+        else {
+            y = 5;
+        }
+        out_x_1 = x;
+        out_y_1 = y;
+    };
+    var out_x_1, out_y_1;
+    for (var x = 1, y = 2; x < y; ++x, --y) {
+        out_x_1 = x;
+        out_y_1 = y;
+        var state_1 = _loop_1(x, y);
+        x = out_x_1;
+        y = out_y_1;
+        if (typeof state_1 === "object") return state_1.value;
+    }
+}

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop4.js
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop4.js
@@ -26,8 +26,6 @@ function f1() {
     };
     var out_x_1, out_y_1;
     for (var x = 1, y = 2; x < y; ++x, --y) {
-        out_x_1 = x;
-        out_y_1 = y;
         var state_1 = _loop_1(x, y);
         x = out_x_1;
         y = out_y_1;

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop4.symbols
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop4.symbols
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/blockScopedBindingsReassignedInLoop4.ts ===
+function f1() {
+>f1 : Symbol(f1, Decl(blockScopedBindingsReassignedInLoop4.ts, 0, 0))
+
+    for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop4.ts, 1, 12))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop4.ts, 1, 19))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop4.ts, 1, 12))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop4.ts, 1, 19))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop4.ts, 1, 12))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop4.ts, 1, 19))
+
+        let a = () => x++ + y++;
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop4.ts, 2, 11))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop4.ts, 1, 12))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop4.ts, 1, 19))
+
+        if (x == 1) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop4.ts, 1, 12))
+
+            return 1;
+        }
+        else {
+            y = 5;
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop4.ts, 1, 19))
+        }
+    }
+}

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop4.types
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop4.types
@@ -1,0 +1,43 @@
+=== tests/cases/compiler/blockScopedBindingsReassignedInLoop4.ts ===
+function f1() {
+>f1 : () => number
+
+    for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : number
+>1 : number
+>y : number
+>2 : number
+>x < y : boolean
+>x : number
+>y : number
+>++x, --y : number
+>++x : number
+>x : number
+>--y : number
+>y : number
+
+        let a = () => x++ + y++;
+>a : () => number
+>() => x++ + y++ : () => number
+>x++ + y++ : number
+>x++ : number
+>x : number
+>y++ : number
+>y : number
+
+        if (x == 1) {
+>x == 1 : boolean
+>x : number
+>1 : number
+
+            return 1;
+>1 : number
+        }
+        else {
+            y = 5;
+>y = 5 : number
+>y : number
+>5 : number
+        }
+    }
+}

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop5.js
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop5.js
@@ -20,8 +20,6 @@ var _loop_1 = function(x, y) {
 };
 var out_x_1, out_y_1;
 for (var x = 1, y = 2; x < y; ++x, --y) {
-    out_x_1 = x;
-    out_y_1 = y;
     var state_1 = _loop_1(x, y);
     x = out_x_1;
     y = out_y_1;

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop5.js
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop5.js
@@ -1,0 +1,29 @@
+//// [blockScopedBindingsReassignedInLoop5.ts]
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) 
+        break;
+    else 
+        y = 5;
+}
+
+
+//// [blockScopedBindingsReassignedInLoop5.js]
+var _loop_1 = function(x, y) {
+    var a = function () { return x++ + y++; };
+    if (x == 1)
+        return out_x_1 = x, out_y_1 = y, "break";
+    else
+        y = 5;
+    out_x_1 = x;
+    out_y_1 = y;
+};
+var out_x_1, out_y_1;
+for (var x = 1, y = 2; x < y; ++x, --y) {
+    out_x_1 = x;
+    out_y_1 = y;
+    var state_1 = _loop_1(x, y);
+    x = out_x_1;
+    y = out_y_1;
+    if (state_1 === "break") break;
+}

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop5.symbols
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop5.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/blockScopedBindingsReassignedInLoop5.ts ===
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop5.ts, 0, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop5.ts, 0, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop5.ts, 0, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop5.ts, 0, 15))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop5.ts, 0, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop5.ts, 0, 15))
+
+    let a = () => x++ + y++;
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop5.ts, 1, 7))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop5.ts, 0, 8))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop5.ts, 0, 15))
+
+    if (x == 1) 
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop5.ts, 0, 8))
+
+        break;
+    else 
+        y = 5;
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop5.ts, 0, 15))
+}
+

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop5.types
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop5.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/blockScopedBindingsReassignedInLoop5.ts ===
+for (let x = 1, y = 2; x < y; ++x, --y) {
+>x : number
+>1 : number
+>y : number
+>2 : number
+>x < y : boolean
+>x : number
+>y : number
+>++x, --y : number
+>++x : number
+>x : number
+>--y : number
+>y : number
+
+    let a = () => x++ + y++;
+>a : () => number
+>() => x++ + y++ : () => number
+>x++ + y++ : number
+>x++ : number
+>x : number
+>y++ : number
+>y : number
+
+    if (x == 1) 
+>x == 1 : boolean
+>x : number
+>1 : number
+
+        break;
+    else 
+        y = 5;
+>y = 5 : number
+>y : number
+>5 : number
+}
+

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop6.js
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop6.js
@@ -1,0 +1,78 @@
+//// [blockScopedBindingsReassignedInLoop6.ts]
+function f1() {
+    for (let [x, y] = [1, 2]; x < y; ++x, --y) {
+        let a = () => x++ + y++;
+        if (x == 1)
+            break;
+        else if (y == 2)
+            y = 5;
+        else
+            return;
+    }
+}
+
+function f2() {
+    for (let [{a: x, b: {c: y}}] = [{a: 1, b: {c: 2}}]; x < y; ++x, --y) {
+        let a = () => x++ + y++;
+        if (x == 1)
+            break;
+        else if (y == 2)
+            y = 5;
+        else
+            return;
+    }
+}
+
+
+
+
+
+
+
+//// [blockScopedBindingsReassignedInLoop6.js]
+function f1() {
+    var _loop_1 = function(x, y) {
+        var a = function () { return x++ + y++; };
+        if (x == 1)
+            return out_x_1 = x, out_y_1 = y, "break";
+        else if (y == 2)
+            y = 5;
+        else
+            return { value: void 0 };
+        out_x_1 = x;
+        out_y_1 = y;
+    };
+    var out_x_1, out_y_1;
+    for (var _a = [1, 2], x = _a[0], y = _a[1]; x < y; ++x, --y) {
+        out_x_1 = x;
+        out_y_1 = y;
+        var state_1 = _loop_1(x, y);
+        x = out_x_1;
+        y = out_y_1;
+        if (typeof state_1 === "object") return state_1.value;
+        if (state_1 === "break") break;
+    }
+}
+function f2() {
+    var _loop_2 = function(x, y) {
+        var a = function () { return x++ + y++; };
+        if (x == 1)
+            return out_x_2 = x, out_y_2 = y, "break";
+        else if (y == 2)
+            y = 5;
+        else
+            return { value: void 0 };
+        out_x_2 = x;
+        out_y_2 = y;
+    };
+    var out_x_2, out_y_2;
+    for (var _a = [{ a: 1, b: { c: 2 } }][0], x = _a.a, y = _a.b.c; x < y; ++x, --y) {
+        out_x_2 = x;
+        out_y_2 = y;
+        var state_2 = _loop_2(x, y);
+        x = out_x_2;
+        y = out_y_2;
+        if (typeof state_2 === "object") return state_2.value;
+        if (state_2 === "break") break;
+    }
+}

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop6.js
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop6.js
@@ -44,8 +44,6 @@ function f1() {
     };
     var out_x_1, out_y_1;
     for (var _a = [1, 2], x = _a[0], y = _a[1]; x < y; ++x, --y) {
-        out_x_1 = x;
-        out_y_1 = y;
         var state_1 = _loop_1(x, y);
         x = out_x_1;
         y = out_y_1;
@@ -67,8 +65,6 @@ function f2() {
     };
     var out_x_2, out_y_2;
     for (var _a = [{ a: 1, b: { c: 2 } }][0], x = _a.a, y = _a.b.c; x < y; ++x, --y) {
-        out_x_2 = x;
-        out_y_2 = y;
         var state_2 = _loop_2(x, y);
         x = out_x_2;
         y = out_y_2;

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop6.symbols
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop6.symbols
@@ -1,0 +1,74 @@
+=== tests/cases/compiler/blockScopedBindingsReassignedInLoop6.ts ===
+function f1() {
+>f1 : Symbol(f1, Decl(blockScopedBindingsReassignedInLoop6.ts, 0, 0))
+
+    for (let [x, y] = [1, 2]; x < y; ++x, --y) {
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop6.ts, 1, 14))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop6.ts, 1, 16))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop6.ts, 1, 14))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop6.ts, 1, 16))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop6.ts, 1, 14))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop6.ts, 1, 16))
+
+        let a = () => x++ + y++;
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop6.ts, 2, 11))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop6.ts, 1, 14))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop6.ts, 1, 16))
+
+        if (x == 1)
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop6.ts, 1, 14))
+
+            break;
+        else if (y == 2)
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop6.ts, 1, 16))
+
+            y = 5;
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop6.ts, 1, 16))
+
+        else
+            return;
+    }
+}
+
+function f2() {
+>f2 : Symbol(f2, Decl(blockScopedBindingsReassignedInLoop6.ts, 10, 1))
+
+    for (let [{a: x, b: {c: y}}] = [{a: 1, b: {c: 2}}]; x < y; ++x, --y) {
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 37))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 15))
+>b : Symbol(b, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 42))
+>c : Symbol(c, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 47))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 25))
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 37))
+>b : Symbol(b, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 42))
+>c : Symbol(c, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 47))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 15))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 25))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 15))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 25))
+
+        let a = () => x++ + y++;
+>a : Symbol(a, Decl(blockScopedBindingsReassignedInLoop6.ts, 14, 11))
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 15))
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 25))
+
+        if (x == 1)
+>x : Symbol(x, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 15))
+
+            break;
+        else if (y == 2)
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 25))
+
+            y = 5;
+>y : Symbol(y, Decl(blockScopedBindingsReassignedInLoop6.ts, 13, 25))
+
+        else
+            return;
+    }
+}
+
+
+
+
+
+

--- a/tests/baselines/reference/blockScopedBindingsReassignedInLoop6.types
+++ b/tests/baselines/reference/blockScopedBindingsReassignedInLoop6.types
@@ -1,0 +1,110 @@
+=== tests/cases/compiler/blockScopedBindingsReassignedInLoop6.ts ===
+function f1() {
+>f1 : () => void
+
+    for (let [x, y] = [1, 2]; x < y; ++x, --y) {
+>x : number
+>y : number
+>[1, 2] : [number, number]
+>1 : number
+>2 : number
+>x < y : boolean
+>x : number
+>y : number
+>++x, --y : number
+>++x : number
+>x : number
+>--y : number
+>y : number
+
+        let a = () => x++ + y++;
+>a : () => number
+>() => x++ + y++ : () => number
+>x++ + y++ : number
+>x++ : number
+>x : number
+>y++ : number
+>y : number
+
+        if (x == 1)
+>x == 1 : boolean
+>x : number
+>1 : number
+
+            break;
+        else if (y == 2)
+>y == 2 : boolean
+>y : number
+>2 : number
+
+            y = 5;
+>y = 5 : number
+>y : number
+>5 : number
+
+        else
+            return;
+    }
+}
+
+function f2() {
+>f2 : () => void
+
+    for (let [{a: x, b: {c: y}}] = [{a: 1, b: {c: 2}}]; x < y; ++x, --y) {
+>a : any
+>x : number
+>b : any
+>c : any
+>y : number
+>[{a: 1, b: {c: 2}}] : [{ a: number; b: { c: number; }; }]
+>{a: 1, b: {c: 2}} : { a: number; b: { c: number; }; }
+>a : number
+>1 : number
+>b : { c: number; }
+>{c: 2} : { c: number; }
+>c : number
+>2 : number
+>x < y : boolean
+>x : number
+>y : number
+>++x, --y : number
+>++x : number
+>x : number
+>--y : number
+>y : number
+
+        let a = () => x++ + y++;
+>a : () => number
+>() => x++ + y++ : () => number
+>x++ + y++ : number
+>x++ : number
+>x : number
+>y++ : number
+>y : number
+
+        if (x == 1)
+>x == 1 : boolean
+>x : number
+>1 : number
+
+            break;
+        else if (y == 2)
+>y == 2 : boolean
+>y : number
+>2 : number
+
+            y = 5;
+>y = 5 : number
+>y : number
+>5 : number
+
+        else
+            return;
+    }
+}
+
+
+
+
+
+

--- a/tests/baselines/reference/nestedBlockScopedBindings3.js
+++ b/tests/baselines/reference/nestedBlockScopedBindings3.js
@@ -127,7 +127,6 @@ function a4() {
     };
     var out_x_1;
     for (var x = void 0; x < 1;) {
-        out_x_1 = x;
         _loop_5(x);
         x = out_x_1;
     }
@@ -145,7 +144,6 @@ function a5() {
     };
     var out_x_2;
     for (var x = void 0; x < 1;) {
-        out_x_2 = x;
         _loop_6(x);
         x = out_x_2;
     }

--- a/tests/baselines/reference/nestedBlockScopedBindings3.js
+++ b/tests/baselines/reference/nestedBlockScopedBindings3.js
@@ -123,9 +123,13 @@ function a4() {
     var _loop_5 = function(x) {
         x = x + 1;
         (function () { return x; });
+        out_x_1 = x;
     };
+    var out_x_1;
     for (var x = void 0; x < 1;) {
+        out_x_1 = x;
         _loop_5(x);
+        x = out_x_1;
     }
     switch (1) {
         case 1:
@@ -137,9 +141,13 @@ function a5() {
     var _loop_6 = function(x) {
         x = x + 1;
         (function () { return x; });
+        out_x_2 = x;
     };
+    var out_x_2;
     for (var x = void 0; x < 1;) {
+        out_x_2 = x;
         _loop_6(x);
+        x = out_x_2;
     }
     switch (1) {
         case 1:

--- a/tests/baselines/reference/nestedBlockScopedBindings4.js
+++ b/tests/baselines/reference/nestedBlockScopedBindings4.js
@@ -57,7 +57,6 @@ function a1() {
     };
     var out_x_1;
     for (var x = void 0; x < 1;) {
-        out_x_1 = x;
         _loop_1(x);
         x = out_x_1;
     }
@@ -76,7 +75,6 @@ function a2() {
     };
     var out_x_2;
     for (var x = void 0;;) {
-        out_x_2 = x;
         _loop_2(x);
         x = out_x_2;
     }
@@ -89,7 +87,6 @@ function a3() {
     };
     var out_x_3;
     for (var x = void 0; x < 1;) {
-        out_x_3 = x;
         _loop_3(x);
         x = out_x_3;
     }
@@ -100,7 +97,6 @@ function a3() {
     };
     var out_x_4;
     for (var x = void 0;;) {
-        out_x_4 = x;
         _loop_4(x);
         x = out_x_4;
     }

--- a/tests/baselines/reference/nestedBlockScopedBindings4.js
+++ b/tests/baselines/reference/nestedBlockScopedBindings4.js
@@ -53,9 +53,13 @@ function a1() {
     var _loop_1 = function(x) {
         x = x + 1;
         (function () { return x; });
+        out_x_1 = x;
     };
+    var out_x_1;
     for (var x = void 0; x < 1;) {
+        out_x_1 = x;
         _loop_1(x);
+        x = out_x_1;
     }
     for (var x = void 0;;) {
         x = x + 2;
@@ -68,24 +72,36 @@ function a2() {
     var _loop_2 = function(x) {
         x = x + 2;
         (function () { return x; });
+        out_x_2 = x;
     };
+    var out_x_2;
     for (var x = void 0;;) {
+        out_x_2 = x;
         _loop_2(x);
+        x = out_x_2;
     }
 }
 function a3() {
     var _loop_3 = function(x) {
         x = x + 1;
         (function () { return x; });
+        out_x_3 = x;
     };
+    var out_x_3;
     for (var x = void 0; x < 1;) {
+        out_x_3 = x;
         _loop_3(x);
+        x = out_x_3;
     }
     var _loop_4 = function(x) {
         x = x + 2;
         (function () { return x; });
+        out_x_4 = x;
     };
+    var out_x_4;
     for (var x = void 0;;) {
+        out_x_4 = x;
         _loop_4(x);
+        x = out_x_4;
     }
 }

--- a/tests/baselines/reference/nestedBlockScopedBindings5.js
+++ b/tests/baselines/reference/nestedBlockScopedBindings5.js
@@ -112,7 +112,6 @@ function a2() {
     };
     var out_x_1;
     for (var x = void 0;;) {
-        out_x_1 = x;
         _loop_2(x);
         x = out_x_1;
     }
@@ -132,7 +131,6 @@ function a3() {
     };
     var out_x_2;
     for (var x = void 0; false;) {
-        out_x_2 = x;
         _loop_4(x);
         x = out_x_2;
     }
@@ -169,7 +167,6 @@ function a5() {
     };
     var out_x_3;
     for (var x = void 0; false;) {
-        out_x_3 = x;
         _loop_5(x);
         x = out_x_3;
     }

--- a/tests/baselines/reference/nestedBlockScopedBindings5.js
+++ b/tests/baselines/reference/nestedBlockScopedBindings5.js
@@ -108,9 +108,13 @@ function a2() {
     var _loop_2 = function(x) {
         x = x + 2;
         (function () { return x; });
+        out_x_1 = x;
     };
+    var out_x_1;
     for (var x = void 0;;) {
+        out_x_1 = x;
         _loop_2(x);
+        x = out_x_1;
     }
 }
 function a3() {
@@ -124,9 +128,13 @@ function a3() {
     var _loop_4 = function(x) {
         x = x + 2;
         (function () { return x; });
+        out_x_2 = x;
     };
+    var out_x_2;
     for (var x = void 0; false;) {
+        out_x_2 = x;
         _loop_4(x);
+        x = out_x_2;
     }
     switch (1) {
         case 1:
@@ -157,9 +165,13 @@ function a5() {
     var _loop_5 = function(x) {
         x = x + 2;
         (function () { return x; });
+        out_x_3 = x;
     };
+    var out_x_3;
     for (var x = void 0; false;) {
+        out_x_3 = x;
         _loop_5(x);
+        x = out_x_3;
     }
     switch (1) {
         case 1:

--- a/tests/baselines/reference/nestedBlockScopedBindings6.js
+++ b/tests/baselines/reference/nestedBlockScopedBindings6.js
@@ -119,9 +119,13 @@ function a2() {
     var _loop_2 = function(x) {
         x = x + 2;
         (function () { return x; });
+        out_x_1 = x;
     };
+    var out_x_1;
     for (var x = void 0;;) {
+        out_x_1 = x;
         _loop_2(x);
+        x = out_x_1;
     }
 }
 function a3() {
@@ -136,9 +140,13 @@ function a3() {
     var _loop_4 = function(x) {
         x = x + 2;
         (function () { return x; });
+        out_x_2 = x;
     };
+    var out_x_2;
     for (var x = void 0;;) {
+        out_x_2 = x;
         _loop_4(x);
+        x = out_x_2;
     }
 }
 function a4() {

--- a/tests/baselines/reference/nestedBlockScopedBindings6.js
+++ b/tests/baselines/reference/nestedBlockScopedBindings6.js
@@ -123,7 +123,6 @@ function a2() {
     };
     var out_x_1;
     for (var x = void 0;;) {
-        out_x_1 = x;
         _loop_2(x);
         x = out_x_1;
     }
@@ -144,7 +143,6 @@ function a3() {
     };
     var out_x_2;
     for (var x = void 0;;) {
-        out_x_2 = x;
         _loop_4(x);
         x = out_x_2;
     }

--- a/tests/cases/compiler/blockScopedBindingsReassignedInLoop1.ts
+++ b/tests/cases/compiler/blockScopedBindingsReassignedInLoop1.ts
@@ -1,0 +1,7 @@
+declare function use(n: number): void;
+(function () {
+  'use strict'
+  for (let i = 0; i < 9; ++i) {
+    (() => use(++i))();
+  }
+})();

--- a/tests/cases/compiler/blockScopedBindingsReassignedInLoop2.ts
+++ b/tests/cases/compiler/blockScopedBindingsReassignedInLoop2.ts
@@ -1,0 +1,41 @@
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) {
+        break;
+    }
+    else {
+        y = 5;
+    }
+}
+
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) {
+        continue;
+    }
+    else {
+        y = 5;
+    }
+}
+
+loop:
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) {
+        break loop;
+    }
+    else {
+        y = 5;
+    }
+}
+
+loop:
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) {
+        continue loop;
+    }
+    else {
+        y = 5;
+    }
+}

--- a/tests/cases/compiler/blockScopedBindingsReassignedInLoop3.ts
+++ b/tests/cases/compiler/blockScopedBindingsReassignedInLoop3.ts
@@ -1,0 +1,91 @@
+
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) {
+        break;
+    }
+    else {
+        for (let a = 1; a < 5; --a) {
+            let f = () => a;
+            if (a) {
+                a = x;
+                break;
+            }
+            else {
+                y++;
+            }
+        }
+        
+        y = 5;
+    }
+}
+
+
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) {
+        continue;
+    }
+    else {
+        for (let a = 1; a < 5; --a) {
+            let f = () => a;
+            if (a) {
+                a = x;
+                continue;
+            }
+            else {
+                y++;
+            }
+        }
+        
+        y = 5;
+    }
+}
+
+loop2:
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) {
+        break loop2;
+    }
+    else {
+        loop1:
+        for (let a = 1; a < 5; --a) {
+            let f = () => a;
+            if (a) {
+                a = x;
+                break loop1;
+            }
+            else {
+                y++;
+                break loop2
+            }
+        }
+        
+        y = 5;
+    }
+}
+
+loop2:
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) {
+        continue loop2;
+    }
+    else {
+        loop1:
+        for (let a = 1; a < 5; --a) {
+            let f = () => a;
+            if (a) {
+                a = x;
+                continue loop1;
+            }
+            else {
+                y++;
+                continue loop2
+            }
+        }
+        
+        y = 5;
+    }
+}

--- a/tests/cases/compiler/blockScopedBindingsReassignedInLoop4.ts
+++ b/tests/cases/compiler/blockScopedBindingsReassignedInLoop4.ts
@@ -1,0 +1,11 @@
+function f1() {
+    for (let x = 1, y = 2; x < y; ++x, --y) {
+        let a = () => x++ + y++;
+        if (x == 1) {
+            return 1;
+        }
+        else {
+            y = 5;
+        }
+    }
+}

--- a/tests/cases/compiler/blockScopedBindingsReassignedInLoop5.ts
+++ b/tests/cases/compiler/blockScopedBindingsReassignedInLoop5.ts
@@ -1,0 +1,7 @@
+for (let x = 1, y = 2; x < y; ++x, --y) {
+    let a = () => x++ + y++;
+    if (x == 1) 
+        break;
+    else 
+        y = 5;
+}

--- a/tests/cases/compiler/blockScopedBindingsReassignedInLoop6.ts
+++ b/tests/cases/compiler/blockScopedBindingsReassignedInLoop6.ts
@@ -1,0 +1,28 @@
+function f1() {
+    for (let [x, y] = [1, 2]; x < y; ++x, --y) {
+        let a = () => x++ + y++;
+        if (x == 1)
+            break;
+        else if (y == 2)
+            y = 5;
+        else
+            return;
+    }
+}
+
+function f2() {
+    for (let [{a: x, b: {c: y}}] = [{a: 1, b: {c: 2}}]; x < y; ++x, --y) {
+        let a = () => x++ + y++;
+        if (x == 1)
+            break;
+        else if (y == 2)
+            y = 5;
+        else
+            return;
+    }
+}
+
+
+
+
+


### PR DESCRIPTION
fixes #6877.
NOTE: it will be cleaner to emit loop body as 
```ts
let loop = function(...) {
    try { loop body }
    finally { copy local values to out parameters }
}
```
instead of writing copy snippet at every point where control flow exits loop. However currently V8 does not optimize [protected regions](https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#2-unsupported-syntax) so between prettiness and perf of generated code I'd prefer to favor the second one