### PR TITLE
Js module search depth

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -299,6 +299,11 @@ namespace ts {
             name: "noImplicitUseStrict",
             type: "boolean",
             description: Diagnostics.Do_not_emit_use_strict_directives_in_module_output
+        },
+        {
+            name: "maxNodeSearchJsDepth",
+            type: "number",
+            description: Diagnostics.The_maximum_depth_of_JavaScript_modules_to_load_by_searching_node_modules
         }
     ];
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2450,6 +2450,10 @@
         "category": "Message",
         "code": 6112
     },
+    "The maximum depth of JavaScript modules to load by searching node_modules": {
+        "category": "Message",
+        "code": 6085
+    },
 
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -65,8 +65,7 @@ namespace ts {
                 : { resolvedModule: undefined, failedLookupLocations };
         }
         else {
-            let result = loadModuleFromNodeModules(moduleName, containingDirectory, host, compilerOptions);
-            return result;
+            return loadModuleFromNodeModules(moduleName, containingDirectory, host, compilerOptions);
         }
     }
 
@@ -145,7 +144,7 @@ namespace ts {
                 const nodeModulesFolderExists = directoryProbablyExists(nodeModulesFolder, host);
                 const candidate = normalizePath(combinePaths(nodeModulesFolder, moduleName));
 
-                let supportedExtensions = getSupportedExtensions(compilerOptions);
+                const supportedExtensions = getSupportedExtensions(compilerOptions);
                 let result = loadNodeModuleFromFile(supportedExtensions, candidate, failedLookupLocations, !nodeModulesFolderExists, host);
                 if (result) {
                     return { resolvedModule: { resolvedFileName: result, isExternalLibraryImport: true }, failedLookupLocations };
@@ -1075,10 +1074,10 @@ namespace ts {
                 }
 
                 // If this was a file found by a node_modules search, set the nodeModuleSearchDistance to parent distance + 1.
-                if(isFileFromNodeSearch){
+                if (isFileFromNodeSearch) {
                     const newDistance = (refFile && refFile.nodeModuleSearchDistance) === undefined ? 1 : refFile.nodeModuleSearchDistance + 1;
                     // If already set on the file, don't overwrite if it was already found closer (which may be '0' if added as a root file)
-                    file.nodeModuleSearchDistance = (typeof file.nodeModuleSearchDistance === 'number') ? Math.min(file.nodeModuleSearchDistance, newDistance) : newDistance;
+                    file.nodeModuleSearchDistance = (typeof file.nodeModuleSearchDistance === "number") ? Math.min(file.nodeModuleSearchDistance, newDistance) : newDistance;
                 }
 
                 return file;
@@ -1101,7 +1100,7 @@ namespace ts {
 
                 // Default to same distance as parent. Add one if found by a search.
                 file.nodeModuleSearchDistance = (refFile && refFile.nodeModuleSearchDistance) || 0;
-                if(isFileFromNodeSearch){
+                if (isFileFromNodeSearch) {
                     file.nodeModuleSearchDistance++;
                 }
 
@@ -1149,7 +1148,7 @@ namespace ts {
         }
 
         function processImportedModules(file: SourceFile, basePath: string) {
-            let maxJsNodeModuleSearchDistance = options.maxNodeSearchJsDepth || 0;
+            const maxJsNodeModuleSearchDistance = options.maxNodeSearchJsDepth || 0;
             collectExternalModuleReferences(file);
             if (file.imports.length || file.moduleAugmentations.length) {
                 file.resolvedModules = {};

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1152,7 +1152,7 @@ namespace ts {
         }
 
         function processImportedModules(file: SourceFile, basePath: string) {
-            const maxJsNodeModuleSearchDistance = 1; // TODO (billti): Make a compiler option
+            let maxJsNodeModuleSearchDistance = options.maxNodeSearchJsDepth || 0;
             collectExternalModuleReferences(file);
             if (file.imports.length || file.moduleAugmentations.length) {
                 file.resolvedModules = {};

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2438,6 +2438,7 @@ namespace ts {
         allowSyntheticDefaultImports?: boolean;
         allowJs?: boolean;
         noImplicitUseStrict?: boolean;
+        maxNodeSearchJsDepth?: number;
         /* @internal */ stripInternal?: boolean;
 
         // Skip checking lib.d.ts to help speed up tests.

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1565,6 +1565,8 @@ namespace ts {
         /* @internal */ externalModuleIndicator: Node;
         // The first node that causes this file to be a CommonJS module
         /* @internal */ commonJsModuleIndicator: Node;
+        // The number of times node_modules was searched and loaded a non-TypeScript file on the path to this one
+        /* @internal */ jsNodeModuleSearchDistance?: number;
 
         /* @internal */ identifiers: Map<string>;
         /* @internal */ nodeCount: number;
@@ -2680,6 +2682,7 @@ namespace ts {
          * - don't use tripleslash references
          */
         isExternalLibraryImport?: boolean;
+        isJsFileFromNodeSearch?: boolean;
     }
 
     export interface ResolvedModuleWithFailedLookupLocations {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1565,8 +1565,8 @@ namespace ts {
         /* @internal */ externalModuleIndicator: Node;
         // The first node that causes this file to be a CommonJS module
         /* @internal */ commonJsModuleIndicator: Node;
-        // The number of times node_modules was searched and loaded a non-TypeScript file on the path to this one
-        /* @internal */ jsNodeModuleSearchDistance?: number;
+        // The number of times node_modules was searched to locate the package containing this file
+        /* @internal */ nodeModuleSearchDistance?: number;
 
         /* @internal */ identifiers: Map<string>;
         /* @internal */ nodeCount: number;
@@ -2683,7 +2683,6 @@ namespace ts {
          * - don't use tripleslash references
          */
         isExternalLibraryImport?: boolean;
-        isJsFileFromNodeSearch?: boolean;
     }
 
     export interface ResolvedModuleWithFailedLookupLocations {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2033,7 +2033,7 @@ namespace ts {
         else {
             const sourceFiles = targetSourceFile === undefined ? host.getSourceFiles() : [targetSourceFile];
             for (const sourceFile of sourceFiles) {
-                if (!isDeclarationFile(sourceFile)) {
+                if (!isDeclarationFile(sourceFile) && !sourceFile.nodeModuleSearchDistance) {
                     onSingleFileEmit(host, sourceFile);
                 }
             }
@@ -2068,6 +2068,7 @@ namespace ts {
             // Can emit only sources that are not declaration file and are either non module code or module with --module or --target es6 specified
             const bundledSources = filter(host.getSourceFiles(),
                 sourceFile => !isDeclarationFile(sourceFile) && // Not a declaration file
+                    !sourceFile.nodeModuleSearchDistance &&     // Not loaded from searching under node_modules
                     (!isExternalModule(sourceFile) || // non module file
                         (getEmitModuleKind(options) && isExternalModule(sourceFile)))); // module that can emit - note falsy value from getEmitModuleKind means the module kind that shouldn't be emitted
             if (bundledSources.length) {

--- a/tests/baselines/reference/nodeResolution6.js
+++ b/tests/baselines/reference/nodeResolution6.js
@@ -13,7 +13,5 @@ export declare var y;
 import y = require("a"); 
 
 
-//// [ref.js]
-var x = 1;
 //// [b.js]
 "use strict";

--- a/tests/baselines/reference/nodeResolution8.js
+++ b/tests/baselines/reference/nodeResolution8.js
@@ -12,7 +12,5 @@ export declare var y;
 //// [b.ts]
 import y = require("a");
 
-//// [ref.js]
-var x = 1;
 //// [b.js]
 "use strict";

--- a/tests/cases/unittests/moduleResolution.ts
+++ b/tests/cases/unittests/moduleResolution.ts
@@ -179,6 +179,9 @@ module ts {
                     "/a/b/foo.ts",
                     "/a/b/foo.tsx",
                     "/a/b/foo.d.ts",
+                    "/c/d.ts",
+                    "/c/d.tsx",
+                    "/c/d.d.ts",
                     "/a/b/foo/index.ts",
                     "/a/b/foo/index.tsx",
                 ]);


### PR DESCRIPTION
This is a possible solution for #6670 (load JavaScript files from `node_modules`).

A concern with searching node_modules and loading JavaScript code is just how much code we might suck in on a project with lots of dependencies (or even a few, if those have a large dependency chain). This adds a setting to specify how many "hops" to go when loading JavaScript files while searching `node_modules`.

As an example, just using Gulp, with a setting of `1` it loads all the JavaScript files in the 'gulp' package, but does not follow its top level imports. This gives intellisense such as the below.

<img width="345" alt="screen shot 2016-02-05 at 11 03 22 am" src="https://cloud.githubusercontent.com/assets/993909/12856231/b4e4d10c-cbf8-11e5-9cc7-afb533936c79.png">

Note how the gulp exports are visible, however `src` is showing as `any` as this is a re-export of another dependency. With a setting of `2` (or deeper), this resolves also, as shown below:

<img width="463" alt="screen shot 2016-02-05 at 11 04 10 am" src="https://cloud.githubusercontent.com/assets/993909/12856322/2acde3ea-cbf9-11e5-821a-ed621ca493a0.png">

A question is what to default this setting at. Even with just Gulp, this loads 147 JavaScript files if loading all dependencies. `0` seems unhelpful. Perhaps `1` is a reasonable default?

@vladima for feedback on the code, and @egamma for feedback on the defaults.