### PR TITLE
Avoid writing files that are not changed while compiling incrementally.

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -623,7 +623,7 @@ namespace ts {
                 const hash = sys.createHash(data);
                 const mtimeBefore = sys.getModifiedTime(fileName);
 
-                if (mtimeBefore && outputFingerprints.hasOwnProperty(fileName)) {
+                if (mtimeBefore && hasProperty(outputFingerprints, fileName)) {
                     const fingerprint = outputFingerprints[fileName];
 
                     // If output has not been changed, and the file has no external modification

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -229,6 +229,7 @@ namespace ts {
             const _path = require("path");
             const _os = require("os");
             const _crypto = require("crypto");
+            let hash: any;
 
             // average async stat takes about 30 microseconds
             // set chunk size to do 30 files in < 1 millisecond
@@ -560,10 +561,18 @@ namespace ts {
                 },
                 readDirectory,
                 getModifiedTime(path) {
-                    return _fs.existsSync(path) && _fs.statSync(path).mtime;
+                    try {
+                        return _fs.statSync(path).mtime;
+                    }
+                    catch (e) {
+                        return undefined;
+                    }
                 },
                 createHash(data) {
-                    const hash = _crypto.createHash("md5");
+                    if (!hash) {
+                        hash = _crypto.createHash("md5");
+                    }
+
                     hash.update(data);
                     return hash.digest("hex");
                 },

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -229,7 +229,6 @@ namespace ts {
             const _path = require("path");
             const _os = require("os");
             const _crypto = require("crypto");
-            let hash: any;
 
             // average async stat takes about 30 microseconds
             // set chunk size to do 30 files in < 1 millisecond
@@ -569,10 +568,7 @@ namespace ts {
                     }
                 },
                 createHash(data) {
-                    if (!hash) {
-                        hash = _crypto.createHash("md5");
-                    }
-
+                    const hash = _crypto.createHash("md5");
                     hash.update(data);
                     return hash.digest("hex");
                 },


### PR DESCRIPTION
#3113 

If output and related file satisfy these conditions, it will now skip outputting the file:

1. An output of this file has been made and the last modified time has not changed comparing to last actual output.
2. The md5 hash of output has not changed comparing to last actual output.