### PR TITLE
Fixed watcher for rename operations, and for allowJs in config file

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -381,7 +381,8 @@ namespace ts {
                     const filePath = typeof relativeFileName !== "string"
                         ? undefined
                         : toPath(relativeFileName, baseDirPath, createGetCanonicalFileName(sys.useCaseSensitiveFileNames));
-                    if (eventName === "change" && fileWatcherCallbacks.contains(filePath)) {
+                    // Some applications save a working file via rename operations
+                    if ((eventName === "change" || eventName === "rename") && fileWatcherCallbacks.contains(filePath)) {
                         for (const fileCallback of fileWatcherCallbacks.get(filePath)) {
                             fileCallback(filePath);
                         }

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -486,7 +486,7 @@ namespace ts {
         }
 
         function watchedDirectoryChanged(fileName: string) {
-            if (fileName && !ts.isSupportedSourceFileName(fileName, commandLine.options)) {
+            if (fileName && !ts.isSupportedSourceFileName(fileName, compilerOptions)) {
                 return;
             }
 


### PR DESCRIPTION
Fix for #6941 (and for watching not honoring `allowJs` in a config file... which took far longer than the original bug :cry: )