### PR TITLE
Fix module resolution falling back to classic

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -100,7 +100,7 @@ namespace ts {
 
         let moduleResolution = compilerOptions.moduleResolution;
         if (moduleResolution === undefined) {
-            moduleResolution = compilerOptions.module === ModuleKind.CommonJS ? ModuleResolutionKind.NodeJs : ModuleResolutionKind.Classic;
+            moduleResolution = getEmitModuleKind(compilerOptions) === ModuleKind.CommonJS ? ModuleResolutionKind.NodeJs : ModuleResolutionKind.Classic;
             if (traceEnabled) {
                 trace(host, Diagnostics.Module_resolution_kind_is_not_specified_using_0, ModuleResolutionKind[moduleResolution]);
             }

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -896,8 +896,7 @@ namespace Harness {
             { name: "fileName", type: "string" },
             { name: "libFiles", type: "string" },
             { name: "noErrorTruncation", type: "boolean" },
-            { name: "suppressOutputPathCheck", type: "boolean" },
-            { name: "moduleResolution", type: "string"}
+            { name: "suppressOutputPathCheck", type: "boolean" }
         ];
 
         let optionsIndex: ts.Map<ts.CommandLineOption>;

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -896,7 +896,8 @@ namespace Harness {
             { name: "fileName", type: "string" },
             { name: "libFiles", type: "string" },
             { name: "noErrorTruncation", type: "boolean" },
-            { name: "suppressOutputPathCheck", type: "boolean" }
+            { name: "suppressOutputPathCheck", type: "boolean" },
+            { name: "moduleResolution", type: "string"}
         ];
 
         let optionsIndex: ts.Map<ts.CommandLineOption>;

--- a/tests/baselines/reference/importAliasAnExternalModuleInsideAnInternalModule.js
+++ b/tests/baselines/reference/importAliasAnExternalModuleInsideAnInternalModule.js
@@ -6,7 +6,7 @@ export module m {
 }
 
 //// [importAliasAnExternalModuleInsideAnInternalModule_file1.ts]
-import r = require('importAliasAnExternalModuleInsideAnInternalModule_file0');
+import r = require('./importAliasAnExternalModuleInsideAnInternalModule_file0');
 module m_private {
     //import r2 = require('m'); // would be error
     export import C = r; // no error
@@ -23,7 +23,7 @@ var m;
 })(m = exports.m || (exports.m = {}));
 //// [importAliasAnExternalModuleInsideAnInternalModule_file1.js]
 "use strict";
-var r = require('importAliasAnExternalModuleInsideAnInternalModule_file0');
+var r = require('./importAliasAnExternalModuleInsideAnInternalModule_file0');
 var m_private;
 (function (m_private) {
     //import r2 = require('m'); // would be error

--- a/tests/baselines/reference/importAliasAnExternalModuleInsideAnInternalModule.symbols
+++ b/tests/baselines/reference/importAliasAnExternalModuleInsideAnInternalModule.symbols
@@ -1,9 +1,9 @@
 === tests/cases/compiler/importAliasAnExternalModuleInsideAnInternalModule_file1.ts ===
-import r = require('importAliasAnExternalModuleInsideAnInternalModule_file0');
+import r = require('./importAliasAnExternalModuleInsideAnInternalModule_file0');
 >r : Symbol(r, Decl(importAliasAnExternalModuleInsideAnInternalModule_file1.ts, 0, 0))
 
 module m_private {
->m_private : Symbol(m_private, Decl(importAliasAnExternalModuleInsideAnInternalModule_file1.ts, 0, 78))
+>m_private : Symbol(m_private, Decl(importAliasAnExternalModuleInsideAnInternalModule_file1.ts, 0, 80))
 
     //import r2 = require('m'); // would be error
     export import C = r; // no error

--- a/tests/baselines/reference/importAliasAnExternalModuleInsideAnInternalModule.types
+++ b/tests/baselines/reference/importAliasAnExternalModuleInsideAnInternalModule.types
@@ -1,5 +1,5 @@
 === tests/cases/compiler/importAliasAnExternalModuleInsideAnInternalModule_file1.ts ===
-import r = require('importAliasAnExternalModuleInsideAnInternalModule_file0');
+import r = require('./importAliasAnExternalModuleInsideAnInternalModule_file0');
 >r : typeof r
 
 module m_private {

--- a/tests/cases/compiler/importAliasAnExternalModuleInsideAnInternalModule.ts
+++ b/tests/cases/compiler/importAliasAnExternalModuleInsideAnInternalModule.ts
@@ -4,7 +4,7 @@ export module m {
 }
 
 // @Filename: importAliasAnExternalModuleInsideAnInternalModule_file1.ts 
-import r = require('importAliasAnExternalModuleInsideAnInternalModule_file0');
+import r = require('./importAliasAnExternalModuleInsideAnInternalModule_file0');
 module m_private {
     //import r2 = require('m'); // would be error
     export import C = r; // no error

--- a/tests/cases/conformance/externalModules/relativePathToDeclarationFile.ts
+++ b/tests/cases/conformance/externalModules/relativePathToDeclarationFile.ts
@@ -1,3 +1,4 @@
+// @ModuleResolution: classic
 // @Filename: test/foo.d.ts
 export declare module M2 {
 	export var x: boolean;

--- a/tests/cases/fourslash/cancellationWhenfindingAllRefsOnDefinition.ts
+++ b/tests/cases/fourslash/cancellationWhenfindingAllRefsOnDefinition.ts
@@ -17,7 +17,7 @@
 ////}
 
 //@Filename: findAllRefsOnDefinition.ts
-////import Second = require("findAllRefsOnDefinition-import");
+////import Second = require("./findAllRefsOnDefinition-import");
 ////
 ////var second = new Second.Test()
 ////second.start();

--- a/tests/cases/fourslash/cloduleAsBaseClass2.ts
+++ b/tests/cases/fourslash/cloduleAsBaseClass2.ts
@@ -15,7 +15,7 @@
 ////export = A;
 
 // @Filename: cloduleAsBaseClass2_1.ts
-////import B = require('cloduleAsBaseClass2_0');
+////import B = require('./cloduleAsBaseClass2_0');
 ////class D extends B {
 ////    constructor() {
 ////        super(1);

--- a/tests/cases/fourslash/commentsExternalModules.ts
+++ b/tests/cases/fourslash/commentsExternalModules.ts
@@ -27,7 +27,7 @@
 
 // @Filename: commentsExternalModules_file1.ts
 /////**This is on import declaration*/
-////import ex/*9*/tMod = require("commentsExternalModules_file0");
+////import ex/*9*/tMod = require("./commentsExternalModules_file0");
 /////*10*/extMod./*11*/m1./*12*/fooExp/*13q*/ort(/*13*/);
 ////var new/*14*/Var = new extMod.m1.m2./*15*/c();
 
@@ -69,10 +69,10 @@ verify.memberListContains("i", "var m1.m2.i: m1.m2.c", "i");
 
 goTo.file("commentsExternalModules_file1.ts");
 goTo.marker('9');
-verify.quickInfoIs('import extMod = require("commentsExternalModules_file0")', "This is on import declaration");
+verify.quickInfoIs('import extMod = require("./commentsExternalModules_file0")', "This is on import declaration");
 
 goTo.marker('10');
-verify.completionListContains("extMod", 'import extMod = require("commentsExternalModules_file0")', "This is on import declaration");
+verify.completionListContains("extMod", 'import extMod = require("./commentsExternalModules_file0")', "This is on import declaration");
 
 goTo.marker('11');
 verify.memberListContains("m1", "namespace extMod.m1");

--- a/tests/cases/fourslash/commentsImportDeclaration.ts
+++ b/tests/cases/fourslash/commentsImportDeclaration.ts
@@ -20,7 +20,7 @@
 // @Filename: commentsImportDeclaration_file1.ts
 ///////<reference path='commentsImportDeclaration_file0.ts'/>
 /////** Import declaration*/
-////import /*3*/extMod = require("commentsImportDeclaration_file0/*4*/");
+////import /*3*/extMod = require("./commentsImportDeclaration_file0/*4*/");
 ////extMod./*6*/m1./*7*/fooEx/*8q*/port(/*8*/);
 ////var new/*9*/Var = new extMod.m1.m2./*10*/c();
 
@@ -28,7 +28,7 @@ goTo.marker('2');
 verify.quickInfoIs("namespace m1", "NamespaceComment");
 
 goTo.marker('3');
-verify.quickInfoIs('import extMod = require("commentsImportDeclaration_file0")', "Import declaration");
+verify.quickInfoIs('import extMod = require("./commentsImportDeclaration_file0")', "Import declaration");
 
 goTo.marker('6');
 verify.memberListContains("m1", "namespace extMod.m1");

--- a/tests/cases/fourslash/completionListForTransitivelyExportedMembers01.ts
+++ b/tests/cases/fourslash/completionListForTransitivelyExportedMembers01.ts
@@ -24,11 +24,11 @@
 
 // @Filename: C.ts
 ////export var cVar = "see!";
-////export * from "A";
-////export * from "B"
+////export * from "./A";
+////export * from "./B"
 
 // @Filename: D.ts
-////import * as c from "C";
+////import * as c from "./C";
 ////var x = c./**/
 
 goTo.marker();

--- a/tests/cases/fourslash/completionListForTransitivelyExportedMembers02.ts
+++ b/tests/cases/fourslash/completionListForTransitivelyExportedMembers02.ts
@@ -25,11 +25,11 @@
 
 // @Filename: C.ts
 ////export var cVar = "see!";
-////export * from "A";
-////export * from "B"
+////export * from "./A";
+////export * from "./B"
 
 // @Filename: D.ts
-////import * as c from "C";
+////import * as c from "./C";
 ////var x = c.Inner./**/
 
 goTo.marker();

--- a/tests/cases/fourslash/completionListForTransitivelyExportedMembers03.ts
+++ b/tests/cases/fourslash/completionListForTransitivelyExportedMembers03.ts
@@ -25,11 +25,11 @@
 
 // @Filename: C.ts
 ////export var cVar = "see!";
-////export * from "A";
-////export * from "B"
+////export * from "./A";
+////export * from "./B"
 
 // @Filename: D.ts
-////import * as c from "C";
+////import * as c from "./C";
 ////var x: c./**/
 
 goTo.marker();

--- a/tests/cases/fourslash/completionListForTransitivelyExportedMembers04.ts
+++ b/tests/cases/fourslash/completionListForTransitivelyExportedMembers04.ts
@@ -1,5 +1,5 @@
 ﻿///<reference path="fourslash.ts" />
-
+// @ModuleResolution: classic
 
 // @Filename: A.ts
 ////export interface I1 { one: number }

--- a/tests/cases/fourslash/completionListInExportClause01.ts
+++ b/tests/cases/fourslash/completionListInExportClause01.ts
@@ -6,11 +6,11 @@
 ////export function baz() { return 10; }
 
 // @Filename: m2.ts
-////export {/*1*/, /*2*/ from "m1"
-////export {/*3*/} from "m1"
-////export {foo,/*4*/ from "m1"
-////export {bar as /*5*/, /*6*/ from "m1"
-////export {foo, bar, baz as b,/*7*/} from "m1"
+////export {/*1*/, /*2*/ from "./m1"
+////export {/*3*/} from "./m1"
+////export {foo,/*4*/ from "./m1"
+////export {bar as /*5*/, /*6*/ from "./m1"
+////export {foo, bar, baz as b,/*7*/} from "./m1"
 
 function verifyCompletionAtMarker(marker: string, showBuilder: boolean, ...completions: string[]) {
     goTo.marker(marker);

--- a/tests/cases/fourslash/completionListInImportClause01.ts
+++ b/tests/cases/fourslash/completionListInImportClause01.ts
@@ -1,4 +1,5 @@
 /// <reference path='fourslash.ts'/>
+// @ModuleResolution: classic
 
 // @Filename: m1.ts
 ////export var foo: number = 1;

--- a/tests/cases/fourslash/definition.ts
+++ b/tests/cases/fourslash/definition.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts'/>
 
 // @Filename: b.ts
-////import n = require('a/*1*/');
+////import n = require('./a/*1*/');
 ////var x = new n.Foo();
 
 // @Filename: a.ts

--- a/tests/cases/fourslash/exportEqualCallableInterface.ts
+++ b/tests/cases/fourslash/exportEqualCallableInterface.ts
@@ -9,7 +9,7 @@
 
 // @Filename: exportEqualCallableInterface_file1.ts
 ///////<reference path='exportEqualCallableInterface_file0.ts'/>
-////import test = require('exportEqualCallableInterface_file0');
+////import test = require('./exportEqualCallableInterface_file0');
 ////var t2: test;
 ////t2./**/
 

--- a/tests/cases/fourslash/exportEqualTypes.ts
+++ b/tests/cases/fourslash/exportEqualTypes.ts
@@ -9,13 +9,13 @@
 
 // @Filename: exportEqualTypes_file1.ts
 ///////<reference path='exportEqualTypes_file0.ts'/>
-////import test = require('exportEqualTypes_file0');
+////import test = require('./exportEqualTypes_file0');
 ////var t: /*1*/test;  // var 't' should be of type 'test'
 ////var /*2*/r1 = t(); // Should return a Date
 ////var /*3*/r2 = t./*4*/foo; // t should have 'foo' in dropdown list and be of type 'string'
 
 goTo.marker('1');
-verify.quickInfoIs("import test = require('exportEqualTypes_file0')");
+verify.quickInfoIs("import test = require('./exportEqualTypes_file0')");
 goTo.marker('2');
 verify.quickInfoIs('var r1: Date');
 goTo.marker('3');

--- a/tests/cases/fourslash/externalModuleIntellisense.ts
+++ b/tests/cases/fourslash/externalModuleIntellisense.ts
@@ -14,7 +14,7 @@
 
 // @Filename: externalModuleIntellisense_file1.ts
 ///////<reference path='externalModuleIntellisense_file0.ts'/>
-////import express = require('externalModuleIntellisense_file0');
+////import express = require('./externalModuleIntellisense_file0');
 ////var x = express();/*1*/
 
 goTo.marker('1');

--- a/tests/cases/fourslash/externalModuleWithExportAssignment.ts
+++ b/tests/cases/fourslash/externalModuleWithExportAssignment.ts
@@ -18,7 +18,7 @@
 ////export = m2;
 
 // @Filename: externalModuleWithExportAssignment_file1.ts
-////import /*1*/a1 = require("externalModuleWithExportAssignment_file0");
+////import /*1*/a1 = require("./externalModuleWithExportAssignment_file0");
 ////export var /*2*/a = a1;
 ////a./*3*/test1(/*4*/null, null, null);
 ////var /*6*/r1 = a.test2(/*5*/);
@@ -30,7 +30,7 @@
 
 goTo.file("externalModuleWithExportAssignment_file1.ts");
 goTo.marker('1');
-verify.quickInfoIs('import a1 = require("externalModuleWithExportAssignment_file0")');
+verify.quickInfoIs('import a1 = require("./externalModuleWithExportAssignment_file0")');
 
 goTo.marker('2');
 verify.quickInfoIs("var a: {\n    (): a1.connectExport;\n    test1: a1.connectModule;\n    test2(): a1.connectModule;\n}", undefined);

--- a/tests/cases/fourslash/findAllRefsOnDefinition.ts
+++ b/tests/cases/fourslash/findAllRefsOnDefinition.ts
@@ -17,7 +17,7 @@
 ////}
 
 //@Filename: findAllRefsOnDefinition.ts
-////import Second = require("findAllRefsOnDefinition-import");
+////import Second = require("./findAllRefsOnDefinition-import");
 ////
 ////var second = new Second.Test()
 ////second.start();

--- a/tests/cases/fourslash/findAllRefsOnDefinition2.ts
+++ b/tests/cases/fourslash/findAllRefsOnDefinition2.ts
@@ -9,7 +9,7 @@
 ////}
 
 //@Filename: findAllRefsOnDefinition2.ts
-////import Second = require("findAllRefsOnDefinition2-import");
+////import Second = require("./findAllRefsOnDefinition2-import");
 ////
 ////var start: Second.Test.start;
 ////var stop: Second.Test.stop;

--- a/tests/cases/fourslash/findAllRefsOnImportAliases.ts
+++ b/tests/cases/fourslash/findAllRefsOnImportAliases.ts
@@ -5,12 +5,12 @@
 ////}
 
 //@Filename: b.ts
-////import { /*2*/Class } from "a";
+////import { /*2*/Class } from "./a";
 ////
 ////var c = new /*3*/Class();
 
 //@Filename: c.ts
-////export { /*4*/Class } from "a";
+////export { /*4*/Class } from "./a";
 
 goTo.file("a.ts");
 goTo.marker("1");

--- a/tests/cases/fourslash/findAllRefsOnImportAliases2.ts
+++ b/tests/cases/fourslash/findAllRefsOnImportAliases2.ts
@@ -5,12 +5,12 @@
 ////}
 
 //@Filename: b.ts
-////import { /*2*/Class as /*3*/C2} from "a";
+////import { /*2*/Class as /*3*/C2} from "./a";
 ////
 ////var c = new C2();
 
 //@Filename: c.ts
-////export { /*4*/Class as /*5*/C3 } from "a";
+////export { /*4*/Class as /*5*/C3 } from "./a";
 
 goTo.file("a.ts");
 goTo.marker("1");

--- a/tests/cases/fourslash/getJavaScriptCompletions15.ts
+++ b/tests/cases/fourslash/getJavaScriptCompletions15.ts
@@ -11,11 +11,11 @@
 //// export var V = "123"
 
 // @Filename: main.js
-//// import ref1 = require("refFile1");
-//// var ref2 = require("refFile2");
+//// import ref1 = require("./refFile1");
+//// var ref2 = require("./refFile2");
 //// ref1.V./*1*/;
 //// ref2.V./*2*/;
-//// var v = { x: require("refFile3") };
+//// var v = { x: require("./refFile3") };
 //// v.x./*3*/;
 //// v.x.V./*4*/;
 

--- a/tests/cases/fourslash/getPreProcessedFile.ts
+++ b/tests/cases/fourslash/getPreProcessedFile.ts
@@ -1,4 +1,5 @@
 /// <reference path="fourslash.ts" />
+// @ModuleResolution: classic
 
 // @Filename: refFile1.ts
 //// class D { }

--- a/tests/cases/fourslash/goToDefinitionExternalModuleName.ts
+++ b/tests/cases/fourslash/goToDefinitionExternalModuleName.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts'/>
 
 // @Filename: b.ts
-////import n = require('a/*1*/');
+////import n = require('./a/*1*/');
 ////var x = new n.Foo();
 
 // @Filename: a.ts

--- a/tests/cases/fourslash/goToDefinitionExternalModuleName2.ts
+++ b/tests/cases/fourslash/goToDefinitionExternalModuleName2.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts'/>
 
 // @Filename: b.ts
-////import n = require('a/*1*/');
+////import n = require('./a/*1*/');
 ////var x = new n.Foo();
 
 // @Filename: a.ts

--- a/tests/cases/fourslash/goToDefinitionImportedNames.ts
+++ b/tests/cases/fourslash/goToDefinitionImportedNames.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: b.ts
-////export {/*classAliasDefinition*/Class} from "a";
+////export {/*classAliasDefinition*/Class} from "./a";
 
 
 // @Filename: a.ts

--- a/tests/cases/fourslash/goToDefinitionImportedNames2.ts
+++ b/tests/cases/fourslash/goToDefinitionImportedNames2.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: b.ts
-////import {/*classAliasDefinition*/Class} from "a";
+////import {/*classAliasDefinition*/Class} from "./a";
 
 
 // @Filename: a.ts

--- a/tests/cases/fourslash/goToDefinitionImportedNames3.ts
+++ b/tests/cases/fourslash/goToDefinitionImportedNames3.ts
@@ -1,20 +1,20 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: e.ts
-//// import {M, /*classAliasDefinition*/C, I} from "d";
+//// import {M, /*classAliasDefinition*/C, I} from "./d";
 //// var c = new /*classReference*/C();
 
 
 // @Filename: d.ts
-////export * from "c";
+////export * from "./c";
 
 
 // @Filename: c.ts
-////export {Module as M, Class as C, Interface as I} from "b";
+////export {Module as M, Class as C, Interface as I} from "./b";
 
 
 // @Filename: b.ts
-////export * from "a";
+////export * from "./a";
 
 
 // @Filename: a.ts

--- a/tests/cases/fourslash/goToDefinitionImportedNames4.ts
+++ b/tests/cases/fourslash/goToDefinitionImportedNames4.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: b.ts
-////import {Class as /*classAliasDefinition*/ClassAlias} from "a";
+////import {Class as /*classAliasDefinition*/ClassAlias} from "./a";
 
 
 // @Filename: a.ts

--- a/tests/cases/fourslash/goToDefinitionImportedNames5.ts
+++ b/tests/cases/fourslash/goToDefinitionImportedNames5.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: b.ts
-////export {Class as /*classAliasDefinition*/ClassAlias} from "a";
+////export {Class as /*classAliasDefinition*/ClassAlias} from "./a";
 
 
 // @Filename: a.ts

--- a/tests/cases/fourslash/goToDefinitionImportedNames6.ts
+++ b/tests/cases/fourslash/goToDefinitionImportedNames6.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: b.ts
-////import /*moduleAliasDefinition*/alias = require("a");
+////import /*moduleAliasDefinition*/alias = require("./a");
 
 
 // @Filename: a.ts

--- a/tests/cases/fourslash/goToDefinitionImportedNames7.ts
+++ b/tests/cases/fourslash/goToDefinitionImportedNames7.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: b.ts
-////import /*classAliasDefinition*/defaultExport from "a";
+////import /*classAliasDefinition*/defaultExport from "./a";
 
 
 // @Filename: a.ts

--- a/tests/cases/fourslash/goToTypeDefinitionAliases.ts
+++ b/tests/cases/fourslash/goToTypeDefinitionAliases.ts
@@ -7,12 +7,12 @@
 ////export {I as I2};
 
 // @Filename: goToTypeDefinitioAliases_module2.ts
-////import {I2 as I3} from "goToTypeDefinitioAliases_module1";
+////import {I2 as I3} from "./goToTypeDefinitioAliases_module1";
 ////var v1: I3;
 ////export {v1 as v2};
 
 // @Filename: goToTypeDefinitioAliases_module3.ts
-////import {/*reference1*/v2 as v3} from "goToTypeDefinitioAliases_module2";
+////import {/*reference1*/v2 as v3} from "./goToTypeDefinitioAliases_module2";
 /////*reference2*/v3;
 
 goTo.marker('reference1');

--- a/tests/cases/fourslash/javaScriptModules13.ts
+++ b/tests/cases/fourslash/javaScriptModules13.ts
@@ -13,7 +13,7 @@
 //// var y = 10;
 
 // @Filename: consumer.js
-//// var x = require('myMod');
+//// var x = require('./myMod');
 //// /**/;
 
 goTo.file('consumer.js');

--- a/tests/cases/fourslash/javaScriptModules15.ts
+++ b/tests/cases/fourslash/javaScriptModules15.ts
@@ -14,7 +14,7 @@
 //// }
 
 // @Filename: consumer.js
-//// var x = require('myMod');
+//// var x = require('./myMod');
 //// x/**/;
 
 goTo.file('consumer.js');

--- a/tests/cases/fourslash/javaScriptModules16.ts
+++ b/tests/cases/fourslash/javaScriptModules16.ts
@@ -9,7 +9,7 @@
 //// exports.b = true;
 
 // @Filename: consumer.js
-//// var x = require('myMod');
+//// var x = require('./myMod');
 //// x/**/;
 
 goTo.file('consumer.js');

--- a/tests/cases/fourslash/javaScriptModules19.ts
+++ b/tests/cases/fourslash/javaScriptModules19.ts
@@ -11,7 +11,7 @@
 //// var y = 10;
 
 // @Filename: consumer.js
-//// var x = require('myMod');
+//// var x = require('./myMod');
 //// /**/;
 
 goTo.file('consumer.js');

--- a/tests/cases/fourslash/memberListOfEnumFromExternalModule.ts
+++ b/tests/cases/fourslash/memberListOfEnumFromExternalModule.ts
@@ -5,7 +5,7 @@
 ////var topic = Topic.One;
 
 // @Filename: memberListOfEnumFromExternalModule_file1.ts
-////import t = require('memberListOfEnumFromExternalModule_file0');
+////import t = require('./memberListOfEnumFromExternalModule_file0');
 ////var topic = t.Topic./*1*/
 
 goTo.file("memberListOfEnumFromExternalModule_file1.ts");

--- a/tests/cases/fourslash/mergedDeclarationsWithExportAssignment1.ts
+++ b/tests/cases/fourslash/mergedDeclarationsWithExportAssignment1.ts
@@ -11,7 +11,7 @@
 
 // @Filename: mergedDeclarationsWithExportAssignment1_file1.ts
 ///////<reference path='mergedDeclarationsWithExportAssignment1_file0.ts'/>
-////import /*1*/Foo = require('mergedDeclarationsWithExportAssignment1_file0');
+////import /*1*/Foo = require('./mergedDeclarationsWithExportAssignment1_file0');
 ////var /*3*/z = new /*2*/Foo();
 ////var /*5*/r2 = Foo./*4*/x;
 
@@ -19,7 +19,7 @@
 edit.insert('');
 
 goTo.marker('1');
-verify.quickInfoIs("import Foo = require('mergedDeclarationsWithExportAssignment1_file0')");
+verify.quickInfoIs("import Foo = require('./mergedDeclarationsWithExportAssignment1_file0')");
 
 goTo.marker('2');
 verify.completionListContains('Foo');

--- a/tests/cases/fourslash/quickInfoDisplayPartsExternalModuleAlias.ts
+++ b/tests/cases/fourslash/quickInfoDisplayPartsExternalModuleAlias.ts
@@ -7,9 +7,9 @@
 ////}
 
 // @Filename: quickInfoDisplayPartsExternalModuleAlias_file1.ts
-////import /*1*/a1 = require(/*mod1*/"quickInfoDisplayPartsExternalModuleAlias_file0");
+////import /*1*/a1 = require(/*mod1*/"./quickInfoDisplayPartsExternalModuleAlias_file0");
 ////new /*2*/a1.m1.c();
-////export import /*3*/a2 = require(/*mod2*/"quickInfoDisplayPartsExternalModuleAlias_file0");
+////export import /*3*/a2 = require(/*mod2*/"./quickInfoDisplayPartsExternalModuleAlias_file0");
 ////new /*4*/a2.m1.c();
 
 var marker = 0;
@@ -24,7 +24,7 @@ function verifyImport(name: string, isExported: boolean) {
         [{ text: "import", kind: "keyword" }, { text: " ", kind: "space" }, { text: name, kind: "aliasName" },
             { text: " ", kind: "space" }, { text: "=", kind: "operator" }, { text: " ", kind: "space" },
             { text: "require", kind: "keyword" }, { text: "(", kind: "punctuation" },
-            { text: "\"quickInfoDisplayPartsExternalModuleAlias_file0\"", kind: "stringLiteral" },
+            { text: "\"./quickInfoDisplayPartsExternalModuleAlias_file0\"", kind: "stringLiteral" },
             { text: ")", kind: "punctuation" }],
         []);
 }
@@ -35,7 +35,7 @@ verifyImport("a2", /*isExported*/true);
 
 function verifyExternalModuleStringLiteral(marker: string) {
     goTo.marker(marker);
-    verify.verifyQuickInfoDisplayParts("module", "", { start: test.markerByName(marker).position, length: "\"quickInfoDisplayPartsExternalModuleAlias_file0\"".length },
+    verify.verifyQuickInfoDisplayParts("module", "", { start: test.markerByName(marker).position, length: "\"./quickInfoDisplayPartsExternalModuleAlias_file0\"".length },
         [{ text: "module", kind: "keyword" }, { text: " ", kind: "space" }, { text: "a1", kind: "aliasName" }],
         []);
 }

--- a/tests/cases/fourslash/quickInfoExportAssignmentOfGenericInterface.ts
+++ b/tests/cases/fourslash/quickInfoExportAssignmentOfGenericInterface.ts
@@ -7,7 +7,7 @@
 ////export = Foo;
 
 // @Filename: quickInfoExportAssignmentOfGenericInterface_1.ts
-////import a = require('quickInfoExportAssignmentOfGenericInterface_0');
+////import a = require('./quickInfoExportAssignmentOfGenericInterface_0');
 ////export var /*1*/x: a<a<string>>;
 ////x.a;
 

--- a/tests/cases/fourslash/quickInfoForRequire.ts
+++ b/tests/cases/fourslash/quickInfoForRequire.ts
@@ -4,7 +4,7 @@
 ////export class a{}
 
 //@Filename: quickInfoForRequire_input.ts
-////import a = require("AA/B/*1*/B");
+////import a = require("./AA/B/*1*/B");
 
 goTo.marker('1');
 verify.quickInfoIs('module a');

--- a/tests/cases/fourslash/selfReferencedExternalModule.ts
+++ b/tests/cases/fourslash/selfReferencedExternalModule.ts
@@ -1,9 +1,9 @@
 /// <reference path='fourslash.ts' />
 // @Filename: app.ts
-////export import A = require('app');
+////export import A = require('./app');
 ////export var I = 1;
 ////A./**/I
 
 goTo.marker();
-verify.completionListContains("A", "import A = require('app')");
+verify.completionListContains("A", "import A = require('./app')");
 verify.completionListContains("I", "var I: number");

--- a/tests/cases/fourslash/selfReferencedExternalModule2.ts
+++ b/tests/cases/fourslash/selfReferencedExternalModule2.ts
@@ -1,12 +1,12 @@
 /// <reference path='fourslash.ts' />
 // @Filename: app.ts
-////export import A = require('app2');
+////export import A = require('./app2');
 ////export var I = 1;
 ////A./*1*/Y;
 ////A.B.A.B./*2*/I;
 
 // @Filename: app2.ts
-////export import B = require('app');
+////export import B = require('./app');
 ////export var Y = 1;
 
 goTo.marker("1");

--- a/tests/cases/fourslash/shims-pp/getPreProcessedFile.ts
+++ b/tests/cases/fourslash/shims-pp/getPreProcessedFile.ts
@@ -1,4 +1,5 @@
 /// <reference path="fourslash.ts" />
+// @ModuleResolution: classic
 
 // @Filename: refFile1.ts
 //// class D { }

--- a/tests/cases/fourslash/shims-pp/getReferencesAtPosition.ts
+++ b/tests/cases/fourslash/shims-pp/getReferencesAtPosition.ts
@@ -17,7 +17,7 @@
 ////}
 
 //@Filename: findAllRefsOnDefinition.ts
-////import Second = require("findAllRefsOnDefinition-import");
+////import Second = require("./findAllRefsOnDefinition-import");
 ////
 ////var second = new Second.Test()
 ////second.start();

--- a/tests/cases/fourslash/shims/getPreProcessedFile.ts
+++ b/tests/cases/fourslash/shims/getPreProcessedFile.ts
@@ -1,4 +1,5 @@
 /// <reference path="fourslash.ts" />
+// @ModuleResolution: classic
 
 // @Filename: refFile1.ts
 //// class D { }

--- a/tests/cases/fourslash/shims/getReferencesAtPosition.ts
+++ b/tests/cases/fourslash/shims/getReferencesAtPosition.ts
@@ -17,7 +17,7 @@
 ////}
 
 //@Filename: findAllRefsOnDefinition.ts
-////import Second = require("findAllRefsOnDefinition-import");
+////import Second = require("./findAllRefsOnDefinition-import");
 ////
 ////var second = new Second.Test()
 ////second.start();

--- a/tests/cases/fourslash/verifySingleFileEmitOutput1.ts
+++ b/tests/cases/fourslash/verifySingleFileEmitOutput1.ts
@@ -7,7 +7,7 @@
 ////}
 
 // @Filename: verifySingleFileEmitOutput1_file1.ts
-////import f = require("verifySingleFileEmitOutput1_file0");
+////import f = require("./verifySingleFileEmitOutput1_file0");
 ////var /**/b = new f.A();
 
 goTo.marker();


### PR DESCRIPTION
The actual module resolution algorithm was still falling back to `classic` if the module kind wasn't specified explicitly in the settings. This fixes that (and impacts a lot of tests in the process).