### PR TITLE
classic resolution: don't perform folder walk if module name is relative

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -533,18 +533,25 @@ namespace ts {
         }
 
         let referencedSourceFile: string;
-        while (true) {
-            const searchName = normalizePath(combinePaths(containingDirectory, moduleName));
-            referencedSourceFile = loadModuleFromFile(searchName, supportedExtensions, failedLookupLocations, /*onlyRecordFailures*/ false, state);
-            if (referencedSourceFile) {
-                break;
+        if (moduleHasNonRelativeName(moduleName)) {
+            while (true) {
+                const searchName = normalizePath(combinePaths(containingDirectory, moduleName));
+                referencedSourceFile = loadModuleFromFile(searchName, supportedExtensions, failedLookupLocations, /*onlyRecordFailures*/ false, state);
+                if (referencedSourceFile) {
+                    break;
+                }
+                const parentPath = getDirectoryPath(containingDirectory);
+                if (parentPath === containingDirectory) {
+                    break;
+                }
+                containingDirectory = parentPath;
             }
-            const parentPath = getDirectoryPath(containingDirectory);
-            if (parentPath === containingDirectory) {
-                break;
-            }
-            containingDirectory = parentPath;
         }
+        else {
+            const candidate = normalizePath(combinePaths(containingDirectory, moduleName));
+            referencedSourceFile = loadModuleFromFile(candidate, supportedExtensions, failedLookupLocations, /*onlyRecordFailures*/ false, state);
+        }
+
 
         return referencedSourceFile
             ? { resolvedModule: { resolvedFileName: referencedSourceFile  }, failedLookupLocations }

--- a/tests/baselines/reference/relativeNamesInClassicResolution.errors.txt
+++ b/tests/baselines/reference/relativeNamesInClassicResolution.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/somefolder/a.ts(2,17): error TS2307: Cannot find module './b'.
+
+
+==== tests/cases/compiler/somefolder/a.ts (1 errors) ====
+    
+    import {x} from "./b"
+                    ~~~~~
+!!! error TS2307: Cannot find module './b'.
+    
+==== tests/cases/compiler/b.ts (0 errors) ====
+    export let x = 1;

--- a/tests/baselines/reference/relativeNamesInClassicResolution.js
+++ b/tests/baselines/reference/relativeNamesInClassicResolution.js
@@ -1,0 +1,18 @@
+//// [tests/cases/compiler/relativeNamesInClassicResolution.ts] ////
+
+//// [a.ts]
+
+import {x} from "./b"
+
+//// [b.ts]
+export let x = 1;
+
+//// [a.js]
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+});
+//// [b.js]
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    exports.x = 1;
+});

--- a/tests/cases/compiler/relativeNamesInClassicResolution.ts
+++ b/tests/cases/compiler/relativeNamesInClassicResolution.ts
@@ -1,0 +1,7 @@
+// @module:amd
+
+// @filename: somefolder/a.ts
+import {x} from "./b"
+
+// @filename: b.ts
+export let x = 1;

--- a/tests/cases/unittests/moduleResolution.ts
+++ b/tests/cases/unittests/moduleResolution.ts
@@ -48,7 +48,7 @@ module ts {
                     return hasProperty(directories, path); 
                 },
                 fileExists: path => {
-                    assert.isTrue(hasProperty(directories, getDirectoryPath(path)), "'fileExists' request in non-existing directory");
+                    assert.isTrue(hasProperty(directories, getDirectoryPath(path)), `'fileExists' '${path}' request in non-existing directory`);
                     return hasProperty(map, path);
                 }
             }
@@ -814,7 +814,6 @@ import b = require("./moduleB.ts");
 
         it ("classic + rootDirs", () => {
             test(/*hasDirectoryExists*/ false);
-            test(/*hasDirectoryExists*/ true);
 
             function test(hasDirectoryExists: boolean) {
                 let file1: File = { name: "/root/folder1/file1.ts" };
@@ -844,24 +843,20 @@ import b = require("./moduleB.ts");
                     "/root/generated/folder1/file1.d.ts",
                     // then try alternative rootDir entry
                 ]);
-                check("../folder1/file1_1", file3, file4, [
-                    // load from initial location
+                check("folder1/file1_1", file3, file4, [
+                    // current location
+                    "/root/generated/folder2/folder1/file1_1.ts",
+                    "/root/generated/folder2/folder1/file1_1.tsx",
+                    "/root/generated/folder2/folder1/file1_1.d.ts",
+                    // other entry in rootDirs
                     "/root/generated/folder1/file1_1.ts",
                     "/root/generated/folder1/file1_1.tsx",
                     "/root/generated/folder1/file1_1.d.ts",
-                    // load from alternative rootDir entry
+                    // fallback
                     "/root/folder1/file1_1.ts",
                     "/root/folder1/file1_1.tsx",
                     "/root/folder1/file1_1.d.ts",
-                    // fallback to classic
-                    // step1: initial location 
-                    "/root/generated/folder1/file1_1.ts",
-                    "/root/generated/folder1/file1_1.tsx",
-                    "/root/generated/folder1/file1_1.d.ts",
-                    // step2: walk 1 level up
-                    "/root/folder1/file1_1.ts",
-                    "/root/folder1/file1_1.tsx",
-                    "/root/folder1/file1_1.d.ts",
+                    // found one
                 ]);
 
                 function check(name: string, container: File, expected: File, expectedFailedLookups: string[]) {


### PR DESCRIPTION
fixes #7051 