### PR TITLE
Ignore js baselines by using the correct glob

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,9 +28,9 @@ build.json
 *.actual
 tests/webhost/*.d.ts
 tests/webhost/webtsc.js
-tests/**/*.js
-tests/**/*.js.map
-tests/**/*.d.ts
+tests/cases/**/*.js
+tests/cases/**/*.js.map
+tests/cases/**/*.d.ts
 *.config
 scripts/debug.bat
 scripts/run.bat


### PR DESCRIPTION
Fixes problems introduced by 46ee63906f9db6aa97d2a21033a7b4f6c411bb88.

@RyanCavanaugh can you review this change? Was there a specific reason you needed to do this?