### PR TITLE
Apply lib.webworker.d.ts  to lib.core.es6.d.ts

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -165,7 +165,7 @@ var harnessSources = harnessCoreSources.concat([
 var librarySourceMap = [
         { target: "lib.core.d.ts", sources: ["header.d.ts", "core.d.ts"] },
         { target: "lib.dom.d.ts", sources: ["importcore.d.ts", "intl.d.ts", "dom.generated.d.ts"], },
-        { target: "lib.webworker.d.ts", sources: ["importcore.d.ts", "intl.d.ts", "webworker.generated.d.ts"], },
+        { target: "lib.webworker.d.ts", sources: ["importcore.d.ts", "intl.d.ts", "webworker.generated.d.ts", "header.d.ts", "core.d.ts", "es6.d.ts"], },
         { target: "lib.scriptHost.d.ts", sources: ["importcore.d.ts", "scriptHost.d.ts"], },
         { target: "lib.d.ts", sources: ["header.d.ts", "core.d.ts", "intl.d.ts", "dom.generated.d.ts", "webworker.importscripts.d.ts", "scriptHost.d.ts"], },
         { target: "lib.core.es6.d.ts", sources: ["header.d.ts", "core.d.ts", "es6.d.ts"]},


### PR DESCRIPTION
This change will  ease webworker to write with ES6.
[Add an ES6 lib.webworker.d.ts #6282 ](https://github.com/Microsoft/TypeScript/issues/6282)