### PR TITLE
Port #7106 to master

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -389,7 +389,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 
         return {
             emitSkipped,
-            diagnostics: emitterDiagnostics.getDiagnostics(),
+            declarationDiagnostics: emitterDiagnostics.getDiagnostics(),
             sourceMaps: sourceMapDataList
         };
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -963,7 +963,7 @@ namespace ts {
             // immediately bail out.  Note that we pass 'undefined' for 'sourceFile' so that we
             // get any preEmit diagnostics, not just the ones
             if (options.noEmitOnError) {
-                let diagnostics = program.getOptionsDiagnostics(cancellationToken).concat(
+                const diagnostics = program.getOptionsDiagnostics(cancellationToken).concat(
                     program.getSyntacticDiagnostics(sourceFile, cancellationToken),
                     program.getGlobalDiagnostics(cancellationToken),
                     program.getSemanticDiagnostics(sourceFile, cancellationToken));

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -590,30 +590,21 @@ namespace ts {
                 }
             }
 
-            reportDiagnostics(diagnostics, compilerHost);
-
-            // If the user doesn't want us to emit, then we're done at this point.
-            if (compilerOptions.noEmit) {
-                return diagnostics.length
-                    ? ExitStatus.DiagnosticsPresent_OutputsSkipped
-                    : ExitStatus.Success;
-            }
-
             // Otherwise, emit and report any errors we ran into.
             const emitOutput = program.emit();
-            reportDiagnostics(emitOutput.diagnostics, compilerHost);
+            diagnostics = diagnostics.concat(emitOutput.declarationDiagnostics);
 
-            // If the emitter didn't emit anything, then pass that value along.
-            if (emitOutput.emitSkipped) {
+            reportDiagnostics(sortAndDeduplicateDiagnostics(diagnostics), compilerHost);
+
+            if (emitOutput.emitSkipped && diagnostics.length > 0) {
+                // If the emitter didn't emit anything, then pass that value along.
                 return ExitStatus.DiagnosticsPresent_OutputsSkipped;
             }
-
-            // The emitter emitted something, inform the caller if that happened in the presence
-            // of diagnostics or not.
-            if (diagnostics.length > 0 || emitOutput.diagnostics.length > 0) {
+            else if (diagnostics.length > 0) {
+                // The emitter emitted something, inform the caller if that happened in the presence
+                // of diagnostics or not.
                 return ExitStatus.DiagnosticsPresent_OutputsGenerated;
             }
-
             return ExitStatus.Success;
         }
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1680,7 +1680,7 @@ namespace ts {
 
     export interface EmitResult {
         emitSkipped: boolean;
-        diagnostics: Diagnostic[];
+        /* @internal */ declarationDiagnostics: Diagnostic[];
         /* @internal */ sourceMaps: SourceMapData[];  // Array of sourceMapData if compiler emitted sourcemaps
     }
 

--- a/src/harness/projectsRunner.ts
+++ b/src/harness/projectsRunner.ts
@@ -127,7 +127,7 @@ class ProjectRunner extends RunnerBase {
             let errors = ts.getPreEmitDiagnostics(program);
 
             const emitResult = program.emit();
-            errors = ts.concatenate(errors, emitResult.diagnostics);
+            errors = ts.concatenate(errors, emitResult.declarationDiagnostics);
             const sourceMapData = emitResult.sourceMaps;
 
             // Clean up source map data that will be used in baselining

--- a/tests/baselines/reference/APISample_compile.js
+++ b/tests/baselines/reference/APISample_compile.js
@@ -16,7 +16,7 @@ export function compile(fileNames: string[], options: ts.CompilerOptions): void 
     var program = ts.createProgram(fileNames, options);
     var emitResult = program.emit();
 
-    var allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
+    var allDiagnostics = ts.getPreEmitDiagnostics(program);
 
     allDiagnostics.forEach(diagnostic => {
         var { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
@@ -45,7 +45,7 @@ var ts = require("typescript");
 function compile(fileNames, options) {
     var program = ts.createProgram(fileNames, options);
     var emitResult = program.emit();
-    var allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
+    var allDiagnostics = ts.getPreEmitDiagnostics(program);
     allDiagnostics.forEach(function (diagnostic) {
         var _a = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start), line = _a.line, character = _a.character;
         var message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');

--- a/tests/cases/compiler/APISample_compile.ts
+++ b/tests/cases/compiler/APISample_compile.ts
@@ -18,7 +18,7 @@ export function compile(fileNames: string[], options: ts.CompilerOptions): void 
     var program = ts.createProgram(fileNames, options);
     var emitResult = program.emit();
 
-    var allDiagnostics = ts.getPreEmitDiagnostics(program).concat(emitResult.diagnostics);
+    var allDiagnostics = ts.getPreEmitDiagnostics(program);
 
     allDiagnostics.forEach(diagnostic => {
         var { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);


### PR DESCRIPTION
Ports the fix of #7093 from #7106 to master. 

Note that there are some additional changes that were not in #7106, namelly renaming `EmitOutput.diagnostics` to `EmitOutput.declarationDiagnostics` to avoid confusion, and making it internal as it is already exposed in `getPreEmitDiagnostics`.

also some changes to simplify our return code processing in tsc.ts.