### PR TITLE
Nested private and protected class members

### DIFF
--- a/tests/baselines/reference/privateClassPropertyAccessibleWithinNestedClass.js
+++ b/tests/baselines/reference/privateClassPropertyAccessibleWithinNestedClass.js
@@ -1,0 +1,84 @@
+//// [privateClassPropertyAccessibleWithinNestedClass.ts]
+// no errors
+
+class C {
+    private x: string;
+    private get y() { return this.x; }
+    private set y(x) { this.y = this.x; }
+    private foo() { return this.foo; }
+
+    private static x: string;
+    private static get y() { return this.x; }
+    private static set y(x) { this.y = this.x; }
+    private static foo() { return this.foo; }
+    private static bar() { this.foo(); }
+
+    private bar() {
+        class C2 {
+            private foo() {
+                let x: C;
+                var x1 = x.foo;
+                var x2 = x.bar;
+                var x3 = x.x;
+                var x4 = x.y;
+
+                var sx1 = C.x;
+                var sx2 = C.y;
+                var sx3 = C.bar;
+                var sx4 = C.foo;
+
+                let y = new C();
+                var y1 = y.foo;
+                var y2 = y.bar;
+                var y3 = y.x;
+                var y4 = y.y;
+            }
+        }
+    }
+}
+
+//// [privateClassPropertyAccessibleWithinNestedClass.js]
+// no errors
+var C = (function () {
+    function C() {
+    }
+    Object.defineProperty(C.prototype, "y", {
+        get: function () { return this.x; },
+        set: function (x) { this.y = this.x; },
+        enumerable: true,
+        configurable: true
+    });
+    C.prototype.foo = function () { return this.foo; };
+    Object.defineProperty(C, "y", {
+        get: function () { return this.x; },
+        set: function (x) { this.y = this.x; },
+        enumerable: true,
+        configurable: true
+    });
+    C.foo = function () { return this.foo; };
+    C.bar = function () { this.foo(); };
+    C.prototype.bar = function () {
+        var C2 = (function () {
+            function C2() {
+            }
+            C2.prototype.foo = function () {
+                var x;
+                var x1 = x.foo;
+                var x2 = x.bar;
+                var x3 = x.x;
+                var x4 = x.y;
+                var sx1 = C.x;
+                var sx2 = C.y;
+                var sx3 = C.bar;
+                var sx4 = C.foo;
+                var y = new C();
+                var y1 = y.foo;
+                var y2 = y.bar;
+                var y3 = y.x;
+                var y4 = y.y;
+            };
+            return C2;
+        }());
+    };
+    return C;
+}());

--- a/tests/baselines/reference/privateClassPropertyAccessibleWithinNestedClass.symbols
+++ b/tests/baselines/reference/privateClassPropertyAccessibleWithinNestedClass.symbols
@@ -1,0 +1,154 @@
+=== tests/cases/conformance/classes/members/accessibility/privateClassPropertyAccessibleWithinNestedClass.ts ===
+// no errors
+
+class C {
+>C : Symbol(C, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+
+    private x: string;
+>x : Symbol(x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+
+    private get y() { return this.x; }
+>y : Symbol(y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 3, 22), Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 4, 38))
+>this.x : Symbol(x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+>this : Symbol(C, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>x : Symbol(x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+
+    private set y(x) { this.y = this.x; }
+>y : Symbol(y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 3, 22), Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 4, 38))
+>x : Symbol(x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 5, 18))
+>this.y : Symbol(y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 3, 22), Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 4, 38))
+>this : Symbol(C, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>y : Symbol(y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 3, 22), Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 4, 38))
+>this.x : Symbol(x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+>this : Symbol(C, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>x : Symbol(x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+
+    private foo() { return this.foo; }
+>foo : Symbol(foo, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 5, 41))
+>this.foo : Symbol(foo, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 5, 41))
+>this : Symbol(C, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>foo : Symbol(foo, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 5, 41))
+
+    private static x: string;
+>x : Symbol(C.x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 6, 38))
+
+    private static get y() { return this.x; }
+>y : Symbol(C.y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 8, 29), Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 9, 45))
+>this.x : Symbol(C.x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 6, 38))
+>this : Symbol(C, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>x : Symbol(C.x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 6, 38))
+
+    private static set y(x) { this.y = this.x; }
+>y : Symbol(C.y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 8, 29), Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 9, 45))
+>x : Symbol(x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 10, 25))
+>this.y : Symbol(C.y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 8, 29), Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 9, 45))
+>this : Symbol(C, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>y : Symbol(C.y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 8, 29), Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 9, 45))
+>this.x : Symbol(C.x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 6, 38))
+>this : Symbol(C, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>x : Symbol(C.x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 6, 38))
+
+    private static foo() { return this.foo; }
+>foo : Symbol(C.foo, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 10, 48))
+>this.foo : Symbol(C.foo, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 10, 48))
+>this : Symbol(C, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>foo : Symbol(C.foo, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 10, 48))
+
+    private static bar() { this.foo(); }
+>bar : Symbol(C.bar, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 11, 45))
+>this.foo : Symbol(C.foo, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 10, 48))
+>this : Symbol(C, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>foo : Symbol(C.foo, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 10, 48))
+
+    private bar() {
+>bar : Symbol(bar, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 12, 40))
+
+        class C2 {
+>C2 : Symbol(C2, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 14, 19))
+
+            private foo() {
+>foo : Symbol(foo, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 15, 18))
+
+                let x: C;
+>x : Symbol(x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 17, 19))
+>C : Symbol(C, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+
+                var x1 = x.foo;
+>x1 : Symbol(x1, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 18, 19))
+>x.foo : Symbol(C.foo, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 5, 41))
+>x : Symbol(x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 17, 19))
+>foo : Symbol(C.foo, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 5, 41))
+
+                var x2 = x.bar;
+>x2 : Symbol(x2, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 19, 19))
+>x.bar : Symbol(C.bar, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 12, 40))
+>x : Symbol(x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 17, 19))
+>bar : Symbol(C.bar, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 12, 40))
+
+                var x3 = x.x;
+>x3 : Symbol(x3, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 20, 19))
+>x.x : Symbol(x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+>x : Symbol(x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 17, 19))
+>x : Symbol(x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+
+                var x4 = x.y;
+>x4 : Symbol(x4, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 21, 19))
+>x.y : Symbol(C.y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 3, 22), Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 4, 38))
+>x : Symbol(x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 17, 19))
+>y : Symbol(C.y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 3, 22), Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 4, 38))
+
+                var sx1 = C.x;
+>sx1 : Symbol(sx1, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 23, 19))
+>C.x : Symbol(C.x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 6, 38))
+>C : Symbol(C, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>x : Symbol(C.x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 6, 38))
+
+                var sx2 = C.y;
+>sx2 : Symbol(sx2, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 24, 19))
+>C.y : Symbol(C.y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 8, 29), Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 9, 45))
+>C : Symbol(C, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>y : Symbol(C.y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 8, 29), Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 9, 45))
+
+                var sx3 = C.bar;
+>sx3 : Symbol(sx3, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 25, 19))
+>C.bar : Symbol(C.bar, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 11, 45))
+>C : Symbol(C, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>bar : Symbol(C.bar, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 11, 45))
+
+                var sx4 = C.foo;
+>sx4 : Symbol(sx4, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 26, 19))
+>C.foo : Symbol(C.foo, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 10, 48))
+>C : Symbol(C, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>foo : Symbol(C.foo, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 10, 48))
+
+                let y = new C();
+>y : Symbol(y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 28, 19))
+>C : Symbol(C, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+
+                var y1 = y.foo;
+>y1 : Symbol(y1, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 29, 19))
+>y.foo : Symbol(C.foo, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 5, 41))
+>y : Symbol(y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 28, 19))
+>foo : Symbol(C.foo, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 5, 41))
+
+                var y2 = y.bar;
+>y2 : Symbol(y2, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 30, 19))
+>y.bar : Symbol(C.bar, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 12, 40))
+>y : Symbol(y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 28, 19))
+>bar : Symbol(C.bar, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 12, 40))
+
+                var y3 = y.x;
+>y3 : Symbol(y3, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 31, 19))
+>y.x : Symbol(x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+>y : Symbol(y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 28, 19))
+>x : Symbol(x, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+
+                var y4 = y.y;
+>y4 : Symbol(y4, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 32, 19))
+>y.y : Symbol(C.y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 3, 22), Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 4, 38))
+>y : Symbol(y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 28, 19))
+>y : Symbol(C.y, Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 3, 22), Decl(privateClassPropertyAccessibleWithinNestedClass.ts, 4, 38))
+            }
+        }
+    }
+}

--- a/tests/baselines/reference/privateClassPropertyAccessibleWithinNestedClass.types
+++ b/tests/baselines/reference/privateClassPropertyAccessibleWithinNestedClass.types
@@ -1,0 +1,158 @@
+=== tests/cases/conformance/classes/members/accessibility/privateClassPropertyAccessibleWithinNestedClass.ts ===
+// no errors
+
+class C {
+>C : C
+
+    private x: string;
+>x : string
+
+    private get y() { return this.x; }
+>y : string
+>this.x : string
+>this : this
+>x : string
+
+    private set y(x) { this.y = this.x; }
+>y : string
+>x : string
+>this.y = this.x : string
+>this.y : string
+>this : this
+>y : string
+>this.x : string
+>this : this
+>x : string
+
+    private foo() { return this.foo; }
+>foo : () => any
+>this.foo : () => any
+>this : this
+>foo : () => any
+
+    private static x: string;
+>x : string
+
+    private static get y() { return this.x; }
+>y : string
+>this.x : string
+>this : typeof C
+>x : string
+
+    private static set y(x) { this.y = this.x; }
+>y : string
+>x : string
+>this.y = this.x : string
+>this.y : string
+>this : typeof C
+>y : string
+>this.x : string
+>this : typeof C
+>x : string
+
+    private static foo() { return this.foo; }
+>foo : () => typeof C.foo
+>this.foo : () => typeof C.foo
+>this : typeof C
+>foo : () => typeof C.foo
+
+    private static bar() { this.foo(); }
+>bar : () => void
+>this.foo() : () => typeof C.foo
+>this.foo : () => typeof C.foo
+>this : typeof C
+>foo : () => typeof C.foo
+
+    private bar() {
+>bar : () => void
+
+        class C2 {
+>C2 : C2
+
+            private foo() {
+>foo : () => void
+
+                let x: C;
+>x : C
+>C : C
+
+                var x1 = x.foo;
+>x1 : () => any
+>x.foo : () => any
+>x : C
+>foo : () => any
+
+                var x2 = x.bar;
+>x2 : () => void
+>x.bar : () => void
+>x : C
+>bar : () => void
+
+                var x3 = x.x;
+>x3 : string
+>x.x : string
+>x : C
+>x : string
+
+                var x4 = x.y;
+>x4 : string
+>x.y : string
+>x : C
+>y : string
+
+                var sx1 = C.x;
+>sx1 : string
+>C.x : string
+>C : typeof C
+>x : string
+
+                var sx2 = C.y;
+>sx2 : string
+>C.y : string
+>C : typeof C
+>y : string
+
+                var sx3 = C.bar;
+>sx3 : () => void
+>C.bar : () => void
+>C : typeof C
+>bar : () => void
+
+                var sx4 = C.foo;
+>sx4 : () => typeof C.foo
+>C.foo : () => typeof C.foo
+>C : typeof C
+>foo : () => typeof C.foo
+
+                let y = new C();
+>y : C
+>new C() : C
+>C : typeof C
+
+                var y1 = y.foo;
+>y1 : () => any
+>y.foo : () => any
+>y : C
+>foo : () => any
+
+                var y2 = y.bar;
+>y2 : () => void
+>y.bar : () => void
+>y : C
+>bar : () => void
+
+                var y3 = y.x;
+>y3 : string
+>y.x : string
+>y : C
+>x : string
+
+                var y4 = y.y;
+>y4 : string
+>y.y : string
+>y : C
+>y : string
+            }
+        }
+    }
+}

--- a/tests/baselines/reference/protectedClassPropertyAccessibleWithinNestedClass.js
+++ b/tests/baselines/reference/protectedClassPropertyAccessibleWithinNestedClass.js
@@ -1,0 +1,84 @@
+//// [protectedClassPropertyAccessibleWithinNestedClass.ts]
+// no errors
+
+class C {
+    protected x: string;
+    protected get y() { return this.x; }
+    protected set y(x) { this.y = this.x; }
+    protected foo() { return this.foo; }
+
+    protected static x: string;
+    protected static get y() { return this.x; }
+    protected static set y(x) { this.y = this.x; }
+    protected static foo() { return this.foo; }
+    protected static bar() { this.foo(); }
+
+    protected bar() {
+        class C2 {
+            protected foo() {
+                let x: C;
+                var x1 = x.foo;
+                var x2 = x.bar;
+                var x3 = x.x;
+                var x4 = x.y;
+
+                var sx1 = C.x;
+                var sx2 = C.y;
+                var sx3 = C.bar;
+                var sx4 = C.foo;
+
+                let y = new C();
+                var y1 = y.foo;
+                var y2 = y.bar;
+                var y3 = y.x;
+                var y4 = y.y;
+            }
+        }
+    }
+}
+
+//// [protectedClassPropertyAccessibleWithinNestedClass.js]
+// no errors
+var C = (function () {
+    function C() {
+    }
+    Object.defineProperty(C.prototype, "y", {
+        get: function () { return this.x; },
+        set: function (x) { this.y = this.x; },
+        enumerable: true,
+        configurable: true
+    });
+    C.prototype.foo = function () { return this.foo; };
+    Object.defineProperty(C, "y", {
+        get: function () { return this.x; },
+        set: function (x) { this.y = this.x; },
+        enumerable: true,
+        configurable: true
+    });
+    C.foo = function () { return this.foo; };
+    C.bar = function () { this.foo(); };
+    C.prototype.bar = function () {
+        var C2 = (function () {
+            function C2() {
+            }
+            C2.prototype.foo = function () {
+                var x;
+                var x1 = x.foo;
+                var x2 = x.bar;
+                var x3 = x.x;
+                var x4 = x.y;
+                var sx1 = C.x;
+                var sx2 = C.y;
+                var sx3 = C.bar;
+                var sx4 = C.foo;
+                var y = new C();
+                var y1 = y.foo;
+                var y2 = y.bar;
+                var y3 = y.x;
+                var y4 = y.y;
+            };
+            return C2;
+        }());
+    };
+    return C;
+}());

--- a/tests/baselines/reference/protectedClassPropertyAccessibleWithinNestedClass.symbols
+++ b/tests/baselines/reference/protectedClassPropertyAccessibleWithinNestedClass.symbols
@@ -1,0 +1,154 @@
+=== tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedClass.ts ===
+// no errors
+
+class C {
+>C : Symbol(C, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+
+    protected x: string;
+>x : Symbol(x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+
+    protected get y() { return this.x; }
+>y : Symbol(y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 3, 24), Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 4, 40))
+>this.x : Symbol(x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+>this : Symbol(C, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>x : Symbol(x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+
+    protected set y(x) { this.y = this.x; }
+>y : Symbol(y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 3, 24), Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 4, 40))
+>x : Symbol(x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 5, 20))
+>this.y : Symbol(y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 3, 24), Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 4, 40))
+>this : Symbol(C, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>y : Symbol(y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 3, 24), Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 4, 40))
+>this.x : Symbol(x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+>this : Symbol(C, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>x : Symbol(x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+
+    protected foo() { return this.foo; }
+>foo : Symbol(foo, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 5, 43))
+>this.foo : Symbol(foo, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 5, 43))
+>this : Symbol(C, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>foo : Symbol(foo, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 5, 43))
+
+    protected static x: string;
+>x : Symbol(C.x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 6, 40))
+
+    protected static get y() { return this.x; }
+>y : Symbol(C.y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 8, 31), Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 9, 47))
+>this.x : Symbol(C.x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 6, 40))
+>this : Symbol(C, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>x : Symbol(C.x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 6, 40))
+
+    protected static set y(x) { this.y = this.x; }
+>y : Symbol(C.y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 8, 31), Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 9, 47))
+>x : Symbol(x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 10, 27))
+>this.y : Symbol(C.y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 8, 31), Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 9, 47))
+>this : Symbol(C, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>y : Symbol(C.y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 8, 31), Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 9, 47))
+>this.x : Symbol(C.x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 6, 40))
+>this : Symbol(C, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>x : Symbol(C.x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 6, 40))
+
+    protected static foo() { return this.foo; }
+>foo : Symbol(C.foo, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 10, 50))
+>this.foo : Symbol(C.foo, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 10, 50))
+>this : Symbol(C, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>foo : Symbol(C.foo, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 10, 50))
+
+    protected static bar() { this.foo(); }
+>bar : Symbol(C.bar, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 11, 47))
+>this.foo : Symbol(C.foo, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 10, 50))
+>this : Symbol(C, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>foo : Symbol(C.foo, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 10, 50))
+
+    protected bar() {
+>bar : Symbol(bar, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 12, 42))
+
+        class C2 {
+>C2 : Symbol(C2, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 14, 21))
+
+            protected foo() {
+>foo : Symbol(foo, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 15, 18))
+
+                let x: C;
+>x : Symbol(x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 17, 19))
+>C : Symbol(C, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+
+                var x1 = x.foo;
+>x1 : Symbol(x1, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 18, 19))
+>x.foo : Symbol(C.foo, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 5, 43))
+>x : Symbol(x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 17, 19))
+>foo : Symbol(C.foo, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 5, 43))
+
+                var x2 = x.bar;
+>x2 : Symbol(x2, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 19, 19))
+>x.bar : Symbol(C.bar, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 12, 42))
+>x : Symbol(x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 17, 19))
+>bar : Symbol(C.bar, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 12, 42))
+
+                var x3 = x.x;
+>x3 : Symbol(x3, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 20, 19))
+>x.x : Symbol(x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+>x : Symbol(x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 17, 19))
+>x : Symbol(x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+
+                var x4 = x.y;
+>x4 : Symbol(x4, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 21, 19))
+>x.y : Symbol(C.y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 3, 24), Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 4, 40))
+>x : Symbol(x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 17, 19))
+>y : Symbol(C.y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 3, 24), Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 4, 40))
+
+                var sx1 = C.x;
+>sx1 : Symbol(sx1, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 23, 19))
+>C.x : Symbol(C.x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 6, 40))
+>C : Symbol(C, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>x : Symbol(C.x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 6, 40))
+
+                var sx2 = C.y;
+>sx2 : Symbol(sx2, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 24, 19))
+>C.y : Symbol(C.y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 8, 31), Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 9, 47))
+>C : Symbol(C, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>y : Symbol(C.y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 8, 31), Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 9, 47))
+
+                var sx3 = C.bar;
+>sx3 : Symbol(sx3, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 25, 19))
+>C.bar : Symbol(C.bar, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 11, 47))
+>C : Symbol(C, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>bar : Symbol(C.bar, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 11, 47))
+
+                var sx4 = C.foo;
+>sx4 : Symbol(sx4, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 26, 19))
+>C.foo : Symbol(C.foo, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 10, 50))
+>C : Symbol(C, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+>foo : Symbol(C.foo, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 10, 50))
+
+                let y = new C();
+>y : Symbol(y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 28, 19))
+>C : Symbol(C, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 0, 0))
+
+                var y1 = y.foo;
+>y1 : Symbol(y1, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 29, 19))
+>y.foo : Symbol(C.foo, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 5, 43))
+>y : Symbol(y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 28, 19))
+>foo : Symbol(C.foo, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 5, 43))
+
+                var y2 = y.bar;
+>y2 : Symbol(y2, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 30, 19))
+>y.bar : Symbol(C.bar, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 12, 42))
+>y : Symbol(y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 28, 19))
+>bar : Symbol(C.bar, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 12, 42))
+
+                var y3 = y.x;
+>y3 : Symbol(y3, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 31, 19))
+>y.x : Symbol(x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+>y : Symbol(y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 28, 19))
+>x : Symbol(x, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 2, 9))
+
+                var y4 = y.y;
+>y4 : Symbol(y4, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 32, 19))
+>y.y : Symbol(C.y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 3, 24), Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 4, 40))
+>y : Symbol(y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 28, 19))
+>y : Symbol(C.y, Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 3, 24), Decl(protectedClassPropertyAccessibleWithinNestedClass.ts, 4, 40))
+            }
+        }
+    }
+}

--- a/tests/baselines/reference/protectedClassPropertyAccessibleWithinNestedClass.types
+++ b/tests/baselines/reference/protectedClassPropertyAccessibleWithinNestedClass.types
@@ -1,0 +1,158 @@
+=== tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedClass.ts ===
+// no errors
+
+class C {
+>C : C
+
+    protected x: string;
+>x : string
+
+    protected get y() { return this.x; }
+>y : string
+>this.x : string
+>this : this
+>x : string
+
+    protected set y(x) { this.y = this.x; }
+>y : string
+>x : string
+>this.y = this.x : string
+>this.y : string
+>this : this
+>y : string
+>this.x : string
+>this : this
+>x : string
+
+    protected foo() { return this.foo; }
+>foo : () => any
+>this.foo : () => any
+>this : this
+>foo : () => any
+
+    protected static x: string;
+>x : string
+
+    protected static get y() { return this.x; }
+>y : string
+>this.x : string
+>this : typeof C
+>x : string
+
+    protected static set y(x) { this.y = this.x; }
+>y : string
+>x : string
+>this.y = this.x : string
+>this.y : string
+>this : typeof C
+>y : string
+>this.x : string
+>this : typeof C
+>x : string
+
+    protected static foo() { return this.foo; }
+>foo : () => typeof C.foo
+>this.foo : () => typeof C.foo
+>this : typeof C
+>foo : () => typeof C.foo
+
+    protected static bar() { this.foo(); }
+>bar : () => void
+>this.foo() : () => typeof C.foo
+>this.foo : () => typeof C.foo
+>this : typeof C
+>foo : () => typeof C.foo
+
+    protected bar() {
+>bar : () => void
+
+        class C2 {
+>C2 : C2
+
+            protected foo() {
+>foo : () => void
+
+                let x: C;
+>x : C
+>C : C
+
+                var x1 = x.foo;
+>x1 : () => any
+>x.foo : () => any
+>x : C
+>foo : () => any
+
+                var x2 = x.bar;
+>x2 : () => void
+>x.bar : () => void
+>x : C
+>bar : () => void
+
+                var x3 = x.x;
+>x3 : string
+>x.x : string
+>x : C
+>x : string
+
+                var x4 = x.y;
+>x4 : string
+>x.y : string
+>x : C
+>y : string
+
+                var sx1 = C.x;
+>sx1 : string
+>C.x : string
+>C : typeof C
+>x : string
+
+                var sx2 = C.y;
+>sx2 : string
+>C.y : string
+>C : typeof C
+>y : string
+
+                var sx3 = C.bar;
+>sx3 : () => void
+>C.bar : () => void
+>C : typeof C
+>bar : () => void
+
+                var sx4 = C.foo;
+>sx4 : () => typeof C.foo
+>C.foo : () => typeof C.foo
+>C : typeof C
+>foo : () => typeof C.foo
+
+                let y = new C();
+>y : C
+>new C() : C
+>C : typeof C
+
+                var y1 = y.foo;
+>y1 : () => any
+>y.foo : () => any
+>y : C
+>foo : () => any
+
+                var y2 = y.bar;
+>y2 : () => void
+>y.bar : () => void
+>y : C
+>bar : () => void
+
+                var y3 = y.x;
+>y3 : string
+>y.x : string
+>y : C
+>x : string
+
+                var y4 = y.y;
+>y4 : string
+>y.y : string
+>y : C
+>y : string
+            }
+        }
+    }
+}

--- a/tests/baselines/reference/protectedClassPropertyAccessibleWithinNestedSubclass.errors.txt
+++ b/tests/baselines/reference/protectedClassPropertyAccessibleWithinNestedSubclass.errors.txt
@@ -1,0 +1,44 @@
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass.ts(25,28): error TS2339: Property 'z' does not exist on type 'C'.
+
+
+==== tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass.ts (1 errors) ====
+    
+    class B {
+        protected x: string;
+        protected static x: string;
+    }
+    
+    class C extends B {
+        protected get y() { return this.x; }
+        protected set y(x) { this.y = this.x; }
+        protected foo() { return this.x; }
+    
+        protected static get y() { return this.x; }
+        protected static set y(x) { this.y = this.x; }
+        protected static foo() { return this.x; }
+        protected static bar() { this.foo(); }
+        
+        protected bar() { 
+            class D {
+                protected foo() {
+                    var c = new C();
+                    var c1 = c.y;
+                    var c2 = c.x;
+                    var c3 = c.foo;
+                    var c4 = c.bar;
+                    var c5 = c.z; // error
+                               ~
+!!! error TS2339: Property 'z' does not exist on type 'C'.
+                    
+                    var sc1 = C.x;
+                    var sc2 = C.y;
+                    var sc3 = C.foo;
+                    var sc4 = C.bar;
+                }
+            }
+        }
+    }
+    
+    class E extends C {
+        protected z: string;
+    }

--- a/tests/baselines/reference/protectedClassPropertyAccessibleWithinNestedSubclass.js
+++ b/tests/baselines/reference/protectedClassPropertyAccessibleWithinNestedSubclass.js
@@ -1,0 +1,99 @@
+//// [protectedClassPropertyAccessibleWithinNestedSubclass.ts]
+
+class B {
+    protected x: string;
+    protected static x: string;
+}
+
+class C extends B {
+    protected get y() { return this.x; }
+    protected set y(x) { this.y = this.x; }
+    protected foo() { return this.x; }
+
+    protected static get y() { return this.x; }
+    protected static set y(x) { this.y = this.x; }
+    protected static foo() { return this.x; }
+    protected static bar() { this.foo(); }
+    
+    protected bar() { 
+        class D {
+            protected foo() {
+                var c = new C();
+                var c1 = c.y;
+                var c2 = c.x;
+                var c3 = c.foo;
+                var c4 = c.bar;
+                var c5 = c.z; // error
+                
+                var sc1 = C.x;
+                var sc2 = C.y;
+                var sc3 = C.foo;
+                var sc4 = C.bar;
+            }
+        }
+    }
+}
+
+class E extends C {
+    protected z: string;
+}
+
+//// [protectedClassPropertyAccessibleWithinNestedSubclass.js]
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var B = (function () {
+    function B() {
+    }
+    return B;
+}());
+var C = (function (_super) {
+    __extends(C, _super);
+    function C() {
+        _super.apply(this, arguments);
+    }
+    Object.defineProperty(C.prototype, "y", {
+        get: function () { return this.x; },
+        set: function (x) { this.y = this.x; },
+        enumerable: true,
+        configurable: true
+    });
+    C.prototype.foo = function () { return this.x; };
+    Object.defineProperty(C, "y", {
+        get: function () { return this.x; },
+        set: function (x) { this.y = this.x; },
+        enumerable: true,
+        configurable: true
+    });
+    C.foo = function () { return this.x; };
+    C.bar = function () { this.foo(); };
+    C.prototype.bar = function () {
+        var D = (function () {
+            function D() {
+            }
+            D.prototype.foo = function () {
+                var c = new C();
+                var c1 = c.y;
+                var c2 = c.x;
+                var c3 = c.foo;
+                var c4 = c.bar;
+                var c5 = c.z; // error
+                var sc1 = C.x;
+                var sc2 = C.y;
+                var sc3 = C.foo;
+                var sc4 = C.bar;
+            };
+            return D;
+        }());
+    };
+    return C;
+}(B));
+var E = (function (_super) {
+    __extends(E, _super);
+    function E() {
+        _super.apply(this, arguments);
+    }
+    return E;
+}(C));

--- a/tests/baselines/reference/protectedClassPropertyAccessibleWithinNestedSubclass1.errors.txt
+++ b/tests/baselines/reference/protectedClassPropertyAccessibleWithinNestedSubclass1.errors.txt
@@ -1,0 +1,180 @@
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(15,17): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(32,17): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(34,17): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(35,17): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(36,17): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(52,17): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(53,17): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(55,17): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(73,17): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(74,17): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(75,17): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(77,17): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(93,17): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(94,17): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(95,17): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(96,17): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(110,1): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(111,1): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(112,1): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(113,1): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts(114,1): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
+
+
+==== tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts (21 errors) ====
+    class Base {
+        protected x: string;
+        method() {
+            class A {
+                methoda() {
+                    var b: Base;
+                    var d1: Derived1;
+                    var d2: Derived2;
+                    var d3: Derived3;
+                    var d4: Derived4;
+    
+                    b.x;            // OK, accessed within their declaring class
+                    d1.x;           // OK, accessed within their declaring class
+                    d2.x;           // OK, accessed within their declaring class
+                    d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
+                    ~~~~
+!!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+                    d4.x;           // OK, accessed within their declaring class
+                }
+            }
+        }
+    }
+    
+    class Derived1 extends Base {
+        method1() {
+            class B {
+                method1b() {
+                    var b: Base;
+                    var d1: Derived1;
+                    var d2: Derived2;
+                    var d3: Derived3;
+                    var d4: Derived4;
+    
+                    b.x;            // Error, isn't accessed through an instance of the enclosing class
+                    ~~~
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+                    d1.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
+                    d2.x;           // Error, isn't accessed through an instance of the enclosing class
+                    ~~~~
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+                    d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
+                    ~~~~
+!!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+                    d4.x;           // Error, isn't accessed through an instance of the enclosing class
+                    ~~~~
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+                }
+            }
+        }
+    }
+    
+    class Derived2 extends Base {
+        method2() {
+            class C {
+                method2c() {
+                    var b: Base;
+                    var d1: Derived1;
+                    var d2: Derived2;
+                    var d3: Derived3;
+                    var d4: Derived4;
+    
+                    b.x;            // Error, isn't accessed through an instance of the enclosing class
+                    ~~~
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
+                    d1.x;           // Error, isn't accessed through an instance of the enclosing class
+                    ~~~~
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
+                    d2.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
+                    d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
+                    ~~~~
+!!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+                    d4.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class or one of its subclasses
+                }
+            }
+        }
+    }
+    
+    class Derived3 extends Derived1 {
+        protected x: string;
+        method3() {
+            class D {
+                method3d() {
+                    var b: Base;
+                    var d1: Derived1;
+                    var d2: Derived2;
+                    var d3: Derived3;
+                    var d4: Derived4;
+    
+                    b.x;            // Error, isn't accessed through an instance of the enclosing class
+                    ~~~
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+                    d1.x;           // Error, isn't accessed through an instance of the enclosing class
+                    ~~~~
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+                    d2.x;           // Error, isn't accessed through an instance of the enclosing class
+                    ~~~~
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+                    d3.x;           // OK, accessed within their declaring class
+                    d4.x;           // Error, isn't accessed through an instance of the enclosing class
+                    ~~~~
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+                }
+            }
+        }
+    }
+    
+    class Derived4 extends Derived2 {
+        method4() {
+            class E {
+                method4e() {
+                    var b: Base;
+                    var d1: Derived1;
+                    var d2: Derived2;
+                    var d3: Derived3;
+                    var d4: Derived4;
+    
+                    b.x;            // Error, isn't accessed through an instance of the enclosing class
+                    ~~~
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+                    d1.x;           // Error, isn't accessed through an instance of the enclosing class
+                    ~~~~
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+                    d2.x;           // Error, isn't accessed through an instance of the enclosing class
+                    ~~~~
+!!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+                    d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
+                    ~~~~
+!!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+                    d4.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
+                }
+            }
+        }
+    }
+    
+    
+    var b: Base;
+    var d1: Derived1;
+    var d2: Derived2;
+    var d3: Derived3;
+    var d4: Derived4;
+    
+    b.x;                    // Error, neither within their declaring class nor classes derived from their declaring class
+    ~~~
+!!! error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
+    d1.x;                   // Error, neither within their declaring class nor classes derived from their declaring class
+    ~~~~
+!!! error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
+    d2.x;                   // Error, neither within their declaring class nor classes derived from their declaring class
+    ~~~~
+!!! error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
+    d3.x;                   // Error, neither within their declaring class nor classes derived from their declaring class
+    ~~~~
+!!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+    d4.x;                   // Error, neither within their declaring class nor classes derived from their declaring class
+    ~~~~
+!!! error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.

--- a/tests/baselines/reference/protectedClassPropertyAccessibleWithinNestedSubclass1.js
+++ b/tests/baselines/reference/protectedClassPropertyAccessibleWithinNestedSubclass1.js
@@ -1,0 +1,260 @@
+//// [protectedClassPropertyAccessibleWithinNestedSubclass1.ts]
+class Base {
+    protected x: string;
+    method() {
+        class A {
+            methoda() {
+                var b: Base;
+                var d1: Derived1;
+                var d2: Derived2;
+                var d3: Derived3;
+                var d4: Derived4;
+
+                b.x;            // OK, accessed within their declaring class
+                d1.x;           // OK, accessed within their declaring class
+                d2.x;           // OK, accessed within their declaring class
+                d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
+                d4.x;           // OK, accessed within their declaring class
+            }
+        }
+    }
+}
+
+class Derived1 extends Base {
+    method1() {
+        class B {
+            method1b() {
+                var b: Base;
+                var d1: Derived1;
+                var d2: Derived2;
+                var d3: Derived3;
+                var d4: Derived4;
+
+                b.x;            // Error, isn't accessed through an instance of the enclosing class
+                d1.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
+                d2.x;           // Error, isn't accessed through an instance of the enclosing class
+                d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
+                d4.x;           // Error, isn't accessed through an instance of the enclosing class
+            }
+        }
+    }
+}
+
+class Derived2 extends Base {
+    method2() {
+        class C {
+            method2c() {
+                var b: Base;
+                var d1: Derived1;
+                var d2: Derived2;
+                var d3: Derived3;
+                var d4: Derived4;
+
+                b.x;            // Error, isn't accessed through an instance of the enclosing class
+                d1.x;           // Error, isn't accessed through an instance of the enclosing class
+                d2.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
+                d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
+                d4.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class or one of its subclasses
+            }
+        }
+    }
+}
+
+class Derived3 extends Derived1 {
+    protected x: string;
+    method3() {
+        class D {
+            method3d() {
+                var b: Base;
+                var d1: Derived1;
+                var d2: Derived2;
+                var d3: Derived3;
+                var d4: Derived4;
+
+                b.x;            // Error, isn't accessed through an instance of the enclosing class
+                d1.x;           // Error, isn't accessed through an instance of the enclosing class
+                d2.x;           // Error, isn't accessed through an instance of the enclosing class
+                d3.x;           // OK, accessed within their declaring class
+                d4.x;           // Error, isn't accessed through an instance of the enclosing class
+            }
+        }
+    }
+}
+
+class Derived4 extends Derived2 {
+    method4() {
+        class E {
+            method4e() {
+                var b: Base;
+                var d1: Derived1;
+                var d2: Derived2;
+                var d3: Derived3;
+                var d4: Derived4;
+
+                b.x;            // Error, isn't accessed through an instance of the enclosing class
+                d1.x;           // Error, isn't accessed through an instance of the enclosing class
+                d2.x;           // Error, isn't accessed through an instance of the enclosing class
+                d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
+                d4.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
+            }
+        }
+    }
+}
+
+
+var b: Base;
+var d1: Derived1;
+var d2: Derived2;
+var d3: Derived3;
+var d4: Derived4;
+
+b.x;                    // Error, neither within their declaring class nor classes derived from their declaring class
+d1.x;                   // Error, neither within their declaring class nor classes derived from their declaring class
+d2.x;                   // Error, neither within their declaring class nor classes derived from their declaring class
+d3.x;                   // Error, neither within their declaring class nor classes derived from their declaring class
+d4.x;                   // Error, neither within their declaring class nor classes derived from their declaring class
+
+//// [protectedClassPropertyAccessibleWithinNestedSubclass1.js]
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var Base = (function () {
+    function Base() {
+    }
+    Base.prototype.method = function () {
+        var A = (function () {
+            function A() {
+            }
+            A.prototype.methoda = function () {
+                var b;
+                var d1;
+                var d2;
+                var d3;
+                var d4;
+                b.x; // OK, accessed within their declaring class
+                d1.x; // OK, accessed within their declaring class
+                d2.x; // OK, accessed within their declaring class
+                d3.x; // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
+                d4.x; // OK, accessed within their declaring class
+            };
+            return A;
+        }());
+    };
+    return Base;
+}());
+var Derived1 = (function (_super) {
+    __extends(Derived1, _super);
+    function Derived1() {
+        _super.apply(this, arguments);
+    }
+    Derived1.prototype.method1 = function () {
+        var B = (function () {
+            function B() {
+            }
+            B.prototype.method1b = function () {
+                var b;
+                var d1;
+                var d2;
+                var d3;
+                var d4;
+                b.x; // Error, isn't accessed through an instance of the enclosing class
+                d1.x; // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
+                d2.x; // Error, isn't accessed through an instance of the enclosing class
+                d3.x; // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
+                d4.x; // Error, isn't accessed through an instance of the enclosing class
+            };
+            return B;
+        }());
+    };
+    return Derived1;
+}(Base));
+var Derived2 = (function (_super) {
+    __extends(Derived2, _super);
+    function Derived2() {
+        _super.apply(this, arguments);
+    }
+    Derived2.prototype.method2 = function () {
+        var C = (function () {
+            function C() {
+            }
+            C.prototype.method2c = function () {
+                var b;
+                var d1;
+                var d2;
+                var d3;
+                var d4;
+                b.x; // Error, isn't accessed through an instance of the enclosing class
+                d1.x; // Error, isn't accessed through an instance of the enclosing class
+                d2.x; // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
+                d3.x; // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
+                d4.x; // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class or one of its subclasses
+            };
+            return C;
+        }());
+    };
+    return Derived2;
+}(Base));
+var Derived3 = (function (_super) {
+    __extends(Derived3, _super);
+    function Derived3() {
+        _super.apply(this, arguments);
+    }
+    Derived3.prototype.method3 = function () {
+        var D = (function () {
+            function D() {
+            }
+            D.prototype.method3d = function () {
+                var b;
+                var d1;
+                var d2;
+                var d3;
+                var d4;
+                b.x; // Error, isn't accessed through an instance of the enclosing class
+                d1.x; // Error, isn't accessed through an instance of the enclosing class
+                d2.x; // Error, isn't accessed through an instance of the enclosing class
+                d3.x; // OK, accessed within their declaring class
+                d4.x; // Error, isn't accessed through an instance of the enclosing class
+            };
+            return D;
+        }());
+    };
+    return Derived3;
+}(Derived1));
+var Derived4 = (function (_super) {
+    __extends(Derived4, _super);
+    function Derived4() {
+        _super.apply(this, arguments);
+    }
+    Derived4.prototype.method4 = function () {
+        var E = (function () {
+            function E() {
+            }
+            E.prototype.method4e = function () {
+                var b;
+                var d1;
+                var d2;
+                var d3;
+                var d4;
+                b.x; // Error, isn't accessed through an instance of the enclosing class
+                d1.x; // Error, isn't accessed through an instance of the enclosing class
+                d2.x; // Error, isn't accessed through an instance of the enclosing class
+                d3.x; // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
+                d4.x; // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
+            };
+            return E;
+        }());
+    };
+    return Derived4;
+}(Derived2));
+var b;
+var d1;
+var d2;
+var d3;
+var d4;
+b.x; // Error, neither within their declaring class nor classes derived from their declaring class
+d1.x; // Error, neither within their declaring class nor classes derived from their declaring class
+d2.x; // Error, neither within their declaring class nor classes derived from their declaring class
+d3.x; // Error, neither within their declaring class nor classes derived from their declaring class
+d4.x; // Error, neither within their declaring class nor classes derived from their declaring class

--- a/tests/cases/conformance/classes/members/accessibility/privateClassPropertyAccessibleWithinNestedClass.ts
+++ b/tests/cases/conformance/classes/members/accessibility/privateClassPropertyAccessibleWithinNestedClass.ts
@@ -1,0 +1,38 @@
+// @target: ES5
+// no errors
+
+class C {
+    private x: string;
+    private get y() { return this.x; }
+    private set y(x) { this.y = this.x; }
+    private foo() { return this.foo; }
+
+    private static x: string;
+    private static get y() { return this.x; }
+    private static set y(x) { this.y = this.x; }
+    private static foo() { return this.foo; }
+    private static bar() { this.foo(); }
+
+    private bar() {
+        class C2 {
+            private foo() {
+                let x: C;
+                var x1 = x.foo;
+                var x2 = x.bar;
+                var x3 = x.x;
+                var x4 = x.y;
+
+                var sx1 = C.x;
+                var sx2 = C.y;
+                var sx3 = C.bar;
+                var sx4 = C.foo;
+
+                let y = new C();
+                var y1 = y.foo;
+                var y2 = y.bar;
+                var y3 = y.x;
+                var y4 = y.y;
+            }
+        }
+    }
+}

--- a/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedClass.ts
+++ b/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedClass.ts
@@ -1,0 +1,38 @@
+// @target: ES5
+// no errors
+
+class C {
+    protected x: string;
+    protected get y() { return this.x; }
+    protected set y(x) { this.y = this.x; }
+    protected foo() { return this.foo; }
+
+    protected static x: string;
+    protected static get y() { return this.x; }
+    protected static set y(x) { this.y = this.x; }
+    protected static foo() { return this.foo; }
+    protected static bar() { this.foo(); }
+
+    protected bar() {
+        class C2 {
+            protected foo() {
+                let x: C;
+                var x1 = x.foo;
+                var x2 = x.bar;
+                var x3 = x.x;
+                var x4 = x.y;
+
+                var sx1 = C.x;
+                var sx2 = C.y;
+                var sx3 = C.bar;
+                var sx4 = C.foo;
+
+                let y = new C();
+                var y1 = y.foo;
+                var y2 = y.bar;
+                var y3 = y.x;
+                var y4 = y.y;
+            }
+        }
+    }
+}

--- a/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass.ts
+++ b/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass.ts
@@ -1,0 +1,39 @@
+// @target: ES5
+
+class B {
+    protected x: string;
+    protected static x: string;
+}
+
+class C extends B {
+    protected get y() { return this.x; }
+    protected set y(x) { this.y = this.x; }
+    protected foo() { return this.x; }
+
+    protected static get y() { return this.x; }
+    protected static set y(x) { this.y = this.x; }
+    protected static foo() { return this.x; }
+    protected static bar() { this.foo(); }
+    
+    protected bar() { 
+        class D {
+            protected foo() {
+                var c = new C();
+                var c1 = c.y;
+                var c2 = c.x;
+                var c3 = c.foo;
+                var c4 = c.bar;
+                var c5 = c.z; // error
+                
+                var sc1 = C.x;
+                var sc2 = C.y;
+                var sc3 = C.foo;
+                var sc4 = C.bar;
+            }
+        }
+    }
+}
+
+class E extends C {
+    protected z: string;
+}

--- a/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts
+++ b/tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinNestedSubclass1.ts
@@ -1,0 +1,114 @@
+class Base {
+    protected x: string;
+    method() {
+        class A {
+            methoda() {
+                var b: Base;
+                var d1: Derived1;
+                var d2: Derived2;
+                var d3: Derived3;
+                var d4: Derived4;
+
+                b.x;            // OK, accessed within their declaring class
+                d1.x;           // OK, accessed within their declaring class
+                d2.x;           // OK, accessed within their declaring class
+                d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
+                d4.x;           // OK, accessed within their declaring class
+            }
+        }
+    }
+}
+
+class Derived1 extends Base {
+    method1() {
+        class B {
+            method1b() {
+                var b: Base;
+                var d1: Derived1;
+                var d2: Derived2;
+                var d3: Derived3;
+                var d4: Derived4;
+
+                b.x;            // Error, isn't accessed through an instance of the enclosing class
+                d1.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
+                d2.x;           // Error, isn't accessed through an instance of the enclosing class
+                d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
+                d4.x;           // Error, isn't accessed through an instance of the enclosing class
+            }
+        }
+    }
+}
+
+class Derived2 extends Base {
+    method2() {
+        class C {
+            method2c() {
+                var b: Base;
+                var d1: Derived1;
+                var d2: Derived2;
+                var d3: Derived3;
+                var d4: Derived4;
+
+                b.x;            // Error, isn't accessed through an instance of the enclosing class
+                d1.x;           // Error, isn't accessed through an instance of the enclosing class
+                d2.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
+                d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
+                d4.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class or one of its subclasses
+            }
+        }
+    }
+}
+
+class Derived3 extends Derived1 {
+    protected x: string;
+    method3() {
+        class D {
+            method3d() {
+                var b: Base;
+                var d1: Derived1;
+                var d2: Derived2;
+                var d3: Derived3;
+                var d4: Derived4;
+
+                b.x;            // Error, isn't accessed through an instance of the enclosing class
+                d1.x;           // Error, isn't accessed through an instance of the enclosing class
+                d2.x;           // Error, isn't accessed through an instance of the enclosing class
+                d3.x;           // OK, accessed within their declaring class
+                d4.x;           // Error, isn't accessed through an instance of the enclosing class
+            }
+        }
+    }
+}
+
+class Derived4 extends Derived2 {
+    method4() {
+        class E {
+            method4e() {
+                var b: Base;
+                var d1: Derived1;
+                var d2: Derived2;
+                var d3: Derived3;
+                var d4: Derived4;
+
+                b.x;            // Error, isn't accessed through an instance of the enclosing class
+                d1.x;           // Error, isn't accessed through an instance of the enclosing class
+                d2.x;           // Error, isn't accessed through an instance of the enclosing class
+                d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
+                d4.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
+            }
+        }
+    }
+}
+
+
+var b: Base;
+var d1: Derived1;
+var d2: Derived2;
+var d3: Derived3;
+var d4: Derived4;
+
+b.x;                    // Error, neither within their declaring class nor classes derived from their declaring class
+d1.x;                   // Error, neither within their declaring class nor classes derived from their declaring class
+d2.x;                   // Error, neither within their declaring class nor classes derived from their declaring class
+d3.x;                   // Error, neither within their declaring class nor classes derived from their declaring class
+d4.x;                   // Error, neither within their declaring class nor classes derived from their declaring class


### PR DESCRIPTION
Fixes #7058

Allows classes to access private and protected member of parent (enclosed) classes.