### PR TITLE
Instantiate anonymous types less

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5184,6 +5184,11 @@ namespace ts {
                         if (decl.typeParameters && decl.typeParameters.length && forEach(decl.typeParameters, p => mapper.mapsType(getSymbolOfNode(p)))) {
                             return true;
                         }
+                        if ((node.kind === SyntaxKind.ClassDeclaration || node.kind === SyntaxKind.ClassExpression || isIndependentInterface(getSymbolOfNode(node))) &&
+                            mapper.mapsType(getSymbolOfNode(decl))) {
+                            // mapper maps the this class type of a class
+                            return true;
+                        }
                     }
                     node = node.parent;
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5163,33 +5163,35 @@ namespace ts {
             for (const original of type.symbol.declarations) {
                 let node: Node = original;
                 while (node !== undefined) {
-                    if (node.kind === SyntaxKind.FunctionType ||
-                        node.kind === SyntaxKind.ConstructorType ||
-                        node.kind === SyntaxKind.FunctionDeclaration ||
-                        node.kind === SyntaxKind.MethodDeclaration ||
-                        node.kind === SyntaxKind.MethodSignature ||
-                        node.kind === SyntaxKind.Constructor ||
-                        node.kind === SyntaxKind.CallSignature ||
-                        node.kind === SyntaxKind.ConstructSignature ||
-                        node.kind === SyntaxKind.IndexSignature ||
-                        node.kind === SyntaxKind.GetAccessor ||
-                        node.kind === SyntaxKind.SetAccessor ||
-                        node.kind === SyntaxKind.FunctionExpression ||
-                        node.kind === SyntaxKind.ArrowFunction ||
-                        node.kind === SyntaxKind.JSDocFunctionType ||
-                        node.kind === SyntaxKind.ClassDeclaration ||
-                        node.kind === SyntaxKind.ClassExpression ||
-                        node.kind === SyntaxKind.TypeAliasDeclaration ||
-                        node.kind === SyntaxKind.InterfaceDeclaration) {
-                        const decl = <SignatureDeclaration | ClassLikeDeclaration | InterfaceDeclaration>node;
-                        if (decl.typeParameters && decl.typeParameters.length && forEach(decl.typeParameters, p => mapper.mapsType(getSymbolOfNode(p)))) {
-                            return true;
-                        }
-                        if ((node.kind === SyntaxKind.ClassDeclaration || node.kind === SyntaxKind.InterfaceDeclaration || node.kind === SyntaxKind.ClassExpression) &&
-                            mapper.mapsType(getSymbolOfNode(decl))) {
-                            // mapper maps the this class type of a class
-                            return true;
-                        }
+                    switch (node.kind) {
+                        case SyntaxKind.FunctionType:
+                        case SyntaxKind.ConstructorType:
+                        case SyntaxKind.FunctionDeclaration:
+                        case SyntaxKind.MethodDeclaration:
+                        case SyntaxKind.MethodSignature:
+                        case SyntaxKind.Constructor:
+                        case SyntaxKind.CallSignature:
+                        case SyntaxKind.ConstructSignature:
+                        case SyntaxKind.IndexSignature:
+                        case SyntaxKind.GetAccessor:
+                        case SyntaxKind.SetAccessor:
+                        case SyntaxKind.FunctionExpression:
+                        case SyntaxKind.ArrowFunction:
+                        case SyntaxKind.JSDocFunctionType:
+                        case SyntaxKind.ClassDeclaration:
+                        case SyntaxKind.ClassExpression:
+                        case SyntaxKind.TypeAliasDeclaration:
+                        case SyntaxKind.InterfaceDeclaration:
+                            const decl = <SignatureDeclaration | ClassLikeDeclaration | InterfaceDeclaration>node;
+                            if (decl.typeParameters && decl.typeParameters.length && forEach(decl.typeParameters, p => mapper.mapsType(getSymbolOfNode(p)))) {
+                                return true;
+                            }
+                            if ((isClassLike(node) || node.kind === SyntaxKind.InterfaceDeclaration) &&
+                                mapper.mapsType(getSymbolOfNode(decl))) {
+                                // mapper maps the this class type of a class
+                                return true;
+                            }
+                            break;
                     }
                     node = node.parent;
                 }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5184,7 +5184,7 @@ namespace ts {
                         if (decl.typeParameters && decl.typeParameters.length && forEach(decl.typeParameters, p => mapper.mapsType(getSymbolOfNode(p)))) {
                             return true;
                         }
-                        if ((node.kind === SyntaxKind.ClassDeclaration || node.kind === SyntaxKind.ClassExpression || isIndependentInterface(getSymbolOfNode(node))) &&
+                        if ((node.kind === SyntaxKind.ClassDeclaration || node.kind === SyntaxKind.InterfaceDeclaration || node.kind === SyntaxKind.ClassExpression) &&
                             mapper.mapsType(getSymbolOfNode(decl))) {
                             // mapper maps the this class type of a class
                             return true;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4959,13 +4959,13 @@ namespace ts {
 
         function createUnaryTypeMapper(source: Type, target: Type): TypeMapper {
             const mapper = <TypeMapper>(t => t === source ? target : t);
-            mapper.mapsType = sym => sym === source.symbol;
+            mapper.mapsType = sym => sym.name === source.symbol.name;
             return mapper;
         }
 
         function createBinaryTypeMapper(source1: Type, target1: Type, source2: Type, target2: Type): TypeMapper {
             const mapper = <TypeMapper>(t => t === source1 ? target1 : t === source2 ? target2 : t);
-            mapper.mapsType = sym => sym === source1.symbol || sym === source2.symbol;
+            mapper.mapsType = sym => sym.name === source1.symbol.name || sym.name === source2.symbol.name;
             return mapper;
         }
 
@@ -4982,19 +4982,19 @@ namespace ts {
                 }
                 return t;
             });
-            mapper.mapsType = sym => forEach(sources, source => sym === source.symbol);
+            mapper.mapsType = sym => forEach(sources, source => sym.name === source.symbol.name);
             return mapper;
         }
 
         function createUnaryTypeEraser(source: Type): TypeMapper {
             const eraser = <TypeMapper>(t => t === source ? <Type>anyType : <Type>t);
-            eraser.mapsType = sym => sym === source.symbol;
+            eraser.mapsType = sym => sym.name === source.symbol.name;
             return eraser;
         }
 
         function createBinaryTypeEraser(source1: Type, source2: Type): TypeMapper {
             const eraser = <TypeMapper>(t => t === source1 || t === source2 ? <Type>anyType : <Type>t);
-            eraser.mapsType = sym => sym === source1.symbol || sym === source2.symbol;
+            eraser.mapsType = sym => sym.name === source1.symbol.name || sym.name === source2.symbol.name;
             return eraser;
         }
 
@@ -5011,7 +5011,7 @@ namespace ts {
                 }
                 return <Type>t;
             });
-            mapper.mapsType = sym => forEach(sources, source => source.symbol === sym);
+            mapper.mapsType = sym => forEach(sources, source => source.symbol.name === sym.name);
             return mapper;
         }
 
@@ -5028,7 +5028,7 @@ namespace ts {
                     return t;
                 });
                 mapper.context = context;
-                mapper.mapsType = sym => forEach(context.typeParameters, param => param.symbol === sym);
+                mapper.mapsType = sym => forEach(context.typeParameters, param => param.symbol.name === sym.name);
                 context.mapper = mapper;
             }
             return context.mapper;
@@ -5179,6 +5179,7 @@ namespace ts {
                         node.kind === SyntaxKind.JSDocFunctionType ||
                         node.kind === SyntaxKind.ClassDeclaration ||
                         node.kind === SyntaxKind.ClassExpression ||
+                        node.kind === SyntaxKind.TypeAliasDeclaration ||
                         node.kind === SyntaxKind.InterfaceDeclaration) {
                         const decl = <SignatureDeclaration | ClassLikeDeclaration | InterfaceDeclaration>node;
                         if (decl.typeParameters && decl.typeParameters.length && forEach(decl.typeParameters, p => mapper.mapsType(getSymbolOfNode(p)))) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2286,6 +2286,7 @@ namespace ts {
         context?: InferenceContext; // The inference context this mapper was created from.
                                     // Only inference mappers have this set (in createInferenceMapper).
                                     // The identity mapper and regular instantiation mappers do not need it.
+        mapsType(s: Symbol): boolean;
     }
 
     /* @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2282,11 +2282,11 @@ namespace ts {
     /* @internal */
     export interface TypeMapper {
         (t: TypeParameter): Type;
+        mapsType(t: Type): boolean; // whether this mapper maps the type
         instantiations?: Type[];    // Cache of instantiations created using this type mapper.
         context?: InferenceContext; // The inference context this mapper was created from.
                                     // Only inference mappers have this set (in createInferenceMapper).
                                     // The identity mapper and regular instantiation mappers do not need it.
-        mapsType(s: Symbol): boolean;
     }
 
     /* @internal */

--- a/tests/baselines/reference/bluebirdStaticThis.errors.txt
+++ b/tests/baselines/reference/bluebirdStaticThis.errors.txt
@@ -1,0 +1,165 @@
+tests/cases/compiler/bluebirdStaticThis.ts(5,15): error TS2420: Class 'Promise<R>' incorrectly implements interface 'Thenable<R>'.
+  Property 'then' is missing in type 'Promise<R>'.
+tests/cases/compiler/bluebirdStaticThis.ts(22,51): error TS2305: Module 'Promise' has no exported member 'Resolver'.
+tests/cases/compiler/bluebirdStaticThis.ts(57,109): error TS2305: Module 'Promise' has no exported member 'Inspection'.
+tests/cases/compiler/bluebirdStaticThis.ts(58,91): error TS2305: Module 'Promise' has no exported member 'Inspection'.
+tests/cases/compiler/bluebirdStaticThis.ts(59,91): error TS2305: Module 'Promise' has no exported member 'Inspection'.
+tests/cases/compiler/bluebirdStaticThis.ts(60,73): error TS2305: Module 'Promise' has no exported member 'Inspection'.
+
+
+==== tests/cases/compiler/bluebirdStaticThis.ts (6 errors) ====
+    // This version is reduced from the full d.ts by removing almost all the tests
+    // and all the comments.
+    // Then it adds explicit `this` arguments to the static members.
+    // Tests by: Bart van der Schoor <https://github.com/Bartvds>
+    declare class Promise<R> implements Promise.Thenable<R> {
+                  ~~~~~~~
+!!! error TS2420: Class 'Promise<R>' incorrectly implements interface 'Thenable<R>'.
+!!! error TS2420:   Property 'then' is missing in type 'Promise<R>'.
+    	constructor(callback: (resolve: (thenableOrResult: R | Promise.Thenable<R>) => void, reject: (error: any) => void) => void);
+        static try<R>(dit: typeof Promise, fn: () => Promise.Thenable<R>, args?: any[], ctx?: any): Promise<R>;
+        static try<R>(dit: typeof Promise, fn: () => R, args?: any[], ctx?: any): Promise<R>;
+    
+        static attempt<R>(dit: typeof Promise, fn: () => Promise.Thenable<R>, args?: any[], ctx?: any): Promise<R>;
+        static attempt<R>(dit: typeof Promise, fn: () => R, args?: any[], ctx?: any): Promise<R>;
+    
+        static method(dit: typeof Promise, fn: Function): Function;
+    
+        static resolve(dit: typeof Promise): Promise<void>;
+        static resolve<R>(dit: typeof Promise, value: Promise.Thenable<R>): Promise<R>;
+        static resolve<R>(dit: typeof Promise, value: R): Promise<R>;
+    
+        static reject(dit: typeof Promise, reason: any): Promise<any>;
+        static reject<R>(dit: typeof Promise, reason: any): Promise<R>;
+    
+        static defer<R>(dit: typeof Promise): Promise.Resolver<R>;
+                                                      ~~~~~~~~
+!!! error TS2305: Module 'Promise' has no exported member 'Resolver'.
+    
+        static cast<R>(dit: typeof Promise, value: Promise.Thenable<R>): Promise<R>;
+        static cast<R>(dit: typeof Promise, value: R): Promise<R>;
+    
+        static bind(dit: typeof Promise, thisArg: any): Promise<void>;
+    
+        static is(dit: typeof Promise, value: any): boolean;
+    
+        static longStackTraces(dit: typeof Promise): void;
+    
+        static delay<R>(dit: typeof Promise, value: Promise.Thenable<R>, ms: number): Promise<R>;
+        static delay<R>(dit: typeof Promise, value: R, ms: number): Promise<R>;
+        static delay(dit: typeof Promise, ms: number): Promise<void>;
+    
+        static promisify(dit: typeof Promise, nodeFunction: Function, receiver?: any): Function;
+    
+        static promisifyAll(dit: typeof Promise, target: Object): Object;
+    
+        static coroutine<R>(dit: typeof Promise, generatorFunction: Function): Function;
+    
+        static spawn<R>(dit: typeof Promise, generatorFunction: Function): Promise<R>;
+    
+        static noConflict(dit: typeof Promise): typeof Promise;
+    
+        static onPossiblyUnhandledRejection(dit: typeof Promise, handler: (reason: any) => any): void;
+    
+        static all<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<R[]>;
+        static all<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<R[]>;
+        static all<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<R[]>;
+        static all<R>(dit: typeof Promise, values: R[]): Promise<R[]>;
+    
+        static props(dit: typeof Promise, object: Promise<Object>): Promise<Object>;
+        static props(dit: typeof Promise, object: Object): Promise<Object>;
+    
+        static settle<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<Promise.Inspection<R>[]>;
+                                                                                                                ~~~~~~~~~~
+!!! error TS2305: Module 'Promise' has no exported member 'Inspection'.
+        static settle<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<Promise.Inspection<R>[]>;
+                                                                                              ~~~~~~~~~~
+!!! error TS2305: Module 'Promise' has no exported member 'Inspection'.
+        static settle<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<Promise.Inspection<R>[]>;
+                                                                                              ~~~~~~~~~~
+!!! error TS2305: Module 'Promise' has no exported member 'Inspection'.
+        static settle<R>(dit: typeof Promise, values: R[]): Promise<Promise.Inspection<R>[]>;
+                                                                            ~~~~~~~~~~
+!!! error TS2305: Module 'Promise' has no exported member 'Inspection'.
+    
+        static any<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<R>;
+        static any<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<R>;
+        static any<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<R>;
+        static any<R>(dit: typeof Promise, values: R[]): Promise<R>;
+    
+        static race<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<R>;
+        static race<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<R>;
+        static race<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<R>;
+        static race<R>(dit: typeof Promise, values: R[]): Promise<R>;
+    
+        static some<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, count: number): Promise<R[]>;
+        static some<R>(dit: typeof Promise, values: Promise.Thenable<R[]>, count: number): Promise<R[]>;
+        static some<R>(dit: typeof Promise, values: Promise.Thenable<R>[], count: number): Promise<R[]>;
+        static some<R>(dit: typeof Promise, values: R[], count: number): Promise<R[]>;
+    
+        static join<R>(dit: typeof Promise, ...values: Promise.Thenable<R>[]): Promise<R[]>;
+        static join<R>(dit: typeof Promise, ...values: R[]): Promise<R[]>;
+    
+        static map<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+        static map<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
+        static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+        static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
+        static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+        static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
+        static map<R, U>(dit: typeof Promise, values: R[], mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+        static map<R, U>(dit: typeof Promise, values: R[], mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
+    
+        static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
+        static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
+    
+        static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
+        static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
+    
+        static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
+        static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
+    
+        static reduce<R, U>(dit: typeof Promise, values: R[], reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
+        static reduce<R, U>(dit: typeof Promise, values: R[], reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
+    
+        static filter<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
+        static filter<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
+        static filter<R>(dit: typeof Promise, values: Promise.Thenable<R[]>, filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
+        static filter<R>(dit: typeof Promise, values: Promise.Thenable<R[]>, filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
+        static filter<R>(dit: typeof Promise, values: Promise.Thenable<R>[], filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
+        static filter<R>(dit: typeof Promise, values: Promise.Thenable<R>[], filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
+        static filter<R>(dit: typeof Promise, values: R[], filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
+        static filter<R>(dit: typeof Promise, values: R[], filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
+    }
+    
+    declare module Promise {
+    	export interface Thenable<R> {
+    		then<U>(onFulfilled: (value: R) => Thenable<U>, onRejected: (error: any) => Thenable<U>): Thenable<U>;
+    		then<U>(onFulfilled: (value: R) => Thenable<U>, onRejected?: (error: any) => U): Thenable<U>;
+    		then<U>(onFulfilled: (value: R) => U, onRejected: (error: any) => Thenable<U>): Thenable<U>;
+    		then<U>(onFulfilled?: (value: R) => U, onRejected?: (error: any) => U): Thenable<U>;
+    	}
+    
+    }
+    
+    declare module 'bluebird' {
+    	export = Promise;
+    }
+    interface Foo {
+        a: number;
+        b: string;
+    }
+    var x: any;
+    var arr: any[];
+    var foo: Foo;
+    var fooProm: Promise<Foo>;
+    
+    fooProm = Promise.try(Promise, () => {
+    	return foo;
+    });
+    fooProm = Promise.try(Promise, () => {
+    	return foo;
+    }, arr);
+    fooProm = Promise.try(Promise, () => {
+    	return foo;
+    }, arr, x);
+    

--- a/tests/baselines/reference/bluebirdStaticThis.js
+++ b/tests/baselines/reference/bluebirdStaticThis.js
@@ -1,0 +1,158 @@
+//// [bluebirdStaticThis.ts]
+// This version is reduced from the full d.ts by removing almost all the tests
+// and all the comments.
+// Then it adds explicit `this` arguments to the static members.
+// Tests by: Bart van der Schoor <https://github.com/Bartvds>
+declare class Promise<R> implements Promise.Thenable<R> {
+	constructor(callback: (resolve: (thenableOrResult: R | Promise.Thenable<R>) => void, reject: (error: any) => void) => void);
+    static try<R>(dit: typeof Promise, fn: () => Promise.Thenable<R>, args?: any[], ctx?: any): Promise<R>;
+    static try<R>(dit: typeof Promise, fn: () => R, args?: any[], ctx?: any): Promise<R>;
+
+    static attempt<R>(dit: typeof Promise, fn: () => Promise.Thenable<R>, args?: any[], ctx?: any): Promise<R>;
+    static attempt<R>(dit: typeof Promise, fn: () => R, args?: any[], ctx?: any): Promise<R>;
+
+    static method(dit: typeof Promise, fn: Function): Function;
+
+    static resolve(dit: typeof Promise): Promise<void>;
+    static resolve<R>(dit: typeof Promise, value: Promise.Thenable<R>): Promise<R>;
+    static resolve<R>(dit: typeof Promise, value: R): Promise<R>;
+
+    static reject(dit: typeof Promise, reason: any): Promise<any>;
+    static reject<R>(dit: typeof Promise, reason: any): Promise<R>;
+
+    static defer<R>(dit: typeof Promise): Promise.Resolver<R>;
+
+    static cast<R>(dit: typeof Promise, value: Promise.Thenable<R>): Promise<R>;
+    static cast<R>(dit: typeof Promise, value: R): Promise<R>;
+
+    static bind(dit: typeof Promise, thisArg: any): Promise<void>;
+
+    static is(dit: typeof Promise, value: any): boolean;
+
+    static longStackTraces(dit: typeof Promise): void;
+
+    static delay<R>(dit: typeof Promise, value: Promise.Thenable<R>, ms: number): Promise<R>;
+    static delay<R>(dit: typeof Promise, value: R, ms: number): Promise<R>;
+    static delay(dit: typeof Promise, ms: number): Promise<void>;
+
+    static promisify(dit: typeof Promise, nodeFunction: Function, receiver?: any): Function;
+
+    static promisifyAll(dit: typeof Promise, target: Object): Object;
+
+    static coroutine<R>(dit: typeof Promise, generatorFunction: Function): Function;
+
+    static spawn<R>(dit: typeof Promise, generatorFunction: Function): Promise<R>;
+
+    static noConflict(dit: typeof Promise): typeof Promise;
+
+    static onPossiblyUnhandledRejection(dit: typeof Promise, handler: (reason: any) => any): void;
+
+    static all<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<R[]>;
+    static all<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<R[]>;
+    static all<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<R[]>;
+    static all<R>(dit: typeof Promise, values: R[]): Promise<R[]>;
+
+    static props(dit: typeof Promise, object: Promise<Object>): Promise<Object>;
+    static props(dit: typeof Promise, object: Object): Promise<Object>;
+
+    static settle<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<Promise.Inspection<R>[]>;
+    static settle<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<Promise.Inspection<R>[]>;
+    static settle<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<Promise.Inspection<R>[]>;
+    static settle<R>(dit: typeof Promise, values: R[]): Promise<Promise.Inspection<R>[]>;
+
+    static any<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<R>;
+    static any<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<R>;
+    static any<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<R>;
+    static any<R>(dit: typeof Promise, values: R[]): Promise<R>;
+
+    static race<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<R>;
+    static race<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<R>;
+    static race<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<R>;
+    static race<R>(dit: typeof Promise, values: R[]): Promise<R>;
+
+    static some<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, count: number): Promise<R[]>;
+    static some<R>(dit: typeof Promise, values: Promise.Thenable<R[]>, count: number): Promise<R[]>;
+    static some<R>(dit: typeof Promise, values: Promise.Thenable<R>[], count: number): Promise<R[]>;
+    static some<R>(dit: typeof Promise, values: R[], count: number): Promise<R[]>;
+
+    static join<R>(dit: typeof Promise, ...values: Promise.Thenable<R>[]): Promise<R[]>;
+    static join<R>(dit: typeof Promise, ...values: R[]): Promise<R[]>;
+
+    static map<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+    static map<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
+    static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+    static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
+    static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+    static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
+    static map<R, U>(dit: typeof Promise, values: R[], mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+    static map<R, U>(dit: typeof Promise, values: R[], mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
+
+    static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
+    static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
+
+    static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
+    static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
+
+    static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
+    static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
+
+    static reduce<R, U>(dit: typeof Promise, values: R[], reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
+    static reduce<R, U>(dit: typeof Promise, values: R[], reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
+
+    static filter<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
+    static filter<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
+    static filter<R>(dit: typeof Promise, values: Promise.Thenable<R[]>, filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
+    static filter<R>(dit: typeof Promise, values: Promise.Thenable<R[]>, filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
+    static filter<R>(dit: typeof Promise, values: Promise.Thenable<R>[], filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
+    static filter<R>(dit: typeof Promise, values: Promise.Thenable<R>[], filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
+    static filter<R>(dit: typeof Promise, values: R[], filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
+    static filter<R>(dit: typeof Promise, values: R[], filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
+}
+
+declare module Promise {
+	export interface Thenable<R> {
+		then<U>(onFulfilled: (value: R) => Thenable<U>, onRejected: (error: any) => Thenable<U>): Thenable<U>;
+		then<U>(onFulfilled: (value: R) => Thenable<U>, onRejected?: (error: any) => U): Thenable<U>;
+		then<U>(onFulfilled: (value: R) => U, onRejected: (error: any) => Thenable<U>): Thenable<U>;
+		then<U>(onFulfilled?: (value: R) => U, onRejected?: (error: any) => U): Thenable<U>;
+	}
+
+}
+
+declare module 'bluebird' {
+	export = Promise;
+}
+interface Foo {
+    a: number;
+    b: string;
+}
+var x: any;
+var arr: any[];
+var foo: Foo;
+var fooProm: Promise<Foo>;
+
+fooProm = Promise.try(Promise, () => {
+	return foo;
+});
+fooProm = Promise.try(Promise, () => {
+	return foo;
+}, arr);
+fooProm = Promise.try(Promise, () => {
+	return foo;
+}, arr, x);
+
+
+//// [bluebirdStaticThis.js]
+var x;
+var arr;
+var foo;
+var fooProm;
+fooProm = Promise.try(Promise, function () {
+    return foo;
+});
+fooProm = Promise.try(Promise, function () {
+    return foo;
+}, arr);
+fooProm = Promise.try(Promise, function () {
+    return foo;
+}, arr, x);

--- a/tests/baselines/reference/staticAnonymousTypeNotReferencingTypeParameter.js
+++ b/tests/baselines/reference/staticAnonymousTypeNotReferencingTypeParameter.js
@@ -1,0 +1,290 @@
+//// [staticAnonymousTypeNotReferencingTypeParameter.ts]
+function outer<T>(x: T) {
+  class Inner {
+    static y: T = x;
+  }
+  return Inner;
+}
+let y: number = outer(5).y;
+
+class ListWrapper2 {
+  static clone<T>(dit: typeof ListWrapper2, array: T[]): T[] { return array.slice(0); }
+  static reversed<T>(dit: typeof ListWrapper2, array: T[]): T[] {
+    var a = ListWrapper2.clone(dit, array);
+    return a;
+  }
+}
+namespace tessst {
+    /**
+     * Iterates through 'array' by index and performs the callback on each element of array until the callback
+     * returns a truthy value, then returns that value.
+     * If no such value is found, the callback is applied to each element of array and undefined is returned.
+     */
+    export function funkyFor<T, U>(array: T[], callback: (element: T, index: number) => U): U {
+        if (array) {
+            for (let i = 0, len = array.length; i < len; i++) {
+                const result = callback(array[i], i);
+                if (result) {
+                    return result;
+                }
+            }
+        }
+        return undefined;
+    }
+}
+interface Scanner {
+  scanRange<T>(start: number, length: number, callback: () => T): T;
+}
+class ListWrapper {
+  // JS has no way to express a statically fixed size list, but dart does so we
+  // keep both methods.
+  static createFixedSize(dit: typeof ListWrapper, size: number): any[] { return new Array(size); }
+  static createGrowableSize(dit: typeof ListWrapper, size: number): any[] { return new Array(size); }
+  static clone<T>(dit: typeof ListWrapper, array: T[]): T[] { return array.slice(0); }
+  static forEachWithIndex<T>(dit: typeof ListWrapper, array: T[], fn: (t: T, n: number) => void) {
+    for (var i = 0; i < array.length; i++) {
+      fn(array[i], i);
+    }
+  }
+  static first<T>(dit: typeof ListWrapper, array: T[]): T {
+    if (!array) return null;
+    return array[0];
+  }
+  static last<T>(dit: typeof ListWrapper, array: T[]): T {
+    if (!array || array.length == 0) return null;
+    return array[array.length - 1];
+  }
+  static indexOf<T>(dit: typeof ListWrapper, array: T[], value: T, startIndex: number = 0): number {
+    return array.indexOf(value, startIndex);
+  }
+  static contains<T>(dit: typeof ListWrapper, list: T[], el: T): boolean { return list.indexOf(el) !== -1; }
+  static reversed<T>(dit: typeof ListWrapper, array: T[]): T[] {
+    var a = ListWrapper.clone(dit, array);
+    let scanner: Scanner;
+    scanner.scanRange(3, 5, () => {  });
+    return tessst.funkyFor(array, t => t.toString()) ? a.reverse() : a;
+  }
+  static concat(dit: typeof ListWrapper, a: any[], b: any[]): any[] { return a.concat(b); }
+  static insert<T>(dit: typeof ListWrapper, list: T[], index: number, value: T) { list.splice(index, 0, value); }
+  static removeAt<T>(dit: typeof ListWrapper, list: T[], index: number): T {
+    var res = list[index];
+    list.splice(index, 1);
+    return res;
+  }
+  static removeAll<T>(dit: typeof ListWrapper, list: T[], items: T[]) {
+    for (var i = 0; i < items.length; ++i) {
+      var index = list.indexOf(items[i]);
+      list.splice(index, 1);
+    }
+  }
+  static remove<T>(dit: typeof ListWrapper, list: T[], el: T): boolean {
+    var index = list.indexOf(el);
+    if (index > -1) {
+      list.splice(index, 1);
+      return true;
+    }
+    return false;
+  }
+  static clear(dit: typeof ListWrapper, list: any[]) { list.length = 0; }
+  static isEmpty(dit: typeof ListWrapper, list: any[]): boolean { return list.length == 0; }
+  static fill(dit: typeof ListWrapper, list: any[], value: any, start: number = 0, end: number = null) {
+    list.fill(value, start, end === null ? list.length : end);
+  }
+  static equals(dit: typeof ListWrapper, a: any[], b: any[]): boolean {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; ++i) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
+  }
+  static slice<T>(dit: typeof ListWrapper, l: T[], from: number = 0, to: number = null): T[] {
+    return l.slice(from, to === null ? undefined : to);
+  }
+  static splice<T>(dit: typeof ListWrapper, l: T[], from: number, length: number): T[] { return l.splice(from, length); }
+  static sort<T>(dit: typeof ListWrapper, l: T[], compareFn?: (a: T, b: T) => number) {
+    if (isPresent(compareFn)) {
+      l.sort(compareFn);
+    } else {
+      l.sort();
+    }
+  }
+  static toString<T>(dit: typeof ListWrapper, l: T[]): string { return l.toString(); }
+  static toJSON<T>(dit: typeof ListWrapper, l: T[]): string { return JSON.stringify(l); }
+
+  static maximum<T>(dit: typeof ListWrapper, list: T[], predicate: (t: T) => number): T {
+    if (list.length == 0) {
+      return null;
+    }
+    var solution: T = null;
+    var maxValue = -Infinity;
+    for (var index = 0; index < list.length; index++) {
+      var candidate = list[index];
+      if (isBlank(candidate)) {
+        continue;
+      }
+      var candidateValue = predicate(candidate);
+      if (candidateValue > maxValue) {
+        solution = candidate;
+        maxValue = candidateValue;
+      }
+    }
+    return solution;
+  }
+}
+let cloned = ListWrapper.clone(ListWrapper, [1,2,3,4]);
+declare function isBlank(x: any): boolean;
+declare function isPresent<T>(compareFn?: (a: T, b: T) => number): boolean;
+interface Array<T> {
+	fill(value: any, start: number, end: number): void;
+}
+
+//// [staticAnonymousTypeNotReferencingTypeParameter.js]
+function outer(x) {
+    var Inner = (function () {
+        function Inner() {
+        }
+        Inner.y = x;
+        return Inner;
+    }());
+    return Inner;
+}
+var y = outer(5).y;
+var ListWrapper2 = (function () {
+    function ListWrapper2() {
+    }
+    ListWrapper2.clone = function (dit, array) { return array.slice(0); };
+    ListWrapper2.reversed = function (dit, array) {
+        var a = ListWrapper2.clone(dit, array);
+        return a;
+    };
+    return ListWrapper2;
+}());
+var tessst;
+(function (tessst) {
+    /**
+     * Iterates through 'array' by index and performs the callback on each element of array until the callback
+     * returns a truthy value, then returns that value.
+     * If no such value is found, the callback is applied to each element of array and undefined is returned.
+     */
+    function funkyFor(array, callback) {
+        if (array) {
+            for (var i = 0, len = array.length; i < len; i++) {
+                var result = callback(array[i], i);
+                if (result) {
+                    return result;
+                }
+            }
+        }
+        return undefined;
+    }
+    tessst.funkyFor = funkyFor;
+})(tessst || (tessst = {}));
+var ListWrapper = (function () {
+    function ListWrapper() {
+    }
+    // JS has no way to express a statically fixed size list, but dart does so we
+    // keep both methods.
+    ListWrapper.createFixedSize = function (dit, size) { return new Array(size); };
+    ListWrapper.createGrowableSize = function (dit, size) { return new Array(size); };
+    ListWrapper.clone = function (dit, array) { return array.slice(0); };
+    ListWrapper.forEachWithIndex = function (dit, array, fn) {
+        for (var i = 0; i < array.length; i++) {
+            fn(array[i], i);
+        }
+    };
+    ListWrapper.first = function (dit, array) {
+        if (!array)
+            return null;
+        return array[0];
+    };
+    ListWrapper.last = function (dit, array) {
+        if (!array || array.length == 0)
+            return null;
+        return array[array.length - 1];
+    };
+    ListWrapper.indexOf = function (dit, array, value, startIndex) {
+        if (startIndex === void 0) { startIndex = 0; }
+        return array.indexOf(value, startIndex);
+    };
+    ListWrapper.contains = function (dit, list, el) { return list.indexOf(el) !== -1; };
+    ListWrapper.reversed = function (dit, array) {
+        var a = ListWrapper.clone(dit, array);
+        var scanner;
+        scanner.scanRange(3, 5, function () { });
+        return tessst.funkyFor(array, function (t) { return t.toString(); }) ? a.reverse() : a;
+    };
+    ListWrapper.concat = function (dit, a, b) { return a.concat(b); };
+    ListWrapper.insert = function (dit, list, index, value) { list.splice(index, 0, value); };
+    ListWrapper.removeAt = function (dit, list, index) {
+        var res = list[index];
+        list.splice(index, 1);
+        return res;
+    };
+    ListWrapper.removeAll = function (dit, list, items) {
+        for (var i = 0; i < items.length; ++i) {
+            var index = list.indexOf(items[i]);
+            list.splice(index, 1);
+        }
+    };
+    ListWrapper.remove = function (dit, list, el) {
+        var index = list.indexOf(el);
+        if (index > -1) {
+            list.splice(index, 1);
+            return true;
+        }
+        return false;
+    };
+    ListWrapper.clear = function (dit, list) { list.length = 0; };
+    ListWrapper.isEmpty = function (dit, list) { return list.length == 0; };
+    ListWrapper.fill = function (dit, list, value, start, end) {
+        if (start === void 0) { start = 0; }
+        if (end === void 0) { end = null; }
+        list.fill(value, start, end === null ? list.length : end);
+    };
+    ListWrapper.equals = function (dit, a, b) {
+        if (a.length != b.length)
+            return false;
+        for (var i = 0; i < a.length; ++i) {
+            if (a[i] !== b[i])
+                return false;
+        }
+        return true;
+    };
+    ListWrapper.slice = function (dit, l, from, to) {
+        if (from === void 0) { from = 0; }
+        if (to === void 0) { to = null; }
+        return l.slice(from, to === null ? undefined : to);
+    };
+    ListWrapper.splice = function (dit, l, from, length) { return l.splice(from, length); };
+    ListWrapper.sort = function (dit, l, compareFn) {
+        if (isPresent(compareFn)) {
+            l.sort(compareFn);
+        }
+        else {
+            l.sort();
+        }
+    };
+    ListWrapper.toString = function (dit, l) { return l.toString(); };
+    ListWrapper.toJSON = function (dit, l) { return JSON.stringify(l); };
+    ListWrapper.maximum = function (dit, list, predicate) {
+        if (list.length == 0) {
+            return null;
+        }
+        var solution = null;
+        var maxValue = -Infinity;
+        for (var index = 0; index < list.length; index++) {
+            var candidate = list[index];
+            if (isBlank(candidate)) {
+                continue;
+            }
+            var candidateValue = predicate(candidate);
+            if (candidateValue > maxValue) {
+                solution = candidate;
+                maxValue = candidateValue;
+            }
+        }
+        return solution;
+    };
+    return ListWrapper;
+}());
+var cloned = ListWrapper.clone(ListWrapper, [1, 2, 3, 4]);

--- a/tests/baselines/reference/staticAnonymousTypeNotReferencingTypeParameter.symbols
+++ b/tests/baselines/reference/staticAnonymousTypeNotReferencingTypeParameter.symbols
@@ -1,0 +1,664 @@
+=== tests/cases/compiler/staticAnonymousTypeNotReferencingTypeParameter.ts ===
+function outer<T>(x: T) {
+>outer : Symbol(outer, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 0, 0))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 0, 15))
+>x : Symbol(x, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 0, 18))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 0, 15))
+
+  class Inner {
+>Inner : Symbol(Inner, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 0, 25))
+
+    static y: T = x;
+>y : Symbol(Inner.y, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 1, 15))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 0, 15))
+>x : Symbol(x, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 0, 18))
+  }
+  return Inner;
+>Inner : Symbol(Inner, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 0, 25))
+}
+let y: number = outer(5).y;
+>y : Symbol(y, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 6, 3))
+>outer(5).y : Symbol(Inner.y, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 1, 15))
+>outer : Symbol(outer, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 0, 0))
+>y : Symbol(Inner.y, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 1, 15))
+
+class ListWrapper2 {
+>ListWrapper2 : Symbol(ListWrapper2, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 6, 27))
+
+  static clone<T>(dit: typeof ListWrapper2, array: T[]): T[] { return array.slice(0); }
+>clone : Symbol(ListWrapper2.clone, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 8, 20))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 9, 15))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 9, 18))
+>ListWrapper2 : Symbol(ListWrapper2, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 6, 27))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 9, 43))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 9, 15))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 9, 15))
+>array.slice : Symbol(Array.slice, Decl(lib.d.ts, --, --))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 9, 43))
+>slice : Symbol(Array.slice, Decl(lib.d.ts, --, --))
+
+  static reversed<T>(dit: typeof ListWrapper2, array: T[]): T[] {
+>reversed : Symbol(ListWrapper2.reversed, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 9, 87))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 10, 18))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 10, 21))
+>ListWrapper2 : Symbol(ListWrapper2, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 6, 27))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 10, 46))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 10, 18))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 10, 18))
+
+    var a = ListWrapper2.clone(dit, array);
+>a : Symbol(a, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 11, 7))
+>ListWrapper2.clone : Symbol(ListWrapper2.clone, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 8, 20))
+>ListWrapper2 : Symbol(ListWrapper2, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 6, 27))
+>clone : Symbol(ListWrapper2.clone, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 8, 20))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 10, 21))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 10, 46))
+
+    return a;
+>a : Symbol(a, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 11, 7))
+  }
+}
+namespace tessst {
+>tessst : Symbol(tessst, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 14, 1))
+
+    /**
+     * Iterates through 'array' by index and performs the callback on each element of array until the callback
+     * returns a truthy value, then returns that value.
+     * If no such value is found, the callback is applied to each element of array and undefined is returned.
+     */
+    export function funkyFor<T, U>(array: T[], callback: (element: T, index: number) => U): U {
+>funkyFor : Symbol(funkyFor, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 15, 18))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 21, 29))
+>U : Symbol(U, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 21, 31))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 21, 35))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 21, 29))
+>callback : Symbol(callback, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 21, 46))
+>element : Symbol(element, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 21, 58))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 21, 29))
+>index : Symbol(index, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 21, 69))
+>U : Symbol(U, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 21, 31))
+>U : Symbol(U, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 21, 31))
+
+        if (array) {
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 21, 35))
+
+            for (let i = 0, len = array.length; i < len; i++) {
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 23, 20))
+>len : Symbol(len, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 23, 27))
+>array.length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 21, 35))
+>length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 23, 20))
+>len : Symbol(len, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 23, 27))
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 23, 20))
+
+                const result = callback(array[i], i);
+>result : Symbol(result, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 24, 21))
+>callback : Symbol(callback, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 21, 46))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 21, 35))
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 23, 20))
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 23, 20))
+
+                if (result) {
+>result : Symbol(result, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 24, 21))
+
+                    return result;
+>result : Symbol(result, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 24, 21))
+                }
+            }
+        }
+        return undefined;
+>undefined : Symbol(undefined)
+    }
+}
+interface Scanner {
+>Scanner : Symbol(Scanner, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 32, 1))
+
+  scanRange<T>(start: number, length: number, callback: () => T): T;
+>scanRange : Symbol(scanRange, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 33, 19))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 34, 12))
+>start : Symbol(start, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 34, 15))
+>length : Symbol(length, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 34, 29))
+>callback : Symbol(callback, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 34, 45))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 34, 12))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 34, 12))
+}
+class ListWrapper {
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+
+  // JS has no way to express a statically fixed size list, but dart does so we
+  // keep both methods.
+  static createFixedSize(dit: typeof ListWrapper, size: number): any[] { return new Array(size); }
+>createFixedSize : Symbol(ListWrapper.createFixedSize, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 36, 19))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 39, 25))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>size : Symbol(size, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 39, 49))
+>Array : Symbol(Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 134, 75))
+>size : Symbol(size, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 39, 49))
+
+  static createGrowableSize(dit: typeof ListWrapper, size: number): any[] { return new Array(size); }
+>createGrowableSize : Symbol(ListWrapper.createGrowableSize, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 39, 98))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 40, 28))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>size : Symbol(size, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 40, 52))
+>Array : Symbol(Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 134, 75))
+>size : Symbol(size, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 40, 52))
+
+  static clone<T>(dit: typeof ListWrapper, array: T[]): T[] { return array.slice(0); }
+>clone : Symbol(ListWrapper.clone, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 40, 101))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 41, 15))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 41, 18))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 41, 42))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 41, 15))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 41, 15))
+>array.slice : Symbol(Array.slice, Decl(lib.d.ts, --, --))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 41, 42))
+>slice : Symbol(Array.slice, Decl(lib.d.ts, --, --))
+
+  static forEachWithIndex<T>(dit: typeof ListWrapper, array: T[], fn: (t: T, n: number) => void) {
+>forEachWithIndex : Symbol(ListWrapper.forEachWithIndex, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 41, 86))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 42, 26))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 42, 29))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 42, 53))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 42, 26))
+>fn : Symbol(fn, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 42, 65))
+>t : Symbol(t, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 42, 71))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 42, 26))
+>n : Symbol(n, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 42, 76))
+
+    for (var i = 0; i < array.length; i++) {
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 43, 12))
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 43, 12))
+>array.length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 42, 53))
+>length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 43, 12))
+
+      fn(array[i], i);
+>fn : Symbol(fn, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 42, 65))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 42, 53))
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 43, 12))
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 43, 12))
+    }
+  }
+  static first<T>(dit: typeof ListWrapper, array: T[]): T {
+>first : Symbol(ListWrapper.first, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 46, 3))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 47, 15))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 47, 18))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 47, 42))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 47, 15))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 47, 15))
+
+    if (!array) return null;
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 47, 42))
+
+    return array[0];
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 47, 42))
+  }
+  static last<T>(dit: typeof ListWrapper, array: T[]): T {
+>last : Symbol(ListWrapper.last, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 50, 3))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 51, 14))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 51, 17))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 51, 41))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 51, 14))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 51, 14))
+
+    if (!array || array.length == 0) return null;
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 51, 41))
+>array.length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 51, 41))
+>length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+
+    return array[array.length - 1];
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 51, 41))
+>array.length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 51, 41))
+>length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+  }
+  static indexOf<T>(dit: typeof ListWrapper, array: T[], value: T, startIndex: number = 0): number {
+>indexOf : Symbol(ListWrapper.indexOf, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 54, 3))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 55, 17))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 55, 20))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 55, 44))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 55, 17))
+>value : Symbol(value, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 55, 56))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 55, 17))
+>startIndex : Symbol(startIndex, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 55, 66))
+
+    return array.indexOf(value, startIndex);
+>array.indexOf : Symbol(Array.indexOf, Decl(lib.d.ts, --, --))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 55, 44))
+>indexOf : Symbol(Array.indexOf, Decl(lib.d.ts, --, --))
+>value : Symbol(value, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 55, 56))
+>startIndex : Symbol(startIndex, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 55, 66))
+  }
+  static contains<T>(dit: typeof ListWrapper, list: T[], el: T): boolean { return list.indexOf(el) !== -1; }
+>contains : Symbol(ListWrapper.contains, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 57, 3))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 58, 18))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 58, 21))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 58, 45))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 58, 18))
+>el : Symbol(el, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 58, 56))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 58, 18))
+>list.indexOf : Symbol(Array.indexOf, Decl(lib.d.ts, --, --))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 58, 45))
+>indexOf : Symbol(Array.indexOf, Decl(lib.d.ts, --, --))
+>el : Symbol(el, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 58, 56))
+
+  static reversed<T>(dit: typeof ListWrapper, array: T[]): T[] {
+>reversed : Symbol(ListWrapper.reversed, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 58, 108))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 59, 18))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 59, 21))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 59, 45))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 59, 18))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 59, 18))
+
+    var a = ListWrapper.clone(dit, array);
+>a : Symbol(a, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 60, 7))
+>ListWrapper.clone : Symbol(ListWrapper.clone, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 40, 101))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>clone : Symbol(ListWrapper.clone, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 40, 101))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 59, 21))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 59, 45))
+
+    let scanner: Scanner;
+>scanner : Symbol(scanner, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 61, 7))
+>Scanner : Symbol(Scanner, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 32, 1))
+
+    scanner.scanRange(3, 5, () => {  });
+>scanner.scanRange : Symbol(Scanner.scanRange, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 33, 19))
+>scanner : Symbol(scanner, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 61, 7))
+>scanRange : Symbol(Scanner.scanRange, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 33, 19))
+
+    return tessst.funkyFor(array, t => t.toString()) ? a.reverse() : a;
+>tessst.funkyFor : Symbol(tessst.funkyFor, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 15, 18))
+>tessst : Symbol(tessst, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 14, 1))
+>funkyFor : Symbol(tessst.funkyFor, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 15, 18))
+>array : Symbol(array, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 59, 45))
+>t : Symbol(t, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 63, 33))
+>t.toString : Symbol(Object.toString, Decl(lib.d.ts, --, --))
+>t : Symbol(t, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 63, 33))
+>toString : Symbol(Object.toString, Decl(lib.d.ts, --, --))
+>a.reverse : Symbol(Array.reverse, Decl(lib.d.ts, --, --))
+>a : Symbol(a, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 60, 7))
+>reverse : Symbol(Array.reverse, Decl(lib.d.ts, --, --))
+>a : Symbol(a, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 60, 7))
+  }
+  static concat(dit: typeof ListWrapper, a: any[], b: any[]): any[] { return a.concat(b); }
+>concat : Symbol(ListWrapper.concat, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 64, 3))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 65, 16))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>a : Symbol(a, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 65, 40))
+>b : Symbol(b, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 65, 50))
+>a.concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>a : Symbol(a, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 65, 40))
+>concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>b : Symbol(b, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 65, 50))
+
+  static insert<T>(dit: typeof ListWrapper, list: T[], index: number, value: T) { list.splice(index, 0, value); }
+>insert : Symbol(ListWrapper.insert, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 65, 91))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 66, 16))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 66, 19))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 66, 43))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 66, 16))
+>index : Symbol(index, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 66, 54))
+>value : Symbol(value, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 66, 69))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 66, 16))
+>list.splice : Symbol(Array.splice, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 66, 43))
+>splice : Symbol(Array.splice, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>index : Symbol(index, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 66, 54))
+>value : Symbol(value, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 66, 69))
+
+  static removeAt<T>(dit: typeof ListWrapper, list: T[], index: number): T {
+>removeAt : Symbol(ListWrapper.removeAt, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 66, 113))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 67, 18))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 67, 21))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 67, 45))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 67, 18))
+>index : Symbol(index, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 67, 56))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 67, 18))
+
+    var res = list[index];
+>res : Symbol(res, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 68, 7))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 67, 45))
+>index : Symbol(index, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 67, 56))
+
+    list.splice(index, 1);
+>list.splice : Symbol(Array.splice, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 67, 45))
+>splice : Symbol(Array.splice, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>index : Symbol(index, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 67, 56))
+
+    return res;
+>res : Symbol(res, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 68, 7))
+  }
+  static removeAll<T>(dit: typeof ListWrapper, list: T[], items: T[]) {
+>removeAll : Symbol(ListWrapper.removeAll, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 71, 3))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 72, 19))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 72, 22))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 72, 46))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 72, 19))
+>items : Symbol(items, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 72, 57))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 72, 19))
+
+    for (var i = 0; i < items.length; ++i) {
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 73, 12))
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 73, 12))
+>items.length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>items : Symbol(items, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 72, 57))
+>length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 73, 12))
+
+      var index = list.indexOf(items[i]);
+>index : Symbol(index, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 74, 9))
+>list.indexOf : Symbol(Array.indexOf, Decl(lib.d.ts, --, --))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 72, 46))
+>indexOf : Symbol(Array.indexOf, Decl(lib.d.ts, --, --))
+>items : Symbol(items, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 72, 57))
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 73, 12))
+
+      list.splice(index, 1);
+>list.splice : Symbol(Array.splice, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 72, 46))
+>splice : Symbol(Array.splice, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>index : Symbol(index, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 74, 9))
+    }
+  }
+  static remove<T>(dit: typeof ListWrapper, list: T[], el: T): boolean {
+>remove : Symbol(ListWrapper.remove, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 77, 3))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 78, 16))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 78, 19))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 78, 43))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 78, 16))
+>el : Symbol(el, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 78, 54))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 78, 16))
+
+    var index = list.indexOf(el);
+>index : Symbol(index, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 79, 7))
+>list.indexOf : Symbol(Array.indexOf, Decl(lib.d.ts, --, --))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 78, 43))
+>indexOf : Symbol(Array.indexOf, Decl(lib.d.ts, --, --))
+>el : Symbol(el, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 78, 54))
+
+    if (index > -1) {
+>index : Symbol(index, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 79, 7))
+
+      list.splice(index, 1);
+>list.splice : Symbol(Array.splice, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 78, 43))
+>splice : Symbol(Array.splice, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>index : Symbol(index, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 79, 7))
+
+      return true;
+    }
+    return false;
+  }
+  static clear(dit: typeof ListWrapper, list: any[]) { list.length = 0; }
+>clear : Symbol(ListWrapper.clear, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 85, 3))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 86, 15))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 86, 39))
+>list.length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 86, 39))
+>length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+
+  static isEmpty(dit: typeof ListWrapper, list: any[]): boolean { return list.length == 0; }
+>isEmpty : Symbol(ListWrapper.isEmpty, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 86, 73))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 87, 17))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 87, 41))
+>list.length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 87, 41))
+>length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+
+  static fill(dit: typeof ListWrapper, list: any[], value: any, start: number = 0, end: number = null) {
+>fill : Symbol(ListWrapper.fill, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 87, 92))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 88, 14))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 88, 38))
+>value : Symbol(value, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 88, 51))
+>start : Symbol(start, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 88, 63))
+>end : Symbol(end, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 88, 82))
+
+    list.fill(value, start, end === null ? list.length : end);
+>list.fill : Symbol(Array.fill, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 135, 20))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 88, 38))
+>fill : Symbol(Array.fill, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 135, 20))
+>value : Symbol(value, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 88, 51))
+>start : Symbol(start, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 88, 63))
+>end : Symbol(end, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 88, 82))
+>list.length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 88, 38))
+>length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>end : Symbol(end, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 88, 82))
+  }
+  static equals(dit: typeof ListWrapper, a: any[], b: any[]): boolean {
+>equals : Symbol(ListWrapper.equals, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 90, 3))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 91, 16))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>a : Symbol(a, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 91, 40))
+>b : Symbol(b, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 91, 50))
+
+    if (a.length != b.length) return false;
+>a.length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>a : Symbol(a, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 91, 40))
+>length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>b.length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>b : Symbol(b, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 91, 50))
+>length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+
+    for (var i = 0; i < a.length; ++i) {
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 93, 12))
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 93, 12))
+>a.length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>a : Symbol(a, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 91, 40))
+>length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 93, 12))
+
+      if (a[i] !== b[i]) return false;
+>a : Symbol(a, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 91, 40))
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 93, 12))
+>b : Symbol(b, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 91, 50))
+>i : Symbol(i, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 93, 12))
+    }
+    return true;
+  }
+  static slice<T>(dit: typeof ListWrapper, l: T[], from: number = 0, to: number = null): T[] {
+>slice : Symbol(ListWrapper.slice, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 97, 3))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 98, 15))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 98, 18))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>l : Symbol(l, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 98, 42))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 98, 15))
+>from : Symbol(from, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 98, 50))
+>to : Symbol(to, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 98, 68))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 98, 15))
+
+    return l.slice(from, to === null ? undefined : to);
+>l.slice : Symbol(Array.slice, Decl(lib.d.ts, --, --))
+>l : Symbol(l, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 98, 42))
+>slice : Symbol(Array.slice, Decl(lib.d.ts, --, --))
+>from : Symbol(from, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 98, 50))
+>to : Symbol(to, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 98, 68))
+>undefined : Symbol(undefined)
+>to : Symbol(to, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 98, 68))
+  }
+  static splice<T>(dit: typeof ListWrapper, l: T[], from: number, length: number): T[] { return l.splice(from, length); }
+>splice : Symbol(ListWrapper.splice, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 100, 3))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 101, 16))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 101, 19))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>l : Symbol(l, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 101, 43))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 101, 16))
+>from : Symbol(from, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 101, 51))
+>length : Symbol(length, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 101, 65))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 101, 16))
+>l.splice : Symbol(Array.splice, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>l : Symbol(l, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 101, 43))
+>splice : Symbol(Array.splice, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>from : Symbol(from, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 101, 51))
+>length : Symbol(length, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 101, 65))
+
+  static sort<T>(dit: typeof ListWrapper, l: T[], compareFn?: (a: T, b: T) => number) {
+>sort : Symbol(ListWrapper.sort, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 101, 121))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 102, 14))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 102, 17))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>l : Symbol(l, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 102, 41))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 102, 14))
+>compareFn : Symbol(compareFn, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 102, 49))
+>a : Symbol(a, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 102, 63))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 102, 14))
+>b : Symbol(b, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 102, 68))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 102, 14))
+
+    if (isPresent(compareFn)) {
+>isPresent : Symbol(isPresent, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 133, 42))
+>compareFn : Symbol(compareFn, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 102, 49))
+
+      l.sort(compareFn);
+>l.sort : Symbol(Array.sort, Decl(lib.d.ts, --, --))
+>l : Symbol(l, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 102, 41))
+>sort : Symbol(Array.sort, Decl(lib.d.ts, --, --))
+>compareFn : Symbol(compareFn, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 102, 49))
+
+    } else {
+      l.sort();
+>l.sort : Symbol(Array.sort, Decl(lib.d.ts, --, --))
+>l : Symbol(l, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 102, 41))
+>sort : Symbol(Array.sort, Decl(lib.d.ts, --, --))
+    }
+  }
+  static toString<T>(dit: typeof ListWrapper, l: T[]): string { return l.toString(); }
+>toString : Symbol(ListWrapper.toString, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 108, 3))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 109, 18))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 109, 21))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>l : Symbol(l, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 109, 45))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 109, 18))
+>l.toString : Symbol(Array.toString, Decl(lib.d.ts, --, --))
+>l : Symbol(l, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 109, 45))
+>toString : Symbol(Array.toString, Decl(lib.d.ts, --, --))
+
+  static toJSON<T>(dit: typeof ListWrapper, l: T[]): string { return JSON.stringify(l); }
+>toJSON : Symbol(ListWrapper.toJSON, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 109, 86))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 110, 16))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 110, 19))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>l : Symbol(l, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 110, 43))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 110, 16))
+>JSON.stringify : Symbol(JSON.stringify, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>JSON : Symbol(JSON, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>stringify : Symbol(JSON.stringify, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>l : Symbol(l, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 110, 43))
+
+  static maximum<T>(dit: typeof ListWrapper, list: T[], predicate: (t: T) => number): T {
+>maximum : Symbol(ListWrapper.maximum, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 110, 89))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 112, 17))
+>dit : Symbol(dit, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 112, 20))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 112, 44))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 112, 17))
+>predicate : Symbol(predicate, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 112, 55))
+>t : Symbol(t, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 112, 68))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 112, 17))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 112, 17))
+
+    if (list.length == 0) {
+>list.length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 112, 44))
+>length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+
+      return null;
+    }
+    var solution: T = null;
+>solution : Symbol(solution, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 116, 7))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 112, 17))
+
+    var maxValue = -Infinity;
+>maxValue : Symbol(maxValue, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 117, 7))
+>Infinity : Symbol(Infinity, Decl(lib.d.ts, --, --))
+
+    for (var index = 0; index < list.length; index++) {
+>index : Symbol(index, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 118, 12))
+>index : Symbol(index, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 118, 12))
+>list.length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 112, 44))
+>length : Symbol(Array.length, Decl(lib.d.ts, --, --))
+>index : Symbol(index, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 118, 12))
+
+      var candidate = list[index];
+>candidate : Symbol(candidate, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 119, 9))
+>list : Symbol(list, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 112, 44))
+>index : Symbol(index, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 118, 12))
+
+      if (isBlank(candidate)) {
+>isBlank : Symbol(isBlank, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 132, 55))
+>candidate : Symbol(candidate, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 119, 9))
+
+        continue;
+      }
+      var candidateValue = predicate(candidate);
+>candidateValue : Symbol(candidateValue, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 123, 9))
+>predicate : Symbol(predicate, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 112, 55))
+>candidate : Symbol(candidate, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 119, 9))
+
+      if (candidateValue > maxValue) {
+>candidateValue : Symbol(candidateValue, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 123, 9))
+>maxValue : Symbol(maxValue, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 117, 7))
+
+        solution = candidate;
+>solution : Symbol(solution, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 116, 7))
+>candidate : Symbol(candidate, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 119, 9))
+
+        maxValue = candidateValue;
+>maxValue : Symbol(maxValue, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 117, 7))
+>candidateValue : Symbol(candidateValue, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 123, 9))
+      }
+    }
+    return solution;
+>solution : Symbol(solution, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 116, 7))
+  }
+}
+let cloned = ListWrapper.clone(ListWrapper, [1,2,3,4]);
+>cloned : Symbol(cloned, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 132, 3))
+>ListWrapper.clone : Symbol(ListWrapper.clone, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 40, 101))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+>clone : Symbol(ListWrapper.clone, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 40, 101))
+>ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 35, 1))
+
+declare function isBlank(x: any): boolean;
+>isBlank : Symbol(isBlank, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 132, 55))
+>x : Symbol(x, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 133, 25))
+
+declare function isPresent<T>(compareFn?: (a: T, b: T) => number): boolean;
+>isPresent : Symbol(isPresent, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 133, 42))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 134, 27))
+>compareFn : Symbol(compareFn, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 134, 30))
+>a : Symbol(a, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 134, 43))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 134, 27))
+>b : Symbol(b, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 134, 48))
+>T : Symbol(T, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 134, 27))
+
+interface Array<T> {
+>Array : Symbol(Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 134, 75))
+>T : Symbol(T, Decl(lib.d.ts, --, --), Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 135, 16))
+
+	fill(value: any, start: number, end: number): void;
+>fill : Symbol(fill, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 135, 20))
+>value : Symbol(value, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 136, 6))
+>start : Symbol(start, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 136, 17))
+>end : Symbol(end, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 136, 32))
+}

--- a/tests/baselines/reference/staticAnonymousTypeNotReferencingTypeParameter.types
+++ b/tests/baselines/reference/staticAnonymousTypeNotReferencingTypeParameter.types
@@ -1,0 +1,784 @@
+=== tests/cases/compiler/staticAnonymousTypeNotReferencingTypeParameter.ts ===
+function outer<T>(x: T) {
+>outer : <T>(x: T) => typeof Inner
+>T : T
+>x : T
+>T : T
+
+  class Inner {
+>Inner : Inner
+
+    static y: T = x;
+>y : T
+>T : T
+>x : T
+  }
+  return Inner;
+>Inner : typeof Inner
+}
+let y: number = outer(5).y;
+>y : number
+>outer(5).y : number
+>outer(5) : typeof Inner
+>outer : <T>(x: T) => typeof Inner
+>5 : number
+>y : number
+
+class ListWrapper2 {
+>ListWrapper2 : ListWrapper2
+
+  static clone<T>(dit: typeof ListWrapper2, array: T[]): T[] { return array.slice(0); }
+>clone : <T>(dit: typeof ListWrapper2, array: T[]) => T[]
+>T : T
+>dit : typeof ListWrapper2
+>ListWrapper2 : typeof ListWrapper2
+>array : T[]
+>T : T
+>T : T
+>array.slice(0) : T[]
+>array.slice : (start?: number, end?: number) => T[]
+>array : T[]
+>slice : (start?: number, end?: number) => T[]
+>0 : number
+
+  static reversed<T>(dit: typeof ListWrapper2, array: T[]): T[] {
+>reversed : <T>(dit: typeof ListWrapper2, array: T[]) => T[]
+>T : T
+>dit : typeof ListWrapper2
+>ListWrapper2 : typeof ListWrapper2
+>array : T[]
+>T : T
+>T : T
+
+    var a = ListWrapper2.clone(dit, array);
+>a : T[]
+>ListWrapper2.clone(dit, array) : T[]
+>ListWrapper2.clone : <T>(dit: typeof ListWrapper2, array: T[]) => T[]
+>ListWrapper2 : typeof ListWrapper2
+>clone : <T>(dit: typeof ListWrapper2, array: T[]) => T[]
+>dit : typeof ListWrapper2
+>array : T[]
+
+    return a;
+>a : T[]
+  }
+}
+namespace tessst {
+>tessst : typeof tessst
+
+    /**
+     * Iterates through 'array' by index and performs the callback on each element of array until the callback
+     * returns a truthy value, then returns that value.
+     * If no such value is found, the callback is applied to each element of array and undefined is returned.
+     */
+    export function funkyFor<T, U>(array: T[], callback: (element: T, index: number) => U): U {
+>funkyFor : <T, U>(array: T[], callback: (element: T, index: number) => U) => U
+>T : T
+>U : U
+>array : T[]
+>T : T
+>callback : (element: T, index: number) => U
+>element : T
+>T : T
+>index : number
+>U : U
+>U : U
+
+        if (array) {
+>array : T[]
+
+            for (let i = 0, len = array.length; i < len; i++) {
+>i : number
+>0 : number
+>len : number
+>array.length : number
+>array : T[]
+>length : number
+>i < len : boolean
+>i : number
+>len : number
+>i++ : number
+>i : number
+
+                const result = callback(array[i], i);
+>result : U
+>callback(array[i], i) : U
+>callback : (element: T, index: number) => U
+>array[i] : T
+>array : T[]
+>i : number
+>i : number
+
+                if (result) {
+>result : U
+
+                    return result;
+>result : U
+                }
+            }
+        }
+        return undefined;
+>undefined : undefined
+    }
+}
+interface Scanner {
+>Scanner : Scanner
+
+  scanRange<T>(start: number, length: number, callback: () => T): T;
+>scanRange : <T>(start: number, length: number, callback: () => T) => T
+>T : T
+>start : number
+>length : number
+>callback : () => T
+>T : T
+>T : T
+}
+class ListWrapper {
+>ListWrapper : ListWrapper
+
+  // JS has no way to express a statically fixed size list, but dart does so we
+  // keep both methods.
+  static createFixedSize(dit: typeof ListWrapper, size: number): any[] { return new Array(size); }
+>createFixedSize : (dit: typeof ListWrapper, size: number) => any[]
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>size : number
+>new Array(size) : any[]
+>Array : ArrayConstructor
+>size : number
+
+  static createGrowableSize(dit: typeof ListWrapper, size: number): any[] { return new Array(size); }
+>createGrowableSize : (dit: typeof ListWrapper, size: number) => any[]
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>size : number
+>new Array(size) : any[]
+>Array : ArrayConstructor
+>size : number
+
+  static clone<T>(dit: typeof ListWrapper, array: T[]): T[] { return array.slice(0); }
+>clone : <T>(dit: typeof ListWrapper, array: T[]) => T[]
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>array : T[]
+>T : T
+>T : T
+>array.slice(0) : T[]
+>array.slice : (start?: number, end?: number) => T[]
+>array : T[]
+>slice : (start?: number, end?: number) => T[]
+>0 : number
+
+  static forEachWithIndex<T>(dit: typeof ListWrapper, array: T[], fn: (t: T, n: number) => void) {
+>forEachWithIndex : <T>(dit: typeof ListWrapper, array: T[], fn: (t: T, n: number) => void) => void
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>array : T[]
+>T : T
+>fn : (t: T, n: number) => void
+>t : T
+>T : T
+>n : number
+
+    for (var i = 0; i < array.length; i++) {
+>i : number
+>0 : number
+>i < array.length : boolean
+>i : number
+>array.length : number
+>array : T[]
+>length : number
+>i++ : number
+>i : number
+
+      fn(array[i], i);
+>fn(array[i], i) : void
+>fn : (t: T, n: number) => void
+>array[i] : T
+>array : T[]
+>i : number
+>i : number
+    }
+  }
+  static first<T>(dit: typeof ListWrapper, array: T[]): T {
+>first : <T>(dit: typeof ListWrapper, array: T[]) => T
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>array : T[]
+>T : T
+>T : T
+
+    if (!array) return null;
+>!array : boolean
+>array : T[]
+>null : null
+
+    return array[0];
+>array[0] : T
+>array : T[]
+>0 : number
+  }
+  static last<T>(dit: typeof ListWrapper, array: T[]): T {
+>last : <T>(dit: typeof ListWrapper, array: T[]) => T
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>array : T[]
+>T : T
+>T : T
+
+    if (!array || array.length == 0) return null;
+>!array || array.length == 0 : boolean
+>!array : boolean
+>array : T[]
+>array.length == 0 : boolean
+>array.length : number
+>array : T[]
+>length : number
+>0 : number
+>null : null
+
+    return array[array.length - 1];
+>array[array.length - 1] : T
+>array : T[]
+>array.length - 1 : number
+>array.length : number
+>array : T[]
+>length : number
+>1 : number
+  }
+  static indexOf<T>(dit: typeof ListWrapper, array: T[], value: T, startIndex: number = 0): number {
+>indexOf : <T>(dit: typeof ListWrapper, array: T[], value: T, startIndex?: number) => number
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>array : T[]
+>T : T
+>value : T
+>T : T
+>startIndex : number
+>0 : number
+
+    return array.indexOf(value, startIndex);
+>array.indexOf(value, startIndex) : number
+>array.indexOf : (searchElement: T, fromIndex?: number) => number
+>array : T[]
+>indexOf : (searchElement: T, fromIndex?: number) => number
+>value : T
+>startIndex : number
+  }
+  static contains<T>(dit: typeof ListWrapper, list: T[], el: T): boolean { return list.indexOf(el) !== -1; }
+>contains : <T>(dit: typeof ListWrapper, list: T[], el: T) => boolean
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>list : T[]
+>T : T
+>el : T
+>T : T
+>list.indexOf(el) !== -1 : boolean
+>list.indexOf(el) : number
+>list.indexOf : (searchElement: T, fromIndex?: number) => number
+>list : T[]
+>indexOf : (searchElement: T, fromIndex?: number) => number
+>el : T
+>-1 : number
+>1 : number
+
+  static reversed<T>(dit: typeof ListWrapper, array: T[]): T[] {
+>reversed : <T>(dit: typeof ListWrapper, array: T[]) => T[]
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>array : T[]
+>T : T
+>T : T
+
+    var a = ListWrapper.clone(dit, array);
+>a : T[]
+>ListWrapper.clone(dit, array) : T[]
+>ListWrapper.clone : <T>(dit: typeof ListWrapper, array: T[]) => T[]
+>ListWrapper : typeof ListWrapper
+>clone : <T>(dit: typeof ListWrapper, array: T[]) => T[]
+>dit : typeof ListWrapper
+>array : T[]
+
+    let scanner: Scanner;
+>scanner : Scanner
+>Scanner : Scanner
+
+    scanner.scanRange(3, 5, () => {  });
+>scanner.scanRange(3, 5, () => {  }) : void
+>scanner.scanRange : <T>(start: number, length: number, callback: () => T) => T
+>scanner : Scanner
+>scanRange : <T>(start: number, length: number, callback: () => T) => T
+>3 : number
+>5 : number
+>() => {  } : () => void
+
+    return tessst.funkyFor(array, t => t.toString()) ? a.reverse() : a;
+>tessst.funkyFor(array, t => t.toString()) ? a.reverse() : a : T[]
+>tessst.funkyFor(array, t => t.toString()) : string
+>tessst.funkyFor : <T, U>(array: T[], callback: (element: T, index: number) => U) => U
+>tessst : typeof tessst
+>funkyFor : <T, U>(array: T[], callback: (element: T, index: number) => U) => U
+>array : T[]
+>t => t.toString() : (t: T) => string
+>t : T
+>t.toString() : string
+>t.toString : () => string
+>t : T
+>toString : () => string
+>a.reverse() : T[]
+>a.reverse : () => T[]
+>a : T[]
+>reverse : () => T[]
+>a : T[]
+  }
+  static concat(dit: typeof ListWrapper, a: any[], b: any[]): any[] { return a.concat(b); }
+>concat : (dit: typeof ListWrapper, a: any[], b: any[]) => any[]
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>a : any[]
+>b : any[]
+>a.concat(b) : any[]
+>a.concat : (...items: any[]) => any[]
+>a : any[]
+>concat : (...items: any[]) => any[]
+>b : any[]
+
+  static insert<T>(dit: typeof ListWrapper, list: T[], index: number, value: T) { list.splice(index, 0, value); }
+>insert : <T>(dit: typeof ListWrapper, list: T[], index: number, value: T) => void
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>list : T[]
+>T : T
+>index : number
+>value : T
+>T : T
+>list.splice(index, 0, value) : T[]
+>list.splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>list : T[]
+>splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>index : number
+>0 : number
+>value : T
+
+  static removeAt<T>(dit: typeof ListWrapper, list: T[], index: number): T {
+>removeAt : <T>(dit: typeof ListWrapper, list: T[], index: number) => T
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>list : T[]
+>T : T
+>index : number
+>T : T
+
+    var res = list[index];
+>res : T
+>list[index] : T
+>list : T[]
+>index : number
+
+    list.splice(index, 1);
+>list.splice(index, 1) : T[]
+>list.splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>list : T[]
+>splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>index : number
+>1 : number
+
+    return res;
+>res : T
+  }
+  static removeAll<T>(dit: typeof ListWrapper, list: T[], items: T[]) {
+>removeAll : <T>(dit: typeof ListWrapper, list: T[], items: T[]) => void
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>list : T[]
+>T : T
+>items : T[]
+>T : T
+
+    for (var i = 0; i < items.length; ++i) {
+>i : number
+>0 : number
+>i < items.length : boolean
+>i : number
+>items.length : number
+>items : T[]
+>length : number
+>++i : number
+>i : number
+
+      var index = list.indexOf(items[i]);
+>index : number
+>list.indexOf(items[i]) : number
+>list.indexOf : (searchElement: T, fromIndex?: number) => number
+>list : T[]
+>indexOf : (searchElement: T, fromIndex?: number) => number
+>items[i] : T
+>items : T[]
+>i : number
+
+      list.splice(index, 1);
+>list.splice(index, 1) : T[]
+>list.splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>list : T[]
+>splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>index : number
+>1 : number
+    }
+  }
+  static remove<T>(dit: typeof ListWrapper, list: T[], el: T): boolean {
+>remove : <T>(dit: typeof ListWrapper, list: T[], el: T) => boolean
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>list : T[]
+>T : T
+>el : T
+>T : T
+
+    var index = list.indexOf(el);
+>index : number
+>list.indexOf(el) : number
+>list.indexOf : (searchElement: T, fromIndex?: number) => number
+>list : T[]
+>indexOf : (searchElement: T, fromIndex?: number) => number
+>el : T
+
+    if (index > -1) {
+>index > -1 : boolean
+>index : number
+>-1 : number
+>1 : number
+
+      list.splice(index, 1);
+>list.splice(index, 1) : T[]
+>list.splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>list : T[]
+>splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>index : number
+>1 : number
+
+      return true;
+>true : boolean
+    }
+    return false;
+>false : boolean
+  }
+  static clear(dit: typeof ListWrapper, list: any[]) { list.length = 0; }
+>clear : (dit: typeof ListWrapper, list: any[]) => void
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>list : any[]
+>list.length = 0 : number
+>list.length : number
+>list : any[]
+>length : number
+>0 : number
+
+  static isEmpty(dit: typeof ListWrapper, list: any[]): boolean { return list.length == 0; }
+>isEmpty : (dit: typeof ListWrapper, list: any[]) => boolean
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>list : any[]
+>list.length == 0 : boolean
+>list.length : number
+>list : any[]
+>length : number
+>0 : number
+
+  static fill(dit: typeof ListWrapper, list: any[], value: any, start: number = 0, end: number = null) {
+>fill : (dit: typeof ListWrapper, list: any[], value: any, start?: number, end?: number) => void
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>list : any[]
+>value : any
+>start : number
+>0 : number
+>end : number
+>null : null
+
+    list.fill(value, start, end === null ? list.length : end);
+>list.fill(value, start, end === null ? list.length : end) : void
+>list.fill : (value: any, start: number, end: number) => void
+>list : any[]
+>fill : (value: any, start: number, end: number) => void
+>value : any
+>start : number
+>end === null ? list.length : end : number
+>end === null : boolean
+>end : number
+>null : null
+>list.length : number
+>list : any[]
+>length : number
+>end : number
+  }
+  static equals(dit: typeof ListWrapper, a: any[], b: any[]): boolean {
+>equals : (dit: typeof ListWrapper, a: any[], b: any[]) => boolean
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>a : any[]
+>b : any[]
+
+    if (a.length != b.length) return false;
+>a.length != b.length : boolean
+>a.length : number
+>a : any[]
+>length : number
+>b.length : number
+>b : any[]
+>length : number
+>false : boolean
+
+    for (var i = 0; i < a.length; ++i) {
+>i : number
+>0 : number
+>i < a.length : boolean
+>i : number
+>a.length : number
+>a : any[]
+>length : number
+>++i : number
+>i : number
+
+      if (a[i] !== b[i]) return false;
+>a[i] !== b[i] : boolean
+>a[i] : any
+>a : any[]
+>i : number
+>b[i] : any
+>b : any[]
+>i : number
+>false : boolean
+    }
+    return true;
+>true : boolean
+  }
+  static slice<T>(dit: typeof ListWrapper, l: T[], from: number = 0, to: number = null): T[] {
+>slice : <T>(dit: typeof ListWrapper, l: T[], from?: number, to?: number) => T[]
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>l : T[]
+>T : T
+>from : number
+>0 : number
+>to : number
+>null : null
+>T : T
+
+    return l.slice(from, to === null ? undefined : to);
+>l.slice(from, to === null ? undefined : to) : T[]
+>l.slice : (start?: number, end?: number) => T[]
+>l : T[]
+>slice : (start?: number, end?: number) => T[]
+>from : number
+>to === null ? undefined : to : number
+>to === null : boolean
+>to : number
+>null : null
+>undefined : undefined
+>to : number
+  }
+  static splice<T>(dit: typeof ListWrapper, l: T[], from: number, length: number): T[] { return l.splice(from, length); }
+>splice : <T>(dit: typeof ListWrapper, l: T[], from: number, length: number) => T[]
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>l : T[]
+>T : T
+>from : number
+>length : number
+>T : T
+>l.splice(from, length) : T[]
+>l.splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>l : T[]
+>splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>from : number
+>length : number
+
+  static sort<T>(dit: typeof ListWrapper, l: T[], compareFn?: (a: T, b: T) => number) {
+>sort : <T>(dit: typeof ListWrapper, l: T[], compareFn?: (a: T, b: T) => number) => void
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>l : T[]
+>T : T
+>compareFn : (a: T, b: T) => number
+>a : T
+>T : T
+>b : T
+>T : T
+
+    if (isPresent(compareFn)) {
+>isPresent(compareFn) : boolean
+>isPresent : <T>(compareFn?: (a: T, b: T) => number) => boolean
+>compareFn : (a: T, b: T) => number
+
+      l.sort(compareFn);
+>l.sort(compareFn) : T[]
+>l.sort : (compareFn?: (a: T, b: T) => number) => T[]
+>l : T[]
+>sort : (compareFn?: (a: T, b: T) => number) => T[]
+>compareFn : (a: T, b: T) => number
+
+    } else {
+      l.sort();
+>l.sort() : T[]
+>l.sort : (compareFn?: (a: T, b: T) => number) => T[]
+>l : T[]
+>sort : (compareFn?: (a: T, b: T) => number) => T[]
+    }
+  }
+  static toString<T>(dit: typeof ListWrapper, l: T[]): string { return l.toString(); }
+>toString : <T>(dit: typeof ListWrapper, l: T[]) => string
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>l : T[]
+>T : T
+>l.toString() : string
+>l.toString : () => string
+>l : T[]
+>toString : () => string
+
+  static toJSON<T>(dit: typeof ListWrapper, l: T[]): string { return JSON.stringify(l); }
+>toJSON : <T>(dit: typeof ListWrapper, l: T[]) => string
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>l : T[]
+>T : T
+>JSON.stringify(l) : string
+>JSON.stringify : { (value: any): string; (value: any, replacer: (key: string, value: any) => any): string; (value: any, replacer: any[]): string; (value: any, replacer: (key: string, value: any) => any, space: string | number): string; (value: any, replacer: any[], space: string | number): string; }
+>JSON : JSON
+>stringify : { (value: any): string; (value: any, replacer: (key: string, value: any) => any): string; (value: any, replacer: any[]): string; (value: any, replacer: (key: string, value: any) => any, space: string | number): string; (value: any, replacer: any[], space: string | number): string; }
+>l : T[]
+
+  static maximum<T>(dit: typeof ListWrapper, list: T[], predicate: (t: T) => number): T {
+>maximum : <T>(dit: typeof ListWrapper, list: T[], predicate: (t: T) => number) => T
+>T : T
+>dit : typeof ListWrapper
+>ListWrapper : typeof ListWrapper
+>list : T[]
+>T : T
+>predicate : (t: T) => number
+>t : T
+>T : T
+>T : T
+
+    if (list.length == 0) {
+>list.length == 0 : boolean
+>list.length : number
+>list : T[]
+>length : number
+>0 : number
+
+      return null;
+>null : null
+    }
+    var solution: T = null;
+>solution : T
+>T : T
+>null : null
+
+    var maxValue = -Infinity;
+>maxValue : number
+>-Infinity : number
+>Infinity : number
+
+    for (var index = 0; index < list.length; index++) {
+>index : number
+>0 : number
+>index < list.length : boolean
+>index : number
+>list.length : number
+>list : T[]
+>length : number
+>index++ : number
+>index : number
+
+      var candidate = list[index];
+>candidate : T
+>list[index] : T
+>list : T[]
+>index : number
+
+      if (isBlank(candidate)) {
+>isBlank(candidate) : boolean
+>isBlank : (x: any) => boolean
+>candidate : T
+
+        continue;
+      }
+      var candidateValue = predicate(candidate);
+>candidateValue : number
+>predicate(candidate) : number
+>predicate : (t: T) => number
+>candidate : T
+
+      if (candidateValue > maxValue) {
+>candidateValue > maxValue : boolean
+>candidateValue : number
+>maxValue : number
+
+        solution = candidate;
+>solution = candidate : T
+>solution : T
+>candidate : T
+
+        maxValue = candidateValue;
+>maxValue = candidateValue : number
+>maxValue : number
+>candidateValue : number
+      }
+    }
+    return solution;
+>solution : T
+  }
+}
+let cloned = ListWrapper.clone(ListWrapper, [1,2,3,4]);
+>cloned : number[]
+>ListWrapper.clone(ListWrapper, [1,2,3,4]) : number[]
+>ListWrapper.clone : <T>(dit: typeof ListWrapper, array: T[]) => T[]
+>ListWrapper : typeof ListWrapper
+>clone : <T>(dit: typeof ListWrapper, array: T[]) => T[]
+>ListWrapper : typeof ListWrapper
+>[1,2,3,4] : number[]
+>1 : number
+>2 : number
+>3 : number
+>4 : number
+
+declare function isBlank(x: any): boolean;
+>isBlank : (x: any) => boolean
+>x : any
+
+declare function isPresent<T>(compareFn?: (a: T, b: T) => number): boolean;
+>isPresent : <T>(compareFn?: (a: T, b: T) => number) => boolean
+>T : T
+>compareFn : (a: T, b: T) => number
+>a : T
+>T : T
+>b : T
+>T : T
+
+interface Array<T> {
+>Array : T[]
+>T : T
+
+	fill(value: any, start: number, end: number): void;
+>fill : (value: any, start: number, end: number) => void
+>value : any
+>start : number
+>end : number
+}

--- a/tests/cases/compiler/bluebirdStaticThis.ts
+++ b/tests/cases/compiler/bluebirdStaticThis.ts
@@ -1,0 +1,141 @@
+// This version is reduced from the full d.ts by removing almost all the tests
+// and all the comments.
+// Then it adds explicit `this` arguments to the static members.
+// Tests by: Bart van der Schoor <https://github.com/Bartvds>
+declare class Promise<R> implements Promise.Thenable<R> {
+	constructor(callback: (resolve: (thenableOrResult: R | Promise.Thenable<R>) => void, reject: (error: any) => void) => void);
+    static try<R>(dit: typeof Promise, fn: () => Promise.Thenable<R>, args?: any[], ctx?: any): Promise<R>;
+    static try<R>(dit: typeof Promise, fn: () => R, args?: any[], ctx?: any): Promise<R>;
+
+    static attempt<R>(dit: typeof Promise, fn: () => Promise.Thenable<R>, args?: any[], ctx?: any): Promise<R>;
+    static attempt<R>(dit: typeof Promise, fn: () => R, args?: any[], ctx?: any): Promise<R>;
+
+    static method(dit: typeof Promise, fn: Function): Function;
+
+    static resolve(dit: typeof Promise): Promise<void>;
+    static resolve<R>(dit: typeof Promise, value: Promise.Thenable<R>): Promise<R>;
+    static resolve<R>(dit: typeof Promise, value: R): Promise<R>;
+
+    static reject(dit: typeof Promise, reason: any): Promise<any>;
+    static reject<R>(dit: typeof Promise, reason: any): Promise<R>;
+
+    static defer<R>(dit: typeof Promise): Promise.Resolver<R>;
+
+    static cast<R>(dit: typeof Promise, value: Promise.Thenable<R>): Promise<R>;
+    static cast<R>(dit: typeof Promise, value: R): Promise<R>;
+
+    static bind(dit: typeof Promise, thisArg: any): Promise<void>;
+
+    static is(dit: typeof Promise, value: any): boolean;
+
+    static longStackTraces(dit: typeof Promise): void;
+
+    static delay<R>(dit: typeof Promise, value: Promise.Thenable<R>, ms: number): Promise<R>;
+    static delay<R>(dit: typeof Promise, value: R, ms: number): Promise<R>;
+    static delay(dit: typeof Promise, ms: number): Promise<void>;
+
+    static promisify(dit: typeof Promise, nodeFunction: Function, receiver?: any): Function;
+
+    static promisifyAll(dit: typeof Promise, target: Object): Object;
+
+    static coroutine<R>(dit: typeof Promise, generatorFunction: Function): Function;
+
+    static spawn<R>(dit: typeof Promise, generatorFunction: Function): Promise<R>;
+
+    static noConflict(dit: typeof Promise): typeof Promise;
+
+    static onPossiblyUnhandledRejection(dit: typeof Promise, handler: (reason: any) => any): void;
+
+    static all<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<R[]>;
+    static all<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<R[]>;
+    static all<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<R[]>;
+    static all<R>(dit: typeof Promise, values: R[]): Promise<R[]>;
+
+    static props(dit: typeof Promise, object: Promise<Object>): Promise<Object>;
+    static props(dit: typeof Promise, object: Object): Promise<Object>;
+
+    static settle<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<Promise.Inspection<R>[]>;
+    static settle<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<Promise.Inspection<R>[]>;
+    static settle<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<Promise.Inspection<R>[]>;
+    static settle<R>(dit: typeof Promise, values: R[]): Promise<Promise.Inspection<R>[]>;
+
+    static any<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<R>;
+    static any<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<R>;
+    static any<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<R>;
+    static any<R>(dit: typeof Promise, values: R[]): Promise<R>;
+
+    static race<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<R>;
+    static race<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<R>;
+    static race<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<R>;
+    static race<R>(dit: typeof Promise, values: R[]): Promise<R>;
+
+    static some<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, count: number): Promise<R[]>;
+    static some<R>(dit: typeof Promise, values: Promise.Thenable<R[]>, count: number): Promise<R[]>;
+    static some<R>(dit: typeof Promise, values: Promise.Thenable<R>[], count: number): Promise<R[]>;
+    static some<R>(dit: typeof Promise, values: R[], count: number): Promise<R[]>;
+
+    static join<R>(dit: typeof Promise, ...values: Promise.Thenable<R>[]): Promise<R[]>;
+    static join<R>(dit: typeof Promise, ...values: R[]): Promise<R[]>;
+
+    static map<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+    static map<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
+    static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+    static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
+    static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+    static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
+    static map<R, U>(dit: typeof Promise, values: R[], mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+    static map<R, U>(dit: typeof Promise, values: R[], mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
+
+    static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
+    static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
+
+    static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
+    static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
+
+    static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
+    static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
+
+    static reduce<R, U>(dit: typeof Promise, values: R[], reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
+    static reduce<R, U>(dit: typeof Promise, values: R[], reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
+
+    static filter<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
+    static filter<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
+    static filter<R>(dit: typeof Promise, values: Promise.Thenable<R[]>, filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
+    static filter<R>(dit: typeof Promise, values: Promise.Thenable<R[]>, filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
+    static filter<R>(dit: typeof Promise, values: Promise.Thenable<R>[], filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
+    static filter<R>(dit: typeof Promise, values: Promise.Thenable<R>[], filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
+    static filter<R>(dit: typeof Promise, values: R[], filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
+    static filter<R>(dit: typeof Promise, values: R[], filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
+}
+
+declare module Promise {
+	export interface Thenable<R> {
+		then<U>(onFulfilled: (value: R) => Thenable<U>, onRejected: (error: any) => Thenable<U>): Thenable<U>;
+		then<U>(onFulfilled: (value: R) => Thenable<U>, onRejected?: (error: any) => U): Thenable<U>;
+		then<U>(onFulfilled: (value: R) => U, onRejected: (error: any) => Thenable<U>): Thenable<U>;
+		then<U>(onFulfilled?: (value: R) => U, onRejected?: (error: any) => U): Thenable<U>;
+	}
+
+}
+
+declare module 'bluebird' {
+	export = Promise;
+}
+interface Foo {
+    a: number;
+    b: string;
+}
+var x: any;
+var arr: any[];
+var foo: Foo;
+var fooProm: Promise<Foo>;
+
+fooProm = Promise.try(Promise, () => {
+	return foo;
+});
+fooProm = Promise.try(Promise, () => {
+	return foo;
+}, arr);
+fooProm = Promise.try(Promise, () => {
+	return foo;
+}, arr, x);

--- a/tests/cases/compiler/staticAnonymousTypeNotReferencingTypeParameter.ts
+++ b/tests/cases/compiler/staticAnonymousTypeNotReferencingTypeParameter.ts
@@ -1,0 +1,138 @@
+function outer<T>(x: T) {
+  class Inner {
+    static y: T = x;
+  }
+  return Inner;
+}
+let y: number = outer(5).y;
+
+class ListWrapper2 {
+  static clone<T>(dit: typeof ListWrapper2, array: T[]): T[] { return array.slice(0); }
+  static reversed<T>(dit: typeof ListWrapper2, array: T[]): T[] {
+    var a = ListWrapper2.clone(dit, array);
+    return a;
+  }
+}
+namespace tessst {
+    /**
+     * Iterates through 'array' by index and performs the callback on each element of array until the callback
+     * returns a truthy value, then returns that value.
+     * If no such value is found, the callback is applied to each element of array and undefined is returned.
+     */
+    export function funkyFor<T, U>(array: T[], callback: (element: T, index: number) => U): U {
+        if (array) {
+            for (let i = 0, len = array.length; i < len; i++) {
+                const result = callback(array[i], i);
+                if (result) {
+                    return result;
+                }
+            }
+        }
+        return undefined;
+    }
+}
+interface Scanner {
+  scanRange<T>(start: number, length: number, callback: () => T): T;
+}
+class ListWrapper {
+  // JS has no way to express a statically fixed size list, but dart does so we
+  // keep both methods.
+  static createFixedSize(dit: typeof ListWrapper, size: number): any[] { return new Array(size); }
+  static createGrowableSize(dit: typeof ListWrapper, size: number): any[] { return new Array(size); }
+  static clone<T>(dit: typeof ListWrapper, array: T[]): T[] { return array.slice(0); }
+  static forEachWithIndex<T>(dit: typeof ListWrapper, array: T[], fn: (t: T, n: number) => void) {
+    for (var i = 0; i < array.length; i++) {
+      fn(array[i], i);
+    }
+  }
+  static first<T>(dit: typeof ListWrapper, array: T[]): T {
+    if (!array) return null;
+    return array[0];
+  }
+  static last<T>(dit: typeof ListWrapper, array: T[]): T {
+    if (!array || array.length == 0) return null;
+    return array[array.length - 1];
+  }
+  static indexOf<T>(dit: typeof ListWrapper, array: T[], value: T, startIndex: number = 0): number {
+    return array.indexOf(value, startIndex);
+  }
+  static contains<T>(dit: typeof ListWrapper, list: T[], el: T): boolean { return list.indexOf(el) !== -1; }
+  static reversed<T>(dit: typeof ListWrapper, array: T[]): T[] {
+    var a = ListWrapper.clone(dit, array);
+    let scanner: Scanner;
+    scanner.scanRange(3, 5, () => {  });
+    return tessst.funkyFor(array, t => t.toString()) ? a.reverse() : a;
+  }
+  static concat(dit: typeof ListWrapper, a: any[], b: any[]): any[] { return a.concat(b); }
+  static insert<T>(dit: typeof ListWrapper, list: T[], index: number, value: T) { list.splice(index, 0, value); }
+  static removeAt<T>(dit: typeof ListWrapper, list: T[], index: number): T {
+    var res = list[index];
+    list.splice(index, 1);
+    return res;
+  }
+  static removeAll<T>(dit: typeof ListWrapper, list: T[], items: T[]) {
+    for (var i = 0; i < items.length; ++i) {
+      var index = list.indexOf(items[i]);
+      list.splice(index, 1);
+    }
+  }
+  static remove<T>(dit: typeof ListWrapper, list: T[], el: T): boolean {
+    var index = list.indexOf(el);
+    if (index > -1) {
+      list.splice(index, 1);
+      return true;
+    }
+    return false;
+  }
+  static clear(dit: typeof ListWrapper, list: any[]) { list.length = 0; }
+  static isEmpty(dit: typeof ListWrapper, list: any[]): boolean { return list.length == 0; }
+  static fill(dit: typeof ListWrapper, list: any[], value: any, start: number = 0, end: number = null) {
+    list.fill(value, start, end === null ? list.length : end);
+  }
+  static equals(dit: typeof ListWrapper, a: any[], b: any[]): boolean {
+    if (a.length != b.length) return false;
+    for (var i = 0; i < a.length; ++i) {
+      if (a[i] !== b[i]) return false;
+    }
+    return true;
+  }
+  static slice<T>(dit: typeof ListWrapper, l: T[], from: number = 0, to: number = null): T[] {
+    return l.slice(from, to === null ? undefined : to);
+  }
+  static splice<T>(dit: typeof ListWrapper, l: T[], from: number, length: number): T[] { return l.splice(from, length); }
+  static sort<T>(dit: typeof ListWrapper, l: T[], compareFn?: (a: T, b: T) => number) {
+    if (isPresent(compareFn)) {
+      l.sort(compareFn);
+    } else {
+      l.sort();
+    }
+  }
+  static toString<T>(dit: typeof ListWrapper, l: T[]): string { return l.toString(); }
+  static toJSON<T>(dit: typeof ListWrapper, l: T[]): string { return JSON.stringify(l); }
+
+  static maximum<T>(dit: typeof ListWrapper, list: T[], predicate: (t: T) => number): T {
+    if (list.length == 0) {
+      return null;
+    }
+    var solution: T = null;
+    var maxValue = -Infinity;
+    for (var index = 0; index < list.length; index++) {
+      var candidate = list[index];
+      if (isBlank(candidate)) {
+        continue;
+      }
+      var candidateValue = predicate(candidate);
+      if (candidateValue > maxValue) {
+        solution = candidate;
+        maxValue = candidateValue;
+      }
+    }
+    return solution;
+  }
+}
+let cloned = ListWrapper.clone(ListWrapper, [1,2,3,4]);
+declare function isBlank(x: any): boolean;
+declare function isPresent<T>(compareFn?: (a: T, b: T) => number): boolean;
+interface Array<T> {
+	fill(value: any, start: number, end: number): void;
+}


### PR DESCRIPTION
**Fixes issue:** #7097

This operates during `instantiateType` to skip instantiation of anonymous types whose declarations are *not* bound by the type mapper that will do the instantiation.

I'm not sure this is the right approach, but I want to get suggestions on the right way to do it so I thought a strawman would help the discussion.