### PR TITLE
Rever change to EmitOutput.diagnostics

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -389,7 +389,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 
         return {
             emitSkipped,
-            declarationDiagnostics: emitterDiagnostics.getDiagnostics(),
+            diagnostics: emitterDiagnostics.getDiagnostics(),
             sourceMaps: sourceMapDataList
         };
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -956,7 +956,7 @@ namespace ts {
             let declarationDiagnostics: Diagnostic[] = [];
 
             if (options.noEmit) {
-                return { declarationDiagnostics, sourceMaps: undefined, emitSkipped: true };
+                return { diagnostics: declarationDiagnostics, sourceMaps: undefined, emitSkipped: true };
             }
 
             // If the noEmitOnError flag is set, then check if we have any errors so far.  If so,
@@ -973,7 +973,7 @@ namespace ts {
                 }
 
                 if (diagnostics.length > 0 || declarationDiagnostics.length > 0) {
-                    return { declarationDiagnostics, sourceMaps: undefined, emitSkipped: true };
+                    return { diagnostics, sourceMaps: undefined, emitSkipped: true };
                 }
             }
 

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -592,7 +592,7 @@ namespace ts {
 
             // Otherwise, emit and report any errors we ran into.
             const emitOutput = program.emit();
-            diagnostics = diagnostics.concat(emitOutput.declarationDiagnostics);
+            diagnostics = diagnostics.concat(emitOutput.diagnostics);
 
             reportDiagnostics(sortAndDeduplicateDiagnostics(diagnostics), compilerHost);
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1680,7 +1680,8 @@ namespace ts {
 
     export interface EmitResult {
         emitSkipped: boolean;
-        /* @internal */ declarationDiagnostics: Diagnostic[];
+        /** Contains declaration emit diagnostics */
+        diagnostics: Diagnostic[];
         /* @internal */ sourceMaps: SourceMapData[];  // Array of sourceMapData if compiler emitted sourcemaps
     }
 

--- a/src/harness/projectsRunner.ts
+++ b/src/harness/projectsRunner.ts
@@ -127,7 +127,7 @@ class ProjectRunner extends RunnerBase {
             let errors = ts.getPreEmitDiagnostics(program);
 
             const emitResult = program.emit();
-            errors = ts.concatenate(errors, emitResult.declarationDiagnostics);
+            errors = ts.concatenate(errors, emitResult.diagnostics);
             const sourceMapData = emitResult.sourceMaps;
 
             // Clean up source map data that will be used in baselining


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

**Fixes issue:** https://github.com/Microsoft/TypeScript/issues/7133

The break was introduced in https://github.com/Microsoft/TypeScript/pull/7108, the assumption was that it was not used often, and using getPreEmitDiagnostics should be sufficient, but after examining gulp-typescript extension this does not seem to be the case.
