### PR TITLE
Firefox has Object.prototype.watch

### DIFF
--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -415,7 +415,8 @@ namespace ts {
 
             const compileResult = compile(rootFileNames, compilerOptions, compilerHost);
 
-            if (!compilerOptions.watch) {
+            // Firefox has Object.prototype.watch
+            if (!compilerOptions.watch || !compilerOptions.hasOwnProperty("watch")) {
                 return sys.exit(compileResult.exitStatus);
             }
 
@@ -441,7 +442,8 @@ namespace ts {
             }
             // Use default host function
             const sourceFile = hostGetSourceFile(fileName, languageVersion, onError);
-            if (sourceFile && compilerOptions.watch) {
+            // Firefox has Object.prototype.watch
+            if (sourceFile && compilerOptions.watch && compilerOptions.hasOwnProperty("watch")) {
                 // Attach a file watcher
                 const filePath = toPath(sourceFile.fileName, sys.getCurrentDirectory(), createGetCanonicalFileName(sys.useCaseSensitiveFileNames));
                 sourceFile.fileWatcher = sys.watchFile(filePath, (fileName: string, removed?: boolean) => sourceFileChanged(sourceFile, removed));


### PR DESCRIPTION
**Fixes issue:** #7141 Repeat of "Conflict with Object.prototype.watch in FireFox/Gecko"

Previously that featured as issue #3649 and PR #3648

I've got an in-browser environment running `tsc.js` compiler (with ChakraHost as its emulation interface). Recently testing in Tor Browser (which internally is Gecko) got a failure due to the compiler misinterpreting `compilerOptions.watch`.