### PR TITLE
Enforce identical type constraints

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14033,16 +14033,17 @@ namespace ts {
 
         /** Check that type parameter lists are identical across multiple declarations */
         function checkTypeParameterListsIdentical(node: ClassLikeDeclaration | InterfaceDeclaration, symbol: Symbol) {
+            if (symbol.declarations.length === 1) {
+                return;
+            }
             let firstDecl: ClassLikeDeclaration | InterfaceDeclaration;
-            if (symbol.declarations.length > 1) {
-                for (const declaration of symbol.declarations) {
-                    if (declaration.kind === SyntaxKind.ClassDeclaration || declaration.kind === SyntaxKind.InterfaceDeclaration) {
-                        if (!firstDecl) {
-                            firstDecl = <ClassLikeDeclaration | InterfaceDeclaration>declaration;
-                        }
-                        else if (!areTypeParametersIdentical(firstDecl.typeParameters, node.typeParameters)) {
-                            error(node.name, Diagnostics.All_declarations_must_have_identical_type_parameters);
-                        }
+            for (const declaration of symbol.declarations) {
+                if (declaration.kind === SyntaxKind.ClassDeclaration || declaration.kind === SyntaxKind.InterfaceDeclaration) {
+                    if (!firstDecl) {
+                        firstDecl = <ClassLikeDeclaration | InterfaceDeclaration>declaration;
+                    }
+                    else if (!areTypeParametersIdentical(firstDecl.typeParameters, node.typeParameters)) {
+                        error(node.name, Diagnostics.All_declarations_of_0_must_have_identical_type_parameters, node.name.text);
                     }
                 }
             }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1311,7 +1311,7 @@
         "category": "Error",
         "code": 2427
     },
-    "All declarations of an interface must have identical type parameters.": {
+    "All declarations must have identical type parameters.": {
         "category": "Error",
         "code": 2428
     },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1311,7 +1311,7 @@
         "category": "Error",
         "code": 2427
     },
-    "All declarations must have identical type parameters.": {
+    "All declarations of '{0}' must have identical type parameters.": {
         "category": "Error",
         "code": 2428
     },

--- a/tests/baselines/reference/constructSignaturesWithOverloads2.errors.txt
+++ b/tests/baselines/reference/constructSignaturesWithOverloads2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/types/objectTypeLiteral/constructSignatures/constructSignaturesWithOverloads2.ts(32,11): error TS2428: All declarations of an interface must have identical type parameters.
+tests/cases/conformance/types/objectTypeLiteral/constructSignatures/constructSignaturesWithOverloads2.ts(32,11): error TS2428: All declarations must have identical type parameters.
 
 
 ==== tests/cases/conformance/types/objectTypeLiteral/constructSignatures/constructSignaturesWithOverloads2.ts (1 errors) ====
@@ -35,7 +35,7 @@ tests/cases/conformance/types/objectTypeLiteral/constructSignatures/constructSig
     
     interface I<T> {
               ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
         new (x: T, y?: number): C2<T>;
         new (x: T, y: number): C2<T>;
     }

--- a/tests/baselines/reference/constructSignaturesWithOverloads2.errors.txt
+++ b/tests/baselines/reference/constructSignaturesWithOverloads2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/types/objectTypeLiteral/constructSignatures/constructSignaturesWithOverloads2.ts(32,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/types/objectTypeLiteral/constructSignatures/constructSignaturesWithOverloads2.ts(32,11): error TS2428: All declarations of 'I' must have identical type parameters.
 
 
 ==== tests/cases/conformance/types/objectTypeLiteral/constructSignatures/constructSignaturesWithOverloads2.ts (1 errors) ====
@@ -35,7 +35,7 @@ tests/cases/conformance/types/objectTypeLiteral/constructSignatures/constructSig
     
     interface I<T> {
               ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'I' must have identical type parameters.
         new (x: T, y?: number): C2<T>;
         new (x: T, y: number): C2<T>;
     }

--- a/tests/baselines/reference/extendedInterfacesWithDuplicateTypeParameters.errors.txt
+++ b/tests/baselines/reference/extendedInterfacesWithDuplicateTypeParameters.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/extendedInterfacesWithDuplicateTypeParameters.ts(1,42): error TS2300: Duplicate identifier 'A'.
-tests/cases/compiler/extendedInterfacesWithDuplicateTypeParameters.ts(9,11): error TS2428: All declarations of an interface must have identical type parameters.
+tests/cases/compiler/extendedInterfacesWithDuplicateTypeParameters.ts(9,11): error TS2428: All declarations must have identical type parameters.
 tests/cases/compiler/extendedInterfacesWithDuplicateTypeParameters.ts(9,38): error TS2300: Duplicate identifier 'C'.
 
 
@@ -16,7 +16,7 @@ tests/cases/compiler/extendedInterfacesWithDuplicateTypeParameters.ts(9,38): err
     
     interface InterfaceWithSomeTypars<C, C> { // should error
               ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
                                          ~
 !!! error TS2300: Duplicate identifier 'C'.
     	bar2(): void;

--- a/tests/baselines/reference/extendedInterfacesWithDuplicateTypeParameters.errors.txt
+++ b/tests/baselines/reference/extendedInterfacesWithDuplicateTypeParameters.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/extendedInterfacesWithDuplicateTypeParameters.ts(1,42): error TS2300: Duplicate identifier 'A'.
-tests/cases/compiler/extendedInterfacesWithDuplicateTypeParameters.ts(9,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/compiler/extendedInterfacesWithDuplicateTypeParameters.ts(9,11): error TS2428: All declarations of 'InterfaceWithSomeTypars' must have identical type parameters.
 tests/cases/compiler/extendedInterfacesWithDuplicateTypeParameters.ts(9,38): error TS2300: Duplicate identifier 'C'.
 
 
@@ -16,7 +16,7 @@ tests/cases/compiler/extendedInterfacesWithDuplicateTypeParameters.ts(9,38): err
     
     interface InterfaceWithSomeTypars<C, C> { // should error
               ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'InterfaceWithSomeTypars' must have identical type parameters.
                                          ~
 !!! error TS2300: Duplicate identifier 'C'.
     	bar2(): void;

--- a/tests/baselines/reference/genericAndNonGenericInterfaceWithTheSameName.errors.txt
+++ b/tests/baselines/reference/genericAndNonGenericInterfaceWithTheSameName.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName.ts(7,11): error TS2428: All declarations must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName.ts(16,15): error TS2428: All declarations must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName.ts(40,22): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName.ts(7,11): error TS2428: All declarations of 'A' must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName.ts(16,15): error TS2428: All declarations of 'A' must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName.ts(40,22): error TS2428: All declarations of 'A' must have identical type parameters.
 
 
 ==== tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName.ts (3 errors) ====
@@ -12,7 +12,7 @@ tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterf
     
     interface A<T> { // error
               ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'A' must have identical type parameters.
         bar: T;
     }
     
@@ -23,7 +23,7 @@ tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterf
     
         interface A { // error
                   ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'A' must have identical type parameters.
             foo: string;
         }
     }
@@ -49,7 +49,7 @@ tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterf
     module M3 {
         export interface A<T> { // error
                          ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'A' must have identical type parameters.
             bar: T;
         }
     }

--- a/tests/baselines/reference/genericAndNonGenericInterfaceWithTheSameName.errors.txt
+++ b/tests/baselines/reference/genericAndNonGenericInterfaceWithTheSameName.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName.ts(7,11): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName.ts(16,15): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName.ts(40,22): error TS2428: All declarations of an interface must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName.ts(7,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName.ts(16,15): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName.ts(40,22): error TS2428: All declarations must have identical type parameters.
 
 
 ==== tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterfaceWithTheSameName.ts (3 errors) ====
@@ -12,7 +12,7 @@ tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterf
     
     interface A<T> { // error
               ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
         bar: T;
     }
     
@@ -23,7 +23,7 @@ tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterf
     
         interface A { // error
                   ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
             foo: string;
         }
     }
@@ -49,7 +49,7 @@ tests/cases/conformance/interfaces/declarationMerging/genericAndNonGenericInterf
     module M3 {
         export interface A<T> { // error
                          ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
             bar: T;
         }
     }

--- a/tests/baselines/reference/interfaceWithMultipleDeclarations.errors.txt
+++ b/tests/baselines/reference/interfaceWithMultipleDeclarations.errors.txt
@@ -1,14 +1,14 @@
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(3,11): error TS2428: All declarations must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(5,11): error TS2428: All declarations must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(7,11): error TS2428: All declarations must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(9,11): error TS2428: All declarations must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(11,11): error TS2428: All declarations must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(16,11): error TS2428: All declarations must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(18,11): error TS2428: All declarations must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(20,11): error TS2428: All declarations must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(22,11): error TS2428: All declarations must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(24,11): error TS2428: All declarations must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(29,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(3,11): error TS2428: All declarations of 'I1' must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(5,11): error TS2428: All declarations of 'I1' must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(7,11): error TS2428: All declarations of 'I1' must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(9,11): error TS2428: All declarations of 'I1' must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(11,11): error TS2428: All declarations of 'I1' must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(16,11): error TS2428: All declarations of 'I2' must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(18,11): error TS2428: All declarations of 'I2' must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(20,11): error TS2428: All declarations of 'I2' must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(22,11): error TS2428: All declarations of 'I2' must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(24,11): error TS2428: All declarations of 'I2' must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(29,11): error TS2428: All declarations of 'I3' must have identical type parameters.
 
 
 ==== tests/cases/compiler/interfaceWithMultipleDeclarations.ts (11 errors) ====
@@ -16,53 +16,53 @@ tests/cases/compiler/interfaceWithMultipleDeclarations.ts(29,11): error TS2428: 
     }
     interface I1<S> { // Name mismatch
               ~~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'I1' must have identical type parameters.
     }
     interface I1<T, U extends T> { // Length mismatch
               ~~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'I1' must have identical type parameters.
     }
     interface I1<V extends string> { // constraint present
               ~~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'I1' must have identical type parameters.
     }
     interface I1<V, X extends V> { // Length mismatch
               ~~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'I1' must have identical type parameters.
     }
     interface I1 { // Length mismatch
               ~~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'I1' must have identical type parameters.
     }
     
     interface I2<T extends string> {
     }
     interface I2<T extends () => string> { // constraint mismatch
               ~~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'I2' must have identical type parameters.
     }
     interface I2<T> { // constraint absent
               ~~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'I2' must have identical type parameters.
     }
     interface I2<U> { // name mismatch
               ~~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'I2' must have identical type parameters.
     }
     interface I2<X, Y> { // length mismatch
               ~~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'I2' must have identical type parameters.
     }
     interface I2 { // length mismatch
               ~~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'I2' must have identical type parameters.
     }
     
     interface I3 {
     }
     interface I3<T> { // length mismatch
               ~~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'I3' must have identical type parameters.
     }
     
     class Foo<T> {

--- a/tests/baselines/reference/interfaceWithMultipleDeclarations.errors.txt
+++ b/tests/baselines/reference/interfaceWithMultipleDeclarations.errors.txt
@@ -1,14 +1,14 @@
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(3,11): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(5,11): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(7,11): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(9,11): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(11,11): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(16,11): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(18,11): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(20,11): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(22,11): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(24,11): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/compiler/interfaceWithMultipleDeclarations.ts(29,11): error TS2428: All declarations of an interface must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(3,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(5,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(7,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(9,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(11,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(16,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(18,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(20,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(22,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(24,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/compiler/interfaceWithMultipleDeclarations.ts(29,11): error TS2428: All declarations must have identical type parameters.
 
 
 ==== tests/cases/compiler/interfaceWithMultipleDeclarations.ts (11 errors) ====
@@ -16,53 +16,53 @@ tests/cases/compiler/interfaceWithMultipleDeclarations.ts(29,11): error TS2428: 
     }
     interface I1<S> { // Name mismatch
               ~~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
     }
     interface I1<T, U extends T> { // Length mismatch
               ~~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
     }
     interface I1<V extends string> { // constraint present
               ~~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
     }
     interface I1<V, X extends V> { // Length mismatch
               ~~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
     }
     interface I1 { // Length mismatch
               ~~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
     }
     
     interface I2<T extends string> {
     }
     interface I2<T extends () => string> { // constraint mismatch
               ~~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
     }
     interface I2<T> { // constraint absent
               ~~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
     }
     interface I2<U> { // name mismatch
               ~~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
     }
     interface I2<X, Y> { // length mismatch
               ~~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
     }
     interface I2 { // length mismatch
               ~~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
     }
     
     interface I3 {
     }
     interface I3<T> { // length mismatch
               ~~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
     }
     
     class Foo<T> {

--- a/tests/baselines/reference/multipleNumericIndexers.errors.txt
+++ b/tests/baselines/reference/multipleNumericIndexers.errors.txt
@@ -3,7 +3,7 @@ tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericI
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericIndexers.ts(15,5): error TS2375: Duplicate number index signature.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericIndexers.ts(20,5): error TS2375: Duplicate number index signature.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericIndexers.ts(25,5): error TS2375: Duplicate number index signature.
-tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericIndexers.ts(28,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericIndexers.ts(28,11): error TS2428: All declarations of 'I' must have identical type parameters.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericIndexers.ts(29,5): error TS2375: Duplicate number index signature.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericIndexers.ts(30,5): error TS2375: Duplicate number index signature.
 
@@ -48,7 +48,7 @@ tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericI
     
     interface I<T> {
               ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'I' must have identical type parameters.
         [x: number]: string;
         ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2375: Duplicate number index signature.

--- a/tests/baselines/reference/multipleNumericIndexers.errors.txt
+++ b/tests/baselines/reference/multipleNumericIndexers.errors.txt
@@ -3,7 +3,7 @@ tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericI
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericIndexers.ts(15,5): error TS2375: Duplicate number index signature.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericIndexers.ts(20,5): error TS2375: Duplicate number index signature.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericIndexers.ts(25,5): error TS2375: Duplicate number index signature.
-tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericIndexers.ts(28,11): error TS2428: All declarations of an interface must have identical type parameters.
+tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericIndexers.ts(28,11): error TS2428: All declarations must have identical type parameters.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericIndexers.ts(29,5): error TS2375: Duplicate number index signature.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericIndexers.ts(30,5): error TS2375: Duplicate number index signature.
 
@@ -48,7 +48,7 @@ tests/cases/conformance/types/objectTypeLiteral/indexSignatures/multipleNumericI
     
     interface I<T> {
               ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
         [x: number]: string;
         ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2375: Duplicate number index signature.

--- a/tests/baselines/reference/nonIdenticalTypeConstraints.errors.txt
+++ b/tests/baselines/reference/nonIdenticalTypeConstraints.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/compiler/nonIdenticalTypeConstraints.ts(10,11): error TS2428: All declarations must have identical type parameters.
-tests/cases/compiler/nonIdenticalTypeConstraints.ts(16,7): error TS2428: All declarations must have identical type parameters.
-tests/cases/compiler/nonIdenticalTypeConstraints.ts(36,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/compiler/nonIdenticalTypeConstraints.ts(10,11): error TS2428: All declarations of 'Foo' must have identical type parameters.
+tests/cases/compiler/nonIdenticalTypeConstraints.ts(16,7): error TS2428: All declarations of 'Qux' must have identical type parameters.
+tests/cases/compiler/nonIdenticalTypeConstraints.ts(36,11): error TS2428: All declarations of 'Quux' must have identical type parameters.
 
 
 ==== tests/cases/compiler/nonIdenticalTypeConstraints.ts (3 errors) ====
@@ -15,7 +15,7 @@ tests/cases/compiler/nonIdenticalTypeConstraints.ts(36,11): error TS2428: All de
     }
     interface Foo<T extends Different> {
               ~~~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'Foo' must have identical type parameters.
         y: T;
     }
     interface Qux<T extends Different> {
@@ -23,7 +23,7 @@ tests/cases/compiler/nonIdenticalTypeConstraints.ts(36,11): error TS2428: All de
     }
     class Qux<T extends Function> {
           ~~~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'Qux' must have identical type parameters.
         n: T;
     }
     
@@ -45,6 +45,6 @@ tests/cases/compiler/nonIdenticalTypeConstraints.ts(36,11): error TS2428: All de
     }
     interface Quux<U> {
               ~~~~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'Quux' must have identical type parameters.
         m: U;
     }

--- a/tests/baselines/reference/nonIdenticalTypeConstraints.errors.txt
+++ b/tests/baselines/reference/nonIdenticalTypeConstraints.errors.txt
@@ -1,0 +1,50 @@
+tests/cases/compiler/nonIdenticalTypeConstraints.ts(10,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/compiler/nonIdenticalTypeConstraints.ts(16,7): error TS2428: All declarations must have identical type parameters.
+tests/cases/compiler/nonIdenticalTypeConstraints.ts(36,11): error TS2428: All declarations must have identical type parameters.
+
+
+==== tests/cases/compiler/nonIdenticalTypeConstraints.ts (3 errors) ====
+    class Different {
+        a: number;
+        b: string;
+        c: boolean;
+    }
+    
+    class Foo<T extends Function> {
+        n: T;
+    }
+    interface Foo<T extends Different> {
+              ~~~
+!!! error TS2428: All declarations must have identical type parameters.
+        y: T;
+    }
+    interface Qux<T extends Different> {
+        y: T;
+    }
+    class Qux<T extends Function> {
+          ~~~
+!!! error TS2428: All declarations must have identical type parameters.
+        n: T;
+    }
+    
+    class Bar<T extends Function> {
+        n: T;
+    }
+    interface Bar<T extends Function> {
+        y: T;
+    }
+    interface Baz<T extends Function> {
+        y: T;
+    }
+    class Baz<T extends Function> {
+        n: T;
+    }
+    
+    class Quux<T> {
+        n: T;
+    }
+    interface Quux<U> {
+              ~~~~
+!!! error TS2428: All declarations must have identical type parameters.
+        m: U;
+    }

--- a/tests/baselines/reference/nonIdenticalTypeConstraints.js
+++ b/tests/baselines/reference/nonIdenticalTypeConstraints.js
@@ -1,0 +1,71 @@
+//// [nonIdenticalTypeConstraints.ts]
+class Different {
+    a: number;
+    b: string;
+    c: boolean;
+}
+
+class Foo<T extends Function> {
+    n: T;
+}
+interface Foo<T extends Different> {
+    y: T;
+}
+interface Qux<T extends Different> {
+    y: T;
+}
+class Qux<T extends Function> {
+    n: T;
+}
+
+class Bar<T extends Function> {
+    n: T;
+}
+interface Bar<T extends Function> {
+    y: T;
+}
+interface Baz<T extends Function> {
+    y: T;
+}
+class Baz<T extends Function> {
+    n: T;
+}
+
+class Quux<T> {
+    n: T;
+}
+interface Quux<U> {
+    m: U;
+}
+
+//// [nonIdenticalTypeConstraints.js]
+var Different = (function () {
+    function Different() {
+    }
+    return Different;
+}());
+var Foo = (function () {
+    function Foo() {
+    }
+    return Foo;
+}());
+var Qux = (function () {
+    function Qux() {
+    }
+    return Qux;
+}());
+var Bar = (function () {
+    function Bar() {
+    }
+    return Bar;
+}());
+var Baz = (function () {
+    function Baz() {
+    }
+    return Baz;
+}());
+var Quux = (function () {
+    function Quux() {
+    }
+    return Quux;
+}());

--- a/tests/baselines/reference/twoGenericInterfacesDifferingByTypeParameterName.errors.txt
+++ b/tests/baselines/reference/twoGenericInterfacesDifferingByTypeParameterName.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(7,11): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(15,11): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(24,15): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(32,15): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(56,22): error TS2428: All declarations of an interface must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(7,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(15,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(24,15): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(32,15): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(56,22): error TS2428: All declarations must have identical type parameters.
 
 
 ==== tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts (5 errors) ====
@@ -14,7 +14,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDiffer
     
     interface A<U> { // error
               ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
         y: U;
     }
     
@@ -24,7 +24,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDiffer
     
     interface B<T,V> { // error
               ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
         y: V;
     }
     
@@ -35,7 +35,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDiffer
     
         interface A<U> { // error
                   ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
             y: U;
         }
     
@@ -45,7 +45,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDiffer
     
         interface B<T, V> { // error
                   ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
             y: V;
         }
     }
@@ -71,7 +71,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDiffer
     module M3 {
         export interface B<T, V> { // error
                          ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
             y: V;
         }
     }

--- a/tests/baselines/reference/twoGenericInterfacesDifferingByTypeParameterName.errors.txt
+++ b/tests/baselines/reference/twoGenericInterfacesDifferingByTypeParameterName.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(7,11): error TS2428: All declarations must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(15,11): error TS2428: All declarations must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(24,15): error TS2428: All declarations must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(32,15): error TS2428: All declarations must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(56,22): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(7,11): error TS2428: All declarations of 'A' must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(15,11): error TS2428: All declarations of 'B' must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(24,15): error TS2428: All declarations of 'A' must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(32,15): error TS2428: All declarations of 'B' must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts(56,22): error TS2428: All declarations of 'B' must have identical type parameters.
 
 
 ==== tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName.ts (5 errors) ====
@@ -14,7 +14,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDiffer
     
     interface A<U> { // error
               ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'A' must have identical type parameters.
         y: U;
     }
     
@@ -24,7 +24,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDiffer
     
     interface B<T,V> { // error
               ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'B' must have identical type parameters.
         y: V;
     }
     
@@ -35,7 +35,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDiffer
     
         interface A<U> { // error
                   ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'A' must have identical type parameters.
             y: U;
         }
     
@@ -45,7 +45,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDiffer
     
         interface B<T, V> { // error
                   ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'B' must have identical type parameters.
             y: V;
         }
     }
@@ -71,7 +71,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDiffer
     module M3 {
         export interface B<T, V> { // error
                          ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'B' must have identical type parameters.
             y: V;
         }
     }

--- a/tests/baselines/reference/twoGenericInterfacesDifferingByTypeParameterName2.errors.txt
+++ b/tests/baselines/reference/twoGenericInterfacesDifferingByTypeParameterName2.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts(7,11): error TS2428: All declarations of an interface must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts(7,11): error TS2428: All declarations must have identical type parameters.
 tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts(8,8): error TS2304: Cannot find name 'V'.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts(16,15): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts(40,22): error TS2428: All declarations of an interface must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts(16,15): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts(40,22): error TS2428: All declarations must have identical type parameters.
 
 
 ==== tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts (4 errors) ====
@@ -13,7 +13,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDiffer
     
     interface B<U, T> { // error
               ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
         y: V;
            ~
 !!! error TS2304: Cannot find name 'V'.
@@ -26,7 +26,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDiffer
     
         interface B<U, T> { // error
                   ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
             y: T;
         }
     }
@@ -52,7 +52,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDiffer
     module M3 {
         export interface B<U, T> { // error
                          ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
             y: T;
         }
     }

--- a/tests/baselines/reference/twoGenericInterfacesDifferingByTypeParameterName2.errors.txt
+++ b/tests/baselines/reference/twoGenericInterfacesDifferingByTypeParameterName2.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts(7,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts(7,11): error TS2428: All declarations of 'B' must have identical type parameters.
 tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts(8,8): error TS2304: Cannot find name 'V'.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts(16,15): error TS2428: All declarations must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts(40,22): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts(16,15): error TS2428: All declarations of 'B' must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts(40,22): error TS2428: All declarations of 'B' must have identical type parameters.
 
 
 ==== tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDifferingByTypeParameterName2.ts (4 errors) ====
@@ -13,7 +13,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDiffer
     
     interface B<U, T> { // error
               ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'B' must have identical type parameters.
         y: V;
            ~
 !!! error TS2304: Cannot find name 'V'.
@@ -26,7 +26,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDiffer
     
         interface B<U, T> { // error
                   ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'B' must have identical type parameters.
             y: T;
         }
     }
@@ -52,7 +52,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesDiffer
     module M3 {
         export interface B<U, T> { // error
                          ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'B' must have identical type parameters.
             y: T;
         }
     }

--- a/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.errors.txt
+++ b/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(5,11): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(14,15): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(38,22): error TS2428: All declarations of an interface must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(5,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(14,15): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(38,22): error TS2428: All declarations must have identical type parameters.
 
 
 ==== tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts (3 errors) ====
@@ -10,7 +10,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDi
     
     interface A<T extends Number> { // error
               ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
         y: T;
     }
     
@@ -21,7 +21,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDi
     
         interface B<T extends A<any>> { // error
                   ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
             y: T;
         }
     }
@@ -47,7 +47,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDi
     module M3 {
         export interface A<T extends Number> { // error
                          ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
             y: T;
         }
     }

--- a/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.errors.txt
+++ b/tests/baselines/reference/twoGenericInterfacesWithDifferentConstraints.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(5,11): error TS2428: All declarations must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(14,15): error TS2428: All declarations must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(38,22): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(5,11): error TS2428: All declarations of 'A' must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(14,15): error TS2428: All declarations of 'B' must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts(38,22): error TS2428: All declarations of 'A' must have identical type parameters.
 
 
 ==== tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDifferentConstraints.ts (3 errors) ====
@@ -10,7 +10,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDi
     
     interface A<T extends Number> { // error
               ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'A' must have identical type parameters.
         y: T;
     }
     
@@ -21,7 +21,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDi
     
         interface B<T extends A<any>> { // error
                   ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'B' must have identical type parameters.
             y: T;
         }
     }
@@ -47,7 +47,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithDi
     module M3 {
         export interface A<T extends Number> { // error
                          ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'A' must have identical type parameters.
             y: T;
         }
     }

--- a/tests/baselines/reference/twoGenericInterfacesWithTheSameNameButDifferentArity.errors.txt
+++ b/tests/baselines/reference/twoGenericInterfacesWithTheSameNameButDifferentArity.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTheSameNameButDifferentArity.ts(5,11): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTheSameNameButDifferentArity.ts(14,15): error TS2428: All declarations of an interface must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTheSameNameButDifferentArity.ts(38,22): error TS2428: All declarations of an interface must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTheSameNameButDifferentArity.ts(5,11): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTheSameNameButDifferentArity.ts(14,15): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTheSameNameButDifferentArity.ts(38,22): error TS2428: All declarations must have identical type parameters.
 
 
 ==== tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTheSameNameButDifferentArity.ts (3 errors) ====
@@ -10,7 +10,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTh
     
     interface A<T, U> { // error
               ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
         y: T;
     }
     
@@ -21,7 +21,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTh
     
         interface A<T, U> { // error
                   ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
             y: T;
         }
     }
@@ -47,7 +47,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTh
     module M3 {
         export interface A<T, U> { // error
                          ~
-!!! error TS2428: All declarations of an interface must have identical type parameters.
+!!! error TS2428: All declarations must have identical type parameters.
             y: T;
         }
     }

--- a/tests/baselines/reference/twoGenericInterfacesWithTheSameNameButDifferentArity.errors.txt
+++ b/tests/baselines/reference/twoGenericInterfacesWithTheSameNameButDifferentArity.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTheSameNameButDifferentArity.ts(5,11): error TS2428: All declarations must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTheSameNameButDifferentArity.ts(14,15): error TS2428: All declarations must have identical type parameters.
-tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTheSameNameButDifferentArity.ts(38,22): error TS2428: All declarations must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTheSameNameButDifferentArity.ts(5,11): error TS2428: All declarations of 'A' must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTheSameNameButDifferentArity.ts(14,15): error TS2428: All declarations of 'A' must have identical type parameters.
+tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTheSameNameButDifferentArity.ts(38,22): error TS2428: All declarations of 'A' must have identical type parameters.
 
 
 ==== tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTheSameNameButDifferentArity.ts (3 errors) ====
@@ -10,7 +10,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTh
     
     interface A<T, U> { // error
               ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'A' must have identical type parameters.
         y: T;
     }
     
@@ -21,7 +21,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTh
     
         interface A<T, U> { // error
                   ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'A' must have identical type parameters.
             y: T;
         }
     }
@@ -47,7 +47,7 @@ tests/cases/conformance/interfaces/declarationMerging/twoGenericInterfacesWithTh
     module M3 {
         export interface A<T, U> { // error
                          ~
-!!! error TS2428: All declarations must have identical type parameters.
+!!! error TS2428: All declarations of 'A' must have identical type parameters.
             y: T;
         }
     }

--- a/tests/cases/compiler/nonIdenticalTypeConstraints.ts
+++ b/tests/cases/compiler/nonIdenticalTypeConstraints.ts
@@ -1,0 +1,38 @@
+class Different {
+    a: number;
+    b: string;
+    c: boolean;
+}
+
+class Foo<T extends Function> {
+    n: T;
+}
+interface Foo<T extends Different> {
+    y: T;
+}
+interface Qux<T extends Different> {
+    y: T;
+}
+class Qux<T extends Function> {
+    n: T;
+}
+
+class Bar<T extends Function> {
+    n: T;
+}
+interface Bar<T extends Function> {
+    y: T;
+}
+interface Baz<T extends Function> {
+    y: T;
+}
+class Baz<T extends Function> {
+    n: T;
+}
+
+class Quux<T> {
+    n: T;
+}
+interface Quux<U> {
+    m: U;
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #6210 and #6211.

Before class/interface merging, only interfaces needed to be checked for differing type parameter lists. Now classes and interfaces all need to be checked. Refactor the check into its own function as well.
