### PR TITLE
do not make inferences with the same source\target pair multiple times

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6524,6 +6524,7 @@ namespace ts {
             let targetStack: Type[];
             let depth = 0;
             let inferiority = 0;
+            const visited: Map<boolean> = {};
             inferFromTypes(source, target);
 
             function isInProcess(source: Type, target: Type) {
@@ -6652,6 +6653,12 @@ namespace ts {
                         if (isDeeplyNestedGeneric(source, sourceStack, depth) && isDeeplyNestedGeneric(target, targetStack, depth)) {
                             return;
                         }
+
+                        const key = source.id + "," + target.id;
+                        if (hasProperty(visited, key)) {
+                            return;
+                        }
+                        visited[key] = true;
 
                         if (depth === 0) {
                             sourceStack = [];

--- a/src/server/protocol.d.ts
+++ b/src/server/protocol.d.ts
@@ -469,7 +469,7 @@ declare namespace ts.server.protocol {
         placeOpenBraceOnNewLineForControlBlocks?: boolean;
 
         /** Index operator */
-        [key: string] : string | number | boolean;
+        [key: string]: string | number | boolean;
     }
 
     /**


### PR DESCRIPTION
partial fix for #7081 
```ts
var a = new Rx.Subject<string>();
var b = new Rx.Subject<Immutable.Set<number>>();
var c1 = a.withLatestFrom(b, x => x); // 1

```
Total compilation time for an original repro case (above) has dropped from +20 minutes to 1.5s (check time: ~0.9s ). However caching is local to every inference session so it still scales pretty badly

Number of times line (1) appear in the code | Check time (s)
------------ | -------------
1 | 0.93
5 | 1.12
10 | 1.37
20 | 1.79
40 | 2.75
80 | 4.54
160 | 8.28
320 | 15.59 

Note: I'm not sure how to write a self-contained test for this issue without including `rx.all.d.ts` and `immutable.d.ts`