### PR TITLE
Error messages consistently use non- prefix

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12196,7 +12196,7 @@ namespace ts {
                     forEach(overloads, o => {
                         const deviation = getEffectiveDeclarationFlags(o, flagsToCheck) ^ canonicalFlags;
                         if (deviation & NodeFlags.Export) {
-                            error(o.name, Diagnostics.Overload_signatures_must_all_be_exported_or_not_exported);
+                            error(o.name, Diagnostics.Overload_signatures_must_all_be_exported_or_non_exported);
                         }
                         else if (deviation & NodeFlags.Ambient) {
                             error(o.name, Diagnostics.Overload_signatures_must_all_be_ambient_or_non_ambient);
@@ -12205,7 +12205,7 @@ namespace ts {
                             error(o.name || o, Diagnostics.Overload_signatures_must_all_be_public_private_or_protected);
                         }
                         else if (deviation & NodeFlags.Abstract) {
-                            error(o.name, Diagnostics.Overload_signatures_must_all_be_abstract_or_not_abstract);
+                            error(o.name, Diagnostics.Overload_signatures_must_all_be_abstract_or_non_abstract);
                         }
                     });
                 }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1151,7 +1151,7 @@
         "category": "Error",
         "code": 2382
     },
-    "Overload signatures must all be exported or not exported.": {
+    "Overload signatures must all be exported or non-exported.": {
         "category": "Error",
         "code": 2383
     },
@@ -1635,7 +1635,7 @@
         "category": "Error",
         "code": 2511
     },
-    "Overload signatures must all be abstract or not abstract.": {
+    "Overload signatures must all be abstract or non-abstract.": {
         "category": "Error",
         "code": 2512
     },

--- a/tests/baselines/reference/classAbstractInstantiations2.errors.txt
+++ b/tests/baselines/reference/classAbstractInstantiations2.errors.txt
@@ -5,7 +5,7 @@ tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbst
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts(21,1): error TS2511: Cannot create an instance of the abstract class 'B'.
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts(26,7): error TS2515: Non-abstract class 'C' does not implement inherited abstract member 'bar' from class 'B'.
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts(46,5): error TS2391: Function implementation is missing or not immediately following the declaration.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts(46,5): error TS2512: Overload signatures must all be abstract or not abstract.
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts(46,5): error TS2512: Overload signatures must all be abstract or non-abstract.
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractInstantiations2.ts(50,5): error TS1244: Abstract methods can only appear within an abstract class.
 
 
@@ -70,7 +70,7 @@ tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbst
         ~~~
 !!! error TS2391: Function implementation is missing or not immediately following the declaration.
         ~~~
-!!! error TS2512: Overload signatures must all be abstract or not abstract.
+!!! error TS2512: Overload signatures must all be abstract or non-abstract.
     }
     
     class H { // error -- not declared abstract

--- a/tests/baselines/reference/classAbstractOverloads.errors.txt
+++ b/tests/baselines/reference/classAbstractOverloads.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverloads.ts(7,5): error TS2512: Overload signatures must all be abstract or not abstract.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverloads.ts(10,14): error TS2512: Overload signatures must all be abstract or not abstract.
-tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverloads.ts(12,14): error TS2512: Overload signatures must all be abstract or not abstract.
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverloads.ts(7,5): error TS2512: Overload signatures must all be abstract or non-abstract.
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverloads.ts(10,14): error TS2512: Overload signatures must all be abstract or non-abstract.
+tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverloads.ts(12,14): error TS2512: Overload signatures must all be abstract or non-abstract.
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverloads.ts(15,5): error TS2391: Function implementation is missing or not immediately following the declaration.
 tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbstractOverloads.ts(20,14): error TS2516: All declarations of an abstract method must be consecutive.
 
@@ -14,16 +14,16 @@ tests/cases/conformance/classes/classDeclarations/classAbstractKeyword/classAbst
         abstract bar();
         bar();
         ~~~
-!!! error TS2512: Overload signatures must all be abstract or not abstract.
+!!! error TS2512: Overload signatures must all be abstract or non-abstract.
         abstract bar();
         
         abstract baz();
                  ~~~
-!!! error TS2512: Overload signatures must all be abstract or not abstract.
+!!! error TS2512: Overload signatures must all be abstract or non-abstract.
         baz();
         abstract baz();
                  ~~~
-!!! error TS2512: Overload signatures must all be abstract or not abstract.
+!!! error TS2512: Overload signatures must all be abstract or non-abstract.
         baz() {}
         
         qux();

--- a/tests/baselines/reference/functionOverloadErrors.errors.txt
+++ b/tests/baselines/reference/functionOverloadErrors.errors.txt
@@ -4,8 +4,8 @@ tests/cases/conformance/functions/functionOverloadErrors.ts(50,25): error TS2304
 tests/cases/conformance/functions/functionOverloadErrors.ts(51,32): error TS2304: Cannot find name 'window'.
 tests/cases/conformance/functions/functionOverloadErrors.ts(65,13): error TS2385: Overload signatures must all be public, private or protected.
 tests/cases/conformance/functions/functionOverloadErrors.ts(68,13): error TS2385: Overload signatures must all be public, private or protected.
-tests/cases/conformance/functions/functionOverloadErrors.ts(75,21): error TS2383: Overload signatures must all be exported or not exported.
-tests/cases/conformance/functions/functionOverloadErrors.ts(79,14): error TS2383: Overload signatures must all be exported or not exported.
+tests/cases/conformance/functions/functionOverloadErrors.ts(75,21): error TS2383: Overload signatures must all be exported or non-exported.
+tests/cases/conformance/functions/functionOverloadErrors.ts(79,14): error TS2383: Overload signatures must all be exported or non-exported.
 tests/cases/conformance/functions/functionOverloadErrors.ts(85,18): error TS2384: Overload signatures must all be ambient or non-ambient.
 tests/cases/conformance/functions/functionOverloadErrors.ts(90,18): error TS2384: Overload signatures must all be ambient or non-ambient.
 tests/cases/conformance/functions/functionOverloadErrors.ts(94,10): error TS2394: Overload signature is not compatible with function implementation.
@@ -103,13 +103,13 @@ tests/cases/conformance/functions/functionOverloadErrors.ts(116,19): error TS237
     module M {
         export function fn1();
                         ~~~
-!!! error TS2383: Overload signatures must all be exported or not exported.
+!!! error TS2383: Overload signatures must all be exported or non-exported.
         function fn1(n: string);
         function fn1() { } 
     
         function fn2(n: string);
                  ~~~
-!!! error TS2383: Overload signatures must all be exported or not exported.
+!!! error TS2383: Overload signatures must all be exported or non-exported.
         export function fn2();
         export function fn2() { } 
     }

--- a/tests/baselines/reference/overloadModifiersMustAgree.errors.txt
+++ b/tests/baselines/reference/overloadModifiersMustAgree.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/overloadModifiersMustAgree.ts(2,12): error TS2385: Overload signatures must all be public, private or protected.
 tests/cases/compiler/overloadModifiersMustAgree.ts(6,18): error TS2384: Overload signatures must all be ambient or non-ambient.
-tests/cases/compiler/overloadModifiersMustAgree.ts(7,17): error TS2383: Overload signatures must all be exported or not exported.
+tests/cases/compiler/overloadModifiersMustAgree.ts(7,17): error TS2383: Overload signatures must all be exported or non-exported.
 tests/cases/compiler/overloadModifiersMustAgree.ts(12,5): error TS2386: Overload signatures must all be optional or required.
 
 
@@ -17,7 +17,7 @@ tests/cases/compiler/overloadModifiersMustAgree.ts(12,5): error TS2386: Overload
 !!! error TS2384: Overload signatures must all be ambient or non-ambient.
     export function bar(s: string);
                     ~~~
-!!! error TS2383: Overload signatures must all be exported or not exported.
+!!! error TS2383: Overload signatures must all be exported or non-exported.
     function bar(s?: string) { }
     
     interface I {


### PR DESCRIPTION
Fixes #7186

In the construction "*x* must either be *y* or non-*y*", we previously used "*y* or not *y*", even though *y* is always an adjective.