### PR TITLE
Invalid this emit in contextual object

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10742,6 +10742,7 @@ namespace ts {
 
             // The identityMapper object is used to indicate that function expressions are wildcards
             if (contextualMapper === identityMapper && isContextSensitive(node)) {
+                checkNodeDeferred(node);
                 return anyFunctionType;
             }
 

--- a/tests/baselines/reference/invalidThisEmitInContextualObjectLiteral.js
+++ b/tests/baselines/reference/invalidThisEmitInContextualObjectLiteral.js
@@ -1,0 +1,27 @@
+//// [invalidThisEmitInContextualObjectLiteral.ts]
+interface IDef {
+	p1: (e:string) => void;
+	p2: () => (n: number) => any;
+}
+
+class TestController {
+	public m(def: IDef) { }
+	public p = this.m({
+		p1: e => { },
+		p2: () => { return vvvvvvvvv => this; },
+	});
+}
+
+
+//// [invalidThisEmitInContextualObjectLiteral.js]
+var TestController = (function () {
+    function TestController() {
+        var _this = this;
+        this.p = this.m({
+            p1: function (e) { },
+            p2: function () { return function (vvvvvvvvv) { return _this; }; }
+        });
+    }
+    TestController.prototype.m = function (def) { };
+    return TestController;
+}());

--- a/tests/baselines/reference/invalidThisEmitInContextualObjectLiteral.symbols
+++ b/tests/baselines/reference/invalidThisEmitInContextualObjectLiteral.symbols
@@ -1,0 +1,39 @@
+=== tests/cases/compiler/invalidThisEmitInContextualObjectLiteral.ts ===
+interface IDef {
+>IDef : Symbol(IDef, Decl(invalidThisEmitInContextualObjectLiteral.ts, 0, 0))
+
+	p1: (e:string) => void;
+>p1 : Symbol(p1, Decl(invalidThisEmitInContextualObjectLiteral.ts, 0, 16))
+>e : Symbol(e, Decl(invalidThisEmitInContextualObjectLiteral.ts, 1, 6))
+
+	p2: () => (n: number) => any;
+>p2 : Symbol(p2, Decl(invalidThisEmitInContextualObjectLiteral.ts, 1, 24))
+>n : Symbol(n, Decl(invalidThisEmitInContextualObjectLiteral.ts, 2, 12))
+}
+
+class TestController {
+>TestController : Symbol(TestController, Decl(invalidThisEmitInContextualObjectLiteral.ts, 3, 1))
+
+	public m(def: IDef) { }
+>m : Symbol(m, Decl(invalidThisEmitInContextualObjectLiteral.ts, 5, 22))
+>def : Symbol(def, Decl(invalidThisEmitInContextualObjectLiteral.ts, 6, 10))
+>IDef : Symbol(IDef, Decl(invalidThisEmitInContextualObjectLiteral.ts, 0, 0))
+
+	public p = this.m({
+>p : Symbol(p, Decl(invalidThisEmitInContextualObjectLiteral.ts, 6, 24))
+>this.m : Symbol(m, Decl(invalidThisEmitInContextualObjectLiteral.ts, 5, 22))
+>this : Symbol(TestController, Decl(invalidThisEmitInContextualObjectLiteral.ts, 3, 1))
+>m : Symbol(m, Decl(invalidThisEmitInContextualObjectLiteral.ts, 5, 22))
+
+		p1: e => { },
+>p1 : Symbol(p1, Decl(invalidThisEmitInContextualObjectLiteral.ts, 7, 20))
+>e : Symbol(e, Decl(invalidThisEmitInContextualObjectLiteral.ts, 8, 5))
+
+		p2: () => { return vvvvvvvvv => this; },
+>p2 : Symbol(p2, Decl(invalidThisEmitInContextualObjectLiteral.ts, 8, 15))
+>vvvvvvvvv : Symbol(vvvvvvvvv, Decl(invalidThisEmitInContextualObjectLiteral.ts, 9, 20))
+>this : Symbol(TestController, Decl(invalidThisEmitInContextualObjectLiteral.ts, 3, 1))
+
+	});
+}
+

--- a/tests/baselines/reference/invalidThisEmitInContextualObjectLiteral.types
+++ b/tests/baselines/reference/invalidThisEmitInContextualObjectLiteral.types
@@ -1,0 +1,44 @@
+=== tests/cases/compiler/invalidThisEmitInContextualObjectLiteral.ts ===
+interface IDef {
+>IDef : IDef
+
+	p1: (e:string) => void;
+>p1 : (e: string) => void
+>e : string
+
+	p2: () => (n: number) => any;
+>p2 : () => (n: number) => any
+>n : number
+}
+
+class TestController {
+>TestController : TestController
+
+	public m(def: IDef) { }
+>m : (def: IDef) => void
+>def : IDef
+>IDef : IDef
+
+	public p = this.m({
+>p : void
+>this.m({		p1: e => { },		p2: () => { return vvvvvvvvv => this; },	}) : void
+>this.m : (def: IDef) => void
+>this : this
+>m : (def: IDef) => void
+>{		p1: e => { },		p2: () => { return vvvvvvvvv => this; },	} : { p1: (e: string) => void; p2: () => {}; }
+
+		p1: e => { },
+>p1 : (e: string) => void
+>e => { } : (e: string) => void
+>e : string
+
+		p2: () => { return vvvvvvvvv => this; },
+>p2 : () => {}
+>() => { return vvvvvvvvv => this; } : () => {}
+>vvvvvvvvv => this : (vvvvvvvvv: number) => this
+>vvvvvvvvv : number
+>this : this
+
+	});
+}
+

--- a/tests/cases/compiler/invalidThisEmitInContextualObjectLiteral.ts
+++ b/tests/cases/compiler/invalidThisEmitInContextualObjectLiteral.ts
@@ -1,0 +1,12 @@
+interface IDef {
+	p1: (e:string) => void;
+	p2: () => (n: number) => any;
+}
+
+class TestController {
+	public m(def: IDef) { }
+	public p = this.m({
+		p1: e => { },
+		p2: () => { return vvvvvvvvv => this; },
+	});
+}


### PR DESCRIPTION
Fixes #7212

When we check context sensitive functions inside an object literal we short-circuit checking of the return type because it might be circular. But the short-circuit means that the checker doesn't go back to check the function later (because it's in a call to checkExpressionCached), which means that this doesn't get marked as needing the _this = this emit.

Thanks @vladima for the psychic debugging here. We came up with two fixes with two variants:

1. Call checkNodeDeferred in the short-circuit logic in checkFunctionExpressionOrObjectLiteralMethod, same as it is for the non-short-circuit path.
2. When aggregating return types, call checkExpression instead of checkExpressionCached.

1a. Only call checkNodeDeferred in checkFunctionExpressionOrObjectLiteralMethod if the node hasn't already been added to the deferred node list. Maybe using a nodeflags or something.
2a. Only call checkExpression when the contextual mapper is identityMapper.

This PR goes with (1) since it's the simplest. @ahejlsberg, can you take a look?