### PR TITLE
Fix CommonJs modules

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -278,7 +278,7 @@ namespace ts {
         function declareSymbol(symbolTable: SymbolTable, parent: Symbol, node: Declaration, includes: SymbolFlags, excludes: SymbolFlags): Symbol {
             Debug.assert(!hasDynamicName(node));
 
-            const isJsModuleExport = node.kind === SyntaxKind.BinaryExpression ? getSpecialPropertyAssignmentKind(node) === SpecialPropertyAssignmentKind.ModuleExports : false;
+            const isJsModuleExport = getSpecialPropertyAssignmentKind(node) === SpecialPropertyAssignmentKind.ModuleExports;
             const isDefaultExport = node.flags & NodeFlags.Default;
 
             // The exported symbol for an export default function/class node is always named "default"

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -278,11 +278,10 @@ namespace ts {
         function declareSymbol(symbolTable: SymbolTable, parent: Symbol, node: Declaration, includes: SymbolFlags, excludes: SymbolFlags): Symbol {
             Debug.assert(!hasDynamicName(node));
 
-            const isJsModuleExport = getSpecialPropertyAssignmentKind(node) === SpecialPropertyAssignmentKind.ModuleExports;
             const isDefaultExport = node.flags & NodeFlags.Default;
 
             // The exported symbol for an export default function/class node is always named "default"
-            const name = isJsModuleExport ? "export=" : isDefaultExport && parent ? "default" : getDeclarationName(node);
+            const name = isDefaultExport && parent ? "default" : getDeclarationName(node);
 
             let symbol: Symbol;
             if (name !== undefined) {

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -278,9 +278,11 @@ namespace ts {
         function declareSymbol(symbolTable: SymbolTable, parent: Symbol, node: Declaration, includes: SymbolFlags, excludes: SymbolFlags): Symbol {
             Debug.assert(!hasDynamicName(node));
 
+            const isJsModuleExport = node.kind === SyntaxKind.BinaryExpression ? getSpecialPropertyAssignmentKind(node) === SpecialPropertyAssignmentKind.ModuleExports : false;
             const isDefaultExport = node.flags & NodeFlags.Default;
+
             // The exported symbol for an export default function/class node is always named "default"
-            const name = isDefaultExport && parent ? "default" : getDeclarationName(node);
+            const name = isJsModuleExport ? "export=" : isDefaultExport && parent ? "default" : getDeclarationName(node);
 
             let symbol: Symbol;
             if (name !== undefined) {
@@ -1428,7 +1430,7 @@ namespace ts {
         function bindModuleExportsAssignment(node: BinaryExpression) {
             // 'module.exports = expr' assignment
             setCommonJsModuleIndicator(node);
-            bindExportAssignment(node);
+            declareSymbol(file.symbol.exports, file.symbol, node, SymbolFlags.Property | SymbolFlags.Export | SymbolFlags.ValueModule, SymbolFlags.None);
         }
 
         function bindThisPropertyAssignment(node: BinaryExpression) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -888,8 +888,12 @@ namespace ts {
 
         function getTargetOfImportClause(node: ImportClause): Symbol {
             const moduleSymbol = resolveExternalModuleName(node, (<ImportDeclaration>node.parent).moduleSpecifier);
+
             if (moduleSymbol) {
-                const exportDefaultSymbol = resolveSymbol(moduleSymbol.exports["default"]);
+                const exportDefaultSymbol = moduleSymbol.exports["export="] ?
+                    getPropertyOfType(getTypeOfSymbol(moduleSymbol.exports["export="]), "default") :
+                    resolveSymbol(moduleSymbol.exports["default"]);
+
                 if (!exportDefaultSymbol && !allowSyntheticDefaultImports) {
                     error(node.name, Diagnostics.Module_0_has_no_default_export, symbolToString(moduleSymbol));
                 }
@@ -963,8 +967,7 @@ namespace ts {
                     let symbolFromVariable: Symbol;
                     // First check if module was specified with "export=". If so, get the member from the resolved type
                     if (moduleSymbol && moduleSymbol.exports && moduleSymbol.exports["export="]) {
-                        const members = (getTypeOfSymbol(targetSymbol) as ResolvedType).members;
-                        symbolFromVariable = members && members[name.text];
+                        symbolFromVariable = getPropertyOfType(getTypeOfSymbol(targetSymbol), name.text);
                     }
                     else {
                         symbolFromVariable = getPropertyOfVariable(targetSymbol, name.text);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -960,8 +960,16 @@ namespace ts {
             if (targetSymbol) {
                 const name = specifier.propertyName || specifier.name;
                 if (name.text) {
+                    let symbolFromVariable: Symbol;
+                    // First check if module was specified with "export=". If so, get the member from the resolved type
+                    if (moduleSymbol && moduleSymbol.exports && moduleSymbol.exports["export="]) {
+                        const members = (getTypeOfSymbol(targetSymbol) as ResolvedType).members;
+                        symbolFromVariable = members && members[name.text];
+                    }
+                    else {
+                        symbolFromVariable = getPropertyOfVariable(targetSymbol, name.text);
+                    }
                     const symbolFromModule = getExportOfModule(targetSymbol, name.text);
-                    const symbolFromVariable = getPropertyOfVariable(targetSymbol, name.text);
                     const symbol = symbolFromModule && symbolFromVariable ?
                         combineValueAndTypeSymbols(symbolFromVariable, symbolFromModule) :
                         symbolFromModule || symbolFromVariable;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1107,6 +1107,9 @@ namespace ts {
     /// Given a BinaryExpression, returns SpecialPropertyAssignmentKind for the various kinds of property
     /// assignments we treat as special in the binder
     export function getSpecialPropertyAssignmentKind(expression: Node): SpecialPropertyAssignmentKind {
+        if (!isInJavaScriptFile(expression)) {
+            return SpecialPropertyAssignmentKind.None;
+        }
         if (expression.kind !== SyntaxKind.BinaryExpression) {
             return SpecialPropertyAssignmentKind.None;
         }

--- a/tests/baselines/reference/exportEqualsDefaultProperty.js
+++ b/tests/baselines/reference/exportEqualsDefaultProperty.js
@@ -1,0 +1,27 @@
+//// [tests/cases/compiler/exportEqualsDefaultProperty.ts] ////
+
+//// [exp.ts]
+
+var x = {
+    "greeting": "hello, world",
+    "default": 42
+};
+
+export = x
+
+//// [imp.ts]
+import foo from "./exp";
+foo.toExponential(2);
+
+
+//// [exp.js]
+"use strict";
+var x = {
+    "greeting": "hello, world",
+    "default": 42
+};
+module.exports = x;
+//// [imp.js]
+"use strict";
+var exp_1 = require("./exp");
+exp_1["default"].toExponential(2);

--- a/tests/baselines/reference/exportEqualsDefaultProperty.symbols
+++ b/tests/baselines/reference/exportEqualsDefaultProperty.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/compiler/exp.ts ===
+
+var x = {
+>x : Symbol(x, Decl(exp.ts, 1, 3))
+
+    "greeting": "hello, world",
+    "default": 42
+};
+
+export = x
+>x : Symbol(x, Decl(exp.ts, 1, 3))
+
+=== tests/cases/compiler/imp.ts ===
+import foo from "./exp";
+>foo : Symbol(foo, Decl(imp.ts, 0, 6))
+
+foo.toExponential(2);
+>foo.toExponential : Symbol(Number.toExponential, Decl(lib.d.ts, --, --))
+>foo : Symbol(foo, Decl(imp.ts, 0, 6))
+>toExponential : Symbol(Number.toExponential, Decl(lib.d.ts, --, --))
+

--- a/tests/baselines/reference/exportEqualsDefaultProperty.types
+++ b/tests/baselines/reference/exportEqualsDefaultProperty.types
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/exp.ts ===
+
+var x = {
+>x : { "greeting": string; "default": number; }
+>{    "greeting": "hello, world",    "default": 42} : { "greeting": string; "default": number; }
+
+    "greeting": "hello, world",
+>"hello, world" : string
+
+    "default": 42
+>42 : number
+
+};
+
+export = x
+>x : { "greeting": string; "default": number; }
+
+=== tests/cases/compiler/imp.ts ===
+import foo from "./exp";
+>foo : number
+
+foo.toExponential(2);
+>foo.toExponential(2) : string
+>foo.toExponential : (fractionDigits?: number) => string
+>foo : number
+>toExponential : (fractionDigits?: number) => string
+>2 : number
+

--- a/tests/cases/compiler/exportEqualsDefaultProperty.ts
+++ b/tests/cases/compiler/exportEqualsDefaultProperty.ts
@@ -1,0 +1,12 @@
+
+// @Filename: exp.ts
+var x = {
+    "greeting": "hello, world",
+    "default": 42
+};
+
+export = x
+
+// @Filename: imp.ts
+import foo from "./exp";
+foo.toExponential(2);

--- a/tests/cases/fourslash/javascriptModules20.ts
+++ b/tests/cases/fourslash/javascriptModules20.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts'/>
+// @allowJs: true
+
+// @Filename: mod.js
+//// function foo() { return {a: true}; }
+//// module.exports = foo();
+
+// @Filename: app.js
+//// import * as mod from "./mod"
+//// mod./**/
+
+goTo.marker();
+verify.completionListContains('a');

--- a/tests/cases/fourslash/javascriptModules21.ts
+++ b/tests/cases/fourslash/javascriptModules21.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts'/>
+// @allowJs: true
+// @module: system
+
+// @Filename: mod.js
+//// function foo() { return {a: true}; }
+//// module.exports = foo();
+
+// @Filename: app.js
+//// import mod from "./mod"
+//// mod./**/
+
+goTo.marker();
+verify.completionListContains('a');

--- a/tests/cases/fourslash/javascriptModules22.ts
+++ b/tests/cases/fourslash/javascriptModules22.ts
@@ -5,9 +5,28 @@
 //// function foo() { return {a: "hello, world"}; }
 //// module.exports = foo();
 
+// @Filename: mod2.js
+//// var x = {name: 'test'};
+//// (function createExport(obj){
+////     module.exports = {
+////         "default": x,
+////         "sausages": {eggs: 2}
+////     };
+//// })();
+
 // @Filename: app.js
 //// import {a} from "./mod"
+//// import def, {sausages} from "./mod2"
 //// a./**/
 
 goTo.marker();
 verify.completionListContains('toString');
+
+edit.backspace(2);
+edit.insert("def.");
+verify.completionListContains("name");
+
+edit.insert("name;\nsausages.");
+verify.completionListContains("eggs");
+edit.insert("eggs;");
+verify.numberOfErrorsInCurrentFile(0);

--- a/tests/cases/fourslash/javascriptModules22.ts
+++ b/tests/cases/fourslash/javascriptModules22.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts'/>
+// @allowJs: true
+
+// @Filename: mod.js
+//// function foo() { return {a: "hello, world"}; }
+//// module.exports = foo();
+
+// @Filename: app.js
+//// import {a} from "./mod"
+//// a./**/
+
+goTo.marker();
+verify.completionListContains('toString');

--- a/tests/cases/fourslash/javascriptModules23.ts
+++ b/tests/cases/fourslash/javascriptModules23.ts
@@ -1,0 +1,12 @@
+/// <reference path='fourslash.ts'/>
+
+// @Filename: mod.ts
+//// var foo = {a: "test"};
+//// export = foo;
+
+// @Filename: app.ts
+//// import {a} from "./mod"
+//// a./**/
+
+goTo.marker();
+verify.completionListContains('toString');

--- a/tests/cases/fourslash/javascriptModules24.ts
+++ b/tests/cases/fourslash/javascriptModules24.ts
@@ -1,0 +1,21 @@
+/// <reference path='fourslash.ts'/>
+
+// @Filename: mod.ts
+//// function foo() { return 42; }
+//// namespace foo {
+////   export function bar (a: string) { return a; }
+//// }
+//// export = foo;
+
+// @Filename: app.ts
+//// import * as foo from "./mod"
+//// foo/*1*/();
+//// foo.bar(/*2*/"test");
+
+goTo.marker('1');
+
+/**** BUG: Should be an error to invoke a call signature on a namespace import ****/
+//verify.errorExistsBeforeMarker('1');
+verify.quickInfoIs("(alias) foo(): number\nimport foo");
+goTo.marker('2');
+verify.signatureHelpArgumentCountIs(1);


### PR DESCRIPTION
This fix allows ES2015 module syntax (namespace imports and import lists) to work with:

 a) JavaScript modules using the "module.exports = <expr>" pattern
 b) TypeScript modules using the "export = " pattern

Ping @RyanCavanaugh and @mhegazy 