### PR TITLE
Stop destructuring private properties

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2607,8 +2607,7 @@ namespace ts {
         // Return the inferred type for a binding element
         function getTypeForBindingElement(declaration: BindingElement): Type {
             const pattern = <BindingPattern>declaration.parent;
-            const parent = <VariableLikeDeclaration>pattern.parent;
-            const parentType = getTypeForBindingElementParent(parent);
+            const parentType = getTypeForBindingElementParent(<VariableLikeDeclaration>pattern.parent);
             // If parent has the unknown (error) type, then so does this binding element
             if (parentType === unknownType) {
                 return unknownType;
@@ -2642,11 +2641,6 @@ namespace ts {
                 if (!type) {
                     error(name, Diagnostics.Type_0_has_no_property_1_and_no_string_index_signature, typeToString(parentType), declarationNameToString(name));
                     return unknownType;
-                }
-
-                const property = getPropertyOfType(parentType, text);
-                if (parent && parent.initializer && property && getParentOfSymbol(property)) {
-                    checkClassPropertyAccess(parent, parent.initializer, parentType, property);
                 }
             }
             else {
@@ -13313,6 +13307,15 @@ namespace ts {
                 // check computed properties inside property names of binding elements
                 if (node.propertyName && node.propertyName.kind === SyntaxKind.ComputedPropertyName) {
                     checkComputedPropertyName(<ComputedPropertyName>node.propertyName);
+                }
+
+                // check private/protected variable access
+                const parent = <VariableLikeDeclaration>(<BindingPattern>node.parent).parent;
+                const parentType = getTypeForBindingElementParent(parent);
+                const name = node.propertyName || <Identifier>node.name;
+                const property = getPropertyOfType(parentType, getTextOfPropertyName(name));
+                if (parent.initializer && property && getParentOfSymbol(property)) {
+                    checkClassPropertyAccess(parent, parent.initializer, parentType, property);
                 }
             }
 

--- a/tests/baselines/reference/ClassAndModuleThatMergeWithModulesExportedStaticFunctionUsingClassPrivateStatics.errors.txt
+++ b/tests/baselines/reference/ClassAndModuleThatMergeWithModulesExportedStaticFunctionUsingClassPrivateStatics.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithModulesExportedStaticFunctionUsingClassPrivateStatics.ts(11,16): error TS2341: Property 'sfn' is private and only accessible within class 'clodule<T>'.
+tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithModulesExportedStaticFunctionUsingClassPrivateStatics.ts(11,24): error TS2341: Property 'sfn' is private and only accessible within class 'clodule<T>'.
 
 
 ==== tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMergeWithModulesExportedStaticFunctionUsingClassPrivateStatics.ts (1 errors) ====
@@ -13,7 +13,7 @@ tests/cases/conformance/internalModules/DeclarationMerging/ClassAndModuleThatMer
         // error: duplicate identifier expected
         export function fn<T>(x: T, y: T): number {
             return clodule.sfn('a');
-                   ~~~~~~~~~~~
+                           ~~~
 !!! error TS2341: Property 'sfn' is private and only accessible within class 'clodule<T>'.
         }
     }

--- a/tests/baselines/reference/classConstructorParametersAccessibility.errors.txt
+++ b/tests/baselines/reference/classConstructorParametersAccessibility.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility.ts(12,1): error TS2341: Property 'p' is private and only accessible within class 'C2'.
-tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility.ts(19,1): error TS2445: Property 'p' is protected and only accessible within class 'C3' and its subclasses.
+tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility.ts(12,4): error TS2341: Property 'p' is private and only accessible within class 'C2'.
+tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility.ts(19,4): error TS2445: Property 'p' is protected and only accessible within class 'C3' and its subclasses.
 
 
 ==== tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility.ts (2 errors) ====
@@ -15,7 +15,7 @@ tests/cases/conformance/classes/constructorDeclarations/classConstructorParamete
     }
     var c2: C2;
     c2.p // private, error
-    ~~~~
+       ~
 !!! error TS2341: Property 'p' is private and only accessible within class 'C2'.
     
     
@@ -24,7 +24,7 @@ tests/cases/conformance/classes/constructorDeclarations/classConstructorParamete
     }
     var c3: C3;
     c3.p // protected, error
-    ~~~~
+       ~
 !!! error TS2445: Property 'p' is protected and only accessible within class 'C3' and its subclasses.
     class Derived extends C3 {
         constructor(p: number) {

--- a/tests/baselines/reference/classConstructorParametersAccessibility2.errors.txt
+++ b/tests/baselines/reference/classConstructorParametersAccessibility2.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility2.ts(12,1): error TS2341: Property 'p' is private and only accessible within class 'C2'.
-tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility2.ts(19,1): error TS2445: Property 'p' is protected and only accessible within class 'C3' and its subclasses.
+tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility2.ts(12,4): error TS2341: Property 'p' is private and only accessible within class 'C2'.
+tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility2.ts(19,4): error TS2445: Property 'p' is protected and only accessible within class 'C3' and its subclasses.
 
 
 ==== tests/cases/conformance/classes/constructorDeclarations/classConstructorParametersAccessibility2.ts (2 errors) ====
@@ -15,7 +15,7 @@ tests/cases/conformance/classes/constructorDeclarations/classConstructorParamete
     }
     var c2: C2;
     c2.p // private, error
-    ~~~~
+       ~
 !!! error TS2341: Property 'p' is private and only accessible within class 'C2'.
     
     
@@ -24,7 +24,7 @@ tests/cases/conformance/classes/constructorDeclarations/classConstructorParamete
     }
     var c3: C3;
     c3.p // protected, error
-    ~~~~
+       ~
 !!! error TS2445: Property 'p' is protected and only accessible within class 'C3' and its subclasses.
     class Derived extends C3 {
         constructor(p: number) {

--- a/tests/baselines/reference/classPropertyAsPrivate.errors.txt
+++ b/tests/baselines/reference/classPropertyAsPrivate.errors.txt
@@ -2,14 +2,14 @@ tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(
 tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(4,17): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(8,24): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(9,24): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(15,1): error TS2341: Property 'x' is private and only accessible within class 'C'.
-tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(16,1): error TS2341: Property 'y' is private and only accessible within class 'C'.
-tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(17,1): error TS2341: Property 'y' is private and only accessible within class 'C'.
-tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(18,1): error TS2341: Property 'foo' is private and only accessible within class 'C'.
-tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(20,1): error TS2341: Property 'a' is private and only accessible within class 'C'.
-tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(21,1): error TS2341: Property 'b' is private and only accessible within class 'C'.
-tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(22,1): error TS2341: Property 'b' is private and only accessible within class 'C'.
-tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(23,1): error TS2341: Property 'foo' is private and only accessible within class 'C'.
+tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(15,3): error TS2341: Property 'x' is private and only accessible within class 'C'.
+tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(16,3): error TS2341: Property 'y' is private and only accessible within class 'C'.
+tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(17,3): error TS2341: Property 'y' is private and only accessible within class 'C'.
+tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(18,3): error TS2341: Property 'foo' is private and only accessible within class 'C'.
+tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(20,3): error TS2341: Property 'a' is private and only accessible within class 'C'.
+tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(21,3): error TS2341: Property 'b' is private and only accessible within class 'C'.
+tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(22,3): error TS2341: Property 'b' is private and only accessible within class 'C'.
+tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(23,3): error TS2341: Property 'foo' is private and only accessible within class 'C'.
 
 
 ==== tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts (12 errors) ====
@@ -36,27 +36,27 @@ tests/cases/conformance/classes/members/accessibility/classPropertyAsPrivate.ts(
     var c: C;
     // all errors
     c.x;
-    ~~~
+      ~
 !!! error TS2341: Property 'x' is private and only accessible within class 'C'.
     c.y;
-    ~~~
+      ~
 !!! error TS2341: Property 'y' is private and only accessible within class 'C'.
     c.y = 1;
-    ~~~
+      ~
 !!! error TS2341: Property 'y' is private and only accessible within class 'C'.
     c.foo();
-    ~~~~~
+      ~~~
 !!! error TS2341: Property 'foo' is private and only accessible within class 'C'.
     
     C.a;
-    ~~~
+      ~
 !!! error TS2341: Property 'a' is private and only accessible within class 'C'.
     C.b();
-    ~~~
+      ~
 !!! error TS2341: Property 'b' is private and only accessible within class 'C'.
     C.b = 1;
-    ~~~
+      ~
 !!! error TS2341: Property 'b' is private and only accessible within class 'C'.
     C.foo();
-    ~~~~~
+      ~~~
 !!! error TS2341: Property 'foo' is private and only accessible within class 'C'.

--- a/tests/baselines/reference/classPropertyAsProtected.errors.txt
+++ b/tests/baselines/reference/classPropertyAsProtected.errors.txt
@@ -2,14 +2,14 @@ tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.t
 tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(4,19): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(8,26): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(9,26): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(15,1): error TS2445: Property 'x' is protected and only accessible within class 'C' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(16,1): error TS2445: Property 'y' is protected and only accessible within class 'C' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(17,1): error TS2445: Property 'y' is protected and only accessible within class 'C' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(18,1): error TS2445: Property 'foo' is protected and only accessible within class 'C' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(20,1): error TS2445: Property 'a' is protected and only accessible within class 'C' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(21,1): error TS2445: Property 'b' is protected and only accessible within class 'C' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(22,1): error TS2445: Property 'b' is protected and only accessible within class 'C' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(23,1): error TS2445: Property 'foo' is protected and only accessible within class 'C' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(15,3): error TS2445: Property 'x' is protected and only accessible within class 'C' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(16,3): error TS2445: Property 'y' is protected and only accessible within class 'C' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(17,3): error TS2445: Property 'y' is protected and only accessible within class 'C' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(18,3): error TS2445: Property 'foo' is protected and only accessible within class 'C' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(20,3): error TS2445: Property 'a' is protected and only accessible within class 'C' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(21,3): error TS2445: Property 'b' is protected and only accessible within class 'C' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(22,3): error TS2445: Property 'b' is protected and only accessible within class 'C' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts(23,3): error TS2445: Property 'foo' is protected and only accessible within class 'C' and its subclasses.
 
 
 ==== tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.ts (12 errors) ====
@@ -36,27 +36,27 @@ tests/cases/conformance/classes/members/accessibility/classPropertyAsProtected.t
     var c: C;
     // all errors
     c.x;
-    ~~~
+      ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'C' and its subclasses.
     c.y;
-    ~~~
+      ~
 !!! error TS2445: Property 'y' is protected and only accessible within class 'C' and its subclasses.
     c.y = 1;
-    ~~~
+      ~
 !!! error TS2445: Property 'y' is protected and only accessible within class 'C' and its subclasses.
     c.foo();
-    ~~~~~
+      ~~~
 !!! error TS2445: Property 'foo' is protected and only accessible within class 'C' and its subclasses.
     
     C.a;
-    ~~~
+      ~
 !!! error TS2445: Property 'a' is protected and only accessible within class 'C' and its subclasses.
     C.b();
-    ~~~
+      ~
 !!! error TS2445: Property 'b' is protected and only accessible within class 'C' and its subclasses.
     C.b = 1;
-    ~~~
+      ~
 !!! error TS2445: Property 'b' is protected and only accessible within class 'C' and its subclasses.
     C.foo();
-    ~~~~~
+      ~~~
 !!! error TS2445: Property 'foo' is protected and only accessible within class 'C' and its subclasses.

--- a/tests/baselines/reference/classWithPrivateProperty.errors.txt
+++ b/tests/baselines/reference/classWithPrivateProperty.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/conformance/types/members/classWithPrivateProperty.ts(15,18): error TS2341: Property 'x' is private and only accessible within class 'C'.
-tests/cases/conformance/types/members/classWithPrivateProperty.ts(16,18): error TS2341: Property 'a' is private and only accessible within class 'C'.
-tests/cases/conformance/types/members/classWithPrivateProperty.ts(17,18): error TS2341: Property 'b' is private and only accessible within class 'C'.
-tests/cases/conformance/types/members/classWithPrivateProperty.ts(18,18): error TS2341: Property 'c' is private and only accessible within class 'C'.
-tests/cases/conformance/types/members/classWithPrivateProperty.ts(19,18): error TS2341: Property 'd' is private and only accessible within class 'C'.
-tests/cases/conformance/types/members/classWithPrivateProperty.ts(20,18): error TS2341: Property 'e' is private and only accessible within class 'C'.
-tests/cases/conformance/types/members/classWithPrivateProperty.ts(21,18): error TS2341: Property 'f' is private and only accessible within class 'C'.
-tests/cases/conformance/types/members/classWithPrivateProperty.ts(22,18): error TS2341: Property 'g' is private and only accessible within class 'C'.
+tests/cases/conformance/types/members/classWithPrivateProperty.ts(15,20): error TS2341: Property 'x' is private and only accessible within class 'C'.
+tests/cases/conformance/types/members/classWithPrivateProperty.ts(16,20): error TS2341: Property 'a' is private and only accessible within class 'C'.
+tests/cases/conformance/types/members/classWithPrivateProperty.ts(17,20): error TS2341: Property 'b' is private and only accessible within class 'C'.
+tests/cases/conformance/types/members/classWithPrivateProperty.ts(18,20): error TS2341: Property 'c' is private and only accessible within class 'C'.
+tests/cases/conformance/types/members/classWithPrivateProperty.ts(19,20): error TS2341: Property 'd' is private and only accessible within class 'C'.
+tests/cases/conformance/types/members/classWithPrivateProperty.ts(20,20): error TS2341: Property 'e' is private and only accessible within class 'C'.
+tests/cases/conformance/types/members/classWithPrivateProperty.ts(21,20): error TS2341: Property 'f' is private and only accessible within class 'C'.
+tests/cases/conformance/types/members/classWithPrivateProperty.ts(22,20): error TS2341: Property 'g' is private and only accessible within class 'C'.
 
 
 ==== tests/cases/conformance/types/members/classWithPrivateProperty.ts (8 errors) ====
@@ -24,26 +24,26 @@ tests/cases/conformance/types/members/classWithPrivateProperty.ts(22,18): error 
     
     var c = new C();
     var r1: string = c.x;
-                     ~~~
+                       ~
 !!! error TS2341: Property 'x' is private and only accessible within class 'C'.
     var r2: string = c.a;
-                     ~~~
+                       ~
 !!! error TS2341: Property 'a' is private and only accessible within class 'C'.
     var r3: string = c.b;
-                     ~~~
+                       ~
 !!! error TS2341: Property 'b' is private and only accessible within class 'C'.
     var r4: string = c.c();
-                     ~~~
+                       ~
 !!! error TS2341: Property 'c' is private and only accessible within class 'C'.
     var r5: string = c.d();
-                     ~~~
+                       ~
 !!! error TS2341: Property 'd' is private and only accessible within class 'C'.
     var r6: string = C.e;
-                     ~~~
+                       ~
 !!! error TS2341: Property 'e' is private and only accessible within class 'C'.
     var r7: string = C.f();
-                     ~~~
+                       ~
 !!! error TS2341: Property 'f' is private and only accessible within class 'C'.
     var r8: string = C.g();
-                     ~~~
+                       ~
 !!! error TS2341: Property 'g' is private and only accessible within class 'C'.

--- a/tests/baselines/reference/cloduleStaticMembers.errors.txt
+++ b/tests/baselines/reference/cloduleStaticMembers.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/cloduleStaticMembers.ts(6,13): error TS2341: Property 'x' is private and only accessible within class 'Clod'.
+tests/cases/compiler/cloduleStaticMembers.ts(6,18): error TS2341: Property 'x' is private and only accessible within class 'Clod'.
 tests/cases/compiler/cloduleStaticMembers.ts(7,13): error TS2304: Cannot find name 'x'.
 tests/cases/compiler/cloduleStaticMembers.ts(10,13): error TS2304: Cannot find name 'y'.
 
@@ -10,7 +10,7 @@ tests/cases/compiler/cloduleStaticMembers.ts(10,13): error TS2304: Cannot find n
     }
     module Clod {
         var p = Clod.x;
-                ~~~~~~
+                     ~
 !!! error TS2341: Property 'x' is private and only accessible within class 'Clod'.
         var q = x;
                 ~

--- a/tests/baselines/reference/constructorParameterProperties.errors.txt
+++ b/tests/baselines/reference/constructorParameterProperties.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties.ts(8,10): error TS2341: Property 'x' is private and only accessible within class 'C'.
-tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties.ts(9,10): error TS2445: Property 'z' is protected and only accessible within class 'C' and its subclasses.
-tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties.ts(18,10): error TS2341: Property 'x' is private and only accessible within class 'D<T>'.
+tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties.ts(8,12): error TS2341: Property 'x' is private and only accessible within class 'C'.
+tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties.ts(9,12): error TS2445: Property 'z' is protected and only accessible within class 'C' and its subclasses.
+tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties.ts(18,12): error TS2341: Property 'x' is private and only accessible within class 'D<T>'.
 tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties.ts(19,12): error TS2339: Property 'a' does not exist on type 'D<string>'.
-tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties.ts(20,10): error TS2445: Property 'z' is protected and only accessible within class 'D<T>' and its subclasses.
+tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties.ts(20,12): error TS2445: Property 'z' is protected and only accessible within class 'D<T>' and its subclasses.
 
 
 ==== tests/cases/conformance/classes/constructorDeclarations/constructorParameters/constructorParameterProperties.ts (5 errors) ====
@@ -14,10 +14,10 @@ tests/cases/conformance/classes/constructorDeclarations/constructorParameters/co
     var c: C;
     var r = c.y;
     var r2 = c.x; // error
-             ~~~
+               ~
 !!! error TS2341: Property 'x' is private and only accessible within class 'C'.
     var r3 = c.z; // error
-             ~~~
+               ~
 !!! error TS2445: Property 'z' is protected and only accessible within class 'C' and its subclasses.
     
     class D<T> {
@@ -28,12 +28,12 @@ tests/cases/conformance/classes/constructorDeclarations/constructorParameters/co
     var d: D<string>;
     var r = d.y;
     var r2 = d.x; // error
-             ~~~
+               ~
 !!! error TS2341: Property 'x' is private and only accessible within class 'D<T>'.
     var r3 = d.a; // error
                ~
 !!! error TS2339: Property 'a' does not exist on type 'D<string>'.
     var r4 = d.z; // error
-             ~~~
+               ~
 !!! error TS2445: Property 'z' is protected and only accessible within class 'D<T>' and its subclasses.
     

--- a/tests/baselines/reference/derivedClassTransitivity4.errors.txt
+++ b/tests/baselines/reference/derivedClassTransitivity4.errors.txt
@@ -3,7 +3,7 @@ tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTra
     Type '(x?: string) => void' is not assignable to type '(x: number) => void'.
       Types of parameters 'x' and 'x' are incompatible.
         Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity4.ts(19,9): error TS2445: Property 'foo' is protected and only accessible within class 'C' and its subclasses.
+tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity4.ts(19,11): error TS2445: Property 'foo' is protected and only accessible within class 'C' and its subclasses.
 
 
 ==== tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity4.ts (2 errors) ====
@@ -32,6 +32,6 @@ tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTra
 !!! error TS2322:       Types of parameters 'x' and 'x' are incompatible.
 !!! error TS2322:         Type 'string' is not assignable to type 'number'.
     var r = c.foo(1);
-            ~~~~~
+              ~~~
 !!! error TS2445: Property 'foo' is protected and only accessible within class 'C' and its subclasses.
     var r2 = e.foo('');

--- a/tests/baselines/reference/derivedClassWithPrivateStaticShadowingPublicStatic.errors.txt
+++ b/tests/baselines/reference/derivedClassWithPrivateStaticShadowingPublicStatic.errors.txt
@@ -4,10 +4,10 @@ tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWit
   Property 'x' is private in type 'typeof Derived' but not in type 'typeof Base'.
 tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingPublicStatic.ts(19,24): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingPublicStatic.ts(20,24): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
-tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingPublicStatic.ts(24,10): error TS2341: Property 'x' is private and only accessible within class 'Derived'.
-tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingPublicStatic.ts(27,10): error TS2341: Property 'fn' is private and only accessible within class 'Derived'.
-tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingPublicStatic.ts(32,10): error TS2341: Property 'a' is private and only accessible within class 'Derived'.
-tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingPublicStatic.ts(33,1): error TS2341: Property 'a' is private and only accessible within class 'Derived'.
+tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingPublicStatic.ts(24,18): error TS2341: Property 'x' is private and only accessible within class 'Derived'.
+tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingPublicStatic.ts(27,18): error TS2341: Property 'fn' is private and only accessible within class 'Derived'.
+tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingPublicStatic.ts(32,18): error TS2341: Property 'a' is private and only accessible within class 'Derived'.
+tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingPublicStatic.ts(33,9): error TS2341: Property 'a' is private and only accessible within class 'Derived'.
 
 
 ==== tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWithPrivateStaticShadowingPublicStatic.ts (9 errors) ====
@@ -46,20 +46,20 @@ tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassWit
     
     var r = Base.x; // ok
     var r2 = Derived.x; // error
-             ~~~~~~~~~
+                     ~
 !!! error TS2341: Property 'x' is private and only accessible within class 'Derived'.
     
     var r3 = Base.fn(); // ok
     var r4 = Derived.fn(); // error
-             ~~~~~~~~~~
+                     ~~
 !!! error TS2341: Property 'fn' is private and only accessible within class 'Derived'.
     
     var r5 = Base.a; // ok
     Base.a = 2; // ok
     
     var r6 = Derived.a; // error
-             ~~~~~~~~~
+                     ~
 !!! error TS2341: Property 'a' is private and only accessible within class 'Derived'.
     Derived.a = 2; // error
-    ~~~~~~~~~
+            ~
 !!! error TS2341: Property 'a' is private and only accessible within class 'Derived'.

--- a/tests/baselines/reference/errorSuperPropertyAccess.errors.txt
+++ b/tests/baselines/reference/errorSuperPropertyAccess.errors.txt
@@ -25,15 +25,15 @@ tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess
 tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(99,19): error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
 tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(109,15): error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
 tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(110,15): error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
-tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(111,9): error TS2341: Property 'privateStaticFunc' is private and only accessible within class 'SomeBase'.
+tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(111,15): error TS2341: Property 'privateStaticFunc' is private and only accessible within class 'SomeBase'.
 tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(113,16): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(114,15): error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
 tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(115,15): error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
-tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(116,9): error TS2341: Property 'privateStaticFunc' is private and only accessible within class 'SomeBase'.
+tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(116,15): error TS2341: Property 'privateStaticFunc' is private and only accessible within class 'SomeBase'.
 tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(119,16): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(120,15): error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
 tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(121,15): error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
-tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(122,9): error TS2341: Property 'privateStaticFunc' is private and only accessible within class 'SomeBase'.
+tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(122,15): error TS2341: Property 'privateStaticFunc' is private and only accessible within class 'SomeBase'.
 tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(127,16): error TS2660: 'super' can only be referenced in members of derived classes or object literal expressions.
 tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess.ts(127,30): error TS2660: 'super' can only be referenced in members of derived classes or object literal expressions.
 
@@ -204,7 +204,7 @@ tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess
                   ~~~~~~~~~~~~~~~~~~~
 !!! error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
             super.privateStaticFunc();
-            ~~~~~~~~~~~~~~~~~~~~~~~
+                  ~~~~~~~~~~~~~~~~~
 !!! error TS2341: Property 'privateStaticFunc' is private and only accessible within class 'SomeBase'.
         }
         static get a() {
@@ -217,7 +217,7 @@ tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess
                   ~~~~~~~~~~~~~~~~~~~
 !!! error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
             super.privateStaticFunc();
-            ~~~~~~~~~~~~~~~~~~~~~~~
+                  ~~~~~~~~~~~~~~~~~
 !!! error TS2341: Property 'privateStaticFunc' is private and only accessible within class 'SomeBase'.
             return '';
         }
@@ -231,7 +231,7 @@ tests/cases/conformance/expressions/superPropertyAccess/errorSuperPropertyAccess
                   ~~~~~~~~~~~~~~~~~~~
 !!! error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
             super.privateStaticFunc();
-            ~~~~~~~~~~~~~~~~~~~~~~~
+                  ~~~~~~~~~~~~~~~~~
 !!! error TS2341: Property 'privateStaticFunc' is private and only accessible within class 'SomeBase'.
         }
     }

--- a/tests/baselines/reference/implementingAnInterfaceExtendingClassWithPrivates2.errors.txt
+++ b/tests/baselines/reference/implementingAnInterfaceExtendingClassWithPrivates2.errors.txt
@@ -16,7 +16,7 @@ tests/cases/conformance/interfaces/interfacesExtendingClasses/implementingAnInte
   Property 'z' is missing in type 'Bar3'.
 tests/cases/conformance/interfaces/interfacesExtendingClasses/implementingAnInterfaceExtendingClassWithPrivates2.ts(67,11): error TS2420: Class 'Bar' incorrectly implements interface 'I'.
   Property 'y' is missing in type 'Bar'.
-tests/cases/conformance/interfaces/interfacesExtendingClasses/implementingAnInterfaceExtendingClassWithPrivates2.ts(73,14): error TS2341: Property 'x' is private and only accessible within class 'Foo'.
+tests/cases/conformance/interfaces/interfacesExtendingClasses/implementingAnInterfaceExtendingClassWithPrivates2.ts(73,16): error TS2341: Property 'x' is private and only accessible within class 'Foo'.
 tests/cases/conformance/interfaces/interfacesExtendingClasses/implementingAnInterfaceExtendingClassWithPrivates2.ts(74,16): error TS2339: Property 'y' does not exist on type 'Bar'.
 tests/cases/conformance/interfaces/interfacesExtendingClasses/implementingAnInterfaceExtendingClassWithPrivates2.ts(76,11): error TS2415: Class 'Bar2' incorrectly extends base class 'Foo'.
   Property 'x' is private in type 'Foo' but not in type 'Bar2'.
@@ -129,7 +129,7 @@ tests/cases/conformance/interfaces/interfacesExtendingClasses/implementingAnInte
         var b: Bar;
         var r1 = b.z;
         var r2 = b.x; // error
-                 ~~~
+                   ~
 !!! error TS2341: Property 'x' is private and only accessible within class 'Foo'.
         var r3 = b.y; // error
                    ~

--- a/tests/baselines/reference/interfaceExtendingClassWithPrivates.errors.txt
+++ b/tests/baselines/reference/interfaceExtendingClassWithPrivates.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates.ts(5,11): error TS2430: Interface 'I' incorrectly extends interface 'Foo'.
   Property 'x' is private in type 'Foo' but not in type 'I'.
-tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates.ts(15,10): error TS2341: Property 'x' is private and only accessible within class 'Foo'.
+tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates.ts(15,12): error TS2341: Property 'x' is private and only accessible within class 'Foo'.
 
 
 ==== tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates.ts (2 errors) ====
@@ -22,5 +22,5 @@ tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtending
     var i: I2;
     var r = i.y;
     var r2 = i.x; // error
-             ~~~
+               ~
 !!! error TS2341: Property 'x' is private and only accessible within class 'Foo'.

--- a/tests/baselines/reference/interfaceExtendingClassWithPrivates2.errors.txt
+++ b/tests/baselines/reference/interfaceExtendingClassWithPrivates2.errors.txt
@@ -4,8 +4,8 @@ tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtending
   Property 'x' is private in type 'Bar' but not in type 'I4'.
 tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates2.ts(12,11): error TS2430: Interface 'I4' incorrectly extends interface 'Foo'.
   Property 'x' is private in type 'Foo' but not in type 'I4'.
-tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates2.ts(26,10): error TS2341: Property 'x' is private and only accessible within class 'Foo'.
-tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates2.ts(27,10): error TS2341: Property 'y' is private and only accessible within class 'Baz'.
+tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates2.ts(26,12): error TS2341: Property 'x' is private and only accessible within class 'Foo'.
+tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates2.ts(27,12): error TS2341: Property 'y' is private and only accessible within class 'Baz'.
 
 
 ==== tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithPrivates2.ts (5 errors) ====
@@ -44,8 +44,8 @@ tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtending
     var i: I5;
     var r: string = i.z;
     var r2 = i.x; // error
-             ~~~
+               ~
 !!! error TS2341: Property 'x' is private and only accessible within class 'Foo'.
     var r3 = i.y; // error
-             ~~~
+               ~
 !!! error TS2341: Property 'y' is private and only accessible within class 'Baz'.

--- a/tests/baselines/reference/interfaceExtendingClassWithProtecteds.errors.txt
+++ b/tests/baselines/reference/interfaceExtendingClassWithProtecteds.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds.ts(5,11): error TS2430: Interface 'I' incorrectly extends interface 'Foo'.
   Property 'x' is protected but type 'I' is not a class derived from 'Foo'.
-tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds.ts(15,10): error TS2445: Property 'x' is protected and only accessible within class 'Foo' and its subclasses.
+tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds.ts(15,12): error TS2445: Property 'x' is protected and only accessible within class 'Foo' and its subclasses.
 
 
 ==== tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds.ts (2 errors) ====
@@ -22,5 +22,5 @@ tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtending
     var i: I2;
     var r = i.y;
     var r2 = i.x; // error
-             ~~~
+               ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Foo' and its subclasses.

--- a/tests/baselines/reference/interfaceExtendingClassWithProtecteds2.errors.txt
+++ b/tests/baselines/reference/interfaceExtendingClassWithProtecteds2.errors.txt
@@ -4,8 +4,8 @@ tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtending
   Property 'x' is protected but type 'I4' is not a class derived from 'Bar'.
 tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds2.ts(12,11): error TS2430: Interface 'I4' incorrectly extends interface 'Foo'.
   Property 'x' is protected but type 'I4' is not a class derived from 'Foo'.
-tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds2.ts(26,10): error TS2445: Property 'x' is protected and only accessible within class 'Foo' and its subclasses.
-tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds2.ts(27,10): error TS2445: Property 'y' is protected and only accessible within class 'Baz' and its subclasses.
+tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds2.ts(26,12): error TS2445: Property 'x' is protected and only accessible within class 'Foo' and its subclasses.
+tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds2.ts(27,12): error TS2445: Property 'y' is protected and only accessible within class 'Baz' and its subclasses.
 
 
 ==== tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtendingClassWithProtecteds2.ts (5 errors) ====
@@ -44,8 +44,8 @@ tests/cases/conformance/interfaces/interfacesExtendingClasses/interfaceExtending
     var i: I5;
     var r: string = i.z;
     var r2 = i.x; // error
-             ~~~
+               ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Foo' and its subclasses.
     var r3 = i.y; // error
-             ~~~
+               ~
 !!! error TS2445: Property 'y' is protected and only accessible within class 'Baz' and its subclasses.

--- a/tests/baselines/reference/memberFunctionsWithPrivateOverloads.errors.txt
+++ b/tests/baselines/reference/memberFunctionsWithPrivateOverloads.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPrivateOverloads.ts(43,9): error TS2341: Property 'foo' is private and only accessible within class 'C'.
-tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPrivateOverloads.ts(46,10): error TS2341: Property 'foo' is private and only accessible within class 'D<T>'.
-tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPrivateOverloads.ts(48,10): error TS2341: Property 'foo' is private and only accessible within class 'C'.
-tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPrivateOverloads.ts(49,10): error TS2341: Property 'bar' is private and only accessible within class 'D<T>'.
+tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPrivateOverloads.ts(43,11): error TS2341: Property 'foo' is private and only accessible within class 'C'.
+tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPrivateOverloads.ts(46,12): error TS2341: Property 'foo' is private and only accessible within class 'D<T>'.
+tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPrivateOverloads.ts(48,12): error TS2341: Property 'foo' is private and only accessible within class 'C'.
+tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPrivateOverloads.ts(49,12): error TS2341: Property 'bar' is private and only accessible within class 'D<T>'.
 
 
 ==== tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPrivateOverloads.ts (4 errors) ====
@@ -48,17 +48,17 @@ tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclara
     
     var c: C;
     var r = c.foo(1); // error
-            ~~~~~
+              ~~~
 !!! error TS2341: Property 'foo' is private and only accessible within class 'C'.
     
     var d: D<number>;
     var r2 = d.foo(2); // error
-             ~~~~~
+               ~~~
 !!! error TS2341: Property 'foo' is private and only accessible within class 'D<T>'.
     
     var r3 = C.foo(1); // error
-             ~~~~~
+               ~~~
 !!! error TS2341: Property 'foo' is private and only accessible within class 'C'.
     var r4 = D.bar(''); // error
-             ~~~~~
+               ~~~
 !!! error TS2341: Property 'bar' is private and only accessible within class 'D<T>'.

--- a/tests/baselines/reference/memberFunctionsWithPublicPrivateOverloads.errors.txt
+++ b/tests/baselines/reference/memberFunctionsWithPublicPrivateOverloads.errors.txt
@@ -11,8 +11,8 @@ tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclara
 tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicPrivateOverloads.ts(45,19): error TS2385: Overload signatures must all be public, private or protected.
 tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicPrivateOverloads.ts(49,19): error TS2385: Overload signatures must all be public, private or protected.
 tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicPrivateOverloads.ts(53,19): error TS2385: Overload signatures must all be public, private or protected.
-tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicPrivateOverloads.ts(59,9): error TS2341: Property 'foo' is private and only accessible within class 'C'.
-tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicPrivateOverloads.ts(62,10): error TS2341: Property 'foo' is private and only accessible within class 'D<T>'.
+tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicPrivateOverloads.ts(59,11): error TS2341: Property 'foo' is private and only accessible within class 'C'.
+tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicPrivateOverloads.ts(62,12): error TS2341: Property 'foo' is private and only accessible within class 'D<T>'.
 
 
 ==== tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclarations/memberFunctionsWithPublicPrivateOverloads.ts (15 errors) ====
@@ -101,10 +101,10 @@ tests/cases/conformance/classes/propertyMemberDeclarations/memberFunctionDeclara
     
     var c: C;
     var r = c.foo(1); // error
-            ~~~~~
+              ~~~
 !!! error TS2341: Property 'foo' is private and only accessible within class 'C'.
     
     var d: D<number>;
     var r2 = d.foo(2); // error
-             ~~~~~
+               ~~~
 !!! error TS2341: Property 'foo' is private and only accessible within class 'D<T>'.

--- a/tests/baselines/reference/mergedInterfacesWithInheritedPrivates.errors.txt
+++ b/tests/baselines/reference/mergedInterfacesWithInheritedPrivates.errors.txt
@@ -2,7 +2,7 @@ tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheri
   Types have separate declarations of a private property 'x'.
 tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates.ts(19,7): error TS2420: Class 'E' incorrectly implements interface 'A'.
   Property 'x' is private in type 'A' but not in type 'E'.
-tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates.ts(26,9): error TS2341: Property 'x' is private and only accessible within class 'C'.
+tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates.ts(26,11): error TS2341: Property 'x' is private and only accessible within class 'C'.
 
 
 ==== tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates.ts (3 errors) ====
@@ -38,5 +38,5 @@ tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheri
     
     var a: A;
     var r = a.x; // error
-            ~~~
+              ~
 !!! error TS2341: Property 'x' is private and only accessible within class 'C'.

--- a/tests/baselines/reference/mergedInterfacesWithInheritedPrivates2.errors.txt
+++ b/tests/baselines/reference/mergedInterfacesWithInheritedPrivates2.errors.txt
@@ -4,8 +4,8 @@ tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheri
   Property 'w' is private in type 'C2' but not in type 'E'.
 tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates2.ts(23,7): error TS2420: Class 'E' incorrectly implements interface 'A'.
   Property 'x' is missing in type 'E'.
-tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates2.ts(30,9): error TS2341: Property 'x' is private and only accessible within class 'C'.
-tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates2.ts(31,10): error TS2341: Property 'w' is private and only accessible within class 'C2'.
+tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates2.ts(30,11): error TS2341: Property 'x' is private and only accessible within class 'C'.
+tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates2.ts(31,12): error TS2341: Property 'w' is private and only accessible within class 'C2'.
 
 
 ==== tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheritedPrivates2.ts (5 errors) ====
@@ -48,8 +48,8 @@ tests/cases/conformance/interfaces/declarationMerging/mergedInterfacesWithInheri
     
     var a: A;
     var r = a.x; // error
-            ~~~
+              ~
 !!! error TS2341: Property 'x' is private and only accessible within class 'C'.
     var r2 = a.w; // error
-             ~~~
+               ~
 !!! error TS2341: Property 'w' is private and only accessible within class 'C2'.

--- a/tests/baselines/reference/privateAccessInSubclass1.errors.txt
+++ b/tests/baselines/reference/privateAccessInSubclass1.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/privateAccessInSubclass1.ts(7,5): error TS2341: Property 'options' is private and only accessible within class 'Base'.
+tests/cases/compiler/privateAccessInSubclass1.ts(7,10): error TS2341: Property 'options' is private and only accessible within class 'Base'.
 
 
 ==== tests/cases/compiler/privateAccessInSubclass1.ts (1 errors) ====
@@ -9,7 +9,7 @@ tests/cases/compiler/privateAccessInSubclass1.ts(7,5): error TS2341: Property 'o
     class D extends Base {
       myMethod() {
         this.options;
-        ~~~~~~~~~~~~
+             ~~~~~~~
 !!! error TS2341: Property 'options' is private and only accessible within class 'Base'.
       }
     }

--- a/tests/baselines/reference/privateProtectedMembersAreNotAccessibleDestructuring.errors.txt
+++ b/tests/baselines/reference/privateProtectedMembersAreNotAccessibleDestructuring.errors.txt
@@ -1,0 +1,45 @@
+tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts(12,13): error TS2341: Property 'priv' is private and only accessible within class 'K'.
+tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts(17,5): error TS2341: Property 'priv' is private and only accessible within class 'K'.
+tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts(18,5): error TS2445: Property 'prot' is protected and only accessible within class 'K' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts(19,5): error TS2341: Property 'privateMethod' is private and only accessible within class 'K'.
+tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts(20,5): error TS2341: Property 'priv' is private and only accessible within class 'K'.
+tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts(20,5): error TS2341: Property 'privateMethod' is private and only accessible within class 'K'.
+tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts(20,5): error TS2445: Property 'prot' is protected and only accessible within class 'K' and its subclasses.
+
+
+==== tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts (7 errors) ====
+    class K {
+        private priv;
+        protected prot;
+        private privateMethod() { }
+        m() {
+            let { priv: a, prot: b } = this; // ok
+            let { priv, prot } = new K(); // ok
+        }
+    }
+    class C extends K {
+        m2() {
+            let { priv: a } = this; // error
+                ~~~~~~~~~~~
+!!! error TS2341: Property 'priv' is private and only accessible within class 'K'.
+            let { prot: b } = this; // ok
+        }
+    }
+    let k = new K();
+    let { priv } = k; // error 
+        ~~~~~~~~
+!!! error TS2341: Property 'priv' is private and only accessible within class 'K'.
+    let { prot } = k; // error
+        ~~~~~~~~
+!!! error TS2445: Property 'prot' is protected and only accessible within class 'K' and its subclasses.
+    let { privateMethod } = k; // error
+        ~~~~~~~~~~~~~~~~~
+!!! error TS2341: Property 'privateMethod' is private and only accessible within class 'K'.
+    let { priv: a, prot: b, privateMethod: f } = k; // error
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2341: Property 'priv' is private and only accessible within class 'K'.
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2341: Property 'privateMethod' is private and only accessible within class 'K'.
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2445: Property 'prot' is protected and only accessible within class 'K' and its subclasses.
+    

--- a/tests/baselines/reference/privateProtectedMembersAreNotAccessibleDestructuring.js
+++ b/tests/baselines/reference/privateProtectedMembersAreNotAccessibleDestructuring.js
@@ -1,0 +1,55 @@
+//// [privateProtectedMembersAreNotAccessibleDestructuring.ts]
+class K {
+    private priv;
+    protected prot;
+    private privateMethod() { }
+    m() {
+        let { priv: a, prot: b } = this; // ok
+        let { priv, prot } = new K(); // ok
+    }
+}
+class C extends K {
+    m2() {
+        let { priv: a } = this; // error
+        let { prot: b } = this; // ok
+    }
+}
+let k = new K();
+let { priv } = k; // error 
+let { prot } = k; // error
+let { privateMethod } = k; // error
+let { priv: a, prot: b, privateMethod: f } = k; // error
+
+
+//// [privateProtectedMembersAreNotAccessibleDestructuring.js]
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var K = (function () {
+    function K() {
+    }
+    K.prototype.privateMethod = function () { };
+    K.prototype.m = function () {
+        var _a = this, a = _a.priv, b = _a.prot; // ok
+        var _b = new K(), priv = _b.priv, prot = _b.prot; // ok
+    };
+    return K;
+}());
+var C = (function (_super) {
+    __extends(C, _super);
+    function C() {
+        _super.apply(this, arguments);
+    }
+    C.prototype.m2 = function () {
+        var a = this.priv; // error
+        var b = this.prot; // ok
+    };
+    return C;
+}(K));
+var k = new K();
+var priv = k.priv; // error 
+var prot = k.prot; // error
+var privateMethod = k.privateMethod; // error
+var a = k.priv, b = k.prot, f = k.privateMethod; // error

--- a/tests/baselines/reference/privateStaticMemberAccessibility.errors.txt
+++ b/tests/baselines/reference/privateStaticMemberAccessibility.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/classes/members/accessibility/privateStaticMemberAccessibility.ts(6,18): error TS2341: Property 'foo' is private and only accessible within class 'Base'.
-tests/cases/conformance/classes/members/accessibility/privateStaticMemberAccessibility.ts(7,18): error TS2341: Property 'foo' is private and only accessible within class 'Base'.
+tests/cases/conformance/classes/members/accessibility/privateStaticMemberAccessibility.ts(6,23): error TS2341: Property 'foo' is private and only accessible within class 'Base'.
+tests/cases/conformance/classes/members/accessibility/privateStaticMemberAccessibility.ts(7,23): error TS2341: Property 'foo' is private and only accessible within class 'Base'.
 
 
 ==== tests/cases/conformance/classes/members/accessibility/privateStaticMemberAccessibility.ts (2 errors) ====
@@ -9,9 +9,9 @@ tests/cases/conformance/classes/members/accessibility/privateStaticMemberAccessi
     
     class Derived extends Base {
         static bar = Base.foo; // error
-                     ~~~~~~~~
+                          ~~~
 !!! error TS2341: Property 'foo' is private and only accessible within class 'Base'.
         bing = () => Base.foo; // error
-                     ~~~~~~~~
+                          ~~~
 !!! error TS2341: Property 'foo' is private and only accessible within class 'Base'.
     }

--- a/tests/baselines/reference/privateStaticNotAccessibleInClodule.errors.txt
+++ b/tests/baselines/reference/privateStaticNotAccessibleInClodule.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/classes/members/accessibility/privateStaticNotAccessibleInClodule.ts(9,20): error TS2341: Property 'bar' is private and only accessible within class 'C'.
+tests/cases/conformance/classes/members/accessibility/privateStaticNotAccessibleInClodule.ts(9,22): error TS2341: Property 'bar' is private and only accessible within class 'C'.
 
 
 ==== tests/cases/conformance/classes/members/accessibility/privateStaticNotAccessibleInClodule.ts (1 errors) ====
@@ -11,6 +11,6 @@ tests/cases/conformance/classes/members/accessibility/privateStaticNotAccessible
     
     module C {
         export var y = C.bar; // error
-                       ~~~~~
+                         ~~~
 !!! error TS2341: Property 'bar' is private and only accessible within class 'C'.
     }

--- a/tests/baselines/reference/privateStaticNotAccessibleInClodule2.errors.txt
+++ b/tests/baselines/reference/privateStaticNotAccessibleInClodule2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/classes/members/accessibility/privateStaticNotAccessibleInClodule2.ts(13,20): error TS2341: Property 'bar' is private and only accessible within class 'C'.
+tests/cases/conformance/classes/members/accessibility/privateStaticNotAccessibleInClodule2.ts(13,22): error TS2341: Property 'bar' is private and only accessible within class 'C'.
 
 
 ==== tests/cases/conformance/classes/members/accessibility/privateStaticNotAccessibleInClodule2.ts (1 errors) ====
@@ -15,6 +15,6 @@ tests/cases/conformance/classes/members/accessibility/privateStaticNotAccessible
     
     module D {
         export var y = D.bar; // error
-                       ~~~~~
+                         ~~~
 !!! error TS2341: Property 'bar' is private and only accessible within class 'C'.
     }

--- a/tests/baselines/reference/privateVisibility.errors.txt
+++ b/tests/baselines/reference/privateVisibility.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/compiler/privateVisibility.ts(9,1): error TS2341: Property 'privMeth' is private and only accessible within class 'Foo'.
-tests/cases/compiler/privateVisibility.ts(10,1): error TS2341: Property 'privProp' is private and only accessible within class 'Foo'.
-tests/cases/compiler/privateVisibility.ts(24,1): error TS2341: Property 'priv' is private and only accessible within class 'C'.
+tests/cases/compiler/privateVisibility.ts(9,3): error TS2341: Property 'privMeth' is private and only accessible within class 'Foo'.
+tests/cases/compiler/privateVisibility.ts(10,3): error TS2341: Property 'privProp' is private and only accessible within class 'Foo'.
+tests/cases/compiler/privateVisibility.ts(24,3): error TS2341: Property 'priv' is private and only accessible within class 'C'.
 
 
 ==== tests/cases/compiler/privateVisibility.ts (3 errors) ====
@@ -13,10 +13,10 @@ tests/cases/compiler/privateVisibility.ts(24,1): error TS2341: Property 'priv' i
     
     var f = new Foo();
     f.privMeth(); // should not work
-    ~~~~~~~~~~
+      ~~~~~~~~
 !!! error TS2341: Property 'privMeth' is private and only accessible within class 'Foo'.
     f.privProp; // should not work
-    ~~~~~~~~~~
+      ~~~~~~~~
 !!! error TS2341: Property 'privProp' is private and only accessible within class 'Foo'.
     
     f.pubMeth(); // should work
@@ -32,7 +32,7 @@ tests/cases/compiler/privateVisibility.ts(24,1): error TS2341: Property 'priv' i
     
     c.pub; // should work
     c.priv; // should not work
-    ~~~~~~
+      ~~~~
 !!! error TS2341: Property 'priv' is private and only accessible within class 'C'.
     
     

--- a/tests/baselines/reference/propertyAccessibility1.errors.txt
+++ b/tests/baselines/reference/propertyAccessibility1.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/propertyAccessibility1.ts(5,1): error TS2341: Property 'privProp' is private and only accessible within class 'Foo'.
+tests/cases/compiler/propertyAccessibility1.ts(5,3): error TS2341: Property 'privProp' is private and only accessible within class 'Foo'.
 
 
 ==== tests/cases/compiler/propertyAccessibility1.ts (1 errors) ====
@@ -7,6 +7,6 @@ tests/cases/compiler/propertyAccessibility1.ts(5,1): error TS2341: Property 'pri
     }
     var f = new Foo();
     f.privProp;
-    ~~~~~~~~~~
+      ~~~~~~~~
 !!! error TS2341: Property 'privProp' is private and only accessible within class 'Foo'.
     

--- a/tests/baselines/reference/propertyAccessibility2.errors.txt
+++ b/tests/baselines/reference/propertyAccessibility2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/propertyAccessibility2.ts(4,9): error TS2341: Property 'x' is private and only accessible within class 'C'.
+tests/cases/compiler/propertyAccessibility2.ts(4,11): error TS2341: Property 'x' is private and only accessible within class 'C'.
 
 
 ==== tests/cases/compiler/propertyAccessibility2.ts (1 errors) ====
@@ -6,6 +6,6 @@ tests/cases/compiler/propertyAccessibility2.ts(4,9): error TS2341: Property 'x' 
       private static x = 1;
     }
     var c = C.x;
-            ~~~
+              ~
 !!! error TS2341: Property 'x' is private and only accessible within class 'C'.
     

--- a/tests/baselines/reference/protectedClassPropertyAccessibleWithinSubclass2.errors.txt
+++ b/tests/baselines/reference/protectedClassPropertyAccessibleWithinSubclass2.errors.txt
@@ -1,24 +1,24 @@
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(13,9): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(26,9): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(28,9): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(29,9): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(30,9): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(42,9): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(43,9): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(45,9): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(59,9): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(60,9): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(61,9): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(63,9): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(75,9): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(76,9): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(77,9): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(78,9): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(90,1): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(91,1): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(92,1): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(93,1): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(94,1): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(13,12): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(26,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(28,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(29,12): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(30,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(42,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(43,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(45,12): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(59,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(60,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(61,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(63,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(75,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(76,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(77,12): error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(78,12): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(90,3): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(91,4): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(92,4): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(93,4): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts(94,4): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
 
 
 ==== tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAccessibleWithinSubclass2.ts (21 errors) ====
@@ -35,7 +35,7 @@ tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAcce
             d1.x;           // OK, accessed within their declaring class
             d2.x;           // OK, accessed within their declaring class
             d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
-            ~~~~
+               ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
             d4.x;           // OK, accessed within their declaring class
         }
@@ -50,17 +50,17 @@ tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAcce
             var d4: Derived4;
     
             b.x;            // Error, isn't accessed through an instance of the enclosing class
-            ~~~
+              ~
 !!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
             d1.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
             d2.x;           // Error, isn't accessed through an instance of the enclosing class
-            ~~~~
+               ~
 !!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
             d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
-            ~~~~
+               ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
             d4.x;           // Error, isn't accessed through an instance of the enclosing class
-            ~~~~
+               ~
 !!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived1'.
         }
     }
@@ -74,14 +74,14 @@ tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAcce
             var d4: Derived4;
     
             b.x;            // Error, isn't accessed through an instance of the enclosing class
-            ~~~
+              ~
 !!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
             d1.x;           // Error, isn't accessed through an instance of the enclosing class
-            ~~~~
+               ~
 !!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived2'.
             d2.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
             d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
-            ~~~~
+               ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
             d4.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class or one of its subclasses
         }
@@ -97,17 +97,17 @@ tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAcce
             var d4: Derived4;
     
             b.x;            // Error, isn't accessed through an instance of the enclosing class
-            ~~~
+              ~
 !!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
             d1.x;           // Error, isn't accessed through an instance of the enclosing class
-            ~~~~
+               ~
 !!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
             d2.x;           // Error, isn't accessed through an instance of the enclosing class
-            ~~~~
+               ~
 !!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
             d3.x;           // OK, accessed within their declaring class
             d4.x;           // Error, isn't accessed through an instance of the enclosing class
-            ~~~~
+               ~
 !!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived3'.
         }
     }
@@ -121,16 +121,16 @@ tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAcce
             var d4: Derived4;
     
             b.x;            // Error, isn't accessed through an instance of the enclosing class
-            ~~~
+              ~
 !!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
             d1.x;           // Error, isn't accessed through an instance of the enclosing class
-            ~~~~
+               ~
 !!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
             d2.x;           // Error, isn't accessed through an instance of the enclosing class
-            ~~~~
+               ~
 !!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'Derived4'.
             d3.x;           // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
-            ~~~~
+               ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
             d4.x;           // OK, accessed within a class derived from their declaring class, and through an instance of the enclosing class
         }
@@ -144,17 +144,17 @@ tests/cases/conformance/classes/members/accessibility/protectedClassPropertyAcce
     var d4: Derived4;
     
     b.x;                    // Error, neither within their declaring class nor classes derived from their declaring class
-    ~~~
+      ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
     d1.x;                   // Error, neither within their declaring class nor classes derived from their declaring class
-    ~~~~
+       ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
     d2.x;                   // Error, neither within their declaring class nor classes derived from their declaring class
-    ~~~~
+       ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
     d3.x;                   // Error, neither within their declaring class nor classes derived from their declaring class
-    ~~~~
+       ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
     d4.x;                   // Error, neither within their declaring class nor classes derived from their declaring class
-    ~~~~
+       ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.

--- a/tests/baselines/reference/protectedInstanceMemberAccessibility.errors.txt
+++ b/tests/baselines/reference/protectedInstanceMemberAccessibility.errors.txt
@@ -2,15 +2,15 @@ tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAcc
 tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(16,24): error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
 tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(18,24): error TS2339: Property 'y' does not exist on type 'A'.
 tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(19,24): error TS2339: Property 'z' does not exist on type 'A'.
-tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(22,18): error TS2446: Property 'x' is protected and only accessible through an instance of class 'B'.
-tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(23,18): error TS2446: Property 'f' is protected and only accessible through an instance of class 'B'.
+tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(22,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'B'.
+tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(23,20): error TS2446: Property 'f' is protected and only accessible through an instance of class 'B'.
 tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(24,20): error TS2339: Property 'y' does not exist on type 'A'.
 tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(25,20): error TS2339: Property 'z' does not exist on type 'A'.
 tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(31,20): error TS2339: Property 'z' does not exist on type 'B'.
-tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(34,18): error TS2446: Property 'x' is protected and only accessible through an instance of class 'B'.
-tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(35,18): error TS2446: Property 'f' is protected and only accessible through an instance of class 'B'.
+tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(34,20): error TS2446: Property 'x' is protected and only accessible through an instance of class 'B'.
+tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(35,20): error TS2446: Property 'f' is protected and only accessible through an instance of class 'B'.
 tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(36,20): error TS2339: Property 'y' does not exist on type 'C'.
-tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(37,18): error TS2445: Property 'z' is protected and only accessible within class 'C' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts(37,20): error TS2445: Property 'z' is protected and only accessible within class 'C' and its subclasses.
 
 
 ==== tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAccessibility.ts (13 errors) ====
@@ -44,10 +44,10 @@ tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAcc
     
             var a: A;
             var a1 = a.x;    // error
-                     ~~~
+                       ~
 !!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'B'.
             var a2 = a.f();  // error
-                     ~~~
+                       ~
 !!! error TS2446: Property 'f' is protected and only accessible through an instance of class 'B'.
             var a3 = a.y;    // error
                        ~
@@ -66,16 +66,16 @@ tests/cases/conformance/classes/members/accessibility/protectedInstanceMemberAcc
     
             var c: C;
             var c1 = c.x;    // error
-                     ~~~
+                       ~
 !!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'B'.
             var c2 = c.f();  // error
-                     ~~~
+                       ~
 !!! error TS2446: Property 'f' is protected and only accessible through an instance of class 'B'.
             var c3 = c.y;    // error
                        ~
 !!! error TS2339: Property 'y' does not exist on type 'C'.
             var c4 = c.z;    // error
-                     ~~~
+                       ~
 !!! error TS2445: Property 'z' is protected and only accessible within class 'C' and its subclasses.
         }
     }

--- a/tests/baselines/reference/protectedMembers.errors.txt
+++ b/tests/baselines/reference/protectedMembers.errors.txt
@@ -1,13 +1,13 @@
-tests/cases/compiler/protectedMembers.ts(40,1): error TS2445: Property 'x' is protected and only accessible within class 'C1' and its subclasses.
-tests/cases/compiler/protectedMembers.ts(41,1): error TS2445: Property 'f' is protected and only accessible within class 'C1' and its subclasses.
-tests/cases/compiler/protectedMembers.ts(42,1): error TS2445: Property 'sx' is protected and only accessible within class 'C1' and its subclasses.
-tests/cases/compiler/protectedMembers.ts(43,1): error TS2445: Property 'sf' is protected and only accessible within class 'C1' and its subclasses.
-tests/cases/compiler/protectedMembers.ts(46,1): error TS2445: Property 'x' is protected and only accessible within class 'C1' and its subclasses.
-tests/cases/compiler/protectedMembers.ts(47,1): error TS2445: Property 'f' is protected and only accessible within class 'C2' and its subclasses.
-tests/cases/compiler/protectedMembers.ts(48,1): error TS2445: Property 'sx' is protected and only accessible within class 'C1' and its subclasses.
-tests/cases/compiler/protectedMembers.ts(49,1): error TS2445: Property 'sf' is protected and only accessible within class 'C2' and its subclasses.
-tests/cases/compiler/protectedMembers.ts(68,9): error TS2446: Property 'x' is protected and only accessible through an instance of class 'C'.
-tests/cases/compiler/protectedMembers.ts(69,9): error TS2446: Property 'x' is protected and only accessible through an instance of class 'C'.
+tests/cases/compiler/protectedMembers.ts(40,4): error TS2445: Property 'x' is protected and only accessible within class 'C1' and its subclasses.
+tests/cases/compiler/protectedMembers.ts(41,4): error TS2445: Property 'f' is protected and only accessible within class 'C1' and its subclasses.
+tests/cases/compiler/protectedMembers.ts(42,4): error TS2445: Property 'sx' is protected and only accessible within class 'C1' and its subclasses.
+tests/cases/compiler/protectedMembers.ts(43,4): error TS2445: Property 'sf' is protected and only accessible within class 'C1' and its subclasses.
+tests/cases/compiler/protectedMembers.ts(46,4): error TS2445: Property 'x' is protected and only accessible within class 'C1' and its subclasses.
+tests/cases/compiler/protectedMembers.ts(47,4): error TS2445: Property 'f' is protected and only accessible within class 'C2' and its subclasses.
+tests/cases/compiler/protectedMembers.ts(48,4): error TS2445: Property 'sx' is protected and only accessible within class 'C1' and its subclasses.
+tests/cases/compiler/protectedMembers.ts(49,4): error TS2445: Property 'sf' is protected and only accessible within class 'C2' and its subclasses.
+tests/cases/compiler/protectedMembers.ts(68,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'C'.
+tests/cases/compiler/protectedMembers.ts(69,11): error TS2446: Property 'x' is protected and only accessible through an instance of class 'C'.
 tests/cases/compiler/protectedMembers.ts(97,1): error TS2322: Type 'B1' is not assignable to type 'A1'.
   Property 'x' is protected but type 'B1' is not a class derived from 'A1'.
 tests/cases/compiler/protectedMembers.ts(98,1): error TS2322: Type 'A1' is not assignable to type 'B1'.
@@ -57,30 +57,30 @@ tests/cases/compiler/protectedMembers.ts(111,7): error TS2415: Class 'B3' incorr
     
     // All of these should be errors
     c1.x;
-    ~~~~
+       ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'C1' and its subclasses.
     c1.f();
-    ~~~~
+       ~
 !!! error TS2445: Property 'f' is protected and only accessible within class 'C1' and its subclasses.
     C1.sx;
-    ~~~~~
+       ~~
 !!! error TS2445: Property 'sx' is protected and only accessible within class 'C1' and its subclasses.
     C1.sf();
-    ~~~~~
+       ~~
 !!! error TS2445: Property 'sf' is protected and only accessible within class 'C1' and its subclasses.
     
     // All of these should be errors
     c2.x;
-    ~~~~
+       ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'C1' and its subclasses.
     c2.f();
-    ~~~~
+       ~
 !!! error TS2445: Property 'f' is protected and only accessible within class 'C2' and its subclasses.
     C2.sx;
-    ~~~~~
+       ~~
 !!! error TS2445: Property 'sx' is protected and only accessible within class 'C1' and its subclasses.
     C2.sf();
-    ~~~~~
+       ~~
 !!! error TS2445: Property 'sf' is protected and only accessible within class 'C2' and its subclasses.
     
     // All of these should be ok
@@ -101,10 +101,10 @@ tests/cases/compiler/protectedMembers.ts(111,7): error TS2415: Class 'B3' incorr
         z;
         static foo(a: A, b: B, c: C, d: D, e: E) {
             a.x = 1;  // Error, access must be through C or type derived from C
-            ~~~
+              ~
 !!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'C'.
             b.x = 1;  // Error, access must be through C or type derived from C
-            ~~~
+              ~
 !!! error TS2446: Property 'x' is protected and only accessible through an instance of class 'C'.
             c.x = 1;
             d.x = 1;

--- a/tests/baselines/reference/protectedStaticClassPropertyAccessibleWithinSubclass.errors.txt
+++ b/tests/baselines/reference/protectedStaticClassPropertyAccessibleWithinSubclass.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts(7,9): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts(16,9): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts(25,9): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts(40,1): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts(41,1): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts(42,1): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
-tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts(43,1): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts(7,18): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts(16,18): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts(25,18): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts(40,6): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts(41,10): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts(42,10): error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts(43,10): error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
 
 
 ==== tests/cases/conformance/classes/members/accessibility/protectedStaticClassPropertyAccessibleWithinSubclass.ts (7 errors) ====
@@ -15,7 +15,7 @@ tests/cases/conformance/classes/members/accessibility/protectedStaticClassProper
             Derived1.x;     // OK, accessed within their declaring class
             Derived2.x;     // OK, accessed within their declaring class
             Derived3.x;     // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
-            ~~~~~~~~~~
+                     ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
         }
     }
@@ -26,7 +26,7 @@ tests/cases/conformance/classes/members/accessibility/protectedStaticClassProper
             Derived1.x;     // OK, accessed within a class derived from their declaring class
             Derived2.x;     // OK, accessed within a class derived from their declaring class
             Derived3.x;     // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
-            ~~~~~~~~~~
+                     ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
         }
     }
@@ -37,7 +37,7 @@ tests/cases/conformance/classes/members/accessibility/protectedStaticClassProper
             Derived1.x;     // OK, accessed within a class derived from their declaring class
             Derived2.x;     // OK, accessed within a class derived from their declaring class
             Derived3.x;     // Error, redefined in a subclass, can only be accessed in the declaring class or one of its subclasses
-            ~~~~~~~~~~
+                     ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.
         }
     }
@@ -54,14 +54,14 @@ tests/cases/conformance/classes/members/accessibility/protectedStaticClassProper
     
     
     Base.x;         // Error, neither within their declaring class nor classes derived from their declaring class
-    ~~~~~~
+         ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
     Derived1.x;     // Error, neither within their declaring class nor classes derived from their declaring class
-    ~~~~~~~~~~
+             ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
     Derived2.x;     // Error, neither within their declaring class nor classes derived from their declaring class
-    ~~~~~~~~~~
+             ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Base' and its subclasses.
     Derived3.x;     // Error, neither within their declaring class nor classes derived from their declaring class
-    ~~~~~~~~~~
+             ~
 !!! error TS2445: Property 'x' is protected and only accessible within class 'Derived3' and its subclasses.

--- a/tests/baselines/reference/protectedStaticNotAccessibleInClodule.errors.txt
+++ b/tests/baselines/reference/protectedStaticNotAccessibleInClodule.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/classes/members/accessibility/protectedStaticNotAccessibleInClodule.ts(10,20): error TS2445: Property 'bar' is protected and only accessible within class 'C' and its subclasses.
+tests/cases/conformance/classes/members/accessibility/protectedStaticNotAccessibleInClodule.ts(10,22): error TS2445: Property 'bar' is protected and only accessible within class 'C' and its subclasses.
 
 
 ==== tests/cases/conformance/classes/members/accessibility/protectedStaticNotAccessibleInClodule.ts (1 errors) ====
@@ -12,6 +12,6 @@ tests/cases/conformance/classes/members/accessibility/protectedStaticNotAccessib
     module C {
         export var f = C.foo; // OK
         export var b = C.bar; // error
-                       ~~~~~
+                         ~~~
 !!! error TS2445: Property 'bar' is protected and only accessible within class 'C' and its subclasses.
     }

--- a/tests/baselines/reference/superPropertyAccess.errors.txt
+++ b/tests/baselines/reference/superPropertyAccess.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/superPropertyAccess.ts(8,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/superPropertyAccess.ts(9,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/compiler/superPropertyAccess.ts(22,15): error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
-tests/cases/compiler/superPropertyAccess.ts(24,9): error TS2341: Property 'p1' is private and only accessible within class 'MyBase'.
+tests/cases/compiler/superPropertyAccess.ts(24,15): error TS2341: Property 'p1' is private and only accessible within class 'MyBase'.
 tests/cases/compiler/superPropertyAccess.ts(26,24): error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
 tests/cases/compiler/superPropertyAccess.ts(28,24): error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
 tests/cases/compiler/superPropertyAccess.ts(32,15): error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
@@ -39,7 +39,7 @@ tests/cases/compiler/superPropertyAccess.ts(34,23): error TS2340: Only public an
 !!! error TS2340: Only public and protected methods of the base class are accessible via the 'super' keyword.
     
             super.p1();                                         // Should error, private not public instance member function
-            ~~~~~~~~
+                  ~~
 !!! error TS2341: Property 'p1' is private and only accessible within class 'MyBase'.
     
             var l1 = super.d1;                                  // Should error, instance data property not a public instance member function

--- a/tests/baselines/reference/unionTypePropertyAccessibility.errors.txt
+++ b/tests/baselines/reference/unionTypePropertyAccessibility.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/types/union/unionTypePropertyAccessibility.ts(35,1): error TS2445: Property 'member' is protected and only accessible within class 'Protected' and its subclasses.
-tests/cases/conformance/types/union/unionTypePropertyAccessibility.ts(36,1): error TS2341: Property 'member' is private and only accessible within class 'Private'.
+tests/cases/conformance/types/union/unionTypePropertyAccessibility.ts(35,4): error TS2445: Property 'member' is protected and only accessible within class 'Protected' and its subclasses.
+tests/cases/conformance/types/union/unionTypePropertyAccessibility.ts(36,4): error TS2341: Property 'member' is private and only accessible within class 'Private'.
 tests/cases/conformance/types/union/unionTypePropertyAccessibility.ts(38,4): error TS2339: Property 'member' does not exist on type 'Default | Protected'.
 tests/cases/conformance/types/union/unionTypePropertyAccessibility.ts(39,4): error TS2339: Property 'member' does not exist on type 'Default | Private'.
 tests/cases/conformance/types/union/unionTypePropertyAccessibility.ts(40,4): error TS2339: Property 'member' does not exist on type 'Public | Protected'.
@@ -48,10 +48,10 @@ tests/cases/conformance/types/union/unionTypePropertyAccessibility.ts(47,5): err
     v1.member;
     v2.member;
     v3.member;
-    ~~~~~~~~~
+       ~~~~~~
 !!! error TS2445: Property 'member' is protected and only accessible within class 'Protected' and its subclasses.
     v4.member;
-    ~~~~~~~~~
+       ~~~~~~
 !!! error TS2341: Property 'member' is private and only accessible within class 'Private'.
     v5.member;
     v6.member;

--- a/tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts
+++ b/tests/cases/conformance/classes/members/accessibility/privateProtectedMembersAreNotAccessibleDestructuring.ts
@@ -1,0 +1,20 @@
+class K {
+    private priv;
+    protected prot;
+    private privateMethod() { }
+    m() {
+        let { priv: a, prot: b } = this; // ok
+        let { priv, prot } = new K(); // ok
+    }
+}
+class C extends K {
+    m2() {
+        let { priv: a } = this; // error
+        let { prot: b } = this; // ok
+    }
+}
+let k = new K();
+let { priv } = k; // error 
+let { prot } = k; // error
+let { privateMethod } = k; // error
+let { priv: a, prot: b, privateMethod: f } = k; // error


### PR DESCRIPTION
Fixes #7124 

It does this by calling `checkClassPropertyAccess` from `getTypeFromBindingElement`. I don't think this is a good idea, so I'm going to go look whether I can call it from `checkVariableLikeDeclaration` or something similar.

The third commit changes `checkClassPropertyAccess` to tighten the error span. You should review the 3 commits separately.

Update: Now it's called from `checkVariableLikeDeclaration` instead.