### PR TITLE
flip sides source and target when we check signature relations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5337,7 +5337,7 @@ namespace ts {
             for (let i = 0; i < checkCount; i++) {
                 const s = i < sourceMax ? getTypeOfSymbol(sourceParams[i]) : getRestTypeOfSignature(source);
                 const t = i < targetMax ? getTypeOfSymbol(targetParams[i]) : getRestTypeOfSignature(target);
-                const related = compareTypes(t, s, /*reportErrors*/ false) || compareTypes(s, t, reportErrors);
+                const related = compareTypes(s, t, /*reportErrors*/ false) || compareTypes(t, s, reportErrors);
                 if (!related) {
                     if (reportErrors) {
                         errorReporter(Diagnostics.Types_of_parameters_0_and_1_are_incompatible,

--- a/tests/baselines/reference/arrayLiterals3.errors.txt
+++ b/tests/baselines/reference/arrayLiterals3.errors.txt
@@ -16,8 +16,8 @@ tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts(34,5): error
   Types of property 'push' are incompatible.
     Type '(...items: (number | string)[]) => number' is not assignable to type '(...items: Number[]) => number'.
       Types of parameters 'items' and 'items' are incompatible.
-        Type 'number | string' is not assignable to type 'Number'.
-          Type 'string' is not assignable to type 'Number'.
+        Type 'Number' is not assignable to type 'number | string'.
+          Type 'Number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts (6 errors) ====
@@ -79,6 +79,6 @@ tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts(34,5): error
 !!! error TS2322:   Types of property 'push' are incompatible.
 !!! error TS2322:     Type '(...items: (number | string)[]) => number' is not assignable to type '(...items: Number[]) => number'.
 !!! error TS2322:       Types of parameters 'items' and 'items' are incompatible.
-!!! error TS2322:         Type 'number | string' is not assignable to type 'Number'.
-!!! error TS2322:           Type 'string' is not assignable to type 'Number'.
+!!! error TS2322:         Type 'Number' is not assignable to type 'number | string'.
+!!! error TS2322:           Type 'Number' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/assignmentCompatBug5.errors.txt
+++ b/tests/baselines/reference/assignmentCompatBug5.errors.txt
@@ -4,7 +4,7 @@ tests/cases/compiler/assignmentCompatBug5.ts(5,6): error TS2345: Argument of typ
   Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/assignmentCompatBug5.ts(8,6): error TS2345: Argument of type '(s: string) => void' is not assignable to parameter of type '(n: number) => number'.
   Types of parameters 's' and 'n' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/assignmentCompatBug5.ts(9,6): error TS2345: Argument of type '(n: number) => void' is not assignable to parameter of type '(n: number) => number'.
   Type 'void' is not assignable to type 'number'.
 
@@ -27,7 +27,7 @@ tests/cases/compiler/assignmentCompatBug5.ts(9,6): error TS2345: Argument of typ
          ~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(s: string) => void' is not assignable to parameter of type '(n: number) => number'.
 !!! error TS2345:   Types of parameters 's' and 'n' are incompatible.
-!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
     foo3((n) => { return; });
          ~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(n: number) => void' is not assignable to parameter of type '(n: number) => number'.

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures.errors.txt
@@ -1,27 +1,27 @@
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures.ts(35,1): error TS2322: Type 'S2' is not assignable to type 'T'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures.ts(36,1): error TS2322: Type '(x: string) => void' is not assignable to type 'T'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures.ts(37,1): error TS2322: Type '(x: string) => number' is not assignable to type 'T'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures.ts(38,1): error TS2322: Type '(x: string) => string' is not assignable to type 'T'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures.ts(39,1): error TS2322: Type 'S2' is not assignable to type '(x: number) => void'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures.ts(40,1): error TS2322: Type '(x: string) => void' is not assignable to type '(x: number) => void'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures.ts(41,1): error TS2322: Type '(x: string) => number' is not assignable to type '(x: number) => void'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures.ts(42,1): error TS2322: Type '(x: string) => string' is not assignable to type '(x: number) => void'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures.ts (8 errors) ====
@@ -63,40 +63,40 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
     ~
 !!! error TS2322: Type 'S2' is not assignable to type 'T'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     t = a3;
     ~
 !!! error TS2322: Type '(x: string) => void' is not assignable to type 'T'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     t = (x: string) => 1;
     ~
 !!! error TS2322: Type '(x: string) => number' is not assignable to type 'T'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     t = function (x: string) { return ''; }
     ~
 !!! error TS2322: Type '(x: string) => string' is not assignable to type 'T'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     a = s2;
     ~
 !!! error TS2322: Type 'S2' is not assignable to type '(x: number) => void'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     a = a3;
     ~
 !!! error TS2322: Type '(x: string) => void' is not assignable to type '(x: number) => void'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     a = (x: string) => 1;
     ~
 !!! error TS2322: Type '(x: string) => number' is not assignable to type '(x: number) => void'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     a = function (x: string) { return ''; }
     ~
 !!! error TS2322: Type '(x: string) => string' is not assignable to type '(x: number) => void'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures2.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures2.errors.txt
@@ -10,12 +10,12 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
   Types of property 'f' are incompatible.
     Type '(x: string) => void' is not assignable to type '(x: number) => void'.
       Types of parameters 'x' and 'x' are incompatible.
-        Type 'string' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures2.ts(43,1): error TS2322: Type '{ f(x: string): void; }' is not assignable to type 'T'.
   Types of property 'f' are incompatible.
     Type '(x: string) => void' is not assignable to type '(x: number) => void'.
       Types of parameters 'x' and 'x' are incompatible.
-        Type 'string' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures2.ts(44,1): error TS2322: Type '(x: string) => number' is not assignable to type 'T'.
   Property 'f' is missing in type '(x: string) => number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures2.ts(45,1): error TS2322: Type '(x: string) => string' is not assignable to type 'T'.
@@ -24,12 +24,12 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
   Types of property 'f' are incompatible.
     Type '(x: string) => void' is not assignable to type '(x: number) => void'.
       Types of parameters 'x' and 'x' are incompatible.
-        Type 'string' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures2.ts(47,1): error TS2322: Type '{ f(x: string): void; }' is not assignable to type '{ f(x: number): void; }'.
   Types of property 'f' are incompatible.
     Type '(x: string) => void' is not assignable to type '(x: number) => void'.
       Types of parameters 'x' and 'x' are incompatible.
-        Type 'string' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures2.ts(48,1): error TS2322: Type '(x: string) => number' is not assignable to type '{ f(x: number): void; }'.
   Property 'f' is missing in type '(x: string) => number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures2.ts(49,1): error TS2322: Type '(x: string) => string' is not assignable to type '{ f(x: number): void; }'.
@@ -96,14 +96,14 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 !!! error TS2322:   Types of property 'f' are incompatible.
 !!! error TS2322:     Type '(x: string) => void' is not assignable to type '(x: number) => void'.
 !!! error TS2322:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:         Type 'string' is not assignable to type 'number'.
+!!! error TS2322:         Type 'number' is not assignable to type 'string'.
     t = a3;
     ~
 !!! error TS2322: Type '{ f(x: string): void; }' is not assignable to type 'T'.
 !!! error TS2322:   Types of property 'f' are incompatible.
 !!! error TS2322:     Type '(x: string) => void' is not assignable to type '(x: number) => void'.
 !!! error TS2322:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:         Type 'string' is not assignable to type 'number'.
+!!! error TS2322:         Type 'number' is not assignable to type 'string'.
     t = (x: string) => 1;
     ~
 !!! error TS2322: Type '(x: string) => number' is not assignable to type 'T'.
@@ -118,14 +118,14 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
 !!! error TS2322:   Types of property 'f' are incompatible.
 !!! error TS2322:     Type '(x: string) => void' is not assignable to type '(x: number) => void'.
 !!! error TS2322:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:         Type 'string' is not assignable to type 'number'.
+!!! error TS2322:         Type 'number' is not assignable to type 'string'.
     a = a3;
     ~
 !!! error TS2322: Type '{ f(x: string): void; }' is not assignable to type '{ f(x: number): void; }'.
 !!! error TS2322:   Types of property 'f' are incompatible.
 !!! error TS2322:     Type '(x: string) => void' is not assignable to type '(x: number) => void'.
 !!! error TS2322:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:         Type 'string' is not assignable to type 'number'.
+!!! error TS2322:         Type 'number' is not assignable to type 'string'.
     a = (x: string) => 1;
     ~
 !!! error TS2322: Type '(x: string) => number' is not assignable to type '{ f(x: number): void; }'.

--- a/tests/baselines/reference/assignmentCompatWithCallSignatures4.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithCallSignatures4.errors.txt
@@ -1,13 +1,13 @@
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures4.ts(52,9): error TS2322: Type '<T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U' is not assignable to type '(x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived'.
   Types of parameters 'y' and 'y' are incompatible.
-    Type '(arg2: { foo: number; }) => any' is not assignable to type '(arg2: Base) => Derived'.
+    Type '(arg2: Base) => Derived' is not assignable to type '(arg2: { foo: number; }) => any'.
       Types of parameters 'arg2' and 'arg2' are incompatible.
         Type '{ foo: number; }' is not assignable to type 'Base'.
           Types of property 'foo' are incompatible.
             Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignatures4.ts(53,9): error TS2322: Type '(x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived' is not assignable to type '<T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U'.
   Types of parameters 'y' and 'y' are incompatible.
-    Type '(arg2: Base) => Derived' is not assignable to type '(arg2: { foo: number; }) => any'.
+    Type '(arg2: { foo: number; }) => any' is not assignable to type '(arg2: Base) => Derived'.
       Types of parameters 'arg2' and 'arg2' are incompatible.
         Type 'Base' is not assignable to type '{ foo: number; }'.
           Types of property 'foo' are incompatible.
@@ -70,7 +70,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
             ~~
 !!! error TS2322: Type '<T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U' is not assignable to type '(x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived'.
 !!! error TS2322:   Types of parameters 'y' and 'y' are incompatible.
-!!! error TS2322:     Type '(arg2: { foo: number; }) => any' is not assignable to type '(arg2: Base) => Derived'.
+!!! error TS2322:     Type '(arg2: Base) => Derived' is not assignable to type '(arg2: { foo: number; }) => any'.
 !!! error TS2322:       Types of parameters 'arg2' and 'arg2' are incompatible.
 !!! error TS2322:         Type '{ foo: number; }' is not assignable to type 'Base'.
 !!! error TS2322:           Types of property 'foo' are incompatible.
@@ -79,7 +79,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
             ~~
 !!! error TS2322: Type '(x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived' is not assignable to type '<T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U'.
 !!! error TS2322:   Types of parameters 'y' and 'y' are incompatible.
-!!! error TS2322:     Type '(arg2: Base) => Derived' is not assignable to type '(arg2: { foo: number; }) => any'.
+!!! error TS2322:     Type '(arg2: { foo: number; }) => any' is not assignable to type '(arg2: Base) => Derived'.
 !!! error TS2322:       Types of parameters 'arg2' and 'arg2' are incompatible.
 !!! error TS2322:         Type 'Base' is not assignable to type '{ foo: number; }'.
 !!! error TS2322:           Types of property 'foo' are incompatible.

--- a/tests/baselines/reference/assignmentCompatWithCallSignaturesWithRestParameters.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithCallSignaturesWithRestParameters.errors.txt
@@ -1,30 +1,30 @@
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithRestParameters.ts(13,5): error TS2322: Type '(...args: string[]) => number' is not assignable to type '(...args: number[]) => number'.
   Types of parameters 'args' and 'args' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithRestParameters.ts(17,5): error TS2322: Type '(x?: string) => number' is not assignable to type '(...args: number[]) => number'.
   Types of parameters 'x' and 'args' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithRestParameters.ts(26,5): error TS2322: Type '(x: number, ...args: string[]) => number' is not assignable to type '(x: number, ...z: number[]) => number'.
   Types of parameters 'args' and 'z' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithRestParameters.ts(35,5): error TS2322: Type '(x: number, y?: number, z?: number) => number' is not assignable to type '(x: number, y?: string, ...z: number[]) => number'.
   Types of parameters 'y' and 'y' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithRestParameters.ts(36,5): error TS2322: Type '(x: number, ...z: number[]) => number' is not assignable to type '(x: number, y?: string, ...z: number[]) => number'.
   Types of parameters 'z' and 'y' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithRestParameters.ts(37,5): error TS2322: Type '(x: string, y?: string, z?: string) => number' is not assignable to type '(x: number, y?: string, ...z: number[]) => number'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithRestParameters.ts(41,5): error TS2322: Type '(x?: number, y?: number) => number' is not assignable to type '(x?: number, y?: string, ...z: number[]) => number'.
   Types of parameters 'y' and 'y' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithRestParameters.ts(43,5): error TS2322: Type '(x: number, y?: number) => number' is not assignable to type '(x?: number, y?: string, ...z: number[]) => number'.
   Types of parameters 'y' and 'y' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithRestParameters.ts(45,5): error TS2322: Type '(x: number, ...args: string[]) => number' is not assignable to type '(x?: number, y?: string, ...z: number[]) => number'.
   Types of parameters 'args' and 'z' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithCallSignaturesWithRestParameters.ts (9 errors) ====
@@ -44,7 +44,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         ~
 !!! error TS2322: Type '(...args: string[]) => number' is not assignable to type '(...args: number[]) => number'.
 !!! error TS2322:   Types of parameters 'args' and 'args' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
         a = (x?: number) => 1; // ok, same number of required params
         a = (x?: number, y?: number, z?: number) => 1; // ok, same number of required params
         a = (x: number) => 1; // ok, rest param corresponds to infinite number of params
@@ -52,7 +52,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         ~
 !!! error TS2322: Type '(x?: string) => number' is not assignable to type '(...args: number[]) => number'.
 !!! error TS2322:   Types of parameters 'x' and 'args' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     
     
     var a2: (x: number, ...z: number[]) => number;
@@ -65,7 +65,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         ~~
 !!! error TS2322: Type '(x: number, ...args: string[]) => number' is not assignable to type '(x: number, ...z: number[]) => number'.
 !!! error TS2322:   Types of parameters 'args' and 'z' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
         a2 = (x: number, y: number) => 1; // ok, rest param corresponds to infinite number of params
         a2 = (x: number, y?: number) => 1; // ok, same number of required params
     
@@ -78,17 +78,17 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         ~~
 !!! error TS2322: Type '(x: number, y?: number, z?: number) => number' is not assignable to type '(x: number, y?: string, ...z: number[]) => number'.
 !!! error TS2322:   Types of parameters 'y' and 'y' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2322:     Type 'string' is not assignable to type 'number'.
         a3 = (x: number, ...z: number[]) => 1;  // error
         ~~
 !!! error TS2322: Type '(x: number, ...z: number[]) => number' is not assignable to type '(x: number, y?: string, ...z: number[]) => number'.
 !!! error TS2322:   Types of parameters 'z' and 'y' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2322:     Type 'string' is not assignable to type 'number'.
         a3 = (x: string, y?: string, z?: string) => 1;  // error
         ~~
 !!! error TS2322: Type '(x: string, y?: string, z?: string) => number' is not assignable to type '(x: number, y?: string, ...z: number[]) => number'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     
     var a4: (x?: number, y?: string, ...z: number[]) => number;
         a4 = () => 1; // ok, fewer required params
@@ -96,16 +96,16 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
         ~~
 !!! error TS2322: Type '(x?: number, y?: number) => number' is not assignable to type '(x?: number, y?: string, ...z: number[]) => number'.
 !!! error TS2322:   Types of parameters 'y' and 'y' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2322:     Type 'string' is not assignable to type 'number'.
         a4 = (x: number) => 1; // ok, all present params match
         a4 = (x: number, y?: number) => 1;  // error, second param has type mismatch
         ~~
 !!! error TS2322: Type '(x: number, y?: number) => number' is not assignable to type '(x?: number, y?: string, ...z: number[]) => number'.
 !!! error TS2322:   Types of parameters 'y' and 'y' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2322:     Type 'string' is not assignable to type 'number'.
         a4 = (x?: number, y?: string) => 1;  // ok, same number of required params with matching types
         a4 = (x: number, ...args: string[]) => 1;  // error, rest params have type mismatch
         ~~
 !!! error TS2322: Type '(x: number, ...args: string[]) => number' is not assignable to type '(x?: number, y?: string, ...z: number[]) => number'.
 !!! error TS2322:   Types of parameters 'args' and 'z' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.

--- a/tests/baselines/reference/assignmentCompatWithConstructSignatures4.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithConstructSignatures4.errors.txt
@@ -1,33 +1,33 @@
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts(52,9): error TS2322: Type 'new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U' is not assignable to type 'new (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived'.
   Types of parameters 'y' and 'y' are incompatible.
-    Type '(arg2: { foo: number; }) => any' is not assignable to type '(arg2: Base) => Derived'.
+    Type '(arg2: Base) => Derived' is not assignable to type '(arg2: { foo: number; }) => any'.
       Types of parameters 'arg2' and 'arg2' are incompatible.
         Type '{ foo: number; }' is not assignable to type 'Base'.
           Types of property 'foo' are incompatible.
             Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts(53,9): error TS2322: Type 'new (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived' is not assignable to type 'new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U'.
   Types of parameters 'y' and 'y' are incompatible.
-    Type '(arg2: Base) => Derived' is not assignable to type '(arg2: { foo: number; }) => any'.
+    Type '(arg2: { foo: number; }) => any' is not assignable to type '(arg2: Base) => Derived'.
       Types of parameters 'arg2' and 'arg2' are incompatible.
         Type 'Base' is not assignable to type '{ foo: number; }'.
           Types of property 'foo' are incompatible.
             Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts(77,9): error TS2322: Type 'new <T>(x: (a: T) => T) => T[]' is not assignable to type '{ new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type '(a: any) => any' is not assignable to type '{ new (a: number): number; new (a?: number): number; }'.
-      Type '(a: any) => any' provides no match for the signature 'new (a: number): number'
-tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts(78,9): error TS2322: Type '{ new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }' is not assignable to type 'new <T>(x: (a: T) => T) => T[]'.
-  Types of parameters 'x' and 'x' are incompatible.
     Type '{ new (a: number): number; new (a?: number): number; }' is not assignable to type '(a: any) => any'.
       Type '{ new (a: number): number; new (a?: number): number; }' provides no match for the signature '(a: any): any'
-tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts(81,9): error TS2322: Type 'new <T>(x: (a: T) => T) => any[]' is not assignable to type '{ new (x: { new <T extends Derived>(a: T): T; new <T extends Base>(a: T): T; }): any[]; new (x: { new <T extends Derived2>(a: T): T; new <T extends Base>(a: T): T; }): any[]; }'.
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts(78,9): error TS2322: Type '{ new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }' is not assignable to type 'new <T>(x: (a: T) => T) => T[]'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type '(a: any) => any' is not assignable to type '{ new <T extends Derived>(a: T): T; new <T extends Base>(a: T): T; }'.
-      Type '(a: any) => any' provides no match for the signature 'new <T extends Derived>(a: T): T'
-tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts(82,9): error TS2322: Type '{ new (x: { new <T extends Derived>(a: T): T; new <T extends Base>(a: T): T; }): any[]; new (x: { new <T extends Derived2>(a: T): T; new <T extends Base>(a: T): T; }): any[]; }' is not assignable to type 'new <T>(x: (a: T) => T) => any[]'.
+    Type '(a: any) => any' is not assignable to type '{ new (a: number): number; new (a?: number): number; }'.
+      Type '(a: any) => any' provides no match for the signature 'new (a: number): number'
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts(81,9): error TS2322: Type 'new <T>(x: (a: T) => T) => any[]' is not assignable to type '{ new (x: { new <T extends Derived>(a: T): T; new <T extends Base>(a: T): T; }): any[]; new (x: { new <T extends Derived2>(a: T): T; new <T extends Base>(a: T): T; }): any[]; }'.
   Types of parameters 'x' and 'x' are incompatible.
     Type '{ new <T extends Derived>(a: T): T; new <T extends Base>(a: T): T; }' is not assignable to type '(a: any) => any'.
       Type '{ new <T extends Derived>(a: T): T; new <T extends Base>(a: T): T; }' provides no match for the signature '(a: any): any'
+tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts(82,9): error TS2322: Type '{ new (x: { new <T extends Derived>(a: T): T; new <T extends Base>(a: T): T; }): any[]; new (x: { new <T extends Derived2>(a: T): T; new <T extends Base>(a: T): T; }): any[]; }' is not assignable to type 'new <T>(x: (a: T) => T) => any[]'.
+  Types of parameters 'x' and 'x' are incompatible.
+    Type '(a: any) => any' is not assignable to type '{ new <T extends Derived>(a: T): T; new <T extends Base>(a: T): T; }'.
+      Type '(a: any) => any' provides no match for the signature 'new <T extends Derived>(a: T): T'
 
 
 ==== tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignmentCompatWithConstructSignatures4.ts (6 errors) ====
@@ -86,7 +86,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
             ~~
 !!! error TS2322: Type 'new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U' is not assignable to type 'new (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived'.
 !!! error TS2322:   Types of parameters 'y' and 'y' are incompatible.
-!!! error TS2322:     Type '(arg2: { foo: number; }) => any' is not assignable to type '(arg2: Base) => Derived'.
+!!! error TS2322:     Type '(arg2: Base) => Derived' is not assignable to type '(arg2: { foo: number; }) => any'.
 !!! error TS2322:       Types of parameters 'arg2' and 'arg2' are incompatible.
 !!! error TS2322:         Type '{ foo: number; }' is not assignable to type 'Base'.
 !!! error TS2322:           Types of property 'foo' are incompatible.
@@ -95,7 +95,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
             ~~
 !!! error TS2322: Type 'new (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived' is not assignable to type 'new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U'.
 !!! error TS2322:   Types of parameters 'y' and 'y' are incompatible.
-!!! error TS2322:     Type '(arg2: Base) => Derived' is not assignable to type '(arg2: { foo: number; }) => any'.
+!!! error TS2322:     Type '(arg2: { foo: number; }) => any' is not assignable to type '(arg2: Base) => Derived'.
 !!! error TS2322:       Types of parameters 'arg2' and 'arg2' are incompatible.
 !!! error TS2322:         Type 'Base' is not assignable to type '{ foo: number; }'.
 !!! error TS2322:           Types of property 'foo' are incompatible.
@@ -127,28 +127,28 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/assignme
             ~~~
 !!! error TS2322: Type 'new <T>(x: (a: T) => T) => T[]' is not assignable to type '{ new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type '(a: any) => any' is not assignable to type '{ new (a: number): number; new (a?: number): number; }'.
-!!! error TS2322:       Type '(a: any) => any' provides no match for the signature 'new (a: number): number'
+!!! error TS2322:     Type '{ new (a: number): number; new (a?: number): number; }' is not assignable to type '(a: any) => any'.
+!!! error TS2322:       Type '{ new (a: number): number; new (a?: number): number; }' provides no match for the signature '(a: any): any'
             b16 = a16; // error
             ~~~
 !!! error TS2322: Type '{ new (x: { new (a: number): number; new (a?: number): number; }): number[]; new (x: { new (a: boolean): boolean; new (a?: boolean): boolean; }): boolean[]; }' is not assignable to type 'new <T>(x: (a: T) => T) => T[]'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type '{ new (a: number): number; new (a?: number): number; }' is not assignable to type '(a: any) => any'.
-!!! error TS2322:       Type '{ new (a: number): number; new (a?: number): number; }' provides no match for the signature '(a: any): any'
+!!! error TS2322:     Type '(a: any) => any' is not assignable to type '{ new (a: number): number; new (a?: number): number; }'.
+!!! error TS2322:       Type '(a: any) => any' provides no match for the signature 'new (a: number): number'
     
             var b17: new <T>(x: (a: T) => T) => any[];
             a17 = b17; // error
             ~~~
 !!! error TS2322: Type 'new <T>(x: (a: T) => T) => any[]' is not assignable to type '{ new (x: { new <T extends Derived>(a: T): T; new <T extends Base>(a: T): T; }): any[]; new (x: { new <T extends Derived2>(a: T): T; new <T extends Base>(a: T): T; }): any[]; }'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type '(a: any) => any' is not assignable to type '{ new <T extends Derived>(a: T): T; new <T extends Base>(a: T): T; }'.
-!!! error TS2322:       Type '(a: any) => any' provides no match for the signature 'new <T extends Derived>(a: T): T'
+!!! error TS2322:     Type '{ new <T extends Derived>(a: T): T; new <T extends Base>(a: T): T; }' is not assignable to type '(a: any) => any'.
+!!! error TS2322:       Type '{ new <T extends Derived>(a: T): T; new <T extends Base>(a: T): T; }' provides no match for the signature '(a: any): any'
             b17 = a17; // error
             ~~~
 !!! error TS2322: Type '{ new (x: { new <T extends Derived>(a: T): T; new <T extends Base>(a: T): T; }): any[]; new (x: { new <T extends Derived2>(a: T): T; new <T extends Base>(a: T): T; }): any[]; }' is not assignable to type 'new <T>(x: (a: T) => T) => any[]'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type '{ new <T extends Derived>(a: T): T; new <T extends Base>(a: T): T; }' is not assignable to type '(a: any) => any'.
-!!! error TS2322:       Type '{ new <T extends Derived>(a: T): T; new <T extends Base>(a: T): T; }' provides no match for the signature '(a: any): any'
+!!! error TS2322:     Type '(a: any) => any' is not assignable to type '{ new <T extends Derived>(a: T): T; new <T extends Base>(a: T): T; }'.
+!!! error TS2322:       Type '(a: any) => any' provides no match for the signature 'new <T extends Derived>(a: T): T'
         }
     
         module WithGenericSignaturesInBaseType {

--- a/tests/baselines/reference/assignmentCompatWithOverloads.errors.txt
+++ b/tests/baselines/reference/assignmentCompatWithOverloads.errors.txt
@@ -2,12 +2,12 @@ tests/cases/compiler/assignmentCompatWithOverloads.ts(17,1): error TS2322: Type 
   Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/assignmentCompatWithOverloads.ts(19,1): error TS2322: Type '(x: number) => number' is not assignable to type '(s1: string) => number'.
   Types of parameters 'x' and 's1' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/assignmentCompatWithOverloads.ts(21,1): error TS2322: Type '{ (x: string): string; (x: number): number; }' is not assignable to type '(s1: string) => number'.
   Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/assignmentCompatWithOverloads.ts(30,1): error TS2322: Type 'typeof C' is not assignable to type 'new (x: number) => void'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/assignmentCompatWithOverloads.ts (4 errors) ====
@@ -36,7 +36,7 @@ tests/cases/compiler/assignmentCompatWithOverloads.ts(30,1): error TS2322: Type 
     ~
 !!! error TS2322: Type '(x: number) => number' is not assignable to type '(s1: string) => number'.
 !!! error TS2322:   Types of parameters 'x' and 's1' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2322:     Type 'string' is not assignable to type 'number'.
     
     g = f4; // Error
     ~
@@ -54,4 +54,4 @@ tests/cases/compiler/assignmentCompatWithOverloads.ts(30,1): error TS2322: Type 
     ~
 !!! error TS2322: Type 'typeof C' is not assignable to type 'new (x: number) => void'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.

--- a/tests/baselines/reference/callSignatureAssignabilityInInheritance3.errors.txt
+++ b/tests/baselines/reference/callSignatureAssignabilityInInheritance3.errors.txt
@@ -2,12 +2,12 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSign
   Types of property 'a2' are incompatible.
     Type '(x: T) => U[]' is not assignable to type '(x: number) => string[]'.
       Types of parameters 'x' and 'x' are incompatible.
-        Type 'T' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSignatureAssignabilityInInheritance3.ts(60,19): error TS2430: Interface 'I4' incorrectly extends interface 'A'.
   Types of property 'a8' are incompatible.
     Type '<T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U' is not assignable to type '(x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived'.
       Types of parameters 'y' and 'y' are incompatible.
-        Type '(arg2: { foo: number; }) => any' is not assignable to type '(arg2: Base) => Derived'.
+        Type '(arg2: Base) => Derived' is not assignable to type '(arg2: { foo: number; }) => any'.
           Types of parameters 'arg2' and 'arg2' are incompatible.
             Type '{ foo: number; }' is not assignable to type 'Base'.
               Types of property 'foo' are incompatible.
@@ -71,7 +71,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSign
 !!! error TS2430:   Types of property 'a2' are incompatible.
 !!! error TS2430:     Type '(x: T) => U[]' is not assignable to type '(x: number) => string[]'.
 !!! error TS2430:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2430:         Type 'T' is not assignable to type 'number'.
+!!! error TS2430:         Type 'number' is not assignable to type 'T'.
                 a2: (x: T) => U[]; // error, no contextual signature instantiation since I2.a2 is not generic
             }
     
@@ -86,7 +86,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/callSign
 !!! error TS2430:   Types of property 'a8' are incompatible.
 !!! error TS2430:     Type '<T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U' is not assignable to type '(x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived'.
 !!! error TS2430:       Types of parameters 'y' and 'y' are incompatible.
-!!! error TS2430:         Type '(arg2: { foo: number; }) => any' is not assignable to type '(arg2: Base) => Derived'.
+!!! error TS2430:         Type '(arg2: Base) => Derived' is not assignable to type '(arg2: { foo: number; }) => any'.
 !!! error TS2430:           Types of parameters 'arg2' and 'arg2' are incompatible.
 !!! error TS2430:             Type '{ foo: number; }' is not assignable to type 'Base'.
 !!! error TS2430:               Types of property 'foo' are incompatible.

--- a/tests/baselines/reference/constructSignatureAssignabilityInInheritance3.errors.txt
+++ b/tests/baselines/reference/constructSignatureAssignabilityInInheritance3.errors.txt
@@ -2,12 +2,12 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/construc
   Types of property 'a2' are incompatible.
     Type 'new (x: T) => U[]' is not assignable to type 'new (x: number) => string[]'.
       Types of parameters 'x' and 'x' are incompatible.
-        Type 'T' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/assignmentCompatibility/constructSignatureAssignabilityInInheritance3.ts(50,19): error TS2430: Interface 'I4' incorrectly extends interface 'A'.
   Types of property 'a8' are incompatible.
     Type 'new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U' is not assignable to type 'new (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived'.
       Types of parameters 'y' and 'y' are incompatible.
-        Type '(arg2: { foo: number; }) => any' is not assignable to type '(arg2: Base) => Derived'.
+        Type '(arg2: Base) => Derived' is not assignable to type '(arg2: { foo: number; }) => any'.
           Types of parameters 'arg2' and 'arg2' are incompatible.
             Type '{ foo: number; }' is not assignable to type 'Base'.
               Types of property 'foo' are incompatible.
@@ -61,7 +61,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/construc
 !!! error TS2430:   Types of property 'a2' are incompatible.
 !!! error TS2430:     Type 'new (x: T) => U[]' is not assignable to type 'new (x: number) => string[]'.
 !!! error TS2430:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2430:         Type 'T' is not assignable to type 'number'.
+!!! error TS2430:         Type 'number' is not assignable to type 'T'.
                 a2: new (x: T) => U[]; // error, no contextual signature instantiation since I2.a2 is not generic
             }
     
@@ -76,7 +76,7 @@ tests/cases/conformance/types/typeRelationships/assignmentCompatibility/construc
 !!! error TS2430:   Types of property 'a8' are incompatible.
 !!! error TS2430:     Type 'new <T extends Base, U extends Derived>(x: (arg: T) => U, y: (arg2: { foo: number; }) => U) => (r: T) => U' is not assignable to type 'new (x: (arg: Base) => Derived, y: (arg2: Base) => Derived) => (r: Base) => Derived'.
 !!! error TS2430:       Types of parameters 'y' and 'y' are incompatible.
-!!! error TS2430:         Type '(arg2: { foo: number; }) => any' is not assignable to type '(arg2: Base) => Derived'.
+!!! error TS2430:         Type '(arg2: Base) => Derived' is not assignable to type '(arg2: { foo: number; }) => any'.
 !!! error TS2430:           Types of parameters 'arg2' and 'arg2' are incompatible.
 !!! error TS2430:             Type '{ foo: number; }' is not assignable to type 'Base'.
 !!! error TS2430:               Types of property 'foo' are incompatible.

--- a/tests/baselines/reference/contextualTyping24.errors.txt
+++ b/tests/baselines/reference/contextualTyping24.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/contextualTyping24.ts(1,55): error TS2322: Type '(a: string) => number' is not assignable to type '(a: { (): number; (i: number): number; }) => number'.
   Types of parameters 'a' and 'a' are incompatible.
-    Type 'string' is not assignable to type '{ (): number; (i: number): number; }'.
+    Type '{ (): number; (i: number): number; }' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/contextualTyping24.ts (1 errors) ====
@@ -8,4 +8,4 @@ tests/cases/compiler/contextualTyping24.ts(1,55): error TS2322: Type '(a: string
                                                           ~~~
 !!! error TS2322: Type '(a: string) => number' is not assignable to type '(a: { (): number; (i: number): number; }) => number'.
 !!! error TS2322:   Types of parameters 'a' and 'a' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type '{ (): number; (i: number): number; }'.
+!!! error TS2322:     Type '{ (): number; (i: number): number; }' is not assignable to type 'string'.

--- a/tests/baselines/reference/contextualTypingOfConditionalExpression2.errors.txt
+++ b/tests/baselines/reference/contextualTypingOfConditionalExpression2.errors.txt
@@ -1,7 +1,7 @@
 tests/cases/compiler/contextualTypingOfConditionalExpression2.ts(11,5): error TS2322: Type '((a: C) => number) | ((b: number) => void)' is not assignable to type '(a: A) => void'.
   Type '(b: number) => void' is not assignable to type '(a: A) => void'.
     Types of parameters 'b' and 'a' are incompatible.
-      Type 'number' is not assignable to type 'A'.
+      Type 'A' is not assignable to type 'number'.
 
 
 ==== tests/cases/compiler/contextualTypingOfConditionalExpression2.ts (1 errors) ====
@@ -20,5 +20,5 @@ tests/cases/compiler/contextualTypingOfConditionalExpression2.ts(11,5): error TS
 !!! error TS2322: Type '((a: C) => number) | ((b: number) => void)' is not assignable to type '(a: A) => void'.
 !!! error TS2322:   Type '(b: number) => void' is not assignable to type '(a: A) => void'.
 !!! error TS2322:     Types of parameters 'b' and 'a' are incompatible.
-!!! error TS2322:       Type 'number' is not assignable to type 'A'.
+!!! error TS2322:       Type 'A' is not assignable to type 'number'.
     

--- a/tests/baselines/reference/derivedClassTransitivity.errors.txt
+++ b/tests/baselines/reference/derivedClassTransitivity.errors.txt
@@ -2,7 +2,7 @@ tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTra
   Types of property 'foo' are incompatible.
     Type '(x?: string) => void' is not assignable to type '(x: number) => void'.
       Types of parameters 'x' and 'x' are incompatible.
-        Type 'string' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity.ts (1 errors) ====
@@ -29,6 +29,6 @@ tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTra
 !!! error TS2322:   Types of property 'foo' are incompatible.
 !!! error TS2322:     Type '(x?: string) => void' is not assignable to type '(x: number) => void'.
 !!! error TS2322:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:         Type 'string' is not assignable to type 'number'.
+!!! error TS2322:         Type 'number' is not assignable to type 'string'.
     var r = c.foo(1);
     var r2 = e.foo('');

--- a/tests/baselines/reference/derivedClassTransitivity2.errors.txt
+++ b/tests/baselines/reference/derivedClassTransitivity2.errors.txt
@@ -2,7 +2,7 @@ tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTra
   Types of property 'foo' are incompatible.
     Type '(x: number, y?: string) => void' is not assignable to type '(x: number, y: number) => void'.
       Types of parameters 'y' and 'y' are incompatible.
-        Type 'string' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity2.ts (1 errors) ====
@@ -29,6 +29,6 @@ tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTra
 !!! error TS2322:   Types of property 'foo' are incompatible.
 !!! error TS2322:     Type '(x: number, y?: string) => void' is not assignable to type '(x: number, y: number) => void'.
 !!! error TS2322:       Types of parameters 'y' and 'y' are incompatible.
-!!! error TS2322:         Type 'string' is not assignable to type 'number'.
+!!! error TS2322:         Type 'number' is not assignable to type 'string'.
     var r = c.foo(1, 1);
     var r2 = e.foo(1, '');

--- a/tests/baselines/reference/derivedClassTransitivity3.errors.txt
+++ b/tests/baselines/reference/derivedClassTransitivity3.errors.txt
@@ -2,7 +2,7 @@ tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTra
   Types of property 'foo' are incompatible.
     Type '(x: string, y?: number) => void' is not assignable to type '(x: string, y: string) => void'.
       Types of parameters 'y' and 'y' are incompatible.
-        Type 'number' is not assignable to type 'string'.
+        Type 'string' is not assignable to type 'number'.
 
 
 ==== tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity3.ts (1 errors) ====
@@ -29,6 +29,6 @@ tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTra
 !!! error TS2322:   Types of property 'foo' are incompatible.
 !!! error TS2322:     Type '(x: string, y?: number) => void' is not assignable to type '(x: string, y: string) => void'.
 !!! error TS2322:       Types of parameters 'y' and 'y' are incompatible.
-!!! error TS2322:         Type 'number' is not assignable to type 'string'.
+!!! error TS2322:         Type 'string' is not assignable to type 'number'.
     var r = c.foo('', '');
     var r2 = e.foo('', 1);

--- a/tests/baselines/reference/derivedClassTransitivity4.errors.txt
+++ b/tests/baselines/reference/derivedClassTransitivity4.errors.txt
@@ -2,7 +2,7 @@ tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTra
   Types of property 'foo' are incompatible.
     Type '(x?: string) => void' is not assignable to type '(x: number) => void'.
       Types of parameters 'x' and 'x' are incompatible.
-        Type 'string' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTransitivity4.ts(19,11): error TS2445: Property 'foo' is protected and only accessible within class 'C' and its subclasses.
 
 
@@ -30,7 +30,7 @@ tests/cases/conformance/classes/members/inheritanceAndOverriding/derivedClassTra
 !!! error TS2322:   Types of property 'foo' are incompatible.
 !!! error TS2322:     Type '(x?: string) => void' is not assignable to type '(x: number) => void'.
 !!! error TS2322:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:         Type 'string' is not assignable to type 'number'.
+!!! error TS2322:         Type 'number' is not assignable to type 'string'.
     var r = c.foo(1);
               ~~~
 !!! error TS2445: Property 'foo' is protected and only accessible within class 'C' and its subclasses.

--- a/tests/baselines/reference/destructuringParameterDeclaration2.errors.txt
+++ b/tests/baselines/reference/destructuringParameterDeclaration2.errors.txt
@@ -46,8 +46,8 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(
   Types of property 'd4' are incompatible.
     Type '({x, y, c}: { x: any; y: any; c: any; }) => void' is not assignable to type '({x, y, z}?: { x: any; y: any; z: any; }) => any'.
       Types of parameters '__0' and '__0' are incompatible.
-        Type '{ x: any; y: any; c: any; }' is not assignable to type '{ x: any; y: any; z: any; }'.
-          Property 'z' is missing in type '{ x: any; y: any; c: any; }'.
+        Type '{ x: any; y: any; z: any; }' is not assignable to type '{ x: any; y: any; c: any; }'.
+          Property 'c' is missing in type '{ x: any; y: any; z: any; }'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(56,8): error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(65,18): error TS2300: Duplicate identifier 'number'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(65,26): error TS2300: Duplicate identifier 'number'.
@@ -176,8 +176,8 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(
 !!! error TS2420:   Types of property 'd4' are incompatible.
 !!! error TS2420:     Type '({x, y, c}: { x: any; y: any; c: any; }) => void' is not assignable to type '({x, y, z}?: { x: any; y: any; z: any; }) => any'.
 !!! error TS2420:       Types of parameters '__0' and '__0' are incompatible.
-!!! error TS2420:         Type '{ x: any; y: any; c: any; }' is not assignable to type '{ x: any; y: any; z: any; }'.
-!!! error TS2420:           Property 'z' is missing in type '{ x: any; y: any; c: any; }'.
+!!! error TS2420:         Type '{ x: any; y: any; z: any; }' is not assignable to type '{ x: any; y: any; c: any; }'.
+!!! error TS2420:           Property 'c' is missing in type '{ x: any; y: any; z: any; }'.
         d3([a, b, c]?) { }  // Error, binding pattern can't be optional in implementation signature
            ~~~~~~~~~~
 !!! error TS2463: A binding pattern parameter cannot be optional in an implementation signature.

--- a/tests/baselines/reference/everyTypeWithAnnotationAndInvalidInitializer.errors.txt
+++ b/tests/baselines/reference/everyTypeWithAnnotationAndInvalidInitializer.errors.txt
@@ -16,10 +16,10 @@ tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAnd
     Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts(46,5): error TS2322: Type '(x: number) => boolean' is not assignable to type '(x: string) => number'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts(47,5): error TS2322: Type '(x: number) => boolean' is not assignable to type '(x: string) => number'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts(48,5): error TS2322: Type '(x: string) => string' is not assignable to type '(x: string) => number'.
   Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAndInvalidInitializer.ts(50,5): error TS2322: Type 'typeof N' is not assignable to type 'typeof M'.
@@ -107,12 +107,12 @@ tests/cases/conformance/statements/VariableStatements/everyTypeWithAnnotationAnd
         ~~~~~~~~~
 !!! error TS2322: Type '(x: number) => boolean' is not assignable to type '(x: string) => number'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2322:     Type 'string' is not assignable to type 'number'.
     var anOtherFunction: (x: string) => number = F2;
         ~~~~~~~~~~~~~~~
 !!! error TS2322: Type '(x: number) => boolean' is not assignable to type '(x: string) => number'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2322:     Type 'string' is not assignable to type 'number'.
     var aLambda: typeof F = (x) => 'a string';
         ~~~~~~~
 !!! error TS2322: Type '(x: string) => string' is not assignable to type '(x: string) => number'.

--- a/tests/baselines/reference/functionConstraintSatisfaction2.errors.txt
+++ b/tests/baselines/reference/functionConstraintSatisfaction2.errors.txt
@@ -5,7 +5,7 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstrain
   Type 'Function' provides no match for the signature '(x: string): string'
 tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts(24,15): error TS2345: Argument of type '(x: string[]) => string[]' is not assignable to parameter of type '(x: string) => string'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string[]' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'string[]'.
 tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts(25,15): error TS2345: Argument of type 'typeof C' is not assignable to parameter of type '(x: string) => string'.
   Type 'typeof C' provides no match for the signature '(x: string): string'
 tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstraintSatisfaction2.ts(26,15): error TS2345: Argument of type 'new (x: string) => string' is not assignable to parameter of type '(x: string) => string'.
@@ -63,7 +63,7 @@ tests/cases/conformance/types/typeParameters/typeArgumentLists/functionConstrain
                   ~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: string[]) => string[]' is not assignable to parameter of type '(x: string) => string'.
 !!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2345:     Type 'string[]' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type 'string[]'.
     var r6 = foo2(C);
                   ~
 !!! error TS2345: Argument of type 'typeof C' is not assignable to parameter of type '(x: string) => string'.

--- a/tests/baselines/reference/functionSignatureAssignmentCompat1.errors.txt
+++ b/tests/baselines/reference/functionSignatureAssignmentCompat1.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/functionSignatureAssignmentCompat1.ts(10,5): error TS2322: Type '(delimiter?: string) => ParserFunc' is not assignable to type 'ParserFunc'.
   Types of parameters 'delimiter' and 'eventEmitter' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/functionSignatureAssignmentCompat1.ts (1 errors) ====
@@ -17,5 +17,5 @@ tests/cases/compiler/functionSignatureAssignmentCompat1.ts(10,5): error TS2322: 
         ~
 !!! error TS2322: Type '(delimiter?: string) => ParserFunc' is not assignable to type 'ParserFunc'.
 !!! error TS2322:   Types of parameters 'delimiter' and 'eventEmitter' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     var e: ParserFunc = parsers.readline(); // ok

--- a/tests/baselines/reference/genericAssignmentCompatWithInterfaces1.errors.txt
+++ b/tests/baselines/reference/genericAssignmentCompatWithInterfaces1.errors.txt
@@ -4,7 +4,7 @@ tests/cases/compiler/genericAssignmentCompatWithInterfaces1.ts(12,5): error TS23
       Types of property 'compareTo' are incompatible.
         Type '(other: number) => number' is not assignable to type '(other: string) => number'.
           Types of parameters 'other' and 'other' are incompatible.
-            Type 'number' is not assignable to type 'string'.
+            Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/genericAssignmentCompatWithInterfaces1.ts(13,5): error TS2322: Type '{ x: A<number>; }' is not assignable to type 'I<string>'.
   Types of property 'x' are incompatible.
     Type 'A<number>' is not assignable to type 'Comparable<string>'.
@@ -36,7 +36,7 @@ tests/cases/compiler/genericAssignmentCompatWithInterfaces1.ts(17,5): error TS23
 !!! error TS2322:       Types of property 'compareTo' are incompatible.
 !!! error TS2322:         Type '(other: number) => number' is not assignable to type '(other: string) => number'.
 !!! error TS2322:           Types of parameters 'other' and 'other' are incompatible.
-!!! error TS2322:             Type 'number' is not assignable to type 'string'.
+!!! error TS2322:             Type 'string' is not assignable to type 'number'.
     var a2: I<string> = function (): { x: A<number> } {
         ~~
 !!! error TS2322: Type '{ x: A<number>; }' is not assignable to type 'I<string>'.

--- a/tests/baselines/reference/genericCallWithGenericSignatureArguments2.errors.txt
+++ b/tests/baselines/reference/genericCallWithGenericSignatureArguments2.errors.txt
@@ -4,17 +4,14 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGen
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(16,22): error TS2345: Argument of type 'number' is not assignable to parameter of type 'T'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(25,23): error TS2345: Argument of type '(a: T) => T' is not assignable to parameter of type '(x: Date) => Date'.
   Types of parameters 'a' and 'x' are incompatible.
-    Type 'T' is not assignable to type 'Date'.
-      Type 'RegExp' is not assignable to type 'Date'.
-        Property 'toDateString' is missing in type 'RegExp'.
+    Type 'Date' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(37,36): error TS2345: Argument of type '(x: E) => F' is not assignable to parameter of type '(x: E) => E'.
   Type 'F' is not assignable to type 'E'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(50,21): error TS2345: Argument of type 'Date' is not assignable to parameter of type 'T'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(51,22): error TS2345: Argument of type 'number' is not assignable to parameter of type 'T'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(60,23): error TS2345: Argument of type '(a: T) => T' is not assignable to parameter of type '(x: Date) => Date'.
   Types of parameters 'a' and 'x' are incompatible.
-    Type 'T' is not assignable to type 'Date'.
-      Type 'RegExp' is not assignable to type 'Date'.
+    Type 'Date' is not assignable to type 'T'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(67,51): error TS2304: Cannot find name 'U'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGenericSignatureArguments2.ts(67,57): error TS2304: Cannot find name 'U'.
 
@@ -55,9 +52,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGen
                           ~~~~~~~~~~~
 !!! error TS2345: Argument of type '(a: T) => T' is not assignable to parameter of type '(x: Date) => Date'.
 !!! error TS2345:   Types of parameters 'a' and 'x' are incompatible.
-!!! error TS2345:     Type 'T' is not assignable to type 'Date'.
-!!! error TS2345:       Type 'RegExp' is not assignable to type 'Date'.
-!!! error TS2345:         Property 'toDateString' is missing in type 'RegExp'.
+!!! error TS2345:     Type 'Date' is not assignable to type 'T'.
             var r7b = foo2((a) => a, (b) => b); // valid, T is inferred to be Date
         }
     
@@ -103,8 +98,7 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithGen
                           ~~~~~~~~~~~
 !!! error TS2345: Argument of type '(a: T) => T' is not assignable to parameter of type '(x: Date) => Date'.
 !!! error TS2345:   Types of parameters 'a' and 'x' are incompatible.
-!!! error TS2345:     Type 'T' is not assignable to type 'Date'.
-!!! error TS2345:       Type 'RegExp' is not assignable to type 'Date'.
+!!! error TS2345:     Type 'Date' is not assignable to type 'T'.
             var r7b = foo2((a) => a, (b) => b); 
         }
     

--- a/tests/baselines/reference/genericSpecializations3.errors.txt
+++ b/tests/baselines/reference/genericSpecializations3.errors.txt
@@ -2,17 +2,17 @@ tests/cases/compiler/genericSpecializations3.ts(8,7): error TS2420: Class 'IntFo
   Types of property 'foo' are incompatible.
     Type '(x: string) => string' is not assignable to type '(x: number) => number'.
       Types of parameters 'x' and 'x' are incompatible.
-        Type 'string' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/genericSpecializations3.ts(28,1): error TS2322: Type 'StringFoo2' is not assignable to type 'IntFoo'.
   Types of property 'foo' are incompatible.
     Type '(x: string) => string' is not assignable to type '(x: number) => number'.
       Types of parameters 'x' and 'x' are incompatible.
-        Type 'string' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/genericSpecializations3.ts(29,1): error TS2322: Type 'IntFoo' is not assignable to type 'StringFoo2'.
   Types of property 'foo' are incompatible.
     Type '(x: number) => number' is not assignable to type '(x: string) => string'.
       Types of parameters 'x' and 'x' are incompatible.
-        Type 'number' is not assignable to type 'string'.
+        Type 'string' is not assignable to type 'number'.
 
 
 ==== tests/cases/compiler/genericSpecializations3.ts (3 errors) ====
@@ -29,7 +29,7 @@ tests/cases/compiler/genericSpecializations3.ts(29,1): error TS2322: Type 'IntFo
 !!! error TS2420:   Types of property 'foo' are incompatible.
 !!! error TS2420:     Type '(x: string) => string' is not assignable to type '(x: number) => number'.
 !!! error TS2420:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2420:         Type 'string' is not assignable to type 'number'.
+!!! error TS2420:         Type 'number' is not assignable to type 'string'.
         foo(x: string): string { return null; }
     }
     
@@ -55,14 +55,14 @@ tests/cases/compiler/genericSpecializations3.ts(29,1): error TS2322: Type 'IntFo
 !!! error TS2322:   Types of property 'foo' are incompatible.
 !!! error TS2322:     Type '(x: string) => string' is not assignable to type '(x: number) => number'.
 !!! error TS2322:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:         Type 'string' is not assignable to type 'number'.
+!!! error TS2322:         Type 'number' is not assignable to type 'string'.
     stringFoo2 = intFoo; // error
     ~~~~~~~~~~
 !!! error TS2322: Type 'IntFoo' is not assignable to type 'StringFoo2'.
 !!! error TS2322:   Types of property 'foo' are incompatible.
 !!! error TS2322:     Type '(x: number) => number' is not assignable to type '(x: string) => string'.
 !!! error TS2322:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:         Type 'number' is not assignable to type 'string'.
+!!! error TS2322:         Type 'string' is not assignable to type 'number'.
     
     
     class StringFoo3 implements IFoo<string> { // error

--- a/tests/baselines/reference/genericTypeAssertions2.errors.txt
+++ b/tests/baselines/reference/genericTypeAssertions2.errors.txt
@@ -2,7 +2,7 @@ tests/cases/compiler/genericTypeAssertions2.ts(10,5): error TS2322: Type 'B<stri
   Types of property 'foo' are incompatible.
     Type '(x: string) => void' is not assignable to type '(x: number) => void'.
       Types of parameters 'x' and 'x' are incompatible.
-        Type 'string' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/genericTypeAssertions2.ts(11,5): error TS2322: Type 'A<number>' is not assignable to type 'B<number>'.
   Property 'bar' is missing in type 'A<number>'.
 tests/cases/compiler/genericTypeAssertions2.ts(13,21): error TS2352: Neither type 'undefined[]' nor type 'A<number>' is assignable to the other.
@@ -25,7 +25,7 @@ tests/cases/compiler/genericTypeAssertions2.ts(13,21): error TS2352: Neither typ
 !!! error TS2322:   Types of property 'foo' are incompatible.
 !!! error TS2322:     Type '(x: string) => void' is not assignable to type '(x: number) => void'.
 !!! error TS2322:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:         Type 'string' is not assignable to type 'number'.
+!!! error TS2322:         Type 'number' is not assignable to type 'string'.
     var r3: B<number> = <A<number>>new B(); // error
         ~~
 !!! error TS2322: Type 'A<number>' is not assignable to type 'B<number>'.

--- a/tests/baselines/reference/genericTypeWithNonGenericBaseMisMatch.errors.txt
+++ b/tests/baselines/reference/genericTypeWithNonGenericBaseMisMatch.errors.txt
@@ -2,17 +2,14 @@ tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(4,7): error TS2420
   Types of property 'f' are incompatible.
     Type '(a: T) => void' is not assignable to type '(a: { a: number; }) => void'.
       Types of parameters 'a' and 'a' are incompatible.
-        Type 'T' is not assignable to type '{ a: number; }'.
-          Type '{ a: string; }' is not assignable to type '{ a: number; }'.
-            Types of property 'a' are incompatible.
-              Type 'string' is not assignable to type 'number'.
+        Type '{ a: number; }' is not assignable to type 'T'.
 tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(8,5): error TS2322: Type 'X<{ a: string; }>' is not assignable to type 'I'.
   Types of property 'f' are incompatible.
     Type '(a: { a: string; }) => void' is not assignable to type '(a: { a: number; }) => void'.
       Types of parameters 'a' and 'a' are incompatible.
-        Type '{ a: string; }' is not assignable to type '{ a: number; }'.
+        Type '{ a: number; }' is not assignable to type '{ a: string; }'.
           Types of property 'a' are incompatible.
-            Type 'string' is not assignable to type 'number'.
+            Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts (2 errors) ====
@@ -25,10 +22,7 @@ tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(8,5): error TS2322
 !!! error TS2420:   Types of property 'f' are incompatible.
 !!! error TS2420:     Type '(a: T) => void' is not assignable to type '(a: { a: number; }) => void'.
 !!! error TS2420:       Types of parameters 'a' and 'a' are incompatible.
-!!! error TS2420:         Type 'T' is not assignable to type '{ a: number; }'.
-!!! error TS2420:           Type '{ a: string; }' is not assignable to type '{ a: number; }'.
-!!! error TS2420:             Types of property 'a' are incompatible.
-!!! error TS2420:               Type 'string' is not assignable to type 'number'.
+!!! error TS2420:         Type '{ a: number; }' is not assignable to type 'T'.
     	f(a: T): void { }
     }
     var x = new X<{ a: string }>();
@@ -38,7 +32,7 @@ tests/cases/compiler/genericTypeWithNonGenericBaseMisMatch.ts(8,5): error TS2322
 !!! error TS2322:   Types of property 'f' are incompatible.
 !!! error TS2322:     Type '(a: { a: string; }) => void' is not assignable to type '(a: { a: number; }) => void'.
 !!! error TS2322:       Types of parameters 'a' and 'a' are incompatible.
-!!! error TS2322:         Type '{ a: string; }' is not assignable to type '{ a: number; }'.
+!!! error TS2322:         Type '{ a: number; }' is not assignable to type '{ a: string; }'.
 !!! error TS2322:           Types of property 'a' are incompatible.
-!!! error TS2322:             Type 'string' is not assignable to type 'number'.
+!!! error TS2322:             Type 'number' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/implementGenericWithMismatchedTypes.errors.txt
+++ b/tests/baselines/reference/implementGenericWithMismatchedTypes.errors.txt
@@ -2,7 +2,7 @@ tests/cases/compiler/implementGenericWithMismatchedTypes.ts(7,7): error TS2420: 
   Types of property 'foo' are incompatible.
     Type '(x: string) => number' is not assignable to type '(x: T) => T'.
       Types of parameters 'x' and 'x' are incompatible.
-        Type 'string' is not assignable to type 'T'.
+        Type 'T' is not assignable to type 'string'.
 tests/cases/compiler/implementGenericWithMismatchedTypes.ts(16,7): error TS2420: Class 'C2<T>' incorrectly implements interface 'IFoo2<T>'.
   Types of property 'foo' are incompatible.
     Type '<Tstring>(x: Tstring) => number' is not assignable to type '(x: T) => T'.
@@ -22,7 +22,7 @@ tests/cases/compiler/implementGenericWithMismatchedTypes.ts(16,7): error TS2420:
 !!! error TS2420:   Types of property 'foo' are incompatible.
 !!! error TS2420:     Type '(x: string) => number' is not assignable to type '(x: T) => T'.
 !!! error TS2420:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2420:         Type 'string' is not assignable to type 'T'.
+!!! error TS2420:         Type 'T' is not assignable to type 'string'.
         foo(x: string): number {
             return null;
         }

--- a/tests/baselines/reference/incompatibleTypes.errors.txt
+++ b/tests/baselines/reference/incompatibleTypes.errors.txt
@@ -6,7 +6,7 @@ tests/cases/compiler/incompatibleTypes.ts(15,7): error TS2420: Class 'C2' incorr
   Types of property 'p1' are incompatible.
     Type '(n: number) => number' is not assignable to type '(s: string) => number'.
       Types of parameters 'n' and 's' are incompatible.
-        Type 'number' is not assignable to type 'string'.
+        Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/incompatibleTypes.ts(25,7): error TS2420: Class 'C3' incorrectly implements interface 'IFoo3'.
   Types of property 'p1' are incompatible.
     Type 'number' is not assignable to type 'string'.
@@ -52,7 +52,7 @@ tests/cases/compiler/incompatibleTypes.ts(74,5): error TS2322: Type '(a: any) =>
 !!! error TS2420:   Types of property 'p1' are incompatible.
 !!! error TS2420:     Type '(n: number) => number' is not assignable to type '(s: string) => number'.
 !!! error TS2420:       Types of parameters 'n' and 's' are incompatible.
-!!! error TS2420:         Type 'number' is not assignable to type 'string'.
+!!! error TS2420:         Type 'string' is not assignable to type 'number'.
         public p1(n:number) {
             return 0;
         }

--- a/tests/baselines/reference/interfaceAssignmentCompat.errors.txt
+++ b/tests/baselines/reference/interfaceAssignmentCompat.errors.txt
@@ -1,10 +1,9 @@
 tests/cases/compiler/interfaceAssignmentCompat.ts(32,18): error TS2345: Argument of type '(a: IFrenchEye, b: IFrenchEye) => number' is not assignable to parameter of type '(a: IEye, b: IEye) => number'.
   Types of parameters 'a' and 'a' are incompatible.
-    Type 'IFrenchEye' is not assignable to type 'IEye'.
-      Property 'color' is missing in type 'IFrenchEye'.
+    Type 'IEye' is not assignable to type 'IFrenchEye'.
+      Property 'coleur' is missing in type 'IEye'.
 tests/cases/compiler/interfaceAssignmentCompat.ts(37,29): error TS2339: Property '_map' does not exist on type 'typeof Color'.
 tests/cases/compiler/interfaceAssignmentCompat.ts(42,13): error TS2322: Type 'IEye' is not assignable to type 'IFrenchEye'.
-  Property 'coleur' is missing in type 'IEye'.
 tests/cases/compiler/interfaceAssignmentCompat.ts(44,9): error TS2322: Type 'IEye[]' is not assignable to type 'IFrenchEye[]'.
   Type 'IEye' is not assignable to type 'IFrenchEye'.
 
@@ -45,8 +44,8 @@ tests/cases/compiler/interfaceAssignmentCompat.ts(44,9): error TS2322: Type 'IEy
                      ~~~~~~~~~~~
 !!! error TS2345: Argument of type '(a: IFrenchEye, b: IFrenchEye) => number' is not assignable to parameter of type '(a: IEye, b: IEye) => number'.
 !!! error TS2345:   Types of parameters 'a' and 'a' are incompatible.
-!!! error TS2345:     Type 'IFrenchEye' is not assignable to type 'IEye'.
-!!! error TS2345:       Property 'color' is missing in type 'IFrenchEye'.
+!!! error TS2345:     Type 'IEye' is not assignable to type 'IFrenchEye'.
+!!! error TS2345:       Property 'coleur' is missing in type 'IEye'.
             // type of z inferred from specialized array type
             var z=x.sort(CompareEyes); // ok
     
@@ -61,7 +60,6 @@ tests/cases/compiler/interfaceAssignmentCompat.ts(44,9): error TS2322: Type 'IEy
                 eeks[j]=z[j];  // nope: element assignment
                 ~~~~~~~
 !!! error TS2322: Type 'IEye' is not assignable to type 'IFrenchEye'.
-!!! error TS2322:   Property 'coleur' is missing in type 'IEye'.
             }
             eeks=z; // nope: array assignment
             ~~~~

--- a/tests/baselines/reference/lastPropertyInLiteralWins.errors.txt
+++ b/tests/baselines/reference/lastPropertyInLiteralWins.errors.txt
@@ -2,7 +2,7 @@ tests/cases/compiler/lastPropertyInLiteralWins.ts(7,6): error TS2345: Argument o
   Types of property 'thunk' are incompatible.
     Type '(num: number) => void' is not assignable to type '(str: string) => void'.
       Types of parameters 'num' and 'str' are incompatible.
-        Type 'number' is not assignable to type 'string'.
+        Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/lastPropertyInLiteralWins.ts(8,5): error TS2300: Duplicate identifier 'thunk'.
 tests/cases/compiler/lastPropertyInLiteralWins.ts(9,5): error TS2300: Duplicate identifier 'thunk'.
 tests/cases/compiler/lastPropertyInLiteralWins.ts(13,5): error TS2300: Duplicate identifier 'thunk'.
@@ -32,7 +32,7 @@ tests/cases/compiler/lastPropertyInLiteralWins.ts(14,5): error TS2300: Duplicate
 !!! error TS2345:   Types of property 'thunk' are incompatible.
 !!! error TS2345:     Type '(num: number) => void' is not assignable to type '(str: string) => void'.
 !!! error TS2345:       Types of parameters 'num' and 'str' are incompatible.
-!!! error TS2345:         Type 'number' is not assignable to type 'string'.
+!!! error TS2345:         Type 'string' is not assignable to type 'number'.
     
     test({ // Should be OK.  Last 'thunk' is of correct type
         thunk: (num: number) => {},

--- a/tests/baselines/reference/optionalFunctionArgAssignability.errors.txt
+++ b/tests/baselines/reference/optionalFunctionArgAssignability.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/optionalFunctionArgAssignability.ts(7,1): error TS2322: Type '<U>(onFulFill?: (value: number) => U, onReject?: (reason: any) => U) => Promise<U>' is not assignable to type '<U>(onFulfill?: (value: string) => U, onReject?: (reason: any) => U) => Promise<U>'.
   Types of parameters 'onFulFill' and 'onFulfill' are incompatible.
-    Type '(value: number) => any' is not assignable to type '(value: string) => any'.
+    Type '(value: string) => any' is not assignable to type '(value: number) => any'.
       Types of parameters 'value' and 'value' are incompatible.
         Type 'number' is not assignable to type 'string'.
 
@@ -16,7 +16,7 @@ tests/cases/compiler/optionalFunctionArgAssignability.ts(7,1): error TS2322: Typ
     ~
 !!! error TS2322: Type '<U>(onFulFill?: (value: number) => U, onReject?: (reason: any) => U) => Promise<U>' is not assignable to type '<U>(onFulfill?: (value: string) => U, onReject?: (reason: any) => U) => Promise<U>'.
 !!! error TS2322:   Types of parameters 'onFulFill' and 'onFulfill' are incompatible.
-!!! error TS2322:     Type '(value: number) => any' is not assignable to type '(value: string) => any'.
+!!! error TS2322:     Type '(value: string) => any' is not assignable to type '(value: number) => any'.
 !!! error TS2322:       Types of parameters 'value' and 'value' are incompatible.
 !!! error TS2322:         Type 'number' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/optionalParamAssignmentCompat.errors.txt
+++ b/tests/baselines/reference/optionalParamAssignmentCompat.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/optionalParamAssignmentCompat.ts(10,5): error TS2322: Type '(p1?: string) => I1' is not assignable to type 'I1'.
   Types of parameters 'p1' and 'p1' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/optionalParamAssignmentCompat.ts (1 errors) ====
@@ -17,5 +17,5 @@ tests/cases/compiler/optionalParamAssignmentCompat.ts(10,5): error TS2322: Type 
         ~
 !!! error TS2322: Type '(p1?: string) => I1' is not assignable to type 'I1'.
 !!! error TS2322:   Types of parameters 'p1' and 'p1' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/optionalParamTypeComparison.errors.txt
+++ b/tests/baselines/reference/optionalParamTypeComparison.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/compiler/optionalParamTypeComparison.ts(4,1): error TS2322: Type '(s: string, b?: boolean) => void' is not assignable to type '(s: string, n?: number) => void'.
   Types of parameters 'b' and 'n' are incompatible.
-    Type 'boolean' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'boolean'.
 tests/cases/compiler/optionalParamTypeComparison.ts(5,1): error TS2322: Type '(s: string, n?: number) => void' is not assignable to type '(s: string, b?: boolean) => void'.
   Types of parameters 'n' and 'b' are incompatible.
-    Type 'number' is not assignable to type 'boolean'.
+    Type 'boolean' is not assignable to type 'number'.
 
 
 ==== tests/cases/compiler/optionalParamTypeComparison.ts (2 errors) ====
@@ -14,9 +14,9 @@ tests/cases/compiler/optionalParamTypeComparison.ts(5,1): error TS2322: Type '(s
     ~
 !!! error TS2322: Type '(s: string, b?: boolean) => void' is not assignable to type '(s: string, n?: number) => void'.
 !!! error TS2322:   Types of parameters 'b' and 'n' are incompatible.
-!!! error TS2322:     Type 'boolean' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'boolean'.
     g = f;
     ~
 !!! error TS2322: Type '(s: string, n?: number) => void' is not assignable to type '(s: string, b?: boolean) => void'.
 !!! error TS2322:   Types of parameters 'n' and 'b' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'boolean'.
+!!! error TS2322:     Type 'boolean' is not assignable to type 'number'.

--- a/tests/baselines/reference/overloadOnConstInheritance2.errors.txt
+++ b/tests/baselines/reference/overloadOnConstInheritance2.errors.txt
@@ -2,7 +2,7 @@ tests/cases/compiler/overloadOnConstInheritance2.ts(5,11): error TS2430: Interfa
   Types of property 'addEventListener' are incompatible.
     Type '(x: "bar") => string' is not assignable to type '{ (x: string): any; (x: "foo"): string; }'.
       Types of parameters 'x' and 'x' are incompatible.
-        Type '"bar"' is not assignable to type '"foo"'.
+        Type '"foo"' is not assignable to type '"bar"'.
 
 
 ==== tests/cases/compiler/overloadOnConstInheritance2.ts (1 errors) ====
@@ -16,7 +16,7 @@ tests/cases/compiler/overloadOnConstInheritance2.ts(5,11): error TS2430: Interfa
 !!! error TS2430:   Types of property 'addEventListener' are incompatible.
 !!! error TS2430:     Type '(x: "bar") => string' is not assignable to type '{ (x: string): any; (x: "foo"): string; }'.
 !!! error TS2430:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2430:         Type '"bar"' is not assignable to type '"foo"'.
+!!! error TS2430:         Type '"foo"' is not assignable to type '"bar"'.
         addEventListener(x: 'bar'): string; // shouldn't need to redeclare the string overload
     }
     

--- a/tests/baselines/reference/overloadOnConstNoAnyImplementation2.errors.txt
+++ b/tests/baselines/reference/overloadOnConstNoAnyImplementation2.errors.txt
@@ -1,10 +1,10 @@
 tests/cases/compiler/overloadOnConstNoAnyImplementation2.ts(12,18): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
 tests/cases/compiler/overloadOnConstNoAnyImplementation2.ts(18,9): error TS2345: Argument of type '(x: "bye") => number' is not assignable to parameter of type '(x: "hi") => number'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type '"bye"' is not assignable to type '"hi"'.
+    Type '"hi"' is not assignable to type '"bye"'.
 tests/cases/compiler/overloadOnConstNoAnyImplementation2.ts(21,9): error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: "hi") => number'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'number' is not assignable to type '"hi"'.
+    Type '"hi"' is not assignable to type 'number'.
 
 
 ==== tests/cases/compiler/overloadOnConstNoAnyImplementation2.ts (3 errors) ====
@@ -31,11 +31,11 @@ tests/cases/compiler/overloadOnConstNoAnyImplementation2.ts(21,9): error TS2345:
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: "bye") => number' is not assignable to parameter of type '(x: "hi") => number'.
 !!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2345:     Type '"bye"' is not assignable to type '"hi"'.
+!!! error TS2345:     Type '"hi"' is not assignable to type '"bye"'.
     c.x1(1, (x) => { return 1; } );
     
     c.x1(1, (x: number) => { return 1; } );
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: "hi") => number'.
 !!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type '"hi"'.
+!!! error TS2345:     Type '"hi"' is not assignable to type 'number'.

--- a/tests/baselines/reference/overloadOnConstNoStringImplementation2.errors.txt
+++ b/tests/baselines/reference/overloadOnConstNoStringImplementation2.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/compiler/overloadOnConstNoStringImplementation2.ts(18,9): error TS2345: Argument of type '(x: "bye") => number' is not assignable to parameter of type '(x: "hi") => number'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type '"bye"' is not assignable to type '"hi"'.
+    Type '"hi"' is not assignable to type '"bye"'.
 tests/cases/compiler/overloadOnConstNoStringImplementation2.ts(20,9): error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: "hi") => number'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'number' is not assignable to type '"hi"'.
+    Type '"hi"' is not assignable to type 'number'.
 
 
 ==== tests/cases/compiler/overloadOnConstNoStringImplementation2.ts (2 errors) ====
@@ -28,10 +28,10 @@ tests/cases/compiler/overloadOnConstNoStringImplementation2.ts(20,9): error TS23
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: "bye") => number' is not assignable to parameter of type '(x: "hi") => number'.
 !!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2345:     Type '"bye"' is not assignable to type '"hi"'.
+!!! error TS2345:     Type '"hi"' is not assignable to type '"bye"'.
     c.x1(1, (x: string) => { return 1; } );
     c.x1(1, (x: number) => { return 1; } );
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number) => number' is not assignable to parameter of type '(x: "hi") => number'.
 !!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type '"hi"'.
+!!! error TS2345:     Type '"hi"' is not assignable to type 'number'.

--- a/tests/baselines/reference/overloadresolutionWithConstraintCheckingDeferred.errors.txt
+++ b/tests/baselines/reference/overloadresolutionWithConstraintCheckingDeferred.errors.txt
@@ -5,8 +5,8 @@ tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts(16,5): 
 tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts(16,38): error TS2344: Type 'D' does not satisfy the constraint 'A'.
 tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts(18,27): error TS2345: Argument of type '(x: D) => G<D>' is not assignable to parameter of type '(x: B) => any'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'D' is not assignable to type 'B'.
-      Property 'x' is missing in type 'D'.
+    Type 'B' is not assignable to type 'D'.
+      Property 'q' is missing in type 'B'.
 tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts(19,14): error TS2344: Type 'D' does not satisfy the constraint 'A'.
 
 
@@ -49,6 +49,6 @@ tests/cases/compiler/overloadresolutionWithConstraintCheckingDeferred.ts(19,14):
     ~
 !!! error TS2345: Argument of type '(x: D) => G<D>' is not assignable to parameter of type '(x: B) => any'.
 !!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2345:     Type 'D' is not assignable to type 'B'.
-!!! error TS2345:       Property 'x' is missing in type 'D'.
+!!! error TS2345:     Type 'B' is not assignable to type 'D'.
+!!! error TS2345:       Property 'q' is missing in type 'B'.
     

--- a/tests/baselines/reference/promisePermutations.errors.txt
+++ b/tests/baselines/reference/promisePermutations.errors.txt
@@ -1,18 +1,18 @@
 tests/cases/compiler/promisePermutations.ts(74,70): error TS2345: Argument of type '(x: number) => IPromise<number>' is not assignable to parameter of type '(value: IPromise<number>) => IPromise<number>'.
   Types of parameters 'x' and 'value' are incompatible.
-    Type 'number' is not assignable to type 'IPromise<number>'.
+    Type 'IPromise<number>' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations.ts(79,19): error TS2345: Argument of type '(x: number, y?: string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'x' and 'value' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations.ts(82,19): error TS2345: Argument of type '(x: number, y?: string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'x' and 'value' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations.ts(83,19): error TS2345: Argument of type '(x: number, y?: string) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
   Types of parameters 'x' and 'value' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations.ts(84,19): error TS2345: Argument of type '(x: number, y?: string) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'x' and 'value' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations.ts(88,19): error TS2345: Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 tests/cases/compiler/promisePermutations.ts(91,19): error TS2345: Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 tests/cases/compiler/promisePermutations.ts(92,19): error TS2345: Argument of type '(x: number, cb: (a: string) => string) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
@@ -23,16 +23,16 @@ tests/cases/compiler/promisePermutations.ts(101,19): error TS2345: Argument of t
 tests/cases/compiler/promisePermutations.ts(102,19): error TS2345: Argument of type '(x: number, cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 tests/cases/compiler/promisePermutations.ts(106,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
-    Type '<T>(a: T) => T' is not assignable to type 'string'.
+    Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations.ts(109,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
-    Type '<T>(a: T) => T' is not assignable to type 'string'.
+    Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations.ts(110,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
-    Type '<T>(a: T) => T' is not assignable to type 'string'.
+    Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations.ts(111,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
-    Type '<T>(a: T) => T' is not assignable to type 'string'.
+    Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations.ts(117,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<number>'.
 tests/cases/compiler/promisePermutations.ts(120,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<number>'.
 tests/cases/compiler/promisePermutations.ts(121,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<number>'.
@@ -55,7 +55,7 @@ tests/cases/compiler/promisePermutations.ts(152,12): error TS2453: The type argu
     Types of property 'then' are incompatible.
       Type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }' is not assignable to type '{ <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
         Types of parameters 'success' and 'success' are incompatible.
-          Type '(value: string) => IPromise<any>' is not assignable to type '(value: number) => Promise<any>'.
+          Type '(value: number) => Promise<any>' is not assignable to type '(value: string) => IPromise<any>'.
             Types of parameters 'value' and 'value' are incompatible.
               Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations.ts(156,21): error TS2345: Argument of type '{ (x: number): IPromise<number>; (x: string): IPromise<string>; }' is not assignable to parameter of type '(value: number) => IPromise<string>'.
@@ -72,7 +72,7 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2345: Argument of t
     Types of property 'then' are incompatible.
       Type '{ <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }' is not assignable to type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }'.
         Types of parameters 'success' and 'success' are incompatible.
-          Type '(value: number) => Promise<any>' is not assignable to type '(value: string) => IPromise<any>'.
+          Type '(value: string) => IPromise<any>' is not assignable to type '(value: number) => Promise<any>'.
             Types of parameters 'value' and 'value' are incompatible.
               Type 'number' is not assignable to type 'string'.
 
@@ -155,7 +155,7 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2345: Argument of t
                                                                          ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number) => IPromise<number>' is not assignable to parameter of type '(value: IPromise<number>) => IPromise<number>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type 'IPromise<number>'.
+!!! error TS2345:     Type 'IPromise<number>' is not assignable to type 'number'.
     
     var r4: IPromise<string>;
     var sIPromise: (x: any) => IPromise<string>;
@@ -164,24 +164,24 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2345: Argument of t
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, y?: string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
     var r4b = r4.then(sIPromise, testFunction4, testFunction4).then(sIPromise, testFunction4, testFunction4); // ok
     var s4: Promise<string>;
     var s4a = s4.then(testFunction4, testFunction4, testFunction4); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, y?: string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
     var s4b = s4.then(testFunction4P, testFunction4P, testFunction4P); // error 
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, y?: string) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
     var s4c = s4.then(testFunction4P, testFunction4, testFunction4); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, y?: string) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
     var s4d = s4.then(sIPromise, testFunction4P, testFunction4).then(sIPromise, testFunction4P, testFunction4);
     
     var r5: IPromise<string>;
@@ -223,24 +223,24 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2345: Argument of t
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'cb' and 'value' are incompatible.
-!!! error TS2345:     Type '<T>(a: T) => T' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type '<T>(a: T) => T'.
     var r7b = r7.then(sIPromise, sIPromise, sIPromise).then(sIPromise, sIPromise, sIPromise); // ok
     var s7: Promise<string>;
     var s7a = r7.then(testFunction7, testFunction7, testFunction7); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'cb' and 'value' are incompatible.
-!!! error TS2345:     Type '<T>(a: T) => T' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type '<T>(a: T) => T'.
     var s7b = r7.then(testFunction7P, testFunction7P, testFunction7P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
 !!! error TS2345:   Types of parameters 'cb' and 'value' are incompatible.
-!!! error TS2345:     Type '<T>(a: T) => T' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type '<T>(a: T) => T'.
     var s7c = r7.then(testFunction7P, testFunction7, testFunction7); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'cb' and 'value' are incompatible.
-!!! error TS2345:     Type '<T>(a: T) => T' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type '<T>(a: T) => T'.
     var s7d = r7.then(sPromise, sPromise, sPromise).then(sPromise, sPromise, sPromise); // ok?
     
     var r8: IPromise<number>;
@@ -316,7 +316,7 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2345: Argument of t
 !!! error TS2453:     Types of property 'then' are incompatible.
 !!! error TS2453:       Type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }' is not assignable to type '{ <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
 !!! error TS2453:         Types of parameters 'success' and 'success' are incompatible.
-!!! error TS2453:           Type '(value: string) => IPromise<any>' is not assignable to type '(value: number) => Promise<any>'.
+!!! error TS2453:           Type '(value: number) => Promise<any>' is not assignable to type '(value: string) => IPromise<any>'.
 !!! error TS2453:             Types of parameters 'value' and 'value' are incompatible.
 !!! error TS2453:               Type 'string' is not assignable to type 'number'.
     var s10g = s10.then(testFunctionP, nIPromise, sIPromise).then(sPromise, sIPromise, sIPromise); // ok
@@ -345,7 +345,7 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2345: Argument of t
 !!! error TS2345:     Types of property 'then' are incompatible.
 !!! error TS2345:       Type '{ <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }' is not assignable to type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }'.
 !!! error TS2345:         Types of parameters 'success' and 'success' are incompatible.
-!!! error TS2345:           Type '(value: number) => Promise<any>' is not assignable to type '(value: string) => IPromise<any>'.
+!!! error TS2345:           Type '(value: string) => IPromise<any>' is not assignable to type '(value: number) => Promise<any>'.
 !!! error TS2345:             Types of parameters 'value' and 'value' are incompatible.
 !!! error TS2345:               Type 'number' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/promisePermutations2.errors.txt
+++ b/tests/baselines/reference/promisePermutations2.errors.txt
@@ -1,18 +1,18 @@
 tests/cases/compiler/promisePermutations2.ts(73,70): error TS2345: Argument of type '(x: number) => IPromise<number>' is not assignable to parameter of type '(value: IPromise<number>) => IPromise<number>'.
   Types of parameters 'x' and 'value' are incompatible.
-    Type 'number' is not assignable to type 'IPromise<number>'.
+    Type 'IPromise<number>' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations2.ts(78,19): error TS2345: Argument of type '(x: number, y?: string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'x' and 'value' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations2.ts(81,19): error TS2345: Argument of type '(x: number, y?: string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'x' and 'value' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations2.ts(82,19): error TS2345: Argument of type '(x: number, y?: string) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
   Types of parameters 'x' and 'value' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations2.ts(83,19): error TS2345: Argument of type '(x: number, y?: string) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'x' and 'value' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations2.ts(87,19): error TS2345: Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 tests/cases/compiler/promisePermutations2.ts(90,19): error TS2345: Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 tests/cases/compiler/promisePermutations2.ts(91,19): error TS2345: Argument of type '(x: number, cb: (a: string) => string) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
@@ -23,16 +23,16 @@ tests/cases/compiler/promisePermutations2.ts(100,19): error TS2345: Argument of 
 tests/cases/compiler/promisePermutations2.ts(101,19): error TS2345: Argument of type '(x: number, cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 tests/cases/compiler/promisePermutations2.ts(105,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
-    Type '<T>(a: T) => T' is not assignable to type 'string'.
+    Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations2.ts(108,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
-    Type '<T>(a: T) => T' is not assignable to type 'string'.
+    Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations2.ts(109,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
-    Type '<T>(a: T) => T' is not assignable to type 'string'.
+    Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations2.ts(110,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
-    Type '<T>(a: T) => T' is not assignable to type 'string'.
+    Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations2.ts(116,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<number>'.
 tests/cases/compiler/promisePermutations2.ts(119,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<number>'.
 tests/cases/compiler/promisePermutations2.ts(120,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<number>'.
@@ -55,7 +55,7 @@ tests/cases/compiler/promisePermutations2.ts(151,12): error TS2453: The type arg
     Types of property 'then' are incompatible.
       Type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }' is not assignable to type '<U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void) => Promise<U>'.
         Types of parameters 'success' and 'success' are incompatible.
-          Type '(value: string) => IPromise<any>' is not assignable to type '(value: number) => any'.
+          Type '(value: number) => any' is not assignable to type '(value: string) => IPromise<any>'.
             Types of parameters 'value' and 'value' are incompatible.
               Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations2.ts(155,21): error TS2345: Argument of type '{ (x: number): IPromise<number>; (x: string): IPromise<string>; }' is not assignable to parameter of type '(value: number) => IPromise<string>'.
@@ -72,7 +72,7 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
     Types of property 'then' are incompatible.
       Type '<U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void) => Promise<U>' is not assignable to type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }'.
         Types of parameters 'success' and 'success' are incompatible.
-          Type '(value: number) => any' is not assignable to type '(value: string) => IPromise<any>'.
+          Type '(value: string) => IPromise<any>' is not assignable to type '(value: number) => any'.
             Types of parameters 'value' and 'value' are incompatible.
               Type 'number' is not assignable to type 'string'.
 
@@ -154,7 +154,7 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
                                                                          ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number) => IPromise<number>' is not assignable to parameter of type '(value: IPromise<number>) => IPromise<number>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type 'IPromise<number>'.
+!!! error TS2345:     Type 'IPromise<number>' is not assignable to type 'number'.
     
     var r4: IPromise<string>;
     var sIPromise: (x: any) => IPromise<string>;
@@ -163,24 +163,24 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, y?: string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
     var r4b = r4.then(sIPromise, testFunction4, testFunction4).then(sIPromise, testFunction4, testFunction4); // ok
     var s4: Promise<string>;
     var s4a = s4.then(testFunction4, testFunction4, testFunction4); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, y?: string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
     var s4b = s4.then(testFunction4P, testFunction4P, testFunction4P); // error 
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, y?: string) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
     var s4c = s4.then(testFunction4P, testFunction4, testFunction4); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, y?: string) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
     var s4d = s4.then(sIPromise, testFunction4P, testFunction4).then(sIPromise, testFunction4P, testFunction4);
     
     var r5: IPromise<string>;
@@ -222,24 +222,24 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'cb' and 'value' are incompatible.
-!!! error TS2345:     Type '<T>(a: T) => T' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type '<T>(a: T) => T'.
     var r7b = r7.then(sIPromise, sIPromise, sIPromise).then(sIPromise, sIPromise, sIPromise); // ok
     var s7: Promise<string>;
     var s7a = r7.then(testFunction7, testFunction7, testFunction7); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'cb' and 'value' are incompatible.
-!!! error TS2345:     Type '<T>(a: T) => T' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type '<T>(a: T) => T'.
     var s7b = r7.then(testFunction7P, testFunction7P, testFunction7P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
 !!! error TS2345:   Types of parameters 'cb' and 'value' are incompatible.
-!!! error TS2345:     Type '<T>(a: T) => T' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type '<T>(a: T) => T'.
     var s7c = r7.then(testFunction7P, testFunction7, testFunction7); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'cb' and 'value' are incompatible.
-!!! error TS2345:     Type '<T>(a: T) => T' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type '<T>(a: T) => T'.
     var s7d = r7.then(sPromise, sPromise, sPromise).then(sPromise, sPromise, sPromise); // ok?
     
     var r8: IPromise<number>;
@@ -315,7 +315,7 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
 !!! error TS2453:     Types of property 'then' are incompatible.
 !!! error TS2453:       Type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }' is not assignable to type '<U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void) => Promise<U>'.
 !!! error TS2453:         Types of parameters 'success' and 'success' are incompatible.
-!!! error TS2453:           Type '(value: string) => IPromise<any>' is not assignable to type '(value: number) => any'.
+!!! error TS2453:           Type '(value: number) => any' is not assignable to type '(value: string) => IPromise<any>'.
 !!! error TS2453:             Types of parameters 'value' and 'value' are incompatible.
 !!! error TS2453:               Type 'string' is not assignable to type 'number'.
     var s10g = s10.then(testFunctionP, nIPromise, sIPromise).then(sPromise, sIPromise, sIPromise); // ok
@@ -344,7 +344,7 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
 !!! error TS2345:     Types of property 'then' are incompatible.
 !!! error TS2345:       Type '<U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void) => Promise<U>' is not assignable to type '{ <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }'.
 !!! error TS2345:         Types of parameters 'success' and 'success' are incompatible.
-!!! error TS2345:           Type '(value: number) => any' is not assignable to type '(value: string) => IPromise<any>'.
+!!! error TS2345:           Type '(value: string) => IPromise<any>' is not assignable to type '(value: number) => any'.
 !!! error TS2345:             Types of parameters 'value' and 'value' are incompatible.
 !!! error TS2345:               Type 'number' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/promisePermutations3.errors.txt
+++ b/tests/baselines/reference/promisePermutations3.errors.txt
@@ -1,21 +1,21 @@
 tests/cases/compiler/promisePermutations3.ts(68,69): error TS2345: Argument of type '(x: number) => IPromise<number>' is not assignable to parameter of type '(value: IPromise<number>) => IPromise<number>'.
   Types of parameters 'x' and 'value' are incompatible.
-    Type 'number' is not assignable to type 'IPromise<number>'.
+    Type 'IPromise<number>' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations3.ts(73,70): error TS2345: Argument of type '(x: number) => IPromise<number>' is not assignable to parameter of type '(value: IPromise<number>) => IPromise<number>'.
   Types of parameters 'x' and 'value' are incompatible.
-    Type 'number' is not assignable to type 'IPromise<number>'.
+    Type 'IPromise<number>' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations3.ts(78,19): error TS2345: Argument of type '(x: number, y?: string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'x' and 'value' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations3.ts(81,19): error TS2345: Argument of type '(x: number, y?: string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'x' and 'value' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations3.ts(82,19): error TS2345: Argument of type '(x: number, y?: string) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
   Types of parameters 'x' and 'value' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations3.ts(83,19): error TS2345: Argument of type '(x: number, y?: string) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'x' and 'value' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+    Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations3.ts(87,19): error TS2345: Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 tests/cases/compiler/promisePermutations3.ts(90,19): error TS2345: Argument of type '(x: number, cb: (a: string) => string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 tests/cases/compiler/promisePermutations3.ts(91,19): error TS2345: Argument of type '(x: number, cb: (a: string) => string) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
@@ -26,16 +26,16 @@ tests/cases/compiler/promisePermutations3.ts(100,19): error TS2345: Argument of 
 tests/cases/compiler/promisePermutations3.ts(101,19): error TS2345: Argument of type '(x: number, cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 tests/cases/compiler/promisePermutations3.ts(105,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
-    Type '<T>(a: T) => T' is not assignable to type 'string'.
+    Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations3.ts(108,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
-    Type '<T>(a: T) => T' is not assignable to type 'string'.
+    Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations3.ts(109,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
-    Type '<T>(a: T) => T' is not assignable to type 'string'.
+    Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations3.ts(110,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
-    Type '<T>(a: T) => T' is not assignable to type 'string'.
+    Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations3.ts(116,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<number>'.
 tests/cases/compiler/promisePermutations3.ts(119,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => IPromise<T>' is not assignable to parameter of type '(value: number) => IPromise<number>'.
 tests/cases/compiler/promisePermutations3.ts(120,19): error TS2345: Argument of type '<T>(x: T, cb: (a: T) => T) => Promise<T>' is not assignable to parameter of type '(value: number) => Promise<number>'.
@@ -58,7 +58,7 @@ tests/cases/compiler/promisePermutations3.ts(151,12): error TS2453: The type arg
     Types of property 'then' are incompatible.
       Type '<U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void) => IPromise<U>' is not assignable to type '{ <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
         Types of parameters 'success' and 'success' are incompatible.
-          Type '(value: string) => any' is not assignable to type '(value: number) => Promise<any>'.
+          Type '(value: number) => Promise<any>' is not assignable to type '(value: string) => any'.
             Types of parameters 'value' and 'value' are incompatible.
               Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/promisePermutations3.ts(155,21): error TS2345: Argument of type '{ (x: number): IPromise<number>; (x: string): IPromise<string>; }' is not assignable to parameter of type '(value: number) => IPromise<string>'.
@@ -75,7 +75,7 @@ tests/cases/compiler/promisePermutations3.ts(159,21): error TS2345: Argument of 
     Types of property 'then' are incompatible.
       Type '{ <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }' is not assignable to type '<U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void) => IPromise<U>'.
         Types of parameters 'success' and 'success' are incompatible.
-          Type '(value: number) => Promise<any>' is not assignable to type '(value: string) => any'.
+          Type '(value: string) => any' is not assignable to type '(value: number) => Promise<any>'.
             Types of parameters 'value' and 'value' are incompatible.
               Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of type '{ <T>(x: T): IPromise<T>; <T>(x: T, y: T): Promise<T>; }' is not assignable to parameter of type '(value: (x: any) => any) => Promise<any>'.
@@ -157,7 +157,7 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
                                                                         ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number) => IPromise<number>' is not assignable to parameter of type '(value: IPromise<number>) => IPromise<number>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type 'IPromise<number>'.
+!!! error TS2345:     Type 'IPromise<number>' is not assignable to type 'number'.
     var s3: Promise<number>;
     var s3a = s3.then(testFunction3, testFunction3, testFunction3);
     var s3b = s3.then(testFunction3P, testFunction3P, testFunction3P);
@@ -166,7 +166,7 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
                                                                          ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number) => IPromise<number>' is not assignable to parameter of type '(value: IPromise<number>) => IPromise<number>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type 'IPromise<number>'.
+!!! error TS2345:     Type 'IPromise<number>' is not assignable to type 'number'.
     
     var r4: IPromise<string>;
     var sIPromise: (x: any) => IPromise<string>;
@@ -175,24 +175,24 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, y?: string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
     var r4b = r4.then(sIPromise, testFunction4, testFunction4).then(sIPromise, testFunction4, testFunction4); // ok
     var s4: Promise<string>;
     var s4a = s4.then(testFunction4, testFunction4, testFunction4); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, y?: string) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
     var s4b = s4.then(testFunction4P, testFunction4P, testFunction4P); // error 
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, y?: string) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
     var s4c = s4.then(testFunction4P, testFunction4, testFunction4); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: number, y?: string) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'x' and 'value' are incompatible.
-!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
     var s4d = s4.then(sIPromise, testFunction4P, testFunction4).then(sIPromise, testFunction4P, testFunction4);
     
     var r5: IPromise<string>;
@@ -234,24 +234,24 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'cb' and 'value' are incompatible.
-!!! error TS2345:     Type '<T>(a: T) => T' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type '<T>(a: T) => T'.
     var r7b = r7.then(sIPromise, sIPromise, sIPromise).then(sIPromise, sIPromise, sIPromise); // ok
     var s7: Promise<string>;
     var s7a = r7.then(testFunction7, testFunction7, testFunction7); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'cb' and 'value' are incompatible.
-!!! error TS2345:     Type '<T>(a: T) => T' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type '<T>(a: T) => T'.
     var s7b = r7.then(testFunction7P, testFunction7P, testFunction7P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
 !!! error TS2345:   Types of parameters 'cb' and 'value' are incompatible.
-!!! error TS2345:     Type '<T>(a: T) => T' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type '<T>(a: T) => T'.
     var s7c = r7.then(testFunction7P, testFunction7, testFunction7); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
 !!! error TS2345:   Types of parameters 'cb' and 'value' are incompatible.
-!!! error TS2345:     Type '<T>(a: T) => T' is not assignable to type 'string'.
+!!! error TS2345:     Type 'string' is not assignable to type '<T>(a: T) => T'.
     var s7d = r7.then(sPromise, sPromise, sPromise).then(sPromise, sPromise, sPromise); // ok?
     
     var r8: IPromise<number>;
@@ -327,7 +327,7 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
 !!! error TS2453:     Types of property 'then' are incompatible.
 !!! error TS2453:       Type '<U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void) => IPromise<U>' is not assignable to type '{ <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
 !!! error TS2453:         Types of parameters 'success' and 'success' are incompatible.
-!!! error TS2453:           Type '(value: string) => any' is not assignable to type '(value: number) => Promise<any>'.
+!!! error TS2453:           Type '(value: number) => Promise<any>' is not assignable to type '(value: string) => any'.
 !!! error TS2453:             Types of parameters 'value' and 'value' are incompatible.
 !!! error TS2453:               Type 'string' is not assignable to type 'number'.
     var s10g = s10.then(testFunctionP, nIPromise, sIPromise).then(sPromise, sIPromise, sIPromise); // ok
@@ -356,7 +356,7 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
 !!! error TS2345:     Types of property 'then' are incompatible.
 !!! error TS2345:       Type '{ <U>(success?: (value: number) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: number) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }' is not assignable to type '<U>(success?: (value: string) => U, error?: (error: any) => U, progress?: (progress: any) => void) => IPromise<U>'.
 !!! error TS2345:         Types of parameters 'success' and 'success' are incompatible.
-!!! error TS2345:           Type '(value: number) => Promise<any>' is not assignable to type '(value: string) => any'.
+!!! error TS2345:           Type '(value: string) => any' is not assignable to type '(value: number) => Promise<any>'.
 !!! error TS2345:             Types of parameters 'value' and 'value' are incompatible.
 !!! error TS2345:               Type 'number' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/restArgAssignmentCompat.errors.txt
+++ b/tests/baselines/reference/restArgAssignmentCompat.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/restArgAssignmentCompat.ts(7,1): error TS2322: Type '(...x: number[]) => void' is not assignable to type '(x: number[], y: string) => void'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'number' is not assignable to type 'number[]'.
+    Type 'number[]' is not assignable to type 'number'.
 
 
 ==== tests/cases/compiler/restArgAssignmentCompat.ts (1 errors) ====
@@ -14,6 +14,6 @@ tests/cases/compiler/restArgAssignmentCompat.ts(7,1): error TS2322: Type '(...x:
     ~
 !!! error TS2322: Type '(...x: number[]) => void' is not assignable to type '(x: number[], y: string) => void'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'number[]'.
+!!! error TS2322:     Type 'number[]' is not assignable to type 'number'.
     n([4], 'foo');
     

--- a/tests/baselines/reference/stringLiteralTypesOverloadAssignability01.errors.txt
+++ b/tests/baselines/reference/stringLiteralTypesOverloadAssignability01.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability01.ts(15,1): error TS2322: Type '(x: "bar") => number' is not assignable to type '(x: "foo") => number'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type '"bar"' is not assignable to type '"foo"'.
+    Type '"foo"' is not assignable to type '"bar"'.
 tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability01.ts(16,1): error TS2322: Type '(x: "foo") => number' is not assignable to type '(x: "bar") => number'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type '"foo"' is not assignable to type '"bar"'.
+    Type '"bar"' is not assignable to type '"foo"'.
 
 
 ==== tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability01.ts (2 errors) ====
@@ -25,9 +25,9 @@ tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignabil
     ~
 !!! error TS2322: Type '(x: "bar") => number' is not assignable to type '(x: "foo") => number'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type '"bar"' is not assignable to type '"foo"'.
+!!! error TS2322:     Type '"foo"' is not assignable to type '"bar"'.
     b = a;
     ~
 !!! error TS2322: Type '(x: "foo") => number' is not assignable to type '(x: "bar") => number'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type '"foo"' is not assignable to type '"bar"'.
+!!! error TS2322:     Type '"bar"' is not assignable to type '"foo"'.

--- a/tests/baselines/reference/stringLiteralTypesOverloadAssignability02.errors.txt
+++ b/tests/baselines/reference/stringLiteralTypesOverloadAssignability02.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability02.ts(15,1): error TS2322: Type '(x: "bar") => number' is not assignable to type '(x: "foo") => number'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type '"bar"' is not assignable to type '"foo"'.
+    Type '"foo"' is not assignable to type '"bar"'.
 tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability02.ts(16,1): error TS2322: Type '(x: "foo") => number' is not assignable to type '(x: "bar") => number'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type '"foo"' is not assignable to type '"bar"'.
+    Type '"bar"' is not assignable to type '"foo"'.
 
 
 ==== tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignability02.ts (2 errors) ====
@@ -25,9 +25,9 @@ tests/cases/conformance/types/stringLiteral/stringLiteralTypesOverloadAssignabil
     ~
 !!! error TS2322: Type '(x: "bar") => number' is not assignable to type '(x: "foo") => number'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type '"bar"' is not assignable to type '"foo"'.
+!!! error TS2322:     Type '"foo"' is not assignable to type '"bar"'.
     b = a;
     ~
 !!! error TS2322: Type '(x: "foo") => number' is not assignable to type '(x: "bar") => number'.
 !!! error TS2322:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2322:     Type '"foo"' is not assignable to type '"bar"'.
+!!! error TS2322:     Type '"bar"' is not assignable to type '"foo"'.

--- a/tests/baselines/reference/subtypingWithCallSignaturesWithRestParameters.errors.txt
+++ b/tests/baselines/reference/subtypingWithCallSignaturesWithRestParameters.errors.txt
@@ -2,57 +2,57 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
   Types of property 'a' are incompatible.
     Type '(...args: string[]) => number' is not assignable to type '(...args: number[]) => number'.
       Types of parameters 'args' and 'args' are incompatible.
-        Type 'string' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithRestParameters.ts(34,11): error TS2430: Interface 'I3B' incorrectly extends interface 'Base'.
   Types of property 'a' are incompatible.
     Type '(x?: string) => number' is not assignable to type '(...args: number[]) => number'.
       Types of parameters 'x' and 'args' are incompatible.
-        Type 'string' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithRestParameters.ts(60,11): error TS2430: Interface 'I6C' incorrectly extends interface 'Base'.
   Types of property 'a2' are incompatible.
     Type '(x: number, ...args: string[]) => number' is not assignable to type '(x: number, ...z: number[]) => number'.
       Types of parameters 'args' and 'z' are incompatible.
-        Type 'string' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithRestParameters.ts(90,11): error TS2430: Interface 'I10B' incorrectly extends interface 'Base'.
   Types of property 'a3' are incompatible.
     Type '(x: number, y?: number, z?: number) => number' is not assignable to type '(x: number, y?: string, ...z: number[]) => number'.
       Types of parameters 'y' and 'y' are incompatible.
-        Type 'number' is not assignable to type 'string'.
+        Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithRestParameters.ts(94,11): error TS2430: Interface 'I10C' incorrectly extends interface 'Base'.
   Types of property 'a3' are incompatible.
     Type '(x: number, ...z: number[]) => number' is not assignable to type '(x: number, y?: string, ...z: number[]) => number'.
       Types of parameters 'z' and 'y' are incompatible.
-        Type 'number' is not assignable to type 'string'.
+        Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithRestParameters.ts(98,11): error TS2430: Interface 'I10D' incorrectly extends interface 'Base'.
   Types of property 'a3' are incompatible.
     Type '(x: string, y?: string, z?: string) => number' is not assignable to type '(x: number, y?: string, ...z: number[]) => number'.
       Types of parameters 'x' and 'x' are incompatible.
-        Type 'string' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithRestParameters.ts(102,11): error TS2430: Interface 'I10E' incorrectly extends interface 'Base'.
   Types of property 'a3' are incompatible.
     Type '(x: number, ...z: string[]) => number' is not assignable to type '(x: number, y?: string, ...z: number[]) => number'.
       Types of parameters 'z' and 'z' are incompatible.
-        Type 'string' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithRestParameters.ts(110,11): error TS2430: Interface 'I12' incorrectly extends interface 'Base'.
   Types of property 'a4' are incompatible.
     Type '(x?: number, y?: number) => number' is not assignable to type '(x?: number, y?: string, ...z: number[]) => number'.
       Types of parameters 'y' and 'y' are incompatible.
-        Type 'number' is not assignable to type 'string'.
+        Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithRestParameters.ts(118,11): error TS2430: Interface 'I14' incorrectly extends interface 'Base'.
   Types of property 'a4' are incompatible.
     Type '(x: number, y?: number) => number' is not assignable to type '(x?: number, y?: string, ...z: number[]) => number'.
       Types of parameters 'y' and 'y' are incompatible.
-        Type 'number' is not assignable to type 'string'.
+        Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithRestParameters.ts(126,11): error TS2430: Interface 'I16' incorrectly extends interface 'Base'.
   Types of property 'a4' are incompatible.
     Type '(x: number, ...args: string[]) => number' is not assignable to type '(x?: number, y?: string, ...z: number[]) => number'.
       Types of parameters 'args' and 'z' are incompatible.
-        Type 'string' is not assignable to type 'number'.
+        Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithRestParameters.ts(130,11): error TS2430: Interface 'I17' incorrectly extends interface 'Base'.
   Types of property 'a4' are incompatible.
     Type '(...args: number[]) => number' is not assignable to type '(x?: number, y?: string, ...z: number[]) => number'.
       Types of parameters 'args' and 'y' are incompatible.
-        Type 'number' is not assignable to type 'string'.
+        Type 'string' is not assignable to type 'number'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingWithCallSignaturesWithRestParameters.ts (11 errors) ====
@@ -79,7 +79,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430:   Types of property 'a' are incompatible.
 !!! error TS2430:     Type '(...args: string[]) => number' is not assignable to type '(...args: number[]) => number'.
 !!! error TS2430:       Types of parameters 'args' and 'args' are incompatible.
-!!! error TS2430:         Type 'string' is not assignable to type 'number'.
+!!! error TS2430:         Type 'number' is not assignable to type 'string'.
         a: (...args: string[]) => number; // error, type mismatch
     }
     
@@ -101,7 +101,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430:   Types of property 'a' are incompatible.
 !!! error TS2430:     Type '(x?: string) => number' is not assignable to type '(...args: number[]) => number'.
 !!! error TS2430:       Types of parameters 'x' and 'args' are incompatible.
-!!! error TS2430:         Type 'string' is not assignable to type 'number'.
+!!! error TS2430:         Type 'number' is not assignable to type 'string'.
         a: (x?: string) => number; // error, incompatible type
     }
     
@@ -133,7 +133,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430:   Types of property 'a2' are incompatible.
 !!! error TS2430:     Type '(x: number, ...args: string[]) => number' is not assignable to type '(x: number, ...z: number[]) => number'.
 !!! error TS2430:       Types of parameters 'args' and 'z' are incompatible.
-!!! error TS2430:         Type 'string' is not assignable to type 'number'.
+!!! error TS2430:         Type 'number' is not assignable to type 'string'.
         a2: (x: number, ...args: string[]) => number; // error
     }
     
@@ -169,7 +169,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430:   Types of property 'a3' are incompatible.
 !!! error TS2430:     Type '(x: number, y?: number, z?: number) => number' is not assignable to type '(x: number, y?: string, ...z: number[]) => number'.
 !!! error TS2430:       Types of parameters 'y' and 'y' are incompatible.
-!!! error TS2430:         Type 'number' is not assignable to type 'string'.
+!!! error TS2430:         Type 'string' is not assignable to type 'number'.
         a3: (x: number, y?: number, z?: number) => number;  // error
     }
     
@@ -179,7 +179,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430:   Types of property 'a3' are incompatible.
 !!! error TS2430:     Type '(x: number, ...z: number[]) => number' is not assignable to type '(x: number, y?: string, ...z: number[]) => number'.
 !!! error TS2430:       Types of parameters 'z' and 'y' are incompatible.
-!!! error TS2430:         Type 'number' is not assignable to type 'string'.
+!!! error TS2430:         Type 'string' is not assignable to type 'number'.
         a3: (x: number, ...z: number[]) => number;  // error
     }
     
@@ -189,7 +189,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430:   Types of property 'a3' are incompatible.
 !!! error TS2430:     Type '(x: string, y?: string, z?: string) => number' is not assignable to type '(x: number, y?: string, ...z: number[]) => number'.
 !!! error TS2430:       Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2430:         Type 'string' is not assignable to type 'number'.
+!!! error TS2430:         Type 'number' is not assignable to type 'string'.
         a3: (x: string, y?: string, z?: string) => number;  // error, incompatible types
     }
     
@@ -199,7 +199,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430:   Types of property 'a3' are incompatible.
 !!! error TS2430:     Type '(x: number, ...z: string[]) => number' is not assignable to type '(x: number, y?: string, ...z: number[]) => number'.
 !!! error TS2430:       Types of parameters 'z' and 'z' are incompatible.
-!!! error TS2430:         Type 'string' is not assignable to type 'number'.
+!!! error TS2430:         Type 'number' is not assignable to type 'string'.
         a3: (x: number, ...z: string[]) => number;  // error
     }
     
@@ -213,7 +213,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430:   Types of property 'a4' are incompatible.
 !!! error TS2430:     Type '(x?: number, y?: number) => number' is not assignable to type '(x?: number, y?: string, ...z: number[]) => number'.
 !!! error TS2430:       Types of parameters 'y' and 'y' are incompatible.
-!!! error TS2430:         Type 'number' is not assignable to type 'string'.
+!!! error TS2430:         Type 'string' is not assignable to type 'number'.
         a4: (x?: number, y?: number) => number; // error, type mismatch
     }
     
@@ -227,7 +227,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430:   Types of property 'a4' are incompatible.
 !!! error TS2430:     Type '(x: number, y?: number) => number' is not assignable to type '(x?: number, y?: string, ...z: number[]) => number'.
 !!! error TS2430:       Types of parameters 'y' and 'y' are incompatible.
-!!! error TS2430:         Type 'number' is not assignable to type 'string'.
+!!! error TS2430:         Type 'string' is not assignable to type 'number'.
         a4: (x: number, y?: number) => number;  // error, second param has type mismatch
     }
     
@@ -241,7 +241,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430:   Types of property 'a4' are incompatible.
 !!! error TS2430:     Type '(x: number, ...args: string[]) => number' is not assignable to type '(x?: number, y?: string, ...z: number[]) => number'.
 !!! error TS2430:       Types of parameters 'args' and 'z' are incompatible.
-!!! error TS2430:         Type 'string' is not assignable to type 'number'.
+!!! error TS2430:         Type 'number' is not assignable to type 'string'.
         a4: (x: number, ...args: string[]) => number;  // error, rest param has type mismatch
     }
     
@@ -251,7 +251,7 @@ tests/cases/conformance/types/typeRelationships/subtypesAndSuperTypes/subtypingW
 !!! error TS2430:   Types of property 'a4' are incompatible.
 !!! error TS2430:     Type '(...args: number[]) => number' is not assignable to type '(x?: number, y?: string, ...z: number[]) => number'.
 !!! error TS2430:       Types of parameters 'args' and 'y' are incompatible.
-!!! error TS2430:         Type 'number' is not assignable to type 'string'.
+!!! error TS2430:         Type 'string' is not assignable to type 'number'.
         a4: (...args: number[]) => number; // error
     }
     

--- a/tests/baselines/reference/typeArgumentInferenceConstructSignatures.errors.txt
+++ b/tests/baselines/reference/typeArgumentInferenceConstructSignatures.errors.txt
@@ -2,13 +2,13 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstruct
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(51,19): error TS2304: Cannot find name 'Window'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(61,39): error TS2345: Argument of type '(x: string) => string' is not assignable to parameter of type '(x: number) => void'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(71,39): error TS2345: Argument of type '(x: string) => string' is not assignable to parameter of type '(x: number) => void'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(81,45): error TS2345: Argument of type '(n: string) => string' is not assignable to parameter of type '(b: number) => number'.
   Types of parameters 'n' and 'b' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(106,15): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'string' is not a valid type argument because it is not a supertype of candidate 'number'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstructSignatures.ts(118,9): error TS2304: Cannot find name 'Window'.
@@ -90,7 +90,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstruct
                                           ~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: string) => string' is not assignable to parameter of type '(x: number) => void'.
 !!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
     new someGenerics4<string, number>(null, null);
     
     // 2 parameter generic call with argument 2 of type parameter type and argument 1 of function type whose parameter is of type parameter type
@@ -104,7 +104,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstruct
                                           ~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: string) => string' is not assignable to parameter of type '(x: number) => void'.
 !!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
     new someGenerics5<string, number>(null, null);
     
     // Generic call with multiple arguments of function types that each have parameters of the same generic type
@@ -118,7 +118,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceConstruct
                                                 ~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(n: string) => string' is not assignable to parameter of type '(b: number) => number'.
 !!! error TS2345:   Types of parameters 'n' and 'b' are incompatible.
-!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
     new someGenerics6<number>((n: number) => n, (n: number) => n, (n: number) => n);
     
     // Generic call with multiple arguments of function types that each have parameters of different generic type

--- a/tests/baselines/reference/typeArgumentInferenceErrors.errors.txt
+++ b/tests/baselines/reference/typeArgumentInferenceErrors.errors.txt
@@ -1,13 +1,13 @@
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceErrors.ts(3,31): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceErrors.ts(7,35): error TS2345: Argument of type '(x: string) => string' is not assignable to parameter of type '(x: number) => void'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceErrors.ts(11,35): error TS2345: Argument of type '(x: string) => string' is not assignable to parameter of type '(x: number) => void'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceErrors.ts(15,41): error TS2345: Argument of type '(n: string) => string' is not assignable to parameter of type '(b: number) => number'.
   Types of parameters 'n' and 'b' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceErrors.ts (4 errors) ====
@@ -23,7 +23,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceErrors.ts
                                       ~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: string) => string' is not assignable to parameter of type '(x: number) => void'.
 !!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
     
     // 2 parameter generic call with argument 2 of type parameter type and argument 1 of function type whose parameter is of type parameter type
     function someGenerics5<U, T>(n: T, f: (x: U) => void) { }
@@ -31,7 +31,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceErrors.ts
                                       ~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: string) => string' is not assignable to parameter of type '(x: number) => void'.
 !!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
     
     // Generic call with multiple arguments of function types that each have parameters of the same generic type
     function someGenerics6<A>(a: (a: A) => A, b: (b: A) => A, c: (c: A) => A) { }
@@ -39,5 +39,5 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceErrors.ts
                                             ~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(n: string) => string' is not assignable to parameter of type '(b: number) => number'.
 !!! error TS2345:   Types of parameters 'n' and 'b' are incompatible.
-!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
     

--- a/tests/baselines/reference/typeArgumentInferenceWithConstraints.errors.txt
+++ b/tests/baselines/reference/typeArgumentInferenceWithConstraints.errors.txt
@@ -5,14 +5,14 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConst
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(34,15): error TS2304: Cannot find name 'Window'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(41,35): error TS2345: Argument of type '(x: string) => string' is not assignable to parameter of type '(x: number) => void'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(48,35): error TS2345: Argument of type '(x: string) => string' is not assignable to parameter of type '(x: number) => void'.
   Types of parameters 'x' and 'x' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(49,15): error TS2344: Type 'string' does not satisfy the constraint 'number'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(55,41): error TS2345: Argument of type '(n: string) => string' is not assignable to parameter of type '(b: number) => number'.
   Types of parameters 'n' and 'b' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(66,31): error TS2345: Argument of type '<A, B extends string, C>(a: (a: A) => A, b: (b: B) => B, c: (c: C) => C) => void' is not assignable to parameter of type 'string'.
 tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConstraints.ts(73,11): error TS2453: The type argument for type parameter 'T' cannot be inferred from the usage. Consider specifying the type arguments explicitly.
   Type argument candidate 'string' is not a valid type argument because it is not a supertype of candidate 'number'.
@@ -81,7 +81,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConst
                                       ~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: string) => string' is not assignable to parameter of type '(x: number) => void'.
 !!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
     someGenerics4<string, number>(null, null);
     
     // 2 parameter generic call with argument 2 of type parameter type and argument 1 of function type whose parameter is of type parameter type
@@ -92,7 +92,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConst
                                       ~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(x: string) => string' is not assignable to parameter of type '(x: number) => void'.
 !!! error TS2345:   Types of parameters 'x' and 'x' are incompatible.
-!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
     someGenerics5<string, number>(null, null); // Error
                   ~~~~~~
 !!! error TS2344: Type 'string' does not satisfy the constraint 'number'.
@@ -105,7 +105,7 @@ tests/cases/conformance/expressions/functionCalls/typeArgumentInferenceWithConst
                                             ~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(n: string) => string' is not assignable to parameter of type '(b: number) => number'.
 !!! error TS2345:   Types of parameters 'n' and 'b' are incompatible.
-!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
     someGenerics6<number>((n: number) => n, (n: number) => n, (n: number) => n);
     
     // Generic call with multiple arguments of function types that each have parameters of different generic type

--- a/tests/baselines/reference/typeParameterArgumentEquivalence.errors.txt
+++ b/tests/baselines/reference/typeParameterArgumentEquivalence.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/compiler/typeParameterArgumentEquivalence.ts(4,5): error TS2322: Type '(item: T) => boolean' is not assignable to type '(item: number) => boolean'.
   Types of parameters 'item' and 'item' are incompatible.
-    Type 'T' is not assignable to type 'number'.
+    Type 'number' is not assignable to type 'T'.
 tests/cases/compiler/typeParameterArgumentEquivalence.ts(5,5): error TS2322: Type '(item: number) => boolean' is not assignable to type '(item: T) => boolean'.
   Types of parameters 'item' and 'item' are incompatible.
-    Type 'number' is not assignable to type 'T'.
+    Type 'T' is not assignable to type 'number'.
 
 
 ==== tests/cases/compiler/typeParameterArgumentEquivalence.ts (2 errors) ====
@@ -14,11 +14,11 @@ tests/cases/compiler/typeParameterArgumentEquivalence.ts(5,5): error TS2322: Typ
         ~
 !!! error TS2322: Type '(item: T) => boolean' is not assignable to type '(item: number) => boolean'.
 !!! error TS2322:   Types of parameters 'item' and 'item' are incompatible.
-!!! error TS2322:     Type 'T' is not assignable to type 'number'.
+!!! error TS2322:     Type 'number' is not assignable to type 'T'.
         y = x;  // Shound be an error
         ~
 !!! error TS2322: Type '(item: number) => boolean' is not assignable to type '(item: T) => boolean'.
 !!! error TS2322:   Types of parameters 'item' and 'item' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'T'.
+!!! error TS2322:     Type 'T' is not assignable to type 'number'.
     }
     

--- a/tests/baselines/reference/typeParameterArgumentEquivalence2.errors.txt
+++ b/tests/baselines/reference/typeParameterArgumentEquivalence2.errors.txt
@@ -1,9 +1,9 @@
 tests/cases/compiler/typeParameterArgumentEquivalence2.ts(4,5): error TS2322: Type '(item: T) => boolean' is not assignable to type '(item: U) => boolean'.
   Types of parameters 'item' and 'item' are incompatible.
-    Type 'T' is not assignable to type 'U'.
+    Type 'U' is not assignable to type 'T'.
 tests/cases/compiler/typeParameterArgumentEquivalence2.ts(5,5): error TS2322: Type '(item: U) => boolean' is not assignable to type '(item: T) => boolean'.
   Types of parameters 'item' and 'item' are incompatible.
-    Type 'U' is not assignable to type 'T'.
+    Type 'T' is not assignable to type 'U'.
 
 
 ==== tests/cases/compiler/typeParameterArgumentEquivalence2.ts (2 errors) ====
@@ -14,11 +14,11 @@ tests/cases/compiler/typeParameterArgumentEquivalence2.ts(5,5): error TS2322: Ty
         ~
 !!! error TS2322: Type '(item: T) => boolean' is not assignable to type '(item: U) => boolean'.
 !!! error TS2322:   Types of parameters 'item' and 'item' are incompatible.
-!!! error TS2322:     Type 'T' is not assignable to type 'U'.
+!!! error TS2322:     Type 'U' is not assignable to type 'T'.
         y = x;  // Shound be an error
         ~
 !!! error TS2322: Type '(item: U) => boolean' is not assignable to type '(item: T) => boolean'.
 !!! error TS2322:   Types of parameters 'item' and 'item' are incompatible.
-!!! error TS2322:     Type 'U' is not assignable to type 'T'.
+!!! error TS2322:     Type 'T' is not assignable to type 'U'.
     }
     


### PR DESCRIPTION
and report errors during contravariant check. This is partial rollback of 5e69332cdadc6e3922df2cef89069180fbe87e22 that introduced perf regressions #7293, #7082.

Note: errors in baselines has changed but personally I like new errors more since they more accurately reflect runtime behavior. I.e.
```ts
let a: (s: string) => void;
let b: (s: number) => void;
a = b;
// a("42");
```
used to be
```
t.ts(3,1): error TS2322: Type '(s: number) => void' is not assignable to type '(s: string) => void'.
  Types of parameters 's' and 's' are incompatible.
    Type 'number' is not assignable to type 'string'.
```
now
```
t.ts(3,1): error TS2322: Type '(s: number) => void' is not assignable to type '(s: string) => void'.
  Types of parameters 's' and 's' are incompatible.
    Type 'string' is not assignable to type 'number'.
```

In runtime `a` will have argument of type `string` that is not assignable to type `number` that is expected by `b` and this is exactly what is said in new error message.
