### PR TITLE
Added new diagnostics message to clarify error for type guards

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11815,9 +11815,12 @@ namespace ts {
                             Diagnostics.A_type_predicate_cannot_reference_a_rest_parameter);
                     }
                     else {
+                        const leadingError = chainDiagnosticMessages(undefined, Diagnostics.A_type_predicate_s_type_must_be_assignable_to_its_parameter_s_type);
                         checkTypeAssignableTo(typePredicate.type,
                             getTypeOfNode(parent.parameters[typePredicate.parameterIndex]),
-                            node.type);
+                            node.type,
+                            /*headMessage*/ undefined,
+                            leadingError);
                     }
                 }
                 else if (parameterName) {

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1847,6 +1847,10 @@
         "category": "Error",
         "code": 2676
     },
+    "A type predicate's type must be assignable to its parameter's type.": {
+        "category": "Error",
+        "code": 2677
+    },
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",
         "code": 4000

--- a/tests/baselines/reference/typeGuardFunctionErrors.errors.txt
+++ b/tests/baselines/reference/typeGuardFunctionErrors.errors.txt
@@ -12,10 +12,13 @@ tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(31,5):
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(31,5): error TS7027: Unreachable code detected.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(32,1): error TS1128: Declaration or statement expected.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(34,38): error TS1225: Cannot find parameter 'x'.
-tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(38,51): error TS2322: Type 'B' is not assignable to type 'A'.
-  Property 'propA' is missing in type 'B'.
-tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(42,56): error TS2322: Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(46,56): error TS2322: Type 'T[]' is not assignable to type 'string'.
+tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(38,51): error TS2677: A type predicate's type must be assignable to its parameter's type.
+  Type 'B' is not assignable to type 'A'.
+    Property 'propA' is missing in type 'B'.
+tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(42,56): error TS2677: A type predicate's type must be assignable to its parameter's type.
+  Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(46,56): error TS2677: A type predicate's type must be assignable to its parameter's type.
+  Type 'T[]' is not assignable to type 'string'.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(60,7): error TS2339: Property 'propB' does not exist on type 'A'.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(65,7): error TS2339: Property 'propB' does not exist on type 'A'.
 tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(70,7): error TS2339: Property 'propB' does not exist on type 'A'.
@@ -129,20 +132,23 @@ tests/cases/conformance/expressions/typeGuards/typeGuardFunctionErrors.ts(137,39
     
     function hasNonMatchingParameterType1(x: A): x is B {
                                                       ~
-!!! error TS2322: Type 'B' is not assignable to type 'A'.
-!!! error TS2322:   Property 'propA' is missing in type 'B'.
+!!! error TS2677: A type predicate's type must be assignable to its parameter's type.
+!!! error TS2677:   Type 'B' is not assignable to type 'A'.
+!!! error TS2677:     Property 'propA' is missing in type 'B'.
         return true;
     }
     
     function hasNonMatchingParameterType2(x: string): x is number {
                                                            ~~~~~~
-!!! error TS2322: Type 'number' is not assignable to type 'string'.
+!!! error TS2677: A type predicate's type must be assignable to its parameter's type.
+!!! error TS2677:   Type 'number' is not assignable to type 'string'.
         return true;
     }
     
     function hasNonMathcingGenericType<T>(a: string): a is T[] {
                                                            ~~~
-!!! error TS2322: Type 'T[]' is not assignable to type 'string'.
+!!! error TS2677: A type predicate's type must be assignable to its parameter's type.
+!!! error TS2677:   Type 'T[]' is not assignable to type 'string'.
         return true;
     }
     


### PR DESCRIPTION
Fixes #6540 

New diagnostics message "A type guard's type must be assignable to its parameter's type." number 2677
is now using in chain report to clarify vague error message for type guards.