### PR TITLE
fix(build) `TypingResolutionHost` interface is used by exported function `discoverTypings`

### DIFF
--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -6,7 +6,7 @@
 /* @internal */
 namespace ts.JsTyping {
 
-    interface TypingResolutionHost {
+    export interface TypingResolutionHost {
         directoryExists: (path: string) => boolean;
         fileExists: (fileName: string) => boolean;
         readFile: (path: string, encoding?: string) => string;


### PR DESCRIPTION
Causes nTypeScript build to fail : https://travis-ci.org/TypeStrong/ntypescript/builds/113266089#L327  :rose: 

Similar to https://github.com/Microsoft/TypeScript/pull/4815