### PR TITLE
in noImplicitReturns mode, also disallow "return;"

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13842,11 +13842,11 @@ namespace ts {
                 }
             }
 
-            if (node.expression) {
-                const func = getContainingFunction(node);
-                if (func) {
-                    const signature = getSignatureFromDeclaration(func);
-                    const returnType = getReturnTypeOfSignature(signature);
+            const func = getContainingFunction(node);
+            if (func) {
+                const signature = getSignatureFromDeclaration(func);
+                const returnType = getReturnTypeOfSignature(signature);
+                if (node.expression) {
                     const exprType = checkExpressionCached(node.expression);
 
                     if (func.asteriskToken) {
@@ -13880,6 +13880,10 @@ namespace ts {
                             checkTypeAssignableTo(exprType, returnType, node.expression);
                         }
                     }
+                }
+                else if (compilerOptions.noImplicitReturns && !maybeTypeOfKind(returnType, TypeFlags.Void | TypeFlags.Any)) {
+                    // The function has a return type, but the return statement doesn't have an expression.
+                    error(node, Diagnostics.Not_all_code_paths_return_a_value);
                 }
             }
         }

--- a/tests/baselines/reference/noImplicitReturnsWithoutReturnExpression.errors.txt
+++ b/tests/baselines/reference/noImplicitReturnsWithoutReturnExpression.errors.txt
@@ -1,0 +1,34 @@
+tests/cases/compiler/noImplicitReturnsWithoutReturnExpression.ts(2,5): error TS7030: Not all code paths return a value.
+tests/cases/compiler/noImplicitReturnsWithoutReturnExpression.ts(22,9): error TS7030: Not all code paths return a value.
+
+
+==== tests/cases/compiler/noImplicitReturnsWithoutReturnExpression.ts (2 errors) ====
+    function isMissingReturnExpression(): number {
+        return;
+        ~~~~~~~
+!!! error TS7030: Not all code paths return a value.
+    }
+    
+    function isMissingReturnExpression2(): any {
+        return;
+    }
+    
+    function isMissingReturnExpression3(): number|void {
+        return;
+    }
+    
+    function isMissingReturnExpression4(): void {
+        return;
+    }
+    
+    function isMissingReturnExpression5(x) {
+        if (x) {
+            return 0;
+        }
+        else {
+            return;
+            ~~~~~~~
+!!! error TS7030: Not all code paths return a value.
+        }
+    }
+    

--- a/tests/baselines/reference/noImplicitReturnsWithoutReturnExpression.js
+++ b/tests/baselines/reference/noImplicitReturnsWithoutReturnExpression.js
@@ -1,0 +1,48 @@
+//// [noImplicitReturnsWithoutReturnExpression.ts]
+function isMissingReturnExpression(): number {
+    return;
+}
+
+function isMissingReturnExpression2(): any {
+    return;
+}
+
+function isMissingReturnExpression3(): number|void {
+    return;
+}
+
+function isMissingReturnExpression4(): void {
+    return;
+}
+
+function isMissingReturnExpression5(x) {
+    if (x) {
+        return 0;
+    }
+    else {
+        return;
+    }
+}
+
+
+//// [noImplicitReturnsWithoutReturnExpression.js]
+function isMissingReturnExpression() {
+    return;
+}
+function isMissingReturnExpression2() {
+    return;
+}
+function isMissingReturnExpression3() {
+    return;
+}
+function isMissingReturnExpression4() {
+    return;
+}
+function isMissingReturnExpression5(x) {
+    if (x) {
+        return 0;
+    }
+    else {
+        return;
+    }
+}

--- a/tests/cases/compiler/noImplicitReturnsWithoutReturnExpression.ts
+++ b/tests/cases/compiler/noImplicitReturnsWithoutReturnExpression.ts
@@ -1,0 +1,25 @@
+// @noImplicitReturns: true
+function isMissingReturnExpression(): number {
+    return;
+}
+
+function isMissingReturnExpression2(): any {
+    return;
+}
+
+function isMissingReturnExpression3(): number|void {
+    return;
+}
+
+function isMissingReturnExpression4(): void {
+    return;
+}
+
+function isMissingReturnExpression5(x) {
+    if (x) {
+        return 0;
+    }
+    else {
+        return;
+    }
+}


### PR DESCRIPTION
In --noImplicitReturns mode, if a function specifies a return type,
disallow empty "return;" statements.

Fixes #5916.

---

This is my first TypeScript change, so please review with caution.

Some things wasn't sure about, checked off the resolved ones:
- [x] Should I add more tests for other cases?  E.g. a function that is tagged with `void` return etc.
- [ ] Should I use a different error message?
- [x] Maybe my check against Any here is wrong?  I copied it from elsewhere.