### PR TITLE
Removing cachePath from discoverTypings and DiscoverTypingsInfo.

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2442,7 +2442,6 @@ namespace ts {
 
     export interface DiscoverTypingsInfo {
         fileNames: string[];                            // The file names that belong to the same project.
-        cachePath: string;                              // The path to the typings cache
         projectRootPath: string;                        // The path to the project root directory
         safeListPath: string;                           // The path used to retrieve the safe list
         packageNameToTypingLocation: Map<string>;       // The map of package names to their cached typing locations

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -30,7 +30,6 @@ namespace ts.JsTyping {
     /**
      * @param host is the object providing I/O related operations.
      * @param fileNames are the file names that belong to the same project
-     * @param cachePath is the path to the typings cache
      * @param projectRootPath is the path to the project root directory
      * @param safeListPath is the path used to retrieve the safe list
      * @param packageNameToTypingLocation is the map of package names to their cached typing locations
@@ -40,7 +39,6 @@ namespace ts.JsTyping {
     export function discoverTypings(
         host: TypingResolutionHost,
         fileNames: string[],
-        cachePath: Path,
         projectRootPath: Path,
         safeListPath: Path,
         packageNameToTypingLocation: Map<string>,

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -994,7 +994,6 @@ namespace ts {
                 return ts.JsTyping.discoverTypings(
                     this.host,
                     info.fileNames,
-                    toPath(info.cachePath, info.cachePath, getCanonicalFileName),
                     toPath(info.projectRootPath, info.projectRootPath, getCanonicalFileName),
                     toPath(info.safeListPath, info.safeListPath, getCanonicalFileName),
                     info.packageNameToTypingLocation,


### PR DESCRIPTION
Removing cachePath from discoverTypings and DiscoverTypingsInfo.
With the move to using the packageNameToLocation map it is no longer required.
