### PR TITLE
Expose ts.isExternalModule as public API.

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -407,6 +407,10 @@ namespace ts {
         return result;
     }
 
+    export function isExternalModule(file: SourceFile): boolean {
+        return file.externalModuleIndicator !== undefined;
+    }
+
     // Produces a new SourceFile for the 'newText' provided. The 'textChangeRange' parameter
     // indicates what changed between the 'text' that this SourceFile has and the 'newText'.
     // The SourceFile will be created with the compiler attempting to reuse as many nodes from

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -407,10 +407,6 @@ namespace ts {
         return createTextSpanFromBounds(pos, errorNode.end);
     }
 
-    export function isExternalModule(file: SourceFile): boolean {
-        return file.externalModuleIndicator !== undefined;
-    }
-
     export function isExternalOrCommonJsModule(file: SourceFile): boolean {
         return (file.externalModuleIndicator || file.commonJsModuleIndicator) !== undefined;
     }


### PR DESCRIPTION
Fixes #7359

Since the entire namespace definition in `src/compiler/utilities.ts` is marked `@internal`, I just moved the definition of `isExternalModule` to another file.  See [the effect on the LKG](https://github.com/mattmccutchen/TypeScript/compare/issue7359-lkg~2...mattmccutchen:issue7359-lkg).  Also, `jake runtests` passed.  Let me know if this should be done a different way.