### PR TITLE
Fix #7397: Remove error checks for noEmit and out* compiler options combined.

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1746,7 +1746,7 @@ namespace ts {
                 }
             }
 
-            if (options.allowJs && options.declaration) {
+            if (!options.noEmit && options.allowJs && options.declaration) {
                 programDiagnostics.add(createCompilerDiagnostic(Diagnostics.Option_0_cannot_be_specified_with_option_1, "allowJs", "declaration"));
             }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1746,24 +1746,7 @@ namespace ts {
                 }
             }
 
-            if (options.noEmit) {
-                if (options.out) {
-                    programDiagnostics.add(createCompilerDiagnostic(Diagnostics.Option_0_cannot_be_specified_with_option_1, "noEmit", "out"));
-                }
-
-                if (options.outFile) {
-                    programDiagnostics.add(createCompilerDiagnostic(Diagnostics.Option_0_cannot_be_specified_with_option_1, "noEmit", "outFile"));
-                }
-
-                if (options.outDir) {
-                    programDiagnostics.add(createCompilerDiagnostic(Diagnostics.Option_0_cannot_be_specified_with_option_1, "noEmit", "outDir"));
-                }
-
-                if (options.declaration) {
-                    programDiagnostics.add(createCompilerDiagnostic(Diagnostics.Option_0_cannot_be_specified_with_option_1, "noEmit", "declaration"));
-                }
-            }
-            else if (options.allowJs && options.declaration) {
+            if (options.allowJs && options.declaration) {
                 programDiagnostics.add(createCompilerDiagnostic(Diagnostics.Option_0_cannot_be_specified_with_option_1, "allowJs", "declaration"));
             }
 

--- a/tests/baselines/reference/compilerOptionsDeclarationAndNoEmit.symbols
+++ b/tests/baselines/reference/compilerOptionsDeclarationAndNoEmit.symbols
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/a.ts ===
+
+class c {
+>c : Symbol(c, Decl(a.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/compilerOptionsDeclarationAndNoEmit.types
+++ b/tests/baselines/reference/compilerOptionsDeclarationAndNoEmit.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/a.ts ===
+
+class c {
+>c : c
+}
+

--- a/tests/baselines/reference/compilerOptionsOutAndNoEmit.symbols
+++ b/tests/baselines/reference/compilerOptionsOutAndNoEmit.symbols
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/a.ts ===
+
+class c {
+>c : Symbol(c, Decl(a.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/compilerOptionsOutAndNoEmit.types
+++ b/tests/baselines/reference/compilerOptionsOutAndNoEmit.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/a.ts ===
+
+class c {
+>c : c
+}
+

--- a/tests/baselines/reference/compilerOptionsOutDirAndNoEmit.symbols
+++ b/tests/baselines/reference/compilerOptionsOutDirAndNoEmit.symbols
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/a.ts ===
+
+class c {
+>c : Symbol(c, Decl(a.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/compilerOptionsOutDirAndNoEmit.types
+++ b/tests/baselines/reference/compilerOptionsOutDirAndNoEmit.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/a.ts ===
+
+class c {
+>c : c
+}
+

--- a/tests/baselines/reference/compilerOptionsOutFileAndNoEmit.symbols
+++ b/tests/baselines/reference/compilerOptionsOutFileAndNoEmit.symbols
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/a.ts ===
+
+class c {
+>c : Symbol(c, Decl(a.ts, 0, 0))
+}
+

--- a/tests/baselines/reference/compilerOptionsOutFileAndNoEmit.types
+++ b/tests/baselines/reference/compilerOptionsOutFileAndNoEmit.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/a.ts ===
+
+class c {
+>c : c
+}
+

--- a/tests/cases/compiler/compilerOptionsDeclarationAndNoEmit.ts
+++ b/tests/cases/compiler/compilerOptionsDeclarationAndNoEmit.ts
@@ -1,0 +1,6 @@
+// @declaration: true
+// @noEmit: true
+// @fileName: a.ts
+
+class c {
+}

--- a/tests/cases/compiler/compilerOptionsOutAndNoEmit.ts
+++ b/tests/cases/compiler/compilerOptionsOutAndNoEmit.ts
@@ -1,0 +1,6 @@
+// @out: outDir
+// @noEmit: true
+// @fileName: a.ts
+
+class c {
+}

--- a/tests/cases/compiler/compilerOptionsOutDirAndNoEmit.ts
+++ b/tests/cases/compiler/compilerOptionsOutDirAndNoEmit.ts
@@ -1,0 +1,6 @@
+// @outDir: outDir
+// @noEmit: true
+// @fileName: a.ts
+
+class c {
+}

--- a/tests/cases/compiler/compilerOptionsOutFileAndNoEmit.ts
+++ b/tests/cases/compiler/compilerOptionsOutFileAndNoEmit.ts
@@ -1,0 +1,6 @@
+// @outFile: a.js
+// @noEmit: true
+// @fileName: a.ts
+
+class c {
+}


### PR DESCRIPTION
Fixes #7397.