### PR TITLE
Port acquire d.ts and scriptKind from master to release-1.8

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -920,6 +920,7 @@ var servicesLintTargets = [
     "patternMatcher.ts",
     "services.ts",
     "shims.ts",
+    "jsTyping.ts"
 ].map(function (s) {
     return path.join(servicesDirectory, s);
 });

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -477,7 +477,7 @@ namespace ts {
      *
      * This method replace comment content by whitespace rather than completely remove them to keep positions in json parsing error reporting accurate.
      */
-    function removeComments(jsonText: string): string {
+    export function removeComments(jsonText: string): string {
         let output = "";
         const scanner = createScanner(ScriptTarget.ES5, /* skipTrivia */ false, LanguageVariant.Standard, jsonText);
         let token: SyntaxKind;

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -511,6 +511,7 @@ namespace ts {
         return {
             options,
             fileNames: getFileNames(),
+            typingOptions: getTypingOptions(),
             errors
         };
 
@@ -574,6 +575,32 @@ namespace ts {
                 }
             }
             return fileNames;
+        }
+
+        function getTypingOptions(): TypingOptions {
+            const options: TypingOptions = getBaseFileName(configFileName) === "jsconfig.json"
+                ? { enableAutoDiscovery: true, include: [], exclude: [] }
+                : { enableAutoDiscovery: false, include: [], exclude: [] };
+            const jsonTypingOptions = json["typingOptions"];
+            if (jsonTypingOptions) {
+                for (const id in jsonTypingOptions) {
+                    if (id === "enableAutoDiscovery") {
+                        if (typeof jsonTypingOptions[id] === "boolean") {
+                            options.enableAutoDiscovery = jsonTypingOptions[id];
+                        }
+                    }
+                    else if (id === "include") {
+                        options.include = isArray(jsonTypingOptions[id]) ? <string[]>jsonTypingOptions[id] : [];
+                    }
+                    else if (id === "exclude") {
+                        options.exclude = isArray(jsonTypingOptions[id]) ? <string[]>jsonTypingOptions[id] : [];
+                    }
+                    else {
+                        errors.push(createCompilerDiagnostic(Diagnostics.Unknown_typing_option_0, id));
+                    }
+                }
+            }
+            return options;
         }
     }
 

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -477,7 +477,7 @@ namespace ts {
      *
      * This method replace comment content by whitespace rather than completely remove them to keep positions in json parsing error reporting accurate.
      */
-    export function removeComments(jsonText: string): string {
+    function removeComments(jsonText: string): string {
         let output = "";
         const scanner = createScanner(ScriptTarget.ES5, /* skipTrivia */ false, LanguageVariant.Standard, jsonText);
         let token: SyntaxKind;
@@ -587,6 +587,9 @@ namespace ts {
                     if (id === "enableAutoDiscovery") {
                         if (typeof jsonTypingOptions[id] === "boolean") {
                             options.enableAutoDiscovery = jsonTypingOptions[id];
+                        }
+                        else {
+                            errors.push(createCompilerDiagnostic(Diagnostics.Unknown_typing_option_0, id));
                         }
                     }
                     else if (id === "include") {

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -642,7 +642,7 @@ namespace ts {
                         value = normalizePath(combinePaths(basePath, value));
                        if (value === "") {
                            value = ".";
-                        }
+                       }
                     }
                     options[opt.name] = value;
                 }

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -590,10 +590,10 @@ namespace ts {
                         }
                     }
                     else if (id === "include") {
-                        options.include = ConvertJsonOptionToStringArray(id, jsonTypingOptions[id], errors);
+                        options.include = convertJsonOptionToStringArray(id, jsonTypingOptions[id], errors);
                     }
                     else if (id === "exclude") {
-                        options.exclude = ConvertJsonOptionToStringArray(id, jsonTypingOptions[id], errors);
+                        options.exclude = convertJsonOptionToStringArray(id, jsonTypingOptions[id], errors);
                     }
                     else {
                         errors.push(createCompilerDiagnostic(Diagnostics.Unknown_typing_option_0, id));
@@ -636,9 +636,9 @@ namespace ts {
                         }
                     }
                     if (opt.isFilePath) {
-                       value = normalizePath(combinePaths(basePath, value));
+                        value = normalizePath(combinePaths(basePath, value));
                        if (value === "") {
-                            value = ".";
+                           value = ".";
                         }
                     }
                     options[opt.name] = value;
@@ -655,7 +655,7 @@ namespace ts {
         return { options, errors };
     }
 
-    function ConvertJsonOptionToStringArray(optionName: string, optionJson: any, errors: Diagnostic[], func?: (element: string) => string): string[] {
+    function convertJsonOptionToStringArray(optionName: string, optionJson: any, errors: Diagnostic[], func?: (element: string) => string): string[] {
         const items: string[] = [];
         let invalidOptionType = false;
         if (!isArray(optionJson)) {

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -590,10 +590,10 @@ namespace ts {
                         }
                     }
                     else if (id === "include") {
-                        options.include = isArray(jsonTypingOptions[id]) ? <string[]>jsonTypingOptions[id] : [];
+                        options.include = ConvertJsonOptionToStringArray(id, jsonTypingOptions[id], errors);
                     }
                     else if (id === "exclude") {
-                        options.exclude = isArray(jsonTypingOptions[id]) ? <string[]>jsonTypingOptions[id] : [];
+                        options.exclude = ConvertJsonOptionToStringArray(id, jsonTypingOptions[id], errors);
                     }
                     else {
                         errors.push(createCompilerDiagnostic(Diagnostics.Unknown_typing_option_0, id));
@@ -636,8 +636,8 @@ namespace ts {
                         }
                     }
                     if (opt.isFilePath) {
-                        value = normalizePath(combinePaths(basePath, value));
-                        if (value === "") {
+                       value = normalizePath(combinePaths(basePath, value));
+                       if (value === "") {
                             value = ".";
                         }
                     }
@@ -653,5 +653,29 @@ namespace ts {
         }
 
         return { options, errors };
+    }
+
+    function ConvertJsonOptionToStringArray(optionName: string, optionJson: any, errors: Diagnostic[], func?: (element: string) => string): string[] {
+        let items: string[] = [];
+        let invalidOptionType = false;
+        if (!isArray(optionJson)) {
+            invalidOptionType = true;
+        }
+        else {
+            for (const element of <any[]>optionJson) {
+                if (typeof element === "string") {
+                    const item = func ? func(element) : element;
+                    items.push(item);
+                }
+                else {
+                    invalidOptionType = true;
+                    break;
+                }
+            }
+        }
+        if (invalidOptionType) {
+            errors.push(createCompilerDiagnostic(Diagnostics.Option_0_should_have_array_of_strings_as_a_value, optionName));
+        }
+        return items;
     }
 }

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -656,7 +656,7 @@ namespace ts {
     }
 
     function ConvertJsonOptionToStringArray(optionName: string, optionJson: any, errors: Diagnostic[], func?: (element: string) => string): string[] {
-        let items: string[] = [];
+        const items: string[] = [];
         let invalidOptionType = false;
         if (!isArray(optionJson)) {
             invalidOptionType = true;

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -280,6 +280,14 @@ namespace ts {
         return hasOwnProperty.call(map, key);
     }
 
+    export function getKeys<T>(map: Map<T>): string[] {
+        const keys: string[] = [];
+        for (const key in map) {
+            keys.push(key);
+        }
+        return keys;
+    }
+
     export function getProperty<T>(map: Map<T>, key: string): T {
         return hasOwnProperty.call(map, key) ? map[key] : undefined;
     }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -769,6 +769,32 @@ namespace ts {
         return pathLen > extLen && path.substr(pathLen - extLen, extLen) === extension;
     }
 
+    export function ensureScriptKind(fileName: string, scriptKind?: ScriptKind): ScriptKind {
+        // Using scriptKind as a condition handles both:
+        // - 'scriptKind' is unspecified and thus it is `undefined`
+        // - 'scriptKind' is set and it is `Unknown` (0)
+        // If the 'scriptKind' is 'undefined' or 'Unknown' then we attempt
+        // to get the ScriptKind from the file name. If it cannot be resolved
+        // from the file name then the default 'TS' script kind is returned.
+        return (scriptKind || getScriptKindFromFileName(fileName)) || ScriptKind.TS;
+    }
+
+    export function getScriptKindFromFileName(fileName: string): ScriptKind {
+        const ext = fileName.substr(fileName.lastIndexOf("."));
+        switch (ext.toLowerCase()) {
+            case ".js":
+                return ScriptKind.JS;
+            case ".jsx":
+                return ScriptKind.JSX;
+            case ".ts":
+                return ScriptKind.TS;
+            case ".tsx":
+                return ScriptKind.TSX;
+            default:
+                return ScriptKind.Unknown;
+        }
+    }
+
     /**
      *  List of supported extensions in order of file resolution precedence.
      */

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2654,5 +2654,9 @@
     "'super' must be called before accessing 'this' in the constructor of a derived class.": {
         "category": "Error",
         "code": 17009
+    },
+    "Unknown typing option '{0}'.": {
+        "category": "Error",
+        "code": 17010
     }
 }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2450,11 +2450,14 @@
         "category": "Message",
         "code": 6084
     },
+    "Option '{0}' should have array of strings as a value.": {
+        "category": "Error",
+        "code": 6103
+    },
     "Do not emit 'use strict' directives in module output.": {
         "category": "Message",
         "code": 6112
     },
-
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",
         "code": 7005

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -409,15 +409,15 @@ namespace ts {
 
     /* @internal */
     export function getScriptKindFromFileName(fileName: string): ScriptKind {
-        const ext = fileName.split(".").pop();
+        const ext = fileName.substr(fileName.lastIndexOf("."));
         switch (ext.toLowerCase()) {
-            case "js":
+            case ".js":
                 return ScriptKind.JS;
-            case "jsx":
+            case ".jsx":
                 return ScriptKind.JSX;
-            case "ts":
+            case ".ts":
                 return ScriptKind.TS;
-            case "tsx":
+            case ".tsx":
                 return ScriptKind.TSX;
             default:
                 return ScriptKind.TS;

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -407,23 +407,6 @@ namespace ts {
         return result;
     }
 
-    /* @internal */
-    export function getScriptKindFromFileName(fileName: string): ScriptKind {
-        const ext = fileName.substr(fileName.lastIndexOf("."));
-        switch (ext.toLowerCase()) {
-            case ".js":
-                return ScriptKind.JS;
-            case ".jsx":
-                return ScriptKind.JSX;
-            case ".ts":
-                return ScriptKind.TS;
-            case ".tsx":
-                return ScriptKind.TSX;
-            default:
-                return ScriptKind.TS;
-        }
-    }
-
     // Produces a new SourceFile for the 'newText' provided. The 'textChangeRange' parameter
     // indicates what changed between the 'text' that this SourceFile has and the 'newText'.
     // The SourceFile will be created with the compiler attempting to reuse as many nodes from
@@ -551,12 +534,7 @@ namespace ts {
         let parseErrorBeforeNextFinishedNode = false;
 
         export function parseSourceFile(fileName: string, _sourceText: string, languageVersion: ScriptTarget, _syntaxCursor: IncrementalParser.SyntaxCursor, setParentNodes?: boolean, scriptKind?: ScriptKind): SourceFile {
-            // Using scriptKind as a condition handles both:
-            // - 'scriptKind' is unspecified and thus it is `undefined`
-            // - 'scriptKind' is set and it is `Unknown` (0)
-            // If the 'scriptKind' is 'undefined' or 'Unknown' then attempt
-            // to get the ScriptKind from the file name.
-            scriptKind = scriptKind ? scriptKind : getScriptKindFromFileName(fileName);
+            scriptKind = ensureScriptKind(fileName, scriptKind);
 
             initializeState(fileName, _sourceText, languageVersion, _syntaxCursor, scriptKind);
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -536,7 +536,7 @@ namespace ts {
 
         export function parseSourceFile(fileName: string, _sourceText: string, languageVersion: ScriptTarget, _syntaxCursor: IncrementalParser.SyntaxCursor, setParentNodes?: boolean, scriptKind?: ScriptKind): SourceFile {
 
-            const isJavaScriptFile = hasJavaScriptFileExtension(fileName) || _sourceText.lastIndexOf("// @language=javascript", 0) === 0 || scriptKind == ScriptKind.Js;
+            const isJavaScriptFile = hasJavaScriptFileExtension(fileName) || _sourceText.lastIndexOf("// @language=javascript", 0) === 0 || scriptKind == ScriptKind.JS;
 
             initializeState(fileName, _sourceText, languageVersion, isJavaScriptFile, _syntaxCursor);
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -417,8 +417,8 @@ namespace ts {
     // from this SourceFile that are being held onto may change as a result (including
     // becoming detached from any SourceFile).  It is recommended that this SourceFile not
     // be used once 'update' is called on it.
-    export function updateSourceFile(sourceFile: SourceFile, newText: string, textChangeRange: TextChangeRange, aggressiveChecks?: boolean, scriptKind?: ScriptKind): SourceFile {
-        return IncrementalParser.updateSourceFile(sourceFile, newText, textChangeRange, aggressiveChecks, scriptKind);
+    export function updateSourceFile(sourceFile: SourceFile, newText: string, textChangeRange: TextChangeRange, aggressiveChecks?: boolean): SourceFile {
+        return IncrementalParser.updateSourceFile(sourceFile, newText, textChangeRange, aggressiveChecks);
     }
 
     /* @internal */
@@ -536,11 +536,10 @@ namespace ts {
 
         export function parseSourceFile(fileName: string, _sourceText: string, languageVersion: ScriptTarget, _syntaxCursor: IncrementalParser.SyntaxCursor, setParentNodes?: boolean, scriptKind?: ScriptKind): SourceFile {
 
-            const isJavaScriptFile = hasJavaScriptFileExtension(fileName) || _sourceText.lastIndexOf("// @language=javascript", 0) === 0 || scriptKind == ScriptKind.JS;
-
+            const isJavaScriptFile = scriptKind === ScriptKind.JS || hasJavaScriptFileExtension(fileName);
             initializeState(fileName, _sourceText, languageVersion, isJavaScriptFile, _syntaxCursor);
 
-            const result = parseSourceFileWorker(fileName, languageVersion, setParentNodes);
+            const result = parseSourceFileWorker(fileName, languageVersion, setParentNodes, scriptKind);
 
             clearState();
 
@@ -588,8 +587,8 @@ namespace ts {
             sourceText = undefined;
         }
 
-        function parseSourceFileWorker(fileName: string, languageVersion: ScriptTarget, setParentNodes: boolean): SourceFile {
-            sourceFile = createSourceFile(fileName, languageVersion);
+        function parseSourceFileWorker(fileName: string, languageVersion: ScriptTarget, setParentNodes: boolean, scriptKind?: ScriptKind): SourceFile {
+            sourceFile = createSourceFile(fileName, languageVersion, scriptKind);
 
             if (contextFlags & ParserContextFlags.JavaScriptFile) {
                 sourceFile.parserContextFlags = ParserContextFlags.JavaScriptFile;
@@ -659,7 +658,7 @@ namespace ts {
             }
         }
 
-        function createSourceFile(fileName: string, languageVersion: ScriptTarget): SourceFile {
+        function createSourceFile(fileName: string, languageVersion: ScriptTarget, scriptKind?: ScriptKind): SourceFile {
             // code from createNode is inlined here so createNode won't have to deal with special case of creating source files
             // this is quite rare comparing to other nodes and createNode should be as fast as possible
             const sourceFile = <SourceFile>new SourceFileConstructor(SyntaxKind.SourceFile, /*pos*/ 0, /* end */ sourceText.length);
@@ -671,6 +670,9 @@ namespace ts {
             sourceFile.fileName = normalizePath(fileName);
             sourceFile.flags = fileExtensionIs(sourceFile.fileName, ".d.ts") ? NodeFlags.DeclarationFile : 0;
             sourceFile.languageVariant = getLanguageVariant(sourceFile.fileName);
+
+            scriptKind = scriptKind || ScriptKind.Unknown;
+            sourceFile.scriptKind = scriptKind !== ScriptKind.Unknown ? scriptKind : ScriptKind.TS;
 
             return sourceFile;
         }
@@ -6240,7 +6242,7 @@ namespace ts {
     }
 
     namespace IncrementalParser {
-        export function updateSourceFile(sourceFile: SourceFile, newText: string, textChangeRange: TextChangeRange, aggressiveChecks: boolean, scriptKind?: ScriptKind): SourceFile {
+        export function updateSourceFile(sourceFile: SourceFile, newText: string, textChangeRange: TextChangeRange, aggressiveChecks: boolean): SourceFile {
             aggressiveChecks = aggressiveChecks || Debug.shouldAssert(AssertionLevel.Aggressive);
 
             checkChangeRange(sourceFile, newText, textChangeRange, aggressiveChecks);
@@ -6252,7 +6254,7 @@ namespace ts {
             if (sourceFile.statements.length === 0) {
                 // If we don't have any statements in the current source file, then there's no real
                 // way to incrementally parse.  So just do a full parse instead.
-                return Parser.parseSourceFile(sourceFile.fileName, newText, sourceFile.languageVersion, /*syntaxCursor*/ undefined, /*setParentNodes*/ true, scriptKind);
+                return Parser.parseSourceFile(sourceFile.fileName, newText, sourceFile.languageVersion, /*syntaxCursor*/ undefined, /*setParentNodes*/ true, sourceFile.scriptKind);
             }
 
             // Make sure we're not trying to incrementally update a source file more than once.  Once
@@ -6316,7 +6318,7 @@ namespace ts {
             // inconsistent tree.  Setting the parents on the new tree should be very fast.  We
             // will immediately bail out of walking any subtrees when we can see that their parents
             // are already correct.
-            const result = Parser.parseSourceFile(sourceFile.fileName, newText, sourceFile.languageVersion, syntaxCursor, /*setParentNodes*/ true, scriptKind);
+            const result = Parser.parseSourceFile(sourceFile.fileName, newText, sourceFile.languageVersion, syntaxCursor, /*setParentNodes*/ true, sourceFile.scriptKind);
 
             return result;
         }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -407,6 +407,22 @@ namespace ts {
         return result;
     }
 
+    /* @internal */
+    export function getScriptKindFromFileName(fileName: string): ScriptKind {
+        const ext = fileName.split(".").pop();
+        switch (ext.toLowerCase()) {
+            case "js":
+                return ScriptKind.JS;
+            case "jsx":
+                return ScriptKind.JSX;
+            case "ts":
+                return ScriptKind.TS;
+            case "tsx":
+                return ScriptKind.TSX;
+            default:
+                return ScriptKind.TS;
+        }
+    }
 
     // Produces a new SourceFile for the 'newText' provided. The 'textChangeRange' parameter
     // indicates what changed between the 'text' that this SourceFile has and the 'newText'.
@@ -549,22 +565,6 @@ namespace ts {
             clearState();
 
             return result;
-        }
-
-        function getScriptKindFromFileName(fileName: string): ScriptKind {
-            const ext = fileName.split(".").pop();
-            switch (ext.toLowerCase()) {
-                case "js":
-                    return ScriptKind.JS;
-                case "jsx":
-                    return ScriptKind.JSX;
-                case "ts":
-                    return ScriptKind.TS;
-                case "tsx":
-                    return ScriptKind.TSX;
-                default:
-                    return ScriptKind.TS;
-            }
         }
 
         function getLanguageVariant(scriptKind: ScriptKind) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2449,6 +2449,13 @@ namespace ts {
         [option: string]: string | number | boolean;
     }
 
+    export interface TypingOptions {
+        enableAutoDiscovery?: boolean;
+        include?: string[];
+        exclude?: string[];
+        [option: string]: any;
+    }
+
     export const enum ModuleKind {
         None = 0,
         CommonJS = 1,
@@ -2507,6 +2514,7 @@ namespace ts {
 
     export interface ParsedCommandLine {
         options: CompilerOptions;
+        typingOptions?: TypingOptions;
         fileNames: string[];
         errors: Diagnostic[];
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1560,6 +1560,7 @@ namespace ts {
         hasNoDefaultLib: boolean;
 
         languageVersion: ScriptTarget;
+        /* @internal */ scriptKind: ScriptKind;
 
         // The first node that causes this file to be an external module
         /* @internal */ externalModuleIndicator: Node;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1,3 +1,4 @@
+
 namespace ts {
     export interface Map<T> {
         [index: string]: T;
@@ -2474,6 +2475,14 @@ namespace ts {
          * This value denotes the character position in line and is different from the 'column' because of tab characters.
          */
         character: number;
+    }
+
+    export const enum ScriptKind {
+        Unknown = 0,
+        Js = 1,
+        Jsx = 2,
+        Ts = 3,
+        Tsx = 4
     }
 
     export const enum ScriptTarget {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2458,7 +2458,6 @@ namespace ts {
 
     export interface DiscoverTypingsInfo {
         fileNames: string[];                            // The file names that belong to the same project.
-        cachePath: string;                              // The path to the typings cache
         projectRootPath: string;                        // The path to the project root directory
         safeListPath: string;                           // The path used to retrieve the safe list
         packageNameToTypingLocation: Map<string>;       // The map of package names to their cached typing locations

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2453,7 +2453,17 @@ namespace ts {
         enableAutoDiscovery?: boolean;
         include?: string[];
         exclude?: string[];
-        [option: string]: any;
+        [option: string]: string[] | boolean;
+    }
+
+    export interface DiscoverTypingsSettings {
+        fileNames: string[];                            // The file names that belong to the same project.
+        cachePath: string;                              // The path to the typings cache
+        projectRootPath: string;                        // The path to the project root directory
+        safeListPath: string;                           // The path used to retrieve the safe list
+        packageNameToTypingLocation: Map<string>;       // The map of package names to their cached typing locations
+        typingOptions: TypingOptions;                   // Used to customize the typing inference process
+        compilerOptions: CompilerOptions;               // Used as a source for typing inference
     }
 
     export const enum ModuleKind {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2479,10 +2479,10 @@ namespace ts {
 
     export const enum ScriptKind {
         Unknown = 0,
-        Js = 1,
-        Jsx = 2,
-        Ts = 3,
-        Tsx = 4
+        JS = 1,
+        JSX = 2,
+        TS = 3,
+        TSX = 4
     }
 
     export const enum ScriptTarget {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2456,7 +2456,7 @@ namespace ts {
         [option: string]: string[] | boolean;
     }
 
-    export interface DiscoverTypingsSettings {
+    export interface DiscoverTypingsInfo {
         fileNames: string[];                            // The file names that belong to the same project.
         cachePath: string;                              // The path to the typings cache
         projectRootPath: string;                        // The path to the project root directory

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -183,7 +183,7 @@ namespace Harness.LanguageService {
             const script = this.getScriptInfo(fileName);
             return script ? new ScriptSnapshot(script) : undefined;
         }
-        getScriptKind(fileName: string): ScriptKind { return ScriptKind.Unknown; }
+        getScriptKind(fileName: string): ts.ScriptKind { return ts.ScriptKind.Unknown; }
         getScriptVersion(fileName: string): string {
             const script = this.getScriptInfo(fileName);
             return script ? script.version.toString() : undefined;
@@ -254,7 +254,7 @@ namespace Harness.LanguageService {
             const nativeScriptSnapshot = this.nativeHost.getScriptSnapshot(fileName);
             return nativeScriptSnapshot && new ScriptSnapshotProxy(nativeScriptSnapshot);
         }
-        getScriptKind(fileName: string): ScriptKind { return this.nativeHost.getScriptKind(fileName); }
+        getScriptKind(fileName: string): ts.ScriptKind { return this.nativeHost.getScriptKind(fileName); }
         getScriptVersion(fileName: string): string { return this.nativeHost.getScriptVersion(fileName); }
         getLocalizedDiagnosticMessages(): string { return JSON.stringify({}); }
 

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -183,6 +183,7 @@ namespace Harness.LanguageService {
             const script = this.getScriptInfo(fileName);
             return script ? new ScriptSnapshot(script) : undefined;
         }
+        getScriptKind(fileName: string): ScriptKind { return ScriptKind.Unknown; }
         getScriptVersion(fileName: string): string {
             const script = this.getScriptInfo(fileName);
             return script ? script.version.toString() : undefined;
@@ -253,6 +254,7 @@ namespace Harness.LanguageService {
             const nativeScriptSnapshot = this.nativeHost.getScriptSnapshot(fileName);
             return nativeScriptSnapshot && new ScriptSnapshotProxy(nativeScriptSnapshot);
         }
+        getScriptKind(fileName: string): ScriptKind { return this.nativeHost.getScriptKind(fileName); }
         getScriptVersion(fileName: string): string { return this.nativeHost.getScriptVersion(fileName); }
         getLocalizedDiagnosticMessages(): string { return JSON.stringify({}); }
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -192,6 +192,10 @@ namespace ts.server {
             return this.roots.map(root => root.fileName);
         }
 
+        getScriptKind() {
+            return ScriptKind.Unknown;
+        }
+
         getScriptVersion(filename: string) {
             return this.getScriptInfo(filename).svc.latestVersion().toString();
         }

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -173,6 +173,9 @@ namespace ts.JsTyping {
                 if (jsonDict.hasOwnProperty("dependencies")) {
                     mergeTypings(Object.keys(jsonDict.dependencies));
                 }
+                if (jsonDict.hasOwnProperty("devDependencies")) {
+                    mergeTypings(Object.keys(jsonDict.devDependencies));
+                }
             }
         }
 

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -85,7 +85,7 @@ namespace ts.JsTyping {
             getTypingNamesFromJson(bowerJsonPath, filesToWatch);
 
             const nodeModulesPath = combinePaths(searchDir, "node_modules");
-            getTypingNamesFromNodeModuleFolder(nodeModulesPath, filesToWatch);
+            getTypingNamesFromNodeModuleFolder(nodeModulesPath);
         }
         getTypingNamesFromSourceFileNames(fileNames);
 
@@ -178,7 +178,7 @@ namespace ts.JsTyping {
          * Infer typing names from node_module folder
          * @param nodeModulesPath is the path to the "node_modules" folder
          */
-        function getTypingNamesFromNodeModuleFolder(nodeModulesPath: string, filesToWatch: string[]) {
+        function getTypingNamesFromNodeModuleFolder(nodeModulesPath: string) {
             // Todo: add support for ModuleResolutionHost too
             if (!host.directoryExists(nodeModulesPath)) {
                 return;
@@ -192,7 +192,6 @@ namespace ts.JsTyping {
                 const result = readConfigFile(normalizedFileName, (path: string) => host.readFile(path));
                 if (!result.config) { continue; }
                 const packageJson: PackageJson = result.config;
-                filesToWatch.push(normalizedFileName);
 
                 // npm 3's package.json contains a "_requiredBy" field
                 // we should include all the top level module names for npm 2, and only module names whose

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -6,7 +6,7 @@
 /* @internal */
 namespace ts.JsTyping {
 
-    interface TypingResolutionHost {
+    export interface TypingResolutionHost {
         directoryExists: (path: string) => boolean;
         fileExists: (fileName: string) => boolean;
         readFile: (path: string, encoding?: string) => string;

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -193,8 +193,8 @@ namespace ts.JsTyping {
                 mergeTypings(filter(cleanedTypingNames, f => hasProperty(safeList, f)));
             }
 
-            const jsxFileNames = filter(fileNames, f => scriptKindIs(f, /*LanguageServiceHost*/ undefined, ScriptKind.JSX));
-            if (jsxFileNames.length > 0) {
+            const hasJsxFile = forEach(fileNames, f => scriptKindIs(f, /*LanguageServiceHost*/ undefined, ScriptKind.JSX));
+            if (hasJsxFile) {
                 mergeTypings(["react"]);
             }
         }
@@ -214,6 +214,7 @@ namespace ts.JsTyping {
                 filter(
                     host.readDirectory(nodeModulesPath, /*extension*/ undefined, /*exclude*/ undefined, /*depth*/ 2),
                     f => ts.getBaseFileName(f) === "package.json");
+
             for (const packageJsonFile of packageJsonFiles) {
                 const packageJsonDict = tryParseJson(packageJsonFile, host);
                 if (!packageJsonDict) { continue; }
@@ -246,13 +247,6 @@ namespace ts.JsTyping {
             const typingNames: string[] = [];
             if (!options) {
                 return;
-            }
-
-            if (options.jsx === JsxEmit.React) {
-                typingNames.push("react");
-            }
-            if (options.moduleResolution === ModuleResolutionKind.NodeJs) {
-                typingNames.push("node");
             }
             mergeTypings(typingNames);
         }

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -30,7 +30,6 @@ namespace ts.JsTyping {
     /**
      * @param host is the object providing I/O related operations.
      * @param fileNames are the file names that belong to the same project
-     * @param cachePath is the path to the typings cache
      * @param projectRootPath is the path to the project root directory
      * @param safeListPath is the path used to retrieve the safe list
      * @param packageNameToTypingLocation is the map of package names to their cached typing locations
@@ -40,7 +39,6 @@ namespace ts.JsTyping {
     export function discoverTypings(
         host: TypingResolutionHost,
         fileNames: string[],
-        cachePath: Path,
         projectRootPath: Path,
         safeListPath: Path,
         packageNameToTypingLocation: Map<string>,

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -63,7 +63,7 @@ namespace ts.JsTyping {
             }
             else {
                 safeList = {};
-            };
+            }
         }
 
         const filesToWatch: string[] = [];

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -55,8 +55,8 @@ namespace ts.JsTyping {
         globalCachePath: Path,
         projectRootPath: Path,
         typingOptions: TypingOptions,
-        compilerOptions: CompilerOptions)
-        : { cachedTypingPaths: string[], newTypingNames: string[], filesToWatch: string[] } {
+        compilerOptions: CompilerOptions):
+        { cachedTypingPaths: string[], newTypingNames: string[], filesToWatch: string[] } {
 
         // A typing name to typing file path mapping
         const inferredTypings: Map<string> = {};

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -21,8 +21,7 @@ namespace ts.JsTyping {
     function tryParseJson(jsonPath: string, host: TypingResolutionHost): any {
         if (host.fileExists(jsonPath)) {
             try {
-                // Strip out single-line comments
-                const contents = host.readFile(jsonPath).replace(/^\s*\/\/(.*)$/gm, "");
+                const contents = removeComments(host.readFile(jsonPath));
                 return JSON.parse(contents);
             }
             catch (e) { }

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -1,0 +1,286 @@
+﻿// Copyright (c) Microsoft. All rights reserved. Licensed under the Apache License, Version 2.0.
+// See LICENSE.txt in the project root for complete license information.
+
+/// <reference path='services.ts' />
+
+/* @internal */
+namespace ts.JsTyping {
+
+    interface TypingResolutionHost {
+        directoryExists: (path: string) => boolean;
+        fileExists: (fileName: string) => boolean;
+        readFile: (path: string, encoding?: string) => string;
+        readDirectory: (path: string, extension?: string, exclude?: string[], depth?: number) => string[];
+    };
+
+    // A map of loose file names to library names
+    // that we are confident require typings
+    let safeList: Map<string>;
+    const notFoundTypingNames: string[] = [];
+
+    function tryParseJson(jsonPath: string, host: TypingResolutionHost): any {
+        if (host.fileExists(jsonPath)) {
+            try {
+                // Strip out single-line comments
+                const contents = host.readFile(jsonPath).replace(/^\/\/(.*)$/gm, "");
+                return JSON.parse(contents);
+            }
+            catch (e) { }
+        }
+        return undefined;
+    }
+
+    function isTypingEnabled(options: TypingOptions): boolean {
+        if (options) {
+            if (options.enableAutoDiscovery ||
+                (options.include && options.include.length > 0) ||
+                (options.exclude && options.exclude.length > 0)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @param host is the object providing I/O related operations.
+     * @param fileNames are the file names that belong to the same project.
+     * @param globalCachePath is used to get the safe list file path and as cache path if the project root path isn't specified.
+     * @param projectRootPath is the path to the project root directory. This is used for the local typings cache.
+     * @param typingOptions are used for customizing the typing inference process.
+     * @param compilerOptions are used as a source of typing inference.
+     */
+    export function discoverTypings(
+        host: TypingResolutionHost,
+        fileNames: string[],
+        globalCachePath: Path,
+        projectRootPath: Path,
+        typingOptions: TypingOptions,
+        compilerOptions: CompilerOptions)
+        : { cachedTypingPaths: string[], newTypingNames: string[], filesToWatch: string[] } {
+
+        // A typing name to typing file path mapping
+        const inferredTypings: Map<string> = {};
+
+        if (!isTypingEnabled(typingOptions)) {
+            return { cachedTypingPaths: [], newTypingNames: [], filesToWatch: [] };
+        }
+
+        const cachePath = projectRootPath ? projectRootPath : globalCachePath;
+        // Only infer typings for .js and .jsx files
+        fileNames = fileNames
+            .map(ts.normalizePath)
+            .filter(f => scriptKindIs(f, /*LanguageServiceHost*/ undefined, ScriptKind.JS, ScriptKind.JSX));
+
+        const safeListFilePath = ts.combinePaths(globalCachePath, "safeList.json");
+        if (!safeList && host.fileExists(safeListFilePath)) {
+            safeList = tryParseJson(safeListFilePath, host);
+        }
+
+        const filesToWatch: string[] = [];
+        // Directories to search for package.json, bower.json and other typing information
+        let searchDirs: string[] = [];
+        let exclude: string[] = [];
+
+        mergeTypings(typingOptions.include);
+        exclude = typingOptions.exclude ? typingOptions.exclude : [];
+
+        if (typingOptions.enableAutoDiscovery) {
+            const possibleSearchDirs = fileNames.map(ts.getDirectoryPath);
+            if (projectRootPath !== undefined) {
+                possibleSearchDirs.push(projectRootPath);
+            }
+            searchDirs = ts.deduplicate(possibleSearchDirs);
+            for (const searchDir of searchDirs) {
+                const packageJsonPath = ts.combinePaths(searchDir, "package.json");
+                getTypingNamesFromJson(packageJsonPath, filesToWatch);
+
+                const bowerJsonPath = ts.combinePaths(searchDir, "bower.json");
+                getTypingNamesFromJson(bowerJsonPath, filesToWatch);
+
+                const nodeModulesPath = ts.combinePaths(searchDir, "node_modules");
+                getTypingNamesFromNodeModuleFolder(nodeModulesPath, filesToWatch);
+            }
+
+            getTypingNamesFromSourceFileNames(fileNames);
+            getTypingNamesFromCompilerOptions(compilerOptions);
+        }
+
+        const typingsPath = ts.combinePaths(cachePath, "typings");
+        const tsdJsonPath = ts.combinePaths(cachePath, "tsd.json");
+        const tsdJsonDict = tryParseJson(tsdJsonPath, host);
+        if (tsdJsonDict) {
+            for (const notFoundTypingName of notFoundTypingNames) {
+                if (inferredTypings.hasOwnProperty(notFoundTypingName) && !inferredTypings[notFoundTypingName]) {
+                    delete inferredTypings[notFoundTypingName];
+                }
+            }
+
+            // The "installed" property in the tsd.json serves as a registry of installed typings. Each item
+            // of this object has a key of the relative file path, and a value that contains the corresponding
+            // commit hash.
+            if (hasProperty(tsdJsonDict, "installed")) {
+                for (const cachedTypingPath in tsdJsonDict.installed) {
+                    // Assuming the cachedTypingPath has the format of "[package name]/[file name]"
+                    const cachedTypingName = cachedTypingPath.substr(0, cachedTypingPath.indexOf("/"));
+                    // If the inferred[cachedTypingName] is already not null, which means we found a corresponding
+                    // d.ts file that coming with the package. That one should take higher priority.
+                    if (hasProperty(inferredTypings, cachedTypingName) && !inferredTypings[cachedTypingName]) {
+                        inferredTypings[cachedTypingName] = ts.combinePaths(typingsPath, cachedTypingPath);
+                    }
+                }
+            }
+        }
+
+        // Remove typings that the user has added to the exclude list
+        for (const excludeTypingName of exclude) {
+            delete inferredTypings[excludeTypingName];
+        }
+
+        const newTypingNames: string[] = [];
+        const cachedTypingPaths: string[] = [];
+        for (const typing in inferredTypings) {
+            if (inferredTypings[typing] !== undefined) {
+                cachedTypingPaths.push(inferredTypings[typing]);
+            }
+            else {
+                newTypingNames.push(typing);
+            }
+        }
+        return { cachedTypingPaths, newTypingNames, filesToWatch };
+
+        /**
+         * Merge a given list of typingNames to the inferredTypings map
+         */
+        function mergeTypings(typingNames: string[]) {
+            if (!typingNames) {
+                return;
+            }
+
+            for (const typing of typingNames) {
+                if (!inferredTypings.hasOwnProperty(typing)) {
+                    inferredTypings[typing] = undefined;
+                }
+            }
+        }
+
+        /**
+         * Get the typing info from common package manager json files like package.json or bower.json
+         */
+        function getTypingNamesFromJson(jsonPath: string, filesToWatch: string[]) {
+            const jsonDict = tryParseJson(jsonPath, host);
+            if (jsonDict) {
+                filesToWatch.push(jsonPath);
+                if (jsonDict.hasOwnProperty("dependencies")) {
+                    mergeTypings(Object.keys(jsonDict.dependencies));
+                }
+            }
+        }
+
+        /**
+         * Infer typing names from given file names. For example, the file name "jquery-min.2.3.4.js"
+         * should be inferred to the 'jquery' typing name; and "angular-route.1.2.3.js" should be inferred
+         * to the 'angular-route' typing name.
+         * @param fileNames are the names for source files in the project
+         */
+        function getTypingNamesFromSourceFileNames(fileNames: string[]) {
+            const jsFileNames = fileNames.filter(hasJavaScriptFileExtension);
+            const inferredTypingNames = jsFileNames.map(f => ts.removeFileExtension(ts.getBaseFileName(f.toLowerCase())));
+            const cleanedTypingNames = inferredTypingNames.map(f => f.replace(/((?:\.|-)min(?=\.|$))|((?:-|\.)\d+)/g, ""));
+            safeList === undefined ? mergeTypings(cleanedTypingNames) : mergeTypings(cleanedTypingNames.filter(f => safeList.hasOwnProperty(f)));
+
+            const jsxFileNames = fileNames.filter(f => scriptKindIs(f, /*LanguageServiceHost*/ undefined, ScriptKind.JSX));
+            if (jsxFileNames.length > 0) {
+                mergeTypings(["react"]);
+            }
+        }
+
+        /**
+         * Infer typing names from node_module folder
+         * @param nodeModulesPath is the path to the "node_modules" folder
+         */
+        function getTypingNamesFromNodeModuleFolder(nodeModulesPath: string, filesToWatch: string[]) {
+            // Todo: add support for ModuleResolutionHost too
+            if (!host.directoryExists(nodeModulesPath)) {
+                return;
+            }
+
+            const typingNames: string[] = [];
+            const packageJsonFiles =
+                host.readDirectory(nodeModulesPath, /*extension*/ undefined, /*exclude*/ undefined, /*depth*/ 2).filter(f => ts.getBaseFileName(f) === "package.json");
+            for (const packageJsonFile of packageJsonFiles) {
+                const packageJsonDict = tryParseJson(packageJsonFile, host);
+                if (!packageJsonDict) { continue; }
+
+                filesToWatch.push(packageJsonFile);
+
+                // npm 3 has the package.json contains a "_requiredBy" field
+                // we should include all the top level module names for npm 2, and only module names whose
+                // "_requiredBy" field starts with "#" or equals "/" for npm 3.
+                if (packageJsonDict._requiredBy &&
+                    packageJsonDict._requiredBy.filter((r: string) => r[0] === "#" || r === "/").length === 0) {
+                    continue;
+                }
+
+                // If the package has its own d.ts typings, those will take precedence. Otherwise the package name will be used
+                // to download d.ts files from DefinitelyTyped
+                const packageName = packageJsonDict["name"];
+                if (packageJsonDict.hasOwnProperty("typings")) {
+                    const absPath = ts.getNormalizedAbsolutePath(packageJsonDict.typings, ts.getDirectoryPath(packageJsonFile));
+                    inferredTypings[packageName] = absPath;
+                }
+                else {
+                    typingNames.push(packageName);
+                }
+            }
+            mergeTypings(typingNames);
+        }
+
+        function getTypingNamesFromCompilerOptions(options: CompilerOptions) {
+            const typingNames: string[] = [];
+            if (!options) {
+                return;
+            }
+
+            if (options.jsx === JsxEmit.React) {
+                typingNames.push("react");
+            }
+            if (options.moduleResolution === ModuleResolutionKind.NodeJs) {
+                typingNames.push("node");
+            }
+            mergeTypings(typingNames);
+        }
+    }
+
+    /**
+     * Keep a list of typings names that we know cannot be obtained at the moment (could be because
+     * of network issues or because the package doesn't hava a d.ts file in DefinitelyTyped), so
+     * that we won't try again next time within this session.
+     * @param newTypingNames The list of new typings that the host attempted to acquire
+     * @param cachePath The path to the tsd.json cache
+     * @param host The object providing I/O related operations.
+     */
+    export function updateNotFoundTypingNames(newTypingNames: string[], cachePath: string, host: TypingResolutionHost): void {
+        const tsdJsonPath = ts.combinePaths(cachePath, "tsd.json");
+        const cacheTsdJsonDict = tryParseJson(tsdJsonPath, host);
+        if (cacheTsdJsonDict) {
+            const installedTypingFiles = hasProperty(cacheTsdJsonDict, "installed")
+                ? Object.keys(cacheTsdJsonDict.installed)
+                : [];
+            const newMissingTypingNames =
+                ts.filter(newTypingNames, name => notFoundTypingNames.indexOf(name) < 0 && !isInstalled(name, installedTypingFiles));
+            for (const newMissingTypingName of newMissingTypingNames) {
+                notFoundTypingNames.push(newMissingTypingName);
+            }
+        }
+    }
+
+    function isInstalled(typing: string, installedKeys: string[]) {
+        const typingPrefix = typing + "/";
+        for (const key of installedKeys) {
+            if (key.indexOf(typingPrefix) === 0) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -22,7 +22,7 @@ namespace ts.JsTyping {
         if (host.fileExists(jsonPath)) {
             try {
                 // Strip out single-line comments
-                const contents = host.readFile(jsonPath).replace(/^\/\/(.*)$/gm, "");
+                const contents = host.readFile(jsonPath).replace(/^\s*\/\/(.*)$/gm, "");
                 return JSON.parse(contents);
             }
             catch (e) { }
@@ -65,7 +65,7 @@ namespace ts.JsTyping {
             return { cachedTypingPaths: [], newTypingNames: [], filesToWatch: [] };
         }
 
-        const cachePath = projectRootPath ? projectRootPath : globalCachePath;
+        const cachePath = projectRootPath || globalCachePath;
         // Only infer typings for .js and .jsx files
         fileNames = fileNames
             .map(ts.normalizePath)
@@ -82,7 +82,7 @@ namespace ts.JsTyping {
         let exclude: string[] = [];
 
         mergeTypings(typingOptions.include);
-        exclude = typingOptions.exclude ? typingOptions.exclude : [];
+        exclude = typingOptions.exclude || [];
 
         if (typingOptions.enableAutoDiscovery) {
             const possibleSearchDirs = fileNames.map(ts.getDirectoryPath);

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -173,6 +173,12 @@ namespace ts.JsTyping {
                 if (hasProperty(jsonDict, "devDependencies")) {
                     mergeTypings(getKeys(jsonDict.devDependencies));
                 }
+                if (hasProperty(jsonDict, "optionalDependencies")) {
+                    mergeTypings(getKeys(jsonDict.optionalDependencies));
+                }
+                if (hasProperty(jsonDict, "peerDependencies")) {
+                    mergeTypings(getKeys(jsonDict.peerDependencies));
+                }
             }
         }
 

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -60,8 +60,12 @@ namespace ts.JsTyping {
 
         if (!safeList) {
             const result = readConfigFile(safeListPath, (path: string) => host.readFile(path));
-            if (result.config) { safeList = result.config; }
-            else { safeList = {}; };
+            if (result.config) {
+                safeList = result.config;
+            }
+            else {
+                safeList = {};
+            };
         }
 
         const filesToWatch: string[] = [];
@@ -188,9 +192,13 @@ namespace ts.JsTyping {
             const fileNames = host.readDirectory(nodeModulesPath, "*.json", /*exclude*/ undefined, /*depth*/ 2);
             for (const fileName of fileNames) {
                 const normalizedFileName = normalizePath(fileName);
-                if (getBaseFileName(normalizedFileName) !== "package.json") { continue; }
+                if (getBaseFileName(normalizedFileName) !== "package.json") {
+                    continue;
+                }
                 const result = readConfigFile(normalizedFileName, (path: string) => host.readFile(path));
-                if (!result.config) { continue; }
+                if (!result.config) {
+                    continue;
+                }
                 const packageJson: PackageJson = result.config;
 
                 // npm 3's package.json contains a "_requiredBy" field
@@ -203,7 +211,9 @@ namespace ts.JsTyping {
 
                 // If the package has its own d.ts typings, those will take precedence. Otherwise the package name will be used
                 // to download d.ts files from DefinitelyTyped
-                if (!packageJson.name) { continue; }
+                if (!packageJson.name) {
+                    continue;
+                }
                 if (packageJson.typings) {
                     const absolutePath = getNormalizedAbsolutePath(packageJson.typings, getDirectoryPath(normalizedFileName));
                     inferredTypings[packageJson.name] = absolutePath;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1757,7 +1757,7 @@ namespace ts {
                     hostFileName: fileName,
                     version: this.host.getScriptVersion(fileName),
                     scriptSnapshot: scriptSnapshot,
-                    scriptKind: scriptKind
+                    scriptKind: scriptKind ? scriptKind : getScriptKindFromFileName(fileName)
                 };
             }
 
@@ -2857,7 +2857,7 @@ namespace ts {
                         // We do not support the scenario where a host can modify a registered
                         // file's script kind, i.e. in one project some file is treated as ".ts"
                         // and in another as ".js"
-                        Debug.assert(hostFileInformation.scriptKind === oldSourceFile.scriptKind, "Registered script kind (" + oldSourceFile.scriptKind + ") should match new script kind (" + hostFileInformation.scriptKind +") for file: " + fileName);
+                        Debug.assert(hostFileInformation.scriptKind === oldSourceFile.scriptKind, "Registered script kind (" + oldSourceFile.scriptKind + ") should match new script kind (" + hostFileInformation.scriptKind + ") for file: " + fileName);
 
                         return documentRegistry.updateDocument(fileName, newSettings, hostFileInformation.scriptSnapshot, hostFileInformation.version, hostFileInformation.scriptKind);
                     }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -805,6 +805,7 @@ namespace ts {
         public identifierCount: number;
         public symbolCount: number;
         public version: string;
+        public scriptKind: ScriptKind;
         public languageVersion: ScriptTarget;
         public languageVariant: LanguageVariant;
         public identifiers: Map<string>;
@@ -818,8 +819,8 @@ namespace ts {
             super(kind, pos, end);
         }
 
-        public update(newText: string, textChangeRange: TextChangeRange, scriptKind?: ScriptKind): SourceFile {
-            return updateSourceFile(this, newText, textChangeRange, /*aggressiveChecks*/ undefined, scriptKind);
+        public update(newText: string, textChangeRange: TextChangeRange): SourceFile {
+            return updateSourceFile(this, newText, textChangeRange);
         }
 
         public getLineAndCharacterOfPosition(position: number): LineAndCharacter {
@@ -1833,7 +1834,7 @@ namespace ts {
             else if (this.currentFileVersion !== version) {
                 // This is the same file, just a newer version. Incrementally parse the file.
                 const editRange = scriptSnapshot.getChangeRange(this.currentFileScriptSnapshot);
-                sourceFile = updateLanguageServiceSourceFile(this.currentSourceFile, scriptSnapshot, version, editRange, /*aggressiveChecks*/ undefined, scriptKind);
+                sourceFile = updateLanguageServiceSourceFile(this.currentSourceFile, scriptSnapshot, version, editRange);
             }
 
             if (sourceFile) {
@@ -1968,7 +1969,7 @@ namespace ts {
 
     export let disableIncrementalParsing = false;
 
-    export function updateLanguageServiceSourceFile(sourceFile: SourceFile, scriptSnapshot: IScriptSnapshot, version: string, textChangeRange: TextChangeRange, aggressiveChecks?: boolean, scriptKind?: ScriptKind): SourceFile {
+    export function updateLanguageServiceSourceFile(sourceFile: SourceFile, scriptSnapshot: IScriptSnapshot, version: string, textChangeRange: TextChangeRange, aggressiveChecks?: boolean): SourceFile {
         // If we were given a text change range, and our version or open-ness changed, then
         // incrementally parse this file.
         if (textChangeRange) {
@@ -2002,7 +2003,7 @@ namespace ts {
                                 : (changedText + suffix);
                     }
 
-                    const newSourceFile = updateSourceFile(sourceFile, newText, textChangeRange, aggressiveChecks, scriptKind);
+                    const newSourceFile = updateSourceFile(sourceFile, newText, textChangeRange, aggressiveChecks);
                     setSourceFileFields(newSourceFile, scriptSnapshot, version);
                     // after incremental parsing nameTable might not be up-to-date
                     // drop it so it can be lazily recreated later
@@ -2023,7 +2024,7 @@ namespace ts {
         }
 
         // Otherwise, just create a new source file.
-        return createLanguageServiceSourceFile(sourceFile.fileName, scriptSnapshot, sourceFile.languageVersion, version, /*setNodeParents*/ true, scriptKind);
+        return createLanguageServiceSourceFile(sourceFile.fileName, scriptSnapshot, sourceFile.languageVersion, version, /*setNodeParents*/ true, sourceFile.scriptKind);
     }
 
     export function createDocumentRegistry(useCaseSensitiveFileNames?: boolean, currentDirectory = ""): DocumentRegistry {
@@ -2103,7 +2104,7 @@ namespace ts {
                 // return it as is.
                 if (entry.sourceFile.version !== version) {
                     entry.sourceFile = updateLanguageServiceSourceFile(entry.sourceFile, scriptSnapshot, version,
-                        scriptSnapshot.getChangeRange(entry.sourceFile.scriptSnapshot), /*aggressiveChecks*/ undefined, scriptKind);
+                        scriptSnapshot.getChangeRange(entry.sourceFile.scriptSnapshot));
                 }
             }
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1018,7 +1018,7 @@ namespace ts {
         getNewLine?(): string;
         getProjectVersion?(): string;
         getScriptFileNames(): string[];
-        getScriptKind(fileName: string): ScriptKind;
+        getScriptKind?(fileName: string): ScriptKind;
         getScriptVersion(fileName: string): string;
         getScriptSnapshot(fileName: string): IScriptSnapshot;
         getLocalizedDiagnosticMessages?(): any;
@@ -1749,7 +1749,7 @@ namespace ts {
 
         private createEntry(fileName: string, path: Path) {
             let entry: HostFileInformation;
-            const scriptKind = this.host.getScriptKind(fileName);
+            const scriptKind = this.host.getScriptKind ? this.host.getScriptKind(fileName) : ScriptKind.Unknown;
             const scriptSnapshot = this.host.getScriptSnapshot(fileName);
             if (scriptSnapshot) {
                 entry = {
@@ -1822,7 +1822,7 @@ namespace ts {
                 throw new Error("Could not find file: '" + fileName + "'.");
             }
 
-            const scriptKind = this.host.getScriptKind(fileName);
+            const scriptKind = this.host.getScriptKind ? this.host.getScriptKind(fileName) : ScriptKind.Unknown;
             const version = this.host.getScriptVersion(fileName);
             let sourceFile: SourceFile;
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -7,6 +7,7 @@
 /// <reference path='patternMatcher.ts' />
 /// <reference path='signatureHelp.ts' />
 /// <reference path='utilities.ts' />
+/// <reference path='jsTyping.ts' />
 /// <reference path='formatting\formatting.ts' />
 /// <reference path='formatting\smartIndenter.ts' />
 
@@ -1750,14 +1751,13 @@ namespace ts {
 
         private createEntry(fileName: string, path: Path) {
             let entry: HostFileInformation;
-            const scriptKind = this.host.getScriptKind ? this.host.getScriptKind(fileName) : ScriptKind.Unknown;
             const scriptSnapshot = this.host.getScriptSnapshot(fileName);
             if (scriptSnapshot) {
                 entry = {
                     hostFileName: fileName,
                     version: this.host.getScriptVersion(fileName),
                     scriptSnapshot: scriptSnapshot,
-                    scriptKind: scriptKind ? scriptKind : getScriptKindFromFileName(fileName)
+                    scriptKind: getScriptKind(fileName, this.host)
                 };
             }
 
@@ -1823,7 +1823,7 @@ namespace ts {
                 throw new Error("Could not find file: '" + fileName + "'.");
             }
 
-            const scriptKind = this.host.getScriptKind ? this.host.getScriptKind(fileName) : ScriptKind.Unknown;
+            const scriptKind = getScriptKind(fileName, this.host);
             const version = this.host.getScriptVersion(fileName);
             let sourceFile: SourceFile;
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2102,7 +2102,7 @@ namespace ts {
                 // the script snapshot.  If so, update it appropriately.  Otherwise, we can just
                 // return it as is.
                 if (entry.sourceFile.version !== version) {
-                    entry.sourceFile = updateLanguageServiceSourceFile(entry.sourceFile, scriptSnapshot, version, 
+                    entry.sourceFile = updateLanguageServiceSourceFile(entry.sourceFile, scriptSnapshot, version,
                         scriptSnapshot.getChangeRange(entry.sourceFile.scriptSnapshot), /*aggressiveChecks*/ undefined, scriptKind);
                 }
             }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -13,7 +13,7 @@
 
 namespace ts {
     /** The version of the language service API */
-    export const servicesVersion = "0.4";
+    export const servicesVersion = "0.5";
 
     export interface Node {
         getSourceFile(): SourceFile;

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -2853,6 +2853,12 @@ namespace ts {
                         // it's source file any more, and instead defers to DocumentRegistry to get
                         // either version 1, version 2 (or some other version) depending on what the
                         // host says should be used.
+
+                        // We do not support the scenario where a host can modify a registered
+                        // file's script kind, i.e. in one project some file is treated as ".ts"
+                        // and in another as ".js"
+                        Debug.assert(hostFileInformation.scriptKind === oldSourceFile.scriptKind, "Registered script kind (" + oldSourceFile.scriptKind + ") should match new script kind (" + hostFileInformation.scriptKind +") for file: " + fileName);
+
                         return documentRegistry.updateDocument(fileName, newSettings, hostFileInformation.scriptSnapshot, hostFileInformation.version, hostFileInformation.scriptKind);
                     }
 

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -230,8 +230,7 @@ namespace ts {
         getPreProcessedFileInfo(fileName: string, sourceText: IScriptSnapshot): string;
         getTSConfigFileInfo(fileName: string, sourceText: IScriptSnapshot): string;
         getDefaultCompilationSettings(): string;
-        discoverTypings(fileNamesJson: string, globalCachePath: string, projectRootPath: string, typingOptionsJson: string, compilerOptionsJson: string): string;
-        updateNotFoundTypingNames(newTypingsJson: string, globalCachePath: string, projectRootPath: string): string;
+        discoverTypings(fileNamesJson: string, cachePath: string, projectRootPath: string, safeListPath: string, typingOptionsJson: string, compilerOptionsJson: string): string;
     }
 
     function logInternalError(logger: Logger, err: Error) {
@@ -986,29 +985,20 @@ namespace ts {
             );
         }
 
-        public discoverTypings(fileNamesJson: string, globalCachePath: string, projectRootPath: string, typingOptionsJson: string, compilerOptionsJson: string): string {
+        public discoverTypings(fileNamesJson: string, cachePath: string, projectRootPath: string, safeListPath: string, typingOptionsJson: string, compilerOptionsJson: string): string {
             const getCanonicalFileName = createGetCanonicalFileName(/*useCaseSensitivefileNames:*/ false);
             return this.forwardJSONCall("discoverTypings()", () => {
-                const cachePath = projectRootPath ? projectRootPath : globalCachePath;
                 const typingOptions = <TypingOptions>JSON.parse(typingOptionsJson);
-
                 const compilerOptions = <CompilerOptions>JSON.parse(compilerOptionsJson);
                 const fileNames: string[] = JSON.parse(fileNamesJson);
                 return ts.JsTyping.discoverTypings(
                     this.host,
                     fileNames,
-                    toPath(globalCachePath, globalCachePath, getCanonicalFileName),
                     toPath(cachePath, cachePath, getCanonicalFileName),
+                    toPath(projectRootPath, projectRootPath, getCanonicalFileName),
+                    toPath(safeListPath, safeListPath, getCanonicalFileName),
                     typingOptions,
                     compilerOptions);
-            });
-        }
-
-        public updateNotFoundTypingNames(newTypingsJson: string, globalCachePath: string, projectRootPath: string): string {
-            return this.forwardJSONCall("updateNotFoundTypingNames()", () => {
-                const newTypingNames: string[] = JSON.parse(newTypingsJson);
-                const cachePath = projectRootPath ? projectRootPath : globalCachePath;
-                ts.JsTyping.updateNotFoundTypingNames(newTypingNames, cachePath, this.host);
             });
         }
     }

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -988,16 +988,16 @@ namespace ts {
         public discoverTypings(discoverTypingsJson: string): string {
             const getCanonicalFileName = createGetCanonicalFileName(/*useCaseSensitivefileNames:*/ false);
             return this.forwardJSONCall("discoverTypings()", () => {
-                const settings = <DiscoverTypingsSettings>JSON.parse(discoverTypingsJson);
+                const info = <DiscoverTypingsInfo>JSON.parse(discoverTypingsJson);
                 return ts.JsTyping.discoverTypings(
                     this.host,
-                    settings.fileNames,
-                    toPath(settings.cachePath, settings.cachePath, getCanonicalFileName),
-                    toPath(settings.projectRootPath, settings.projectRootPath, getCanonicalFileName),
-                    toPath(settings.safeListPath, settings.safeListPath, getCanonicalFileName),
-                    settings.packageNameToTypingLocation,
-                    settings.typingOptions,
-                    settings.compilerOptions);
+                    info.fileNames,
+                    toPath(info.cachePath, info.cachePath, getCanonicalFileName),
+                    toPath(info.projectRootPath, info.projectRootPath, getCanonicalFileName),
+                    toPath(info.safeListPath, info.safeListPath, getCanonicalFileName),
+                    info.packageNameToTypingLocation,
+                    info.typingOptions,
+                    info.compilerOptions);
             });
         }
     }

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -230,7 +230,7 @@ namespace ts {
         getPreProcessedFileInfo(fileName: string, sourceText: IScriptSnapshot): string;
         getTSConfigFileInfo(fileName: string, sourceText: IScriptSnapshot): string;
         getDefaultCompilationSettings(): string;
-        resolveTypeDefinitions(fileNamesJson: string, globalCachePath: string, projectRootPath: string, typingOptionsJson: string, compilerOptionsJson: string): string;
+        discoverTypings(fileNamesJson: string, globalCachePath: string, projectRootPath: string, typingOptionsJson: string, compilerOptionsJson: string): string;
         updateNotFoundTypingNames(newTypingsJson: string, globalCachePath: string, projectRootPath: string): string;
     }
 
@@ -986,14 +986,11 @@ namespace ts {
             );
         }
 
-        public resolveTypeDefinitions(fileNamesJson: string, globalCachePath: string, projectRootPath: string, typingOptionsJson: string, compilerOptionsJson: string): string {
+        public discoverTypings(fileNamesJson: string, globalCachePath: string, projectRootPath: string, typingOptionsJson: string, compilerOptionsJson: string): string {
             const getCanonicalFileName = createGetCanonicalFileName(/*useCaseSensitivefileNames:*/ false);
-            return this.forwardJSONCall("resolveTypeDefinitions()", () => {
+            return this.forwardJSONCall("discoverTypings()", () => {
                 const cachePath = projectRootPath ? projectRootPath : globalCachePath;
                 const typingOptions = <TypingOptions>JSON.parse(typingOptionsJson);
-                // Convert the include and exclude lists from a semi-colon delimited string to a string array
-                typingOptions.include = typingOptions.include ? typingOptions.include.toString().split(";") : [];
-                typingOptions.exclude = typingOptions.exclude ? typingOptions.exclude.toString().split(";") : [];
 
                 const compilerOptions = <CompilerOptions>JSON.parse(compilerOptionsJson);
                 const fileNames: string[] = JSON.parse(fileNamesJson);

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -230,7 +230,7 @@ namespace ts {
         getPreProcessedFileInfo(fileName: string, sourceText: IScriptSnapshot): string;
         getTSConfigFileInfo(fileName: string, sourceText: IScriptSnapshot): string;
         getDefaultCompilationSettings(): string;
-        discoverTypings(fileNamesJson: string, cachePath: string, projectRootPath: string, safeListPath: string, typingOptionsJson: string, compilerOptionsJson: string): string;
+        discoverTypings(discoverTypingsJson: string): string;
     }
 
     function logInternalError(logger: Logger, err: Error) {
@@ -985,20 +985,19 @@ namespace ts {
             );
         }
 
-        public discoverTypings(fileNamesJson: string, cachePath: string, projectRootPath: string, safeListPath: string, typingOptionsJson: string, compilerOptionsJson: string): string {
+        public discoverTypings(discoverTypingsJson: string): string {
             const getCanonicalFileName = createGetCanonicalFileName(/*useCaseSensitivefileNames:*/ false);
             return this.forwardJSONCall("discoverTypings()", () => {
-                const typingOptions = <TypingOptions>JSON.parse(typingOptionsJson);
-                const compilerOptions = <CompilerOptions>JSON.parse(compilerOptionsJson);
-                const fileNames: string[] = JSON.parse(fileNamesJson);
+                const settings = <DiscoverTypingsSettings>JSON.parse(discoverTypingsJson);
                 return ts.JsTyping.discoverTypings(
                     this.host,
-                    fileNames,
-                    toPath(cachePath, cachePath, getCanonicalFileName),
-                    toPath(projectRootPath, projectRootPath, getCanonicalFileName),
-                    toPath(safeListPath, safeListPath, getCanonicalFileName),
-                    typingOptions,
-                    compilerOptions);
+                    settings.fileNames,
+                    toPath(settings.cachePath, settings.cachePath, getCanonicalFileName),
+                    toPath(settings.projectRootPath, settings.projectRootPath, getCanonicalFileName),
+                    toPath(settings.safeListPath, settings.safeListPath, getCanonicalFileName),
+                    settings.packageNameToTypingLocation,
+                    settings.typingOptions,
+                    settings.compilerOptions);
             });
         }
     }

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -346,10 +346,10 @@ namespace ts {
         }
 
         public getScriptKind(fileName: string): ScriptKind {
-            try {
+            if ("getScriptKind" in this.shimHost) {
                 return this.shimHost.getScriptKind(fileName);
             }
-            catch (e) {
+            else {
                 return ScriptKind.Unknown;
             }
         }

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -55,7 +55,7 @@ namespace ts {
 
         /** Returns a JSON-encoded value of the type: string[] */
         getScriptFileNames(): string;
-        getScriptKind(fileName: string): ScriptKind;
+        getScriptKind?(fileName: string): ScriptKind;
         getScriptVersion(fileName: string): string;
         getScriptSnapshot(fileName: string): ScriptSnapshotShim;
         getLocalizedDiagnosticMessages(): string;
@@ -348,7 +348,8 @@ namespace ts {
         public getScriptKind(fileName: string): ScriptKind {
             try {
                 return this.shimHost.getScriptKind(fileName);
-            } catch (e) {
+            }
+            catch (e) {
                 return ScriptKind.Unknown;
             }
         }

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -992,7 +992,6 @@ namespace ts {
                 return ts.JsTyping.discoverTypings(
                     this.host,
                     info.fileNames,
-                    toPath(info.cachePath, info.cachePath, getCanonicalFileName),
                     toPath(info.projectRootPath, info.projectRootPath, getCanonicalFileName),
                     toPath(info.safeListPath, info.safeListPath, getCanonicalFileName),
                     info.packageNameToTypingLocation,

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -55,6 +55,7 @@ namespace ts {
 
         /** Returns a JSON-encoded value of the type: string[] */
         getScriptFileNames(): string;
+        getScriptKind(fileName: string): ScriptKind;
         getScriptVersion(fileName: string): string;
         getScriptSnapshot(fileName: string): ScriptSnapshotShim;
         getLocalizedDiagnosticMessages(): string;
@@ -342,6 +343,14 @@ namespace ts {
         public getScriptSnapshot(fileName: string): IScriptSnapshot {
             const scriptSnapshot = this.shimHost.getScriptSnapshot(fileName);
             return scriptSnapshot && new ScriptSnapshotShimAdapter(scriptSnapshot);
+        }
+
+        public getScriptKind(fileName: string): ScriptKind {
+            try {
+                return this.shimHost.getScriptKind(fileName);
+            } catch (e) {
+                return ScriptKind.Unknown;
+            }
         }
 
         public getScriptVersion(fileName: string): string {

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -78,7 +78,7 @@ namespace ts {
          * @param exclude A JSON encoded string[] containing the paths to exclude
          *  when enumerating the directory.
          */
-        readDirectory(rootDir: string, extension: string, exclude?: string): string;
+         readDirectory(rootDir: string, extension: string, exclude?: string, depth?: number): string;
     }
 
     ///
@@ -230,6 +230,8 @@ namespace ts {
         getPreProcessedFileInfo(fileName: string, sourceText: IScriptSnapshot): string;
         getTSConfigFileInfo(fileName: string, sourceText: IScriptSnapshot): string;
         getDefaultCompilationSettings(): string;
+        resolveTypeDefinitions(fileNamesJson: string, globalCachePath: string, projectRootPath: string, typingOptionsJson: string, compilerOptionsJson: string): string;
+        updateNotFoundTypingNames(newTypingsJson: string, globalCachePath: string, projectRootPath: string): string;
     }
 
     function logInternalError(logger: Logger, err: Error) {
@@ -420,8 +422,16 @@ namespace ts {
             }
         }
 
-        public readDirectory(rootDir: string, extension: string, exclude: string[]): string[] {
-            const encoded = this.shimHost.readDirectory(rootDir, extension, JSON.stringify(exclude));
+        public readDirectory(rootDir: string, extension: string, exclude: string[], depth?: number): string[] {
+            // Wrap the API changes for 2.0 release. This try/catch
+            // should be removed once TypeScript 2.0 has shipped.
+            let encoded: string;
+            try {
+                encoded = this.shimHost.readDirectory(rootDir, extension, JSON.stringify(exclude), depth);
+            }
+            catch (e) {
+                encoded = this.shimHost.readDirectory(rootDir, extension, JSON.stringify(exclude));
+            }
             return JSON.parse(encoded);
         }
 
@@ -951,6 +961,7 @@ namespace ts {
                     if (result.error) {
                         return {
                             options: {},
+                            typingOptions: {},
                             files: [],
                             errors: [realizeDiagnostic(result.error, "\r\n")]
                         };
@@ -961,6 +972,7 @@ namespace ts {
 
                     return {
                         options: configFile.options,
+                        typingOptions: configFile.typingOptions,
                         files: configFile.fileNames,
                         errors: realizeDiagnostics(configFile.errors, "\r\n")
                     };
@@ -972,6 +984,35 @@ namespace ts {
                 "getDefaultCompilationSettings()",
                 () => getDefaultCompilerOptions()
             );
+        }
+
+        public resolveTypeDefinitions(fileNamesJson: string, globalCachePath: string, projectRootPath: string, typingOptionsJson: string, compilerOptionsJson: string): string {
+            const getCanonicalFileName = createGetCanonicalFileName(/*useCaseSensitivefileNames:*/ false);
+            return this.forwardJSONCall("resolveTypeDefinitions()", () => {
+                const cachePath = projectRootPath ? projectRootPath : globalCachePath;
+                const typingOptions = <TypingOptions>JSON.parse(typingOptionsJson);
+                // Convert the include and exclude lists from a semi-colon delimited string to a string array
+                typingOptions.include = typingOptions.include ? typingOptions.include.toString().split(";") : [];
+                typingOptions.exclude = typingOptions.exclude ? typingOptions.exclude.toString().split(";") : [];
+
+                const compilerOptions = <CompilerOptions>JSON.parse(compilerOptionsJson);
+                const fileNames: string[] = JSON.parse(fileNamesJson);
+                return ts.JsTyping.discoverTypings(
+                    this.host,
+                    fileNames,
+                    toPath(globalCachePath, globalCachePath, getCanonicalFileName),
+                    toPath(cachePath, cachePath, getCanonicalFileName),
+                    typingOptions,
+                    compilerOptions);
+            });
+        }
+
+        public updateNotFoundTypingNames(newTypingsJson: string, globalCachePath: string, projectRootPath: string): string {
+            return this.forwardJSONCall("updateNotFoundTypingNames()", () => {
+                const newTypingNames: string[] = JSON.parse(newTypingsJson);
+                const cachePath = projectRootPath ? projectRootPath : globalCachePath;
+                ts.JsTyping.updateNotFoundTypingNames(newTypingNames, cachePath, this.host);
+            });
         }
     }
 

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -30,6 +30,7 @@
         "shims.ts",
         "signatureHelp.ts",
         "utilities.ts",
+        "jsTyping.ts",
         "formatting/formatting.ts",
         "formatting/formattingContext.ts",
         "formatting/formattingRequestKind.ts",

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -837,4 +837,19 @@ namespace ts {
         };
         return name;
     }
+
+    export function scriptKindIs(fileName: string, host: LanguageServiceHost, ...scriptKinds: ScriptKind[]): boolean {
+        const scriptKind = getScriptKind(fileName, host);
+        return forEach(scriptKinds, k => k === scriptKind);
+    }
+
+    export function getScriptKind(fileName: string, host?: LanguageServiceHost): ScriptKind {
+        // First check to see if the script kind can be determined from the file name
+        var scriptKind = getScriptKindFromFileName(fileName);
+        if (scriptKind === ScriptKind.Unknown && host && host.getScriptKind) {
+            // Next check to see if the host can resolve the script kind
+            scriptKind = host.getScriptKind(fileName);
+        }
+        return ensureScriptKind(fileName, scriptKind);
+    }
 }


### PR DESCRIPTION
Port acquire d.ts and scriptKind from master to release 1.8

Note: this PR only ports what is already in master. There are a few fixes to jsTypings.ts that are currently in the works. @zhengbli is addressing these in PR#7406 which will also be ported to release-1.8.