### PR TITLE
Fix duplicate errors in JSDoc function types with anon parameters

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -753,6 +753,7 @@ namespace ts {
                 case SyntaxKind.GetAccessor:
                 case SyntaxKind.SetAccessor:
                 case SyntaxKind.FunctionType:
+                case SyntaxKind.JSDocFunctionType:
                 case SyntaxKind.ConstructorType:
                 case SyntaxKind.FunctionExpression:
                 case SyntaxKind.ArrowFunction:

--- a/tests/cases/fourslash/jsDocFunctionSignatures4.ts
+++ b/tests/cases/fourslash/jsDocFunctionSignatures4.ts
@@ -1,0 +1,11 @@
+///<reference path="fourslash.ts" />
+
+// @allowNonTsExtensions: true
+// @Filename: Foo.js
+
+//// /** @param {function ({OwnerID:string,AwayID:string}):void} x
+////   * @param {function (string):void} y */
+//// function fn(x, y) { }
+
+verify.numberOfErrorsInCurrentFile(0);
+


### PR DESCRIPTION
Fixes #6993 in master branch

This fix went into release-1.8 with #7266 but I failed to merge it into master