### PR TITLE
Always run lint, even for runtests-parallel

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -652,7 +652,7 @@ function deleteTemporaryProjectOutput() {
     }
 }
 
-function runConsoleTests(defaultReporter, defaultSubsets, postLint) {
+function runConsoleTests(defaultReporter, defaultSubsets) {
     cleanTestDirs();
     var debug = process.env.debug || process.env.d;
     tests = process.env.test || process.env.tests || process.env.t;
@@ -685,13 +685,13 @@ function runConsoleTests(defaultReporter, defaultSubsets, postLint) {
         subsetRegexes = subsets.map(function (sub) { return "^" + sub + ".*$"; });
         subsetRegexes.push("^(?!" + subsets.join("|") + ").*$");
     }
-    subsetRegexes.forEach(function (subsetRegex) {
+    subsetRegexes.forEach(function (subsetRegex, i) {
         tests = subsetRegex ? ' -g "' + subsetRegex + '"' : '';
         var cmd = "mocha" + (debug ? " --debug-brk" : "") + " -R " + reporter + tests + colors + ' -t ' + testTimeout + ' ' + run;
         console.log(cmd);
         exec(cmd, function () {
             deleteTemporaryProjectOutput();
-            if (postLint) {
+            if (i === 0) {
                 var lint = jake.Task['lint'];
                 lint.addListener('complete', function () {
                     complete();
@@ -713,7 +713,7 @@ task("runtests-parallel", ["build-rules", "tests", builtLocalDirectory], functio
 
 desc("Runs the tests using the built run.js file. Optional arguments are: t[ests]=regex r[eporter]=[list|spec|json|<more>] d[ebug]=true color[s]=false.");
 task("runtests", ["build-rules", "tests", builtLocalDirectory], function() {
-    runConsoleTests('mocha-fivemat-progress-reporter', [], /*postLint*/ true);
+    runConsoleTests('mocha-fivemat-progress-reporter', []);
 }, {async: true});
 
 desc("Generates code coverage data via instanbul");


### PR DESCRIPTION
Previously, runtests-parallel did not run lint. Now, the first runner runs lint -- not necessarily the first to complete.

This still does not address the issue that the first runner to fail will fail the job, so you will not necessarily see all failures in one parallel run, meaning that `jake runtests-parallel baseline-accept` is still not equivalent to `jake runtests baseline-accept`.