### PR TITLE
AllowJS files in tsserver when no project is given

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1317,6 +1317,7 @@ namespace ts.server {
             else {
                 const defaultOpts = ts.getDefaultCompilerOptions();
                 defaultOpts.allowNonTsExtensions = true;
+                defaultOpts.allowJs = true;
                 this.setCompilerOptions(defaultOpts);
             }
             this.languageService = ts.createLanguageService(this.host, this.documentRegistry);


### PR DESCRIPTION
This is a hot issue for VSCode. Effectively, with no config file provided, we don't resolve CommonJS modules in JavaScript files.

The issue is that although `allowNonTsExtensions` is set by default, `allowJs` currently isn't, and when `nodeModuleNameResolver` is called, it only resolves files with [supportedExtensions](https://github.com/Microsoft/TypeScript/blob/master/src/compiler/program.ts#L370). If `allowJs` isn't set, then `.js` isn't in the set of file extensions it looks for.

This is a one line change in `tsserver` only, so should not impact VS. (We should decide if `getDefaultCompilerOptions` in `services.ts` should set this by default also, but this is the minimal/least risk change for now).