### PR TITLE
do not add 'this' type for classes that considered safe (use 'this' only in property\element access expressions)

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -387,7 +387,7 @@ namespace ts {
         Const =              1 << 11,  // Variable declaration
         Namespace =          1 << 12,  // Namespace declaration
         ExportContext =      1 << 13,  // Export context (initialized by binding)
-        ContainsThis =       1 << 14,  // Interface contains references to "this"
+        UsesThisTypeOrReference = 1 << 14,  // Class\interface contains references to "this"
         HasImplicitReturn =  1 << 15,  // If function implicitly returns on one of codepaths (initialized by binding)
         HasExplicitReturn =  1 << 16,  // If function has explicit reachable return on one of codepaths (initialized by binding)
         GlobalAugmentation = 1 << 17,  // Set if module declaration is an augmentation for the global scope

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -676,7 +676,11 @@ namespace ts {
     }
 
     export function isClassLike(node: Node): node is ClassLikeDeclaration {
-        return node && (node.kind === SyntaxKind.ClassDeclaration || node.kind === SyntaxKind.ClassExpression);
+        return node && isClassLikeKind(node.kind);
+    }
+
+    export function isClassLikeKind(kind: SyntaxKind): boolean {
+        return kind === SyntaxKind.ClassDeclaration || kind === SyntaxKind.ClassExpression;
     }
 
     export function isFunctionLike(node: Node): node is FunctionLikeDeclaration {

--- a/tests/baselines/reference/2dArrays.types
+++ b/tests/baselines/reference/2dArrays.types
@@ -28,7 +28,7 @@ class Board {
 >this.ships.every(function (val) { return val.isSunk; }) : boolean
 >this.ships.every : (callbackfn: (value: Ship, index: number, array: Ship[]) => boolean, thisArg?: any) => boolean
 >this.ships : Ship[]
->this : this
+>this : Board
 >ships : Ship[]
 >every : (callbackfn: (value: Ship, index: number, array: Ship[]) => boolean, thisArg?: any) => boolean
 >function (val) { return val.isSunk; } : (val: Ship) => boolean

--- a/tests/baselines/reference/accessOverriddenBaseClassMember1.types
+++ b/tests/baselines/reference/accessOverriddenBaseClassMember1.types
@@ -15,11 +15,11 @@ class Point {
 >"x=" + this.x : string
 >"x=" : string
 >this.x : number
->this : this
+>this : Point
 >x : number
 >" y=" : string
 >this.y : number
->this : this
+>this : Point
 >y : number
     }
 }
@@ -50,7 +50,7 @@ class ColoredPoint extends Point {
 >toString : () => string
 >" color=" : string
 >this.color : string
->this : this
+>this : ColoredPoint
 >color : string
     }
 }

--- a/tests/baselines/reference/aliasUsageInAccessorsOfClass.types
+++ b/tests/baselines/reference/aliasUsageInAccessorsOfClass.types
@@ -26,7 +26,7 @@ class C2 {
 
         return this.x;
 >this.x : IHasVisualizationModel
->this : this
+>this : C2
 >x : IHasVisualizationModel
     }
     set A(x) {

--- a/tests/baselines/reference/ambiguousCallsWhereReturnTypesAgree.types
+++ b/tests/baselines/reference/ambiguousCallsWhereReturnTypesAgree.types
@@ -31,7 +31,7 @@ class TestClass {
         this.bar(x); // should not error
 >this.bar(x) : void
 >this.bar : { (x: string): void; (x: string[]): void; }
->this : this
+>this : TestClass
 >bar : { (x: string): void; (x: string[]): void; }
 >x : any
     }
@@ -71,7 +71,7 @@ class TestClass2 {
         return this.bar(x); // should not error
 >this.bar(x) : number
 >this.bar : { (x: string): number; (x: string[]): number; }
->this : this
+>this : TestClass2
 >bar : { (x: string): number; (x: string[]): number; }
 >x : any
     }

--- a/tests/baselines/reference/amdModuleName1.types
+++ b/tests/baselines/reference/amdModuleName1.types
@@ -10,7 +10,7 @@ class Foo {
         this.x = 5;
 >this.x = 5 : number
 >this.x : number
->this : this
+>this : Foo
 >x : number
 >5 : number
     }

--- a/tests/baselines/reference/arrayBestCommonTypes.types
+++ b/tests/baselines/reference/arrayBestCommonTypes.types
@@ -51,7 +51,7 @@ module EmptyTypes {
 >(this.voidIfAny([4, 2][0])) : number
 >this.voidIfAny([4, 2][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[4, 2][0] : number
 >[4, 2] : number[]
@@ -64,7 +64,7 @@ module EmptyTypes {
 >(this.voidIfAny([4, 2, undefined][0])) : number
 >this.voidIfAny([4, 2, undefined][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[4, 2, undefined][0] : number
 >[4, 2, undefined] : number[]
@@ -78,7 +78,7 @@ module EmptyTypes {
 >(this.voidIfAny([undefined, 2, 4][0])) : number
 >this.voidIfAny([undefined, 2, 4][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[undefined, 2, 4][0] : number
 >[undefined, 2, 4] : number[]
@@ -92,7 +92,7 @@ module EmptyTypes {
 >(this.voidIfAny([null, 2, 4][0])) : number
 >this.voidIfAny([null, 2, 4][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[null, 2, 4][0] : number
 >[null, 2, 4] : number[]
@@ -106,7 +106,7 @@ module EmptyTypes {
 >(this.voidIfAny([2, 4, null][0])) : number
 >this.voidIfAny([2, 4, null][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[2, 4, null][0] : number
 >[2, 4, null] : number[]
@@ -120,7 +120,7 @@ module EmptyTypes {
 >(this.voidIfAny([undefined, 4, null][0])) : number
 >this.voidIfAny([undefined, 4, null][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[undefined, 4, null][0] : number
 >[undefined, 4, null] : number[]
@@ -134,7 +134,7 @@ module EmptyTypes {
 >(this.voidIfAny(['', "q"][0])) : number
 >this.voidIfAny(['', "q"][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >['', "q"][0] : string
 >['', "q"] : string[]
@@ -147,7 +147,7 @@ module EmptyTypes {
 >(this.voidIfAny(['', "q", undefined][0])) : number
 >this.voidIfAny(['', "q", undefined][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >['', "q", undefined][0] : string
 >['', "q", undefined] : string[]
@@ -161,7 +161,7 @@ module EmptyTypes {
 >(this.voidIfAny([undefined, "q", ''][0])) : number
 >this.voidIfAny([undefined, "q", ''][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[undefined, "q", ''][0] : string
 >[undefined, "q", ''] : string[]
@@ -175,7 +175,7 @@ module EmptyTypes {
 >(this.voidIfAny([null, "q", ''][0])) : number
 >this.voidIfAny([null, "q", ''][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[null, "q", ''][0] : string
 >[null, "q", ''] : string[]
@@ -189,7 +189,7 @@ module EmptyTypes {
 >(this.voidIfAny(["q", '', null][0])) : number
 >this.voidIfAny(["q", '', null][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >["q", '', null][0] : string
 >["q", '', null] : string[]
@@ -203,7 +203,7 @@ module EmptyTypes {
 >(this.voidIfAny([undefined, '', null][0])) : number
 >this.voidIfAny([undefined, '', null][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[undefined, '', null][0] : string
 >[undefined, '', null] : string[]
@@ -217,7 +217,7 @@ module EmptyTypes {
 >(this.voidIfAny([[3, 4], [null]][0][0])) : number
 >this.voidIfAny([[3, 4], [null]][0][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[[3, 4], [null]][0][0] : number
 >[[3, 4], [null]][0] : number[]
@@ -454,7 +454,7 @@ module NonEmptyTypes {
 >(this.voidIfAny([4, 2][0])) : number
 >this.voidIfAny([4, 2][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[4, 2][0] : number
 >[4, 2] : number[]
@@ -467,7 +467,7 @@ module NonEmptyTypes {
 >(this.voidIfAny([4, 2, undefined][0])) : number
 >this.voidIfAny([4, 2, undefined][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[4, 2, undefined][0] : number
 >[4, 2, undefined] : number[]
@@ -481,7 +481,7 @@ module NonEmptyTypes {
 >(this.voidIfAny([undefined, 2, 4][0])) : number
 >this.voidIfAny([undefined, 2, 4][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[undefined, 2, 4][0] : number
 >[undefined, 2, 4] : number[]
@@ -495,7 +495,7 @@ module NonEmptyTypes {
 >(this.voidIfAny([null, 2, 4][0])) : number
 >this.voidIfAny([null, 2, 4][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[null, 2, 4][0] : number
 >[null, 2, 4] : number[]
@@ -509,7 +509,7 @@ module NonEmptyTypes {
 >(this.voidIfAny([2, 4, null][0])) : number
 >this.voidIfAny([2, 4, null][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[2, 4, null][0] : number
 >[2, 4, null] : number[]
@@ -523,7 +523,7 @@ module NonEmptyTypes {
 >(this.voidIfAny([undefined, 4, null][0])) : number
 >this.voidIfAny([undefined, 4, null][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[undefined, 4, null][0] : number
 >[undefined, 4, null] : number[]
@@ -537,7 +537,7 @@ module NonEmptyTypes {
 >(this.voidIfAny(['', "q"][0])) : number
 >this.voidIfAny(['', "q"][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >['', "q"][0] : string
 >['', "q"] : string[]
@@ -550,7 +550,7 @@ module NonEmptyTypes {
 >(this.voidIfAny(['', "q", undefined][0])) : number
 >this.voidIfAny(['', "q", undefined][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >['', "q", undefined][0] : string
 >['', "q", undefined] : string[]
@@ -564,7 +564,7 @@ module NonEmptyTypes {
 >(this.voidIfAny([undefined, "q", ''][0])) : number
 >this.voidIfAny([undefined, "q", ''][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[undefined, "q", ''][0] : string
 >[undefined, "q", ''] : string[]
@@ -578,7 +578,7 @@ module NonEmptyTypes {
 >(this.voidIfAny([null, "q", ''][0])) : number
 >this.voidIfAny([null, "q", ''][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[null, "q", ''][0] : string
 >[null, "q", ''] : string[]
@@ -592,7 +592,7 @@ module NonEmptyTypes {
 >(this.voidIfAny(["q", '', null][0])) : number
 >this.voidIfAny(["q", '', null][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >["q", '', null][0] : string
 >["q", '', null] : string[]
@@ -606,7 +606,7 @@ module NonEmptyTypes {
 >(this.voidIfAny([undefined, '', null][0])) : number
 >this.voidIfAny([undefined, '', null][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[undefined, '', null][0] : string
 >[undefined, '', null] : string[]
@@ -620,7 +620,7 @@ module NonEmptyTypes {
 >(this.voidIfAny([[3, 4], [null]][0][0])) : number
 >this.voidIfAny([[3, 4], [null]][0][0]) : number
 >this.voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
->this : this
+>this : f
 >voidIfAny : { (x: boolean, y?: boolean): number; (x: string, y?: boolean): number; (x: number, y?: boolean): number; }
 >[[3, 4], [null]][0][0] : number
 >[[3, 4], [null]][0] : number[]

--- a/tests/baselines/reference/arrayOfExportedClass.types
+++ b/tests/baselines/reference/arrayOfExportedClass.types
@@ -18,7 +18,7 @@ class Road {
         this.cars = cars;
 >this.cars = cars : Car[]
 >this.cars : Car[]
->this : this
+>this : Road
 >cars : Car[]
 >cars : Car[]
     }

--- a/tests/baselines/reference/arrayconcat.types
+++ b/tests/baselines/reference/arrayconcat.types
@@ -38,12 +38,12 @@ class parser {
 		this.options = this.options.sort(function(a, b) {
 >this.options = this.options.sort(function(a, b) {            var aName = a.name.toLowerCase();            var bName = b.name.toLowerCase();            if (aName > bName) {                return 1;            } else if (aName < bName) {                return -1;            } else {                return 0;            }        }) : IOptions[]
 >this.options : IOptions[]
->this : this
+>this : parser
 >options : IOptions[]
 >this.options.sort(function(a, b) {            var aName = a.name.toLowerCase();            var bName = b.name.toLowerCase();            if (aName > bName) {                return 1;            } else if (aName < bName) {                return -1;            } else {                return 0;            }        }) : IOptions[]
 >this.options.sort : (compareFn?: (a: IOptions, b: IOptions) => number) => IOptions[]
 >this.options : IOptions[]
->this : this
+>this : parser
 >options : IOptions[]
 >sort : (compareFn?: (a: IOptions, b: IOptions) => number) => IOptions[]
 >function(a, b) {            var aName = a.name.toLowerCase();            var bName = b.name.toLowerCase();            if (aName > bName) {                return 1;            } else if (aName < bName) {                return -1;            } else {                return 0;            }        } : (a: IOptions, b: IOptions) => number

--- a/tests/baselines/reference/binopAssignmentShouldHaveType.types
+++ b/tests/baselines/reference/binopAssignmentShouldHaveType.types
@@ -32,7 +32,7 @@ module Test {
 >name : string
 >this.getName() : string
 >this.getName : () => string
->this : this
+>this : Bug
 >getName : () => string
 >length : number
 >0 : number

--- a/tests/baselines/reference/callWithSpread.types
+++ b/tests/baselines/reference/callWithSpread.types
@@ -180,7 +180,7 @@ class C {
         this.foo(x, y);
 >this.foo(x, y) : void
 >this.foo : (x: number, y: number, ...z: string[]) => void
->this : this
+>this : C
 >foo : (x: number, y: number, ...z: string[]) => void
 >x : number
 >y : number
@@ -188,7 +188,7 @@ class C {
         this.foo(x, y, ...z);
 >this.foo(x, y, ...z) : void
 >this.foo : (x: number, y: number, ...z: string[]) => void
->this : this
+>this : C
 >foo : (x: number, y: number, ...z: string[]) => void
 >x : number
 >y : number

--- a/tests/baselines/reference/callWithSpreadES6.types
+++ b/tests/baselines/reference/callWithSpreadES6.types
@@ -181,7 +181,7 @@ class C {
         this.foo(x, y);
 >this.foo(x, y) : void
 >this.foo : (x: number, y: number, ...z: string[]) => void
->this : this
+>this : C
 >foo : (x: number, y: number, ...z: string[]) => void
 >x : number
 >y : number
@@ -189,7 +189,7 @@ class C {
         this.foo(x, y, ...z);
 >this.foo(x, y, ...z) : void
 >this.foo : (x: number, y: number, ...z: string[]) => void
->this : this
+>this : C
 >foo : (x: number, y: number, ...z: string[]) => void
 >x : number
 >y : number

--- a/tests/baselines/reference/captureThisInSuperCall.types
+++ b/tests/baselines/reference/captureThisInSuperCall.types
@@ -18,7 +18,7 @@ class B extends A {
 >() => this.someMethod() : () => void
 >this.someMethod() : void
 >this.someMethod : () => void
->this : this
+>this : B
 >someMethod : () => void
 
     someMethod() {}

--- a/tests/baselines/reference/capturedLetConstInLoop10.types
+++ b/tests/baselines/reference/capturedLetConstInLoop10.types
@@ -18,7 +18,7 @@ class A {
             this.bar(f());
 >this.bar(f()) : void
 >this.bar : (a: number) => void
->this : this
+>this : A
 >bar : (a: number) => void
 >f() : number
 >f : () => number
@@ -55,7 +55,7 @@ class A {
                 this.bar(b());
 >this.bar(b()) : void
 >this.bar : (a: number) => void
->this : this
+>this : A
 >bar : (a: number) => void
 >b() : number
 >b : () => number
@@ -63,7 +63,7 @@ class A {
             this.bar(a());
 >this.bar(a()) : void
 >this.bar : (a: number) => void
->this : this
+>this : A
 >bar : (a: number) => void
 >a() : number
 >a : () => number
@@ -85,7 +85,7 @@ class A {
             this.bar(a());
 >this.bar(a()) : void
 >this.bar : (a: number) => void
->this : this
+>this : A
 >bar : (a: number) => void
 >a() : number
 >a : () => number
@@ -103,7 +103,7 @@ class A {
                 this.bar(b());
 >this.bar(b()) : void
 >this.bar : (a: number) => void
->this : this
+>this : A
 >bar : (a: number) => void
 >b() : number
 >b : () => number
@@ -137,7 +137,7 @@ class B {
                     this.bar(f());
 >this.bar(f()) : void
 >this.bar : (a: number) => void
->this : this
+>this : B
 >bar : (a: number) => void
 >f() : number
 >f : () => number

--- a/tests/baselines/reference/capturedLetConstInLoop10_ES6.types
+++ b/tests/baselines/reference/capturedLetConstInLoop10_ES6.types
@@ -18,7 +18,7 @@ class A {
             this.bar(f());
 >this.bar(f()) : void
 >this.bar : (a: number) => void
->this : this
+>this : A
 >bar : (a: number) => void
 >f() : number
 >f : () => number
@@ -55,7 +55,7 @@ class A {
                 this.bar(b());
 >this.bar(b()) : void
 >this.bar : (a: number) => void
->this : this
+>this : A
 >bar : (a: number) => void
 >b() : number
 >b : () => number
@@ -63,7 +63,7 @@ class A {
             this.bar(a());
 >this.bar(a()) : void
 >this.bar : (a: number) => void
->this : this
+>this : A
 >bar : (a: number) => void
 >a() : number
 >a : () => number
@@ -85,7 +85,7 @@ class A {
             this.bar(a());
 >this.bar(a()) : void
 >this.bar : (a: number) => void
->this : this
+>this : A
 >bar : (a: number) => void
 >a() : number
 >a : () => number
@@ -103,7 +103,7 @@ class A {
                 this.bar(b());
 >this.bar(b()) : void
 >this.bar : (a: number) => void
->this : this
+>this : A
 >bar : (a: number) => void
 >b() : number
 >b : () => number
@@ -137,7 +137,7 @@ class B {
                     this.bar(f());
 >this.bar(f()) : void
 >this.bar : (a: number) => void
->this : this
+>this : B
 >bar : (a: number) => void
 >f() : number
 >f : () => number

--- a/tests/baselines/reference/capturedLetConstInLoop9.types
+++ b/tests/baselines/reference/capturedLetConstInLoop9.types
@@ -319,7 +319,7 @@ class C {
 >() => this.N * i : () => number
 >this.N * i : number
 >this.N : number
->this : this
+>this : C
 >N : number
 >i : number
         }

--- a/tests/baselines/reference/capturedLetConstInLoop9_ES6.types
+++ b/tests/baselines/reference/capturedLetConstInLoop9_ES6.types
@@ -319,7 +319,7 @@ class C {
 >() => this.N * i : () => number
 >this.N * i : number
 >this.N : number
->this : this
+>this : C
 >N : number
 >i : number
         }

--- a/tests/baselines/reference/checkSuperCallBeforeThisAccessing3.types
+++ b/tests/baselines/reference/checkSuperCallBeforeThisAccessing3.types
@@ -20,7 +20,7 @@ class Derived extends Based {
                 this.y = true;
 >this.y = true : boolean
 >this.y : boolean
->this : this
+>this : innver
 >y : boolean
 >true : boolean
             }

--- a/tests/baselines/reference/classConstructorParametersAccessibility3.types
+++ b/tests/baselines/reference/classConstructorParametersAccessibility3.types
@@ -20,7 +20,7 @@ class Derived extends Base {
 
         this.p; // OK
 >this.p : number
->this : this
+>this : Derived
 >p : number
     }
 }

--- a/tests/baselines/reference/classOrder2.types
+++ b/tests/baselines/reference/classOrder2.types
@@ -8,7 +8,7 @@ class A extends B {
 >foo : () => void
 >this.bar() : void
 >this.bar : () => void
->this : this
+>this : A
 >bar : () => void
 
 }

--- a/tests/baselines/reference/classOrderBug.types
+++ b/tests/baselines/reference/classOrderBug.types
@@ -11,7 +11,7 @@ class bar {
         this.baz = new foo();
 >this.baz = new foo() : foo
 >this.baz : foo
->this : this
+>this : bar
 >baz : foo
 >new foo() : foo
 >foo : typeof foo

--- a/tests/baselines/reference/commentsClassMembers.types
+++ b/tests/baselines/reference/commentsClassMembers.types
@@ -16,7 +16,7 @@ class c1 {
         return this.p1 + b;
 >this.p1 + b : number
 >this.p1 : number
->this : this
+>this : c1
 >p1 : number
 >b : number
 
@@ -28,10 +28,10 @@ class c1 {
         return this.p2(this.p1);
 >this.p2(this.p1) : number
 >this.p2 : (b: number) => number
->this : this
+>this : c1
 >p2 : (b: number) => number
 >this.p1 : number
->this : this
+>this : c1
 >p1 : number
 
     }// trailing comment Getter
@@ -43,11 +43,11 @@ class c1 {
         this.p1 = this.p2(value);
 >this.p1 = this.p2(value) : number
 >this.p1 : number
->this : this
+>this : c1
 >p1 : number
 >this.p2(value) : number
 >this.p2 : (b: number) => number
->this : this
+>this : c1
 >p2 : (b: number) => number
 >value : number
 
@@ -64,7 +64,7 @@ class c1 {
         return this.p1 + b;
 >this.p1 + b : number
 >this.p1 : number
->this : this
+>this : c1
 >p1 : number
 >b : number
 
@@ -76,10 +76,10 @@ class c1 {
         return this.pp2(this.pp1);
 >this.pp2(this.pp1) : number
 >this.pp2 : (b: number) => number
->this : this
+>this : c1
 >pp2 : (b: number) => number
 >this.pp1 : number
->this : this
+>this : c1
 >pp1 : number
     }
     /** setter property*/
@@ -90,11 +90,11 @@ class c1 {
         this.pp1 = this.pp2(value);
 >this.pp1 = this.pp2(value) : number
 >this.pp1 : number
->this : this
+>this : c1
 >pp1 : number
 >this.pp2(value) : number
 >this.pp2 : (b: number) => number
->this : this
+>this : c1
 >pp2 : (b: number) => number
 >value : number
     }
@@ -158,7 +158,7 @@ class c1 {
         return this.nc_p1 + b;
 >this.nc_p1 + b : number
 >this.nc_p1 : number
->this : this
+>this : c1
 >nc_p1 : number
 >b : number
     }
@@ -168,10 +168,10 @@ class c1 {
         return this.nc_p2(this.nc_p1);
 >this.nc_p2(this.nc_p1) : number
 >this.nc_p2 : (b: number) => number
->this : this
+>this : c1
 >nc_p2 : (b: number) => number
 >this.nc_p1 : number
->this : this
+>this : c1
 >nc_p1 : number
     }
     public set nc_p3(value: number) {
@@ -181,11 +181,11 @@ class c1 {
         this.nc_p1 = this.nc_p2(value);
 >this.nc_p1 = this.nc_p2(value) : number
 >this.nc_p1 : number
->this : this
+>this : c1
 >nc_p1 : number
 >this.nc_p2(value) : number
 >this.nc_p2 : (b: number) => number
->this : this
+>this : c1
 >nc_p2 : (b: number) => number
 >value : number
     }
@@ -199,7 +199,7 @@ class c1 {
         return this.nc_pp1 + b;
 >this.nc_pp1 + b : number
 >this.nc_pp1 : number
->this : this
+>this : c1
 >nc_pp1 : number
 >b : number
     }
@@ -209,10 +209,10 @@ class c1 {
         return this.nc_pp2(this.nc_pp1);
 >this.nc_pp2(this.nc_pp1) : number
 >this.nc_pp2 : (b: number) => number
->this : this
+>this : c1
 >nc_pp2 : (b: number) => number
 >this.nc_pp1 : number
->this : this
+>this : c1
 >nc_pp1 : number
     }
     private set nc_pp3(value: number) {
@@ -222,11 +222,11 @@ class c1 {
         this.nc_pp1 = this.nc_pp2(value);
 >this.nc_pp1 = this.nc_pp2(value) : number
 >this.nc_pp1 : number
->this : this
+>this : c1
 >nc_pp1 : number
 >this.nc_pp2(value) : number
 >this.nc_pp2 : (b: number) => number
->this : this
+>this : c1
 >nc_pp2 : (b: number) => number
 >value : number
     }
@@ -284,7 +284,7 @@ class c1 {
         return this.a_p1 + b;
 >this.a_p1 + b : number
 >this.a_p1 : number
->this : this
+>this : c1
 >a_p1 : number
 >b : number
     }
@@ -295,10 +295,10 @@ class c1 {
         return this.a_p2(this.a_p1);
 >this.a_p2(this.a_p1) : number
 >this.a_p2 : (b: number) => number
->this : this
+>this : c1
 >a_p2 : (b: number) => number
 >this.a_p1 : number
->this : this
+>this : c1
 >a_p1 : number
     }
     // setter property
@@ -309,11 +309,11 @@ class c1 {
         this.a_p1 = this.a_p2(value);
 >this.a_p1 = this.a_p2(value) : number
 >this.a_p1 : number
->this : this
+>this : c1
 >a_p1 : number
 >this.a_p2(value) : number
 >this.a_p2 : (b: number) => number
->this : this
+>this : c1
 >a_p2 : (b: number) => number
 >value : number
     }
@@ -329,7 +329,7 @@ class c1 {
         return this.a_p1 + b;
 >this.a_p1 + b : number
 >this.a_p1 : number
->this : this
+>this : c1
 >a_p1 : number
 >b : number
     }
@@ -340,10 +340,10 @@ class c1 {
         return this.a_pp2(this.a_pp1);
 >this.a_pp2(this.a_pp1) : number
 >this.a_pp2 : (b: number) => number
->this : this
+>this : c1
 >a_pp2 : (b: number) => number
 >this.a_pp1 : number
->this : this
+>this : c1
 >a_pp1 : number
     }
     // setter property
@@ -354,11 +354,11 @@ class c1 {
         this.a_pp1 = this.a_pp2(value);
 >this.a_pp1 = this.a_pp2(value) : number
 >this.a_pp1 : number
->this : this
+>this : c1
 >a_pp1 : number
 >this.a_pp2(value) : number
 >this.a_pp2 : (b: number) => number
->this : this
+>this : c1
 >a_pp2 : (b: number) => number
 >value : number
     }
@@ -422,7 +422,7 @@ class c1 {
         return this.b_p1 + b;
 >this.b_p1 + b : number
 >this.b_p1 : number
->this : this
+>this : c1
 >b_p1 : number
 >b : number
     }
@@ -433,10 +433,10 @@ class c1 {
         return this.b_p2(this.b_p1);
 >this.b_p2(this.b_p1) : number
 >this.b_p2 : (b: number) => number
->this : this
+>this : c1
 >b_p2 : (b: number) => number
 >this.b_p1 : number
->this : this
+>this : c1
 >b_p1 : number
     }
     /** setter property */
@@ -447,11 +447,11 @@ class c1 {
         this.b_p1 = this.b_p2(value);
 >this.b_p1 = this.b_p2(value) : number
 >this.b_p1 : number
->this : this
+>this : c1
 >b_p1 : number
 >this.b_p2(value) : number
 >this.b_p2 : (b: number) => number
->this : this
+>this : c1
 >b_p2 : (b: number) => number
 >value : number
     }
@@ -467,7 +467,7 @@ class c1 {
         return this.b_p1 + b;
 >this.b_p1 + b : number
 >this.b_p1 : number
->this : this
+>this : c1
 >b_p1 : number
 >b : number
     }
@@ -478,10 +478,10 @@ class c1 {
         return this.b_pp2(this.b_pp1);
 >this.b_pp2(this.b_pp1) : number
 >this.b_pp2 : (b: number) => number
->this : this
+>this : c1
 >b_pp2 : (b: number) => number
 >this.b_pp1 : number
->this : this
+>this : c1
 >b_pp1 : number
     }
     /** setter property */
@@ -492,11 +492,11 @@ class c1 {
         this.b_pp1 = this.b_pp2(value);
 >this.b_pp1 = this.b_pp2(value) : number
 >this.b_pp1 : number
->this : this
+>this : c1
 >b_pp1 : number
 >this.b_pp2(value) : number
 >this.b_pp2 : (b: number) => number
->this : this
+>this : c1
 >b_pp2 : (b: number) => number
 >value : number
     }
@@ -704,7 +704,7 @@ class cProperties {
 
         return this.val;
 >this.val : number
->this : this
+>this : cProperties
 >val : number
 
     } // trailing comment of only getter
@@ -713,7 +713,7 @@ class cProperties {
 
         return this.val;
 >this.val : number
->this : this
+>this : cProperties
 >val : number
     }
     /**setter only property*/
@@ -724,7 +724,7 @@ class cProperties {
         this.val = value;
 >this.val = value : number
 >this.val : number
->this : this
+>this : cProperties
 >val : number
 >value : number
     }
@@ -735,7 +735,7 @@ class cProperties {
         this.val = value;
 >this.val = value : number
 >this.val : number
->this : this
+>this : cProperties
 >val : number
 >value : number
 

--- a/tests/baselines/reference/commentsInheritance.types
+++ b/tests/baselines/reference/commentsInheritance.types
@@ -170,7 +170,7 @@ class c2 {
         this.c2_p1 = a;
 >this.c2_p1 = a : number
 >this.c2_p1 : number
->this : this
+>this : c2
 >c2_p1 : number
 >a : number
     }

--- a/tests/baselines/reference/commentsdoNotEmitComments.types
+++ b/tests/baselines/reference/commentsdoNotEmitComments.types
@@ -43,7 +43,7 @@ class c {
 
         return this.b;
 >this.b : number
->this : this
+>this : c
 >b : number
     }
 
@@ -53,7 +53,7 @@ class c {
 
         return this.b;
 >this.b : number
->this : this
+>this : c
 >b : number
     }
 
@@ -65,7 +65,7 @@ class c {
         this.b = val;
 >this.b = val : number
 >this.b : number
->this : this
+>this : c
 >b : number
 >val : number
     }

--- a/tests/baselines/reference/commentsemitComments.types
+++ b/tests/baselines/reference/commentsemitComments.types
@@ -43,7 +43,7 @@ class c {
 
         return this.b;
 >this.b : number
->this : this
+>this : c
 >b : number
     }
 
@@ -53,7 +53,7 @@ class c {
 
         return this.b;
 >this.b : number
->this : this
+>this : c
 >b : number
     }
 
@@ -65,7 +65,7 @@ class c {
         this.b = val;
 >this.b = val : number
 >this.b : number
->this : this
+>this : c
 >b : number
 >val : number
     }

--- a/tests/baselines/reference/computedPropertyNames22_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames22_ES5.types
@@ -12,7 +12,7 @@ class C {
             [this.bar()]() { }
 >this.bar() : number
 >this.bar : () => number
->this : this
+>this : C
 >bar : () => number
 
         };

--- a/tests/baselines/reference/computedPropertyNames22_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames22_ES6.types
@@ -12,7 +12,7 @@ class C {
             [this.bar()]() { }
 >this.bar() : number
 >this.bar : () => number
->this : this
+>this : C
 >bar : () => number
 
         };

--- a/tests/baselines/reference/computedPropertyNames29_ES5.types
+++ b/tests/baselines/reference/computedPropertyNames29_ES5.types
@@ -15,7 +15,7 @@ class C {
                 [this.bar()]() { } // needs capture
 >this.bar() : number
 >this.bar : () => number
->this : this
+>this : C
 >bar : () => number
 
             };

--- a/tests/baselines/reference/computedPropertyNames29_ES6.types
+++ b/tests/baselines/reference/computedPropertyNames29_ES6.types
@@ -15,7 +15,7 @@ class C {
                 [this.bar()]() { } // needs capture
 >this.bar() : number
 >this.bar : () => number
->this : this
+>this : C
 >bar : () => number
 
             };

--- a/tests/baselines/reference/constDeclarationShadowedByVarDeclaration3.types
+++ b/tests/baselines/reference/constDeclarationShadowedByVarDeclaration3.types
@@ -20,7 +20,7 @@ class Rule {
         this.name = name;
 >this.name = name : string
 >this.name : string
->this : this
+>this : Rule
 >name : string
 >name : string
     }

--- a/tests/baselines/reference/declFileForTypeParameters.types
+++ b/tests/baselines/reference/declFileForTypeParameters.types
@@ -16,7 +16,7 @@ class C<T> {
 
         return this.x;
 >this.x : T
->this : this
+>this : C<T>
 >x : T
     }
 }

--- a/tests/baselines/reference/declFileGenericType2.types
+++ b/tests/baselines/reference/declFileGenericType2.types
@@ -142,7 +142,7 @@ module templa.dom.mvc.composite {
             this._controllers = [];
 >this._controllers = [] : undefined[]
 >this._controllers : templa.mvc.IController<templa.mvc.IModel>[]
->this : this
+>this : AbstractCompositeElementController<ModelType>
 >_controllers : templa.mvc.IController<templa.mvc.IModel>[]
 >[] : undefined[]
         }

--- a/tests/baselines/reference/declarationEmit_protectedMembers.types
+++ b/tests/baselines/reference/declarationEmit_protectedMembers.types
@@ -12,7 +12,7 @@ class C1 {
 
         return this.x;
 >this.x : number
->this : this
+>this : C1
 >x : number
     }
 
@@ -60,7 +60,7 @@ class C2 extends C1 {
 >super : C1
 >f : () => number
 >this.x : number
->this : this
+>this : C2
 >x : number
     }
     protected static sf() {

--- a/tests/baselines/reference/declarationMerging1.types
+++ b/tests/baselines/reference/declarationMerging1.types
@@ -8,7 +8,7 @@ class A {
     getF() { return this._f; }
 >getF : () => number
 >this._f : number
->this : this
+>this : A
 >_f : number
 }
 

--- a/tests/baselines/reference/declarationMerging2.types
+++ b/tests/baselines/reference/declarationMerging2.types
@@ -9,7 +9,7 @@ export class A {
     getF() { return this._f; }
 >getF : () => number
 >this._f : number
->this : this
+>this : A
 >_f : number
 }
 

--- a/tests/baselines/reference/decoratorMetadataWithImportDeclarationNameCollision.types
+++ b/tests/baselines/reference/decoratorMetadataWithImportDeclarationNameCollision.types
@@ -35,7 +35,7 @@ class MyClass {
         this.db = db;
 >this.db = db : db
 >this.db : db
->this : this
+>this : MyClass
 >db : db
 >db : db
 
@@ -43,7 +43,7 @@ class MyClass {
 >this.db.doSomething() : void
 >this.db.doSomething : () => void
 >this.db : db
->this : this
+>this : MyClass
 >db : db
 >doSomething : () => void
     }

--- a/tests/baselines/reference/decoratorMetadataWithImportDeclarationNameCollision2.types
+++ b/tests/baselines/reference/decoratorMetadataWithImportDeclarationNameCollision2.types
@@ -36,7 +36,7 @@ class MyClass {
         this.db = db;
 >this.db = db : Database
 >this.db : Database
->this : this
+>this : MyClass
 >db : Database
 >db : Database
 
@@ -44,7 +44,7 @@ class MyClass {
 >this.db.doSomething() : void
 >this.db.doSomething : () => void
 >this.db : Database
->this : this
+>this : MyClass
 >db : Database
 >doSomething : () => void
     }

--- a/tests/baselines/reference/decoratorMetadataWithImportDeclarationNameCollision3.types
+++ b/tests/baselines/reference/decoratorMetadataWithImportDeclarationNameCollision3.types
@@ -28,7 +28,7 @@ class MyClass {
         this.db = db;
 >this.db = db : db.db
 >this.db : db.db
->this : this
+>this : MyClass
 >db : db.db
 >db : db.db
 
@@ -36,7 +36,7 @@ class MyClass {
 >this.db.doSomething() : void
 >this.db.doSomething : () => void
 >this.db : db.db
->this : this
+>this : MyClass
 >db : db.db
 >doSomething : () => void
     }

--- a/tests/baselines/reference/decoratorMetadataWithImportDeclarationNameCollision5.types
+++ b/tests/baselines/reference/decoratorMetadataWithImportDeclarationNameCollision5.types
@@ -35,7 +35,7 @@ class MyClass {
         this.db = db;
 >this.db = db : db
 >this.db : db
->this : this
+>this : MyClass
 >db : db
 >db : db
 
@@ -43,7 +43,7 @@ class MyClass {
 >this.db.doSomething() : void
 >this.db.doSomething : () => void
 >this.db : db
->this : this
+>this : MyClass
 >db : db
 >doSomething : () => void
     }

--- a/tests/baselines/reference/decoratorMetadataWithImportDeclarationNameCollision6.types
+++ b/tests/baselines/reference/decoratorMetadataWithImportDeclarationNameCollision6.types
@@ -35,7 +35,7 @@ class MyClass {
         this.db = db;
 >this.db = db : database
 >this.db : database
->this : this
+>this : MyClass
 >db : database
 >db : database
 
@@ -43,7 +43,7 @@ class MyClass {
 >this.db.doSomething() : void
 >this.db.doSomething : () => void
 >this.db : database
->this : this
+>this : MyClass
 >db : database
 >doSomething : () => void
     }

--- a/tests/baselines/reference/decoratorMetadataWithImportDeclarationNameCollision8.types
+++ b/tests/baselines/reference/decoratorMetadataWithImportDeclarationNameCollision8.types
@@ -28,7 +28,7 @@ class MyClass {
         this.db = db;
 >this.db = db : database.db
 >this.db : database.db
->this : this
+>this : MyClass
 >db : database.db
 >db : database.db
 
@@ -36,7 +36,7 @@ class MyClass {
 >this.db.doSomething() : void
 >this.db.doSomething : () => void
 >this.db : database.db
->this : this
+>this : MyClass
 >db : database.db
 >doSomething : () => void
     }

--- a/tests/baselines/reference/derivedClasses.types
+++ b/tests/baselines/reference/derivedClasses.types
@@ -11,7 +11,7 @@ class Red extends Color {
 >() => { return this.hue(); } : () => string
 >this.hue() : string
 >this.hue : () => string
->this : this
+>this : Red
 >hue : () => string
 
     	return getHue() + " red"; 
@@ -46,7 +46,7 @@ class Blue extends Color {
 >() => { return this.hue(); } : () => string
 >this.hue() : string
 >this.hue : () => string
->this : this
+>this : Blue
 >hue : () => string
 
     	return getHue() + " blue"; 

--- a/tests/baselines/reference/detachedCommentAtStartOfConstructor1.types
+++ b/tests/baselines/reference/detachedCommentAtStartOfConstructor1.types
@@ -19,13 +19,13 @@ class TestFile {
 >message + this.name : string
 >message : string
 >this.name : any
->this : this
+>this : TestFile
 >name : any
 
         this.message = getMessage();
 >this.message = getMessage() : string
 >this.message : string
->this : this
+>this : TestFile
 >message : string
 >getMessage() : string
 >getMessage : () => string

--- a/tests/baselines/reference/detachedCommentAtStartOfConstructor2.types
+++ b/tests/baselines/reference/detachedCommentAtStartOfConstructor2.types
@@ -20,13 +20,13 @@ class TestFile {
 >message + this.name : string
 >message : string
 >this.name : string
->this : this
+>this : TestFile
 >name : string
 
         this.message = getMessage();
 >this.message = getMessage() : string
 >this.message : string
->this : this
+>this : TestFile
 >message : string
 >getMessage() : string
 >getMessage : () => string

--- a/tests/baselines/reference/detachedCommentAtStartOfLambdaFunction1.types
+++ b/tests/baselines/reference/detachedCommentAtStartOfLambdaFunction1.types
@@ -20,7 +20,7 @@ class TestFile {
 >message + this.name : string
 >message : string
 >this.name : string
->this : this
+>this : TestFile
 >name : string
     }
 }

--- a/tests/baselines/reference/detachedCommentAtStartOfLambdaFunction2.types
+++ b/tests/baselines/reference/detachedCommentAtStartOfLambdaFunction2.types
@@ -21,7 +21,7 @@ class TestFile {
 >message + this.name : string
 >message : string
 >this.name : string
->this : this
+>this : TestFile
 >name : string
     }
 }

--- a/tests/baselines/reference/emitClassDeclarationWithConstructorInES6.types
+++ b/tests/baselines/reference/emitClassDeclarationWithConstructorInES6.types
@@ -38,7 +38,7 @@ class B {
         this.y = 10;
 >this.y = 10 : number
 >this.y : number
->this : this
+>this : B
 >y : number
 >10 : number
     }
@@ -53,7 +53,7 @@ class B {
 
         return this._bar;
 >this._bar : string
->this : this
+>this : B
 >_bar : string
     } 
 }

--- a/tests/baselines/reference/emitClassDeclarationWithGetterSetterInES6.types
+++ b/tests/baselines/reference/emitClassDeclarationWithGetterSetterInES6.types
@@ -10,7 +10,7 @@ class C {
 
         return this._name;
 >this._name : string
->this : this
+>this : C
 >_name : string
     }
     static get name2(): string {

--- a/tests/baselines/reference/emitClassDeclarationWithMethodInES6.types
+++ b/tests/baselines/reference/emitClassDeclarationWithMethodInES6.types
@@ -25,7 +25,7 @@ class D {
 
         return this._bar;
 >this._bar : string
->this : this
+>this : D
 >_bar : string
     } 
     baz(a: any, x: string): string {

--- a/tests/baselines/reference/emitClassDeclarationWithPropertyAssignmentInES6.types
+++ b/tests/baselines/reference/emitClassDeclarationWithPropertyAssignmentInES6.types
@@ -21,7 +21,7 @@ class D {
         this.y = 10;
 >this.y = 10 : number
 >this.y : number
->this : this
+>this : D
 >y : number
 >10 : number
     }
@@ -55,7 +55,7 @@ class F extends D{
         this.j = "HI";
 >this.j = "HI" : string
 >this.j : string
->this : this
+>this : F
 >j : string
 >"HI" : string
     }

--- a/tests/baselines/reference/emitClassDeclarationWithThisKeywordInES6.types
+++ b/tests/baselines/reference/emitClassDeclarationWithThisKeywordInES6.types
@@ -10,7 +10,7 @@ class B {
         this.x = 10;
 >this.x = 10 : number
 >this.x : number
->this : this
+>this : B
 >x : number
 >10 : number
     }
@@ -27,7 +27,7 @@ class B {
 >B : typeof B
 >log : (a: number) => void
 >this.x : number
->this : this
+>this : B
 >x : number
     }
 
@@ -36,7 +36,7 @@ class B {
 
         return this.x;
 >this.x : number
->this : this
+>this : B
 >x : number
     }
 
@@ -47,7 +47,7 @@ class B {
         this.x = y;
 >this.x = y : number
 >this.x : number
->this : this
+>this : B
 >x : number
 >y : number
     }

--- a/tests/baselines/reference/emitClassDeclarationWithTypeArgumentAndOverloadInES6.types
+++ b/tests/baselines/reference/emitClassDeclarationWithTypeArgumentAndOverloadInES6.types
@@ -24,7 +24,7 @@ class B<T> {
 >T : T
 >this.B = a : T
 >this.B : T
->this : this
+>this : B<T>
 >B : T
 >a : T
 
@@ -47,7 +47,7 @@ class B<T> {
 
         return this.x;
 >this.x : T
->this : this
+>this : B<T>
 >x : T
     }
 
@@ -57,7 +57,7 @@ class B<T> {
 
         return this.B;
 >this.B : T
->this : this
+>this : B<T>
 >B : T
     }
     set BBWith(c: T) {
@@ -68,7 +68,7 @@ class B<T> {
         this.B = c;
 >this.B = c : T
 >this.B : T
->this : this
+>this : B<T>
 >B : T
 >c : T
     }

--- a/tests/baselines/reference/emitClassDeclarationWithTypeArgumentInES6.types
+++ b/tests/baselines/reference/emitClassDeclarationWithTypeArgumentInES6.types
@@ -16,7 +16,7 @@ class B<T> {
 >T : T
 >this.B = a : T
 >this.B : T
->this : this
+>this : B<T>
 >B : T
 >a : T
 
@@ -26,7 +26,7 @@ class B<T> {
 
         return this.x;
 >this.x : T
->this : this
+>this : B<T>
 >x : T
     }
     get BB(): T {
@@ -35,7 +35,7 @@ class B<T> {
 
         return this.B;
 >this.B : T
->this : this
+>this : B<T>
 >B : T
     }
     set BBWith(c: T) {
@@ -46,7 +46,7 @@ class B<T> {
         this.B = c;
 >this.B = c : T
 >this.B : T
->this : this
+>this : B<T>
 >B : T
 >c : T
     }

--- a/tests/baselines/reference/es6ClassTest3.types
+++ b/tests/baselines/reference/es6ClassTest3.types
@@ -24,14 +24,14 @@ module M {
 	        this.x = 1;
 >this.x = 1 : number
 >this.x : number
->this : this
+>this : Visibility
 >x : number
 >1 : number
 
 	        this.y = 2;
 >this.y = 2 : number
 >this.y : number
->this : this
+>this : Visibility
 >y : number
 >2 : number
 	    }

--- a/tests/baselines/reference/es6ClassTest8.types
+++ b/tests/baselines/reference/es6ClassTest8.types
@@ -119,7 +119,7 @@ class Camera {
         this.forward = Vector.norm(Vector.minus(lookAt,this.pos));
 >this.forward = Vector.norm(Vector.minus(lookAt,this.pos)) : Vector
 >this.forward : Vector
->this : this
+>this : Camera
 >forward : Vector
 >Vector.norm(Vector.minus(lookAt,this.pos)) : Vector
 >Vector.norm : (v: Vector) => Vector
@@ -131,13 +131,13 @@ class Camera {
 >minus : (v1: Vector, v2: Vector) => Vector
 >lookAt : Vector
 >this.pos : Vector
->this : this
+>this : Camera
 >pos : Vector
 
         this.right = Vector.times(down, Vector.norm(Vector.cross(this.forward, down)));
 >this.right = Vector.times(down, Vector.norm(Vector.cross(this.forward, down))) : Vector
 >this.right : Vector
->this : this
+>this : Camera
 >right : Vector
 >Vector.times(down, Vector.norm(Vector.cross(this.forward, down))) : Vector
 >Vector.times : (v1: Vector, v2: Vector) => Vector
@@ -153,14 +153,14 @@ class Camera {
 >Vector : typeof Vector
 >cross : (v1: Vector, v2: Vector) => Vector
 >this.forward : Vector
->this : this
+>this : Camera
 >forward : Vector
 >down : Vector
 
         this.up = Vector.times(down, Vector.norm(Vector.cross(this.forward, this.right)));    
 >this.up = Vector.times(down, Vector.norm(Vector.cross(this.forward, this.right))) : Vector
 >this.up : Vector
->this : this
+>this : Camera
 >up : Vector
 >Vector.times(down, Vector.norm(Vector.cross(this.forward, this.right))) : Vector
 >Vector.times : (v1: Vector, v2: Vector) => Vector
@@ -176,10 +176,10 @@ class Camera {
 >Vector : typeof Vector
 >cross : (v1: Vector, v2: Vector) => Vector
 >this.forward : Vector
->this : this
+>this : Camera
 >forward : Vector
 >this.right : Vector
->this : this
+>this : Camera
 >right : Vector
     }
 }

--- a/tests/baselines/reference/fatArrowSelf.types
+++ b/tests/baselines/reference/fatArrowSelf.types
@@ -38,7 +38,7 @@ module Consumer {
 >this.emitter.addListener('change', (e) => {                this.changed();            }) : void
 >this.emitter.addListener : (type: string, listener: Events.ListenerCallback) => void
 >this.emitter : Events.EventEmitter
->this : this
+>this : EventEmitterConsummer
 >emitter : Events.EventEmitter
 >addListener : (type: string, listener: Events.ListenerCallback) => void
 >'change' : string
@@ -48,7 +48,7 @@ module Consumer {
                 this.changed();
 >this.changed() : void
 >this.changed : () => void
->this : this
+>this : EventEmitterConsummer
 >changed : () => void
 
             });

--- a/tests/baselines/reference/functionOverloads7.types
+++ b/tests/baselines/reference/functionOverloads7.types
@@ -21,7 +21,7 @@ class foo {
 >foo : any
 >this.bar() : any
 >this.bar : { (): any; (foo: string): any; }
->this : this
+>this : foo
 >bar : { (): any; (foo: string): any; }
 
      foo = this.bar("test");
@@ -29,7 +29,7 @@ class foo {
 >foo : any
 >this.bar("test") : any
 >this.bar : { (): any; (foo: string): any; }
->this : this
+>this : foo
 >bar : { (): any; (foo: string): any; }
 >"test" : string
    }

--- a/tests/baselines/reference/functionSubtypingOfVarArgs.types
+++ b/tests/baselines/reference/functionSubtypingOfVarArgs.types
@@ -15,7 +15,7 @@ class EventBase {
 >this._listeners.push(listener) : number
 >this._listeners.push : (...items: any[]) => number
 >this._listeners : any[]
->this : this
+>this : EventBase
 >_listeners : any[]
 >push : (...items: any[]) => number
 >listener : (...args: any[]) => void

--- a/tests/baselines/reference/functionSubtypingOfVarArgs2.types
+++ b/tests/baselines/reference/functionSubtypingOfVarArgs2.types
@@ -16,7 +16,7 @@ class EventBase {
 >this._listeners.push(listener) : number
 >this._listeners.push : (...items: ((...args: any[]) => void)[]) => number
 >this._listeners : ((...args: any[]) => void)[]
->this : this
+>this : EventBase
 >_listeners : ((...args: any[]) => void)[]
 >push : (...items: ((...args: any[]) => void)[]) => number
 >listener : (...args: any[]) => void

--- a/tests/baselines/reference/functionsInClassExpressions.types
+++ b/tests/baselines/reference/functionsInClassExpressions.types
@@ -7,7 +7,7 @@ let Foo = class {
         this.bar++;
 >this.bar++ : number
 >this.bar : number
->this : this
+>this : (Anonymous class)
 >bar : number
     }
     bar = 0;
@@ -21,12 +21,12 @@ let Foo = class {
         this.bar++;
 >this.bar++ : number
 >this.bar : number
->this : this
+>this : (Anonymous class)
 >bar : number
     }
     m() { return this.bar; }
 >m : () => number
 >this.bar : number
->this : this
+>this : (Anonymous class)
 >bar : number
 }

--- a/tests/baselines/reference/genericBaseClassLiteralProperty.types
+++ b/tests/baselines/reference/genericBaseClassLiteralProperty.types
@@ -23,14 +23,14 @@ class SubClass extends BaseClass<number> {
 >x : number
 >this._getValue1() : number
 >this._getValue1 : () => number
->this : this
+>this : SubClass
 >_getValue1 : () => number
 
         var y : number = this._getValue2();
 >y : number
 >this._getValue2() : number
 >this._getValue2 : () => number
->this : this
+>this : SubClass
 >_getValue2 : () => number
     }
 }

--- a/tests/baselines/reference/genericBaseClassLiteralProperty2.types
+++ b/tests/baselines/reference/genericBaseClassLiteralProperty2.types
@@ -16,7 +16,7 @@ class BaseCollection2<TItem extends CollectionItem2> {
         this._itemsByKey = {};
 >this._itemsByKey = {} : {}
 >this._itemsByKey : { [key: string]: TItem; }
->this : this
+>this : BaseCollection2<TItem>
 >_itemsByKey : { [key: string]: TItem; }
 >{} : {}
     }
@@ -36,7 +36,7 @@ class DataView2 extends BaseCollection2<CollectionItem2> {
 >this._itemsByKey['dummy'] = item : CollectionItem2
 >this._itemsByKey['dummy'] : CollectionItem2
 >this._itemsByKey : { [key: string]: CollectionItem2; }
->this : this
+>this : DataView2
 >_itemsByKey : { [key: string]: CollectionItem2; }
 >'dummy' : string
 >item : CollectionItem2

--- a/tests/baselines/reference/genericClasses4.types
+++ b/tests/baselines/reference/genericClasses4.types
@@ -26,7 +26,7 @@ class Vec2_T<A>
 >f(this.x) : B
 >f : (a: A) => B
 >this.x : A
->this : this
+>this : Vec2_T<A>
 >x : A
 
         var y:B = f(this.y);
@@ -35,7 +35,7 @@ class Vec2_T<A>
 >f(this.y) : B
 >f : (a: A) => B
 >this.y : A
->this : this
+>this : Vec2_T<A>
 >y : A
 
         var retval: Vec2_T<B> = new Vec2_T(x, y);
@@ -69,7 +69,7 @@ class Vec2_T<A>
 >f : Vec2_T<(a: A) => B>
 >x : (a: A) => B
 >this.x : A
->this : this
+>this : Vec2_T<A>
 >x : A
 
         var y:B = f.y(this.y);
@@ -80,7 +80,7 @@ class Vec2_T<A>
 >f : Vec2_T<(a: A) => B>
 >y : (a: A) => B
 >this.y : A
->this : this
+>this : Vec2_T<A>
 >y : A
 
         var retval: Vec2_T<B> = new Vec2_T(x, y);

--- a/tests/baselines/reference/genericConstraintOnExtendedBuiltinTypes.types
+++ b/tests/baselines/reference/genericConstraintOnExtendedBuiltinTypes.types
@@ -37,7 +37,7 @@ module EndGate.Tweening {
             this._from = from.Clone();
 >this._from = from.Clone() : any
 >this._from : T
->this : this
+>this : Tween<T>
 >_from : T
 >from.Clone() : any
 >from.Clone : () => any

--- a/tests/baselines/reference/genericConstraintOnExtendedBuiltinTypes2.types
+++ b/tests/baselines/reference/genericConstraintOnExtendedBuiltinTypes2.types
@@ -36,7 +36,7 @@ module EndGate.Tweening {
             this._from = from.Clone();
 >this._from = from.Clone() : any
 >this._from : T
->this : this
+>this : Tween<T>
 >_from : T
 >from.Clone() : any
 >from.Clone : () => any

--- a/tests/baselines/reference/genericInstanceOf.types
+++ b/tests/baselines/reference/genericInstanceOf.types
@@ -21,10 +21,10 @@ class C<T> {
         if (this.a instanceof this.b) {
 >this.a instanceof this.b : boolean
 >this.a : T
->this : this
+>this : C<T>
 >a : T
 >this.b : F
->this : this
+>this : C<T>
 >b : F
         }
     }

--- a/tests/baselines/reference/genericTypeWithCallableMembers.types
+++ b/tests/baselines/reference/genericTypeWithCallableMembers.types
@@ -24,14 +24,14 @@ class C<T extends Constructable> {
 >x : Constructable
 >new this.data() : Constructable
 >this.data : T
->this : this
+>this : C<T>
 >data : T
 
         var x2 = new this.data2(); // was error, shouldn't be
 >x2 : Constructable
 >new this.data2() : Constructable
 >this.data2 : Constructable
->this : this
+>this : C<T>
 >data2 : Constructable
     }
 }

--- a/tests/baselines/reference/genericWithCallSignatures1.types
+++ b/tests/baselines/reference/genericWithCallSignatures1.types
@@ -15,7 +15,7 @@ class MyClass {
 ><string> this.callableThing() : string
 >this.callableThing() : string
 >this.callableThing : CallableExtention<string>
->this : this
+>this : MyClass
 >callableThing : CallableExtention<string>
     }
 }

--- a/tests/baselines/reference/genericWithIndexerOfTypeParameterType1.types
+++ b/tests/baselines/reference/genericWithIndexerOfTypeParameterType1.types
@@ -15,7 +15,7 @@ class LazyArray<T> {
 
         return this.objects;
 >this.objects : { [objectId: string]: T; }
->this : this
+>this : LazyArray<T>
 >objects : { [objectId: string]: T; }
     }
 }

--- a/tests/baselines/reference/inheritance1.errors.txt
+++ b/tests/baselines/reference/inheritance1.errors.txt
@@ -7,11 +7,9 @@ tests/cases/compiler/inheritance1.ts(31,1): error TS2322: Type 'Control' is not 
 tests/cases/compiler/inheritance1.ts(37,1): error TS2322: Type 'Control' is not assignable to type 'TextBox'.
   Property 'select' is missing in type 'Control'.
 tests/cases/compiler/inheritance1.ts(40,1): error TS2322: Type 'ImageBase' is not assignable to type 'SelectableControl'.
-  Property 'select' is missing in type 'ImageBase'.
 tests/cases/compiler/inheritance1.ts(46,1): error TS2322: Type 'Image1' is not assignable to type 'SelectableControl'.
   Property 'select' is missing in type 'Image1'.
 tests/cases/compiler/inheritance1.ts(52,1): error TS2322: Type 'Locations' is not assignable to type 'SelectableControl'.
-  Property 'state' is missing in type 'Locations'.
 tests/cases/compiler/inheritance1.ts(53,1): error TS2322: Type 'Locations' is not assignable to type 'Control'.
   Property 'state' is missing in type 'Locations'.
 tests/cases/compiler/inheritance1.ts(55,1): error TS2322: Type 'Control' is not assignable to type 'Locations'.
@@ -79,7 +77,6 @@ tests/cases/compiler/inheritance1.ts(61,1): error TS2322: Type 'Control' is not 
     sc = i;
     ~~
 !!! error TS2322: Type 'ImageBase' is not assignable to type 'SelectableControl'.
-!!! error TS2322:   Property 'select' is missing in type 'ImageBase'.
     c = i;
     i = sc;
     i = c;
@@ -97,7 +94,6 @@ tests/cases/compiler/inheritance1.ts(61,1): error TS2322: Type 'Control' is not 
     sc = l;
     ~~
 !!! error TS2322: Type 'Locations' is not assignable to type 'SelectableControl'.
-!!! error TS2322:   Property 'state' is missing in type 'Locations'.
     c = l;
     ~
 !!! error TS2322: Type 'Locations' is not assignable to type 'Control'.

--- a/tests/baselines/reference/instanceAndStaticDeclarations1.symbols
+++ b/tests/baselines/reference/instanceAndStaticDeclarations1.symbols
@@ -18,18 +18,18 @@ class Point {
 >this.x : Symbol(x, Decl(instanceAndStaticDeclarations1.ts, 3, 16))
 >this : Symbol(Point, Decl(instanceAndStaticDeclarations1.ts, 0, 0))
 >x : Symbol(x, Decl(instanceAndStaticDeclarations1.ts, 3, 16))
->p.x : Symbol(Point.x, Decl(instanceAndStaticDeclarations1.ts, 3, 16))
+>p.x : Symbol(x, Decl(instanceAndStaticDeclarations1.ts, 3, 16))
 >p : Symbol(p, Decl(instanceAndStaticDeclarations1.ts, 4, 20))
->x : Symbol(Point.x, Decl(instanceAndStaticDeclarations1.ts, 3, 16))
+>x : Symbol(x, Decl(instanceAndStaticDeclarations1.ts, 3, 16))
 
         var dy = this.y - p.y;
 >dy : Symbol(dy, Decl(instanceAndStaticDeclarations1.ts, 6, 11))
 >this.y : Symbol(y, Decl(instanceAndStaticDeclarations1.ts, 3, 33))
 >this : Symbol(Point, Decl(instanceAndStaticDeclarations1.ts, 0, 0))
 >y : Symbol(y, Decl(instanceAndStaticDeclarations1.ts, 3, 33))
->p.y : Symbol(Point.y, Decl(instanceAndStaticDeclarations1.ts, 3, 33))
+>p.y : Symbol(y, Decl(instanceAndStaticDeclarations1.ts, 3, 33))
 >p : Symbol(p, Decl(instanceAndStaticDeclarations1.ts, 4, 20))
->y : Symbol(Point.y, Decl(instanceAndStaticDeclarations1.ts, 3, 33))
+>y : Symbol(y, Decl(instanceAndStaticDeclarations1.ts, 3, 33))
 
         return Math.sqrt(dx * dx + dy * dy);
 >Math.sqrt : Symbol(Math.sqrt, Decl(lib.d.ts, --, --))
@@ -50,8 +50,8 @@ class Point {
 >Point : Symbol(Point, Decl(instanceAndStaticDeclarations1.ts, 0, 0))
 >p2 : Symbol(p2, Decl(instanceAndStaticDeclarations1.ts, 10, 30))
 >Point : Symbol(Point, Decl(instanceAndStaticDeclarations1.ts, 0, 0))
->p1.distance : Symbol(Point.distance, Decl(instanceAndStaticDeclarations1.ts, 3, 55))
+>p1.distance : Symbol(distance, Decl(instanceAndStaticDeclarations1.ts, 3, 55))
 >p1 : Symbol(p1, Decl(instanceAndStaticDeclarations1.ts, 10, 20))
->distance : Symbol(Point.distance, Decl(instanceAndStaticDeclarations1.ts, 3, 55))
+>distance : Symbol(distance, Decl(instanceAndStaticDeclarations1.ts, 3, 55))
 >p2 : Symbol(p2, Decl(instanceAndStaticDeclarations1.ts, 10, 30))
 }

--- a/tests/baselines/reference/instanceAndStaticDeclarations1.types
+++ b/tests/baselines/reference/instanceAndStaticDeclarations1.types
@@ -17,7 +17,7 @@ class Point {
 >dx : number
 >this.x - p.x : number
 >this.x : number
->this : this
+>this : Point
 >x : number
 >p.x : number
 >p : Point
@@ -27,7 +27,7 @@ class Point {
 >dy : number
 >this.y - p.y : number
 >this.y : number
->this : this
+>this : Point
 >y : number
 >p.y : number
 >p : Point

--- a/tests/baselines/reference/interfaceClassMerging.types
+++ b/tests/baselines/reference/interfaceClassMerging.types
@@ -30,7 +30,7 @@ class Foo {
         return this.method(0);
 >this.method(0) : string
 >this.method : (a: number) => string
->this : this
+>this : Foo
 >method : (a: number) => string
 >0 : number
     }
@@ -46,7 +46,7 @@ class Bar extends Foo {
 
         return this.optionalProperty;
 >this.optionalProperty : string
->this : this
+>this : Bar
 >optionalProperty : string
     }
 }

--- a/tests/baselines/reference/interfaceContextualType.types
+++ b/tests/baselines/reference/interfaceContextualType.types
@@ -29,7 +29,7 @@ class Bug {
         this.values = {};
 >this.values = {} : {}
 >this.values : IMap
->this : this
+>this : Bug
 >values : IMap
 >{} : {}
 
@@ -37,7 +37,7 @@ class Bug {
 >this.values['comments'] = { italic: true } : { italic: boolean; }
 >this.values['comments'] : IOptions
 >this.values : IMap
->this : this
+>this : Bug
 >values : IMap
 >'comments' : string
 >{ italic: true } : { italic: boolean; }
@@ -50,7 +50,7 @@ class Bug {
         this.values = {
 >this.values = {            comments: { italic: true }        } : { comments: { italic: boolean; }; }
 >this.values : IMap
->this : this
+>this : Bug
 >values : IMap
 >{            comments: { italic: true }        } : { comments: { italic: boolean; }; }
 

--- a/tests/baselines/reference/jsFileCompilationClassMethodContainingArrowFunction.types
+++ b/tests/baselines/reference/jsFileCompilationClassMethodContainingArrowFunction.types
@@ -13,7 +13,7 @@ class c {
 >a : any
 >this.method(a) : void
 >this.method : (a: any) => void
->this : this
+>this : c
 >method : (a: any) => void
 >a : any
     }

--- a/tests/baselines/reference/listFailure.types
+++ b/tests/baselines/reference/listFailure.types
@@ -30,7 +30,7 @@ module Editor {
 >this.lines.add(line) : List<Line>
 >this.lines.add : (data: Line) => List<Line>
 >this.lines : List<Line>
->this : this
+>this : Buffer
 >lines : List<Line>
 >add : (data: Line) => List<Line>
 >line : Line
@@ -94,7 +94,7 @@ module Editor {
             this.next = ListMakeEntry(data);
 >this.next = ListMakeEntry(data) : List<T>
 >this.next : List<T>
->this : this
+>this : List<T>
 >next : List<T>
 >ListMakeEntry(data) : List<T>
 >ListMakeEntry : <U>(data: U) => List<U>
@@ -102,7 +102,7 @@ module Editor {
 
             return this.next;
 >this.next : List<T>
->this : this
+>this : List<T>
 >next : List<T>
         }
 
@@ -119,7 +119,7 @@ module Editor {
 >ListRemoveEntry(this.next) : List<T>
 >ListRemoveEntry : <U>(entry: List<U>) => List<U>
 >this.next : List<T>
->this : this
+>this : List<T>
 >next : List<T>
         }      
     }

--- a/tests/baselines/reference/localTypes5.types
+++ b/tests/baselines/reference/localTypes5.types
@@ -36,9 +36,9 @@ function foo<A>() {
 
     return x.m<number, boolean>();
 >x.m<number, boolean>() : X.m<number, boolean>.<Date>.Y<string>
->x.m : <B, C>() => X.m<B, C>.<Date>.Y<string>
+>x.m : <B, C>() => <Date>.Y<string>
 >x : X
->m : <B, C>() => X.m<B, C>.<Date>.Y<string>
+>m : <B, C>() => <Date>.Y<string>
 }
 var x = foo<void>();
 >x : foo<void>.X.m<number, boolean>.<Date>.Y<string>

--- a/tests/baselines/reference/memberVariableDeclarations1.types
+++ b/tests/baselines/reference/memberVariableDeclarations1.types
@@ -49,21 +49,21 @@ class Employee2 {
         this.retired = false;
 >this.retired = false : boolean
 >this.retired : boolean
->this : this
+>this : Employee2
 >retired : boolean
 >false : boolean
 
         this.manager = null;
 >this.manager = null : null
 >this.manager : Employee
->this : this
+>this : Employee2
 >manager : Employee
 >null : null
 
         this.reports = [];
 >this.reports = [] : undefined[]
 >this.reports : Employee[]
->this : this
+>this : Employee2
 >reports : Employee[]
 >[] : undefined[]
     }

--- a/tests/baselines/reference/mergedDeclarations6.types
+++ b/tests/baselines/reference/mergedDeclarations6.types
@@ -13,7 +13,7 @@ export class A {
         this.protected = val;
 >this.protected = val : any
 >this.protected : any
->this : this
+>this : A
 >protected : any
 >val : any
     }

--- a/tests/baselines/reference/missingSelf.types
+++ b/tests/baselines/reference/missingSelf.types
@@ -6,7 +6,7 @@ class CalcButton
 >a : () => void
 >this.onClick() : void
 >this.onClick : () => void
->this : this
+>this : CalcButton
 >onClick : () => void
 
     public onClick() { }
@@ -21,7 +21,7 @@ class CalcButton2
 >() => this.onClick() : () => void
 >this.onClick() : void
 >this.onClick : () => void
->this : this
+>this : CalcButton2
 >onClick : () => void
 
     public onClick() { }

--- a/tests/baselines/reference/moduleMemberWithoutTypeAnnotation1.types
+++ b/tests/baselines/reference/moduleMemberWithoutTypeAnnotation1.types
@@ -71,7 +71,7 @@ module TypeScript {
 >positionedToken : any
 >this.findTokenInternal(null, position, 0) : any
 >this.findTokenInternal : (x: any, y: any, z: any) => any
->this : this
+>this : SyntaxNode
 >findTokenInternal : (x: any, y: any, z: any) => any
 >null : null
 >position : number

--- a/tests/baselines/reference/moduleMergeConstructor.types
+++ b/tests/baselines/reference/moduleMergeConstructor.types
@@ -36,7 +36,7 @@ class Test {
         this.bar = new foo.Foo();
 >this.bar = new foo.Foo() : foo.Foo
 >this.bar : foo.Foo
->this : this
+>this : Test
 >bar : foo.Foo
 >new foo.Foo() : foo.Foo
 >foo.Foo : typeof foo.Foo

--- a/tests/baselines/reference/nestedSelf.types
+++ b/tests/baselines/reference/nestedSelf.types
@@ -22,7 +22,7 @@ module M {
 >x : number
 >this.n * x : number
 >this.n : number
->this : this
+>this : C
 >n : number
 >x : number
  }

--- a/tests/baselines/reference/newArrays.types
+++ b/tests/baselines/reference/newArrays.types
@@ -26,17 +26,17 @@ module M {
 			this.fa = new Array<Foo>(this.x * this.y);		
 >this.fa = new Array<Foo>(this.x * this.y) : Foo[]
 >this.fa : Foo[]
->this : this
+>this : Gar
 >fa : Foo[]
 >new Array<Foo>(this.x * this.y) : Foo[]
 >Array : ArrayConstructor
 >Foo : Foo
 >this.x * this.y : number
 >this.x : number
->this : this
+>this : Gar
 >x : number
 >this.y : number
->this : this
+>this : Gar
 >y : number
 		}
 	}

--- a/tests/baselines/reference/objectIndexer.types
+++ b/tests/baselines/reference/objectIndexer.types
@@ -25,7 +25,7 @@ class Emitter {
         this.listeners = {};
 >this.listeners = {} : {}
 >this.listeners : IMap
->this : this
+>this : Emitter
 >listeners : IMap
 >{} : {}
     }

--- a/tests/baselines/reference/parserErrorRecovery_IncompleteMemberVariable1.types
+++ b/tests/baselines/reference/parserErrorRecovery_IncompleteMemberVariable1.types
@@ -34,17 +34,17 @@ module Shapes {
 >this.x * this.x + this.y * this.y : number
 >this.x * this.x : number
 >this.x : number
->this : this
+>this : Point
 >x : number
 >this.x : number
->this : this
+>this : Point
 >x : number
 >this.y * this.y : number
 >this.y : number
->this : this
+>this : Point
 >y : number
 >this.y : number
->this : this
+>this : Point
 >y : number
 
         // Static member

--- a/tests/baselines/reference/privateInstanceVisibility.types
+++ b/tests/baselines/reference/privateInstanceVisibility.types
@@ -45,7 +45,7 @@ class C {
     getX() { return this.x; }
 >getX : () => number
 >this.x : number
->this : this
+>this : C
 >x : number
 
     clone(other: C) {
@@ -56,7 +56,7 @@ class C {
         this.x = other.x;
 >this.x = other.x : number
 >this.x : number
->this : this
+>this : C
 >x : number
 >other.x : number
 >other : C

--- a/tests/baselines/reference/privateVisibles.types
+++ b/tests/baselines/reference/privateVisibles.types
@@ -10,7 +10,7 @@ class Foo {
 	    var n = this.pvar;
 >n : number
 >this.pvar : number
->this : this
+>this : Foo
 >pvar : number
 	}
 
@@ -18,7 +18,7 @@ class Foo {
 >meth : () => void
 >q : number
 >this.pvar : number
->this : this
+>this : Foo
 >pvar : number
 }
 

--- a/tests/baselines/reference/promiseChaining.types
+++ b/tests/baselines/reference/promiseChaining.types
@@ -22,7 +22,7 @@ class Chain<T> {
 >cb(this.value) : S
 >cb : (x: T) => S
 >this.value : T
->this : this
+>this : Chain<T>
 >value : T
 
         // should get a fresh type parameter which each then call
@@ -34,7 +34,7 @@ class Chain<T> {
 >this.then(x => result)/*S*/.then : <S>(cb: (x: S) => S) => Chain<S>
 >this.then(x => result) : Chain<S>
 >this.then : <S>(cb: (x: T) => S) => Chain<S>
->this : this
+>this : Chain<T>
 >then : <S>(cb: (x: T) => S) => Chain<S>
 >x => result : (x: T) => S
 >x : T

--- a/tests/baselines/reference/protectedClassPropertyAccessibleWithinClass.types
+++ b/tests/baselines/reference/protectedClassPropertyAccessibleWithinClass.types
@@ -10,7 +10,7 @@ class C {
     protected get y() { return this.x; }
 >y : string
 >this.x : string
->this : this
+>this : C
 >x : string
 
     protected set y(x) { this.y = this.x; }
@@ -18,16 +18,16 @@ class C {
 >x : string
 >this.y = this.x : string
 >this.y : string
->this : this
+>this : C
 >y : string
 >this.x : string
->this : this
+>this : C
 >x : string
 
     protected foo() { return this.foo; }
 >foo : () => any
 >this.foo : () => any
->this : this
+>this : C
 >foo : () => any
 
     protected static x: string;
@@ -75,7 +75,7 @@ class C2 {
 >y : any
 >() => this.x : () => string
 >this.x : string
->this : this
+>this : C2
 >x : string
 >null : null
 
@@ -85,17 +85,17 @@ class C2 {
 >() => { this.y = this.x; } : () => void
 >this.y = this.x : string
 >this.y : any
->this : this
+>this : C2
 >y : any
 >this.x : string
->this : this
+>this : C2
 >x : string
 
     protected foo() { () => this.foo; }
 >foo : () => void
 >() => this.foo : () => () => void
 >this.foo : () => void
->this : this
+>this : C2
 >foo : () => void
 
     protected static x: string;

--- a/tests/baselines/reference/protectedClassPropertyAccessibleWithinSubclass.types
+++ b/tests/baselines/reference/protectedClassPropertyAccessibleWithinSubclass.types
@@ -18,7 +18,7 @@ class C extends B {
     protected get y() { return this.x; }
 >y : string
 >this.x : string
->this : this
+>this : C
 >x : string
 
     protected set y(x) { this.y = this.x; }
@@ -26,23 +26,23 @@ class C extends B {
 >x : string
 >this.y = this.x : string
 >this.y : string
->this : this
+>this : C
 >y : string
 >this.x : string
->this : this
+>this : C
 >x : string
 
     protected foo() { return this.x; }
 >foo : () => string
 >this.x : string
->this : this
+>this : C
 >x : string
 
     protected bar() { return this.foo(); }
 >bar : () => string
 >this.foo() : string
 >this.foo : () => string
->this : this
+>this : C
 >foo : () => string
 
     protected static get y() { return this.x; }

--- a/tests/baselines/reference/protoInIndexer.types
+++ b/tests/baselines/reference/protoInIndexer.types
@@ -6,7 +6,7 @@ class X {
         this['__proto__'] = null; // used to cause ICE
 >this['__proto__'] = null : null
 >this['__proto__'] : any
->this : this
+>this : X
 >'__proto__' : string
 >null : null
     }

--- a/tests/baselines/reference/quotedPropertyName3.types
+++ b/tests/baselines/reference/quotedPropertyName3.types
@@ -10,7 +10,7 @@ class Test {
 >x : () => number
 >() => this["prop1"] : () => number
 >this["prop1"] : number
->this : this
+>this : Test
 >"prop1" : string
 
         var y: number = x();

--- a/tests/baselines/reference/recursiveComplicatedClasses.types
+++ b/tests/baselines/reference/recursiveComplicatedClasses.types
@@ -24,7 +24,7 @@ class Symbol {
 >bound : boolean
 
     public visible() {
->visible : () => any
+>visible : () => boolean
 
         var b: TypeSymbol;
 >b : TypeSymbol

--- a/tests/baselines/reference/recursiveProperties.types
+++ b/tests/baselines/reference/recursiveProperties.types
@@ -5,7 +5,7 @@ class A {
     get testProp() { return this.testProp; }
 >testProp : any
 >this.testProp : any
->this : this
+>this : A
 >testProp : any
 }
 
@@ -17,7 +17,7 @@ class B {
 >value : string
 >this.testProp = value : string
 >this.testProp : string
->this : this
+>this : B
 >testProp : string
 >value : string
 }

--- a/tests/baselines/reference/scopeResolutionIdentifiers.types
+++ b/tests/baselines/reference/scopeResolutionIdentifiers.types
@@ -56,7 +56,7 @@ class C {
     n = this.s;
 >n : Date
 >this.s : Date
->this : this
+>this : C
 >s : Date
 
     x() {
@@ -65,7 +65,7 @@ class C {
         var p = this.n;
 >p : Date
 >this.n : Date
->this : this
+>this : C
 >n : Date
 
         var p: Date;

--- a/tests/baselines/reference/selfInCallback.types
+++ b/tests/baselines/reference/selfInCallback.types
@@ -18,12 +18,12 @@ class C {
 		this.callback(()=>{this.p1+1});
 >this.callback(()=>{this.p1+1}) : void
 >this.callback : (cb: () => void) => void
->this : this
+>this : C
 >callback : (cb: () => void) => void
 >()=>{this.p1+1} : () => void
 >this.p1+1 : number
 >this.p1 : number
->this : this
+>this : C
 >p1 : number
 >1 : number
 	}

--- a/tests/baselines/reference/selfInLambdas.types
+++ b/tests/baselines/reference/selfInLambdas.types
@@ -79,7 +79,7 @@ class X {
             var x = this.value;
 >x : string
 >this.value : string
->this : this
+>this : X
 >value : string
 
             var inner = () => {
@@ -89,7 +89,7 @@ class X {
                 var y = this.value;
 >y : string
 >this.value : string
->this : this
+>this : X
 >value : string
 			}
 

--- a/tests/baselines/reference/sourceMap-FileWithComments.types
+++ b/tests/baselines/reference/sourceMap-FileWithComments.types
@@ -32,17 +32,17 @@ module Shapes {
 >this.x * this.x + this.y * this.y : number
 >this.x * this.x : number
 >this.x : number
->this : this
+>this : Point
 >x : number
 >this.x : number
->this : this
+>this : Point
 >x : number
 >this.y * this.y : number
 >this.y : number
->this : this
+>this : Point
 >y : number
 >this.y : number
->this : this
+>this : Point
 >y : number
 
         // Static member

--- a/tests/baselines/reference/sourceMapValidationClass.types
+++ b/tests/baselines/reference/sourceMapValidationClass.types
@@ -14,7 +14,7 @@ class Greeter {
 >"<h1>" + this.greeting : string
 >"<h1>" : string
 >this.greeting : string
->this : this
+>this : Greeter
 >greeting : string
 >"</h1>" : string
     }
@@ -30,7 +30,7 @@ class Greeter {
 
         return this.greeting;
 >this.greeting : string
->this : this
+>this : Greeter
 >greeting : string
     }
     get greetings() {
@@ -38,7 +38,7 @@ class Greeter {
 
         return this.greeting;
 >this.greeting : string
->this : this
+>this : Greeter
 >greeting : string
     }
     set greetings(greetings: string) {
@@ -48,7 +48,7 @@ class Greeter {
         this.greeting = greetings;
 >this.greeting = greetings : string
 >this.greeting : string
->this : this
+>this : Greeter
 >greeting : string
 >greetings : string
     }

--- a/tests/baselines/reference/sourceMapValidationClassWithDefaultConstructorAndCapturedThisStatement.types
+++ b/tests/baselines/reference/sourceMapValidationClassWithDefaultConstructorAndCapturedThisStatement.types
@@ -10,6 +10,6 @@ class Greeter {
 >returnA : () => number
 >() => this.a : () => number
 >this.a : number
->this : this
+>this : Greeter
 >a : number
 }

--- a/tests/baselines/reference/sourceMapValidationClasses.types
+++ b/tests/baselines/reference/sourceMapValidationClasses.types
@@ -21,7 +21,7 @@ module Foo.Bar {
 >"<h1>" + this.greeting : string
 >"<h1>" : string
 >this.greeting : string
->this : this
+>this : Greeter
 >greeting : string
 >"</h1>" : string
         }

--- a/tests/baselines/reference/sourceMapValidationDecorators.types
+++ b/tests/baselines/reference/sourceMapValidationDecorators.types
@@ -93,7 +93,7 @@ class Greeter {
 >"<h1>" + this.greeting : string
 >"<h1>" : string
 >this.greeting : string
->this : this
+>this : Greeter
 >greeting : string
 >"</h1>" : string
     }
@@ -137,7 +137,7 @@ class Greeter {
 
         return this.greeting;
 >this.greeting : string
->this : this
+>this : Greeter
 >greeting : string
     }
 
@@ -154,7 +154,7 @@ class Greeter {
 
         return this.greeting;
 >this.greeting : string
->this : this
+>this : Greeter
 >greeting : string
     }
 
@@ -175,7 +175,7 @@ class Greeter {
         this.greeting = greetings;
 >this.greeting = greetings : string
 >this.greeting : string
->this : this
+>this : Greeter
 >greeting : string
 >greetings : string
     }    

--- a/tests/baselines/reference/staticInstanceResolution.symbols
+++ b/tests/baselines/reference/staticInstanceResolution.symbols
@@ -14,17 +14,17 @@ class Comment {
 >Comment : Symbol(Comment, Decl(staticInstanceResolution.ts, 0, 0))
     {
         comments[0].getDocCommentText();
->comments[0].getDocCommentText : Symbol(Comment.getDocCommentText, Decl(staticInstanceResolution.ts, 0, 15))
+>comments[0].getDocCommentText : Symbol(getDocCommentText, Decl(staticInstanceResolution.ts, 0, 15))
 >comments : Symbol(comments, Decl(staticInstanceResolution.ts, 7, 29))
->getDocCommentText : Symbol(Comment.getDocCommentText, Decl(staticInstanceResolution.ts, 0, 15))
+>getDocCommentText : Symbol(getDocCommentText, Decl(staticInstanceResolution.ts, 0, 15))
 
         var c: Comment;
 >c : Symbol(c, Decl(staticInstanceResolution.ts, 10, 11))
 >Comment : Symbol(Comment, Decl(staticInstanceResolution.ts, 0, 0))
 
         c.getDocCommentText();
->c.getDocCommentText : Symbol(Comment.getDocCommentText, Decl(staticInstanceResolution.ts, 0, 15))
+>c.getDocCommentText : Symbol(getDocCommentText, Decl(staticInstanceResolution.ts, 0, 15))
 >c : Symbol(c, Decl(staticInstanceResolution.ts, 10, 11))
->getDocCommentText : Symbol(Comment.getDocCommentText, Decl(staticInstanceResolution.ts, 0, 15))
+>getDocCommentText : Symbol(getDocCommentText, Decl(staticInstanceResolution.ts, 0, 15))
     }
 }

--- a/tests/baselines/reference/superAccessInFatArrow1.types
+++ b/tests/baselines/reference/superAccessInFatArrow1.types
@@ -23,7 +23,7 @@ module test {
             this.bar(() => {
 >this.bar(() => {                super.foo();            }) : void
 >this.bar : (callback: () => void) => void
->this : this
+>this : B
 >bar : (callback: () => void) => void
 >() => {                super.foo();            } : () => void
 

--- a/tests/baselines/reference/superCallBeforeThisAccessing1.types
+++ b/tests/baselines/reference/superCallBeforeThisAccessing1.types
@@ -28,7 +28,7 @@ class D extends Base {
             t: this._t
 >t : any
 >this._t : any
->this : this
+>this : D
 >_t : any
         }
         var i = Factory.create(s);

--- a/tests/baselines/reference/superCallBeforeThisAccessing2.types
+++ b/tests/baselines/reference/superCallBeforeThisAccessing2.types
@@ -18,7 +18,7 @@ class D extends Base {
 >super : typeof Base
 >() => { this._t } : () => void
 >this._t : any
->this : this
+>this : D
 >_t : any
     }
 }

--- a/tests/baselines/reference/superCallBeforeThisAccessing5.types
+++ b/tests/baselines/reference/superCallBeforeThisAccessing5.types
@@ -9,7 +9,7 @@ class D extends null {
     constructor() {
         this._t;  // No error
 >this._t : any
->this : this
+>this : D
 >_t : any
     }
 }

--- a/tests/baselines/reference/superCallBeforeThisAccessing8.types
+++ b/tests/baselines/reference/superCallBeforeThisAccessing8.types
@@ -26,7 +26,7 @@ class D extends Base {
             j: this._t,  // no error
 >j : any
 >this._t : any
->this : this
+>this : D
 >_t : any
         }
     }

--- a/tests/baselines/reference/superPropertyAccess_ES6.types
+++ b/tests/baselines/reference/superPropertyAccess_ES6.types
@@ -56,7 +56,7 @@ class A {
     get property() { return this._property; }
 >property : string
 >this._property : string
->this : this
+>this : A
 >_property : string
 
     set property(value: string) { this._property = value }
@@ -64,7 +64,7 @@ class A {
 >value : string
 >this._property = value : string
 >this._property : string
->this : this
+>this : A
 >_property : string
 >value : string
 }

--- a/tests/baselines/reference/thisBinding2.types
+++ b/tests/baselines/reference/thisBinding2.types
@@ -9,7 +9,7 @@ class C {
         this.x = (() => {
 >this.x = (() => {   var x = 1;   return this.x;  })() : number
 >this.x : number
->this : this
+>this : C
 >x : number
 >(() => {   var x = 1;   return this.x;  })() : number
 >(() => {   var x = 1;   return this.x;  }) : () => number
@@ -21,14 +21,14 @@ class C {
 
    return this.x;
 >this.x : number
->this : this
+>this : C
 >x : number
 
   })();
   this.x = function() {
 >this.x = function() {   var x = 1;   return this.x;  }() : any
 >this.x : number
->this : this
+>this : C
 >x : number
 >function() {   var x = 1;   return this.x;  }() : any
 >function() {   var x = 1;   return this.x;  } : () => any

--- a/tests/baselines/reference/thisCapture1.types
+++ b/tests/baselines/reference/thisCapture1.types
@@ -25,7 +25,7 @@ class X {
             this.y = 0;
 >this.y = 0 : number
 >this.y : number
->this : this
+>this : X
 >y : number
 >0 : number
 

--- a/tests/baselines/reference/thisInExtends.js
+++ b/tests/baselines/reference/thisInExtends.js
@@ -1,0 +1,31 @@
+//// [thisInExtends.ts]
+interface Constructed {
+    getThis(): this;
+}
+
+interface Constructor {
+    new(): Constructed;
+}
+
+declare function getConstructor(v: number): Constructor;
+class C extends getConstructor(42) {
+    f() {}
+}
+
+new C().getThis().f();
+
+//// [thisInExtends.js]
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var C = (function (_super) {
+    __extends(C, _super);
+    function C() {
+        _super.apply(this, arguments);
+    }
+    C.prototype.f = function () { };
+    return C;
+}(getConstructor(42)));
+new C().getThis().f();

--- a/tests/baselines/reference/thisInExtends.symbols
+++ b/tests/baselines/reference/thisInExtends.symbols
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/thisInExtends.ts ===
+interface Constructed {
+>Constructed : Symbol(Constructed, Decl(thisInExtends.ts, 0, 0))
+
+    getThis(): this;
+>getThis : Symbol(getThis, Decl(thisInExtends.ts, 0, 23))
+}
+
+interface Constructor {
+>Constructor : Symbol(Constructor, Decl(thisInExtends.ts, 2, 1))
+
+    new(): Constructed;
+>Constructed : Symbol(Constructed, Decl(thisInExtends.ts, 0, 0))
+}
+
+declare function getConstructor(v: number): Constructor;
+>getConstructor : Symbol(getConstructor, Decl(thisInExtends.ts, 6, 1))
+>v : Symbol(v, Decl(thisInExtends.ts, 8, 32))
+>Constructor : Symbol(Constructor, Decl(thisInExtends.ts, 2, 1))
+
+class C extends getConstructor(42) {
+>C : Symbol(C, Decl(thisInExtends.ts, 8, 56))
+>getConstructor : Symbol(getConstructor, Decl(thisInExtends.ts, 6, 1))
+
+    f() {}
+>f : Symbol(f, Decl(thisInExtends.ts, 9, 36))
+}
+
+new C().getThis().f();
+>new C().getThis().f : Symbol(C.f, Decl(thisInExtends.ts, 9, 36))
+>new C().getThis : Symbol(Constructed.getThis, Decl(thisInExtends.ts, 0, 23))
+>C : Symbol(C, Decl(thisInExtends.ts, 8, 56))
+>getThis : Symbol(Constructed.getThis, Decl(thisInExtends.ts, 0, 23))
+>f : Symbol(C.f, Decl(thisInExtends.ts, 9, 36))
+

--- a/tests/baselines/reference/thisInExtends.types
+++ b/tests/baselines/reference/thisInExtends.types
@@ -1,0 +1,40 @@
+=== tests/cases/compiler/thisInExtends.ts ===
+interface Constructed {
+>Constructed : Constructed
+
+    getThis(): this;
+>getThis : () => this
+}
+
+interface Constructor {
+>Constructor : Constructor
+
+    new(): Constructed;
+>Constructed : Constructed
+}
+
+declare function getConstructor(v: number): Constructor;
+>getConstructor : (v: number) => Constructor
+>v : number
+>Constructor : Constructor
+
+class C extends getConstructor(42) {
+>C : C
+>getConstructor(42) : Constructed
+>getConstructor : (v: number) => Constructor
+>42 : number
+
+    f() {}
+>f : () => void
+}
+
+new C().getThis().f();
+>new C().getThis().f() : void
+>new C().getThis().f : () => void
+>new C().getThis() : C
+>new C().getThis : () => C
+>new C() : C
+>C : typeof C
+>getThis : () => C
+>f : () => void
+

--- a/tests/baselines/reference/thisInLambda.types
+++ b/tests/baselines/reference/thisInLambda.types
@@ -11,14 +11,14 @@ class Foo {
 
         this.x; // 'this' is type 'Foo'
 >this.x : string
->this : this
+>this : Foo
 >x : string
 
         var f = () => this.x; // 'this' should be type 'Foo' as well
 >f : () => string
 >() => this.x : () => string
 >this.x : string
->this : this
+>this : Foo
 >x : string
     }
 }

--- a/tests/baselines/reference/thisInPropertyBoundDeclarations.symbols
+++ b/tests/baselines/reference/thisInPropertyBoundDeclarations.symbols
@@ -15,9 +15,9 @@ class Bug {
 >name : Symbol(name, Decl(thisInPropertyBoundDeclarations.ts, 4, 16))
 
          that.foo(name);
->that.foo : Symbol(Bug.foo, Decl(thisInPropertyBoundDeclarations.ts, 7, 6))
+>that.foo : Symbol(foo, Decl(thisInPropertyBoundDeclarations.ts, 7, 6))
 >that : Symbol(that, Decl(thisInPropertyBoundDeclarations.ts, 4, 6))
->foo : Symbol(Bug.foo, Decl(thisInPropertyBoundDeclarations.ts, 7, 6))
+>foo : Symbol(foo, Decl(thisInPropertyBoundDeclarations.ts, 7, 6))
 >name : Symbol(name, Decl(thisInPropertyBoundDeclarations.ts, 4, 16))
      }
     ];

--- a/tests/baselines/reference/thisInPropertyBoundDeclarations.types
+++ b/tests/baselines/reference/thisInPropertyBoundDeclarations.types
@@ -32,7 +32,7 @@ class Bug {
         this.name = name;
 >this.name = name : string
 >this.name : string
->this : this
+>this : Bug
 >name : string
 >name : string
     }

--- a/tests/baselines/reference/typeConstraintsWithConstructSignatures.types
+++ b/tests/baselines/reference/typeConstraintsWithConstructSignatures.types
@@ -23,14 +23,14 @@ class C<T extends Constructable> {
 >x : any
 >new this.data() : any
 >this.data : T
->this : this
+>this : C<T>
 >data : T
 
         var x2 = new this.data2(); // should not error
 >x2 : any
 >new this.data2() : any
 >this.data2 : Constructable
->this : this
+>this : C<T>
 >data2 : Constructable
     }
 }

--- a/tests/baselines/reference/typeGuardsInProperties.types
+++ b/tests/baselines/reference/typeGuardsInProperties.types
@@ -35,11 +35,11 @@ class C1 {
 >typeof this.pp1 === "string" : boolean
 >typeof this.pp1 : string
 >this.pp1 : string | number
->this : this
+>this : C1
 >pp1 : string | number
 >"string" : string
 >this.pp1 : string | number
->this : this
+>this : C1
 >pp1 : string | number
 
         strOrNum = typeof this.pp2 === "string" && this.pp2; // string | number
@@ -49,11 +49,11 @@ class C1 {
 >typeof this.pp2 === "string" : boolean
 >typeof this.pp2 : string
 >this.pp2 : string | number
->this : this
+>this : C1
 >pp2 : string | number
 >"string" : string
 >this.pp2 : string | number
->this : this
+>this : C1
 >pp2 : string | number
 
         strOrNum = typeof this.pp3 === "string" && this.pp3; // string | number
@@ -63,11 +63,11 @@ class C1 {
 >typeof this.pp3 === "string" : boolean
 >typeof this.pp3 : string
 >this.pp3 : string | number
->this : this
+>this : C1
 >pp3 : string | number
 >"string" : string
 >this.pp3 : string | number
->this : this
+>this : C1
 >pp3 : string | number
     }
 }

--- a/tests/baselines/reference/typeInferenceReturnTypeCallback.types
+++ b/tests/baselines/reference/typeInferenceReturnTypeCallback.types
@@ -54,7 +54,7 @@ class Cons<T> implements IList<T>{
         return this.foldRight(new Nil<U>(), (t, acc) => {
 >this.foldRight(new Nil<U>(), (t, acc) => {            return new Cons<U>();        }) : Nil<U>
 >this.foldRight : <E>(z: E, f: (t: T, acc: E) => E) => E
->this : this
+>this : Cons<T>
 >foldRight : <E>(z: E, f: (t: T, acc: E) => E) => E
 >new Nil<U>() : Nil<U>
 >Nil : typeof Nil

--- a/tests/baselines/reference/typeParameterExtendingUnion1.symbols
+++ b/tests/baselines/reference/typeParameterExtendingUnion1.symbols
@@ -33,9 +33,9 @@ function f<T extends Cat | Dog>(a: T) {
 >T : Symbol(T, Decl(typeParameterExtendingUnion1.ts, 8, 11))
 
     a.run();
->a.run : Symbol(run, Decl(typeParameterExtendingUnion1.ts, 0, 14), Decl(typeParameterExtendingUnion1.ts, 0, 14))
+>a.run : Symbol(Animal.run, Decl(typeParameterExtendingUnion1.ts, 0, 14))
 >a : Symbol(a, Decl(typeParameterExtendingUnion1.ts, 8, 32))
->run : Symbol(run, Decl(typeParameterExtendingUnion1.ts, 0, 14), Decl(typeParameterExtendingUnion1.ts, 0, 14))
+>run : Symbol(Animal.run, Decl(typeParameterExtendingUnion1.ts, 0, 14))
 
     run(a);
 >run : Symbol(run, Decl(typeParameterExtendingUnion1.ts, 2, 33))

--- a/tests/baselines/reference/typeParameterExtendingUnion2.symbols
+++ b/tests/baselines/reference/typeParameterExtendingUnion2.symbols
@@ -20,9 +20,9 @@ function run(a: Cat | Dog) {
 >Dog : Symbol(Dog, Decl(typeParameterExtendingUnion2.ts, 1, 33))
 
     a.run();
->a.run : Symbol(run, Decl(typeParameterExtendingUnion2.ts, 0, 14), Decl(typeParameterExtendingUnion2.ts, 0, 14))
+>a.run : Symbol(Animal.run, Decl(typeParameterExtendingUnion2.ts, 0, 14))
 >a : Symbol(a, Decl(typeParameterExtendingUnion2.ts, 4, 13))
->run : Symbol(run, Decl(typeParameterExtendingUnion2.ts, 0, 14), Decl(typeParameterExtendingUnion2.ts, 0, 14))
+>run : Symbol(Animal.run, Decl(typeParameterExtendingUnion2.ts, 0, 14))
 }
 
 function f<T extends Cat | Dog>(a: T) {
@@ -34,9 +34,9 @@ function f<T extends Cat | Dog>(a: T) {
 >T : Symbol(T, Decl(typeParameterExtendingUnion2.ts, 8, 11))
 
     a.run();
->a.run : Symbol(run, Decl(typeParameterExtendingUnion2.ts, 0, 14), Decl(typeParameterExtendingUnion2.ts, 0, 14))
+>a.run : Symbol(Animal.run, Decl(typeParameterExtendingUnion2.ts, 0, 14))
 >a : Symbol(a, Decl(typeParameterExtendingUnion2.ts, 8, 32))
->run : Symbol(run, Decl(typeParameterExtendingUnion2.ts, 0, 14), Decl(typeParameterExtendingUnion2.ts, 0, 14))
+>run : Symbol(Animal.run, Decl(typeParameterExtendingUnion2.ts, 0, 14))
 
     run(a);
 >run : Symbol(run, Decl(typeParameterExtendingUnion2.ts, 2, 33))

--- a/tests/baselines/reference/typeResolution.symbols
+++ b/tests/baselines/reference/typeResolution.symbols
@@ -18,26 +18,26 @@ export module TopLevelModule1 {
                     var a1: ClassA; a1.AisIn1_1_1();
 >a1 : Symbol(a1, Decl(typeResolution.ts, 6, 23))
 >ClassA : Symbol(ClassA, Decl(typeResolution.ts, 2, 37))
->a1.AisIn1_1_1 : Symbol(ClassA.AisIn1_1_1, Decl(typeResolution.ts, 3, 33))
+>a1.AisIn1_1_1 : Symbol(AisIn1_1_1, Decl(typeResolution.ts, 3, 33))
 >a1 : Symbol(a1, Decl(typeResolution.ts, 6, 23))
->AisIn1_1_1 : Symbol(ClassA.AisIn1_1_1, Decl(typeResolution.ts, 3, 33))
+>AisIn1_1_1 : Symbol(AisIn1_1_1, Decl(typeResolution.ts, 3, 33))
 
                     var a2: SubSubModule1.ClassA; a2.AisIn1_1_1();
 >a2 : Symbol(a2, Decl(typeResolution.ts, 7, 23))
 >SubSubModule1 : Symbol(SubSubModule1, Decl(typeResolution.ts, 1, 30))
 >ClassA : Symbol(ClassA, Decl(typeResolution.ts, 2, 37))
->a2.AisIn1_1_1 : Symbol(ClassA.AisIn1_1_1, Decl(typeResolution.ts, 3, 33))
+>a2.AisIn1_1_1 : Symbol(AisIn1_1_1, Decl(typeResolution.ts, 3, 33))
 >a2 : Symbol(a2, Decl(typeResolution.ts, 7, 23))
->AisIn1_1_1 : Symbol(ClassA.AisIn1_1_1, Decl(typeResolution.ts, 3, 33))
+>AisIn1_1_1 : Symbol(AisIn1_1_1, Decl(typeResolution.ts, 3, 33))
 
                     var a3: SubModule1.SubSubModule1.ClassA; a3.AisIn1_1_1();
 >a3 : Symbol(a3, Decl(typeResolution.ts, 8, 23))
 >SubModule1 : Symbol(SubModule1, Decl(typeResolution.ts, 0, 31))
 >SubSubModule1 : Symbol(SubSubModule1, Decl(typeResolution.ts, 1, 30))
 >ClassA : Symbol(ClassA, Decl(typeResolution.ts, 2, 37))
->a3.AisIn1_1_1 : Symbol(ClassA.AisIn1_1_1, Decl(typeResolution.ts, 3, 33))
+>a3.AisIn1_1_1 : Symbol(AisIn1_1_1, Decl(typeResolution.ts, 3, 33))
 >a3 : Symbol(a3, Decl(typeResolution.ts, 8, 23))
->AisIn1_1_1 : Symbol(ClassA.AisIn1_1_1, Decl(typeResolution.ts, 3, 33))
+>AisIn1_1_1 : Symbol(AisIn1_1_1, Decl(typeResolution.ts, 3, 33))
 
                     var a4: TopLevelModule1.SubModule1.SubSubModule1.ClassA; a4.AisIn1_1_1();
 >a4 : Symbol(a4, Decl(typeResolution.ts, 9, 23))
@@ -45,9 +45,9 @@ export module TopLevelModule1 {
 >SubModule1 : Symbol(SubModule1, Decl(typeResolution.ts, 0, 31))
 >SubSubModule1 : Symbol(SubSubModule1, Decl(typeResolution.ts, 1, 30))
 >ClassA : Symbol(ClassA, Decl(typeResolution.ts, 2, 37))
->a4.AisIn1_1_1 : Symbol(ClassA.AisIn1_1_1, Decl(typeResolution.ts, 3, 33))
+>a4.AisIn1_1_1 : Symbol(AisIn1_1_1, Decl(typeResolution.ts, 3, 33))
 >a4 : Symbol(a4, Decl(typeResolution.ts, 9, 23))
->AisIn1_1_1 : Symbol(ClassA.AisIn1_1_1, Decl(typeResolution.ts, 3, 33))
+>AisIn1_1_1 : Symbol(AisIn1_1_1, Decl(typeResolution.ts, 3, 33))
                     
                     // Two variants of qualifying a peer type
                     var b1: ClassB; b1.BisIn1_1_1();
@@ -142,9 +142,9 @@ export module TopLevelModule1 {
                     var b1: ClassB; b1.BisIn1_1_1();
 >b1 : Symbol(b1, Decl(typeResolution.ts, 34, 23))
 >ClassB : Symbol(ClassB, Decl(typeResolution.ts, 22, 13))
->b1.BisIn1_1_1 : Symbol(ClassB.BisIn1_1_1, Decl(typeResolution.ts, 23, 33))
+>b1.BisIn1_1_1 : Symbol(BisIn1_1_1, Decl(typeResolution.ts, 23, 33))
 >b1 : Symbol(b1, Decl(typeResolution.ts, 34, 23))
->BisIn1_1_1 : Symbol(ClassB.BisIn1_1_1, Decl(typeResolution.ts, 23, 33))
+>BisIn1_1_1 : Symbol(BisIn1_1_1, Decl(typeResolution.ts, 23, 33))
 
                     var b2: TopLevelModule1.SubModule1.SubSubModule1.ClassB; b2.BisIn1_1_1();
 >b2 : Symbol(b2, Decl(typeResolution.ts, 35, 23))
@@ -152,9 +152,9 @@ export module TopLevelModule1 {
 >SubModule1 : Symbol(SubModule1, Decl(typeResolution.ts, 0, 31))
 >SubSubModule1 : Symbol(SubSubModule1, Decl(typeResolution.ts, 1, 30))
 >ClassB : Symbol(ClassB, Decl(typeResolution.ts, 22, 13))
->b2.BisIn1_1_1 : Symbol(ClassB.BisIn1_1_1, Decl(typeResolution.ts, 23, 33))
+>b2.BisIn1_1_1 : Symbol(BisIn1_1_1, Decl(typeResolution.ts, 23, 33))
 >b2 : Symbol(b2, Decl(typeResolution.ts, 35, 23))
->BisIn1_1_1 : Symbol(ClassB.BisIn1_1_1, Decl(typeResolution.ts, 23, 33))
+>BisIn1_1_1 : Symbol(BisIn1_1_1, Decl(typeResolution.ts, 23, 33))
                     
                     // Type only accessible from the root
                     var c1: TopLevelModule1.SubModule2.SubSubModule2.ClassA; c1.AisIn1_2_2();

--- a/tests/baselines/reference/underscoreMapFirst.types
+++ b/tests/baselines/reference/underscoreMapFirst.types
@@ -124,7 +124,7 @@ class MyView extends View {
 >this.model.get("data") : any
 >this.model.get : any
 >this.model : any
->this : this
+>this : MyView
 >model : any
 >get : any
 >"data" : string

--- a/tests/baselines/reference/varArgsOnConstructorTypes.types
+++ b/tests/baselines/reference/varArgsOnConstructorTypes.types
@@ -28,14 +28,14 @@ export class B extends A {
         this.p1 = element;
 >this.p1 = element : any
 >this.p1 : number
->this : this
+>this : B
 >p1 : number
 >element : any
 
         this.p2 = url;
 >this.p2 = url : string
 >this.p2 : string
->this : this
+>this : B
 >p2 : string
 >url : string
     }

--- a/tests/cases/compiler/thisInExtends.ts
+++ b/tests/cases/compiler/thisInExtends.ts
@@ -1,0 +1,14 @@
+interface Constructed {
+    getThis(): this;
+}
+
+interface Constructor {
+    new(): Constructed;
+}
+
+declare function getConstructor(v: number): Constructor;
+class C extends getConstructor(42) {
+    f() {}
+}
+
+new C().getThis().f();

--- a/tests/cases/fourslash/referencesForInheritedProperties6.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties6.ts
@@ -13,14 +13,28 @@
 //// v./*5*/propName;
 //// v./*6*/doStuff();
 
+//// interface I1 extends I1 {
+////    /*7*/doStuff1();
+////    /*8*/propName1: string;
+//// }
+//// interface I2 extends I1 {
+////    /*9*/doStuff1();
+////    /*10*/propName1: string;
+//// }
+////
+//// var v2: I2;
+//// v2./*11*/propName1;
+//// v2./*12*/doStuff1();
+
+
 goTo.marker("1");
-verify.referencesCountIs(1);
+verify.referencesCountIs(3);
 
 goTo.marker("2");
 verify.referencesCountIs(3);
 
 goTo.marker("3");
-verify.referencesCountIs(2);
+verify.referencesCountIs(3);
 
 goTo.marker("4");
 verify.referencesCountIs(3);
@@ -29,4 +43,22 @@ goTo.marker("5");
 verify.referencesCountIs(3);
 
 goTo.marker("6");
-verify.referencesCountIs(2);
+verify.referencesCountIs(3);
+
+goTo.marker("7");
+verify.referencesCountIs(3);
+
+goTo.marker("8");
+verify.referencesCountIs(3);
+
+goTo.marker("9");
+verify.referencesCountIs(3);
+
+goTo.marker("10");
+verify.referencesCountIs(3);
+
+goTo.marker("11");
+verify.referencesCountIs(3);
+
+goTo.marker("12");
+verify.referencesCountIs(3);

--- a/tests/cases/fourslash/referencesForInheritedProperties7.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties7.ts
@@ -18,7 +18,7 @@
 //// v./*8*/doStuff();
 
 goTo.marker("1");
-verify.referencesCountIs(1);
+verify.referencesCountIs(3);
 
 goTo.marker("2");
 verify.referencesCountIs(3);
@@ -30,7 +30,7 @@ goTo.marker("4");
 verify.referencesCountIs(3);
 
 goTo.marker("5");
-verify.referencesCountIs(3);
+verify.referencesCountIs(4);
 
 goTo.marker("6");
 verify.referencesCountIs(4);
@@ -39,4 +39,4 @@ goTo.marker("7");
 verify.referencesCountIs(4);
 
 goTo.marker("8");
-verify.referencesCountIs(3);
+verify.referencesCountIs(4);


### PR DESCRIPTION
fixes a set of perf issues mostly uncovered by rxjs
