### PR TITLE
Add limit for program size

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2824,5 +2824,9 @@
     "Unknown typing option '{0}'.": {
         "category": "Error",
         "code": 17010
+    },
+    "Too many files are included in the project. Consider add more folders to the `exclude` list.": {
+        "category": "Error",
+        "code": 17012
     }
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Intend to fix #7444 
This is a first attempt to add a upper limit for program size. For experimental purpose, the upper limit was set to 32 Mb, which might be changed to a better value after further tests. The way diagnostics are generated is still in discussion. 

Per our discussion in #7444, the next step is to add a compiler switch (something like `disableSizeLimit`) to disable this check for a project. Though I will do that after the current size-checking logic was reviewed. 