### PR TITLE
RWC runner fixes for reading json files

### DIFF
--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -876,7 +876,7 @@ namespace Harness {
                 useCaseSensitiveFileNames: () => useCaseSensitiveFileNames,
                 getNewLine: () => newLine,
                 fileExists: fileName => getSourceFile(fileName, ts.ScriptTarget.ES5) !== undefined,
-                readFile: (fileName: string): string => { throw new Error("NotYetImplemented"); }
+                readFile: (fileName: string): string => { return Harness.IO.readFile(fileName); }
             };
         }
 

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -31,22 +31,20 @@ namespace RWC {
             let otherFiles: Harness.Compiler.TestFile[] = [];
             let compilerResult: Harness.Compiler.CompilerResult;
             let compilerOptions: ts.CompilerOptions;
-            let baselineOpts: Harness.Baseline.BaselineOptions = {
+            const baselineOpts: Harness.Baseline.BaselineOptions = {
                 Subfolder: "rwc",
                 Baselinefolder: "internal/baselines"
             };
-            let baseName = /(.*)\/(.*).json/.exec(ts.normalizeSlashes(jsonPath))[2];
+            const baseName = /(.*)\/(.*).json/.exec(ts.normalizeSlashes(jsonPath))[2];
             let currentDirectory: string;
             let useCustomLibraryFile: boolean;
             after(() => {
                 // Mocha holds onto the closure environment of the describe callback even after the test is done.
                 // Therefore we have to clean out large objects after the test is done.
-                inputFiles = undefined;
-                otherFiles = undefined;
+                inputFiles = [];
+                otherFiles = [];
                 compilerResult = undefined;
                 compilerOptions = undefined;
-                baselineOpts = undefined;
-                baseName = undefined;
                 currentDirectory = undefined;
                 // useCustomLibraryFile is a flag specified in the json object to indicate whether to use built/local/lib.d.ts
                 // or to use lib.d.ts inside the json object. If the flag is true, use the lib.d.ts inside json file


### PR DESCRIPTION
RWC runner uses the readFile method, which was not implemented, to load .json files like package.json. so adding that.
also a fix for initialization for tests, to make it easier to debug the tests running multiple times in the browser.