### PR TITLE
emit top level classes as class expressions when target=ES6 and module=System

### DIFF
--- a/tests/baselines/reference/anonymousDefaultExportsSystem.js
+++ b/tests/baselines/reference/anonymousDefaultExportsSystem.js
@@ -14,8 +14,8 @@ System.register([], function(exports_1, context_1) {
     return {
         setters:[],
         execute: function() {
-            class default_1 {
-            }
+            default_1 = class {
+            };
             exports_1("default", default_1);
         }
     }

--- a/tests/baselines/reference/decoratedDefaultExportsGetExportedSystem.js
+++ b/tests/baselines/reference/decoratedDefaultExportsGetExportedSystem.js
@@ -26,7 +26,7 @@ System.register([], function(exports_1, context_1) {
     return {
         setters:[],
         execute: function() {
-            let Foo = class Foo {
+            Foo = class Foo {
             };
             Foo = __decorate([
                 decorator
@@ -49,7 +49,7 @@ System.register([], function(exports_1, context_1) {
     return {
         setters:[],
         execute: function() {
-            let default_1 = class {
+            default_1 = class {
             };
             default_1 = __decorate([
                 decorator

--- a/tests/baselines/reference/defaultExportsGetExportedSystem.js
+++ b/tests/baselines/reference/defaultExportsGetExportedSystem.js
@@ -15,8 +15,8 @@ System.register([], function(exports_1, context_1) {
     return {
         setters:[],
         execute: function() {
-            class Foo {
-            }
+            Foo = class Foo {
+            };
             exports_1("default", Foo);
         }
     }

--- a/tests/baselines/reference/outFilerootDirModuleNamesSystem.js
+++ b/tests/baselines/reference/outFilerootDirModuleNamesSystem.js
@@ -37,8 +37,8 @@ System.register("a", ["b"], function(exports_2, context_2) {
                 b_1 = b_1_1;
             }],
         execute: function() {
-            class Foo {
-            }
+            Foo = class Foo {
+            };
             exports_2("default", Foo);
             b_1.default();
         }

--- a/tests/baselines/reference/systemModuleTargetES6.js
+++ b/tests/baselines/reference/systemModuleTargetES6.js
@@ -1,0 +1,42 @@
+//// [systemModuleTargetES6.ts]
+export class MyClass { }
+export class MyClass2 {
+    static value = 42;
+    static getInstance() { return MyClass2.value; }
+}
+
+export function myFunction() {
+    return new MyClass();
+}
+
+export function myFunction2() {
+    return new MyClass2();
+}
+
+//// [systemModuleTargetES6.js]
+System.register([], function(exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    var MyClass, MyClass2;
+    function myFunction() {
+        return new MyClass();
+    }
+    exports_1("myFunction", myFunction);
+    function myFunction2() {
+        return new MyClass2();
+    }
+    exports_1("myFunction2", myFunction2);
+    return {
+        setters:[],
+        execute: function() {
+            MyClass = class MyClass {
+            };
+            exports_1("MyClass", MyClass);
+            MyClass2 = class MyClass2 {
+                static getInstance() { return MyClass2.value; }
+            };
+            MyClass2.value = 42;
+            exports_1("MyClass2", MyClass2);
+        }
+    }
+});

--- a/tests/baselines/reference/systemModuleTargetES6.symbols
+++ b/tests/baselines/reference/systemModuleTargetES6.symbols
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/systemModuleTargetES6.ts ===
+export class MyClass { }
+>MyClass : Symbol(MyClass, Decl(systemModuleTargetES6.ts, 0, 0))
+
+export class MyClass2 {
+>MyClass2 : Symbol(MyClass2, Decl(systemModuleTargetES6.ts, 0, 24))
+
+    static value = 42;
+>value : Symbol(MyClass2.value, Decl(systemModuleTargetES6.ts, 1, 23))
+
+    static getInstance() { return MyClass2.value; }
+>getInstance : Symbol(MyClass2.getInstance, Decl(systemModuleTargetES6.ts, 2, 22))
+>MyClass2.value : Symbol(MyClass2.value, Decl(systemModuleTargetES6.ts, 1, 23))
+>MyClass2 : Symbol(MyClass2, Decl(systemModuleTargetES6.ts, 0, 24))
+>value : Symbol(MyClass2.value, Decl(systemModuleTargetES6.ts, 1, 23))
+}
+
+export function myFunction() {
+>myFunction : Symbol(myFunction, Decl(systemModuleTargetES6.ts, 4, 1))
+
+    return new MyClass();
+>MyClass : Symbol(MyClass, Decl(systemModuleTargetES6.ts, 0, 0))
+}
+
+export function myFunction2() {
+>myFunction2 : Symbol(myFunction2, Decl(systemModuleTargetES6.ts, 8, 1))
+
+    return new MyClass2();
+>MyClass2 : Symbol(MyClass2, Decl(systemModuleTargetES6.ts, 0, 24))
+}

--- a/tests/baselines/reference/systemModuleTargetES6.types
+++ b/tests/baselines/reference/systemModuleTargetES6.types
@@ -1,0 +1,33 @@
+=== tests/cases/compiler/systemModuleTargetES6.ts ===
+export class MyClass { }
+>MyClass : MyClass
+
+export class MyClass2 {
+>MyClass2 : MyClass2
+
+    static value = 42;
+>value : number
+>42 : number
+
+    static getInstance() { return MyClass2.value; }
+>getInstance : () => number
+>MyClass2.value : number
+>MyClass2 : typeof MyClass2
+>value : number
+}
+
+export function myFunction() {
+>myFunction : () => MyClass
+
+    return new MyClass();
+>new MyClass() : MyClass
+>MyClass : typeof MyClass
+}
+
+export function myFunction2() {
+>myFunction2 : () => MyClass2
+
+    return new MyClass2();
+>new MyClass2() : MyClass2
+>MyClass2 : typeof MyClass2
+}

--- a/tests/cases/compiler/systemModuleTargetES6.ts
+++ b/tests/cases/compiler/systemModuleTargetES6.ts
@@ -1,0 +1,15 @@
+// @target: ES6
+// @module: System
+export class MyClass { }
+export class MyClass2 {
+    static value = 42;
+    static getInstance() { return MyClass2.value; }
+}
+
+export function myFunction() {
+    return new MyClass();
+}
+
+export function myFunction2() {
+    return new MyClass2();
+}


### PR DESCRIPTION
fixes #6426. 
This PR reuses existing rewriting facilities that we already have for emitting decorators