### PR TITLE
Fix generic default construct signature inheritance

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3663,6 +3663,7 @@ namespace ts {
                     const sig = typeParamCount ? getSignatureInstantiation(baseSig, typeArguments) : cloneSignature(baseSig);
                     sig.typeParameters = classType.localTypeParameters;
                     sig.resolvedReturnType = classType;
+                    sig.target = undefined;
                     result.push(sig);
                 }
             }

--- a/tests/baselines/reference/inferInstanceOfSubclass.js
+++ b/tests/baselines/reference/inferInstanceOfSubclass.js
@@ -1,0 +1,49 @@
+//// [inferInstanceOfSubclass.ts]
+function create<T>(ctor: { new(): T }) {
+    return new ctor();
+}
+class C<U> { c: U }
+class D<V> extends C<V> { d: V }
+let d = create(D);
+
+class A { a: number }
+class B<T> extends A { b: T }
+let b = create(B);
+
+
+
+//// [inferInstanceOfSubclass.js]
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+function create(ctor) {
+    return new ctor();
+}
+var C = (function () {
+    function C() {
+    }
+    return C;
+}());
+var D = (function (_super) {
+    __extends(D, _super);
+    function D() {
+        _super.apply(this, arguments);
+    }
+    return D;
+}(C));
+var d = create(D);
+var A = (function () {
+    function A() {
+    }
+    return A;
+}());
+var B = (function (_super) {
+    __extends(B, _super);
+    function B() {
+        _super.apply(this, arguments);
+    }
+    return B;
+}(A));
+var b = create(B);

--- a/tests/baselines/reference/inferInstanceOfSubclass.symbols
+++ b/tests/baselines/reference/inferInstanceOfSubclass.symbols
@@ -1,0 +1,46 @@
+=== tests/cases/compiler/inferInstanceOfSubclass.ts ===
+function create<T>(ctor: { new(): T }) {
+>create : Symbol(create, Decl(inferInstanceOfSubclass.ts, 0, 0))
+>T : Symbol(T, Decl(inferInstanceOfSubclass.ts, 0, 16))
+>ctor : Symbol(ctor, Decl(inferInstanceOfSubclass.ts, 0, 19))
+>T : Symbol(T, Decl(inferInstanceOfSubclass.ts, 0, 16))
+
+    return new ctor();
+>ctor : Symbol(ctor, Decl(inferInstanceOfSubclass.ts, 0, 19))
+}
+class C<U> { c: U }
+>C : Symbol(C, Decl(inferInstanceOfSubclass.ts, 2, 1))
+>U : Symbol(U, Decl(inferInstanceOfSubclass.ts, 3, 8))
+>c : Symbol(c, Decl(inferInstanceOfSubclass.ts, 3, 12))
+>U : Symbol(U, Decl(inferInstanceOfSubclass.ts, 3, 8))
+
+class D<V> extends C<V> { d: V }
+>D : Symbol(D, Decl(inferInstanceOfSubclass.ts, 3, 19))
+>V : Symbol(V, Decl(inferInstanceOfSubclass.ts, 4, 8))
+>C : Symbol(C, Decl(inferInstanceOfSubclass.ts, 2, 1))
+>V : Symbol(V, Decl(inferInstanceOfSubclass.ts, 4, 8))
+>d : Symbol(d, Decl(inferInstanceOfSubclass.ts, 4, 25))
+>V : Symbol(V, Decl(inferInstanceOfSubclass.ts, 4, 8))
+
+let d = create(D);
+>d : Symbol(d, Decl(inferInstanceOfSubclass.ts, 5, 3))
+>create : Symbol(create, Decl(inferInstanceOfSubclass.ts, 0, 0))
+>D : Symbol(D, Decl(inferInstanceOfSubclass.ts, 3, 19))
+
+class A { a: number }
+>A : Symbol(A, Decl(inferInstanceOfSubclass.ts, 5, 18))
+>a : Symbol(a, Decl(inferInstanceOfSubclass.ts, 7, 9))
+
+class B<T> extends A { b: T }
+>B : Symbol(B, Decl(inferInstanceOfSubclass.ts, 7, 21))
+>T : Symbol(T, Decl(inferInstanceOfSubclass.ts, 8, 8))
+>A : Symbol(A, Decl(inferInstanceOfSubclass.ts, 5, 18))
+>b : Symbol(b, Decl(inferInstanceOfSubclass.ts, 8, 22))
+>T : Symbol(T, Decl(inferInstanceOfSubclass.ts, 8, 8))
+
+let b = create(B);
+>b : Symbol(b, Decl(inferInstanceOfSubclass.ts, 9, 3))
+>create : Symbol(create, Decl(inferInstanceOfSubclass.ts, 0, 0))
+>B : Symbol(B, Decl(inferInstanceOfSubclass.ts, 7, 21))
+
+

--- a/tests/baselines/reference/inferInstanceOfSubclass.types
+++ b/tests/baselines/reference/inferInstanceOfSubclass.types
@@ -1,0 +1,49 @@
+=== tests/cases/compiler/inferInstanceOfSubclass.ts ===
+function create<T>(ctor: { new(): T }) {
+>create : <T>(ctor: new () => T) => T
+>T : T
+>ctor : new () => T
+>T : T
+
+    return new ctor();
+>new ctor() : T
+>ctor : new () => T
+}
+class C<U> { c: U }
+>C : C<U>
+>U : U
+>c : U
+>U : U
+
+class D<V> extends C<V> { d: V }
+>D : D<V>
+>V : V
+>C : C<V>
+>V : V
+>d : V
+>V : V
+
+let d = create(D);
+>d : D<any>
+>create(D) : D<any>
+>create : <T>(ctor: new () => T) => T
+>D : typeof D
+
+class A { a: number }
+>A : A
+>a : number
+
+class B<T> extends A { b: T }
+>B : B<T>
+>T : T
+>A : A
+>b : T
+>T : T
+
+let b = create(B);
+>b : B<any>
+>create(B) : B<any>
+>create : <T>(ctor: new () => T) => T
+>B : typeof B
+
+

--- a/tests/cases/compiler/inferInstanceOfSubclass.ts
+++ b/tests/cases/compiler/inferInstanceOfSubclass.ts
@@ -1,0 +1,11 @@
+function create<T>(ctor: { new(): T }) {
+    return new ctor();
+}
+class C<U> { c: U }
+class D<V> extends C<V> { d: V }
+let d = create(D);
+
+class A { a: number }
+class B<T> extends A { b: T }
+let b = create(B);
+


### PR DESCRIPTION
Fixes #6783

When getting a default construct signature, if there is base with a generic construct signature, the signature needs to be instantiated with the type parameters from the derived class. When doing this however, the target should not refer back to the base class -- the default construct signature is considered separate from the base's signature.

Unset the instantiated signature's target to make this happen.