### PR TITLE
Allow aliases to be merged with exported types\namespaces

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15085,8 +15085,8 @@ namespace ts {
                 // in order to prevent collisions with declarations that were exported from the current module (they still contribute to local names). 
                 const excludedMeanings =
                     (symbol.flags & (SymbolFlags.Value | SymbolFlags.ExportValue) ? SymbolFlags.Value : 0) |
-                    (symbol.flags & (SymbolFlags.Type | SymbolFlags.ExportType) ? SymbolFlags.Type : 0) |
-                    (symbol.flags & (SymbolFlags.Namespace | SymbolFlags.ExportNamespace) ? SymbolFlags.Namespace : 0);
+                    (symbol.flags & SymbolFlags.Type ? SymbolFlags.Type : 0) |
+                    (symbol.flags & SymbolFlags.Namespace ? SymbolFlags.Namespace : 0);
                 if (target.flags & excludedMeanings) {
                     const message = node.kind === SyntaxKind.ExportSpecifier ?
                         Diagnostics.Export_declaration_conflicts_with_exported_declaration_of_0 :

--- a/tests/baselines/reference/mergeWithImportedNamespace.js
+++ b/tests/baselines/reference/mergeWithImportedNamespace.js
@@ -1,0 +1,20 @@
+//// [tests/cases/compiler/mergeWithImportedNamespace.ts] ////
+
+//// [f1.ts]
+export namespace N { export var x = 1; }
+
+//// [f2.ts]
+import {N} from "./f1";
+// partial revert of https://github.com/Microsoft/TypeScript/pull/7583 to prevent breaking changes
+export namespace N {
+    export interface I {x: any}
+}
+
+//// [f1.js]
+"use strict";
+var N;
+(function (N) {
+    N.x = 1;
+})(N = exports.N || (exports.N = {}));
+//// [f2.js]
+"use strict";

--- a/tests/baselines/reference/mergeWithImportedNamespace.symbols
+++ b/tests/baselines/reference/mergeWithImportedNamespace.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/f1.ts ===
+export namespace N { export var x = 1; }
+>N : Symbol(N, Decl(f1.ts, 0, 0))
+>x : Symbol(x, Decl(f1.ts, 0, 31))
+
+=== tests/cases/compiler/f2.ts ===
+import {N} from "./f1";
+>N : Symbol(N, Decl(f2.ts, 0, 8), Decl(f2.ts, 0, 23))
+
+// partial revert of https://github.com/Microsoft/TypeScript/pull/7583 to prevent breaking changes
+export namespace N {
+>N : Symbol(N, Decl(f2.ts, 0, 23))
+
+    export interface I {x: any}
+>I : Symbol(I, Decl(f2.ts, 2, 20))
+>x : Symbol(I.x, Decl(f2.ts, 3, 24))
+}

--- a/tests/baselines/reference/mergeWithImportedNamespace.types
+++ b/tests/baselines/reference/mergeWithImportedNamespace.types
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/f1.ts ===
+export namespace N { export var x = 1; }
+>N : typeof N
+>x : number
+>1 : number
+
+=== tests/cases/compiler/f2.ts ===
+import {N} from "./f1";
+>N : typeof N
+
+// partial revert of https://github.com/Microsoft/TypeScript/pull/7583 to prevent breaking changes
+export namespace N {
+>N : any
+
+    export interface I {x: any}
+>I : I
+>x : any
+}

--- a/tests/baselines/reference/mergeWithImportedType.js
+++ b/tests/baselines/reference/mergeWithImportedType.js
@@ -1,0 +1,18 @@
+//// [tests/cases/compiler/mergeWithImportedType.ts] ////
+
+//// [f1.ts]
+export enum E {X}
+
+//// [f2.ts]
+import {E} from "./f1";
+// partial revert of https://github.com/Microsoft/TypeScript/pull/7583 to prevent breaking changes
+export type E = E;
+
+//// [f1.js]
+"use strict";
+(function (E) {
+    E[E["X"] = 0] = "X";
+})(exports.E || (exports.E = {}));
+var E = exports.E;
+//// [f2.js]
+"use strict";

--- a/tests/baselines/reference/mergeWithImportedType.symbols
+++ b/tests/baselines/reference/mergeWithImportedType.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/f1.ts ===
+export enum E {X}
+>E : Symbol(E, Decl(f1.ts, 0, 0))
+>X : Symbol(E.X, Decl(f1.ts, 0, 15))
+
+=== tests/cases/compiler/f2.ts ===
+import {E} from "./f1";
+>E : Symbol(E, Decl(f2.ts, 0, 8), Decl(f2.ts, 0, 23))
+
+// partial revert of https://github.com/Microsoft/TypeScript/pull/7583 to prevent breaking changes
+export type E = E;
+>E : Symbol(E, Decl(f2.ts, 0, 23))
+>E : Symbol(E, Decl(f2.ts, 0, 8), Decl(f2.ts, 0, 23))
+

--- a/tests/baselines/reference/mergeWithImportedType.types
+++ b/tests/baselines/reference/mergeWithImportedType.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/f1.ts ===
+export enum E {X}
+>E : E
+>X : E
+
+=== tests/cases/compiler/f2.ts ===
+import {E} from "./f1";
+>E : typeof E
+
+// partial revert of https://github.com/Microsoft/TypeScript/pull/7583 to prevent breaking changes
+export type E = E;
+>E : E
+>E : E
+

--- a/tests/cases/compiler/mergeWithImportedNamespace.ts
+++ b/tests/cases/compiler/mergeWithImportedNamespace.ts
@@ -1,0 +1,10 @@
+// @module:commonjs
+// @filename: f1.ts
+export namespace N { export var x = 1; }
+
+// @filename: f2.ts
+import {N} from "./f1";
+// partial revert of https://github.com/Microsoft/TypeScript/pull/7583 to prevent breaking changes
+export namespace N {
+    export interface I {x: any}
+}

--- a/tests/cases/compiler/mergeWithImportedType.ts
+++ b/tests/cases/compiler/mergeWithImportedType.ts
@@ -1,0 +1,8 @@
+// @module:commonjs
+// @filename: f1.ts
+export enum E {X}
+
+// @filename: f2.ts
+import {E} from "./f1";
+// partial revert of https://github.com/Microsoft/TypeScript/pull/7583 to prevent breaking changes
+export type E = E;


### PR DESCRIPTION
This is partial revert of #7583 based on offline discussion with @mhegazy - we still block merging of value side to prevent runtime errors but now allow namespace\type aliases to be merged with matching local since otherwise it breaks existing code