### PR TITLE
increase inference depth limit to 10

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6673,7 +6673,7 @@ namespace ts {
         function inferTypes(context: InferenceContext, source: Type, target: Type) {
             let sourceStack: Type[];
             let targetStack: Type[];
-            const maxDepth = 5;
+            const maxDepth = 10;
             let depth = 0;
             let inferiority = 0;
             const visited: Map<boolean> = {};

--- a/tests/baselines/reference/inferenceLimit.js
+++ b/tests/baselines/reference/inferenceLimit.js
@@ -1,0 +1,82 @@
+//// [tests/cases/compiler/inferenceLimit.ts] ////
+
+//// [file1.ts]
+"use strict";
+import * as MyModule from "./mymodule";
+
+export class BrokenClass {
+
+  constructor() {}
+
+  public brokenMethod(field: string, value: string) {
+  return new Promise<Array<MyModule.MyModel>>((resolve, reject) => {
+
+    let result: Array<MyModule.MyModel> = [];
+
+    let populateItems = (order) => {
+      return new Promise((resolve, reject) => {
+        this.doStuff(order.id)
+          .then((items) => {
+            order.items = items;
+            resolve(order);
+          });
+      });
+    };
+
+    return Promise.all(result.map(populateItems))
+      .then((orders: Array<MyModule.MyModel>) => {
+        resolve(orders);
+      });
+    });
+  }
+
+  public async doStuff(id: number) {
+    return;
+  }
+}
+
+//// [mymodule.ts]
+export interface MyModel {
+    id: number;
+}
+
+//// [mymodule.js]
+"use strict";
+//// [file1.js]
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments)).next());
+    });
+};
+class BrokenClass {
+    constructor() {
+    }
+    brokenMethod(field, value) {
+        return new Promise((resolve, reject) => {
+            let result = [];
+            let populateItems = (order) => {
+                return new Promise((resolve, reject) => {
+                    this.doStuff(order.id)
+                        .then((items) => {
+                        order.items = items;
+                        resolve(order);
+                    });
+                });
+            };
+            return Promise.all(result.map(populateItems))
+                .then((orders) => {
+                resolve(orders);
+            });
+        });
+    }
+    doStuff(id) {
+        return __awaiter(this, void 0, void 0, function* () {
+            return;
+        });
+    }
+}
+exports.BrokenClass = BrokenClass;

--- a/tests/baselines/reference/inferenceLimit.symbols
+++ b/tests/baselines/reference/inferenceLimit.symbols
@@ -1,0 +1,101 @@
+=== tests/cases/compiler/file1.ts ===
+"use strict";
+import * as MyModule from "./mymodule";
+>MyModule : Symbol(MyModule, Decl(file1.ts, 1, 6))
+
+export class BrokenClass {
+>BrokenClass : Symbol(BrokenClass, Decl(file1.ts, 1, 39))
+
+  constructor() {}
+
+  public brokenMethod(field: string, value: string) {
+>brokenMethod : Symbol(BrokenClass.brokenMethod, Decl(file1.ts, 5, 18))
+>field : Symbol(field, Decl(file1.ts, 7, 22))
+>value : Symbol(value, Decl(file1.ts, 7, 36))
+
+  return new Promise<Array<MyModule.MyModel>>((resolve, reject) => {
+>Promise : Symbol(Promise, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>Array : Symbol(Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>MyModule : Symbol(MyModule, Decl(file1.ts, 1, 6))
+>MyModel : Symbol(MyModule.MyModel, Decl(mymodule.ts, 0, 0))
+>resolve : Symbol(resolve, Decl(file1.ts, 8, 47))
+>reject : Symbol(reject, Decl(file1.ts, 8, 55))
+
+    let result: Array<MyModule.MyModel> = [];
+>result : Symbol(result, Decl(file1.ts, 10, 7))
+>Array : Symbol(Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>MyModule : Symbol(MyModule, Decl(file1.ts, 1, 6))
+>MyModel : Symbol(MyModule.MyModel, Decl(mymodule.ts, 0, 0))
+
+    let populateItems = (order) => {
+>populateItems : Symbol(populateItems, Decl(file1.ts, 12, 7))
+>order : Symbol(order, Decl(file1.ts, 12, 25))
+
+      return new Promise((resolve, reject) => {
+>Promise : Symbol(Promise, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>resolve : Symbol(resolve, Decl(file1.ts, 13, 26))
+>reject : Symbol(reject, Decl(file1.ts, 13, 34))
+
+        this.doStuff(order.id)
+>this.doStuff(order.id)          .then : Symbol(Promise.then, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>this.doStuff : Symbol(BrokenClass.doStuff, Decl(file1.ts, 27, 3))
+>this : Symbol(BrokenClass, Decl(file1.ts, 1, 39))
+>doStuff : Symbol(BrokenClass.doStuff, Decl(file1.ts, 27, 3))
+>order : Symbol(order, Decl(file1.ts, 12, 25))
+
+          .then((items) => {
+>then : Symbol(Promise.then, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>items : Symbol(items, Decl(file1.ts, 15, 17))
+
+            order.items = items;
+>order : Symbol(order, Decl(file1.ts, 12, 25))
+>items : Symbol(items, Decl(file1.ts, 15, 17))
+
+            resolve(order);
+>resolve : Symbol(resolve, Decl(file1.ts, 13, 26))
+>order : Symbol(order, Decl(file1.ts, 12, 25))
+
+          });
+      });
+    };
+
+    return Promise.all(result.map(populateItems))
+>Promise.all(result.map(populateItems))      .then : Symbol(Promise.then, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>Promise.all : Symbol(PromiseConstructor.all, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>all : Symbol(PromiseConstructor.all, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>result.map : Symbol(Array.map, Decl(lib.d.ts, --, --))
+>result : Symbol(result, Decl(file1.ts, 10, 7))
+>map : Symbol(Array.map, Decl(lib.d.ts, --, --))
+>populateItems : Symbol(populateItems, Decl(file1.ts, 12, 7))
+
+      .then((orders: Array<MyModule.MyModel>) => {
+>then : Symbol(Promise.then, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>orders : Symbol(orders, Decl(file1.ts, 23, 13))
+>Array : Symbol(Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>MyModule : Symbol(MyModule, Decl(file1.ts, 1, 6))
+>MyModel : Symbol(MyModule.MyModel, Decl(mymodule.ts, 0, 0))
+
+        resolve(orders);
+>resolve : Symbol(resolve, Decl(file1.ts, 8, 47))
+>orders : Symbol(orders, Decl(file1.ts, 23, 13))
+
+      });
+    });
+  }
+
+  public async doStuff(id: number) {
+>doStuff : Symbol(BrokenClass.doStuff, Decl(file1.ts, 27, 3))
+>id : Symbol(id, Decl(file1.ts, 29, 23))
+
+    return;
+  }
+}
+
+=== tests/cases/compiler/mymodule.ts ===
+export interface MyModel {
+>MyModel : Symbol(MyModel, Decl(mymodule.ts, 0, 0))
+
+    id: number;
+>id : Symbol(MyModel.id, Decl(mymodule.ts, 0, 26))
+}

--- a/tests/baselines/reference/inferenceLimit.types
+++ b/tests/baselines/reference/inferenceLimit.types
@@ -1,0 +1,123 @@
+=== tests/cases/compiler/file1.ts ===
+"use strict";
+>"use strict" : string
+
+import * as MyModule from "./mymodule";
+>MyModule : typeof MyModule
+
+export class BrokenClass {
+>BrokenClass : BrokenClass
+
+  constructor() {}
+
+  public brokenMethod(field: string, value: string) {
+>brokenMethod : (field: string, value: string) => Promise<MyModule.MyModel[]>
+>field : string
+>value : string
+
+  return new Promise<Array<MyModule.MyModel>>((resolve, reject) => {
+>new Promise<Array<MyModule.MyModel>>((resolve, reject) => {    let result: Array<MyModule.MyModel> = [];    let populateItems = (order) => {      return new Promise((resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      });    };    return Promise.all(result.map(populateItems))      .then((orders: Array<MyModule.MyModel>) => {        resolve(orders);      });    }) : Promise<MyModule.MyModel[]>
+>Promise : PromiseConstructor
+>Array : T[]
+>MyModule : any
+>MyModel : MyModule.MyModel
+>(resolve, reject) => {    let result: Array<MyModule.MyModel> = [];    let populateItems = (order) => {      return new Promise((resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      });    };    return Promise.all(result.map(populateItems))      .then((orders: Array<MyModule.MyModel>) => {        resolve(orders);      });    } : (resolve: (value?: MyModule.MyModel[] | PromiseLike<MyModule.MyModel[]>) => void, reject: (reason?: any) => void) => Promise<void>
+>resolve : (value?: MyModule.MyModel[] | PromiseLike<MyModule.MyModel[]>) => void
+>reject : (reason?: any) => void
+
+    let result: Array<MyModule.MyModel> = [];
+>result : MyModule.MyModel[]
+>Array : T[]
+>MyModule : any
+>MyModel : MyModule.MyModel
+>[] : undefined[]
+
+    let populateItems = (order) => {
+>populateItems : (order: any) => Promise<{}>
+>(order) => {      return new Promise((resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      });    } : (order: any) => Promise<{}>
+>order : any
+
+      return new Promise((resolve, reject) => {
+>new Promise((resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      }) : Promise<{}>
+>Promise : PromiseConstructor
+>(resolve, reject) => {        this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          });      } : (resolve: (value?: {} | PromiseLike<{}>) => void, reject: (reason?: any) => void) => void
+>resolve : (value?: {} | PromiseLike<{}>) => void
+>reject : (reason?: any) => void
+
+        this.doStuff(order.id)
+>this.doStuff(order.id)          .then((items) => {            order.items = items;            resolve(order);          }) : Promise<void>
+>this.doStuff(order.id)          .then : { <TResult>(onfulfilled?: (value: void) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>; <TResult>(onfulfilled?: (value: void) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<TResult>; }
+>this.doStuff(order.id) : Promise<void>
+>this.doStuff : (id: number) => Promise<void>
+>this : this
+>doStuff : (id: number) => Promise<void>
+>order.id : any
+>order : any
+>id : any
+
+          .then((items) => {
+>then : { <TResult>(onfulfilled?: (value: void) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>; <TResult>(onfulfilled?: (value: void) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<TResult>; }
+>(items) => {            order.items = items;            resolve(order);          } : (items: void) => void
+>items : void
+
+            order.items = items;
+>order.items = items : void
+>order.items : any
+>order : any
+>items : any
+>items : void
+
+            resolve(order);
+>resolve(order) : void
+>resolve : (value?: {} | PromiseLike<{}>) => void
+>order : any
+
+          });
+      });
+    };
+
+    return Promise.all(result.map(populateItems))
+>Promise.all(result.map(populateItems))      .then((orders: Array<MyModule.MyModel>) => {        resolve(orders);      }) : Promise<void>
+>Promise.all(result.map(populateItems))      .then : { <TResult>(onfulfilled?: (value: {}[]) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>; <TResult>(onfulfilled?: (value: {}[]) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<TResult>; }
+>Promise.all(result.map(populateItems)) : Promise<{}[]>
+>Promise.all : { <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>, T10 | PromiseLike<T10>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>; <T1, T2, T3, T4, T5, T6, T7, T8, T9>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>; <T1, T2, T3, T4, T5, T6, T7, T8>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8]>; <T1, T2, T3, T4, T5, T6, T7>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>]): Promise<[T1, T2, T3, T4, T5, T6, T7]>; <T1, T2, T3, T4, T5, T6>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>]): Promise<[T1, T2, T3, T4, T5, T6]>; <T1, T2, T3, T4, T5>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>]): Promise<[T1, T2, T3, T4, T5]>; <T1, T2, T3, T4>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>]): Promise<[T1, T2, T3, T4]>; <T1, T2, T3>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>]): Promise<[T1, T2, T3]>; <T1, T2>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>]): Promise<[T1, T2]>; <TAll>(values: Iterable<TAll | PromiseLike<TAll>>): Promise<TAll[]>; }
+>Promise : PromiseConstructor
+>all : { <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>, T10 | PromiseLike<T10>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]>; <T1, T2, T3, T4, T5, T6, T7, T8, T9>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>, T9 | PromiseLike<T9>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8, T9]>; <T1, T2, T3, T4, T5, T6, T7, T8>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>, T8 | PromiseLike<T8>]): Promise<[T1, T2, T3, T4, T5, T6, T7, T8]>; <T1, T2, T3, T4, T5, T6, T7>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>, T7 | PromiseLike<T7>]): Promise<[T1, T2, T3, T4, T5, T6, T7]>; <T1, T2, T3, T4, T5, T6>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>, T6 | PromiseLike<T6>]): Promise<[T1, T2, T3, T4, T5, T6]>; <T1, T2, T3, T4, T5>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>, T5 | PromiseLike<T5>]): Promise<[T1, T2, T3, T4, T5]>; <T1, T2, T3, T4>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>, T4 | PromiseLike<T4>]): Promise<[T1, T2, T3, T4]>; <T1, T2, T3>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>, T3 | PromiseLike<T3>]): Promise<[T1, T2, T3]>; <T1, T2>(values: [T1 | PromiseLike<T1>, T2 | PromiseLike<T2>]): Promise<[T1, T2]>; <TAll>(values: Iterable<TAll | PromiseLike<TAll>>): Promise<TAll[]>; }
+>result.map(populateItems) : Promise<{}>[]
+>result.map : <U>(callbackfn: (value: MyModule.MyModel, index: number, array: MyModule.MyModel[]) => U, thisArg?: any) => U[]
+>result : MyModule.MyModel[]
+>map : <U>(callbackfn: (value: MyModule.MyModel, index: number, array: MyModule.MyModel[]) => U, thisArg?: any) => U[]
+>populateItems : (order: any) => Promise<{}>
+
+      .then((orders: Array<MyModule.MyModel>) => {
+>then : { <TResult>(onfulfilled?: (value: {}[]) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>; <TResult>(onfulfilled?: (value: {}[]) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<TResult>; }
+>(orders: Array<MyModule.MyModel>) => {        resolve(orders);      } : (orders: MyModule.MyModel[]) => void
+>orders : MyModule.MyModel[]
+>Array : T[]
+>MyModule : any
+>MyModel : MyModule.MyModel
+
+        resolve(orders);
+>resolve(orders) : void
+>resolve : (value?: MyModule.MyModel[] | PromiseLike<MyModule.MyModel[]>) => void
+>orders : MyModule.MyModel[]
+
+      });
+    });
+  }
+
+  public async doStuff(id: number) {
+>doStuff : (id: number) => Promise<void>
+>id : number
+
+    return;
+  }
+}
+
+=== tests/cases/compiler/mymodule.ts ===
+export interface MyModel {
+>MyModel : MyModel
+
+    id: number;
+>id : number
+}

--- a/tests/cases/compiler/inferenceLimit.ts
+++ b/tests/cases/compiler/inferenceLimit.ts
@@ -1,0 +1,41 @@
+// @target: es6
+// @module: commonjs
+// @filename: file1.ts
+"use strict";
+import * as MyModule from "./mymodule";
+
+export class BrokenClass {
+
+  constructor() {}
+
+  public brokenMethod(field: string, value: string) {
+  return new Promise<Array<MyModule.MyModel>>((resolve, reject) => {
+
+    let result: Array<MyModule.MyModel> = [];
+
+    let populateItems = (order) => {
+      return new Promise((resolve, reject) => {
+        this.doStuff(order.id)
+          .then((items) => {
+            order.items = items;
+            resolve(order);
+          });
+      });
+    };
+
+    return Promise.all(result.map(populateItems))
+      .then((orders: Array<MyModule.MyModel>) => {
+        resolve(orders);
+      });
+    });
+  }
+
+  public async doStuff(id: number) {
+    return;
+  }
+}
+
+// @filename: mymodule.ts
+export interface MyModel {
+    id: number;
+}


### PR DESCRIPTION
fixes #7566. Depth=6 is enough to compile the problematic snipped however it will be better if we have some freedom here given that time difference to compile the problematic snippet is not that big.

```ts
// Repro case
var a = new Rx.Subject<string>();
var b = new Rx.Subject<Immutable.Set<number>>();
var c1 = a.withLatestFrom(b, x => x); // #
```
In the table below `N` is number of times line marked with `#` appear in the code 

N  | Time(Depth=3), s | Time(Depth=5), s| Time(Depth=10), s | Time(Depth=Inf) s
----|-----------|------------|--------------|----------
1  | 0.48 | 0.48 | 0.53 | 0.59
5  | 0.56 | 0.59 | 0.63 | 0.82
10 | 0.63 | 0.63 | 0.69 | 0.99
20 | 0.69 | 0.72 | 0.79 | 1.38
40 | 0.78 | 0.81 | 0.99 | 2.13
80 | 1    | 1.16 | 1.35 | 3.68 
160| 1.5  | 1.63 | 2.19 | 6.8
320| 2.44 | 2.75 | 3.74 | 12.9
640| 4.52 | 4.92 | 7.17 | 26
1280| 8.28 |9.61 | 13.31| 50.62
 
