### PR TITLE
revert changes in the signature of 'convertCompilerOptionsFromJson'

### DIFF
--- a/tests/baselines/reference/APISample_parseConfig.js
+++ b/tests/baselines/reference/APISample_parseConfig.js
@@ -1,0 +1,70 @@
+//// [APISample_parseConfig.ts]
+
+/*
+ * Note: This test is a public API sample. The sample sources can be found 
+         at: https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#a-minimal-compiler
+ *       Please log a "breaking change" issue for any API breaking change affecting this issue
+ */
+
+declare var process: any;
+declare var console: any;
+declare var os: any;
+
+import ts = require("typescript");
+
+function printError(error: ts.Diagnostic): void {
+    if (!error) {
+        return;
+    }
+    console.log(`${error.file && error.file.fileName}: ${error.messageText}`);
+}
+
+export function createProgram(rootFiles: string[], compilerOptionsJson: string): ts.Program {
+    const { config, error } = ts.parseConfigFileTextToJson("tsconfig.json", compilerOptionsJson)
+    if (error) {
+        printError(error);
+        return undefined;
+    }
+    const basePath: string = process.cwd();
+    const settings = ts.convertCompilerOptionsFromJson(config.config["compilerOptions"], basePath);
+    if (!settings.options) {
+        for (const err of settings.errors) {
+            printError(err);
+        }
+        return undefined;
+    }
+    return ts.createProgram(rootFiles, settings.options);
+}
+
+//// [APISample_parseConfig.js]
+/*
+ * Note: This test is a public API sample. The sample sources can be found
+         at: https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#a-minimal-compiler
+ *       Please log a "breaking change" issue for any API breaking change affecting this issue
+ */
+"use strict";
+var ts = require("typescript");
+function printError(error) {
+    if (!error) {
+        return;
+    }
+    console.log((error.file && error.file.fileName) + ": " + error.messageText);
+}
+function createProgram(rootFiles, compilerOptionsJson) {
+    var _a = ts.parseConfigFileTextToJson("tsconfig.json", compilerOptionsJson), config = _a.config, error = _a.error;
+    if (error) {
+        printError(error);
+        return undefined;
+    }
+    var basePath = process.cwd();
+    var settings = ts.convertCompilerOptionsFromJson(config.config["compilerOptions"], basePath);
+    if (!settings.options) {
+        for (var _i = 0, _b = settings.errors; _i < _b.length; _i++) {
+            var err = _b[_i];
+            printError(err);
+        }
+        return undefined;
+    }
+    return ts.createProgram(rootFiles, settings.options);
+}
+exports.createProgram = createProgram;

--- a/tests/cases/compiler/APISample_parseConfig.ts
+++ b/tests/cases/compiler/APISample_parseConfig.ts
@@ -1,0 +1,39 @@
+// @module: commonjs
+// @includebuiltfile: typescript_standalone.d.ts
+// @stripInternal:true
+
+/*
+ * Note: This test is a public API sample. The sample sources can be found 
+         at: https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#a-minimal-compiler
+ *       Please log a "breaking change" issue for any API breaking change affecting this issue
+ */
+
+declare var process: any;
+declare var console: any;
+declare var os: any;
+
+import ts = require("typescript");
+
+function printError(error: ts.Diagnostic): void {
+    if (!error) {
+        return;
+    }
+    console.log(`${error.file && error.file.fileName}: ${error.messageText}`);
+}
+
+export function createProgram(rootFiles: string[], compilerOptionsJson: string): ts.Program {
+    const { config, error } = ts.parseConfigFileTextToJson("tsconfig.json", compilerOptionsJson)
+    if (error) {
+        printError(error);
+        return undefined;
+    }
+    const basePath: string = process.cwd();
+    const settings = ts.convertCompilerOptionsFromJson(config.config["compilerOptions"], basePath);
+    if (!settings.options) {
+        for (const err of settings.errors) {
+            printError(err);
+        }
+        return undefined;
+    }
+    return ts.createProgram(rootFiles, settings.options);
+}

--- a/tests/cases/unittests/convertCompilerOptionsFromJson.ts
+++ b/tests/cases/unittests/convertCompilerOptionsFromJson.ts
@@ -4,8 +4,7 @@
 namespace ts {
     describe('convertCompilerOptionsFromJson', () => {
         function assertCompilerOptions(json: any, configFileName: string, expectedResult: { compilerOptions: CompilerOptions, errors: Diagnostic[] }) {
-            const actualErrors: Diagnostic[] = [];
-            const actualCompilerOptions: CompilerOptions = convertCompilerOptionsFromJson(optionDeclarations, json["compilerOptions"], "/apath/", actualErrors, configFileName);
+            const { options: actualCompilerOptions, errors: actualErrors} = convertCompilerOptionsFromJson(json["compilerOptions"], "/apath/", configFileName);
             
             const parsedCompilerOptions = JSON.stringify(actualCompilerOptions);
             const expectedCompilerOptions = JSON.stringify(expectedResult.compilerOptions);

--- a/tests/cases/unittests/convertTypingOptionsFromJson.ts
+++ b/tests/cases/unittests/convertTypingOptionsFromJson.ts
@@ -4,8 +4,7 @@
 namespace ts {
     describe('convertTypingOptionsFromJson', () => {
         function assertTypingOptions(json: any, configFileName: string, expectedResult: { typingOptions: TypingOptions, errors: Diagnostic[] }) {
-            const actualErrors: Diagnostic[] = [];
-            const actualTypingOptions = convertTypingOptionsFromJson(typingOptionDeclarations, json["typingOptions"], "/apath/", actualErrors, configFileName);
+            const { options: actualTypingOptions, errors: actualErrors } = convertTypingOptionsFromJson(json["typingOptions"], "/apath/", configFileName);
             const parsedTypingOptions = JSON.stringify(actualTypingOptions);
             const expectedTypingOptions = JSON.stringify(expectedResult.typingOptions);
             assert.equal(parsedTypingOptions, expectedTypingOptions);


### PR DESCRIPTION
fixes breaking change in API reported [here](https://github.com/Microsoft/TypeScript/issues/5276#issuecomment-198818504).

We need to enable tests that will verify that there are no unexpected changed in the public surface of the API. I'll do this in a separate PR;