### PR TITLE
Avoid elaborating errors when relating primitives to union types of any form.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5678,7 +5678,7 @@ namespace ts {
                         }
                     }
                     if (target.flags & TypeFlags.Union) {
-                        if (result = typeRelatedToSomeType(source, <UnionType>target, reportErrors)) {
+                        if (result = typeRelatedToSomeType(source, <UnionType>target, reportErrors && !(source.flags & TypeFlags.Primitive))) {
                             return result;
                         }
                     }

--- a/tests/baselines/reference/contextualTypeWithTuple.errors.txt
+++ b/tests/baselines/reference/contextualTypeWithTuple.errors.txt
@@ -3,7 +3,6 @@ tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(3,5): error TS232
     Type '() => number | string | boolean' is not assignable to type '() => number | string'.
       Type 'number | string | boolean' is not assignable to type 'number | string'.
         Type 'boolean' is not assignable to type 'number | string'.
-          Type 'boolean' is not assignable to type 'string'.
 tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(15,1): error TS2322: Type '[number, string, boolean]' is not assignable to type '[number, string]'.
 tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(18,1): error TS2322: Type '[{}, number]' is not assignable to type '[{ a: string; }, number]'.
   Types of property '0' are incompatible.
@@ -34,7 +33,6 @@ tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(25,1): error TS23
 !!! error TS2322:     Type '() => number | string | boolean' is not assignable to type '() => number | string'.
 !!! error TS2322:       Type 'number | string | boolean' is not assignable to type 'number | string'.
 !!! error TS2322:         Type 'boolean' is not assignable to type 'number | string'.
-!!! error TS2322:           Type 'boolean' is not assignable to type 'string'.
     var numStrBoolTuple: [number, string, boolean] = [5, "foo", true];
     var objNumTuple: [{ a: string }, number] = [{ a: "world" }, 5];
     var strTupleTuple: [string, [number, {}]] = ["bar", [5, { x: 1, y: 1 }]];

--- a/tests/baselines/reference/contextuallyTypedBindingInitializerNegative.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedBindingInitializerNegative.errors.txt
@@ -14,7 +14,6 @@ tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTyp
   Types of property '0' are incompatible.
     Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializerNegative.ts(26,14): error TS2322: Type '"baz"' is not assignable to type '"foo" | "bar"'.
-  Type '"baz"' is not assignable to type '"bar"'.
 
 
 ==== tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializerNegative.ts (7 errors) ====
@@ -67,5 +66,4 @@ tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTyp
     function h({ prop = "baz" }: StringUnion) {}
                  ~~~~
 !!! error TS2322: Type '"baz"' is not assignable to type '"foo" | "bar"'.
-!!! error TS2322:   Type '"baz"' is not assignable to type '"bar"'.
     

--- a/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes01.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes01.errors.txt
@@ -1,7 +1,5 @@
 tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx(16,15): error TS2322: Type '"f"' is not assignable to type '"A" | "B" | "C"'.
-  Type '"f"' is not assignable to type '"C"'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx(17,15): error TS2322: Type '"f"' is not assignable to type '"A" | "B" | "C"'.
-  Type '"f"' is not assignable to type '"C"'.
 
 
 ==== tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx (2 errors) ====
@@ -23,8 +21,6 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStr
     <FooComponent foo={"f"} />;
                   ~~~~~~~~~
 !!! error TS2322: Type '"f"' is not assignable to type '"A" | "B" | "C"'.
-!!! error TS2322:   Type '"f"' is not assignable to type '"C"'.
     <FooComponent foo="f"   />;
                   ~~~~~~~
 !!! error TS2322: Type '"f"' is not assignable to type '"A" | "B" | "C"'.
-!!! error TS2322:   Type '"f"' is not assignable to type '"C"'.

--- a/tests/baselines/reference/destructuringParameterDeclaration2.errors.txt
+++ b/tests/baselines/reference/destructuringParameterDeclaration2.errors.txt
@@ -7,7 +7,6 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(
     Type '() => number | string[][] | string' is not assignable to type '() => number | string[][]'.
       Type 'number | string[][] | string' is not assignable to type 'number | string[][]'.
         Type 'string' is not assignable to type 'number | string[][]'.
-          Type 'string' is not assignable to type 'string[][]'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(16,8): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(16,16): error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(23,14): error TS2345: Argument of type '{ x: string; y: boolean; }' is not assignable to parameter of type '{ x: number; y: any; }'.
@@ -29,7 +28,6 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(38,4): error TS2345: Argument of type '{ b: boolean; }' is not assignable to parameter of type '{ b: number | string; }'.
   Types of property 'b' are incompatible.
     Type 'boolean' is not assignable to type 'number | string'.
-      Type 'boolean' is not assignable to type 'string'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(39,4): error TS2345: Argument of type '[number, number, boolean, boolean]' is not assignable to parameter of type '[any, any, [[any]]]'.
   Types of property '2' are incompatible.
     Type 'boolean' is not assignable to type '[[any]]'.
@@ -75,7 +73,6 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(
 !!! error TS2345:     Type '() => number | string[][] | string' is not assignable to type '() => number | string[][]'.
 !!! error TS2345:       Type 'number | string[][] | string' is not assignable to type 'number | string[][]'.
 !!! error TS2345:         Type 'string' is not assignable to type 'number | string[][]'.
-!!! error TS2345:           Type 'string' is not assignable to type 'string[][]'.
     
     
     // If the declaration includes an initializer expression (which is permitted only
@@ -137,7 +134,6 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(
 !!! error TS2345: Argument of type '{ b: boolean; }' is not assignable to parameter of type '{ b: number | string; }'.
 !!! error TS2345:   Types of property 'b' are incompatible.
 !!! error TS2345:     Type 'boolean' is not assignable to type 'number | string'.
-!!! error TS2345:       Type 'boolean' is not assignable to type 'string'.
     c5([1, 2, false, true]);   // Error, implied type is [any, any, [[any]]]
        ~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '[number, number, boolean, boolean]' is not assignable to parameter of type '[any, any, [[any]]]'.

--- a/tests/baselines/reference/destructuringParameterDeclaration4.errors.txt
+++ b/tests/baselines/reference/destructuringParameterDeclaration4.errors.txt
@@ -1,7 +1,6 @@
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts(11,13): error TS2370: A rest parameter must be of an array type.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts(13,13): error TS2370: A rest parameter must be of an array type.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts(20,19): error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'number | string'.
-  Type 'boolean' is not assignable to type 'string'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts(21,7): error TS2304: Cannot find name 'array2'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts(22,4): error TS2345: Argument of type '[number, number, string, boolean, boolean]' is not assignable to parameter of type '[any, any, [[any]]]'.
   Types of property '2' are incompatible.
@@ -43,7 +42,6 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration4.ts(
     a1(1, 2, "hello", true);  // Error, parameter type is (number|string)[]
                       ~~~~
 !!! error TS2345: Argument of type 'boolean' is not assignable to parameter of type 'number | string'.
-!!! error TS2345:   Type 'boolean' is not assignable to type 'string'.
     a1(...array2);            // Error parameter type is (number|string)[]
           ~~~~~~
 !!! error TS2304: Cannot find name 'array2'.

--- a/tests/baselines/reference/errorMessagesIntersectionTypes02.errors.txt
+++ b/tests/baselines/reference/errorMessagesIntersectionTypes02.errors.txt
@@ -1,7 +1,6 @@
 tests/cases/compiler/errorMessagesIntersectionTypes02.ts(14,5): error TS2322: Type '{ fooProp: string; } & Bar' is not assignable to type 'FooBar'.
   Types of property 'fooProp' are incompatible.
     Type 'string' is not assignable to type '"hello" | "world"'.
-      Type 'string' is not assignable to type '"world"'.
 
 
 ==== tests/cases/compiler/errorMessagesIntersectionTypes02.ts (1 errors) ====
@@ -23,6 +22,5 @@ tests/cases/compiler/errorMessagesIntersectionTypes02.ts(14,5): error TS2322: Ty
 !!! error TS2322: Type '{ fooProp: string; } & Bar' is not assignable to type 'FooBar'.
 !!! error TS2322:   Types of property 'fooProp' are incompatible.
 !!! error TS2322:     Type 'string' is not assignable to type '"hello" | "world"'.
-!!! error TS2322:       Type 'string' is not assignable to type '"world"'.
         fooProp: "frizzlebizzle"
     });

--- a/tests/baselines/reference/genericCallWithTupleType.errors.txt
+++ b/tests/baselines/reference/genericCallWithTupleType.errors.txt
@@ -3,7 +3,6 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithTup
     Type '() => string | number | boolean' is not assignable to type '() => string | number'.
       Type 'string | number | boolean' is not assignable to type 'string | number'.
         Type 'boolean' is not assignable to type 'string | number'.
-          Type 'boolean' is not assignable to type 'number'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithTupleType.ts(14,1): error TS2322: Type '{ a: string; }' is not assignable to type 'string | number'.
   Type '{ a: string; }' is not assignable to type 'number'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithTupleType.ts(22,1): error TS2322: Type '[number, string]' is not assignable to type '[string, number]'.
@@ -35,7 +34,6 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithTup
 !!! error TS2322:     Type '() => string | number | boolean' is not assignable to type '() => string | number'.
 !!! error TS2322:       Type 'string | number | boolean' is not assignable to type 'string | number'.
 !!! error TS2322:         Type 'boolean' is not assignable to type 'string | number'.
-!!! error TS2322:           Type 'boolean' is not assignable to type 'number'.
     var e3 = i1.tuple1[2];  // {}
     i1.tuple1[3] = { a: "string" };
     ~~~~~~~~~~~~

--- a/tests/baselines/reference/iteratorSpreadInCall6.errors.txt
+++ b/tests/baselines/reference/iteratorSpreadInCall6.errors.txt
@@ -1,12 +1,10 @@
 tests/cases/conformance/es6/spread/iteratorSpreadInCall6.ts(1,28): error TS2345: Argument of type 'string' is not assignable to parameter of type 'symbol | number'.
-  Type 'string' is not assignable to type 'number'.
 
 
 ==== tests/cases/conformance/es6/spread/iteratorSpreadInCall6.ts (1 errors) ====
     foo(...new SymbolIterator, ...new StringIterator);
                                ~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'symbol | number'.
-!!! error TS2345:   Type 'string' is not assignable to type 'number'.
     
     function foo(...s: (symbol | number)[]) { }
     class SymbolIterator {

--- a/tests/baselines/reference/typeArgumentsWithStringLiteralTypes01.errors.txt
+++ b/tests/baselines/reference/typeArgumentsWithStringLiteralTypes01.errors.txt
@@ -4,15 +4,10 @@ tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes0
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(40,25): error TS2345: Argument of type 'string' is not assignable to parameter of type '"Hello"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(41,25): error TS2345: Argument of type 'string' is not assignable to parameter of type '"Hello"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(44,30): error TS2345: Argument of type 'string' is not assignable to parameter of type '"Hello" | "World"'.
-  Type 'string' is not assignable to type '"World"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(45,30): error TS2345: Argument of type 'string' is not assignable to parameter of type '"Hello" | "World"'.
-  Type 'string' is not assignable to type '"World"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(46,30): error TS2345: Argument of type 'string' is not assignable to parameter of type '"Hello" | "World"'.
-  Type 'string' is not assignable to type '"World"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(47,30): error TS2345: Argument of type 'string' is not assignable to parameter of type '"Hello" | "World"'.
-  Type 'string' is not assignable to type '"World"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(48,30): error TS2345: Argument of type 'string' is not assignable to parameter of type '"Hello" | "World"'.
-  Type 'string' is not assignable to type '"World"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(55,43): error TS2345: Argument of type '"World"' is not assignable to parameter of type '"Hello"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(57,52): error TS2345: Argument of type '"World"' is not assignable to parameter of type '"Hello"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(58,43): error TS2345: Argument of type '"World"' is not assignable to parameter of type '"Hello"'.
@@ -26,9 +21,7 @@ tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes0
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(88,43): error TS2345: Argument of type '"Hello"' is not assignable to parameter of type '"World"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(89,52): error TS2345: Argument of type '"World"' is not assignable to parameter of type '"Hello"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(93,5): error TS2322: Type 'string' is not assignable to type '"Hello" | "World"'.
-  Type 'string' is not assignable to type '"World"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(97,5): error TS2322: Type 'string' is not assignable to type '"Hello" | "World"'.
-  Type 'string' is not assignable to type '"World"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(100,25): error TS2345: Argument of type '"Hello" | "World"' is not assignable to parameter of type '"Hello"'.
   Type '"World"' is not assignable to type '"Hello"'.
 tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes01.ts(104,25): error TS2345: Argument of type '"Hello" | "World"' is not assignable to parameter of type '"Hello"'.
@@ -92,23 +85,18 @@ tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes0
         a = takeReturnHelloWorld(a);
                                  ~
 !!! error TS2345: Argument of type 'string' is not assignable to parameter of type '"Hello" | "World"'.
-!!! error TS2345:   Type 'string' is not assignable to type '"World"'.
         b = takeReturnHelloWorld(b);
                                  ~
 !!! error TS2345: Argument of type 'string' is not assignable to parameter of type '"Hello" | "World"'.
-!!! error TS2345:   Type 'string' is not assignable to type '"World"'.
         c = takeReturnHelloWorld(c);
                                  ~
 !!! error TS2345: Argument of type 'string' is not assignable to parameter of type '"Hello" | "World"'.
-!!! error TS2345:   Type 'string' is not assignable to type '"World"'.
         d = takeReturnHelloWorld(d);
                                  ~
 !!! error TS2345: Argument of type 'string' is not assignable to parameter of type '"Hello" | "World"'.
-!!! error TS2345:   Type 'string' is not assignable to type '"World"'.
         e = takeReturnHelloWorld(e);
                                  ~
 !!! error TS2345: Argument of type 'string' is not assignable to parameter of type '"Hello" | "World"'.
-!!! error TS2345:   Type 'string' is not assignable to type '"World"'.
     }
     
     namespace n2 {
@@ -178,14 +166,12 @@ tests/cases/conformance/types/stringLiteral/typeArgumentsWithStringLiteralTypes0
         a = takeReturnString(a);
         ~
 !!! error TS2322: Type 'string' is not assignable to type '"Hello" | "World"'.
-!!! error TS2322:   Type 'string' is not assignable to type '"World"'.
         b = takeReturnString(b);
         c = takeReturnString(c);
         d = takeReturnString(d);
         e = takeReturnString(e);
         ~
 !!! error TS2322: Type 'string' is not assignable to type '"Hello" | "World"'.
-!!! error TS2322:   Type 'string' is not assignable to type '"World"'.
     
         // Passing these as arguments should cause an error.
         a = takeReturnHello(a);


### PR DESCRIPTION
Fixes #7530.

The idea here is that if you have a primitive, and you're trying to relate to some union type, then that primitive is simply not in the union.