### PR TITLE
Add nullability annotations to core.d.ts and es6.d.ts

### DIFF
--- a/src/lib/core.d.ts
+++ b/src/lib/core.d.ts
@@ -304,13 +304,13 @@ interface String {
       * Matches a string with a regular expression, and returns an array containing the results of that search.
       * @param regexp A variable name or string literal containing the regular expression pattern and flags.
       */
-    match(regexp: string): RegExpMatchArray;
+    match(regexp: string): RegExpMatchArray | null;
 
     /** 
       * Matches a string with a regular expression, and returns an array containing the results of that search.
       * @param regexp A regular expression object that contains the regular expression pattern and applicable flags. 
       */
-    match(regexp: RegExp): RegExpMatchArray;
+    match(regexp: RegExp): RegExpMatchArray | null;
 
     /**
       * Replaces text in a string, using a regular expression or search string.
@@ -813,7 +813,7 @@ interface RegExp {
       * Executes a search on a string using a regular expression pattern, and returns an array containing the results of that search.
       * @param string The String object or string literal on which to perform the search.
       */
-    exec(string: string): RegExpExecArray;
+    exec(string: string): RegExpExecArray | null;
 
     /** 
       * Returns a Boolean value that indicates whether or not a pattern exists in a searched string.
@@ -836,7 +836,7 @@ interface RegExp {
     lastIndex: number;
 
     // Non-standard extensions
-    compile(): RegExp;
+    compile(): RegExp | undefined;
 }
 
 interface RegExpConstructor {
@@ -1108,7 +1108,7 @@ interface Array<T> {
     /**
       * Removes the last element from an array and returns it.
       */
-    pop(): T;
+    pop(): T | undefined;
     /**
       * Combines two or more arrays.
       * @param items Additional items to add to the end of array1.
@@ -1126,7 +1126,7 @@ interface Array<T> {
     /**
       * Removes the first element from an array and returns it.
       */
-    shift(): T;
+    shift(): T | undefined;
     /** 
       * Returns a section of an array.
       * @param start The beginning of the specified portion of the array.
@@ -1519,7 +1519,7 @@ interface Int8Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number;
+    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -1530,7 +1530,7 @@ interface Int8Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -1792,7 +1792,7 @@ interface Uint8Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number;
+    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -1803,7 +1803,7 @@ interface Uint8Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -2066,7 +2066,7 @@ interface Uint8ClampedArray {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number;
+    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -2077,7 +2077,7 @@ interface Uint8ClampedArray {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -2339,7 +2339,7 @@ interface Int16Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number;
+    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -2350,7 +2350,7 @@ interface Int16Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -2613,7 +2613,7 @@ interface Uint16Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number;
+    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -2624,7 +2624,7 @@ interface Uint16Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -2886,7 +2886,7 @@ interface Int32Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number;
+    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -2897,7 +2897,7 @@ interface Int32Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -3159,7 +3159,7 @@ interface Uint32Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number;
+    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -3170,7 +3170,7 @@ interface Uint32Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -3432,7 +3432,7 @@ interface Float32Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number;
+    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -3443,7 +3443,7 @@ interface Float32Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -3706,7 +3706,7 @@ interface Float64Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number;
+    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -3717,7 +3717,7 @@ interface Float64Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.

--- a/src/lib/core.d.ts
+++ b/src/lib/core.d.ts
@@ -836,7 +836,7 @@ interface RegExp {
     lastIndex: number;
 
     // Non-standard extensions
-    compile(): RegExp | undefined;
+    compile(): this;
 }
 
 interface RegExpConstructor {

--- a/src/lib/es6.d.ts
+++ b/src/lib/es6.d.ts
@@ -34,7 +34,7 @@ interface SymbolConstructor {
       * Otherwise, returns a undefined.
       * @param sym Symbol to find the key for.
       */
-    keyFor(sym: symbol): string;
+    keyFor(sym: symbol): string | undefined;
 
     // Well-known Symbols
 
@@ -127,7 +127,7 @@ interface ObjectConstructor {
       * @param target The target object to copy to.
       * @param source The source object from which to copy properties.
       */
-    assign<T, U>(target: T, source: U): T & U;
+    assign<T, U>(target: T, source: U | null | undefined): T & U;
 
     /**
       * Copy the values of all of the enumerable own properties from one or more source objects to a 
@@ -136,7 +136,7 @@ interface ObjectConstructor {
       * @param source1 The first source object from which to copy properties.
       * @param source2 The second source object from which to copy properties.
       */
-    assign<T, U, V>(target: T, source1: U, source2: V): T & U & V;
+    assign<T, U, V>(target: T, source1: U | null | undefined, source2: V | null | undefined): T & U & V;
 
     /**
       * Copy the values of all of the enumerable own properties from one or more source objects to a 
@@ -146,7 +146,7 @@ interface ObjectConstructor {
       * @param source2 The second source object from which to copy properties.
       * @param source3 The third source object from which to copy properties.
       */
-    assign<T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
+    assign<T, U, V, W>(target: T, source1: U | null | undefined, source2: V | null | undefined, source3: W | null | undefined): T & U & V & W;
 
     /**
       * Copy the values of all of the enumerable own properties from one or more source objects to a 
@@ -320,7 +320,7 @@ interface Array<T> {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: T, index: number, obj: Array<T>) => boolean, thisArg?: any): T;
+    find(predicate: (value: T, index: number, obj: Array<T>) => boolean, thisArg?: any): T | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -331,7 +331,7 @@ interface Array<T> {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: T) => boolean, thisArg?: any): number;
+    findIndex(predicate: (value: T) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Returns the this object after filling the section identified by start and end with value
@@ -407,7 +407,7 @@ interface String {
       * If there is no element at that position, the result is undefined. 
       * If a valid UTF-16 surrogate pair does not begin at pos, the result is the code unit at pos.
       */
-    codePointAt(pos: number): number;
+    codePointAt(pos: number): number | undefined;
 
     /**
       * Returns true if searchString appears as a substring of the result of converting this 
@@ -453,7 +453,7 @@ interface String {
       * Matches a string an object that supports being matched against, and returns an array containing the results of that search.
       * @param matcher An object that supports being matched against.
       */
-    match(matcher: { [Symbol.match](string: string): RegExpMatchArray; }): RegExpMatchArray;
+    match(matcher: { [Symbol.match](string: string): RegExpMatchArray | null; }): RegExpMatchArray | null;
 
     /**
       * Replaces text in a string, using an object that supports replacement within a string.
@@ -723,7 +723,7 @@ interface RegExp {
       * that search.
       * @param string A string to search within.
       */
-    [Symbol.match](string: string): RegExpMatchArray;
+    [Symbol.match](string: string): RegExpMatchArray | null;
 
     /**
       * Replaces text in a string, using this regular expression.
@@ -800,7 +800,7 @@ interface Map<K, V> {
     delete(key: K): boolean;
     entries(): IterableIterator<[K, V]>;
     forEach(callbackfn: (value: V, index: K, map: Map<K, V>) => void, thisArg?: any): void;
-    get(key: K): V;
+    get(key: K): V | undefined;
     has(key: K): boolean;
     keys(): IterableIterator<K>;
     set(key: K, value?: V): Map<K, V>;
@@ -821,7 +821,7 @@ declare var Map: MapConstructor;
 interface WeakMap<K, V> {
     clear(): void;
     delete(key: K): boolean;
-    get(key: K): V;
+    get(key: K): V | undefined;
     has(key: K): boolean;
     set(key: K, value?: V): WeakMap<K, V>;
     readonly [Symbol.toStringTag]: "WeakMap";

--- a/src/lib/es6.d.ts
+++ b/src/lib/es6.d.ts
@@ -127,7 +127,7 @@ interface ObjectConstructor {
       * @param target The target object to copy to.
       * @param source The source object from which to copy properties.
       */
-    assign<T, U>(target: T, source: U | null | undefined): T & U;
+    assign<T, U>(target: T, source: U): T & U;
 
     /**
       * Copy the values of all of the enumerable own properties from one or more source objects to a 
@@ -136,7 +136,7 @@ interface ObjectConstructor {
       * @param source1 The first source object from which to copy properties.
       * @param source2 The second source object from which to copy properties.
       */
-    assign<T, U, V>(target: T, source1: U | null | undefined, source2: V | null | undefined): T & U & V;
+    assign<T, U, V>(target: T, source1: U, source2: V): T & U & V;
 
     /**
       * Copy the values of all of the enumerable own properties from one or more source objects to a 
@@ -146,7 +146,7 @@ interface ObjectConstructor {
       * @param source2 The second source object from which to copy properties.
       * @param source3 The third source object from which to copy properties.
       */
-    assign<T, U, V, W>(target: T, source1: U | null | undefined, source2: V | null | undefined, source3: W | null | undefined): T & U & V & W;
+    assign<T, U, V, W>(target: T, source1: U, source2: V, source3: W): T & U & V & W;
 
     /**
       * Copy the values of all of the enumerable own properties from one or more source objects to a 


### PR DESCRIPTION
1. `| null` and `| undefined` where appropriate.

    - As expressed in the original PR, indexers do not have `| undefined`. I *have* added it to the ES6 collection accessors like `Map.get` however. I think that's better.

    - I haven't added `| null` or `| undefined` to functions that stringify their parameter and thus accept `null` and `undefined`, eg `Symbol(null)` is the same as `Symbol("null")`. It doesn't seem right to allow `null` just for that.

~~1. ES6's String.normalize's `form` parameter was typed as string - changed to union of string literals.~~

~~1. Map and Set methods that are specced to return `this` were not annotated as `: this`, changed accordingly.~~

~~I can split the changes into separate PRs if you want. I just fixed them as I came across them while doing the first one.~~

The other changes became too big and will be in another PR.

`jake runtests` passes.