### PR TITLE
`this`-related changes + new String.normalize overload in core.d.ts and es6.d.ts

### DIFF
--- a/src/lib/core.d.ts
+++ b/src/lib/core.d.ts
@@ -1137,7 +1137,7 @@ interface Array<T> {
       * Sorts an array.
       * @param compareFn The name of the function used to determine the order of the elements. If omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: T, b: T) => number): T[];
+    sort(compareFn?: (a: T, b: T) => number): this;
     /**
       * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
       * @param start The zero-based location in the array from which to start removing elements.
@@ -1479,7 +1479,7 @@ interface Int8Array {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value. 
       */
-    copyWithin(target: number, start: number, end?: number): Int8Array;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -1499,7 +1499,7 @@ interface Int8Array {
         * @param end index to stop filling the array at. If end is negative, it is treated as 
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Int8Array;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function. 
@@ -1668,7 +1668,7 @@ interface Int8Array {
       * @param compareFn The name of the function used to determine the order of the elements. If 
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Int8Array;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Int8Array view of the ArrayBuffer store for this array, referencing the elements
@@ -1752,7 +1752,7 @@ interface Uint8Array {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value. 
       */
-    copyWithin(target: number, start: number, end?: number): Uint8Array;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -1772,7 +1772,7 @@ interface Uint8Array {
         * @param end index to stop filling the array at. If end is negative, it is treated as 
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Uint8Array;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function. 
@@ -1941,7 +1941,7 @@ interface Uint8Array {
       * @param compareFn The name of the function used to determine the order of the elements. If 
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Uint8Array;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Uint8Array view of the ArrayBuffer store for this array, referencing the elements
@@ -2026,7 +2026,7 @@ interface Uint8ClampedArray {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value. 
       */
-    copyWithin(target: number, start: number, end?: number): Uint8ClampedArray;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -2046,7 +2046,7 @@ interface Uint8ClampedArray {
         * @param end index to stop filling the array at. If end is negative, it is treated as 
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Uint8ClampedArray;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function. 
@@ -2215,7 +2215,7 @@ interface Uint8ClampedArray {
       * @param compareFn The name of the function used to determine the order of the elements. If 
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Uint8ClampedArray;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Uint8ClampedArray view of the ArrayBuffer store for this array, referencing the elements
@@ -2299,7 +2299,7 @@ interface Int16Array {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value. 
       */
-    copyWithin(target: number, start: number, end?: number): Int16Array;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -2319,7 +2319,7 @@ interface Int16Array {
         * @param end index to stop filling the array at. If end is negative, it is treated as 
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Int16Array;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function. 
@@ -2488,7 +2488,7 @@ interface Int16Array {
       * @param compareFn The name of the function used to determine the order of the elements. If 
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Int16Array;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Int16Array view of the ArrayBuffer store for this array, referencing the elements
@@ -2573,7 +2573,7 @@ interface Uint16Array {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value. 
       */
-    copyWithin(target: number, start: number, end?: number): Uint16Array;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -2593,7 +2593,7 @@ interface Uint16Array {
         * @param end index to stop filling the array at. If end is negative, it is treated as 
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Uint16Array;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function. 
@@ -2762,7 +2762,7 @@ interface Uint16Array {
       * @param compareFn The name of the function used to determine the order of the elements. If 
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Uint16Array;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Uint16Array view of the ArrayBuffer store for this array, referencing the elements
@@ -2846,7 +2846,7 @@ interface Int32Array {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value. 
       */
-    copyWithin(target: number, start: number, end?: number): Int32Array;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -2866,7 +2866,7 @@ interface Int32Array {
         * @param end index to stop filling the array at. If end is negative, it is treated as 
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Int32Array;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function. 
@@ -3035,7 +3035,7 @@ interface Int32Array {
       * @param compareFn The name of the function used to determine the order of the elements. If 
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Int32Array;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Int32Array view of the ArrayBuffer store for this array, referencing the elements
@@ -3119,7 +3119,7 @@ interface Uint32Array {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value. 
       */
-    copyWithin(target: number, start: number, end?: number): Uint32Array;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -3139,7 +3139,7 @@ interface Uint32Array {
         * @param end index to stop filling the array at. If end is negative, it is treated as 
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Uint32Array;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function. 
@@ -3308,7 +3308,7 @@ interface Uint32Array {
       * @param compareFn The name of the function used to determine the order of the elements. If 
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Uint32Array;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Uint32Array view of the ArrayBuffer store for this array, referencing the elements
@@ -3392,7 +3392,7 @@ interface Float32Array {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value. 
       */
-    copyWithin(target: number, start: number, end?: number): Float32Array;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -3412,7 +3412,7 @@ interface Float32Array {
         * @param end index to stop filling the array at. If end is negative, it is treated as 
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Float32Array;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function. 
@@ -3581,7 +3581,7 @@ interface Float32Array {
       * @param compareFn The name of the function used to determine the order of the elements. If 
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Float32Array;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Float32Array view of the ArrayBuffer store for this array, referencing the elements
@@ -3666,7 +3666,7 @@ interface Float64Array {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value. 
       */
-    copyWithin(target: number, start: number, end?: number): Float64Array;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -3686,7 +3686,7 @@ interface Float64Array {
         * @param end index to stop filling the array at. If end is negative, it is treated as 
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Float64Array;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function. 
@@ -3855,7 +3855,7 @@ interface Float64Array {
       * @param compareFn The name of the function used to determine the order of the elements. If 
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Float64Array;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Float64Array view of the ArrayBuffer store for this array, referencing the elements

--- a/src/lib/core.d.ts
+++ b/src/lib/core.d.ts
@@ -1037,55 +1037,55 @@ interface ReadonlyArray<T> {
       * @param callbackfn A function that accepts up to three arguments. The every method calls the callbackfn function for each element in array1 until the callbackfn returns false, or until the end of the array.
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
       */
-    every(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => boolean, thisArg?: any): boolean;
+    every(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): boolean;
     /**
       * Determines whether the specified callback function returns true for any element of an array.
       * @param callbackfn A function that accepts up to three arguments. The some method calls the callbackfn function for each element in array1 until the callbackfn returns true, or until the end of the array.
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
       */
-    some(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => boolean, thisArg?: any): boolean;
+    some(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): boolean;
     /**
       * Performs the specified action for each element in an array.
       * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array. 
       * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
       */
-    forEach(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: T, index: number, array: this) => void, thisArg?: any): void;
     /**
       * Calls a defined callback function on each element of an array, and returns an array that contains the results.
       * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array. 
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
       */
-    map<U>(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => U, thisArg?: any): U[];
+    map<U>(callbackfn: (value: T, index: number, array: this) => U, thisArg?: any): U[];
     /**
       * Returns the elements of an array that meet the condition specified in a callback function.
       * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array. 
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
       */
-    filter(callbackfn: (value: T, index: number, array: ReadonlyArray<T>) => boolean, thisArg?: any): T[];
+    filter(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): T[];
     /**
       * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
       * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
       * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
       */
-    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: ReadonlyArray<T>) => T, initialValue?: T): T;
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T;
     /**
       * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
       * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
       * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
       */
-    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: ReadonlyArray<T>) => U, initialValue: U): U;
+    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U;
     /**
       * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
       * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array. 
       * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
       */
-    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: ReadonlyArray<T>) => T, initialValue?: T): T;
+    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T;
     /**
       * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
       * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array. 
       * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
       */
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: ReadonlyArray<T>) => U, initialValue: U): U;
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U;
 
     readonly [n: number]: T;
 }
@@ -1172,55 +1172,55 @@ interface Array<T> {
       * @param callbackfn A function that accepts up to three arguments. The every method calls the callbackfn function for each element in array1 until the callbackfn returns false, or until the end of the array.
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
       */
-    every(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
+    every(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): boolean;
     /**
       * Determines whether the specified callback function returns true for any element of an array.
       * @param callbackfn A function that accepts up to three arguments. The some method calls the callbackfn function for each element in array1 until the callbackfn returns true, or until the end of the array.
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
       */
-    some(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
+    some(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): boolean;
     /**
       * Performs the specified action for each element in an array.
       * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the array. 
       * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
       */
-    forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: T, index: number, array: this) => void, thisArg?: any): void;
     /**
       * Calls a defined callback function on each element of an array, and returns an array that contains the results.
       * @param callbackfn A function that accepts up to three arguments. The map method calls the callbackfn function one time for each element in the array. 
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
       */
-    map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
+    map<U>(callbackfn: (value: T, index: number, array: this) => U, thisArg?: any): U[];
     /**
       * Returns the elements of an array that meet the condition specified in a callback function. 
       * @param callbackfn A function that accepts up to three arguments. The filter method calls the callbackfn function one time for each element in the array. 
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
       */
-    filter(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T[];
+    filter(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): T[];
     /**
       * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
       * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
       * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
       */
-    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T;
     /**
       * Calls the specified callback function for all the elements in an array. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
       * @param callbackfn A function that accepts up to four arguments. The reduce method calls the callbackfn function one time for each element in the array.
       * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
       */
-    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U;
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
       * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array. 
       * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
       */
-    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
+    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T;
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. The return value of the callback function is the accumulated result, and is provided as an argument in the next call to the callback function.
       * @param callbackfn A function that accepts up to four arguments. The reduceRight method calls the callbackfn function one time for each element in the array. 
       * @param initialValue If initialValue is specified, it is used as the initial value to start the accumulation. The first call to the callbackfn function provides this value as an argument instead of an array value.
       */
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U;
 
     [n: number]: T;
 }
@@ -1489,7 +1489,7 @@ interface Int8Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function.
       * If thisArg is omitted, undefined is used as the this value.
       */
-    every(callbackfn: (value: number, index: number, array: Int8Array) => boolean, thisArg?: any): boolean;
+    every(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
         * Returns the this object after filling the section identified by start and end with value
@@ -1508,7 +1508,7 @@ interface Int8Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    filter(callbackfn: (value: number, index: number, array: Int8Array) => boolean, thisArg?: any): Int8Array;
+    filter(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): Int8Array;
 
     /** 
       * Returns the value of the first element in the array where predicate is true, and undefined 
@@ -1519,7 +1519,7 @@ interface Int8Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -1530,7 +1530,7 @@ interface Int8Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -1539,7 +1539,7 @@ interface Int8Array {
       * @param thisArg  An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    forEach(callbackfn: (value: number, index: number, array: Int8Array) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
 
     /**
       * Returns the index of the first occurrence of a value in an array.
@@ -1577,7 +1577,7 @@ interface Int8Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    map(callbackfn: (value: number, index: number, array: Int8Array) => number, thisArg?: any): Int8Array;
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Int8Array;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -1589,7 +1589,7 @@ interface Int8Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int8Array) => number, initialValue?: number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -1601,7 +1601,7 @@ interface Int8Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument 
       * instead of an array value.
       */
-    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Int8Array) => U, initialValue: U): U;
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -1613,7 +1613,7 @@ interface Int8Array {
       * the accumulation. The first call to the callbackfn function provides this value as an 
       * argument instead of an array value.
       */
-    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int8Array) => number, initialValue?: number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -1625,7 +1625,7 @@ interface Int8Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Int8Array) => U, initialValue: U): U;
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /**
       * Reverses the elements in an Array. 
@@ -1661,7 +1661,7 @@ interface Int8Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    some(callbackfn: (value: number, index: number, array: Int8Array) => boolean, thisArg?: any): boolean;
+    some(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
       * Sorts an array.
@@ -1762,7 +1762,7 @@ interface Uint8Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function.
       * If thisArg is omitted, undefined is used as the this value.
       */
-    every(callbackfn: (value: number, index: number, array: Uint8Array) => boolean, thisArg?: any): boolean;
+    every(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
         * Returns the this object after filling the section identified by start and end with value
@@ -1781,7 +1781,7 @@ interface Uint8Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    filter(callbackfn: (value: number, index: number, array: Uint8Array) => boolean, thisArg?: any): Uint8Array;
+    filter(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): Uint8Array;
 
     /** 
       * Returns the value of the first element in the array where predicate is true, and undefined 
@@ -1792,7 +1792,7 @@ interface Uint8Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -1803,7 +1803,7 @@ interface Uint8Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -1812,7 +1812,7 @@ interface Uint8Array {
       * @param thisArg  An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    forEach(callbackfn: (value: number, index: number, array: Uint8Array) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
 
     /**
       * Returns the index of the first occurrence of a value in an array.
@@ -1850,7 +1850,7 @@ interface Uint8Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    map(callbackfn: (value: number, index: number, array: Uint8Array) => number, thisArg?: any): Uint8Array;
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Uint8Array;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -1862,7 +1862,7 @@ interface Uint8Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array) => number, initialValue?: number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -1874,7 +1874,7 @@ interface Uint8Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument 
       * instead of an array value.
       */
-    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8Array) => U, initialValue: U): U;
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -1886,7 +1886,7 @@ interface Uint8Array {
       * the accumulation. The first call to the callbackfn function provides this value as an 
       * argument instead of an array value.
       */
-    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8Array) => number, initialValue?: number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -1898,7 +1898,7 @@ interface Uint8Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8Array) => U, initialValue: U): U;
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /**
       * Reverses the elements in an Array. 
@@ -1934,7 +1934,7 @@ interface Uint8Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    some(callbackfn: (value: number, index: number, array: Uint8Array) => boolean, thisArg?: any): boolean;
+    some(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
       * Sorts an array.
@@ -2036,7 +2036,7 @@ interface Uint8ClampedArray {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function.
       * If thisArg is omitted, undefined is used as the this value.
       */
-    every(callbackfn: (value: number, index: number, array: Uint8ClampedArray) => boolean, thisArg?: any): boolean;
+    every(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
         * Returns the this object after filling the section identified by start and end with value
@@ -2055,7 +2055,7 @@ interface Uint8ClampedArray {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    filter(callbackfn: (value: number, index: number, array: Uint8ClampedArray) => boolean, thisArg?: any): Uint8ClampedArray;
+    filter(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): Uint8ClampedArray;
 
     /** 
       * Returns the value of the first element in the array where predicate is true, and undefined 
@@ -2066,7 +2066,7 @@ interface Uint8ClampedArray {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -2077,7 +2077,7 @@ interface Uint8ClampedArray {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -2086,7 +2086,7 @@ interface Uint8ClampedArray {
       * @param thisArg  An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    forEach(callbackfn: (value: number, index: number, array: Uint8ClampedArray) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
 
     /**
       * Returns the index of the first occurrence of a value in an array.
@@ -2124,7 +2124,7 @@ interface Uint8ClampedArray {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    map(callbackfn: (value: number, index: number, array: Uint8ClampedArray) => number, thisArg?: any): Uint8ClampedArray;
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Uint8ClampedArray;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -2136,7 +2136,7 @@ interface Uint8ClampedArray {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8ClampedArray) => number, initialValue?: number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -2148,7 +2148,7 @@ interface Uint8ClampedArray {
       * the accumulation. The first call to the callbackfn function provides this value as an argument 
       * instead of an array value.
       */
-    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8ClampedArray) => U, initialValue: U): U;
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -2160,7 +2160,7 @@ interface Uint8ClampedArray {
       * the accumulation. The first call to the callbackfn function provides this value as an 
       * argument instead of an array value.
       */
-    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint8ClampedArray) => number, initialValue?: number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -2172,7 +2172,7 @@ interface Uint8ClampedArray {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint8ClampedArray) => U, initialValue: U): U;
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /**
       * Reverses the elements in an Array. 
@@ -2208,7 +2208,7 @@ interface Uint8ClampedArray {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    some(callbackfn: (value: number, index: number, array: Uint8ClampedArray) => boolean, thisArg?: any): boolean;
+    some(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
       * Sorts an array.
@@ -2309,7 +2309,7 @@ interface Int16Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function.
       * If thisArg is omitted, undefined is used as the this value.
       */
-    every(callbackfn: (value: number, index: number, array: Int16Array) => boolean, thisArg?: any): boolean;
+    every(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
         * Returns the this object after filling the section identified by start and end with value
@@ -2328,7 +2328,7 @@ interface Int16Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    filter(callbackfn: (value: number, index: number, array: Int16Array) => boolean, thisArg?: any): Int16Array;
+    filter(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): Int16Array;
 
     /** 
       * Returns the value of the first element in the array where predicate is true, and undefined 
@@ -2339,7 +2339,7 @@ interface Int16Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -2350,7 +2350,7 @@ interface Int16Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -2359,7 +2359,7 @@ interface Int16Array {
       * @param thisArg  An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    forEach(callbackfn: (value: number, index: number, array: Int16Array) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
 
     /**
       * Returns the index of the first occurrence of a value in an array.
@@ -2397,7 +2397,7 @@ interface Int16Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    map(callbackfn: (value: number, index: number, array: Int16Array) => number, thisArg?: any): Int16Array;
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Int16Array;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -2409,7 +2409,7 @@ interface Int16Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int16Array) => number, initialValue?: number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -2421,7 +2421,7 @@ interface Int16Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument 
       * instead of an array value.
       */
-    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Int16Array) => U, initialValue: U): U;
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -2433,7 +2433,7 @@ interface Int16Array {
       * the accumulation. The first call to the callbackfn function provides this value as an 
       * argument instead of an array value.
       */
-    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int16Array) => number, initialValue?: number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -2445,7 +2445,7 @@ interface Int16Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Int16Array) => U, initialValue: U): U;
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /**
       * Reverses the elements in an Array. 
@@ -2481,7 +2481,7 @@ interface Int16Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    some(callbackfn: (value: number, index: number, array: Int16Array) => boolean, thisArg?: any): boolean;
+    some(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
       * Sorts an array.
@@ -2583,7 +2583,7 @@ interface Uint16Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function.
       * If thisArg is omitted, undefined is used as the this value.
       */
-    every(callbackfn: (value: number, index: number, array: Uint16Array) => boolean, thisArg?: any): boolean;
+    every(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
         * Returns the this object after filling the section identified by start and end with value
@@ -2602,7 +2602,7 @@ interface Uint16Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    filter(callbackfn: (value: number, index: number, array: Uint16Array) => boolean, thisArg?: any): Uint16Array;
+    filter(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): Uint16Array;
 
     /** 
       * Returns the value of the first element in the array where predicate is true, and undefined 
@@ -2613,7 +2613,7 @@ interface Uint16Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -2624,7 +2624,7 @@ interface Uint16Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -2633,7 +2633,7 @@ interface Uint16Array {
       * @param thisArg  An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    forEach(callbackfn: (value: number, index: number, array: Uint16Array) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
 
     /**
       * Returns the index of the first occurrence of a value in an array.
@@ -2671,7 +2671,7 @@ interface Uint16Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    map(callbackfn: (value: number, index: number, array: Uint16Array) => number, thisArg?: any): Uint16Array;
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Uint16Array;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -2683,7 +2683,7 @@ interface Uint16Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint16Array) => number, initialValue?: number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -2695,7 +2695,7 @@ interface Uint16Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument 
       * instead of an array value.
       */
-    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint16Array) => U, initialValue: U): U;
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -2707,7 +2707,7 @@ interface Uint16Array {
       * the accumulation. The first call to the callbackfn function provides this value as an 
       * argument instead of an array value.
       */
-    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint16Array) => number, initialValue?: number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -2719,7 +2719,7 @@ interface Uint16Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint16Array) => U, initialValue: U): U;
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /**
       * Reverses the elements in an Array. 
@@ -2755,7 +2755,7 @@ interface Uint16Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    some(callbackfn: (value: number, index: number, array: Uint16Array) => boolean, thisArg?: any): boolean;
+    some(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
       * Sorts an array.
@@ -2856,7 +2856,7 @@ interface Int32Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function.
       * If thisArg is omitted, undefined is used as the this value.
       */
-    every(callbackfn: (value: number, index: number, array: Int32Array) => boolean, thisArg?: any): boolean;
+    every(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
         * Returns the this object after filling the section identified by start and end with value
@@ -2875,7 +2875,7 @@ interface Int32Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    filter(callbackfn: (value: number, index: number, array: Int32Array) => boolean, thisArg?: any): Int32Array;
+    filter(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): Int32Array;
 
     /** 
       * Returns the value of the first element in the array where predicate is true, and undefined 
@@ -2886,7 +2886,7 @@ interface Int32Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -2897,7 +2897,7 @@ interface Int32Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -2906,7 +2906,7 @@ interface Int32Array {
       * @param thisArg  An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    forEach(callbackfn: (value: number, index: number, array: Int32Array) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
 
     /**
       * Returns the index of the first occurrence of a value in an array.
@@ -2944,7 +2944,7 @@ interface Int32Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    map(callbackfn: (value: number, index: number, array: Int32Array) => number, thisArg?: any): Int32Array;
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Int32Array;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -2956,7 +2956,7 @@ interface Int32Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int32Array) => number, initialValue?: number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -2968,7 +2968,7 @@ interface Int32Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument 
       * instead of an array value.
       */
-    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Int32Array) => U, initialValue: U): U;
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -2980,7 +2980,7 @@ interface Int32Array {
       * the accumulation. The first call to the callbackfn function provides this value as an 
       * argument instead of an array value.
       */
-    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Int32Array) => number, initialValue?: number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -2992,7 +2992,7 @@ interface Int32Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Int32Array) => U, initialValue: U): U;
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /**
       * Reverses the elements in an Array. 
@@ -3028,7 +3028,7 @@ interface Int32Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    some(callbackfn: (value: number, index: number, array: Int32Array) => boolean, thisArg?: any): boolean;
+    some(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
       * Sorts an array.
@@ -3129,7 +3129,7 @@ interface Uint32Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function.
       * If thisArg is omitted, undefined is used as the this value.
       */
-    every(callbackfn: (value: number, index: number, array: Uint32Array) => boolean, thisArg?: any): boolean;
+    every(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
         * Returns the this object after filling the section identified by start and end with value
@@ -3148,7 +3148,7 @@ interface Uint32Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    filter(callbackfn: (value: number, index: number, array: Uint32Array) => boolean, thisArg?: any): Uint32Array;
+    filter(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): Uint32Array;
 
     /** 
       * Returns the value of the first element in the array where predicate is true, and undefined 
@@ -3159,7 +3159,7 @@ interface Uint32Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -3170,7 +3170,7 @@ interface Uint32Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -3179,7 +3179,7 @@ interface Uint32Array {
       * @param thisArg  An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    forEach(callbackfn: (value: number, index: number, array: Uint32Array) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
 
     /**
       * Returns the index of the first occurrence of a value in an array.
@@ -3217,7 +3217,7 @@ interface Uint32Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    map(callbackfn: (value: number, index: number, array: Uint32Array) => number, thisArg?: any): Uint32Array;
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Uint32Array;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -3229,7 +3229,7 @@ interface Uint32Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint32Array) => number, initialValue?: number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -3241,7 +3241,7 @@ interface Uint32Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument 
       * instead of an array value.
       */
-    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint32Array) => U, initialValue: U): U;
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -3253,7 +3253,7 @@ interface Uint32Array {
       * the accumulation. The first call to the callbackfn function provides this value as an 
       * argument instead of an array value.
       */
-    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Uint32Array) => number, initialValue?: number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -3265,7 +3265,7 @@ interface Uint32Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Uint32Array) => U, initialValue: U): U;
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /**
       * Reverses the elements in an Array. 
@@ -3301,7 +3301,7 @@ interface Uint32Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    some(callbackfn: (value: number, index: number, array: Uint32Array) => boolean, thisArg?: any): boolean;
+    some(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
       * Sorts an array.
@@ -3402,7 +3402,7 @@ interface Float32Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function.
       * If thisArg is omitted, undefined is used as the this value.
       */
-    every(callbackfn: (value: number, index: number, array: Float32Array) => boolean, thisArg?: any): boolean;
+    every(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
         * Returns the this object after filling the section identified by start and end with value
@@ -3421,7 +3421,7 @@ interface Float32Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    filter(callbackfn: (value: number, index: number, array: Float32Array) => boolean, thisArg?: any): Float32Array;
+    filter(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): Float32Array;
 
     /** 
       * Returns the value of the first element in the array where predicate is true, and undefined 
@@ -3432,7 +3432,7 @@ interface Float32Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -3443,7 +3443,7 @@ interface Float32Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -3452,7 +3452,7 @@ interface Float32Array {
       * @param thisArg  An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    forEach(callbackfn: (value: number, index: number, array: Float32Array) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
 
     /**
       * Returns the index of the first occurrence of a value in an array.
@@ -3490,7 +3490,7 @@ interface Float32Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    map(callbackfn: (value: number, index: number, array: Float32Array) => number, thisArg?: any): Float32Array;
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Float32Array;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -3502,7 +3502,7 @@ interface Float32Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Float32Array) => number, initialValue?: number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -3514,7 +3514,7 @@ interface Float32Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument 
       * instead of an array value.
       */
-    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Float32Array) => U, initialValue: U): U;
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -3526,7 +3526,7 @@ interface Float32Array {
       * the accumulation. The first call to the callbackfn function provides this value as an 
       * argument instead of an array value.
       */
-    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Float32Array) => number, initialValue?: number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -3538,7 +3538,7 @@ interface Float32Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Float32Array) => U, initialValue: U): U;
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /**
       * Reverses the elements in an Array. 
@@ -3574,7 +3574,7 @@ interface Float32Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    some(callbackfn: (value: number, index: number, array: Float32Array) => boolean, thisArg?: any): boolean;
+    some(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
       * Sorts an array.
@@ -3676,7 +3676,7 @@ interface Float64Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function.
       * If thisArg is omitted, undefined is used as the this value.
       */
-    every(callbackfn: (value: number, index: number, array: Float64Array) => boolean, thisArg?: any): boolean;
+    every(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
         * Returns the this object after filling the section identified by start and end with value
@@ -3695,7 +3695,7 @@ interface Float64Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    filter(callbackfn: (value: number, index: number, array: Float64Array) => boolean, thisArg?: any): Float64Array;
+    filter(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): Float64Array;
 
     /** 
       * Returns the value of the first element in the array where predicate is true, and undefined 
@@ -3706,7 +3706,7 @@ interface Float64Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: number, index: number, obj: Array<number>) => boolean, thisArg?: any): number | undefined;
+    find(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -3717,7 +3717,7 @@ interface Float64Array {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: number) => boolean, thisArg?: any): number | undefined;
+    findIndex(predicate: (value: number, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Performs the specified action for each element in an array.
@@ -3726,7 +3726,7 @@ interface Float64Array {
       * @param thisArg  An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    forEach(callbackfn: (value: number, index: number, array: Float64Array) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: number, index: number, array: this) => void, thisArg?: any): void;
 
     /**
       * Returns the index of the first occurrence of a value in an array.
@@ -3764,7 +3764,7 @@ interface Float64Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    map(callbackfn: (value: number, index: number, array: Float64Array) => number, thisArg?: any): Float64Array;
+    map(callbackfn: (value: number, index: number, array: this) => number, thisArg?: any): Float64Array;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -3776,7 +3776,7 @@ interface Float64Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Float64Array) => number, initialValue?: number): number;
+    reduce(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /**
       * Calls the specified callback function for all the elements in an array. The return value of 
@@ -3788,7 +3788,7 @@ interface Float64Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument 
       * instead of an array value.
       */
-    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Float64Array) => U, initialValue: U): U;
+    reduce<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -3800,7 +3800,7 @@ interface Float64Array {
       * the accumulation. The first call to the callbackfn function provides this value as an 
       * argument instead of an array value.
       */
-    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: Float64Array) => number, initialValue?: number): number;
+    reduceRight(callbackfn: (previousValue: number, currentValue: number, currentIndex: number, array: this) => number, initialValue?: number): number;
 
     /** 
       * Calls the specified callback function for all the elements in an array, in descending order. 
@@ -3812,7 +3812,7 @@ interface Float64Array {
       * the accumulation. The first call to the callbackfn function provides this value as an argument
       * instead of an array value.
       */
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: Float64Array) => U, initialValue: U): U;
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: number, currentIndex: number, array: this) => U, initialValue: U): U;
 
     /**
       * Reverses the elements in an Array. 
@@ -3848,7 +3848,7 @@ interface Float64Array {
       * @param thisArg An object to which the this keyword can refer in the callbackfn function. 
       * If thisArg is omitted, undefined is used as the this value.
       */
-    some(callbackfn: (value: number, index: number, array: Float64Array) => boolean, thisArg?: any): boolean;
+    some(callbackfn: (value: number, index: number, array: this) => boolean, thisArg?: any): boolean;
 
     /**
       * Sorts an array.

--- a/src/lib/es6.d.ts
+++ b/src/lib/es6.d.ts
@@ -799,7 +799,7 @@ interface Map<K, V> {
     clear(): void;
     delete(key: K): boolean;
     entries(): IterableIterator<[K, V]>;
-    forEach(callbackfn: (value: V, index: K, map: Map<K, V>) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: V, index: K, map: this) => void, thisArg?: any): void;
     get(key: K): V | undefined;
     has(key: K): boolean;
     keys(): IterableIterator<K>;
@@ -840,7 +840,7 @@ interface Set<T> {
     clear(): void;
     delete(value: T): boolean;
     entries(): IterableIterator<[T, T]>;
-    forEach(callbackfn: (value: T, index: T, set: Set<T>) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: T, index: T, set: this) => void, thisArg?: any): void;
     has(value: T): boolean;
     keys(): IterableIterator<T>;
     readonly size: number;

--- a/src/lib/es6.d.ts
+++ b/src/lib/es6.d.ts
@@ -803,7 +803,7 @@ interface Map<K, V> {
     get(key: K): V | undefined;
     has(key: K): boolean;
     keys(): IterableIterator<K>;
-    set(key: K, value?: V): Map<K, V>;
+    set(key: K, value?: V): this;
     readonly size: number;
     values(): IterableIterator<V>;
     [Symbol.iterator]():IterableIterator<[K,V]>;
@@ -823,7 +823,7 @@ interface WeakMap<K, V> {
     delete(key: K): boolean;
     get(key: K): V | undefined;
     has(key: K): boolean;
-    set(key: K, value?: V): WeakMap<K, V>;
+    set(key: K, value?: V): this;
     readonly [Symbol.toStringTag]: "WeakMap";
 }
 
@@ -836,7 +836,7 @@ interface WeakMapConstructor {
 declare var WeakMap: WeakMapConstructor;
 
 interface Set<T> {
-    add(value: T): Set<T>;
+    add(value: T): this;
     clear(): void;
     delete(value: T): boolean;
     entries(): IterableIterator<[T, T]>;
@@ -858,7 +858,7 @@ interface SetConstructor {
 declare var Set: SetConstructor;
 
 interface WeakSet<T> {
-    add(value: T): WeakSet<T>;
+    add(value: T): this;
     clear(): void;
     delete(value: T): boolean;
     has(value: T): boolean;

--- a/src/lib/es6.d.ts
+++ b/src/lib/es6.d.ts
@@ -431,6 +431,14 @@ interface String {
       * @param form Applicable values: "NFC", "NFD", "NFKC", or "NFKD", If not specified default
       * is "NFC"
       */
+    normalize(form: "NFC" | "NFD" | "NFKC" | "NFKD"): string;
+
+    /**
+      * Returns the String value result of normalizing the string into the normalization form 
+      * named by form as specified in Unicode Standard Annex #15, Unicode Normalization Forms.
+      * @param form Applicable values: "NFC", "NFD", "NFKC", or "NFKD", If not specified default
+      * is "NFC"
+      */
     normalize(form?: string): string;
 
     /**

--- a/src/lib/es6.d.ts
+++ b/src/lib/es6.d.ts
@@ -320,7 +320,7 @@ interface Array<T> {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    find(predicate: (value: T, index: number, obj: Array<T>) => boolean, thisArg?: any): T | undefined;
+    find(predicate: (value: T, index: number, obj: this) => boolean, thisArg?: any): T | undefined;
 
     /** 
       * Returns the index of the first element in the array where predicate is true, and undefined 
@@ -331,7 +331,7 @@ interface Array<T> {
       * @param thisArg If provided, it will be used as the this value for each invocation of 
       * predicate. If it is not provided, undefined is used instead.
       */
-    findIndex(predicate: (value: T) => boolean, thisArg?: any): number | undefined;
+    findIndex(predicate: (value: T, index: number, obj: this) => boolean, thisArg?: any): number | undefined;
 
     /**
       * Returns the this object after filling the section identified by start and end with value

--- a/src/lib/es6.d.ts
+++ b/src/lib/es6.d.ts
@@ -341,7 +341,7 @@ interface Array<T> {
       * @param end index to stop filling the array at. If end is negative, it is treated as 
       * length+end.
       */
-    fill(value: T, start?: number, end?: number): T[];
+    fill(value: T, start?: number, end?: number): this;
 
     /** 
       * Returns the this object after copying a section of the array identified by start and end
@@ -352,7 +352,7 @@ interface Array<T> {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value. 
       */
-    copyWithin(target: number, start: number, end?: number): T[];
+    copyWithin(target: number, start: number, end?: number): this;
 }
 
 interface IArguments {

--- a/tests/baselines/reference/duplicateOverloadInTypeAugmentation1.js
+++ b/tests/baselines/reference/duplicateOverloadInTypeAugmentation1.js
@@ -1,8 +1,8 @@
 //// [duplicateOverloadInTypeAugmentation1.ts]
 interface Array<T> {
-    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T,
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T,
         initialValue?: T): T;
-    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U,
+    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U,
         initialValue: U): U;
 }
 var a: Array<string>;

--- a/tests/baselines/reference/duplicateOverloadInTypeAugmentation1.symbols
+++ b/tests/baselines/reference/duplicateOverloadInTypeAugmentation1.symbols
@@ -3,7 +3,7 @@ interface Array<T> {
 >Array : Symbol(Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(duplicateOverloadInTypeAugmentation1.ts, 0, 0))
 >T : Symbol(T, Decl(lib.d.ts, --, --), Decl(duplicateOverloadInTypeAugmentation1.ts, 0, 16))
 
-    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T,
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T,
 >reduce : Symbol(Array.reduce, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(duplicateOverloadInTypeAugmentation1.ts, 0, 20), Decl(duplicateOverloadInTypeAugmentation1.ts, 2, 29))
 >callbackfn : Symbol(callbackfn, Decl(duplicateOverloadInTypeAugmentation1.ts, 1, 11))
 >previousValue : Symbol(previousValue, Decl(duplicateOverloadInTypeAugmentation1.ts, 1, 24))
@@ -13,14 +13,13 @@ interface Array<T> {
 >currentIndex : Symbol(currentIndex, Decl(duplicateOverloadInTypeAugmentation1.ts, 1, 58))
 >array : Symbol(array, Decl(duplicateOverloadInTypeAugmentation1.ts, 1, 80))
 >T : Symbol(T, Decl(lib.d.ts, --, --), Decl(duplicateOverloadInTypeAugmentation1.ts, 0, 16))
->T : Symbol(T, Decl(lib.d.ts, --, --), Decl(duplicateOverloadInTypeAugmentation1.ts, 0, 16))
 
         initialValue?: T): T;
->initialValue : Symbol(initialValue, Decl(duplicateOverloadInTypeAugmentation1.ts, 1, 98))
+>initialValue : Symbol(initialValue, Decl(duplicateOverloadInTypeAugmentation1.ts, 1, 99))
 >T : Symbol(T, Decl(lib.d.ts, --, --), Decl(duplicateOverloadInTypeAugmentation1.ts, 0, 16))
 >T : Symbol(T, Decl(lib.d.ts, --, --), Decl(duplicateOverloadInTypeAugmentation1.ts, 0, 16))
 
-    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U,
+    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U,
 >reduce : Symbol(Array.reduce, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(duplicateOverloadInTypeAugmentation1.ts, 0, 20), Decl(duplicateOverloadInTypeAugmentation1.ts, 2, 29))
 >U : Symbol(U, Decl(duplicateOverloadInTypeAugmentation1.ts, 3, 11))
 >callbackfn : Symbol(callbackfn, Decl(duplicateOverloadInTypeAugmentation1.ts, 3, 14))
@@ -30,11 +29,10 @@ interface Array<T> {
 >T : Symbol(T, Decl(lib.d.ts, --, --), Decl(duplicateOverloadInTypeAugmentation1.ts, 0, 16))
 >currentIndex : Symbol(currentIndex, Decl(duplicateOverloadInTypeAugmentation1.ts, 3, 61))
 >array : Symbol(array, Decl(duplicateOverloadInTypeAugmentation1.ts, 3, 83))
->T : Symbol(T, Decl(lib.d.ts, --, --), Decl(duplicateOverloadInTypeAugmentation1.ts, 0, 16))
 >U : Symbol(U, Decl(duplicateOverloadInTypeAugmentation1.ts, 3, 11))
 
         initialValue: U): U;
->initialValue : Symbol(initialValue, Decl(duplicateOverloadInTypeAugmentation1.ts, 3, 101))
+>initialValue : Symbol(initialValue, Decl(duplicateOverloadInTypeAugmentation1.ts, 3, 102))
 >U : Symbol(U, Decl(duplicateOverloadInTypeAugmentation1.ts, 3, 11))
 >U : Symbol(U, Decl(duplicateOverloadInTypeAugmentation1.ts, 3, 11))
 }

--- a/tests/baselines/reference/duplicateOverloadInTypeAugmentation1.types
+++ b/tests/baselines/reference/duplicateOverloadInTypeAugmentation1.types
@@ -3,16 +3,15 @@ interface Array<T> {
 >Array : T[]
 >T : T
 
-    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T,
->reduce : { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U; (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U; }
->callbackfn : (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T,
+>reduce : { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U; (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U; }
+>callbackfn : (previousValue: T, currentValue: T, currentIndex: number, array: this) => T
 >previousValue : T
 >T : T
 >currentValue : T
 >T : T
 >currentIndex : number
->array : T[]
->T : T
+>array : this
 >T : T
 
         initialValue?: T): T;
@@ -20,17 +19,16 @@ interface Array<T> {
 >T : T
 >T : T
 
-    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U,
->reduce : { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U; (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U; }
+    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U,
+>reduce : { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U; (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U; }
 >U : U
->callbackfn : (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U
+>callbackfn : (previousValue: U, currentValue: T, currentIndex: number, array: this) => U
 >previousValue : U
 >U : U
 >currentValue : T
 >T : T
 >currentIndex : number
->array : T[]
->T : T
+>array : this
 >U : U
 
         initialValue: U): U;

--- a/tests/baselines/reference/implementArrayInterface.js
+++ b/tests/baselines/reference/implementArrayInterface.js
@@ -10,22 +10,22 @@ declare class MyArray<T> implements Array<T> {
     reverse(): T[];
     shift(): T;
     slice(start?: number, end?: number): T[];
-    sort(compareFn?: (a: T, b: T) => number): T[];
+    sort(compareFn?: (a: T, b: T) => number): this;
     splice(start: number): T[];
     splice(start: number, deleteCount: number, ...items: T[]): T[];
     unshift(...items: T[]): number;
 
     indexOf(searchElement: T, fromIndex?: number): number;
     lastIndexOf(searchElement: T, fromIndex?: number): number;
-    every(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
-    some(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
-    forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
-    map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
-    filter(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T[];
-    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
-    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
-    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+    every(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): boolean;
+    some(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): boolean;
+    forEach(callbackfn: (value: T, index: number, array: this) => void, thisArg?: any): void;
+    map<U>(callbackfn: (value: T, index: number, array: this) => U, thisArg?: any): U[];
+    filter(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): T[];
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T;
+    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U;
+    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T;
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U;
 
     length: number;
 

--- a/tests/baselines/reference/implementArrayInterface.symbols
+++ b/tests/baselines/reference/implementArrayInterface.symbols
@@ -52,22 +52,21 @@ declare class MyArray<T> implements Array<T> {
 >end : Symbol(end, Decl(implementArrayInterface.ts, 10, 25))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 
-    sort(compareFn?: (a: T, b: T) => number): T[];
+    sort(compareFn?: (a: T, b: T) => number): this;
 >sort : Symbol(MyArray.sort, Decl(implementArrayInterface.ts, 10, 45))
 >compareFn : Symbol(compareFn, Decl(implementArrayInterface.ts, 11, 9))
 >a : Symbol(a, Decl(implementArrayInterface.ts, 11, 22))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 >b : Symbol(b, Decl(implementArrayInterface.ts, 11, 27))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
->T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 
     splice(start: number): T[];
->splice : Symbol(MyArray.splice, Decl(implementArrayInterface.ts, 11, 50), Decl(implementArrayInterface.ts, 12, 31))
+>splice : Symbol(MyArray.splice, Decl(implementArrayInterface.ts, 11, 51), Decl(implementArrayInterface.ts, 12, 31))
 >start : Symbol(start, Decl(implementArrayInterface.ts, 12, 11))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 
     splice(start: number, deleteCount: number, ...items: T[]): T[];
->splice : Symbol(MyArray.splice, Decl(implementArrayInterface.ts, 11, 50), Decl(implementArrayInterface.ts, 12, 31))
+>splice : Symbol(MyArray.splice, Decl(implementArrayInterface.ts, 11, 51), Decl(implementArrayInterface.ts, 12, 31))
 >start : Symbol(start, Decl(implementArrayInterface.ts, 13, 11))
 >deleteCount : Symbol(deleteCount, Decl(implementArrayInterface.ts, 13, 25))
 >items : Symbol(items, Decl(implementArrayInterface.ts, 13, 46))
@@ -91,62 +90,57 @@ declare class MyArray<T> implements Array<T> {
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 >fromIndex : Symbol(fromIndex, Decl(implementArrayInterface.ts, 17, 33))
 
-    every(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
+    every(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): boolean;
 >every : Symbol(MyArray.every, Decl(implementArrayInterface.ts, 17, 62))
 >callbackfn : Symbol(callbackfn, Decl(implementArrayInterface.ts, 18, 10))
 >value : Symbol(value, Decl(implementArrayInterface.ts, 18, 23))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 >index : Symbol(index, Decl(implementArrayInterface.ts, 18, 32))
 >array : Symbol(array, Decl(implementArrayInterface.ts, 18, 47))
->T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
->thisArg : Symbol(thisArg, Decl(implementArrayInterface.ts, 18, 71))
+>thisArg : Symbol(thisArg, Decl(implementArrayInterface.ts, 18, 72))
 
-    some(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
->some : Symbol(MyArray.some, Decl(implementArrayInterface.ts, 18, 96))
+    some(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): boolean;
+>some : Symbol(MyArray.some, Decl(implementArrayInterface.ts, 18, 97))
 >callbackfn : Symbol(callbackfn, Decl(implementArrayInterface.ts, 19, 9))
 >value : Symbol(value, Decl(implementArrayInterface.ts, 19, 22))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 >index : Symbol(index, Decl(implementArrayInterface.ts, 19, 31))
 >array : Symbol(array, Decl(implementArrayInterface.ts, 19, 46))
->T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
->thisArg : Symbol(thisArg, Decl(implementArrayInterface.ts, 19, 70))
+>thisArg : Symbol(thisArg, Decl(implementArrayInterface.ts, 19, 71))
 
-    forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
->forEach : Symbol(MyArray.forEach, Decl(implementArrayInterface.ts, 19, 95))
+    forEach(callbackfn: (value: T, index: number, array: this) => void, thisArg?: any): void;
+>forEach : Symbol(MyArray.forEach, Decl(implementArrayInterface.ts, 19, 96))
 >callbackfn : Symbol(callbackfn, Decl(implementArrayInterface.ts, 20, 12))
 >value : Symbol(value, Decl(implementArrayInterface.ts, 20, 25))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 >index : Symbol(index, Decl(implementArrayInterface.ts, 20, 34))
 >array : Symbol(array, Decl(implementArrayInterface.ts, 20, 49))
->T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
->thisArg : Symbol(thisArg, Decl(implementArrayInterface.ts, 20, 70))
+>thisArg : Symbol(thisArg, Decl(implementArrayInterface.ts, 20, 71))
 
-    map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
->map : Symbol(MyArray.map, Decl(implementArrayInterface.ts, 20, 92))
+    map<U>(callbackfn: (value: T, index: number, array: this) => U, thisArg?: any): U[];
+>map : Symbol(MyArray.map, Decl(implementArrayInterface.ts, 20, 93))
 >U : Symbol(U, Decl(implementArrayInterface.ts, 21, 8))
 >callbackfn : Symbol(callbackfn, Decl(implementArrayInterface.ts, 21, 11))
 >value : Symbol(value, Decl(implementArrayInterface.ts, 21, 24))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 >index : Symbol(index, Decl(implementArrayInterface.ts, 21, 33))
 >array : Symbol(array, Decl(implementArrayInterface.ts, 21, 48))
->T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 >U : Symbol(U, Decl(implementArrayInterface.ts, 21, 8))
->thisArg : Symbol(thisArg, Decl(implementArrayInterface.ts, 21, 66))
+>thisArg : Symbol(thisArg, Decl(implementArrayInterface.ts, 21, 67))
 >U : Symbol(U, Decl(implementArrayInterface.ts, 21, 8))
 
-    filter(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T[];
->filter : Symbol(MyArray.filter, Decl(implementArrayInterface.ts, 21, 87))
+    filter(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): T[];
+>filter : Symbol(MyArray.filter, Decl(implementArrayInterface.ts, 21, 88))
 >callbackfn : Symbol(callbackfn, Decl(implementArrayInterface.ts, 22, 11))
 >value : Symbol(value, Decl(implementArrayInterface.ts, 22, 24))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 >index : Symbol(index, Decl(implementArrayInterface.ts, 22, 33))
 >array : Symbol(array, Decl(implementArrayInterface.ts, 22, 48))
->T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
->thisArg : Symbol(thisArg, Decl(implementArrayInterface.ts, 22, 72))
+>thisArg : Symbol(thisArg, Decl(implementArrayInterface.ts, 22, 73))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 
-    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
->reduce : Symbol(MyArray.reduce, Decl(implementArrayInterface.ts, 22, 93), Decl(implementArrayInterface.ts, 23, 120))
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T;
+>reduce : Symbol(MyArray.reduce, Decl(implementArrayInterface.ts, 22, 94), Decl(implementArrayInterface.ts, 23, 121))
 >callbackfn : Symbol(callbackfn, Decl(implementArrayInterface.ts, 23, 11))
 >previousValue : Symbol(previousValue, Decl(implementArrayInterface.ts, 23, 24))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
@@ -155,13 +149,12 @@ declare class MyArray<T> implements Array<T> {
 >currentIndex : Symbol(currentIndex, Decl(implementArrayInterface.ts, 23, 58))
 >array : Symbol(array, Decl(implementArrayInterface.ts, 23, 80))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
->T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
->initialValue : Symbol(initialValue, Decl(implementArrayInterface.ts, 23, 98))
+>initialValue : Symbol(initialValue, Decl(implementArrayInterface.ts, 23, 99))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 
-    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
->reduce : Symbol(MyArray.reduce, Decl(implementArrayInterface.ts, 22, 93), Decl(implementArrayInterface.ts, 23, 120))
+    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U;
+>reduce : Symbol(MyArray.reduce, Decl(implementArrayInterface.ts, 22, 94), Decl(implementArrayInterface.ts, 23, 121))
 >U : Symbol(U, Decl(implementArrayInterface.ts, 24, 11))
 >callbackfn : Symbol(callbackfn, Decl(implementArrayInterface.ts, 24, 14))
 >previousValue : Symbol(previousValue, Decl(implementArrayInterface.ts, 24, 27))
@@ -170,14 +163,13 @@ declare class MyArray<T> implements Array<T> {
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 >currentIndex : Symbol(currentIndex, Decl(implementArrayInterface.ts, 24, 61))
 >array : Symbol(array, Decl(implementArrayInterface.ts, 24, 83))
->T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 >U : Symbol(U, Decl(implementArrayInterface.ts, 24, 11))
->initialValue : Symbol(initialValue, Decl(implementArrayInterface.ts, 24, 101))
+>initialValue : Symbol(initialValue, Decl(implementArrayInterface.ts, 24, 102))
 >U : Symbol(U, Decl(implementArrayInterface.ts, 24, 11))
 >U : Symbol(U, Decl(implementArrayInterface.ts, 24, 11))
 
-    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
->reduceRight : Symbol(MyArray.reduceRight, Decl(implementArrayInterface.ts, 24, 122), Decl(implementArrayInterface.ts, 25, 125))
+    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T;
+>reduceRight : Symbol(MyArray.reduceRight, Decl(implementArrayInterface.ts, 24, 123), Decl(implementArrayInterface.ts, 25, 126))
 >callbackfn : Symbol(callbackfn, Decl(implementArrayInterface.ts, 25, 16))
 >previousValue : Symbol(previousValue, Decl(implementArrayInterface.ts, 25, 29))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
@@ -186,13 +178,12 @@ declare class MyArray<T> implements Array<T> {
 >currentIndex : Symbol(currentIndex, Decl(implementArrayInterface.ts, 25, 63))
 >array : Symbol(array, Decl(implementArrayInterface.ts, 25, 85))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
->T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
->initialValue : Symbol(initialValue, Decl(implementArrayInterface.ts, 25, 103))
+>initialValue : Symbol(initialValue, Decl(implementArrayInterface.ts, 25, 104))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
->reduceRight : Symbol(MyArray.reduceRight, Decl(implementArrayInterface.ts, 24, 122), Decl(implementArrayInterface.ts, 25, 125))
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U;
+>reduceRight : Symbol(MyArray.reduceRight, Decl(implementArrayInterface.ts, 24, 123), Decl(implementArrayInterface.ts, 25, 126))
 >U : Symbol(U, Decl(implementArrayInterface.ts, 26, 16))
 >callbackfn : Symbol(callbackfn, Decl(implementArrayInterface.ts, 26, 19))
 >previousValue : Symbol(previousValue, Decl(implementArrayInterface.ts, 26, 32))
@@ -201,14 +192,13 @@ declare class MyArray<T> implements Array<T> {
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 >currentIndex : Symbol(currentIndex, Decl(implementArrayInterface.ts, 26, 66))
 >array : Symbol(array, Decl(implementArrayInterface.ts, 26, 88))
->T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 >U : Symbol(U, Decl(implementArrayInterface.ts, 26, 16))
->initialValue : Symbol(initialValue, Decl(implementArrayInterface.ts, 26, 106))
+>initialValue : Symbol(initialValue, Decl(implementArrayInterface.ts, 26, 107))
 >U : Symbol(U, Decl(implementArrayInterface.ts, 26, 16))
 >U : Symbol(U, Decl(implementArrayInterface.ts, 26, 16))
 
     length: number;
->length : Symbol(MyArray.length, Decl(implementArrayInterface.ts, 26, 127))
+>length : Symbol(MyArray.length, Decl(implementArrayInterface.ts, 26, 128))
 
     [n: number]: T;
 >n : Symbol(n, Decl(implementArrayInterface.ts, 30, 5))

--- a/tests/baselines/reference/implementArrayInterface.types
+++ b/tests/baselines/reference/implementArrayInterface.types
@@ -52,13 +52,12 @@ declare class MyArray<T> implements Array<T> {
 >end : number
 >T : T
 
-    sort(compareFn?: (a: T, b: T) => number): T[];
->sort : (compareFn?: (a: T, b: T) => number) => T[]
+    sort(compareFn?: (a: T, b: T) => number): this;
+>sort : (compareFn?: (a: T, b: T) => number) => this
 >compareFn : (a: T, b: T) => number
 >a : T
 >T : T
 >b : T
->T : T
 >T : T
 
     splice(start: number): T[];
@@ -91,117 +90,108 @@ declare class MyArray<T> implements Array<T> {
 >T : T
 >fromIndex : number
 
-    every(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
->every : (callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any) => boolean
->callbackfn : (value: T, index: number, array: T[]) => boolean
+    every(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): boolean;
+>every : (callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any) => boolean
+>callbackfn : (value: T, index: number, array: this) => boolean
 >value : T
 >T : T
 >index : number
->array : T[]
->T : T
+>array : this
 >thisArg : any
 
-    some(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
->some : (callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any) => boolean
->callbackfn : (value: T, index: number, array: T[]) => boolean
+    some(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): boolean;
+>some : (callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any) => boolean
+>callbackfn : (value: T, index: number, array: this) => boolean
 >value : T
 >T : T
 >index : number
->array : T[]
->T : T
+>array : this
 >thisArg : any
 
-    forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
->forEach : (callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any) => void
->callbackfn : (value: T, index: number, array: T[]) => void
+    forEach(callbackfn: (value: T, index: number, array: this) => void, thisArg?: any): void;
+>forEach : (callbackfn: (value: T, index: number, array: this) => void, thisArg?: any) => void
+>callbackfn : (value: T, index: number, array: this) => void
 >value : T
 >T : T
 >index : number
->array : T[]
->T : T
+>array : this
 >thisArg : any
 
-    map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
->map : <U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any) => U[]
+    map<U>(callbackfn: (value: T, index: number, array: this) => U, thisArg?: any): U[];
+>map : <U>(callbackfn: (value: T, index: number, array: this) => U, thisArg?: any) => U[]
 >U : U
->callbackfn : (value: T, index: number, array: T[]) => U
+>callbackfn : (value: T, index: number, array: this) => U
 >value : T
 >T : T
 >index : number
->array : T[]
->T : T
+>array : this
 >U : U
 >thisArg : any
 >U : U
 
-    filter(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T[];
->filter : (callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any) => T[]
->callbackfn : (value: T, index: number, array: T[]) => boolean
+    filter(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): T[];
+>filter : (callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any) => T[]
+>callbackfn : (value: T, index: number, array: this) => boolean
 >value : T
 >T : T
 >index : number
->array : T[]
->T : T
+>array : this
 >thisArg : any
 >T : T
 
-    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
->reduce : { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U; }
->callbackfn : (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T;
+>reduce : { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U; }
+>callbackfn : (previousValue: T, currentValue: T, currentIndex: number, array: this) => T
 >previousValue : T
 >T : T
 >currentValue : T
 >T : T
 >currentIndex : number
->array : T[]
->T : T
+>array : this
 >T : T
 >initialValue : T
 >T : T
 >T : T
 
-    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
->reduce : { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U; }
+    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U;
+>reduce : { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U; }
 >U : U
->callbackfn : (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U
+>callbackfn : (previousValue: U, currentValue: T, currentIndex: number, array: this) => U
 >previousValue : U
 >U : U
 >currentValue : T
 >T : T
 >currentIndex : number
->array : T[]
->T : T
+>array : this
 >U : U
 >initialValue : U
 >U : U
 >U : U
 
-    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
->reduceRight : { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U; }
->callbackfn : (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T
+    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T;
+>reduceRight : { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U; }
+>callbackfn : (previousValue: T, currentValue: T, currentIndex: number, array: this) => T
 >previousValue : T
 >T : T
 >currentValue : T
 >T : T
 >currentIndex : number
->array : T[]
->T : T
+>array : this
 >T : T
 >initialValue : T
 >T : T
 >T : T
 
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
->reduceRight : { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U; }
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U;
+>reduceRight : { (callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T; <U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U; }
 >U : U
->callbackfn : (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U
+>callbackfn : (previousValue: U, currentValue: T, currentIndex: number, array: this) => U
 >previousValue : U
 >U : U
 >currentValue : T
 >T : T
 >currentIndex : number
->array : T[]
->T : T
+>array : this
 >U : U
 >initialValue : U
 >U : U

--- a/tests/cases/compiler/duplicateOverloadInTypeAugmentation1.ts
+++ b/tests/cases/compiler/duplicateOverloadInTypeAugmentation1.ts
@@ -1,7 +1,7 @@
 interface Array<T> {
-    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T,
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T,
         initialValue?: T): T;
-    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U,
+    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U,
         initialValue: U): U;
 }
 var a: Array<string>;

--- a/tests/cases/compiler/implementArrayInterface.ts
+++ b/tests/cases/compiler/implementArrayInterface.ts
@@ -9,22 +9,22 @@ declare class MyArray<T> implements Array<T> {
     reverse(): T[];
     shift(): T;
     slice(start?: number, end?: number): T[];
-    sort(compareFn?: (a: T, b: T) => number): T[];
+    sort(compareFn?: (a: T, b: T) => number): this;
     splice(start: number): T[];
     splice(start: number, deleteCount: number, ...items: T[]): T[];
     unshift(...items: T[]): number;
 
     indexOf(searchElement: T, fromIndex?: number): number;
     lastIndexOf(searchElement: T, fromIndex?: number): number;
-    every(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
-    some(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): boolean;
-    forEach(callbackfn: (value: T, index: number, array: T[]) => void, thisArg?: any): void;
-    map<U>(callbackfn: (value: T, index: number, array: T[]) => U, thisArg?: any): U[];
-    filter(callbackfn: (value: T, index: number, array: T[]) => boolean, thisArg?: any): T[];
-    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
-    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
-    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: T[]) => T, initialValue?: T): T;
-    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: T[]) => U, initialValue: U): U;
+    every(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): boolean;
+    some(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): boolean;
+    forEach(callbackfn: (value: T, index: number, array: this) => void, thisArg?: any): void;
+    map<U>(callbackfn: (value: T, index: number, array: this) => U, thisArg?: any): U[];
+    filter(callbackfn: (value: T, index: number, array: this) => boolean, thisArg?: any): T[];
+    reduce(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T;
+    reduce<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U;
+    reduceRight(callbackfn: (previousValue: T, currentValue: T, currentIndex: number, array: this) => T, initialValue?: T): T;
+    reduceRight<U>(callbackfn: (previousValue: U, currentValue: T, currentIndex: number, array: this) => U, initialValue: U): U;
 
     length: number;
 


### PR DESCRIPTION
1. Array, TypedArray, Map and Set methods that are specced to return the this-object now return `this` instead of explicit type.

1. The callbacks in Array, TypedArray, Map and Set methods that pass the this-object to that callback now pass `this` instead of explicit type.

1. Added an overload for ES6 String.normalize's that has `form` parameter as union of the allowed string literals.

`tests/cases/compiler/implementArrayInterface` started failing until I updated it, since it is now an error to implement array methods with old callback that accepted `T[]`. Breaking change?

`tests/cases/compiler/duplicateOverloadInTypeAugmentation` still passed (with just baseline update for the types). But I've changed the overloads it defines from `T[]` to `this` anyway.

`jake runtests` passes.