### PR TITLE
Explicitly exclude . and .. for fs.readdirSync

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -495,7 +495,9 @@ namespace ts {
                 visitDirectory(path);
                 return result;
                 function visitDirectory(path: string) {
-                    const files = _fs.readdirSync(path || ".").sort();
+                    // This filtering is necessary because on some file system node fails to exclude 
+                    // "." and "..". See https://github.com/nodejs/node/issues/4002
+                    const files = filter(<string[]>_fs.readdirSync(path || "."), f => f !== "." && f !== "..").sort();
                     const directories: string[] = [];
                     for (const current of files) {
                         const name = combinePaths(path, current);

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -495,11 +495,14 @@ namespace ts {
                 visitDirectory(path);
                 return result;
                 function visitDirectory(path: string) {
-                    // This filtering is necessary because on some file system node fails to exclude 
-                    // "." and "..". See https://github.com/nodejs/node/issues/4002
-                    const files = filter(<string[]>_fs.readdirSync(path || "."), f => f !== "." && f !== "..").sort();
+                    const files = _fs.readdirSync(path || ".").sort();
                     const directories: string[] = [];
                     for (const current of files) {
+                        // This is necessary because on some file system node fails to exclude 
+                        // "." and "..". See https://github.com/nodejs/node/issues/4002
+                        if (current === "." || current === "..") {
+                            continue;
+                        }
                         const name = combinePaths(path, current);
                         if (!contains(exclude, getCanonicalPath(name))) {
                             const stat = _fs.statSync(name);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #7469

Exclude "." and ".." from the `fs.readdir` result explicitly due to the node bug that in some cases it fails to exclude these two items. (See https://github.com/Microsoft/vscode/issues/3860 and https://github.com/nodejs/node/issues/4002)

