### PR TITLE
Fix #7101

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4609,7 +4609,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 }
 
                 emitEnd(node);
-                if (kind !== SyntaxKind.MethodDeclaration && kind !== SyntaxKind.MethodSignature) {
+                if (kind !== SyntaxKind.MethodDeclaration &&
+                    kind !== SyntaxKind.MethodSignature &&
+                    kind !== SyntaxKind.ArrowFunction) {
                     emitTrailingComments(node);
                 }
             }

--- a/tests/baselines/reference/commentsAfterFunctionExpression1.js
+++ b/tests/baselines/reference/commentsAfterFunctionExpression1.js
@@ -1,0 +1,14 @@
+//// [commentsAfterFunctionExpression1.ts]
+var v = {
+    f: a => 0 /*t1*/,
+    g: (a => 0) /*t2*/,
+    h: (a => 0 /*t3*/)
+}
+
+
+//// [commentsAfterFunctionExpression1.js]
+var v = {
+    f: function (a) { return 0; } /*t1*/,
+    g: (function (a) { return 0; }) /*t2*/,
+    h: (function (a) { return 0; } /*t3*/)
+};

--- a/tests/baselines/reference/commentsAfterFunctionExpression1.symbols
+++ b/tests/baselines/reference/commentsAfterFunctionExpression1.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/commentsAfterFunctionExpression1.ts ===
+var v = {
+>v : Symbol(v, Decl(commentsAfterFunctionExpression1.ts, 0, 3))
+
+    f: a => 0 /*t1*/,
+>f : Symbol(f, Decl(commentsAfterFunctionExpression1.ts, 0, 9))
+>a : Symbol(a, Decl(commentsAfterFunctionExpression1.ts, 1, 6))
+
+    g: (a => 0) /*t2*/,
+>g : Symbol(g, Decl(commentsAfterFunctionExpression1.ts, 1, 21))
+>a : Symbol(a, Decl(commentsAfterFunctionExpression1.ts, 2, 8))
+
+    h: (a => 0 /*t3*/)
+>h : Symbol(h, Decl(commentsAfterFunctionExpression1.ts, 2, 23))
+>a : Symbol(a, Decl(commentsAfterFunctionExpression1.ts, 3, 8))
+}
+

--- a/tests/baselines/reference/commentsAfterFunctionExpression1.types
+++ b/tests/baselines/reference/commentsAfterFunctionExpression1.types
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/commentsAfterFunctionExpression1.ts ===
+var v = {
+>v : { f: (a: any) => number; g: (a: any) => number; h: (a: any) => number; }
+>{    f: a => 0 /*t1*/,    g: (a => 0) /*t2*/,    h: (a => 0 /*t3*/)} : { f: (a: any) => number; g: (a: any) => number; h: (a: any) => number; }
+
+    f: a => 0 /*t1*/,
+>f : (a: any) => number
+>a => 0 : (a: any) => number
+>a : any
+>0 : number
+
+    g: (a => 0) /*t2*/,
+>g : (a: any) => number
+>(a => 0) : (a: any) => number
+>a => 0 : (a: any) => number
+>a : any
+>0 : number
+
+    h: (a => 0 /*t3*/)
+>h : (a: any) => number
+>(a => 0 /*t3*/) : (a: any) => number
+>a => 0 : (a: any) => number
+>a : any
+>0 : number
+}
+

--- a/tests/cases/compiler/commentsAfterFunctionExpression1.ts
+++ b/tests/cases/compiler/commentsAfterFunctionExpression1.ts
@@ -1,0 +1,6 @@
+// @removeComments: false
+var v = {
+    f: a => 0 /*t1*/,
+    g: (a => 0) /*t2*/,
+    h: (a => 0 /*t3*/)
+}


### PR DESCRIPTION
Fixes #7101.
Duplicate comments were emitted from emitFunctionDeclaration and emitNodeConsideringCommentsOption for ArrowFunction node. I disabled emitTrailingComments in emitFunctionDeclaration if current node is ArrowFunction.

