### PR TITLE
Fix declaration file for default temp var name in declaration file during bundling

### DIFF
--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -530,7 +530,10 @@ namespace ts {
             else {
                 // Expression
                 const tempVarName = getExportDefaultTempVariableName();
-                write("declare var ");
+                if (!noDeclare) {
+                    write("declare ");
+                }
+                write("var ");
                 write(tempVarName);
                 write(": ");
                 writer.getSymbolAccessibilityDiagnostic = getDefaultExportAccessibilityDiagnostic;

--- a/tests/baselines/reference/declarationEmitDefaultExportWithTempVarName.js
+++ b/tests/baselines/reference/declarationEmitDefaultExportWithTempVarName.js
@@ -1,0 +1,19 @@
+//// [pi.ts]
+export default 3.14159;
+
+//// [pi.js]
+System.register([], function(exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters:[],
+        execute: function() {
+            exports_1("default",3.14159);
+        }
+    }
+});
+
+
+//// [pi.d.ts]
+declare var _default: number;
+export default _default;

--- a/tests/baselines/reference/declarationEmitDefaultExportWithTempVarName.symbols
+++ b/tests/baselines/reference/declarationEmitDefaultExportWithTempVarName.symbols
@@ -1,0 +1,3 @@
+=== tests/cases/compiler/pi.ts ===
+export default 3.14159;
+No type information for this code.

--- a/tests/baselines/reference/declarationEmitDefaultExportWithTempVarName.types
+++ b/tests/baselines/reference/declarationEmitDefaultExportWithTempVarName.types
@@ -1,0 +1,3 @@
+=== tests/cases/compiler/pi.ts ===
+export default 3.14159;
+No type information for this code.

--- a/tests/baselines/reference/declarationEmitDefaultExportWithTempVarNameWithBundling.js
+++ b/tests/baselines/reference/declarationEmitDefaultExportWithTempVarNameWithBundling.js
@@ -17,22 +17,6 @@ System.register("pi", [], function(exports_1, context_1) {
 
 //// [app.d.ts]
 declare module "pi" {
-    declare var _default: number;
+    var _default: number;
     export default _default;
 }
-
-
-//// [DtsFileErrors]
-
-
-app.d.ts(2,5): error TS1038: A 'declare' modifier cannot be used in an already ambient context.
-
-
-==== app.d.ts (1 errors) ====
-    declare module "pi" {
-        declare var _default: number;
-        ~~~~~~~
-!!! error TS1038: A 'declare' modifier cannot be used in an already ambient context.
-        export default _default;
-    }
-    

--- a/tests/baselines/reference/declarationEmitDefaultExportWithTempVarNameWithBundling.js
+++ b/tests/baselines/reference/declarationEmitDefaultExportWithTempVarNameWithBundling.js
@@ -1,0 +1,38 @@
+//// [pi.ts]
+
+export default 3.14159;
+
+//// [app.js]
+System.register("pi", [], function(exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    return {
+        setters:[],
+        execute: function() {
+            exports_1("default",3.14159);
+        }
+    }
+});
+
+
+//// [app.d.ts]
+declare module "pi" {
+    declare var _default: number;
+    export default _default;
+}
+
+
+//// [DtsFileErrors]
+
+
+app.d.ts(2,5): error TS1038: A 'declare' modifier cannot be used in an already ambient context.
+
+
+==== app.d.ts (1 errors) ====
+    declare module "pi" {
+        declare var _default: number;
+        ~~~~~~~
+!!! error TS1038: A 'declare' modifier cannot be used in an already ambient context.
+        export default _default;
+    }
+    

--- a/tests/baselines/reference/declarationEmitDefaultExportWithTempVarNameWithBundling.symbols
+++ b/tests/baselines/reference/declarationEmitDefaultExportWithTempVarNameWithBundling.symbols
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/pi.ts ===
+
+No type information for this code.export default 3.14159;
+No type information for this code.

--- a/tests/baselines/reference/declarationEmitDefaultExportWithTempVarNameWithBundling.types
+++ b/tests/baselines/reference/declarationEmitDefaultExportWithTempVarNameWithBundling.types
@@ -1,0 +1,4 @@
+=== tests/cases/compiler/pi.ts ===
+
+No type information for this code.export default 3.14159;
+No type information for this code.

--- a/tests/cases/compiler/declarationEmitDefaultExportWithTempVarName.ts
+++ b/tests/cases/compiler/declarationEmitDefaultExportWithTempVarName.ts
@@ -1,0 +1,4 @@
+// @declaration: true
+// @module: system
+// @Filename: pi.ts
+export default 3.14159;

--- a/tests/cases/compiler/declarationEmitDefaultExportWithTempVarNameWithBundling.ts
+++ b/tests/cases/compiler/declarationEmitDefaultExportWithTempVarNameWithBundling.ts
@@ -1,0 +1,6 @@
+// @declaration: true
+// @module: system
+// @outFile: app.js
+
+// @Filename: pi.ts
+export default 3.14159;


### PR DESCRIPTION
Emit "declare" when emitting default temp var name in declaration file only if context allows it. 
This fixes incorrect emit during bundling where declare was emitted because we didn't check this earlier.

Fixes #7807 
