### PR TITLE
Fixed typo when computing transform flags for exponentation

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2164,7 +2164,7 @@ namespace ts {
             // Destructuring assignments are ES6 syntax.
             transformFlags = TransformFlags.AssertES6 | TransformFlags.DestructuringAssignment;
         }
-        else if (isExponentiation(node)) {
+        else if (isExponentiation(node.operatorToken)) {
             // Exponentiation is ES7 syntax.
             transformFlags = TransformFlags.AssertES7;
         }


### PR DESCRIPTION
Fixes a typo that was preventing down-level transformation of the exponentation operator. This fixes around 80 failing tests.

CC: @vladima, @DanielRosenwasser, @yuit 