### PR TITLE
Fixes indentation of object literals with computed properties

### DIFF
--- a/src/compiler/printer.ts
+++ b/src/compiler/printer.ts
@@ -964,9 +964,18 @@ const _super = (function (geti, seti) {
                     write("{}");
                 }
                 else {
+                    const indentedFlag = getNodeEmitFlags(node) & NodeEmitFlags.Indented;
+                    if (indentedFlag) {
+                        increaseIndent();
+                    }
+
                     const preferNewLine = node.multiLine ? ListFormat.PreferNewLine : ListFormat.None;
                     const allowTrailingComma = languageVersion >= ScriptTarget.ES5 ? ListFormat.AllowTrailingComma : ListFormat.None;
                     emitList(node, properties, ListFormat.ObjectLiteralExpressionProperties | allowTrailingComma | preferNewLine);
+
+                    if (indentedFlag) {
+                        decreaseIndent();
+                    }
                 }
             }
 

--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -1688,10 +1688,13 @@ namespace ts {
             addNode(expressions,
                 createAssignment(
                     temp,
-                    createObjectLiteral(
-                        visitNodes(properties, visitor, isObjectLiteralElement, 0, numInitialNonComputedProperties),
-                        /*location*/ undefined,
-                        node.multiLine
+                    setNodeEmitFlags(
+                        createObjectLiteral(
+                            visitNodes(properties, visitor, isObjectLiteralElement, 0, numInitialNonComputedProperties),
+                            /*location*/ undefined,
+                            node.multiLine
+                        ),
+                        NodeEmitFlags.Indented
                     )
                 ),
                 node.multiLine

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1637,6 +1637,9 @@ namespace ts {
                 const rightHandSideName = (<PropertyAccessExpression>nameExpression).name.text;
                 return getPropertyNameForKnownSymbolName(rightHandSideName);
             }
+            if (isStringOrNumericLiteral(nameExpression.kind)) {
+                return (<LiteralExpression>nameExpression).text;
+            }
         }
 
         return undefined;

--- a/tests/baselines/reference/computedPropertyNames16_ES5.js
+++ b/tests/baselines/reference/computedPropertyNames16_ES5.js
@@ -48,6 +48,16 @@ var C = (function () {
         enumerable: true,
         configurable: true
     });
+    Object.defineProperty(C, "", {
+        set: function (v) { },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(C.prototype, 0, {
+        get: function () { return 0; },
+        enumerable: true,
+        configurable: true
+    });
     Object.defineProperty(C.prototype, a, {
         set: function (v) { },
         enumerable: true,

--- a/tests/baselines/reference/computedPropertyNames36_ES5.js
+++ b/tests/baselines/reference/computedPropertyNames36_ES5.js
@@ -27,6 +27,10 @@ var C = (function () {
     Object.defineProperty(C.prototype, "get1", {
         // Computed properties
         get: function () { return new Foo; },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(C.prototype, "set1", {
         set: function (p) { },
         enumerable: true,
         configurable: true

--- a/tests/baselines/reference/computedPropertyNames37_ES5.js
+++ b/tests/baselines/reference/computedPropertyNames37_ES5.js
@@ -27,6 +27,10 @@ var C = (function () {
     Object.defineProperty(C.prototype, "get1", {
         // Computed properties
         get: function () { return new Foo; },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(C.prototype, "set1", {
         set: function (p) { },
         enumerable: true,
         configurable: true

--- a/tests/baselines/reference/computedPropertyNames43_ES5.js
+++ b/tests/baselines/reference/computedPropertyNames43_ES5.js
@@ -41,6 +41,10 @@ var D = (function (_super) {
     Object.defineProperty(D.prototype, "get1", {
         // Computed properties
         get: function () { return new Foo; },
+        enumerable: true,
+        configurable: true
+    });
+    Object.defineProperty(D.prototype, "set1", {
         set: function (p) { },
         enumerable: true,
         configurable: true

--- a/tests/baselines/reference/computedPropertyNames49_ES5.js
+++ b/tests/baselines/reference/computedPropertyNames49_ES5.js
@@ -60,7 +60,6 @@ var x = (_a = {
         enumerable: true,
         configurable: true
     }),
-    ,
     _a.p2 = 20,
     _a);
 var _a;

--- a/tests/baselines/reference/computedPropertyNames50_ES5.js
+++ b/tests/baselines/reference/computedPropertyNames50_ES5.js
@@ -56,7 +56,6 @@ var x = (_a = {
         enumerable: true,
         configurable: true
     }),
-    ,
     _a.p2 = 20,
     _a);
 var _a;


### PR DESCRIPTION
CC: @vladima, @yuit, @DanielRosenwasser 