### PR TITLE
[Transforms] Fixes class expression names and auto-parens in call/new

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -651,18 +651,9 @@ namespace ts {
             const heritageClauses = visitNodes(node.heritageClauses, visitor, isHeritageClause);
             const members = transformClassMembers(node, heritageClauses !== undefined);
 
-            // emit name if
-            // - node has a name
-            // - node has static initializers
-            //
-            let name = node.name;
-            if (!name && staticProperties.length > 0) {
-                name = getGeneratedNameForNode(node);
-            }
-
             const classExpression = setOriginalNode(
                 createClassExpression(
-                    name,
+                    node.name,
                     heritageClauses,
                     members,
                     /*location*/ node

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -131,12 +131,12 @@ namespace ts {
         [SyntaxKind.CallExpression]: [
             { name: "expression", test: isLeftHandSideExpression, parenthesize: parenthesizeForAccess },
             { name: "typeArguments", test: isTypeNode },
-            { name: "arguments", test: isExpression },
+            { name: "arguments", test: isExpression, parenthesize: parenthesizeExpressionForList },
         ],
         [SyntaxKind.NewExpression]: [
             { name: "expression", test: isLeftHandSideExpression, parenthesize: parenthesizeForNew },
             { name: "typeArguments", test: isTypeNode },
-            { name: "arguments", test: isExpression },
+            { name: "arguments", test: isExpression, parenthesize: parenthesizeExpressionForList },
         ],
         [SyntaxKind.TaggedTemplateExpression]: [
             { name: "tag", test: isLeftHandSideExpression, parenthesize: parenthesizeForAccess },


### PR DESCRIPTION
Fixes #7857.
Fixes #7858.