### PR TITLE
Only bundle if module==AMD or module==System

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2285,10 +2285,12 @@ namespace ts {
         }
 
         function onBundledEmit(host: EmitHost) {
+            const moduleKind = getEmitModuleKind(options);
+            const moduleEmitEnabled = moduleKind === ModuleKind.AMD || moduleKind === ModuleKind.System;
             // Can emit only sources that are not declaration file and are either non module code or module with --module or --target es6 specified
             const bundledSources = filter(host.getSourceFiles(), sourceFile =>
                 !isDeclarationFile(sourceFile)                                       // Not a declaration file
-                && (!isExternalModule(sourceFile) || !!getEmitModuleKind(options))); // and not a module, unless module emit enabled
+                && (!isExternalModule(sourceFile) || moduleEmitEnabled)); // and not a module, unless module emit enabled
 
             if (bundledSources.length) {
                 const jsFilePath = options.outFile || options.out;

--- a/tests/baselines/reference/getEmitOutputSingleFile2.baseline
+++ b/tests/baselines/reference/getEmitOutputSingleFile2.baseline
@@ -23,8 +23,4 @@ declare class Foo {
     x: string;
     y: number;
 }
-declare module "inputFile3" {
-    export var foo: number;
-    export var bar: string;
-}
 

--- a/tests/baselines/reference/getEmitOutputTsxFile_React.baseline
+++ b/tests/baselines/reference/getEmitOutputTsxFile_React.baseline
@@ -19,7 +19,7 @@ EmitSkipped: false
 FileName : tests/cases/fourslash/inputFile2.js.map
 {"version":3,"file":"inputFile2.js","sourceRoot":"","sources":["inputFile2.tsx"],"names":[],"mappings":"AACA,IAAI,CAAC,GAAG,QAAQ,CAAC;AACjB,IAAI,CAAC,GAAG,qBAAC,GAAG,IAAC,IAAI,EAAG,CAAE,EAAG,CAAA"}FileName : tests/cases/fourslash/inputFile2.js
 var y = "my div";
-var x = React.createElement("div", {name: y});
+var x = React.createElement("div", { name: y });
 //# sourceMappingURL=inputFile2.js.mapFileName : tests/cases/fourslash/inputFile2.d.ts
 declare var React: any;
 declare var y: string;


### PR DESCRIPTION
Fixes #7922

this was handled in emitSourceFileNode by having a missing bundleEmitDelegates for commonJS/ES6/none, now we are not doing this, so handling it in forEachExpectedEmitFile instead