### PR TITLE
Emit "use strict" if a prologue only contains "use strict" somewhere inside of it

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -7651,7 +7651,7 @@ const _super = (function (geti, seti) {
             }
 
             function isUseStrictPrologue(node: ExpressionStatement): boolean {
-                return !!(node.expression as StringLiteral).text.match(/use strict/);
+                return (node.expression as StringLiteral).text === "use strict";
             }
 
             function ensureUseStrictPrologue(startWithNewLine: boolean, writeUseStrict: boolean) {

--- a/tests/baselines/reference/useStrictLikePrologueString01.js
+++ b/tests/baselines/reference/useStrictLikePrologueString01.js
@@ -8,6 +8,7 @@ export function f() {
 //// [useStrictLikePrologueString01.js]
 "hey!";
 " use strict ";
+"use strict";
 function f() {
 }
 exports.f = f;

--- a/tests/baselines/reference/useStrictLikePrologueString01.js
+++ b/tests/baselines/reference/useStrictLikePrologueString01.js
@@ -1,0 +1,13 @@
+//// [useStrictLikePrologueString01.ts]
+
+"hey!"
+" use strict "
+export function f() {   
+}
+
+//// [useStrictLikePrologueString01.js]
+"hey!";
+" use strict ";
+function f() {
+}
+exports.f = f;

--- a/tests/baselines/reference/useStrictLikePrologueString01.symbols
+++ b/tests/baselines/reference/useStrictLikePrologueString01.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/useStrictLikePrologueString01.ts ===
+
+"hey!"
+" use strict "
+export function f() {   
+>f : Symbol(f, Decl(useStrictLikePrologueString01.ts, 2, 14))
+}

--- a/tests/baselines/reference/useStrictLikePrologueString01.types
+++ b/tests/baselines/reference/useStrictLikePrologueString01.types
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/useStrictLikePrologueString01.ts ===
+
+"hey!"
+>"hey!" : string
+
+" use strict "
+>" use strict " : string
+
+export function f() {   
+>f : () => void
+}

--- a/tests/cases/compiler/useStrictLikePrologueString01.ts
+++ b/tests/cases/compiler/useStrictLikePrologueString01.ts
@@ -1,0 +1,7 @@
+//@target: commonjs
+//@target: es5
+
+"hey!"
+" use strict "
+export function f() {   
+}


### PR DESCRIPTION
Fixes the main portion of #7918.