### PR TITLE
[Transforms] Emits class name with comments.

### DIFF
--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -549,7 +549,7 @@ namespace ts {
                     /*modifiers*/ undefined,
                     createVariableDeclarationList([
                         createVariableDeclaration(
-                            node.name || getGeneratedNameForNode(node),
+                            getDeclarationName(node, /*allowComments*/ true),
                             transformClassLikeDeclarationToExpression(node)
                         )
                     ]),
@@ -2688,8 +2688,25 @@ namespace ts {
             return node;
         }
 
-        function getDeclarationName(node: ClassExpression | ClassDeclaration | FunctionDeclaration) {
-            return node.name ? getSynthesizedClone(node.name) : getGeneratedNameForNode(node);
+        /**
+         * Gets the name of a declaration, without source map or comments.
+         *
+         * @param node The declaration.
+         * @param allowComments Allow comments for the name.
+         */
+        function getDeclarationName(node: DeclarationStatement | ClassExpression, allowComments?: boolean) {
+            if (node.name) {
+                const name = getMutableClone(node.name);
+                let flags = NodeEmitFlags.NoSourceMap;
+                if (!allowComments) {
+                    flags |= NodeEmitFlags.NoComments;
+                }
+
+                setNodeEmitFlags(name, flags | getNodeEmitFlags(name));
+                return name;
+            }
+
+            return getGeneratedNameForNode(node);
         }
 
         function getClassMemberPrefix(node: ClassExpression | ClassDeclaration, member: ClassElement) {

--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -549,7 +549,7 @@ namespace ts {
                     /*modifiers*/ undefined,
                     createVariableDeclarationList([
                         createVariableDeclaration(
-                            getDeclarationName(node),
+                            node.name || getGeneratedNameForNode(node),
                             transformClassLikeDeclarationToExpression(node)
                         )
                     ]),

--- a/tests/baselines/reference/variableDeclaratorResolvedDuringContextualTyping.js
+++ b/tests/baselines/reference/variableDeclaratorResolvedDuringContextualTyping.js
@@ -132,11 +132,11 @@ var WinJS;
 var Errors;
 (function (Errors) {
     var ConnectionError /* extends Error */ = (function () {
-        function ConnectionError /* extends Error */(request) {
+        function ConnectionError(request) {
         }
-        return ConnectionError /* extends Error */;
+        return ConnectionError;
     }());
-    Errors.ConnectionError /* extends Error */ = ConnectionError /* extends Error */;
+    Errors.ConnectionError = ConnectionError;
 })(Errors || (Errors = {}));
 var FileService = (function () {
     function FileService() {


### PR DESCRIPTION
This fixes #7914, but uses the emit from https://github.com/Microsoft/TypeScript/issues/7914#issuecomment-207028920.

Now also fixes #7869.