### PR TITLE
Fixes rename for destructuring and named imports

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11690,39 +11690,43 @@ namespace ts {
         function checkObjectLiteralAssignment(node: ObjectLiteralExpression, sourceType: Type, contextualMapper?: TypeMapper): Type {
             const properties = node.properties;
             for (const p of properties) {
-                if (p.kind === SyntaxKind.PropertyAssignment || p.kind === SyntaxKind.ShorthandPropertyAssignment) {
-                    const name = <PropertyName>(<PropertyAssignment>p).name;
-                    if (name.kind === SyntaxKind.ComputedPropertyName) {
-                        checkComputedPropertyName(<ComputedPropertyName>name);
-                    }
-                    if (isComputedNonLiteralName(name)) {
-                        continue;
-                    }
+                checkObjectLiteralDestructuringPropertyAssignment(sourceType, p, contextualMapper);
+            }
+            return sourceType;
+        }
 
-                    const text = getTextOfPropertyName(name);
-                    const type = isTypeAny(sourceType)
-                        ? sourceType
-                        : getTypeOfPropertyOfType(sourceType, text) ||
-                        isNumericLiteralName(text) && getIndexTypeOfType(sourceType, IndexKind.Number) ||
-                        getIndexTypeOfType(sourceType, IndexKind.String);
-                    if (type) {
-                        if (p.kind === SyntaxKind.ShorthandPropertyAssignment) {
-                            checkDestructuringAssignment(<ShorthandPropertyAssignment>p, type);
-                        }
-                        else {
-                            // non-shorthand property assignments should always have initializers
-                            checkDestructuringAssignment((<PropertyAssignment>p).initializer, type);
-                        }
+        function checkObjectLiteralDestructuringPropertyAssignment(objectLiteralType: Type, property: ObjectLiteralElement, contextualMapper?: TypeMapper) {
+            if (property.kind === SyntaxKind.PropertyAssignment || property.kind === SyntaxKind.ShorthandPropertyAssignment) {
+                const name = <PropertyName>(<PropertyAssignment>property).name;
+                if (name.kind === SyntaxKind.ComputedPropertyName) {
+                    checkComputedPropertyName(<ComputedPropertyName>name);
+                }
+                if (isComputedNonLiteralName(name)) {
+                    return undefined;
+                }
+
+                const text = getTextOfPropertyName(name);
+                const type = isTypeAny(objectLiteralType)
+                    ? objectLiteralType
+                    : getTypeOfPropertyOfType(objectLiteralType, text) ||
+                    isNumericLiteralName(text) && getIndexTypeOfType(objectLiteralType, IndexKind.Number) ||
+                    getIndexTypeOfType(objectLiteralType, IndexKind.String);
+                if (type) {
+                    if (property.kind === SyntaxKind.ShorthandPropertyAssignment) {
+                        return checkDestructuringAssignment(<ShorthandPropertyAssignment>property, type);
                     }
                     else {
-                        error(name, Diagnostics.Type_0_has_no_property_1_and_no_string_index_signature, typeToString(sourceType), declarationNameToString(name));
+                        // non-shorthand property assignments should always have initializers
+                        return checkDestructuringAssignment((<PropertyAssignment>property).initializer, type);
                     }
                 }
                 else {
-                    error(p, Diagnostics.Property_assignment_expected);
+                    error(name, Diagnostics.Type_0_has_no_property_1_and_no_string_index_signature, typeToString(objectLiteralType), declarationNameToString(name));
                 }
             }
-            return sourceType;
+            else {
+                error(property, Diagnostics.Property_assignment_expected);
+            }
         }
 
         function checkArrayLiteralAssignment(node: ArrayLiteralExpression, sourceType: Type, contextualMapper?: TypeMapper): Type {
@@ -11732,44 +11736,49 @@ namespace ts {
             const elementType = checkIteratedTypeOrElementType(sourceType, node, /*allowStringInput*/ false) || unknownType;
             const elements = node.elements;
             for (let i = 0; i < elements.length; i++) {
-                const e = elements[i];
-                if (e.kind !== SyntaxKind.OmittedExpression) {
-                    if (e.kind !== SyntaxKind.SpreadElementExpression) {
-                        const propName = "" + i;
-                        const type = isTypeAny(sourceType)
-                            ? sourceType
-                            : isTupleLikeType(sourceType)
-                                ? getTypeOfPropertyOfType(sourceType, propName)
-                                : elementType;
-                        if (type) {
-                            checkDestructuringAssignment(e, type, contextualMapper);
-                        }
-                        else {
-                            if (isTupleType(sourceType)) {
-                                error(e, Diagnostics.Tuple_type_0_with_length_1_cannot_be_assigned_to_tuple_with_length_2, typeToString(sourceType), (<TupleType>sourceType).elementTypes.length, elements.length);
-                            }
-                            else {
-                                error(e, Diagnostics.Type_0_has_no_property_1, typeToString(sourceType), propName);
-                            }
-                        }
+                checkArrayLiteralDestructuringElementAssignment(node, sourceType, elements[i], i, elementType, contextualMapper);
+            }
+            return sourceType;
+        }
+
+        function checkArrayLiteralDestructuringElementAssignment(node: ArrayLiteralExpression, sourceType: Type,
+            element: Expression, index: number, elementType: Type, contextualMapper?: TypeMapper) {
+            const elements = node.elements;
+            if (element.kind !== SyntaxKind.OmittedExpression) {
+                if (element.kind !== SyntaxKind.SpreadElementExpression) {
+                    const propName = "" + index;
+                    const type = isTypeAny(sourceType)
+                        ? sourceType
+                        : isTupleLikeType(sourceType)
+                            ? getTypeOfPropertyOfType(sourceType, propName)
+                            : elementType;
+                    if (type) {
+                        return checkDestructuringAssignment(element, type, contextualMapper);
                     }
                     else {
-                        if (i < elements.length - 1) {
-                            error(e, Diagnostics.A_rest_element_must_be_last_in_an_array_destructuring_pattern);
+                        if (isTupleType(sourceType)) {
+                            error(element, Diagnostics.Tuple_type_0_with_length_1_cannot_be_assigned_to_tuple_with_length_2, typeToString(sourceType), (<TupleType>sourceType).elementTypes.length, elements.length);
                         }
                         else {
-                            const restExpression = (<SpreadElementExpression>e).expression;
-                            if (restExpression.kind === SyntaxKind.BinaryExpression && (<BinaryExpression>restExpression).operatorToken.kind === SyntaxKind.EqualsToken) {
-                                error((<BinaryExpression>restExpression).operatorToken, Diagnostics.A_rest_element_cannot_have_an_initializer);
-                            }
-                            else {
-                                checkDestructuringAssignment(restExpression, createArrayType(elementType), contextualMapper);
-                            }
+                            error(element, Diagnostics.Type_0_has_no_property_1, typeToString(sourceType), propName);
+                        }
+                    }
+                }
+                else {
+                    if (index < elements.length - 1) {
+                        error(element, Diagnostics.A_rest_element_must_be_last_in_an_array_destructuring_pattern);
+                    }
+                    else {
+                        const restExpression = (<SpreadElementExpression>element).expression;
+                        if (restExpression.kind === SyntaxKind.BinaryExpression && (<BinaryExpression>restExpression).operatorToken.kind === SyntaxKind.EqualsToken) {
+                            error((<BinaryExpression>restExpression).operatorToken, Diagnostics.A_rest_element_cannot_have_an_initializer);
+                        }
+                        else {
+                            return checkDestructuringAssignment(restExpression, createArrayType(elementType), contextualMapper);
                         }
                     }
                 }
             }
-            return sourceType;
         }
 
         function checkDestructuringAssignment(exprOrAssignment: Expression | ShorthandPropertyAssignment, sourceType: Type, contextualMapper?: TypeMapper): Type {
@@ -16435,6 +16444,36 @@ namespace ts {
         function getTypeOfExpression(expr: Expression): Type {
             if (isRightSideOfQualifiedNameOrPropertyAccess(expr)) {
                 expr = <Expression>expr.parent;
+            }
+            // If this is array literal or object literal from destructuring assignment
+            // handle it specially
+            if (isArrayLiteralOrObjectLiteralDestructuringPattern(expr)) {
+                // If this is from "for of"
+                //     for ( { a } of elemns) {
+                //     }
+                if (expr.parent.kind === SyntaxKind.ForOfStatement) {
+                    const iteratedType = checkRightHandSideOfForOf((<ForOfStatement>expr.parent).expression);
+                    return checkDestructuringAssignment(expr, iteratedType || unknownType);
+                }
+                // If this is from "for" initializer
+                //     for ({a } = elems[0];.....) { }
+                if (expr.parent.kind === SyntaxKind.BinaryExpression) {
+                    const iteratedType = checkExpression((<BinaryExpression>expr.parent).right);
+                    return checkDestructuringAssignment(expr, iteratedType || unknownType);
+                }
+                // If this is from nested object binding pattern
+                //     for ({ skills: { primary, secondary } } = multiRobot, i = 0; i < 1; i++) {
+                if (expr.parent.kind === SyntaxKind.PropertyAssignment) {
+                    const typeOfParentObjectLiteral = getTypeOfNode(expr.parent.parent);
+                    return checkObjectLiteralDestructuringPropertyAssignment(typeOfParentObjectLiteral, <ObjectLiteralElement>expr.parent);
+                }
+                // Array literal assignment - array destructuring pattern
+                Debug.assert(expr.parent.kind === SyntaxKind.ArrayLiteralExpression);
+                //    [{ property1: p1, property2 }] = elems;
+                const typeOfArrayLiteral = getTypeOfNode(expr.parent);
+                const elementType = checkIteratedTypeOrElementType(typeOfArrayLiteral, expr.parent, /*allowStringInput*/ false) || unknownType;
+                return checkArrayLiteralDestructuringElementAssignment(<ArrayLiteralExpression>expr.parent, typeOfArrayLiteral,
+                    expr, indexOf((<ArrayLiteralExpression>expr.parent).elements, expr), elementType);
             }
             return checkExpression(expr);
         }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -358,6 +358,36 @@ namespace ts {
             declaration.parent.kind === SyntaxKind.CatchClause;
     }
 
+    export function isArrayLiteralOrObjectLiteralDestructuringPattern(node: Node) {
+        if (node.kind === SyntaxKind.ArrayLiteralExpression ||
+            node.kind === SyntaxKind.ObjectLiteralExpression) {
+            // [a,b,c] from:
+            // [a, b, c] = someExpression;
+            if (node.parent.kind === SyntaxKind.BinaryExpression &&
+                (<BinaryExpression>node.parent).left === node &&
+                (<BinaryExpression>node.parent).operatorToken.kind === SyntaxKind.EqualsToken) {
+                return true;
+            }
+
+            // [a, b, c] from:
+            // for([a, b, c] of expression)
+            if (node.parent.kind === SyntaxKind.ForOfStatement &&
+                (<ForOfStatement>node.parent).initializer === node) {
+                return true;
+            }
+
+            // [a, b, c] of
+            // [x, [a, b, c] ] = someExpression
+            // or 
+            // {x, a: {a, b, c} } = someExpression
+            if (isArrayLiteralOrObjectLiteralDestructuringPattern(node.parent.kind === SyntaxKind.PropertyAssignment ? node.parent.parent : node.parent)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     // Return display name of an identifier
     // Computed property names will just be emitted as "[<expr>]", where <expr> is the source
     // text of the expression in the computed property.

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -6087,6 +6087,19 @@ namespace ts {
                 // The search set contains at least the current symbol
                 let result = [symbol];
 
+                // If the location is name of property symbol from object literal destructuring pattern
+                // Search the property symbol
+                //      for ( { property: p2 } of elems) { }
+                if (isNameOfPropertyAssignment(location) &&
+                    location.parent.kind !== SyntaxKind.ShorthandPropertyAssignment &&
+                    isArrayLiteralOrObjectLiteralDestructuringPattern(location.parent.parent)) {
+                    const typeOfObjectLiteral = typeChecker.getTypeAtLocation(location.parent.parent);
+                    if (typeOfObjectLiteral) {
+                        const propertySymbol = typeChecker.getPropertyOfType(typeOfObjectLiteral, (<Identifier>location).text);
+                        result.push(propertySymbol);
+                    }
+                }
+
                 // If the symbol is an alias, add what it aliases to the list
                 //     import {a} from "mod";
                 //     export {a}
@@ -6234,13 +6247,32 @@ namespace ts {
                     return getRelatedSymbol(searchSymbols, aliasedSymbol, referenceLocation);
                 }
 
+
                 // If the reference location is in an object literal, try to get the contextual type for the
                 // object literal, lookup the property symbol in the contextual type, and use this symbol to
                 // compare to our searchSymbol
                 if (isNameOfPropertyAssignment(referenceLocation)) {
-                    return forEach(getPropertySymbolsFromContextualType(referenceLocation), contextualSymbol => {
+                    const contexualSymbol = forEach(getPropertySymbolsFromContextualType(referenceLocation), contextualSymbol => {
                         return forEach(typeChecker.getRootSymbols(contextualSymbol), s => searchSymbols.indexOf(s) >= 0 ? s : undefined);
                     });
+
+                    if (contexualSymbol) {
+                        return contexualSymbol;
+                    }
+
+                    // If the reference location is name of property symbol from object literal destructuring pattern
+                    // Compare it to search symbol something similar to 'property' from
+                    //      for ( { property: p2 } of elems) { }
+                    if (isArrayLiteralOrObjectLiteralDestructuringPattern(referenceLocation.parent.parent)) {
+                        // Do work to determine if this is property symbol corresponding to the search symbol
+                        const typeOfObjectLiteral = typeChecker.getTypeAtLocation(referenceLocation.parent.parent);
+                        if (typeOfObjectLiteral) {
+                            const propertySymbol = typeChecker.getPropertyOfType(typeOfObjectLiteral, (<Identifier>referenceLocation).text);
+                            if (searchSymbols.indexOf(propertySymbol) >= 0) {
+                                return propertySymbol;
+                            }
+                        }
+                    }
                 }
 
                 // If the reference location is the binding element and doesn't have property name 

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -582,36 +582,6 @@ namespace ts {
         }
         return true;
     }
-
-    export function isArrayLiteralOrObjectLiteralDestructuringPattern(node: Node) {
-        if (node.kind === SyntaxKind.ArrayLiteralExpression ||
-            node.kind === SyntaxKind.ObjectLiteralExpression) {
-            // [a,b,c] from:
-            // [a, b, c] = someExpression;
-            if (node.parent.kind === SyntaxKind.BinaryExpression &&
-                (<BinaryExpression>node.parent).left === node && 
-                (<BinaryExpression>node.parent).operatorToken.kind === SyntaxKind.EqualsToken) {
-                return true;
-            }
-
-            // [a, b, c] from:
-            // for([a, b, c] of expression)
-            if (node.parent.kind === SyntaxKind.ForOfStatement &&
-                (<ForOfStatement>node.parent).initializer === node) {
-                return true;
-            }
-
-            // [a, b, c] of
-            // [x, [a, b, c] ] = someExpression
-            // or 
-            // {x, a: {a, b, c} } = someExpression
-            if (isArrayLiteralOrObjectLiteralDestructuringPattern(node.parent.kind === SyntaxKind.PropertyAssignment ? node.parent.parent : node.parent)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
 }
 
 // Display-part writer helpers

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName03.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName03.ts
@@ -6,7 +6,7 @@
 ////}
 ////
 ////var foo: I;
-////var [{ [|property1|]: prop1 }, { property1, property2 } ] = [foo, foo];
+////var [{ [|property1|]: prop1 }, { [|property1|], property2 } ] = [foo, foo];
 
 let ranges = test.ranges();
 for (let range of ranges) {

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName04.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName04.ts
@@ -6,14 +6,12 @@
 ////}
 ////
 ////function f({ /**/[|property1|]: p1 }: I,
-////           { /*SHOULD_BE_A_REFERENCE*/property1 }: I,
+////           { [|property1|] }: I,
 ////           { property1: p2 }) {
 ////
-////    return property1 + 1;
+////    return [|property1|] + 1;
 ////}
 
-// NOTE: In the future, the identifier at
-//       SHOULD_BE_A_REFERENCE should be in the set of ranges.
 goTo.marker();
 
 let ranges = test.ranges();

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName06.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName06.ts
@@ -13,7 +13,7 @@
 ////for (var { [|property1|]: p1 } of elems) {
 ////}
 ////var p2;
-////for ({ /*This should be referenced too*/property1 : p2 } of elems) {
+////for ({ [|property1|] : p2 } of elems) {
 ////}
 
 // Note: if this test ever changes, consider updating

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName06.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName06.ts
@@ -8,12 +8,12 @@
 ////var elems: I[];
 ////for (let { [|property1|]: p } of elems) {
 ////}
-////for (let { property1 } of elems) {
+////for (let { [|property1|] } of elems) {
 ////}
 ////for (var { [|property1|]: p1 } of elems) {
 ////}
 ////var p2;
-////for ({ property1 : p2 } of elems) {
+////for ({ /*This should be referenced too*/property1 : p2 } of elems) {
 ////}
 
 // Note: if this test ever changes, consider updating
@@ -23,6 +23,7 @@ let ranges = test.ranges();
 for (let range of ranges) {
     goTo.position(range.start);
 
+    debugger;
     verify.referencesCountIs(ranges.length);
     for (let expectedRange of ranges) {
         verify.referencesAtPositionContains(expectedRange);

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName09.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName09.ts
@@ -1,19 +1,17 @@
 /// <reference path='fourslash.ts'/>
 
 ////interface I {
-////    /*SHOULD_BE_A_REFERENCE1*/property1: number;
+////    [|property1|]: number;
 ////    property2: string;
 ////}
 ////
-////function f({ /*SHOULD_BE_A_REFERENCE2*/property1: p1 }: I,
+////function f({ [|property1|]: p1 }: I,
 ////           { /**/[|property1|] }: I,
 ////           { property1: p2 }) {
 ////
 ////    return [|property1|] + 1;
 ////}
 
-// NOTE: In the future, the identifiers at
-//       SHOULD_BE_A_REFERENCE[1/2] should be in the set of ranges.
 goTo.marker();
 
 let ranges = test.ranges();

--- a/tests/cases/fourslash/renameDestructuringAssignmentInFor.ts
+++ b/tests/cases/fourslash/renameDestructuringAssignmentInFor.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+////interface I {
+////    /*1*/[|property1|]: number;
+////    property2: string;
+////}
+////var elems: I[];
+////
+////var p2: number, property1: number;
+////for ({ [|property1|] } = elems[0]; p2 < 100; p2++) {
+////   p2 = property1++;
+////}
+////for ({ /*2*/[|property1|]: p2 } = elems[0]; p2 < 100; p2++) {
+////}
+
+goTo.marker("1");
+verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+
+goTo.marker("2");
+verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);

--- a/tests/cases/fourslash/renameDestructuringAssignmentInFor2.ts
+++ b/tests/cases/fourslash/renameDestructuringAssignmentInFor2.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+////interface I {
+////    property1: number;
+////    property2: string;
+////}
+////var elems: I[];
+////
+////var p2: number, [|property1|]: number;
+////for ({ [|property1|] } = elems[0]; p2 < 100; p2++) {
+////   p2 = [|property1|]++;
+////}
+////for ({ property1: p2 } = elems[0]; p2 < 100; p2++) {
+////}
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}

--- a/tests/cases/fourslash/renameDestructuringAssignmentInForOf.ts
+++ b/tests/cases/fourslash/renameDestructuringAssignmentInForOf.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+////interface I {
+////    /*1*/[|property1|]: number;
+////    property2: string;
+////}
+////var elems: I[];
+////
+////var property1: number, p2: number;
+////for ({ [|property1|] } of elems) {
+////    property1++;
+////}
+////for ({ /*2*/[|property1|]: p2 } of elems) {
+////}
+
+goTo.marker("1");
+verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+
+goTo.marker("2");
+verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);

--- a/tests/cases/fourslash/renameDestructuringAssignmentInForOf2.ts
+++ b/tests/cases/fourslash/renameDestructuringAssignmentInForOf2.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+////interface I {
+////    property1: number;
+////    property2: string;
+////}
+////var elems: I[];
+////
+////var [|property1|]: number, p2: number;
+////for ({ [|property1|] } of elems) {
+////    [|property1|]++;
+////}
+////for ({ property1: p2 } of elems) {
+////}
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}

--- a/tests/cases/fourslash/renameDestructuringAssignmentNestedInArrayLiteral.ts
+++ b/tests/cases/fourslash/renameDestructuringAssignmentNestedInArrayLiteral.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+////interface I {
+////    /*1*/[|property1|]: number;
+////    property2: string;
+////}
+////var elems: I[], p1: number, property1: number;
+////[{ /*2*/[|property1|]: p1 }] = elems;
+////[{ [|property1|] }] = elems;
+
+goTo.marker("1");
+verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+
+goTo.marker("2");
+verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);

--- a/tests/cases/fourslash/renameDestructuringAssignmentNestedInArrayLiteral2.ts
+++ b/tests/cases/fourslash/renameDestructuringAssignmentNestedInArrayLiteral2.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+////interface I {
+////    property1: number;
+////    property2: string;
+////}
+////var elems: I[], p1: number, [|property1|]: number;
+////[{ property1: p1 }] = elems;
+////[{ [|property1|] }] = elems;
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}

--- a/tests/cases/fourslash/renameDestructuringAssignmentNestedInFor.ts
+++ b/tests/cases/fourslash/renameDestructuringAssignmentNestedInFor.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+////interface MultiRobot {
+////    name: string;
+////    skills: {
+////        /*1*/[|primary|]: string;
+////        secondary: string;
+////    };
+////}
+////let multiRobot: MultiRobot;
+////for ({ skills: { /*2*/[|primary|]: primaryA, secondary: secondaryA } } = multiRobot, i = 0; i < 1; i++) {
+////    console.log(primaryA);
+////}
+////for ({ skills: { [|primary|], secondary } } = multiRobot, i = 0; i < 1; i++) {
+////    console.log(primary);
+////}
+
+goTo.marker("1");
+verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+
+goTo.marker("2");
+verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);

--- a/tests/cases/fourslash/renameDestructuringAssignmentNestedInFor2.ts
+++ b/tests/cases/fourslash/renameDestructuringAssignmentNestedInFor2.ts
@@ -1,0 +1,23 @@
+/// <reference path='fourslash.ts' />
+
+////interface MultiRobot {
+////    name: string;
+////    skills: {
+////        primary: string;
+////        secondary: string;
+////    };
+////}
+////let multiRobot: MultiRobot, [|primary|]: string;
+////for ({ skills: { primary: primaryA, secondary: secondaryA } } = multiRobot, i = 0; i < 1; i++) {
+////    console.log(primaryA);
+////}
+////for ({ skills: { [|primary|], secondary } } = multiRobot, i = 0; i < 1; i++) {
+////    console.log([|primary|]);
+////}
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}
+

--- a/tests/cases/fourslash/renameDestructuringAssignmentNestedInForOf.ts
+++ b/tests/cases/fourslash/renameDestructuringAssignmentNestedInForOf.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+////interface MultiRobot {
+////    name: string;
+////    skills: {
+////        /*1*/[|primary|]: string;
+////        secondary: string;
+////    };
+////}
+////let multiRobots: MultiRobot[];
+////for ({ skills: { /*2*/[|primary|]: primaryA, secondary: secondaryA } } of multiRobots) {
+////    console.log(primaryA);
+////}
+////for ({ skills: { [|primary|], secondary } } of multiRobots) {
+////    console.log(primary);
+////}
+
+goTo.marker("1");
+verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+
+goTo.marker("2");
+verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);

--- a/tests/cases/fourslash/renameDestructuringAssignmentNestedInForOf2.ts
+++ b/tests/cases/fourslash/renameDestructuringAssignmentNestedInForOf2.ts
@@ -1,0 +1,23 @@
+/// <reference path='fourslash.ts' />
+
+////interface MultiRobot {
+////    name: string;
+////    skills: {
+////        primary: string;
+////        secondary: string;
+////    };
+////}
+////let multiRobots: MultiRobot[], [|primary|]: string;
+////for ({ skills: { primary: primaryA, secondary: secondaryA } } of multiRobots) {
+////    console.log(primaryA);
+////}
+////for ({ skills: { [|primary|], secondary } } of multiRobots) {
+////    console.log([|primary|]);
+////}
+
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}

--- a/tests/cases/fourslash/renameDestructuringClassProperty.ts
+++ b/tests/cases/fourslash/renameDestructuringClassProperty.ts
@@ -1,0 +1,23 @@
+/// <reference path='fourslash.ts' />
+
+////class A {
+////    [|foo|]: string;
+////}
+////class B {
+////    syntax1(a: A): void {
+////        let { [|foo|] } = a;
+////    }
+////    syntax2(a: A): void {
+////        let { [|foo|]: foo } = a;
+////    }
+////    syntax11(a: A): void {
+////        let { [|foo|] } = a;
+////        [|foo|] = "newString";
+////    }
+////}
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}

--- a/tests/cases/fourslash/renameDestructuringDeclarationInFor.ts
+++ b/tests/cases/fourslash/renameDestructuringDeclarationInFor.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+////interface I {
+////    [|property1|]: number;
+////    property2: string;
+////}
+////var elems: I[];
+////
+////var p2: number, property1: number;
+////for (let { [|property1|]: p2 } = elems[0]; p2 < 100; p2++) {
+////}
+////for (let { [|property1|] } = elems[0]; p2 < 100; p2++) {
+////    [|property1|] = p2;
+////}
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}

--- a/tests/cases/fourslash/renameDestructuringDeclarationInForOf.ts
+++ b/tests/cases/fourslash/renameDestructuringDeclarationInForOf.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts' />
+
+////interface I {
+////    [|property1|]: number;
+////    property2: string;
+////}
+////var elems: I[];
+////
+////for (let { [|property1|] } of elems) {
+////    [|property1|]++;
+////}
+////for (let { [|property1|]: p2 } of elems) {
+////}
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}

--- a/tests/cases/fourslash/renameDestructuringFunctionParameter.ts
+++ b/tests/cases/fourslash/renameDestructuringFunctionParameter.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts' />
+
+////function f({[|a|]}: {[|a|]}) {
+////    f({[|a|]});
+////}
+let ranges = test.ranges();
+for (let range of ranges) {
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}

--- a/tests/cases/fourslash/renameDestructuringNestedBindingElement.ts
+++ b/tests/cases/fourslash/renameDestructuringNestedBindingElement.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+////interface MultiRobot {
+////    name: string;
+////    skills: {
+////        [|primary|]: string;
+////        secondary: string;
+////    };
+////}
+////let multiRobots: MultiRobot[];
+////for (let { skills: {[|primary|]: primaryA, secondary: secondaryA } } of multiRobots) {
+////    console.log(primaryA);
+////}
+////for (let { skills: {[|primary|], secondary } } of multiRobots) {
+////    console.log([|primary|]);
+////}
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}

--- a/tests/cases/fourslash/renameImportAndExportInDiffFiles.ts
+++ b/tests/cases/fourslash/renameImportAndExportInDiffFiles.ts
@@ -1,0 +1,18 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: a.ts
+////export var /*1*/a;
+
+// @Filename: b.ts
+////import { /*2*/a } from './a';
+////export { /*3*/a };
+
+goTo.file("a.ts");
+goTo.marker("1");
+
+goTo.file("b.ts");
+goTo.marker("2");
+verify.referencesCountIs(3);
+
+goTo.marker("3");
+verify.referencesCountIs(3);


### PR DESCRIPTION
Note this doesn't fix the rename on default imports, that I will fix separately to avoid making this change bigger than it is.
Fixes # #6312 
