### PR TITLE
[Transforms] Fixes issues that were causing runtests-browser to fail

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -909,7 +909,7 @@ compileFile(nodeServerOutFile, [nodeServerInFile], [builtLocalDirectory, tscFile
 
 desc("Runs browserify on run.js to produce a file suitable for running tests in the browser");
 task("browserify", ["tests", builtLocalDirectory, nodeServerOutFile], function() {
-    var cmd = 'browserify built/local/run.js -o built/local/bundle.js';
+    var cmd = 'browserify built/local/run.js -t ./scripts/browserify-optional -o built/local/bundle.js';
     exec(cmd);
 }, {async: true});
 

--- a/scripts/browserify-optional.js
+++ b/scripts/browserify-optional.js
@@ -1,0 +1,24 @@
+// simple script to optionally elide source-map-support (or other optional modules) when running browserify.
+
+var stream = require("stream"),
+    Transform = stream.Transform,
+    resolve = require("browser-resolve");
+
+var requirePattern = /require\s*\(\s*['"](source-map-support)['"]\s*\)/;
+module.exports = function (file) {
+    return new Transform({
+        transform: function (data, encoding, cb) {
+            var text = encoding === "buffer" ? data.toString("utf8") : data;
+            this.push(new Buffer(text.replace(requirePattern, function (originalText, moduleName) {
+                try {
+                    resolve.sync(moduleName, { filename: file });
+                    return originalText;
+                }
+                catch (e) {
+                    return "(function () { throw new Error(\"module '" + moduleName + "' not found.\"); })()";
+                }
+            }), "utf8"));
+            cb();
+        }
+    });
+};

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -644,7 +644,8 @@ namespace ts {
             fileExists: fileName => sys.fileExists(fileName),
             readFile: fileName => sys.readFile(fileName),
             trace: (s: string) => sys.write(s + newLine),
-            directoryExists: directoryName => sys.directoryExists(directoryName)
+            directoryExists: directoryName => sys.directoryExists(directoryName),
+            getEnvironmentVariable: sys.getEnvironmentVariable
         };
     }
 
@@ -995,7 +996,7 @@ namespace ts {
             const start = new Date().getTime();
 
             // TODO(rbuckton): remove USE_TRANSFORMS condition when we switch to transforms permanently.
-            if (/^(y(es)?|t(rue|ransforms?)?|1|\+)$/i.test(sys.getEnvironmentVariable("USE_TRANSFORMS"))) {
+            if (/^(y(es)?|t(rue|ransforms?)?|1|\+)$/i.test(getEnvironmentVariable("USE_TRANSFORMS", host))) {
                 options.experimentalTransforms = true;
             }
 

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -74,6 +74,7 @@ namespace ts {
         readDirectory(path: string, extension?: string, exclude?: string[]): string[];
         watchFile?(path: string, callback: FileWatcherCallback): FileWatcher;
         watchDirectory?(path: string, callback: DirectoryWatcherCallback, recursive?: boolean): FileWatcher;
+        getEnvironmentVariable?(name: string): string;
     };
 
     export var sys: System = (function () {
@@ -632,9 +633,7 @@ namespace ts {
                 createDirectory: ChakraHost.createDirectory,
                 getExecutingFilePath: () => ChakraHost.executingFile,
                 getCurrentDirectory: () => ChakraHost.currentDirectory,
-                getEnvironmentVariable(name: string) {
-                    return "";
-                },
+                getEnvironmentVariable: ChakraHost.getEnvironmentVariable || ((name: string) => ""),
                 readDirectory: ChakraHost.readDirectory,
                 exit: ChakraHost.quit,
             };

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2805,6 +2805,7 @@ namespace ts {
          * 'throw new Error("NotImplemented")'
          */
         resolveModuleNames?(moduleNames: string[], containingFile: string): ResolvedModule[];
+        getEnvironmentVariable?(name: string): string;
     }
 
     /* @internal */

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -169,6 +169,18 @@ namespace ts {
         return `${ file.fileName }(${ loc.line + 1 },${ loc.character + 1 })`;
     }
 
+    export function getEnvironmentVariable(name: string, host?: CompilerHost) {
+        if (host && host.getEnvironmentVariable) {
+            return host.getEnvironmentVariable(name);
+        }
+
+        if (sys && sys.getEnvironmentVariable) {
+            return sys.getEnvironmentVariable(name);
+        }
+
+        return "";
+    }
+
     export function getStartPosOfNode(node: Node): number {
         return node.pos;
     }

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -480,6 +480,8 @@ namespace Harness {
         getExecutingFilePath(): string;
         exit(exitCode?: number): void;
         readDirectory(path: string, extension?: string, exclude?: string[]): string[];
+        tryEnableSourceMapsForHost?(): void;
+        getEnvironmentVariable?(name: string): string;
     }
     export var IO: IO;
 
@@ -518,6 +520,7 @@ namespace Harness {
             export const fileExists: typeof IO.fileExists = fso.FileExists;
             export const log: typeof IO.log = global.WScript && global.WScript.StdOut.WriteLine;
             export const readDirectory: typeof IO.readDirectory = (path, extension, exclude) => ts.sys.readDirectory(path, extension, exclude);
+            export const getEnvironmentVariable: typeof IO.getEnvironmentVariable = name => ts.sys.getEnvironmentVariable(name);
 
             export function createDirectory(path: string) {
                 if (directoryExists(path)) {
@@ -587,6 +590,13 @@ namespace Harness {
             export const log: typeof IO.log = s => console.log(s);
 
             export const readDirectory: typeof IO.readDirectory = (path, extension, exclude) => ts.sys.readDirectory(path, extension, exclude);
+            export const getEnvironmentVariable: typeof IO.getEnvironmentVariable = name => ts.sys.getEnvironmentVariable(name);
+
+            export function tryEnableSourceMapsForHost() {
+                if (ts.sys.tryEnableSourceMapsForHost) {
+                    ts.sys.tryEnableSourceMapsForHost();
+                }
+            }
 
             export function createDirectory(path: string) {
                 if (!directoryExists(path)) {
@@ -1681,8 +1691,8 @@ namespace Harness {
     if (Error) (<any>Error).stackTraceLimit = 1;
 }
 
-if (ts.sys && ts.sys.tryEnableSourceMapsForHost && /^development$/i.test(ts.sys.getEnvironmentVariable("NODE_ENV"))) {
-    ts.sys.tryEnableSourceMapsForHost();
+if (Harness.IO.tryEnableSourceMapsForHost && /^development$/i.test(Harness.IO.getEnvironmentVariable("NODE_ENV"))) {
+    Harness.IO.tryEnableSourceMapsForHost();
 }
 
 // TODO: not sure why Utils.evalFile isn't working with this, eventually will concat it like old compiler instead of eval

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1681,7 +1681,7 @@ namespace Harness {
     if (Error) (<any>Error).stackTraceLimit = 1;
 }
 
-if (ts.sys.tryEnableSourceMapsForHost && /^development$/i.test(ts.sys.getEnvironmentVariable("NODE_ENV"))) {
+if (ts.sys && ts.sys.tryEnableSourceMapsForHost && /^development$/i.test(ts.sys.getEnvironmentVariable("NODE_ENV"))) {
     ts.sys.tryEnableSourceMapsForHost();
 }
 


### PR DESCRIPTION
Even with this fix, transforms are still not enabled by default when running tests in the browser, but this fixes a few issues that were blocking runtests-browser from running at all.

This also adds support for `getEnvironmentVariable` with ChakraHost..