### PR TITLE
[Transforms] Makes transforms the default

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -309,8 +309,8 @@ function compileFile(outFile, sources, prereqs, prefixes, useBuiltCompiler, opts
             options += " --stripInternal"
         }
 
-        if (useBuiltCompiler && Boolean(process.env.USE_TRANSFORMS)) {
-            console.warn("\u001b[93mwarning: Found 'USE_TRANSFORMS' environment variable. Experimental transforms will be enabled by default.\u001b[0m");
+        if (useBuiltCompiler && !/^(no?|f(alse)?|0|-)$/i.test(process.env.USE_TRANSFORMS)) {
+            console.warn("\u001b[93mwarning: 'USE_TRANSFORMS' environment variable is not set to 'false'. Experimental transforms will be enabled by default.\u001b[0m");
         }
 
         var cmd = host + " " + compilerPath + " " + options + " ";

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -333,11 +333,10 @@ namespace ts {
             description: Diagnostics.Do_not_emit_use_strict_directives_in_module_output
         },
         {
-            // this option will be removed when this is merged with master and exists solely
-            // to enable the tree transforming emitter side-by-side with the existing emitter.
-            name: "experimentalTransforms",
+            name: "useLegacyEmitter",
             type: "boolean",
-            experimental: true
+            experimental: true,
+            description: Diagnostics.Use_the_legacy_emitter_instead_of_the_transforming_emitter
         }
     ];
 

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1105,11 +1105,11 @@ namespace ts {
                 return currentAssertionLevel;
             }
 
-            const developmentMode = sys && /^development$/i.test(sys.getEnvironmentVariable("NODE_ENV"));
-            if (developmentMode === undefined) {
+            if (sys === undefined) {
                 return AssertionLevel.None;
             }
 
+            const developmentMode = /^development$/i.test(getEnvironmentVariable("NODE_ENV"));
             currentAssertionLevel = developmentMode
                 ? AssertionLevel.Normal
                 : AssertionLevel.None;

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2604,6 +2604,10 @@
         "category": "Message",
         "code": 6112
     },
+    "Use the legacy emitter instead of the transforming emitter.": {
+        "category": "Message",
+        "code": 6113
+    },
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",
         "code": 7005

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -645,7 +645,7 @@ namespace ts {
             readFile: fileName => sys.readFile(fileName),
             trace: (s: string) => sys.write(s + newLine),
             directoryExists: directoryName => sys.directoryExists(directoryName),
-            getEnvironmentVariable: sys.getEnvironmentVariable
+            getEnvironmentVariable: name => getEnvironmentVariable(name, /*host*/ undefined)
         };
     }
 
@@ -996,11 +996,12 @@ namespace ts {
             const start = new Date().getTime();
 
             // TODO(rbuckton): remove USE_TRANSFORMS condition when we switch to transforms permanently.
-            if (/^(y(es)?|t(rue|ransforms?)?|1|\+)$/i.test(getEnvironmentVariable("USE_TRANSFORMS", host))) {
-                options.experimentalTransforms = true;
+            let useLegacyEmitter = options.useLegacyEmitter;
+            if (/^(no?|f(alse)?|0|-)$/i.test(getEnvironmentVariable("USE_TRANSFORMS", host))) {
+                useLegacyEmitter = true;
             }
 
-            const fileEmitter = options.experimentalTransforms ? printFiles : emitFiles;
+            const fileEmitter = useLegacyEmitter ? emitFiles : printFiles;
             const emitResult = fileEmitter(
                 emitResolver,
                 getEmitHost(writeFileCallback),

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2498,7 +2498,7 @@ namespace ts {
         noImplicitUseStrict?: boolean;
         lib?: string[];
         /* @internal */ stripInternal?: boolean;
-        /* @internal */ experimentalTransforms?: boolean;
+        /* @internal */ useLegacyEmitter?: boolean;
 
         // Skip checking lib.d.ts to help speed up tests.
         /* @internal */ skipDefaultLibCheck?: boolean;


### PR DESCRIPTION
This makes the transforming emitter the default, which should help with running tests in the browser.

This also replaces the `--experimentalTransforms` flag with `--useLegacyEmitter`.