### PR TITLE
[Transforms] Fixes detached comment emit for constructors

### DIFF
--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -735,7 +735,14 @@ namespace ts {
             }
 
             addRange(statements, endLexicalEnvironment());
-            return createBlock(statements, /*location*/ constructor && constructor.body, /*multiLine*/ true);
+            return createBlock(
+                createNodeArray(
+                    statements,
+                    /*location*/ constructor ? constructor.body.statements : undefined
+                ),
+                /*location*/ constructor ? constructor.body : undefined,
+                /*multiLine*/ true
+            );
         }
 
         function transformConstructorBodyWithSynthesizedSuper(node: ConstructorDeclaration) {

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -829,7 +829,13 @@ namespace ts {
             // End the lexical environment.
             addNodes(statements, endLexicalEnvironment());
             return setMultiLine(
-                createBlock(statements, constructor ? constructor.body : undefined),
+                createBlock(
+                    createNodeArray(
+                        statements,
+                        /*location*/ constructor ? constructor.body.statements : undefined
+                    ),
+                    /*location*/ constructor ? constructor.body : undefined
+                ),
                 true
             );
         }


### PR DESCRIPTION
Fixes #7896.

Fixes the following failing tests:
* tests/cases/compiler/callOverloads1.ts
* tests/cases/compiler/callOverloads2.ts
* tests/cases/compiler/callOverloads3.ts
* tests/cases/compiler/callOverloads4.ts
* tests/cases/compiler/callOverloads5.ts
* tests/cases/compiler/commentsClass.ts
* tests/cases/compiler/detachedCommentAtStartOfConstructor2.ts
* tests/cases/compiler/lambdaArgCrash.ts