### PR TITLE
Use an emit helper (or Object.assign) for JsxSpreadAttributes

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -122,6 +122,7 @@ namespace ts {
         let hasAsyncFunctions: boolean;
         let hasDecorators: boolean;
         let hasParameterDecorators: boolean;
+        let hasJsxSpreadAttribute: boolean;
 
         // If this file is an external module, then it is automatically in strict-mode according to
         // ES6.  If it is not an external module, then we'll determine if it is in strict mode or
@@ -161,6 +162,7 @@ namespace ts {
             hasAsyncFunctions = false;
             hasDecorators = false;
             hasParameterDecorators = false;
+            hasJsxSpreadAttribute = false;
         }
 
         return bindSourceFile;
@@ -497,6 +499,9 @@ namespace ts {
                 }
                 if (hasAsyncFunctions) {
                     flags |= NodeFlags.HasAsyncFunctions;
+                }
+                if (hasJsxSpreadAttribute) {
+                    flags |= NodeFlags.HasJsxSpreadAttribute;
                 }
             }
 
@@ -1297,6 +1302,10 @@ namespace ts {
                     return bindPropertyOrMethodOrAccessor(<Declaration>node, SymbolFlags.Property, SymbolFlags.PropertyExcludes);
                 case SyntaxKind.EnumMember:
                     return bindPropertyOrMethodOrAccessor(<Declaration>node, SymbolFlags.EnumMember, SymbolFlags.EnumMemberExcludes);
+
+                case SyntaxKind.JsxSpreadAttribute:
+                    hasJsxSpreadAttribute = true;
+                    return;
 
                 case SyntaxKind.CallSignature:
                 case SyntaxKind.ConstructSignature:

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -347,9 +347,10 @@ var __extends = (this && this.__extends) || function (d, b) {
 
         const assignHelper = `
 var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var i = 1; i < arguments.length; i++) {
-        var s = arguments[i];
-        for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
     }
     return t;
 };`;

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -345,6 +345,15 @@ var __extends = (this && this.__extends) || function (d, b) {
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };`;
 
+        const assignHelper = `
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var i = 1, n = arguments.length; i < n; i++) {
+        var s = arguments[i];
+        if (s != null) for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+    }
+    return t;
+};`;
+
         // emit output for the __decorate helper function
         const decorateHelper = `
 var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
@@ -540,6 +549,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
             let convertedLoopState: ConvertedLoopState;
 
             let extendsEmitted: boolean;
+            let assignEmitted: boolean;
             let decorateEmitted: boolean;
             let paramEmitted: boolean;
             let awaiterEmitted: boolean;
@@ -623,6 +633,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 decorateEmitted = false;
                 paramEmitted = false;
                 awaiterEmitted = false;
+                assignEmitted = false;
                 tempFlags = 0;
                 tempVariables = undefined;
                 tempParameters = undefined;
@@ -1259,11 +1270,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     }
                     else {
                         // Either emit one big object literal (no spread attribs), or
-                        // a call to React.__spread
+                        // a call to the __assign helper
                         const attrs = openingNode.attributes;
                         if (forEach(attrs, attr => attr.kind === SyntaxKind.JsxSpreadAttribute)) {
-                            emitExpressionIdentifier(syntheticReactRef);
-                            write(".__spread(");
+                            write("__assign(");
 
                             let haveOpenedObjectLiteral = false;
                             for (let i = 0; i < attrs.length; i++) {
@@ -7701,9 +7711,14 @@ const _super = (function (geti, seti) {
                 if (!compilerOptions.noEmitHelpers) {
                     // Only Emit __extends function when target ES5.
                     // For target ES6 and above, we can emit classDeclaration as is.
-                    if ((languageVersion < ScriptTarget.ES6) && (!extendsEmitted && node.flags & NodeFlags.HasClassExtends)) {
+                    if (languageVersion < ScriptTarget.ES6 && !extendsEmitted && node.flags & NodeFlags.HasClassExtends) {
                         writeLines(extendsHelper);
                         extendsEmitted = true;
+                    }
+
+                    if (compilerOptions.jsx !== JsxEmit.Preserve && !assignEmitted && (node.flags & NodeFlags.HasJsxSpreadAttribute)) {
+                        writeLines(assignHelper);
+                        assignEmitted = true;
                     }
 
                     if (!decorateEmitted && node.flags & NodeFlags.HasDecorators) {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -347,9 +347,9 @@ var __extends = (this && this.__extends) || function (d, b) {
 
         const assignHelper = `
 var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var i = 1, n = arguments.length; i < n; i++) {
+    for (var i = 1; i < arguments.length; i++) {
         var s = arguments[i];
-        if (s != null) for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+        for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
     }
     return t;
 };`;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -405,6 +405,7 @@ namespace ts {
         JavaScriptFile =     1 << 27,  // If node was parsed in a JavaScript
         ThisNodeOrAnySubNodesHasError = 1 << 28,  // If this node or any of its children had an error
         HasAggregatedChildData = 1 << 29,  // If we've computed data from children and cached it in this node
+        HasJsxSpreadAttribute = 1 << 30,
 
         Modifier = Export | Ambient | Public | Private | Protected | Static | Abstract | Default | Async,
         AccessibilityModifier = Public | Private | Protected,

--- a/tests/baselines/reference/reactNamespaceJSXEmit.js
+++ b/tests/baselines/reference/reactNamespaceJSXEmit.js
@@ -14,9 +14,9 @@ declare var x: any;
 
 //// [reactNamespaceJSXEmit.js]
 var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var i = 1, n = arguments.length; i < n; i++) {
+    for (var i = 1; i < arguments.length; i++) {
         var s = arguments[i];
-        if (s != null) for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+        for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
     }
     return t;
 };

--- a/tests/baselines/reference/reactNamespaceJSXEmit.js
+++ b/tests/baselines/reference/reactNamespaceJSXEmit.js
@@ -13,8 +13,15 @@ declare var x: any;
 
 
 //// [reactNamespaceJSXEmit.js]
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var i = 1, n = arguments.length; i < n; i++) {
+        var s = arguments[i];
+        if (s != null) for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+    }
+    return t;
+};
 myReactLib.createElement("foo", {data: true});
 myReactLib.createElement(Bar, {x: x});
 myReactLib.createElement("x-component", null);
-myReactLib.createElement(Bar, myReactLib.__spread({}, x));
-myReactLib.createElement(Bar, myReactLib.__spread({}, x, {y: 2}));
+myReactLib.createElement(Bar, __assign({}, x));
+myReactLib.createElement(Bar, __assign({}, x, {y: 2}));

--- a/tests/baselines/reference/reactNamespaceJSXEmit.js
+++ b/tests/baselines/reference/reactNamespaceJSXEmit.js
@@ -14,9 +14,10 @@ declare var x: any;
 
 //// [reactNamespaceJSXEmit.js]
 var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var i = 1; i < arguments.length; i++) {
-        var s = arguments[i];
-        for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
     }
     return t;
 };

--- a/tests/baselines/reference/tsxExternalModuleEmit2.js
+++ b/tests/baselines/reference/tsxExternalModuleEmit2.js
@@ -20,9 +20,10 @@ declare var Foo, React;
 //// [app.js]
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var i = 1; i < arguments.length; i++) {
-        var s = arguments[i];
-        for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
     }
     return t;
 };

--- a/tests/baselines/reference/tsxExternalModuleEmit2.js
+++ b/tests/baselines/reference/tsxExternalModuleEmit2.js
@@ -20,9 +20,9 @@ declare var Foo, React;
 //// [app.js]
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var i = 1, n = arguments.length; i < n; i++) {
+    for (var i = 1; i < arguments.length; i++) {
         var s = arguments[i];
-        if (s != null) for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+        for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
     }
     return t;
 };

--- a/tests/baselines/reference/tsxExternalModuleEmit2.js
+++ b/tests/baselines/reference/tsxExternalModuleEmit2.js
@@ -19,8 +19,15 @@ declare var Foo, React;
 
 //// [app.js]
 "use strict";
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var i = 1, n = arguments.length; i < n; i++) {
+        var s = arguments[i];
+        if (s != null) for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+    }
+    return t;
+};
 var mod_1 = require('mod');
 // Should see mod_1['default'] in emit here
 React.createElement(Foo, {handler: mod_1["default"]});
 // Should see mod_1['default'] in emit here
-React.createElement(Foo, React.__spread({}, mod_1["default"]));
+React.createElement(Foo, __assign({}, mod_1["default"]));

--- a/tests/baselines/reference/tsxReactEmit2.js
+++ b/tests/baselines/reference/tsxReactEmit2.js
@@ -16,9 +16,16 @@ var spreads5 = <div x={p2} {...p1} y={p3}>{p2}</div>;
 
 
 //// [file.js]
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var i = 1, n = arguments.length; i < n; i++) {
+        var s = arguments[i];
+        if (s != null) for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+    }
+    return t;
+};
 var p1, p2, p3;
-var spreads1 = React.createElement("div", React.__spread({}, p1), p2);
-var spreads2 = React.createElement("div", React.__spread({}, p1), p2);
-var spreads3 = React.createElement("div", React.__spread({x: p3}, p1), p2);
-var spreads4 = React.createElement("div", React.__spread({}, p1, {x: p3}), p2);
-var spreads5 = React.createElement("div", React.__spread({x: p2}, p1, {y: p3}), p2);
+var spreads1 = React.createElement("div", __assign({}, p1), p2);
+var spreads2 = React.createElement("div", __assign({}, p1), p2);
+var spreads3 = React.createElement("div", __assign({x: p3}, p1), p2);
+var spreads4 = React.createElement("div", __assign({}, p1, {x: p3}), p2);
+var spreads5 = React.createElement("div", __assign({x: p2}, p1, {y: p3}), p2);

--- a/tests/baselines/reference/tsxReactEmit2.js
+++ b/tests/baselines/reference/tsxReactEmit2.js
@@ -17,9 +17,9 @@ var spreads5 = <div x={p2} {...p1} y={p3}>{p2}</div>;
 
 //// [file.js]
 var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var i = 1, n = arguments.length; i < n; i++) {
+    for (var i = 1; i < arguments.length; i++) {
         var s = arguments[i];
-        if (s != null) for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+        for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
     }
     return t;
 };

--- a/tests/baselines/reference/tsxReactEmit2.js
+++ b/tests/baselines/reference/tsxReactEmit2.js
@@ -17,9 +17,10 @@ var spreads5 = <div x={p2} {...p1} y={p3}>{p2}</div>;
 
 //// [file.js]
 var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var i = 1; i < arguments.length; i++) {
-        var s = arguments[i];
-        for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
     }
     return t;
 };

--- a/tests/baselines/reference/tsxReactEmit4.js
+++ b/tests/baselines/reference/tsxReactEmit4.js
@@ -19,9 +19,10 @@ var spread1 = <div {...p} x={0} />;
 
 //// [file.js]
 var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var i = 1; i < arguments.length; i++) {
-        var s = arguments[i];
-        for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
     }
     return t;
 };

--- a/tests/baselines/reference/tsxReactEmit4.js
+++ b/tests/baselines/reference/tsxReactEmit4.js
@@ -18,7 +18,14 @@ var openClosed1 = <div>
 var spread1 = <div {...p} x={0} />;
 
 //// [file.js]
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var i = 1, n = arguments.length; i < n; i++) {
+        var s = arguments[i];
+        if (s != null) for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+    }
+    return t;
+};
 var p;
 var openClosed1 = React.createElement("div", null, blah);
 // Should emit React.__spread({}, p, {x: 0})
-var spread1 = React.createElement("div", React.__spread({}, p, {x: 0}));
+var spread1 = React.createElement("div", __assign({}, p, {x: 0}));

--- a/tests/baselines/reference/tsxReactEmit4.js
+++ b/tests/baselines/reference/tsxReactEmit4.js
@@ -19,9 +19,9 @@ var spread1 = <div {...p} x={0} />;
 
 //// [file.js]
 var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var i = 1, n = arguments.length; i < n; i++) {
+    for (var i = 1; i < arguments.length; i++) {
         var s = arguments[i];
-        if (s != null) for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+        for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
     }
     return t;
 };

--- a/tests/baselines/reference/tsxReactEmit5.js
+++ b/tests/baselines/reference/tsxReactEmit5.js
@@ -24,9 +24,9 @@ var spread1 = <div x='' {...foo} y='' />;
 //// [react-consumer.js]
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var i = 1, n = arguments.length; i < n; i++) {
+    for (var i = 1; i < arguments.length; i++) {
         var s = arguments[i];
-        if (s != null) for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+        for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
     }
     return t;
 };

--- a/tests/baselines/reference/tsxReactEmit5.js
+++ b/tests/baselines/reference/tsxReactEmit5.js
@@ -24,9 +24,10 @@ var spread1 = <div x='' {...foo} y='' />;
 //// [react-consumer.js]
 "use strict";
 var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var i = 1; i < arguments.length; i++) {
-        var s = arguments[i];
-        for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
     }
     return t;
 };

--- a/tests/baselines/reference/tsxReactEmit5.js
+++ b/tests/baselines/reference/tsxReactEmit5.js
@@ -23,8 +23,15 @@ var spread1 = <div x='' {...foo} y='' />;
 //// [file.js]
 //// [react-consumer.js]
 "use strict";
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var i = 1, n = arguments.length; i < n; i++) {
+        var s = arguments[i];
+        if (s != null) for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+    }
+    return t;
+};
 var test_1 = require("./test");
 // Should emit test_1.React.createElement
 //  and React.__spread
 var foo;
-var spread1 = test_1.React.createElement("div", test_1.React.__spread({x: ''}, foo, {y: ''}));
+var spread1 = test_1.React.createElement("div", __assign({x: ''}, foo, {y: ''}));

--- a/tests/baselines/reference/tsxReactEmit6.js
+++ b/tests/baselines/reference/tsxReactEmit6.js
@@ -28,6 +28,13 @@ namespace M {
 
 //// [file.js]
 //// [react-consumer.js]
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var i = 1, n = arguments.length; i < n; i++) {
+        var s = arguments[i];
+        if (s != null) for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+    }
+    return t;
+};
 var M;
 (function (M) {
 })(M || (M = {}));
@@ -36,7 +43,7 @@ var M;
     // Should emit M.React.createElement
     //  and M.React.__spread
     var foo;
-    var spread1 = M.React.createElement("div", M.React.__spread({x: ''}, foo, {y: ''}));
+    var spread1 = M.React.createElement("div", __assign({x: ''}, foo, {y: ''}));
     // Quotes
     var x = M.React.createElement("div", null, "This \"quote\" thing");
 })(M || (M = {}));

--- a/tests/baselines/reference/tsxReactEmit6.js
+++ b/tests/baselines/reference/tsxReactEmit6.js
@@ -29,9 +29,9 @@ namespace M {
 //// [file.js]
 //// [react-consumer.js]
 var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var i = 1, n = arguments.length; i < n; i++) {
+    for (var i = 1; i < arguments.length; i++) {
         var s = arguments[i];
-        if (s != null) for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+        for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
     }
     return t;
 };

--- a/tests/baselines/reference/tsxReactEmit6.js
+++ b/tests/baselines/reference/tsxReactEmit6.js
@@ -29,9 +29,10 @@ namespace M {
 //// [file.js]
 //// [react-consumer.js]
 var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var i = 1; i < arguments.length; i++) {
-        var s = arguments[i];
-        for (var p in s) if (s.hasOwnProperty(p)) t[p] = s[p];
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
     }
     return t;
 };


### PR DESCRIPTION
This PR introduces an `__assign` helper that we can leverage for React emit, as well as object spread properties down the road (with some tweaking).

Fixes #7270.

@rbuckton @RyanCavanaugh @mhegazy 