### PR TITLE
[Transforms] fix `_this = this` capture emitted before `"use strict"` directives in AMD module output 

### DIFF
--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -1252,6 +1252,14 @@ namespace ts {
         return (node.expression as StringLiteral).text === "use strict";
     }
 
+    /**
+     * Add any necessary prologue-directives into target statement-array.
+     * The function needs to be called during each transformation steps.
+     * 
+     * @param target: result statements array
+     * @param source: origin statements array
+     * @param ensureUseStrict: boolean determining whether the function need to add prologue-directives
+     */
     export function addPrologueDirectives(target: Statement[], source: Statement[], ensureUseStrict?: boolean): number {
         let foundUseStrict = false;
         for (let i = 0; i < source.length; i++) {
@@ -1260,11 +1268,11 @@ namespace ts {
                     foundUseStrict = true;
                 }
 
-                target.push(source[i]);
+                target.unshift(source[i]);
             }
             else {
                 if (ensureUseStrict && !foundUseStrict) {
-                    target.push(startOnNewLine(createStatement(createLiteral("use strict"))));
+                    target.unshift(startOnNewLine(createStatement(createLiteral("use strict"))));
                 }
 
                 return i;

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -1254,7 +1254,9 @@ namespace ts {
 
     /**
      * Add any necessary prologue-directives into target statement-array.
-     * The function needs to be called during each transformation steps.
+     * The function needs to be called during each transformation step.
+     * This function needs to be called whenever we transform the statement
+     * list of a source file, namespace, or function-like body.
      * 
      * @param target: result statements array
      * @param source: origin statements array

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -1261,6 +1261,7 @@ namespace ts {
      * @param ensureUseStrict: boolean determining whether the function need to add prologue-directives
      */
     export function addPrologueDirectives(target: Statement[], source: Statement[], ensureUseStrict?: boolean): number {
+        Debug.assert(target.length === 0, "PrologueDirectives should be at the first statement in the target statements array");
         let foundUseStrict = false;
         for (let i = 0; i < source.length; i++) {
             if (isPrologueDirective(source[i])) {
@@ -1268,11 +1269,11 @@ namespace ts {
                     foundUseStrict = true;
                 }
 
-                target.unshift(source[i]);
+                target.push(source[i]);
             }
             else {
                 if (ensureUseStrict && !foundUseStrict) {
-                    target.unshift(startOnNewLine(createStatement(createLiteral("use strict"))));
+                    target.push(startOnNewLine(createStatement(createLiteral("use strict"))));
                 }
 
                 return i;

--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -1217,7 +1217,8 @@ namespace ts {
             const body = node.body;
             if (isBlock(body)) {
                 statementsLocation = body.statements;
-                addRange(statements, visitNodes(body.statements, visitor, isStatement));
+                const statementOffset = addPrologueDirectives(statements, body.statements, /*ensureUseStrict*/ !context.getCompilerOptions().noImplicitUseStrict);
+                addRange(statements, visitNodes(body.statements, visitor, isStatement, statementOffset));
 
                 // If the original body was a multi-line block, this must be a multi-line block.
                 if (!multiLine && body.multiLine) {

--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -1204,7 +1204,15 @@ namespace ts {
             let statementsLocation: TextRange;
 
             const statements: Statement[] = [];
+            const body = node.body;
+            let statementOffset: number;
+
             startLexicalEnvironment();
+            if (isBlock(body)) {
+                // ensureUseStrict is false because no new prologue-directive should be added.
+                // addPrologueDirectives will simply put already-existing directives at the beginning of the target statement-array
+                statementOffset = addPrologueDirectives(statements, body.statements, /*ensureUseStrict*/ false);
+            }
             addCaptureThisForNodeIfNeeded(statements, node);
             addDefaultValueAssignmentsIfNeeded(statements, node);
             addRestParameterIfNeeded(statements, node, /*inConstructorWithSynthesizedSuper*/ false);
@@ -1214,12 +1222,8 @@ namespace ts {
                 multiLine = true;
             }
 
-            const body = node.body;
             if (isBlock(body)) {
                 statementsLocation = body.statements;
-                // ensureUseStrict is false because no new prologue-directive should be added.
-                // the function will simply put already existed directive as a first statement in the target statement-array.
-                const statementOffset = addPrologueDirectives(statements, body.statements, /*ensureUseStrict*/ false);
                 addRange(statements, visitNodes(body.statements, visitor, isStatement, statementOffset));
 
                 // If the original body was a multi-line block, this must be a multi-line block.

--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -1217,7 +1217,9 @@ namespace ts {
             const body = node.body;
             if (isBlock(body)) {
                 statementsLocation = body.statements;
-                const statementOffset = addPrologueDirectives(statements, body.statements, /*ensureUseStrict*/ !context.getCompilerOptions().noImplicitUseStrict);
+                // ensureUseStrict is false because no new prologue-directive should be added.
+                // the function will simply put already existed directive as a first statement in the target statement-array.
+                const statementOffset = addPrologueDirectives(statements, body.statements, /*ensureUseStrict*/ false);
                 addRange(statements, visitNodes(body.statements, visitor, isStatement, statementOffset));
 
                 // If the original body was a multi-line block, this must be a multi-line block.

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -188,7 +188,7 @@ namespace ts {
             startLexicalEnvironment();
 
             // Add any prologue directives.
-            const statementOffset = addPrologueDirectives(statements, node.statements, !compilerOptions.noImplicitUseStrict);
+            const statementOffset = addPrologueDirectives(statements, node.statements, /*ensureUseStrict*/ !compilerOptions.noImplicitUseStrict);
 
             // var __moduleName = context_1 && context_1.id;
             addNode(statements,


### PR DESCRIPTION
Fix issue #7913 