### PR TITLE
[Transforms] Correct destructuring assignment to empty object

### DIFF
--- a/src/compiler/transformers/destructuring.ts
+++ b/src/compiler/transformers/destructuring.ts
@@ -17,10 +17,16 @@ namespace ts {
         node: BinaryExpression,
         needsValue: boolean,
         recordTempVariable: (node: Identifier) => void,
-        visitor?: (node: Node) => VisitResult<Node>) {
+        visitor?: (node: Node) => VisitResult<Node>): Expression {
 
         if (isEmptyObjectLiteralOrArrayLiteral(node.left)) {
-            return node.right;
+            const right = node.right;
+            if (isDestructuringAssignment(right)) {
+                return flattenDestructuringAssignment(context, right, needsValue, recordTempVariable, visitor);
+            }
+            else {
+                return node.right;
+            }
         }
 
         let location: TextRange = node;

--- a/tests/baselines/reference/emptyAssignmentPatterns02_ES5.js
+++ b/tests/baselines/reference/emptyAssignmentPatterns02_ES5.js
@@ -9,8 +9,8 @@ let x, y, z, a1, a2, a3;
 //// [emptyAssignmentPatterns02_ES5.js]
 var a;
 var x, y, z, a1, a2, a3;
-((x = a.x, y = a.y, z = a.z, a));
-((a1 = a[0], a2 = a[1], a3 = a[2], a));
+(x = a.x, y = a.y, z = a.z, a);
+(a1 = a[0], a2 = a[1], a3 = a[2], a);
 
 
 //// [emptyAssignmentPatterns02_ES5.d.ts]


### PR DESCRIPTION
Fixes #7863

Previously, chained destructuring object assignments would fail when the leftmost target was empty because the shortcut code would forget to check whether the right-hand side was also a destructuring assignment.