### PR TITLE
Only emit rest param code for identifiers.

### DIFF
--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -924,7 +924,7 @@ namespace ts {
          *                                          synthesized call to `super`
          */
         function shouldAddRestParameter(node: ParameterDeclaration, inConstructorWithSynthesizedSuper: boolean) {
-            return node && node.dotDotDotToken && !inConstructorWithSynthesizedSuper;
+            return node && node.dotDotDotToken && node.name.kind === SyntaxKind.Identifier && !inConstructorWithSynthesizedSuper;
         }
 
         /**


### PR DESCRIPTION
Fixes #7890

Destructuring of array binding and object binding patterns in rest parameter position is not supported yet. So just skip emit for now.