### PR TITLE
Prefer ChakraHost when available to node and WScript

### DIFF
--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -642,16 +642,16 @@ namespace ts {
             };
         }
 
-        if (typeof WScript !== "undefined" && typeof ActiveXObject === "function") {
+        if (typeof ChakraHost !== "undefined") {
+            return getChakraSystem();
+        }
+        else if (typeof WScript !== "undefined" && typeof ActiveXObject === "function") {
             return getWScriptSystem();
         }
         else if (typeof process !== "undefined" && process.nextTick && !process.browser && typeof require !== "undefined") {
             // process and process.nextTick checks if current environment is node-like
             // process.browser check excludes webpack and browserify
             return getNodeSystem();
-        }
-        else if (typeof ChakraHost !== "undefined") {
-            return getChakraSystem();
         }
         else {
             return undefined; // Unsupported host


### PR DESCRIPTION
ChakraHost is a great abstraction API for running tsc in exotic hosts.

However, some of such hosts may fully or partially emulate node API. It would help if tsc abstraction were accessible regardless of the platform layer emulation.

By detecting `ChakraHost` before `node` and `WScript` this explicit abstraction mode kicks in regardless of the platform.