### PR TITLE
include type reference directives in .d.ts. files

### DIFF
--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -15,7 +15,7 @@ namespace ts {
         reportedDeclarationError: boolean;
         moduleElementDeclarationEmitInfo: ModuleElementDeclarationEmitInfo[];
         synchronousDeclarationOutput: string;
-        referencePathsOutput: string;
+        referencesOutput: string;
     }
 
     type GetSymbolAccessibilityDiagnostic = (symbolAccessibilityResult: SymbolAccessibilityResult) => SymbolAccessibilityDiagnostic;
@@ -73,7 +73,9 @@ namespace ts {
         // Contains the reference paths that needs to go in the declaration file.
         // Collecting this separately because reference paths need to be first thing in the declaration file
         // and we could be collecting these paths from multiple files into single one with --out option
-        let referencePathsOutput = "";
+        let referencesOutput = "";
+
+        let usedTypeDirectiveReferences: Map<string>;
 
         // Emit references corresponding to each file
         const emittedReferencedFiles: SourceFile[] = [];
@@ -153,11 +155,19 @@ namespace ts {
             }
         });
 
+        if (usedTypeDirectiveReferences) {
+            for (const directive in usedTypeDirectiveReferences) {
+                if (hasProperty(usedTypeDirectiveReferences, directive)) {
+                    referencesOutput += `/// <reference types="${directive}" />${newLine}`;
+                }
+            }
+        }
+
         return {
             reportedDeclarationError,
             moduleElementDeclarationEmitInfo: allSourcesModuleElementDeclarationEmitInfo,
             synchronousDeclarationOutput: writer.getText(),
-            referencePathsOutput,
+            referencesOutput,
         };
 
         function hasInternalAnnotation(range: CommentRange) {
@@ -253,6 +263,21 @@ namespace ts {
             setWriter(oldWriter);
         }
 
+        function recordTypeReferenceDirectivesIfNecessary(typeReferenceDirectives: string[]): void {
+            if (!typeReferenceDirectives) {
+                return;
+            }
+
+            if (!usedTypeDirectiveReferences) {
+                usedTypeDirectiveReferences = {};
+            }
+            for (const directive of typeReferenceDirectives) {
+                if (!hasProperty(usedTypeDirectiveReferences, directive)) {
+                    usedTypeDirectiveReferences[directive] = directive;
+                }
+            }
+        }
+
         function handleSymbolAccessibilityError(symbolAccessibilityResult: SymbolAccessibilityResult) {
             if (symbolAccessibilityResult.accessibility === SymbolAccessibility.Accessible) {
                 // write the aliases
@@ -284,6 +309,7 @@ namespace ts {
 
         function trackSymbol(symbol: Symbol, enclosingDeclaration?: Node, meaning?: SymbolFlags) {
             handleSymbolAccessibilityError(resolver.isSymbolAccessible(symbol, enclosingDeclaration, meaning));
+            recordTypeReferenceDirectivesIfNecessary(resolver.getTypeReferenceDirectivesForSymbol(symbol, meaning));
         }
 
         function reportInaccessibleThisError() {
@@ -420,6 +446,7 @@ namespace ts {
                     entityName.parent.kind === SyntaxKind.ImportEqualsDeclaration ? entityName.parent : enclosingDeclaration);
 
                 handleSymbolAccessibilityError(visibilityResult);
+                recordTypeReferenceDirectivesIfNecessary(resolver.getTypeReferenceDirectivesForEntityName(entityName));
                 writeEntityName(entityName);
             }
 
@@ -1688,7 +1715,7 @@ namespace ts {
                     host.getCanonicalFileName,
                     /*isAbsolutePathAnUrl*/ false);
 
-                referencePathsOutput += '/// <reference path="' + declFileName + '" />' + newLine;
+                referencesOutput += `/// <reference path="${declFileName}" />${newLine}`;
             }
             return addedBundledEmitReference;
 
@@ -1710,7 +1737,7 @@ namespace ts {
         const emitDeclarationResult = emitDeclarations(host, resolver, emitterDiagnostics, declarationFilePath, sourceFiles, isBundledEmit);
         const emitSkipped = emitDeclarationResult.reportedDeclarationError || host.isEmitBlocked(declarationFilePath) || host.getCompilerOptions().noEmit;
         if (!emitSkipped) {
-            const declarationOutput = emitDeclarationResult.referencePathsOutput
+            const declarationOutput = emitDeclarationResult.referencesOutput
                 + getDeclarationOutput(emitDeclarationResult.synchronousDeclarationOutput, emitDeclarationResult.moduleElementDeclarationEmitInfo);
             writeFile(host, emitterDiagnostics, declarationFilePath, declarationOutput, host.getCompilerOptions().emitBOM);
         }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1048,7 +1048,7 @@ namespace ts {
             getSymbolCount: () => getDiagnosticsProducingTypeChecker().getSymbolCount(),
             getTypeCount: () => getDiagnosticsProducingTypeChecker().getTypeCount(),
             getFileProcessingDiagnostics: () => fileProcessingDiagnostics,
-            resolvedTypeReferenceDirectives
+            getResolvedTypeReferenceDirectives: () => resolvedTypeReferenceDirectives
         };
 
         verifyCompilerOptions();
@@ -1209,7 +1209,7 @@ namespace ts {
             for (const modifiedFile of modifiedSourceFiles) {
                 fileProcessingDiagnostics.reattachFileDiagnostics(modifiedFile);
             }
-            resolvedTypeReferenceDirectives = oldProgram.resolvedTypeReferenceDirectives;
+            resolvedTypeReferenceDirectives = oldProgram.getResolvedTypeReferenceDirectives();
             oldProgram.structureIsReused = true;
 
             return true;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1662,7 +1662,7 @@ namespace ts {
         /* @internal */ getTypeCount(): number;
 
         /* @internal */ getFileProcessingDiagnostics(): DiagnosticCollection;
-        /* @internal */ resolvedTypeReferenceDirectives: Map<ResolvedTypeReferenceDirective>;
+        /* @internal */ getResolvedTypeReferenceDirectives(): Map<ResolvedTypeReferenceDirective>;
         // For testing purposes only.
         /* @internal */ structureIsReused?: boolean;
     }
@@ -1723,6 +1723,7 @@ namespace ts {
 
         getSourceFiles(): SourceFile[];
         getSourceFile(fileName: string): SourceFile;
+        getResolvedTypeReferenceDirectives(): Map<ResolvedTypeReferenceDirective>;
     }
 
     export interface TypeChecker {
@@ -1930,6 +1931,8 @@ namespace ts {
         moduleExportsSomeValue(moduleReferenceExpression: Expression): boolean;
         isArgumentsLocalBinding(node: Identifier): boolean;
         getExternalModuleFileFromDeclaration(declaration: ImportEqualsDeclaration | ImportDeclaration | ExportDeclaration | ModuleDeclaration): SourceFile;
+        getTypeReferenceDirectivesForEntityName(name: EntityName | PropertyAccessExpression): string[];
+        getTypeReferenceDirectivesForSymbol(symbol: Symbol, meaning?: SymbolFlags): string[];
     }
 
     export const enum SymbolFlags {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -4747,7 +4747,7 @@ namespace ts {
             // Type reference directives
             const typeReferenceDirective = findReferenceInPosition(sourceFile.typeReferenceDirectives, position);
             if (typeReferenceDirective) {
-                const referenceFile = lookUp(program.resolvedTypeReferenceDirectives, typeReferenceDirective.fileName);
+                const referenceFile = lookUp(program.getResolvedTypeReferenceDirectives(), typeReferenceDirective.fileName);
                 if (referenceFile && referenceFile.resolvedFileName) {
                     return [getDefinitionInfoForFileReference(typeReferenceDirective.fileName, referenceFile.resolvedFileName)];
                 }

--- a/tests/baselines/reference/typeReferenceDirectives1.js
+++ b/tests/baselines/reference/typeReferenceDirectives1.js
@@ -1,0 +1,21 @@
+//// [tests/cases/compiler/typeReferenceDirectives1.ts] ////
+
+//// [index.d.ts]
+
+
+interface $ { x }
+
+//// [app.ts]
+/// <reference types="lib"/>
+interface A {
+    x: $
+}
+
+//// [app.js]
+
+
+//// [app.d.ts]
+/// <reference types="lib" />
+interface A {
+    x: $;
+}

--- a/tests/baselines/reference/typeReferenceDirectives1.symbols
+++ b/tests/baselines/reference/typeReferenceDirectives1.symbols
@@ -1,0 +1,16 @@
+=== /app.ts ===
+/// <reference types="lib"/>
+interface A {
+>A : Symbol(A, Decl(app.ts, 0, 0))
+
+    x: $
+>x : Symbol(A.x, Decl(app.ts, 1, 13))
+>$ : Symbol($, Decl(index.d.ts, 0, 0))
+}
+=== /types/lib/index.d.ts ===
+
+
+interface $ { x }
+>$ : Symbol($, Decl(index.d.ts, 0, 0))
+>x : Symbol($.x, Decl(index.d.ts, 2, 13))
+

--- a/tests/baselines/reference/typeReferenceDirectives1.trace.json
+++ b/tests/baselines/reference/typeReferenceDirectives1.trace.json
@@ -1,0 +1,7 @@
+[
+    "======== Resolving type reference directive 'lib', containing file '/app.ts', root directory '/'. ========",
+    "Resolving with primary search path '/types/'",
+    "File '/types/lib/package.json' does not exist.",
+    "File '/types/lib/index.d.ts' exist - use it as a name resolution result.",
+    "======== Type reference directive 'lib' was successfully resolved to '/types/lib/index.d.ts', primary: true. ========"
+]

--- a/tests/baselines/reference/typeReferenceDirectives1.types
+++ b/tests/baselines/reference/typeReferenceDirectives1.types
@@ -1,0 +1,16 @@
+=== /app.ts ===
+/// <reference types="lib"/>
+interface A {
+>A : A
+
+    x: $
+>x : $
+>$ : $
+}
+=== /types/lib/index.d.ts ===
+
+
+interface $ { x }
+>$ : $
+>x : any
+

--- a/tests/baselines/reference/typeReferenceDirectives10.js
+++ b/tests/baselines/reference/typeReferenceDirectives10.js
@@ -1,0 +1,26 @@
+//// [tests/cases/compiler/typeReferenceDirectives10.ts] ////
+
+//// [ref.d.ts]
+
+export interface $ { x }
+
+//// [index.d.ts]
+declare let $: { x: number }
+
+//// [app.ts]
+/// <reference types="lib"/>
+import {$} from "./ref";
+export interface A {
+    x: $
+}
+
+
+//// [app.js]
+"use strict";
+
+
+//// [app.d.ts]
+import { $ } from "./ref";
+export interface A {
+    x: $;
+}

--- a/tests/baselines/reference/typeReferenceDirectives10.symbols
+++ b/tests/baselines/reference/typeReferenceDirectives10.symbols
@@ -1,0 +1,24 @@
+=== /app.ts ===
+/// <reference types="lib"/>
+import {$} from "./ref";
+>$ : Symbol($, Decl(app.ts, 1, 8))
+
+export interface A {
+>A : Symbol(A, Decl(app.ts, 1, 24))
+
+    x: $
+>x : Symbol(A.x, Decl(app.ts, 2, 20))
+>$ : Symbol($, Decl(app.ts, 1, 8))
+}
+
+=== /ref.d.ts ===
+
+export interface $ { x }
+>$ : Symbol($, Decl(ref.d.ts, 0, 0))
+>x : Symbol($.x, Decl(ref.d.ts, 1, 20))
+
+=== /types/lib/index.d.ts ===
+declare let $: { x: number }
+>$ : Symbol($, Decl(index.d.ts, 0, 11))
+>x : Symbol(x, Decl(index.d.ts, 0, 16))
+

--- a/tests/baselines/reference/typeReferenceDirectives10.trace.json
+++ b/tests/baselines/reference/typeReferenceDirectives10.trace.json
@@ -1,0 +1,14 @@
+[
+    "======== Resolving type reference directive 'lib', containing file '/app.ts', root directory '/'. ========",
+    "Resolving with primary search path '/types/'",
+    "File '/types/lib/package.json' does not exist.",
+    "File '/types/lib/index.d.ts' exist - use it as a name resolution result.",
+    "======== Type reference directive 'lib' was successfully resolved to '/types/lib/index.d.ts', primary: true. ========",
+    "======== Resolving module './ref' from '/app.ts'. ========",
+    "Module resolution kind is not specified, using 'NodeJs'.",
+    "Loading module as file / folder, candidate module location '/ref'.",
+    "File '/ref.ts' does not exist.",
+    "File '/ref.tsx' does not exist.",
+    "File '/ref.d.ts' exist - use it as a name resolution result.",
+    "======== Module name './ref' was successfully resolved to '/ref.d.ts'. ========"
+]

--- a/tests/baselines/reference/typeReferenceDirectives10.types
+++ b/tests/baselines/reference/typeReferenceDirectives10.types
@@ -1,0 +1,24 @@
+=== /app.ts ===
+/// <reference types="lib"/>
+import {$} from "./ref";
+>$ : any
+
+export interface A {
+>A : A
+
+    x: $
+>x : $
+>$ : $
+}
+
+=== /ref.d.ts ===
+
+export interface $ { x }
+>$ : $
+>x : any
+
+=== /types/lib/index.d.ts ===
+declare let $: { x: number }
+>$ : { x: number; }
+>x : number
+

--- a/tests/baselines/reference/typeReferenceDirectives11.js
+++ b/tests/baselines/reference/typeReferenceDirectives11.js
@@ -1,0 +1,27 @@
+//// [tests/cases/compiler/typeReferenceDirectives11.ts] ////
+
+//// [index.d.ts]
+
+
+interface Lib { x }
+
+//// [mod1.ts]
+
+export function foo(): Lib { return {x: 1} }
+
+//// [mod2.ts]
+
+import {foo} from "./mod1";
+export const bar = foo();
+
+//// [output.js]
+
+
+//// [output.d.ts]
+/// <reference types="lib" />
+declare module "mod1" {
+    export function foo(): Lib;
+}
+declare module "mod2" {
+    export const bar: Lib;
+}

--- a/tests/baselines/reference/typeReferenceDirectives11.symbols
+++ b/tests/baselines/reference/typeReferenceDirectives11.symbols
@@ -1,0 +1,23 @@
+=== /mod2.ts ===
+
+import {foo} from "./mod1";
+>foo : Symbol(foo, Decl(mod2.ts, 1, 8))
+
+export const bar = foo();
+>bar : Symbol(bar, Decl(mod2.ts, 2, 12))
+>foo : Symbol(foo, Decl(mod2.ts, 1, 8))
+
+=== /types/lib/index.d.ts ===
+
+
+interface Lib { x }
+>Lib : Symbol(Lib, Decl(index.d.ts, 0, 0))
+>x : Symbol(Lib.x, Decl(index.d.ts, 2, 15))
+
+=== /mod1.ts ===
+
+export function foo(): Lib { return {x: 1} }
+>foo : Symbol(foo, Decl(mod1.ts, 0, 0))
+>Lib : Symbol(Lib, Decl(index.d.ts, 0, 0))
+>x : Symbol(x, Decl(mod1.ts, 1, 37))
+

--- a/tests/baselines/reference/typeReferenceDirectives11.trace.json
+++ b/tests/baselines/reference/typeReferenceDirectives11.trace.json
@@ -1,0 +1,12 @@
+[
+    "======== Resolving type reference directive 'lib', containing file not set, root directory '/'. ========",
+    "Resolving with primary search path '/types/'",
+    "File '/types/lib/package.json' does not exist.",
+    "File '/types/lib/index.d.ts' exist - use it as a name resolution result.",
+    "======== Type reference directive 'lib' was successfully resolved to '/types/lib/index.d.ts', primary: true. ========",
+    "======== Resolving module './mod1' from '/mod2.ts'. ========",
+    "Module resolution kind is not specified, using 'NodeJs'.",
+    "Loading module as file / folder, candidate module location '/mod1'.",
+    "File '/mod1.ts' exist - use it as a name resolution result.",
+    "======== Module name './mod1' was successfully resolved to '/mod1.ts'. ========"
+]

--- a/tests/baselines/reference/typeReferenceDirectives11.types
+++ b/tests/baselines/reference/typeReferenceDirectives11.types
@@ -1,0 +1,26 @@
+=== /mod2.ts ===
+
+import {foo} from "./mod1";
+>foo : () => Lib
+
+export const bar = foo();
+>bar : Lib
+>foo() : Lib
+>foo : () => Lib
+
+=== /types/lib/index.d.ts ===
+
+
+interface Lib { x }
+>Lib : Lib
+>x : any
+
+=== /mod1.ts ===
+
+export function foo(): Lib { return {x: 1} }
+>foo : () => Lib
+>Lib : Lib
+>{x: 1} : { x: number; }
+>x : number
+>1 : number
+

--- a/tests/baselines/reference/typeReferenceDirectives12.js
+++ b/tests/baselines/reference/typeReferenceDirectives12.js
@@ -1,0 +1,63 @@
+//// [tests/cases/compiler/typeReferenceDirectives12.ts] ////
+
+//// [index.d.ts]
+
+
+interface Lib { x }
+
+//// [main.ts]
+export class Cls {
+    x
+}
+
+//// [mod1.ts]
+/// <reference types="lib" />
+
+import {Cls} from "./main";
+Cls.prototype.foo = function() { return undefined; }
+
+declare module "./main" {
+    interface Cls {
+        foo(): Lib;
+    }
+    namespace Cls {
+        function bar(): Lib;
+    }
+}
+
+//// [mod2.ts]
+import { Cls } from "./main";
+import "./mod1";
+
+export const cls = Cls;
+export const foo = new Cls().foo();
+export const bar = Cls.bar();
+
+//// [output.js]
+/// <reference types="lib" />
+
+
+//// [output.d.ts]
+/// <reference types="lib" />
+declare module "main" {
+    export class Cls {
+        x: any;
+    }
+}
+declare module "mod1" {
+    module "main" {
+        interface Cls {
+            foo(): Lib;
+        }
+        namespace Cls {
+            function bar(): Lib;
+        }
+    }
+}
+declare module "mod2" {
+    import { Cls } from "main";
+    import "mod1";
+    export const cls: typeof Cls;
+    export const foo: Lib;
+    export const bar: Lib;
+}

--- a/tests/baselines/reference/typeReferenceDirectives12.symbols
+++ b/tests/baselines/reference/typeReferenceDirectives12.symbols
@@ -1,0 +1,68 @@
+=== /mod2.ts ===
+import { Cls } from "./main";
+>Cls : Symbol(Cls, Decl(mod2.ts, 0, 8))
+
+import "./mod1";
+
+export const cls = Cls;
+>cls : Symbol(cls, Decl(mod2.ts, 3, 12))
+>Cls : Symbol(Cls, Decl(mod2.ts, 0, 8))
+
+export const foo = new Cls().foo();
+>foo : Symbol(foo, Decl(mod2.ts, 4, 12))
+>new Cls().foo : Symbol(Cls.foo, Decl(mod1.ts, 6, 19))
+>Cls : Symbol(Cls, Decl(mod2.ts, 0, 8))
+>foo : Symbol(Cls.foo, Decl(mod1.ts, 6, 19))
+
+export const bar = Cls.bar();
+>bar : Symbol(bar, Decl(mod2.ts, 5, 12))
+>Cls.bar : Symbol(Cls.bar, Decl(mod1.ts, 9, 19))
+>Cls : Symbol(Cls, Decl(mod2.ts, 0, 8))
+>bar : Symbol(Cls.bar, Decl(mod1.ts, 9, 19))
+
+=== /types/lib/index.d.ts ===
+
+
+interface Lib { x }
+>Lib : Symbol(Lib, Decl(index.d.ts, 0, 0))
+>x : Symbol(Lib.x, Decl(index.d.ts, 2, 15))
+
+=== /main.ts ===
+export class Cls {
+>Cls : Symbol(Cls, Decl(main.ts, 0, 0), Decl(mod1.ts, 5, 25), Decl(mod1.ts, 8, 5))
+
+    x
+>x : Symbol(Cls.x, Decl(main.ts, 0, 18))
+}
+
+=== /mod1.ts ===
+/// <reference types="lib" />
+
+import {Cls} from "./main";
+>Cls : Symbol(Cls, Decl(mod1.ts, 2, 8))
+
+Cls.prototype.foo = function() { return undefined; }
+>Cls.prototype.foo : Symbol(Cls.foo, Decl(mod1.ts, 6, 19))
+>Cls.prototype : Symbol(Cls.prototype)
+>Cls : Symbol(Cls, Decl(mod1.ts, 2, 8))
+>prototype : Symbol(Cls.prototype)
+>foo : Symbol(Cls.foo, Decl(mod1.ts, 6, 19))
+>undefined : Symbol(undefined)
+
+declare module "./main" {
+    interface Cls {
+>Cls : Symbol(Cls, Decl(main.ts, 0, 0), Decl(mod1.ts, 5, 25), Decl(mod1.ts, 8, 5))
+
+        foo(): Lib;
+>foo : Symbol(Cls.foo, Decl(mod1.ts, 6, 19))
+>Lib : Symbol(Lib, Decl(index.d.ts, 0, 0))
+    }
+    namespace Cls {
+>Cls : Symbol(Cls, Decl(main.ts, 0, 0), Decl(mod1.ts, 5, 25), Decl(mod1.ts, 8, 5))
+
+        function bar(): Lib;
+>bar : Symbol(bar, Decl(mod1.ts, 9, 19))
+>Lib : Symbol(Lib, Decl(index.d.ts, 0, 0))
+    }
+}
+

--- a/tests/baselines/reference/typeReferenceDirectives12.trace.json
+++ b/tests/baselines/reference/typeReferenceDirectives12.trace.json
@@ -1,0 +1,22 @@
+[
+    "======== Resolving module './main' from '/mod2.ts'. ========",
+    "Module resolution kind is not specified, using 'NodeJs'.",
+    "Loading module as file / folder, candidate module location '/main'.",
+    "File '/main.ts' exist - use it as a name resolution result.",
+    "======== Module name './main' was successfully resolved to '/main.ts'. ========",
+    "======== Resolving module './mod1' from '/mod2.ts'. ========",
+    "Module resolution kind is not specified, using 'NodeJs'.",
+    "Loading module as file / folder, candidate module location '/mod1'.",
+    "File '/mod1.ts' exist - use it as a name resolution result.",
+    "======== Module name './mod1' was successfully resolved to '/mod1.ts'. ========",
+    "======== Resolving type reference directive 'lib', containing file '/mod1.ts', root directory '/'. ========",
+    "Resolving with primary search path '/types/'",
+    "File '/types/lib/package.json' does not exist.",
+    "File '/types/lib/index.d.ts' exist - use it as a name resolution result.",
+    "======== Type reference directive 'lib' was successfully resolved to '/types/lib/index.d.ts', primary: true. ========",
+    "======== Resolving module './main' from '/mod1.ts'. ========",
+    "Module resolution kind is not specified, using 'NodeJs'.",
+    "Loading module as file / folder, candidate module location '/main'.",
+    "File '/main.ts' exist - use it as a name resolution result.",
+    "======== Module name './main' was successfully resolved to '/main.ts'. ========"
+]

--- a/tests/baselines/reference/typeReferenceDirectives12.types
+++ b/tests/baselines/reference/typeReferenceDirectives12.types
@@ -1,0 +1,73 @@
+=== /mod2.ts ===
+import { Cls } from "./main";
+>Cls : typeof Cls
+
+import "./mod1";
+
+export const cls = Cls;
+>cls : typeof Cls
+>Cls : typeof Cls
+
+export const foo = new Cls().foo();
+>foo : Lib
+>new Cls().foo() : Lib
+>new Cls().foo : () => Lib
+>new Cls() : Cls
+>Cls : typeof Cls
+>foo : () => Lib
+
+export const bar = Cls.bar();
+>bar : Lib
+>Cls.bar() : Lib
+>Cls.bar : () => Lib
+>Cls : typeof Cls
+>bar : () => Lib
+
+=== /types/lib/index.d.ts ===
+
+
+interface Lib { x }
+>Lib : Lib
+>x : any
+
+=== /main.ts ===
+export class Cls {
+>Cls : Cls
+
+    x
+>x : any
+}
+
+=== /mod1.ts ===
+/// <reference types="lib" />
+
+import {Cls} from "./main";
+>Cls : typeof Cls
+
+Cls.prototype.foo = function() { return undefined; }
+>Cls.prototype.foo = function() { return undefined; } : () => any
+>Cls.prototype.foo : () => Lib
+>Cls.prototype : Cls
+>Cls : typeof Cls
+>prototype : Cls
+>foo : () => Lib
+>function() { return undefined; } : () => any
+>undefined : undefined
+
+declare module "./main" {
+    interface Cls {
+>Cls : Cls
+
+        foo(): Lib;
+>foo : () => Lib
+>Lib : Lib
+    }
+    namespace Cls {
+>Cls : typeof Cls
+
+        function bar(): Lib;
+>bar : () => Lib
+>Lib : Lib
+    }
+}
+

--- a/tests/baselines/reference/typeReferenceDirectives13.js
+++ b/tests/baselines/reference/typeReferenceDirectives13.js
@@ -1,0 +1,26 @@
+//// [tests/cases/compiler/typeReferenceDirectives13.ts] ////
+
+//// [ref.d.ts]
+
+export interface $ { x }
+
+//// [index.d.ts]
+declare let $: { x: number }
+
+//// [app.ts]
+/// <reference types="lib"/>
+import {$} from "./ref";
+export interface A {
+    x: () => typeof $
+}
+
+
+//// [app.js]
+"use strict";
+
+
+//// [app.d.ts]
+/// <reference types="lib" />
+export interface A {
+    x: () => typeof $;
+}

--- a/tests/baselines/reference/typeReferenceDirectives13.symbols
+++ b/tests/baselines/reference/typeReferenceDirectives13.symbols
@@ -1,0 +1,24 @@
+=== /app.ts ===
+/// <reference types="lib"/>
+import {$} from "./ref";
+>$ : Symbol($, Decl(app.ts, 1, 8))
+
+export interface A {
+>A : Symbol(A, Decl(app.ts, 1, 24))
+
+    x: () => typeof $
+>x : Symbol(A.x, Decl(app.ts, 2, 20))
+>$ : Symbol($, Decl(app.ts, 1, 8))
+}
+
+=== /ref.d.ts ===
+
+export interface $ { x }
+>$ : Symbol($, Decl(ref.d.ts, 0, 0))
+>x : Symbol($.x, Decl(ref.d.ts, 1, 20))
+
+=== /types/lib/index.d.ts ===
+declare let $: { x: number }
+>$ : Symbol($, Decl(index.d.ts, 0, 11))
+>x : Symbol(x, Decl(index.d.ts, 0, 16))
+

--- a/tests/baselines/reference/typeReferenceDirectives13.trace.json
+++ b/tests/baselines/reference/typeReferenceDirectives13.trace.json
@@ -1,0 +1,14 @@
+[
+    "======== Resolving type reference directive 'lib', containing file '/app.ts', root directory '/'. ========",
+    "Resolving with primary search path '/types/'",
+    "File '/types/lib/package.json' does not exist.",
+    "File '/types/lib/index.d.ts' exist - use it as a name resolution result.",
+    "======== Type reference directive 'lib' was successfully resolved to '/types/lib/index.d.ts', primary: true. ========",
+    "======== Resolving module './ref' from '/app.ts'. ========",
+    "Module resolution kind is not specified, using 'NodeJs'.",
+    "Loading module as file / folder, candidate module location '/ref'.",
+    "File '/ref.ts' does not exist.",
+    "File '/ref.tsx' does not exist.",
+    "File '/ref.d.ts' exist - use it as a name resolution result.",
+    "======== Module name './ref' was successfully resolved to '/ref.d.ts'. ========"
+]

--- a/tests/baselines/reference/typeReferenceDirectives13.types
+++ b/tests/baselines/reference/typeReferenceDirectives13.types
@@ -1,0 +1,24 @@
+=== /app.ts ===
+/// <reference types="lib"/>
+import {$} from "./ref";
+>$ : any
+
+export interface A {
+>A : A
+
+    x: () => typeof $
+>x : () => { x: number; }
+>$ : { x: number; }
+}
+
+=== /ref.d.ts ===
+
+export interface $ { x }
+>$ : $
+>x : any
+
+=== /types/lib/index.d.ts ===
+declare let $: { x: number }
+>$ : { x: number; }
+>x : number
+

--- a/tests/baselines/reference/typeReferenceDirectives2.js
+++ b/tests/baselines/reference/typeReferenceDirectives2.js
@@ -1,0 +1,19 @@
+//// [tests/cases/compiler/typeReferenceDirectives2.ts] ////
+
+//// [index.d.ts]
+
+interface $ { x }
+
+//// [app.ts]
+interface A {
+    x: $
+}
+
+//// [app.js]
+
+
+//// [app.d.ts]
+/// <reference types="lib" />
+interface A {
+    x: $;
+}

--- a/tests/baselines/reference/typeReferenceDirectives2.symbols
+++ b/tests/baselines/reference/typeReferenceDirectives2.symbols
@@ -1,0 +1,14 @@
+=== /app.ts ===
+interface A {
+>A : Symbol(A, Decl(app.ts, 0, 0))
+
+    x: $
+>x : Symbol(A.x, Decl(app.ts, 0, 13))
+>$ : Symbol($, Decl(index.d.ts, 0, 0))
+}
+=== /types/lib/index.d.ts ===
+
+interface $ { x }
+>$ : Symbol($, Decl(index.d.ts, 0, 0))
+>x : Symbol($.x, Decl(index.d.ts, 1, 13))
+

--- a/tests/baselines/reference/typeReferenceDirectives2.trace.json
+++ b/tests/baselines/reference/typeReferenceDirectives2.trace.json
@@ -1,0 +1,7 @@
+[
+    "======== Resolving type reference directive 'lib', containing file not set, root directory '/'. ========",
+    "Resolving with primary search path '/types/'",
+    "File '/types/lib/package.json' does not exist.",
+    "File '/types/lib/index.d.ts' exist - use it as a name resolution result.",
+    "======== Type reference directive 'lib' was successfully resolved to '/types/lib/index.d.ts', primary: true. ========"
+]

--- a/tests/baselines/reference/typeReferenceDirectives2.types
+++ b/tests/baselines/reference/typeReferenceDirectives2.types
@@ -1,0 +1,14 @@
+=== /app.ts ===
+interface A {
+>A : A
+
+    x: $
+>x : $
+>$ : $
+}
+=== /types/lib/index.d.ts ===
+
+interface $ { x }
+>$ : $
+>x : any
+

--- a/tests/baselines/reference/typeReferenceDirectives3.js
+++ b/tests/baselines/reference/typeReferenceDirectives3.js
@@ -1,0 +1,27 @@
+//// [tests/cases/compiler/typeReferenceDirectives3.ts] ////
+
+//// [ref.d.ts]
+
+// $ comes from d.ts file - no need to add type reference directive
+
+interface $ { x }
+
+//// [index.d.ts]
+declare let $: { x: number }
+
+//// [app.ts]
+/// <reference types="lib"/>
+/// <reference path="ref.d.ts" />
+interface A {
+    x: () => $
+}
+
+//// [app.js]
+/// <reference path="ref.d.ts" />
+
+
+//// [app.d.ts]
+/// <reference path="ref.d.ts" />
+interface A {
+    x: () => $;
+}

--- a/tests/baselines/reference/typeReferenceDirectives3.symbols
+++ b/tests/baselines/reference/typeReferenceDirectives3.symbols
@@ -1,0 +1,23 @@
+=== /app.ts ===
+/// <reference types="lib"/>
+/// <reference path="ref.d.ts" />
+interface A {
+>A : Symbol(A, Decl(app.ts, 0, 0))
+
+    x: () => $
+>x : Symbol(A.x, Decl(app.ts, 2, 13))
+>$ : Symbol($, Decl(ref.d.ts, 0, 0), Decl(index.d.ts, 0, 11))
+}
+=== /ref.d.ts ===
+
+// $ comes from d.ts file - no need to add type reference directive
+
+interface $ { x }
+>$ : Symbol($, Decl(ref.d.ts, 0, 0), Decl(index.d.ts, 0, 11))
+>x : Symbol($.x, Decl(ref.d.ts, 3, 13))
+
+=== /types/lib/index.d.ts ===
+declare let $: { x: number }
+>$ : Symbol($, Decl(ref.d.ts, 0, 0), Decl(index.d.ts, 0, 11))
+>x : Symbol(x, Decl(index.d.ts, 0, 16))
+

--- a/tests/baselines/reference/typeReferenceDirectives3.trace.json
+++ b/tests/baselines/reference/typeReferenceDirectives3.trace.json
@@ -1,0 +1,7 @@
+[
+    "======== Resolving type reference directive 'lib', containing file '/app.ts', root directory '/'. ========",
+    "Resolving with primary search path '/types/'",
+    "File '/types/lib/package.json' does not exist.",
+    "File '/types/lib/index.d.ts' exist - use it as a name resolution result.",
+    "======== Type reference directive 'lib' was successfully resolved to '/types/lib/index.d.ts', primary: true. ========"
+]

--- a/tests/baselines/reference/typeReferenceDirectives3.types
+++ b/tests/baselines/reference/typeReferenceDirectives3.types
@@ -1,0 +1,23 @@
+=== /app.ts ===
+/// <reference types="lib"/>
+/// <reference path="ref.d.ts" />
+interface A {
+>A : A
+
+    x: () => $
+>x : () => $
+>$ : $
+}
+=== /ref.d.ts ===
+
+// $ comes from d.ts file - no need to add type reference directive
+
+interface $ { x }
+>$ : $
+>x : any
+
+=== /types/lib/index.d.ts ===
+declare let $: { x: number }
+>$ : { x: number; }
+>x : number
+

--- a/tests/baselines/reference/typeReferenceDirectives4.js
+++ b/tests/baselines/reference/typeReferenceDirectives4.js
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/typeReferenceDirectives4.ts] ////
+
+//// [ref.d.ts]
+
+// $ comes from d.ts file - no need to add type reference directive
+
+interface $ { x }
+
+//// [index.d.ts]
+declare let $: { x: number }
+
+
+//// [app.ts]
+/// <reference path="./ref.d.ts"/>
+/// <reference types="lib"/>
+
+let x: $;
+let y = () => x
+
+//// [app.js]
+/// <reference path="./ref.d.ts"/>
+/// <reference types="lib"/>
+var x;
+var y = function () { return x; };
+
+
+//// [app.d.ts]
+/// <reference path="ref.d.ts" />
+declare let x: $;
+declare let y: () => $;

--- a/tests/baselines/reference/typeReferenceDirectives4.symbols
+++ b/tests/baselines/reference/typeReferenceDirectives4.symbols
@@ -1,0 +1,26 @@
+=== /app.ts ===
+/// <reference path="./ref.d.ts"/>
+/// <reference types="lib"/>
+
+let x: $;
+>x : Symbol(x, Decl(app.ts, 3, 3))
+>$ : Symbol($, Decl(ref.d.ts, 0, 0), Decl(index.d.ts, 0, 11))
+
+let y = () => x
+>y : Symbol(y, Decl(app.ts, 4, 3))
+>x : Symbol(x, Decl(app.ts, 3, 3))
+
+=== /ref.d.ts ===
+
+// $ comes from d.ts file - no need to add type reference directive
+
+interface $ { x }
+>$ : Symbol($, Decl(ref.d.ts, 0, 0), Decl(index.d.ts, 0, 11))
+>x : Symbol($.x, Decl(ref.d.ts, 3, 13))
+
+=== /types/lib/index.d.ts ===
+declare let $: { x: number }
+>$ : Symbol($, Decl(ref.d.ts, 0, 0), Decl(index.d.ts, 0, 11))
+>x : Symbol(x, Decl(index.d.ts, 0, 16))
+
+

--- a/tests/baselines/reference/typeReferenceDirectives4.trace.json
+++ b/tests/baselines/reference/typeReferenceDirectives4.trace.json
@@ -1,0 +1,7 @@
+[
+    "======== Resolving type reference directive 'lib', containing file '/app.ts', root directory '/'. ========",
+    "Resolving with primary search path '/types/'",
+    "File '/types/lib/package.json' does not exist.",
+    "File '/types/lib/index.d.ts' exist - use it as a name resolution result.",
+    "======== Type reference directive 'lib' was successfully resolved to '/types/lib/index.d.ts', primary: true. ========"
+]

--- a/tests/baselines/reference/typeReferenceDirectives4.types
+++ b/tests/baselines/reference/typeReferenceDirectives4.types
@@ -1,0 +1,27 @@
+=== /app.ts ===
+/// <reference path="./ref.d.ts"/>
+/// <reference types="lib"/>
+
+let x: $;
+>x : $
+>$ : $
+
+let y = () => x
+>y : () => $
+>() => x : () => $
+>x : $
+
+=== /ref.d.ts ===
+
+// $ comes from d.ts file - no need to add type reference directive
+
+interface $ { x }
+>$ : $
+>x : any
+
+=== /types/lib/index.d.ts ===
+declare let $: { x: number }
+>$ : { x: number; }
+>x : number
+
+

--- a/tests/baselines/reference/typeReferenceDirectives5.js
+++ b/tests/baselines/reference/typeReferenceDirectives5.js
@@ -1,0 +1,25 @@
+//// [tests/cases/compiler/typeReferenceDirectives5.ts] ////
+
+//// [ref.d.ts]
+
+export interface $ { x }
+
+//// [index.d.ts]
+declare let $: { x: number }
+
+//// [app.ts]
+/// <reference types="lib"/>
+import {$} from "./ref";
+export interface A {
+    x: typeof $;
+}
+
+//// [app.js]
+"use strict";
+
+
+//// [app.d.ts]
+/// <reference types="lib" />
+export interface A {
+    x: typeof $;
+}

--- a/tests/baselines/reference/typeReferenceDirectives5.symbols
+++ b/tests/baselines/reference/typeReferenceDirectives5.symbols
@@ -1,0 +1,23 @@
+=== /app.ts ===
+/// <reference types="lib"/>
+import {$} from "./ref";
+>$ : Symbol($, Decl(app.ts, 1, 8))
+
+export interface A {
+>A : Symbol(A, Decl(app.ts, 1, 24))
+
+    x: typeof $;
+>x : Symbol(A.x, Decl(app.ts, 2, 20))
+>$ : Symbol($, Decl(app.ts, 1, 8))
+}
+=== /ref.d.ts ===
+
+export interface $ { x }
+>$ : Symbol($, Decl(ref.d.ts, 0, 0))
+>x : Symbol($.x, Decl(ref.d.ts, 1, 20))
+
+=== /types/lib/index.d.ts ===
+declare let $: { x: number }
+>$ : Symbol($, Decl(index.d.ts, 0, 11))
+>x : Symbol(x, Decl(index.d.ts, 0, 16))
+

--- a/tests/baselines/reference/typeReferenceDirectives5.trace.json
+++ b/tests/baselines/reference/typeReferenceDirectives5.trace.json
@@ -1,0 +1,14 @@
+[
+    "======== Resolving type reference directive 'lib', containing file '/app.ts', root directory '/'. ========",
+    "Resolving with primary search path '/types/'",
+    "File '/types/lib/package.json' does not exist.",
+    "File '/types/lib/index.d.ts' exist - use it as a name resolution result.",
+    "======== Type reference directive 'lib' was successfully resolved to '/types/lib/index.d.ts', primary: true. ========",
+    "======== Resolving module './ref' from '/app.ts'. ========",
+    "Module resolution kind is not specified, using 'NodeJs'.",
+    "Loading module as file / folder, candidate module location '/ref'.",
+    "File '/ref.ts' does not exist.",
+    "File '/ref.tsx' does not exist.",
+    "File '/ref.d.ts' exist - use it as a name resolution result.",
+    "======== Module name './ref' was successfully resolved to '/ref.d.ts'. ========"
+]

--- a/tests/baselines/reference/typeReferenceDirectives5.types
+++ b/tests/baselines/reference/typeReferenceDirectives5.types
@@ -1,0 +1,23 @@
+=== /app.ts ===
+/// <reference types="lib"/>
+import {$} from "./ref";
+>$ : any
+
+export interface A {
+>A : A
+
+    x: typeof $;
+>x : { x: number; }
+>$ : { x: number; }
+}
+=== /ref.d.ts ===
+
+export interface $ { x }
+>$ : $
+>x : any
+
+=== /types/lib/index.d.ts ===
+declare let $: { x: number }
+>$ : { x: number; }
+>x : number
+

--- a/tests/baselines/reference/typeReferenceDirectives6.js
+++ b/tests/baselines/reference/typeReferenceDirectives6.js
@@ -1,0 +1,33 @@
+//// [tests/cases/compiler/typeReferenceDirectives6.ts] ////
+
+//// [ref.d.ts]
+
+// $ comes from type declaration file - type reference directive should be added
+
+declare let $: { x: number }
+    
+//// [index.d.ts]
+interface $ { x }
+
+
+//// [app.ts]
+/// <reference path="./ref.d.ts"/>
+/// <reference types="lib"/>
+
+let x: $;
+let y = () => x
+
+
+
+//// [app.js]
+/// <reference path="./ref.d.ts"/>
+/// <reference types="lib"/>
+var x;
+var y = function () { return x; };
+
+
+//// [app.d.ts]
+/// <reference path="ref.d.ts" />
+/// <reference types="lib" />
+declare let x: $;
+declare let y: () => $;

--- a/tests/baselines/reference/typeReferenceDirectives6.symbols
+++ b/tests/baselines/reference/typeReferenceDirectives6.symbols
@@ -1,0 +1,27 @@
+=== /app.ts ===
+/// <reference path="./ref.d.ts"/>
+/// <reference types="lib"/>
+
+let x: $;
+>x : Symbol(x, Decl(app.ts, 3, 3))
+>$ : Symbol($, Decl(ref.d.ts, 3, 11), Decl(index.d.ts, 0, 0))
+
+let y = () => x
+>y : Symbol(y, Decl(app.ts, 4, 3))
+>x : Symbol(x, Decl(app.ts, 3, 3))
+
+
+=== /ref.d.ts ===
+
+// $ comes from type declaration file - type reference directive should be added
+
+declare let $: { x: number }
+>$ : Symbol($, Decl(ref.d.ts, 3, 11), Decl(index.d.ts, 0, 0))
+>x : Symbol(x, Decl(ref.d.ts, 3, 16))
+    
+=== /types/lib/index.d.ts ===
+interface $ { x }
+>$ : Symbol($, Decl(ref.d.ts, 3, 11), Decl(index.d.ts, 0, 0))
+>x : Symbol($.x, Decl(index.d.ts, 0, 13))
+
+

--- a/tests/baselines/reference/typeReferenceDirectives6.trace.json
+++ b/tests/baselines/reference/typeReferenceDirectives6.trace.json
@@ -1,0 +1,7 @@
+[
+    "======== Resolving type reference directive 'lib', containing file '/app.ts', root directory '/'. ========",
+    "Resolving with primary search path '/types/'",
+    "File '/types/lib/package.json' does not exist.",
+    "File '/types/lib/index.d.ts' exist - use it as a name resolution result.",
+    "======== Type reference directive 'lib' was successfully resolved to '/types/lib/index.d.ts', primary: true. ========"
+]

--- a/tests/baselines/reference/typeReferenceDirectives6.types
+++ b/tests/baselines/reference/typeReferenceDirectives6.types
@@ -1,0 +1,28 @@
+=== /app.ts ===
+/// <reference path="./ref.d.ts"/>
+/// <reference types="lib"/>
+
+let x: $;
+>x : $
+>$ : $
+
+let y = () => x
+>y : () => $
+>() => x : () => $
+>x : $
+
+
+=== /ref.d.ts ===
+
+// $ comes from type declaration file - type reference directive should be added
+
+declare let $: { x: number }
+>$ : { x: number; }
+>x : number
+    
+=== /types/lib/index.d.ts ===
+interface $ { x }
+>$ : $
+>x : any
+
+

--- a/tests/baselines/reference/typeReferenceDirectives7.js
+++ b/tests/baselines/reference/typeReferenceDirectives7.js
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/typeReferenceDirectives7.ts] ////
+
+//// [index.d.ts]
+
+// local value shadows global - no need to add type reference directive 
+   
+declare let $: { x: number }
+
+
+//// [app.ts]
+/// <reference types="lib"/>
+
+export let $ = 1;
+
+export let x: typeof $;
+export let y = () => x
+
+//// [app.js]
+/// <reference types="lib"/>
+"use strict";
+exports.$ = 1;
+exports.y = function () { return exports.x; };
+
+
+//// [app.d.ts]
+export declare let $: number;
+export declare let x: typeof $;
+export declare let y: () => number;

--- a/tests/baselines/reference/typeReferenceDirectives7.symbols
+++ b/tests/baselines/reference/typeReferenceDirectives7.symbols
@@ -1,0 +1,23 @@
+=== /app.ts ===
+/// <reference types="lib"/>
+
+export let $ = 1;
+>$ : Symbol($, Decl(app.ts, 2, 10))
+
+export let x: typeof $;
+>x : Symbol(x, Decl(app.ts, 4, 10))
+>$ : Symbol($, Decl(app.ts, 2, 10))
+
+export let y = () => x
+>y : Symbol(y, Decl(app.ts, 5, 10))
+>x : Symbol(x, Decl(app.ts, 4, 10))
+
+=== /types/lib/index.d.ts ===
+
+// local value shadows global - no need to add type reference directive 
+   
+declare let $: { x: number }
+>$ : Symbol($, Decl(index.d.ts, 3, 11))
+>x : Symbol(x, Decl(index.d.ts, 3, 16))
+
+

--- a/tests/baselines/reference/typeReferenceDirectives7.trace.json
+++ b/tests/baselines/reference/typeReferenceDirectives7.trace.json
@@ -1,0 +1,7 @@
+[
+    "======== Resolving type reference directive 'lib', containing file '/app.ts', root directory '/'. ========",
+    "Resolving with primary search path '/types/'",
+    "File '/types/lib/package.json' does not exist.",
+    "File '/types/lib/index.d.ts' exist - use it as a name resolution result.",
+    "======== Type reference directive 'lib' was successfully resolved to '/types/lib/index.d.ts', primary: true. ========"
+]

--- a/tests/baselines/reference/typeReferenceDirectives7.types
+++ b/tests/baselines/reference/typeReferenceDirectives7.types
@@ -1,0 +1,25 @@
+=== /app.ts ===
+/// <reference types="lib"/>
+
+export let $ = 1;
+>$ : number
+>1 : number
+
+export let x: typeof $;
+>x : number
+>$ : number
+
+export let y = () => x
+>y : () => number
+>() => x : () => number
+>x : number
+
+=== /types/lib/index.d.ts ===
+
+// local value shadows global - no need to add type reference directive 
+   
+declare let $: { x: number }
+>$ : { x: number; }
+>x : number
+
+

--- a/tests/baselines/reference/typeReferenceDirectives8.js
+++ b/tests/baselines/reference/typeReferenceDirectives8.js
@@ -1,0 +1,32 @@
+//// [tests/cases/compiler/typeReferenceDirectives8.ts] ////
+
+//// [index.d.ts]
+
+
+interface Lib { x }
+
+//// [mod1.ts]
+
+export function foo(): Lib { return {x: 1} }
+
+//// [mod2.ts]
+
+import {foo} from "./mod1";
+export const bar = foo();
+
+//// [mod1.js]
+"use strict";
+function foo() { return { x: 1 }; }
+exports.foo = foo;
+//// [mod2.js]
+"use strict";
+var mod1_1 = require("./mod1");
+exports.bar = mod1_1.foo();
+
+
+//// [mod1.d.ts]
+/// <reference types="lib" />
+export declare function foo(): Lib;
+//// [mod2.d.ts]
+/// <reference types="lib" />
+export declare const bar: Lib;

--- a/tests/baselines/reference/typeReferenceDirectives8.symbols
+++ b/tests/baselines/reference/typeReferenceDirectives8.symbols
@@ -1,0 +1,23 @@
+=== /mod2.ts ===
+
+import {foo} from "./mod1";
+>foo : Symbol(foo, Decl(mod2.ts, 1, 8))
+
+export const bar = foo();
+>bar : Symbol(bar, Decl(mod2.ts, 2, 12))
+>foo : Symbol(foo, Decl(mod2.ts, 1, 8))
+
+=== /types/lib/index.d.ts ===
+
+
+interface Lib { x }
+>Lib : Symbol(Lib, Decl(index.d.ts, 0, 0))
+>x : Symbol(Lib.x, Decl(index.d.ts, 2, 15))
+
+=== /mod1.ts ===
+
+export function foo(): Lib { return {x: 1} }
+>foo : Symbol(foo, Decl(mod1.ts, 0, 0))
+>Lib : Symbol(Lib, Decl(index.d.ts, 0, 0))
+>x : Symbol(x, Decl(mod1.ts, 1, 37))
+

--- a/tests/baselines/reference/typeReferenceDirectives8.trace.json
+++ b/tests/baselines/reference/typeReferenceDirectives8.trace.json
@@ -1,0 +1,12 @@
+[
+    "======== Resolving type reference directive 'lib', containing file not set, root directory '/'. ========",
+    "Resolving with primary search path '/types/'",
+    "File '/types/lib/package.json' does not exist.",
+    "File '/types/lib/index.d.ts' exist - use it as a name resolution result.",
+    "======== Type reference directive 'lib' was successfully resolved to '/types/lib/index.d.ts', primary: true. ========",
+    "======== Resolving module './mod1' from '/mod2.ts'. ========",
+    "Module resolution kind is not specified, using 'NodeJs'.",
+    "Loading module as file / folder, candidate module location '/mod1'.",
+    "File '/mod1.ts' exist - use it as a name resolution result.",
+    "======== Module name './mod1' was successfully resolved to '/mod1.ts'. ========"
+]

--- a/tests/baselines/reference/typeReferenceDirectives8.types
+++ b/tests/baselines/reference/typeReferenceDirectives8.types
@@ -1,0 +1,26 @@
+=== /mod2.ts ===
+
+import {foo} from "./mod1";
+>foo : () => Lib
+
+export const bar = foo();
+>bar : Lib
+>foo() : Lib
+>foo : () => Lib
+
+=== /types/lib/index.d.ts ===
+
+
+interface Lib { x }
+>Lib : Lib
+>x : any
+
+=== /mod1.ts ===
+
+export function foo(): Lib { return {x: 1} }
+>foo : () => Lib
+>Lib : Lib
+>{x: 1} : { x: number; }
+>x : number
+>1 : number
+

--- a/tests/baselines/reference/typeReferenceDirectives9.js
+++ b/tests/baselines/reference/typeReferenceDirectives9.js
@@ -1,0 +1,79 @@
+//// [tests/cases/compiler/typeReferenceDirectives9.ts] ////
+
+//// [index.d.ts]
+
+
+interface Lib { x }
+
+//// [main.ts]
+export class Cls {
+    x
+}
+
+//// [mod1.ts]
+/// <reference types="lib" />
+
+import {Cls} from "./main";
+Cls.prototype.foo = function() { return undefined; }
+
+declare module "./main" {
+    interface Cls {
+        foo(): Lib;
+    }
+    namespace Cls {
+        function bar(): Lib;
+    }
+}
+
+//// [mod2.ts]
+import { Cls } from "./main";
+import "./mod1";
+
+export const cls = Cls;
+export const foo = new Cls().foo();
+export const bar = Cls.bar();
+
+//// [main.js]
+"use strict";
+var Cls = (function () {
+    function Cls() {
+    }
+    return Cls;
+}());
+exports.Cls = Cls;
+//// [mod1.js]
+/// <reference types="lib" />
+"use strict";
+var main_1 = require("./main");
+main_1.Cls.prototype.foo = function () { return undefined; };
+//// [mod2.js]
+"use strict";
+var main_1 = require("./main");
+require("./mod1");
+exports.cls = main_1.Cls;
+exports.foo = new main_1.Cls().foo();
+exports.bar = main_1.Cls.bar();
+
+
+//// [main.d.ts]
+export declare class Cls {
+    x: any;
+}
+//// [mod1.d.ts]
+/// <reference types="lib" />
+declare module "./main" {
+    interface Cls {
+        foo(): Lib;
+    }
+    namespace Cls {
+        function bar(): Lib;
+    }
+}
+export {};
+//// [mod2.d.ts]
+/// <reference types="lib" />
+import { Cls } from "./main";
+import "./mod1";
+export declare const cls: typeof Cls;
+export declare const foo: Lib;
+export declare const bar: Lib;

--- a/tests/baselines/reference/typeReferenceDirectives9.symbols
+++ b/tests/baselines/reference/typeReferenceDirectives9.symbols
@@ -1,0 +1,68 @@
+=== /mod2.ts ===
+import { Cls } from "./main";
+>Cls : Symbol(Cls, Decl(mod2.ts, 0, 8))
+
+import "./mod1";
+
+export const cls = Cls;
+>cls : Symbol(cls, Decl(mod2.ts, 3, 12))
+>Cls : Symbol(Cls, Decl(mod2.ts, 0, 8))
+
+export const foo = new Cls().foo();
+>foo : Symbol(foo, Decl(mod2.ts, 4, 12))
+>new Cls().foo : Symbol(Cls.foo, Decl(mod1.ts, 6, 19))
+>Cls : Symbol(Cls, Decl(mod2.ts, 0, 8))
+>foo : Symbol(Cls.foo, Decl(mod1.ts, 6, 19))
+
+export const bar = Cls.bar();
+>bar : Symbol(bar, Decl(mod2.ts, 5, 12))
+>Cls.bar : Symbol(Cls.bar, Decl(mod1.ts, 9, 19))
+>Cls : Symbol(Cls, Decl(mod2.ts, 0, 8))
+>bar : Symbol(Cls.bar, Decl(mod1.ts, 9, 19))
+
+=== /types/lib/index.d.ts ===
+
+
+interface Lib { x }
+>Lib : Symbol(Lib, Decl(index.d.ts, 0, 0))
+>x : Symbol(Lib.x, Decl(index.d.ts, 2, 15))
+
+=== /main.ts ===
+export class Cls {
+>Cls : Symbol(Cls, Decl(main.ts, 0, 0), Decl(mod1.ts, 5, 25), Decl(mod1.ts, 8, 5))
+
+    x
+>x : Symbol(Cls.x, Decl(main.ts, 0, 18))
+}
+
+=== /mod1.ts ===
+/// <reference types="lib" />
+
+import {Cls} from "./main";
+>Cls : Symbol(Cls, Decl(mod1.ts, 2, 8))
+
+Cls.prototype.foo = function() { return undefined; }
+>Cls.prototype.foo : Symbol(Cls.foo, Decl(mod1.ts, 6, 19))
+>Cls.prototype : Symbol(Cls.prototype)
+>Cls : Symbol(Cls, Decl(mod1.ts, 2, 8))
+>prototype : Symbol(Cls.prototype)
+>foo : Symbol(Cls.foo, Decl(mod1.ts, 6, 19))
+>undefined : Symbol(undefined)
+
+declare module "./main" {
+    interface Cls {
+>Cls : Symbol(Cls, Decl(main.ts, 0, 0), Decl(mod1.ts, 5, 25), Decl(mod1.ts, 8, 5))
+
+        foo(): Lib;
+>foo : Symbol(Cls.foo, Decl(mod1.ts, 6, 19))
+>Lib : Symbol(Lib, Decl(index.d.ts, 0, 0))
+    }
+    namespace Cls {
+>Cls : Symbol(Cls, Decl(main.ts, 0, 0), Decl(mod1.ts, 5, 25), Decl(mod1.ts, 8, 5))
+
+        function bar(): Lib;
+>bar : Symbol(bar, Decl(mod1.ts, 9, 19))
+>Lib : Symbol(Lib, Decl(index.d.ts, 0, 0))
+    }
+}
+

--- a/tests/baselines/reference/typeReferenceDirectives9.trace.json
+++ b/tests/baselines/reference/typeReferenceDirectives9.trace.json
@@ -1,0 +1,22 @@
+[
+    "======== Resolving module './main' from '/mod2.ts'. ========",
+    "Module resolution kind is not specified, using 'NodeJs'.",
+    "Loading module as file / folder, candidate module location '/main'.",
+    "File '/main.ts' exist - use it as a name resolution result.",
+    "======== Module name './main' was successfully resolved to '/main.ts'. ========",
+    "======== Resolving module './mod1' from '/mod2.ts'. ========",
+    "Module resolution kind is not specified, using 'NodeJs'.",
+    "Loading module as file / folder, candidate module location '/mod1'.",
+    "File '/mod1.ts' exist - use it as a name resolution result.",
+    "======== Module name './mod1' was successfully resolved to '/mod1.ts'. ========",
+    "======== Resolving type reference directive 'lib', containing file '/mod1.ts', root directory '/'. ========",
+    "Resolving with primary search path '/types/'",
+    "File '/types/lib/package.json' does not exist.",
+    "File '/types/lib/index.d.ts' exist - use it as a name resolution result.",
+    "======== Type reference directive 'lib' was successfully resolved to '/types/lib/index.d.ts', primary: true. ========",
+    "======== Resolving module './main' from '/mod1.ts'. ========",
+    "Module resolution kind is not specified, using 'NodeJs'.",
+    "Loading module as file / folder, candidate module location '/main'.",
+    "File '/main.ts' exist - use it as a name resolution result.",
+    "======== Module name './main' was successfully resolved to '/main.ts'. ========"
+]

--- a/tests/baselines/reference/typeReferenceDirectives9.types
+++ b/tests/baselines/reference/typeReferenceDirectives9.types
@@ -1,0 +1,73 @@
+=== /mod2.ts ===
+import { Cls } from "./main";
+>Cls : typeof Cls
+
+import "./mod1";
+
+export const cls = Cls;
+>cls : typeof Cls
+>Cls : typeof Cls
+
+export const foo = new Cls().foo();
+>foo : Lib
+>new Cls().foo() : Lib
+>new Cls().foo : () => Lib
+>new Cls() : Cls
+>Cls : typeof Cls
+>foo : () => Lib
+
+export const bar = Cls.bar();
+>bar : Lib
+>Cls.bar() : Lib
+>Cls.bar : () => Lib
+>Cls : typeof Cls
+>bar : () => Lib
+
+=== /types/lib/index.d.ts ===
+
+
+interface Lib { x }
+>Lib : Lib
+>x : any
+
+=== /main.ts ===
+export class Cls {
+>Cls : Cls
+
+    x
+>x : any
+}
+
+=== /mod1.ts ===
+/// <reference types="lib" />
+
+import {Cls} from "./main";
+>Cls : typeof Cls
+
+Cls.prototype.foo = function() { return undefined; }
+>Cls.prototype.foo = function() { return undefined; } : () => any
+>Cls.prototype.foo : () => Lib
+>Cls.prototype : Cls
+>Cls : typeof Cls
+>prototype : Cls
+>foo : () => Lib
+>function() { return undefined; } : () => any
+>undefined : undefined
+
+declare module "./main" {
+    interface Cls {
+>Cls : Cls
+
+        foo(): Lib;
+>foo : () => Lib
+>Lib : Lib
+    }
+    namespace Cls {
+>Cls : typeof Cls
+
+        function bar(): Lib;
+>bar : () => Lib
+>Lib : Lib
+    }
+}
+

--- a/tests/cases/compiler/typeReferenceDirectives1.ts
+++ b/tests/cases/compiler/typeReferenceDirectives1.ts
@@ -1,0 +1,14 @@
+// @noImplicitReferences: true
+// @traceResolution: true
+// @declaration: true
+// @typesRoot: /
+
+
+// @filename: /types/lib/index.d.ts
+interface $ { x }
+
+// @filename: /app.ts
+/// <reference types="lib"/>
+interface A {
+    x: $
+}

--- a/tests/cases/compiler/typeReferenceDirectives10.ts
+++ b/tests/cases/compiler/typeReferenceDirectives10.ts
@@ -1,0 +1,17 @@
+// @noImplicitReferences: true
+// @declaration: true
+// @typesRoot: /
+// @traceResolution: true
+
+// @filename: /ref.d.ts
+export interface $ { x }
+
+// @filename: /types/lib/index.d.ts
+declare let $: { x: number }
+
+// @filename: /app.ts
+/// <reference types="lib"/>
+import {$} from "./ref";
+export interface A {
+    x: $
+}

--- a/tests/cases/compiler/typeReferenceDirectives11.ts
+++ b/tests/cases/compiler/typeReferenceDirectives11.ts
@@ -1,0 +1,19 @@
+// @noImplicitReferences: true
+// @declaration: true
+// @typesRoot: /
+// @traceResolution: true
+// @types: lib
+// @out: output.js
+
+// @filename: /types/lib/index.d.ts
+
+interface Lib { x }
+
+// @filename: /mod1.ts
+
+export function foo(): Lib { return {x: 1} }
+
+// @filename: /mod2.ts
+
+import {foo} from "./mod1";
+export const bar = foo();

--- a/tests/cases/compiler/typeReferenceDirectives12.ts
+++ b/tests/cases/compiler/typeReferenceDirectives12.ts
@@ -1,0 +1,37 @@
+// @noImplicitReferences: true
+// @declaration: true
+// @typesRoot: /
+// @traceResolution: true
+// @out: output.js
+
+// @filename: /types/lib/index.d.ts
+
+interface Lib { x }
+
+// @filename: /main.ts
+export class Cls {
+    x
+}
+
+// @filename: /mod1.ts
+/// <reference types="lib" />
+
+import {Cls} from "./main";
+Cls.prototype.foo = function() { return undefined; }
+
+declare module "./main" {
+    interface Cls {
+        foo(): Lib;
+    }
+    namespace Cls {
+        function bar(): Lib;
+    }
+}
+
+// @filename: /mod2.ts
+import { Cls } from "./main";
+import "./mod1";
+
+export const cls = Cls;
+export const foo = new Cls().foo();
+export const bar = Cls.bar();

--- a/tests/cases/compiler/typeReferenceDirectives13.ts
+++ b/tests/cases/compiler/typeReferenceDirectives13.ts
@@ -1,0 +1,17 @@
+// @noImplicitReferences: true
+// @declaration: true
+// @typesRoot: /
+// @traceResolution: true
+
+// @filename: /ref.d.ts
+export interface $ { x }
+
+// @filename: /types/lib/index.d.ts
+declare let $: { x: number }
+
+// @filename: /app.ts
+/// <reference types="lib"/>
+import {$} from "./ref";
+export interface A {
+    x: () => typeof $
+}

--- a/tests/cases/compiler/typeReferenceDirectives2.ts
+++ b/tests/cases/compiler/typeReferenceDirectives2.ts
@@ -1,0 +1,13 @@
+// @noImplicitReferences: true
+// @traceResolution: true
+// @declaration: true
+// @typesRoot: /
+// @types: lib
+
+// @filename: /types/lib/index.d.ts
+interface $ { x }
+
+// @filename: /app.ts
+interface A {
+    x: $
+}

--- a/tests/cases/compiler/typeReferenceDirectives3.ts
+++ b/tests/cases/compiler/typeReferenceDirectives3.ts
@@ -1,0 +1,19 @@
+// @noImplicitReferences: true
+// @declaration: true
+// @typesRoot: /
+// @traceResolution: true
+
+// $ comes from d.ts file - no need to add type reference directive
+
+// @filename: /ref.d.ts
+interface $ { x }
+
+// @filename: /types/lib/index.d.ts
+declare let $: { x: number }
+
+// @filename: /app.ts
+/// <reference types="lib"/>
+/// <reference path="ref.d.ts" />
+interface A {
+    x: () => $
+}

--- a/tests/cases/compiler/typeReferenceDirectives4.ts
+++ b/tests/cases/compiler/typeReferenceDirectives4.ts
@@ -1,0 +1,20 @@
+// @noImplicitReferences: true
+// @traceResolution: true
+// @declaration: true
+// @typesRoot: /
+
+// $ comes from d.ts file - no need to add type reference directive
+
+// @filename: /ref.d.ts
+interface $ { x }
+
+// @filename: /types/lib/index.d.ts
+declare let $: { x: number }
+
+
+// @filename: /app.ts
+/// <reference path="./ref.d.ts"/>
+/// <reference types="lib"/>
+
+let x: $;
+let y = () => x

--- a/tests/cases/compiler/typeReferenceDirectives5.ts
+++ b/tests/cases/compiler/typeReferenceDirectives5.ts
@@ -1,0 +1,17 @@
+// @noImplicitReferences: true
+// @traceResolution: true
+// @declaration: true
+// @typesRoot: /
+
+// @filename: /ref.d.ts
+export interface $ { x }
+
+// @filename: /types/lib/index.d.ts
+declare let $: { x: number }
+
+// @filename: /app.ts
+/// <reference types="lib"/>
+import {$} from "./ref";
+export interface A {
+    x: typeof $;
+}

--- a/tests/cases/compiler/typeReferenceDirectives6.ts
+++ b/tests/cases/compiler/typeReferenceDirectives6.ts
@@ -1,0 +1,21 @@
+// @noImplicitReferences: true
+// @traceResolution: true
+// @declaration: true
+// @typesRoot: /
+
+// $ comes from type declaration file - type reference directive should be added
+
+// @filename: /ref.d.ts
+declare let $: { x: number }
+    
+// @filename: /types/lib/index.d.ts
+interface $ { x }
+
+
+// @filename: /app.ts
+/// <reference path="./ref.d.ts"/>
+/// <reference types="lib"/>
+
+let x: $;
+let y = () => x
+

--- a/tests/cases/compiler/typeReferenceDirectives7.ts
+++ b/tests/cases/compiler/typeReferenceDirectives7.ts
@@ -1,0 +1,18 @@
+// @noImplicitReferences: true
+// @traceResolution: true
+// @declaration: true
+// @typesRoot: /
+
+// local value shadows global - no need to add type reference directive 
+   
+// @filename: /types/lib/index.d.ts
+declare let $: { x: number }
+
+
+// @filename: /app.ts
+/// <reference types="lib"/>
+
+export let $ = 1;
+
+export let x: typeof $;
+export let y = () => x

--- a/tests/cases/compiler/typeReferenceDirectives8.ts
+++ b/tests/cases/compiler/typeReferenceDirectives8.ts
@@ -1,0 +1,18 @@
+// @noImplicitReferences: true
+// @declaration: true
+// @typesRoot: /
+// @traceResolution: true
+// @types: lib
+
+// @filename: /types/lib/index.d.ts
+
+interface Lib { x }
+
+// @filename: /mod1.ts
+
+export function foo(): Lib { return {x: 1} }
+
+// @filename: /mod2.ts
+
+import {foo} from "./mod1";
+export const bar = foo();

--- a/tests/cases/compiler/typeReferenceDirectives9.ts
+++ b/tests/cases/compiler/typeReferenceDirectives9.ts
@@ -1,0 +1,36 @@
+// @noImplicitReferences: true
+// @declaration: true
+// @typesRoot: /
+// @traceResolution: true
+
+// @filename: /types/lib/index.d.ts
+
+interface Lib { x }
+
+// @filename: /main.ts
+export class Cls {
+    x
+}
+
+// @filename: /mod1.ts
+/// <reference types="lib" />
+
+import {Cls} from "./main";
+Cls.prototype.foo = function() { return undefined; }
+
+declare module "./main" {
+    interface Cls {
+        foo(): Lib;
+    }
+    namespace Cls {
+        function bar(): Lib;
+    }
+}
+
+// @filename: /mod2.ts
+import { Cls } from "./main";
+import "./mod1";
+
+export const cls = Cls;
+export const foo = new Cls().foo();
+export const bar = Cls.bar();


### PR DESCRIPTION
in this PR type reference directives are included in every file that exposes something from type declaration file on its public surface 