### PR TITLE
[Transforms] Do not emit ES6 import/export inside namespaces

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -157,7 +157,15 @@ namespace ts {
          * @param node The node to visit.
          */
         function namespaceElementVisitorWorker(node: Node): VisitResult<Node> {
-            if (node.transformFlags & TransformFlags.TypeScript || hasModifier(node, ModifierFlags.Export)) {
+            if (node.kind === SyntaxKind.ExportDeclaration ||
+                node.kind === SyntaxKind.ImportDeclaration ||
+                node.kind === SyntaxKind.ImportClause ||
+                (node.kind === SyntaxKind.ImportEqualsDeclaration &&
+                 (<ImportEqualsDeclaration>node).moduleReference.kind === SyntaxKind.ExternalModuleReference)) {
+                // do not emit ES6 imports and exports since they are illegal inside a namespace
+                return createNotEmittedStatement(node);
+           }
+           else if (node.transformFlags & TransformFlags.TypeScript || hasModifier(node, ModifierFlags.Export)) {
                 // This node is explicitly marked as TypeScript, or is exported at the namespace
                 // level, so we should transform the node.
                 return visitTypeScript(node);

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -163,7 +163,7 @@ namespace ts {
                 (node.kind === SyntaxKind.ImportEqualsDeclaration &&
                  (<ImportEqualsDeclaration>node).moduleReference.kind === SyntaxKind.ExternalModuleReference)) {
                 // do not emit ES6 imports and exports since they are illegal inside a namespace
-                return createNotEmittedStatement(node);
+                return undefined;
            }
            else if (node.transformFlags & TransformFlags.TypeScript || hasModifier(node, ModifierFlags.Export)) {
                 // This node is explicitly marked as TypeScript, or is exported at the namespace

--- a/tests/baselines/reference/es5ModuleInternalNamedImports.errors.txt
+++ b/tests/baselines/reference/es5ModuleInternalNamedImports.errors.txt
@@ -6,9 +6,13 @@ tests/cases/compiler/es5ModuleInternalNamedImports.ts(27,5): error TS1194: Expor
 tests/cases/compiler/es5ModuleInternalNamedImports.ts(28,5): error TS1194: Export declarations are not permitted in a namespace.
 tests/cases/compiler/es5ModuleInternalNamedImports.ts(29,5): error TS1194: Export declarations are not permitted in a namespace.
 tests/cases/compiler/es5ModuleInternalNamedImports.ts(30,5): error TS1194: Export declarations are not permitted in a namespace.
+tests/cases/compiler/es5ModuleInternalNamedImports.ts(31,25): error TS1147: Import declarations in a namespace cannot reference a module.
+tests/cases/compiler/es5ModuleInternalNamedImports.ts(32,20): error TS1147: Import declarations in a namespace cannot reference a module.
+tests/cases/compiler/es5ModuleInternalNamedImports.ts(33,32): error TS1147: Import declarations in a namespace cannot reference a module.
+tests/cases/compiler/es5ModuleInternalNamedImports.ts(35,16): error TS2307: Cannot find module 'M3'.
 
 
-==== tests/cases/compiler/es5ModuleInternalNamedImports.ts (8 errors) ====
+==== tests/cases/compiler/es5ModuleInternalNamedImports.ts (12 errors) ====
     
     export module M {
         // variable
@@ -55,5 +59,17 @@ tests/cases/compiler/es5ModuleInternalNamedImports.ts(30,5): error TS1194: Expor
         export {M_A as a};
         ~~~~~~~~~~~~~~~~~~
 !!! error TS1194: Export declarations are not permitted in a namespace.
+        import * as M2 from "M2";
+                            ~~~~
+!!! error TS1147: Import declarations in a namespace cannot reference a module.
+        import M4 from "M4";
+                       ~~~~
+!!! error TS1147: Import declarations in a namespace cannot reference a module.
+        export import M5 = require("M5");
+                                   ~~~~
+!!! error TS1147: Import declarations in a namespace cannot reference a module.
     }
+    import M3 from "M3";
+                   ~~~~
+!!! error TS2307: Cannot find module 'M3'.
     

--- a/tests/baselines/reference/es5ModuleInternalNamedImports.js
+++ b/tests/baselines/reference/es5ModuleInternalNamedImports.js
@@ -29,7 +29,11 @@ export module M {
     export {M_F as f};
     export {M_E as e};
     export {M_A as a};
+    import * as M2 from "M2";
+    import M4 from "M4";
+    export import M5 = require("M5");
 }
+import M3 from "M3";
 
 
 //// [es5ModuleInternalNamedImports.js]
@@ -60,6 +64,5 @@ define(["require", "exports"], function (require, exports) {
         var M_E = M.M_E;
         // alias
         M.M_A = M_M;
-        // Reexports
     })(M = exports.M || (exports.M = {}));
 });

--- a/tests/baselines/reference/es6ModuleInternalNamedImports.js
+++ b/tests/baselines/reference/es6ModuleInternalNamedImports.js
@@ -55,11 +55,4 @@ export var M;
     var M_E = M.M_E;
     // alias
     M.M_A = M_M;
-    // Reexports
-    export { M_V as v };
-    export { M_C as c };
-    export { M_M as m };
-    export { M_F as f };
-    export { M_E as e };
-    export { M_A as a };
 })(M || (M = {}));

--- a/tests/baselines/reference/es6ModuleInternalNamedImports2.js
+++ b/tests/baselines/reference/es6ModuleInternalNamedImports2.js
@@ -59,11 +59,4 @@ export var M;
     M.M_A = M_M;
 })(M || (M = {}));
 (function (M) {
-    // Reexports
-    export { M_V as v };
-    export { M_C as c };
-    export { M_M as m };
-    export { M_F as f };
-    export { M_E as e };
-    export { M_A as a };
 })(M || (M = {}));

--- a/tests/baselines/reference/exportDeclarationInInternalModule.js
+++ b/tests/baselines/reference/exportDeclarationInInternalModule.js
@@ -53,7 +53,6 @@ var Bbb;
         return SomeType;
     }());
     Bbb.SomeType = SomeType;
-     // this line causes the nullref
 })(Bbb || (Bbb = {}));
 var a;
 

--- a/tests/cases/compiler/es5ModuleInternalNamedImports.ts
+++ b/tests/cases/compiler/es5ModuleInternalNamedImports.ts
@@ -30,4 +30,8 @@ export module M {
     export {M_F as f};
     export {M_E as e};
     export {M_A as a};
+    import * as M2 from "M2";
+    import M4 from "M4";
+    export import M5 = require("M5");
 }
+import M3 from "M3";


### PR DESCRIPTION
Fixes #7874

ES6 imports and exports are illegal inside namespaces. In order to emit syntactically legal code, skip emit for these incorrect statements.

Fixes tests:

1. es5ModuleInternalNamedImport
1. es6ModuleInternalNamedImports
1. es6ModuleInternalNamedImports2
1. exportDeclarationInInternalModule
1. importInsideModule
1. multipleExports
1. privacyGloImportParseErrors
1. privacyImportParseErrors*
1. privacyCheckOnImportedModuleDeclarationsInsideModule

*Still has some incorrect, unrelated emit at the end of the module
