### PR TITLE
Reorder host in jakefile so TYPESCRIPT_HOST is checked before localhost

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -244,7 +244,7 @@ function concatenateFiles(destinationFile, sourceFiles) {
 }
 
 var useDebugMode = true;
-var host = (process.env.host || process.env.TYPESCRIPT_HOST || "node");
+var host = (process.env.TYPESCRIPT_HOST || process.env.host || "node");
 var compilerFilename = "tsc.js";
 var LKGCompiler = path.join(LKGDirectory, compilerFilename);
 var builtLocalCompiler = path.join(builtLocalDirectory, compilerFilename);


### PR DESCRIPTION
My `HOST` environment variable is set to `localhost` for another tool, and previously that took precedence over `TYPESCRIPT_HOST` in the jake file which caused build errors.