### PR TITLE
[Transforms] Fix the name when synthesized node is clone of auto generate identifier kind

### DIFF
--- a/src/compiler/printer.ts
+++ b/src/compiler/printer.ts
@@ -2607,8 +2607,10 @@ const _super = (function (geti, seti) {
             function getSourceNodeForGeneratedName(name: Identifier) {
                 let node: Node = name;
                 while (node.original !== undefined) {
+                    const nodeId = node.id;
                     node = node.original;
-                    if (isIdentifier(node) && node.autoGenerateKind === GeneratedIdentifierKind.Node) {
+                    // If this is not the exact clone of identifier use this identifier to generate the name
+                    if (isIdentifier(node) && node.autoGenerateKind === GeneratedIdentifierKind.Node && node.id !== nodeId) {
                         break;
                     }
                 }

--- a/src/compiler/printer.ts
+++ b/src/compiler/printer.ts
@@ -2609,7 +2609,7 @@ const _super = (function (geti, seti) {
                 while (node.original !== undefined) {
                     const nodeId = node.id;
                     node = node.original;
-                    // If this is not the exact clone of identifier use this identifier to generate the name
+                    // If "node" is not the exact clone of "original" identifier, use "original" identifier to generate the name
                     if (isIdentifier(node) && node.autoGenerateKind === GeneratedIdentifierKind.Node && node.id !== nodeId) {
                         break;
                     }

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -461,7 +461,7 @@ namespace ts {
         const edgeTraversalPath = nodeEdgeTraversalMap[node.kind];
         if (edgeTraversalPath) {
             for (const edge of edgeTraversalPath) {
-                const value = (<Map<any>>node)[edge.name];
+                const value = edge && (<Map<any>>node)[edge.name];
                 if (value !== undefined) {
                     result = isArray(value)
                         ? reduceLeft(<NodeArray<Node>>value, f, result)
@@ -619,7 +619,7 @@ namespace ts {
         const edgeTraversalPath = nodeEdgeTraversalMap[node.kind];
         if (edgeTraversalPath) {
             for (const edge of edgeTraversalPath) {
-                const value = <Node | NodeArray<Node>>node[edge.name];
+                const value = edge && <Node | NodeArray<Node>>node[edge.name];
                 if (value !== undefined) {
                     let visited: Node | NodeArray<Node>;
                     if (isArray(value)) {

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -461,7 +461,7 @@ namespace ts {
         const edgeTraversalPath = nodeEdgeTraversalMap[node.kind];
         if (edgeTraversalPath) {
             for (const edge of edgeTraversalPath) {
-                const value = edge && (<Map<any>>node)[edge.name];
+                const value = (<Map<any>>node)[edge.name];
                 if (value !== undefined) {
                     result = isArray(value)
                         ? reduceLeft(<NodeArray<Node>>value, f, result)
@@ -619,7 +619,7 @@ namespace ts {
         const edgeTraversalPath = nodeEdgeTraversalMap[node.kind];
         if (edgeTraversalPath) {
             for (const edge of edgeTraversalPath) {
-                const value = edge && <Node | NodeArray<Node>>node[edge.name];
+                const value = <Node | NodeArray<Node>>node[edge.name];
                 if (value !== undefined) {
                     let visited: Node | NodeArray<Node>;
                     if (isArray(value)) {


### PR DESCRIPTION
This fixes variable declaration created for default exported class without name
Fixes #7875

Fixes baselines:
- tests/cases/compiler/es5ExportDefaultClassDeclaration2.ts
- tests/cases/conformance/es6/moduleExportsSystem/decoratedDefaultExportsGetExportedSystem.ts