### PR TITLE
[Transforms] Fix emit for es6 import without clause

### DIFF
--- a/src/compiler/printer.ts
+++ b/src/compiler/printer.ts
@@ -1643,8 +1643,10 @@ const _super = (function (geti, seti) {
             function emitImportDeclaration(node: ImportDeclaration) {
                 emitModifiers(node, node.modifiers);
                 write("import ");
-                emit(node.importClause);
-                write(" from ");
+                if (node.importClause) {
+                    emit(node.importClause);
+                    write(" from ");
+                }
                 emitExpression(node.moduleSpecifier);
                 write(";");
             }


### PR DESCRIPTION
Fixes #8036 

Fixed tests:
- tests/cases/compiler/es6ImportWithoutFromClause.ts
- tests/cases/compiler/es6ImportWithoutFromClauseNonInstantiatedModule.ts
- tests/cases/compiler/moduleElementsInWrongContext.ts
- tests/cases/compiler/moduleElementsInWrongContext2.ts
- tests/cases/compiler/moduleElementsInWrongContext3.ts