### PR TITLE
[Transforms] Fixes trailing comments emit for modules and enum declaration

### DIFF
--- a/src/compiler/comments.ts
+++ b/src/compiler/comments.ts
@@ -120,7 +120,7 @@ namespace ts {
                 const node = range as Node;
                 if (node.kind === SyntaxKind.VariableStatement &&
                     node.original &&
-                    node.original.kind === SyntaxKind.ModuleDeclaration) {
+                    (node.original.kind === SyntaxKind.ModuleDeclaration || node.original.kind === SyntaxKind.EnumDeclaration)) {
                     // Trailing comments for module declaration should be emitted with function closure instead of variable statement
                     //     /** Module comment*/
                     //     module m1 {

--- a/src/compiler/comments.ts
+++ b/src/compiler/comments.ts
@@ -117,6 +117,25 @@ namespace ts {
                     return undefined;
                 }
 
+                const node = range as Node;
+                if (node.kind === SyntaxKind.VariableStatement &&
+                    node.original &&
+                    node.original.kind === SyntaxKind.ModuleDeclaration) {
+                    // Trailing comments for module declaration should be emitted with function closure instead of variable statement
+                    //     /** Module comment*/
+                    //     module m1 {
+                    //         function foo4Export() {
+                    //         }
+                    //     } // trailing comment module
+                    // Should emit
+                    //     /** Module comment*/
+                    //     var m1;
+                    //     (function (m1) {
+                    //         function foo4Export() {
+                    //         }
+                    //     })(m1 || (m1 = {})); // trailing comment module
+                    return undefined;
+                }
                 return getTrailingCommentsOfPosition(range.end);
             }
 

--- a/src/compiler/comments.ts
+++ b/src/compiler/comments.ts
@@ -117,25 +117,6 @@ namespace ts {
                     return undefined;
                 }
 
-                const node = range as Node;
-                if (node.kind === SyntaxKind.VariableStatement &&
-                    node.original &&
-                    (node.original.kind === SyntaxKind.ModuleDeclaration || node.original.kind === SyntaxKind.EnumDeclaration)) {
-                    // Trailing comments for module declaration should be emitted with function closure instead of variable statement
-                    //     /** Module comment*/
-                    //     module m1 {
-                    //         function foo4Export() {
-                    //         }
-                    //     } // trailing comment module
-                    // Should emit
-                    //     /** Module comment*/
-                    //     var m1;
-                    //     (function (m1) {
-                    //         function foo4Export() {
-                    //         }
-                    //     })(m1 || (m1 = {})); // trailing comment module
-                    return undefined;
-                }
                 return getTrailingCommentsOfPosition(range.end);
             }
 

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -2214,24 +2214,6 @@ namespace ts {
         }
 
         /**
-         * Adds a leading VariableStatement for an enum or module declaration.
-         */
-        function addVarForEnumDeclaration(statements: Statement[], node: EnumDeclaration) {
-            // Emit a variable statement for the enum.
-            statements.push(
-                createVariableStatement(
-                    isES6ExportedDeclaration(node)
-                        ? visitNodes(node.modifiers, visitor, isModifier)
-                        : undefined,
-                    [createVariableDeclaration(
-                        getDeclarationName(node)
-                    )],
-                    /*location*/ node
-                )
-            );
-        }
-
-        /**
          * Adds a trailing VariableStatement for an enum or module declaration.
          */
         function addVarForEnumExportedFromNamespace(statements: Statement[], node: EnumDeclaration | ModuleDeclaration) {
@@ -2261,7 +2243,7 @@ namespace ts {
 
             const statements: Statement[] = [];
             if (shouldEmitVarForEnumDeclaration(node)) {
-                addVarForEnumDeclaration(statements, node);
+                addVarForEnumOrModuleDeclaration(statements, node);
             }
 
             const localName = getGeneratedNameForNode(node);
@@ -2395,9 +2377,9 @@ namespace ts {
         }
 
         /**
-         * Adds a leading VariableStatement for a module declaration.
+         * Adds a leading VariableStatement for a enum or module declaration.
          */
-        function addVarForModuleDeclaration(statements: Statement[], node: ModuleDeclaration) {
+        function addVarForEnumOrModuleDeclaration(statements: Statement[], node: ModuleDeclaration | EnumDeclaration) {
             // Emit a variable statement for the module.
             statements.push(
                 setOriginalNode(
@@ -2433,7 +2415,7 @@ namespace ts {
             const statements: Statement[] = [];
 
             if (shouldEmitVarForModuleDeclaration(node)) {
-                addVarForModuleDeclaration(statements, node);
+                addVarForEnumOrModuleDeclaration(statements, node);
             }
 
             const localName = getGeneratedNameForNode(node);

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -2390,7 +2390,21 @@ namespace ts {
                         [createVariableDeclaration(
                             getDeclarationName(node)
                         )],
-                        /*location*/ node
+                        // Trailing comments for module declaration should be emitted with function closure instead of variable statement
+                        // So do not set the end position for the variable statement node
+                        //     /** Module comment*/
+                        //     module m1 {
+                        //         function foo4Export() {
+                        //         }
+                        //     } // trailing comment module
+                        // Should emit
+                        //     /** Module comment*/
+                        //     var m1;
+                        //     (function (m1) {
+                        //         function foo4Export() {
+                        //         }
+                        //     })(m1 || (m1 = {})); // trailing comment module
+                        /*location*/ { pos: node.pos, end: -1 }
                     ),
                     node
                 )


### PR DESCRIPTION
This also unifies ```addVarForEnumDeclaration``` and ```addVarForModuleDeclaration```
Fixes #8045

Tests Fixed:
- tests\cases\compiler\augmentedTypesClass.ts
- tests\cases\compiler\augmentedTypesClass3.ts
- tests\cases\compiler\augmentedTypesEnum.ts
- tests\cases\compiler\augmentedTypesEnum2.ts
- tests\cases\compiler\augmentedTypesFunction.ts
- tests\cases\compiler\augmentedTypesModules.ts
- tests\cases\compiler\augmentedTypesVar.ts
- tests\cases\compiler\commentsEnums.ts
- tests\cases\compiler\commentsModules.ts
