### PR TITLE
[Transforms] Set LocalName flag for exported local then skip it

### DIFF
--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -552,7 +552,7 @@ namespace ts {
             }
             else {
                 statements.push(
-                    createExportStatement(node.name, node.name, /*location*/ node)
+                    createExportStatement(node.name, setNodeEmitFlags(getSynthesizedClone(node.name), NodeEmitFlags.LocalName), /*location*/ node)
                 );
             }
         }
@@ -712,6 +712,10 @@ namespace ts {
         }
 
         function substituteExpressionIdentifier(node: Identifier): Expression {
+            if (getNodeEmitFlags(node) & NodeEmitFlags.LocalName) {
+                return node;
+            }
+
             const container = resolver.getReferencedExportContainer(node, (getNodeEmitFlags(node) & NodeEmitFlags.ExportName) !== 0);
             if (container) {
                 if (container.kind === SyntaxKind.SourceFile) {


### PR DESCRIPTION
Fixes #7894 


The module transformer now skips substitution of LocalName, just like ts transformer already does.

Fixes test:
1. tests/cases/compiler/functionAndImportNameConflict.ts