### PR TITLE
generate docs for compiler

### DIFF
--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "noImplicitAny": true,
-        "removeComments": true,
+        "removeComments": false,
         "preserveConstEnums": true,
         "out": "../../built/local/tsc.js",
         "sourceMap": true


### PR DESCRIPTION
 We need documentation for typescript compiler's functions. Now there are no docs in typescript.d.ts

