### PR TITLE
[Transforms] Add calls to unescapeIdentifier for destructured identifiers

### DIFF
--- a/src/compiler/transformers/destructuring.ts
+++ b/src/compiler/transformers/destructuring.ts
@@ -370,16 +370,19 @@ namespace ts {
                 );
             }
             else if (isLiteralExpression(propertyName)) {
-                return createElementAccess(
-                    expression,
-                    getSynthesizedClone(propertyName)
-                );
+                const clone = getSynthesizedClone(propertyName);
+                clone.text = unescapeIdentifier(clone.text);
+                return createElementAccess(expression, clone);
             }
             else {
-                return createPropertyAccess(
-                    expression,
-                    isGeneratedIdentifier(propertyName) ? getSynthesizedClone(propertyName) : createIdentifier(propertyName.text)
-                );
+                if (isGeneratedIdentifier(propertyName)) {
+                    const clone = getSynthesizedClone(propertyName);
+                    clone.text = unescapeIdentifier(clone.text);
+                    return createPropertyAccess(expression, clone);
+                }
+                else {
+                    return createPropertyAccess(expression, createIdentifier(unescapeIdentifier(propertyName.text)));
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes #8077.

Fixes tests exportsAndImportsWithUnderscores1, 2 and 3.