### PR TITLE
[Transforms] Fixes the incorrectly assigned arrow expression trailing comments

### DIFF
--- a/src/compiler/printer.ts
+++ b/src/compiler/printer.ts
@@ -1505,8 +1505,11 @@ const _super = (function (geti, seti) {
                 const endingLine = writer.getLine();
                 emitLexicalEnvironment(endLexicalEnvironment(), /*newLine*/ startingLine !== endingLine);
 
-                const range = collapseRangeToEnd(body.statements);
-                emitLeadingComments(range, getLeadingComments(range));
+                // Do not emit leading comments if the body belongs to arrow expression
+                if (!body.original || isBlock(body.original)) {
+                    const range = collapseRangeToEnd(body.statements);
+                    emitLeadingComments(range, getLeadingComments(range));
+                }
                 decreaseIndent();
             }
 

--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -1271,6 +1271,7 @@ namespace ts {
                 setNodeEmitFlags(block, NodeEmitFlags.SingleLine);
             }
 
+            setOriginalNode(block, node.body);
             return block;
         }
 

--- a/tests/baselines/reference/disallowLineTerminatorBeforeArrow.js
+++ b/tests/baselines/reference/disallowLineTerminatorBeforeArrow.js
@@ -110,9 +110,7 @@ var f8 = function (x, y, z) {
 var f9 = function (a) { return a; };
 var f10 = function (a) { return a; };
 var f11 = function (a) { return a; };
-var f12 = function (a) {
-    return a;
-};
+var f12 = function (a) { return a; };
 // Should be valid.
 var f11 = function (a) { return a; };
 // Should be valid.


### PR DESCRIPTION
Fixes #8041

Test fixed:
- disallowLineTerminatorBeforeArrow.ts