### PR TITLE
Filter library text from RWC output

### DIFF
--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -190,8 +190,9 @@ namespace RWC {
                     if (compilerResult.errors.length === 0) {
                         return null;
                     }
-
-                    return Harness.Compiler.getErrorBaseline(inputFiles.concat(otherFiles), compilerResult.errors);
+                    // Do not include the library in the baselines to avoid noise
+                    const baselineFiles = inputFiles.concat(otherFiles).filter(f => !Harness.isDefaultLibraryFile(f.unitName));
+                    return Harness.Compiler.getErrorBaseline(baselineFiles, compilerResult.errors);
                 }, false, baselineOpts);
             });
 


### PR DESCRIPTION
This removes the text of the library file from the output of RWC tests. if the library files has errors, they will still be reported, it is the text of the file to avoid noise in the tests every time someone touches the library,