### PR TITLE
Assign the node to expression statement of variable so that it emits comments

### DIFF
--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -1418,7 +1418,7 @@ namespace ts {
                     }
                 }
                 if (assignments) {
-                    return createStatement(reduceLeft(assignments, (acc, v) => createBinary(v, SyntaxKind.CommaToken, acc)));
+                    return createStatement(reduceLeft(assignments, (acc, v) => createBinary(v, SyntaxKind.CommaToken, acc)), node);
                 }
                 else {
                     // none of declarations has initializer - the entire variable statement can be deleted

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -586,7 +586,8 @@ namespace ts {
                 return createStatement(
                     inlineExpressions(
                         map(variables, transformInitializedVariable)
-                    )
+                    ),
+                    node
                 );
             }
             return node;

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -607,7 +607,7 @@ namespace ts {
             }
 
             if (expressions.length) {
-                return createStatement(inlineExpressions(expressions));
+                return createStatement(inlineExpressions(expressions), node);
             }
 
             return undefined;

--- a/tests/baselines/reference/es6ImportNamedImportDts.js
+++ b/tests/baselines/reference/es6ImportNamedImportDts.js
@@ -154,7 +154,7 @@ exports.xxxx9 = new server_7.x111();
 var server_8 = require("./server");
 exports.z111 = new server_8.z1();
 var server_9 = require("./server");
-exports.z2 = new server_9.z2();
+exports.z2 = new server_9.z2(); // z2 shouldn't give redeclare error
 
 
 //// [server.d.ts]

--- a/tests/baselines/reference/es6ImportNamedImportWithExport.js
+++ b/tests/baselines/reference/es6ImportNamedImportWithExport.js
@@ -72,7 +72,7 @@ exports.xxxx = server_7.x1;
 var server_8 = require("./server");
 exports.z111 = server_8.z1;
 var server_9 = require("./server");
-exports.z2 = server_9.z2;
+exports.z2 = server_9.z2; // z2 shouldn't give redeclare error
 
 
 //// [server.d.ts]

--- a/tests/baselines/reference/privacyCheckAnonymousFunctionParameter2.js
+++ b/tests/baselines/reference/privacyCheckAnonymousFunctionParameter2.js
@@ -17,7 +17,7 @@ module Q {
 //// [privacyCheckAnonymousFunctionParameter2.js]
 define(["require", "exports"], function (require, exports) {
     "use strict";
-    exports.x = 1;
+    exports.x = 1; // Makes this an external module 
     var Q;
     (function (Q) {
         function foo(x) {


### PR DESCRIPTION
Fixes #8156

Tests fixed:
- decoratorInstantiateModulesInFunctionBodies.ts
- downlevelLetConst13.ts
- es6ImportNamedImportDts.ts
- es6ImportNamedImportWithExport.ts
- exportedBlockScopedDeclarations.ts
- exportNonInitializedVariablesAMD.ts
- exportNonInitializedVariablesCommonJS.ts
- exportNonInitializedVariablesSystem.ts
- exportNonInitializedVariablesUMD.ts
- privacyCannotNameVarTypeDeclFile.ts
- privacyCheckAnonymousFunctionParameter.ts
- privacyCheckAnonymousFunctionParameter2.ts
- privacyImport.ts
- privacyTopLevelInternalReferenceImportWithExport.ts
- privacyVar.ts