### PR TITLE
Change file watching back to polling.

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2104,7 +2104,7 @@ namespace ts {
         jsxFlags?: JsxFlags;              // flags for knowing what kind of element/attributes we're dealing with
         resolvedJsxType?: Type;           // resolved element attributes type of a JSX openinglike element
         hasSuperCall?: boolean;           // recorded result when we try to find super-call. We only try to find one if this flag is undefined, indicating that we haven't made an attempt.
-        superCall?: ExpressionStatement;  // Cached first super-call found in the constructor. Used in checking whether super is called before this-accessing 
+        superCall?: ExpressionStatement;  // Cached first super-call found in the constructor. Used in checking whether super is called before this-accessing
     }
 
     export const enum TypeFlags {
@@ -2484,7 +2484,7 @@ namespace ts {
         // When options come from a config file, its path is recorded here
         configFilePath?: string;
         /* @internal */
-        // Path used to used to compute primary search locations 
+        // Path used to used to compute primary search locations
         typesRoot?: string;
         types?: string[];
 
@@ -2801,7 +2801,7 @@ namespace ts {
          */
         resolveModuleNames?(moduleNames: string[], containingFile: string): ResolvedModule[];
         /**
-         * This method is a companion for 'resolveModuleNames' and is used to resolve 'types' references to actual type declaration files 
+         * This method is a companion for 'resolveModuleNames' and is used to resolve 'types' references to actual type declaration files
          */
         resolveTypeReferenceDirectives?(typeReferenceDirectiveNames: string[], containingFile: string): ResolvedTypeReferenceDirective[];
     }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -111,12 +111,6 @@ namespace ts.server {
         detailLevel?: string;
     }
 
-    interface WatchedFile {
-        fileName: string;
-        callback: FileWatcherCallback;
-        mtime?: Date;
-    }
-
     function parseLoggingEnvironmentString(logEnvStr: string): LogOptions {
         const logEnv: LogOptions = {};
         const args = logEnvStr.split(" ");


### PR DESCRIPTION
We tried the non-polling solution for file watching since last year, and it kept causing us a number of problems regarding watcher instance count limit, cross-platform compatibility, file locking, network file system compatibility etc; while the gain wasn't quite significant to justify all the efforts spent fixing these issues. Therefore it may be better to just go back to polling, which worked reliably for us before and don't have these problems.