### PR TITLE
do not validate module names in augmentations defined in ambient context

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -398,7 +398,11 @@ namespace ts {
             }
             else {
                 // find a module that about to be augmented
-                let mainModule = resolveExternalModuleNameWorker(moduleName, moduleName, Diagnostics.Invalid_module_name_in_augmentation_module_0_cannot_be_found);
+                // do not validate names of augmentations that are defined in ambient context
+                const moduleNotFoundError = !isInAmbientContext(moduleName.parent.parent)
+                    ? Diagnostics.Invalid_module_name_in_augmentation_module_0_cannot_be_found
+                    : undefined;
+                let mainModule = resolveExternalModuleNameWorker(moduleName, moduleName, moduleNotFoundError);
                 if (!mainModule) {
                     return;
                 }

--- a/tests/baselines/reference/moduleAugmentationInDependency.js
+++ b/tests/baselines/reference/moduleAugmentationInDependency.js
@@ -1,0 +1,13 @@
+//// [tests/cases/compiler/moduleAugmentationInDependency.ts] ////
+
+//// [index.d.ts]
+declare module "ext" {
+}
+export {};
+
+//// [app.ts]
+import "A"
+
+//// [app.js]
+"use strict";
+require("A");

--- a/tests/baselines/reference/moduleAugmentationInDependency.symbols
+++ b/tests/baselines/reference/moduleAugmentationInDependency.symbols
@@ -1,0 +1,8 @@
+=== /node_modules/A/index.d.ts ===
+declare module "ext" {
+No type information for this code.}
+No type information for this code.export {};
+No type information for this code.
+No type information for this code.=== /src/app.ts ===
+import "A"
+No type information for this code.

--- a/tests/baselines/reference/moduleAugmentationInDependency.types
+++ b/tests/baselines/reference/moduleAugmentationInDependency.types
@@ -1,0 +1,8 @@
+=== /node_modules/A/index.d.ts ===
+declare module "ext" {
+No type information for this code.}
+No type information for this code.export {};
+No type information for this code.
+No type information for this code.=== /src/app.ts ===
+import "A"
+No type information for this code.

--- a/tests/baselines/reference/moduleAugmentationInDependency2.errors.txt
+++ b/tests/baselines/reference/moduleAugmentationInDependency2.errors.txt
@@ -1,0 +1,12 @@
+/node_modules/A/index.ts(1,16): error TS2664: Invalid module name in augmentation, module 'ext' cannot be found.
+
+
+==== /node_modules/A/index.ts (1 errors) ====
+    declare module "ext" {
+                   ~~~~~
+!!! error TS2664: Invalid module name in augmentation, module 'ext' cannot be found.
+    }
+    export {};
+    
+==== /src/app.ts (0 errors) ====
+    import "A"

--- a/tests/baselines/reference/moduleAugmentationInDependency2.js
+++ b/tests/baselines/reference/moduleAugmentationInDependency2.js
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/moduleAugmentationInDependency2.ts] ////
+
+//// [index.ts]
+declare module "ext" {
+}
+export {};
+
+//// [app.ts]
+import "A"
+
+//// [index.js]
+"use strict";
+//// [app.js]
+"use strict";
+require("A");

--- a/tests/baselines/reference/privacyGloImportParseErrors.errors.txt
+++ b/tests/baselines/reference/privacyGloImportParseErrors.errors.txt
@@ -14,12 +14,11 @@ tests/cases/compiler/privacyGloImportParseErrors.ts(125,45): error TS1147: Impor
 tests/cases/compiler/privacyGloImportParseErrors.ts(133,9): error TS1038: A 'declare' modifier cannot be used in an already ambient context.
 tests/cases/compiler/privacyGloImportParseErrors.ts(133,24): error TS2435: Ambient modules cannot be nested in other modules or namespaces.
 tests/cases/compiler/privacyGloImportParseErrors.ts(138,16): error TS2435: Ambient modules cannot be nested in other modules or namespaces.
-tests/cases/compiler/privacyGloImportParseErrors.ts(141,12): error TS2664: Invalid module name in augmentation, module 'abc3' cannot be found.
 tests/cases/compiler/privacyGloImportParseErrors.ts(146,25): error TS1147: Import declarations in a namespace cannot reference a module.
 tests/cases/compiler/privacyGloImportParseErrors.ts(149,29): error TS1147: Import declarations in a namespace cannot reference a module.
 
 
-==== tests/cases/compiler/privacyGloImportParseErrors.ts (19 errors) ====
+==== tests/cases/compiler/privacyGloImportParseErrors.ts (18 errors) ====
     module m1 {
         export module m1_M1_public {
             export class c1 {
@@ -193,8 +192,6 @@ tests/cases/compiler/privacyGloImportParseErrors.ts(149,29): error TS1147: Impor
             }
         }
         module "abc3" {
-               ~~~~~~
-!!! error TS2664: Invalid module name in augmentation, module 'abc3' cannot be found.
         }
     }
     

--- a/tests/cases/compiler/moduleAugmentationInDependency.ts
+++ b/tests/cases/compiler/moduleAugmentationInDependency.ts
@@ -1,0 +1,7 @@
+// @filename: /node_modules/A/index.d.ts
+declare module "ext" {
+}
+export {};
+
+// @filename: /src/app.ts
+import "A"

--- a/tests/cases/compiler/moduleAugmentationInDependency2.ts
+++ b/tests/cases/compiler/moduleAugmentationInDependency2.ts
@@ -1,0 +1,7 @@
+// @filename: /node_modules/A/index.ts
+declare module "ext" {
+}
+export {};
+
+// @filename: /src/app.ts
+import "A"


### PR DESCRIPTION
fixes #8113