### PR TITLE
Fix #8162 and #8173: Add root symbols to search in find all referecnes

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -6286,7 +6286,7 @@ namespace ts {
                         if (type) {
                             const propertySymbol = typeChecker.getPropertyOfType(type, propertyName);
                             if (propertySymbol) {
-                                result.push(propertySymbol);
+                                result.push(...typeChecker.getRootSymbols(propertySymbol));
                             }
 
                             // Visit the typeReference as well to see if it directly or indirectly use that property

--- a/tests/cases/fourslash/referencesForClassMembers.ts
+++ b/tests/cases/fourslash/referencesForClassMembers.ts
@@ -1,0 +1,32 @@
+/// <reference path='fourslash.ts'/>
+
+////class Base {
+////    /*1*/a: number;
+////    /*2*/method(): void { }
+////}
+////class MyClass extends Base {
+////    /*3*/a;
+////    /*4*/method() { }
+////}
+////
+////var c: MyClass;
+////c./*5*/a;
+////c./*6*/method();
+
+goTo.marker("1");
+verify.referencesCountIs(3);
+
+goTo.marker("2");
+verify.referencesCountIs(3);
+
+goTo.marker("3");
+verify.referencesCountIs(3);
+
+goTo.marker("4");
+verify.referencesCountIs(3);
+
+goTo.marker("5");
+verify.referencesCountIs(3);
+
+goTo.marker("6");
+verify.referencesCountIs(3);

--- a/tests/cases/fourslash/referencesForClassMembersExtendingAbstractClass.ts
+++ b/tests/cases/fourslash/referencesForClassMembersExtendingAbstractClass.ts
@@ -1,0 +1,32 @@
+/// <reference path='fourslash.ts'/>
+
+////abstract class Base {
+////    abstract /*1*/a: number;
+////    abstract /*2*/method(): void;
+////}
+////class MyClass extends Base {
+////    /*3*/a;
+////    /*4*/method() { }
+////}
+////
+////var c: MyClass;
+////c./*5*/a;
+////c./*6*/method();
+
+goTo.marker("1");
+verify.referencesCountIs(3);
+
+goTo.marker("2");
+verify.referencesCountIs(3);
+
+goTo.marker("3");
+verify.referencesCountIs(3);
+
+goTo.marker("4");
+verify.referencesCountIs(3);
+
+goTo.marker("5");
+verify.referencesCountIs(3);
+
+goTo.marker("6");
+verify.referencesCountIs(3);

--- a/tests/cases/fourslash/referencesForClassMembersExtendingGenericClass.ts
+++ b/tests/cases/fourslash/referencesForClassMembersExtendingGenericClass.ts
@@ -1,0 +1,32 @@
+/// <reference path='fourslash.ts'/>
+
+////class Base<T> {
+////    /*1*/a: this;
+////    /*2*/method<U>(a?:T, b?:U): this { }
+////}
+////class MyClass extends Base<number> {
+////    /*3*/a;
+////    /*4*/method() { }
+////}
+////
+////var c: MyClass;
+////c./*5*/a;
+////c./*6*/method();
+
+goTo.marker("1");
+verify.referencesCountIs(3);
+
+goTo.marker("2");
+verify.referencesCountIs(3);
+
+goTo.marker("3");
+verify.referencesCountIs(3);
+
+goTo.marker("4");
+verify.referencesCountIs(3);
+
+goTo.marker("5");
+verify.referencesCountIs(3);
+
+goTo.marker("6");
+verify.referencesCountIs(3);

--- a/tests/cases/fourslash/referencesForInheritedProperties6.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties6.ts
@@ -14,13 +14,13 @@
 //// v./*6*/doStuff();
 
 goTo.marker("1");
-verify.referencesCountIs(1);
+verify.referencesCountIs(3);
 
 goTo.marker("2");
 verify.referencesCountIs(3);
 
 goTo.marker("3");
-verify.referencesCountIs(2);
+verify.referencesCountIs(3);
 
 goTo.marker("4");
 verify.referencesCountIs(3);
@@ -29,4 +29,4 @@ goTo.marker("5");
 verify.referencesCountIs(3);
 
 goTo.marker("6");
-verify.referencesCountIs(2);
+verify.referencesCountIs(3);

--- a/tests/cases/fourslash/referencesForInheritedProperties7.ts
+++ b/tests/cases/fourslash/referencesForInheritedProperties7.ts
@@ -18,7 +18,7 @@
 //// v./*8*/doStuff();
 
 goTo.marker("1");
-verify.referencesCountIs(1);
+verify.referencesCountIs(3);
 
 goTo.marker("2");
 verify.referencesCountIs(3);
@@ -30,7 +30,7 @@ goTo.marker("4");
 verify.referencesCountIs(3);
 
 goTo.marker("5");
-verify.referencesCountIs(3);
+verify.referencesCountIs(4);
 
 goTo.marker("6");
 verify.referencesCountIs(4);
@@ -39,4 +39,4 @@ goTo.marker("7");
 verify.referencesCountIs(4);
 
 goTo.marker("8");
-verify.referencesCountIs(3);
+verify.referencesCountIs(4);


### PR DESCRIPTION
This is a regression caused by the polymorphic this type, since all classes are now generic. Make sure to include the target symbols of any symbols we get to the search.

Fixes #8162 
Fixes #8173

