### PR TITLE
Type corrections for Promise to adhere to Promises/A+ standard

### DIFF
--- a/src/lib/es2015.promise.d.ts
+++ b/src/lib/es2015.promise.d.ts
@@ -8,8 +8,8 @@ interface Promise<T> {
     * @param onrejected The callback to execute when the Promise is rejected.
     * @returns A Promise for the completion of which ever callback is executed.
     */
-    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>;
-    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<TResult>;
+    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<T|TResult>;
+    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<T|TResult>;
 
     /**
      * Attaches a callback for only the rejection of the Promise.

--- a/src/lib/es2015.promise.d.ts
+++ b/src/lib/es2015.promise.d.ts
@@ -8,8 +8,11 @@ interface Promise<T> {
     * @param onrejected The callback to execute when the Promise is rejected.
     * @returns A Promise for the completion of which ever callback is executed.
     */
-    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): Promise<T|TResult>;
-    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): Promise<T|TResult>;
+    then<TResult>(onfulfilled?: null | undefined, onrejected?: null | undefined): Promise<T>;
+    then<TResult>(onfulfilled?: null | undefined, onrejected: (reason: any) => TResult | PromiseLike<TResult>): Promise<T|TResult>;
+    then<TResult>(onfulfilled?: null | undefined, onrejected: (reason: any) => void): Promise<T|TResult>;
+    then<TResult>(onfulfilled: (value: T) => TResult | PromiseLike<TResult>, onrejected: (reason: any) => TResult | PromiseLike<TResult>): Promise<TResult>;
+    then<TResult>(onfulfilled: (value: T) => TResult | PromiseLike<TResult>, onrejected: (reason: any) => void): Promise<TResult>;
 
     /**
      * Attaches a callback for only the rejection of the Promise.

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1264,8 +1264,8 @@ interface PromiseLike<T> {
     * @param onrejected The callback to execute when the Promise is rejected.
     * @returns A Promise for the completion of which ever callback is executed.
     */
-    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): PromiseLike<T|TResult>;
-    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): PromiseLike<T|TResult>;
+    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): PromiseLike<TResult>;
+    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): PromiseLike<TResult>;
 }
 
 interface ArrayLike<T> {

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1264,8 +1264,8 @@ interface PromiseLike<T> {
     * @param onrejected The callback to execute when the Promise is rejected.
     * @returns A Promise for the completion of which ever callback is executed.
     */
-    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): PromiseLike<TResult>;
-    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): PromiseLike<TResult>;
+    then<TResult>(onfulfilled?: (value: T | PromiseLike<T>) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): PromiseLike<T|TResult>;
+    then<TResult>(onfulfilled?: (value: T | PromiseLike<T>) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): PromiseLike<T|TResult>;
 }
 
 interface ArrayLike<T> {

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1264,8 +1264,8 @@ interface PromiseLike<T> {
     * @param onrejected The callback to execute when the Promise is rejected.
     * @returns A Promise for the completion of which ever callback is executed.
     */
-    then<TResult>(onfulfilled?: (value: T | PromiseLike<T>) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): PromiseLike<T|TResult>;
-    then<TResult>(onfulfilled?: (value: T | PromiseLike<T>) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): PromiseLike<T|TResult>;
+    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => TResult | PromiseLike<TResult>): PromiseLike<T|TResult>;
+    then<TResult>(onfulfilled?: (value: T) => TResult | PromiseLike<TResult>, onrejected?: (reason: any) => void): PromiseLike<T|TResult>;
 }
 
 interface ArrayLike<T> {


### PR DESCRIPTION
The type definition for promises need to be changed in two ways in order to adhere to the [Promises A+ specification](https://promisesaplus.com/):

1. The return type of `then` must be `PromiseLike<T|U>` (for `PromiseLike`) and `Promise<T|U>` (for `Promise`), respectively. This is due to rule 2.2.7.3 in the spec: if the argument `onfulfilled` of `then` is not defined, then the promise returned by `then` must be fulfilled with the same value as the originating promise – however, this value is of type `T`.

2. The type of `value` of the argument `onfulfilled` of `then` in the interface `PromiseLike` must be  `T | PromiseLike<T>` instead of `T`. This is partially due to rule 2.3.3.3.1 of the spec: the value `y` can be of type `T | PromiseLike<T>` instead of `T` only. Unfortunately, rule 2.3.3.3.1 and the entire Promises A+ standard does not explicitely state that `y` is also allowed to be a `PromiseLike<T>`. However, the [Promises/A+ Compliance Test Suite](https://github.com/promises-aplus/promises-tests) will fail if `y` is assumed to be only of type `T` and not `T | PromiseLike<T>` (see test case '`y` is a thenable' in [https://github.com/promises-aplus/promises-tests/blob/master/lib/tests/2.3.3.js](https://github.com/promises-aplus/promises-tests/blob/master/lib/tests/2.3.3.js)).

Remark: the type of `value` of the argument `onfulfilled` of `then` in the class `Promise` must be only `T`, though.

For references see my [repository](https://github.com/TorstenStueber/PromiseAPlusTypeScript), an implementation of the Promises A+ spec in TypeScript – in this project `Promise` is named `Tomise` and `PromiseLike` is referred to as `Thenable`.


<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
