### PR TITLE
[Transforms] Fixes for ShorthandPropertyAssignments and exported namespaces

### DIFF
--- a/src/compiler/printer.ts
+++ b/src/compiler/printer.ts
@@ -2174,10 +2174,6 @@ const _super = (function (geti, seti) {
             }
 
             function tryEmitSubstitute(node: Node, emitNode: (node: Node) => void, isExpression: boolean) {
-                if ((<any>node).text === "localizedDiagnosticMessages" && isExpression) {
-                    debugger;
-                }
-
                 if (isSubstitutionEnabled(node) && (getNodeEmitFlags(node) & NodeEmitFlags.NoSubstitution) === 0) {
                     const substitute = onSubstituteNode(node, isExpression);
                     if (substitute !== node) {

--- a/src/compiler/transformers/destructuring.ts
+++ b/src/compiler/transformers/destructuring.ts
@@ -405,6 +405,7 @@ namespace ts {
         location: TextRange,
         emitTempVariableAssignment: (value: Expression, location: TextRange) => Identifier,
         visitor?: (node: Node) => VisitResult<Node>) {
+
         if (isIdentifier(value) && reuseIdentifierExpressions) {
             return value;
         }

--- a/src/compiler/transformers/destructuring.ts
+++ b/src/compiler/transformers/destructuring.ts
@@ -39,7 +39,7 @@ namespace ts {
             //
             // The source map location for the assignment should point to the entire binary
             // expression.
-            value = ensureIdentifier(node.right, /*reuseIdentifierExpressions*/ true, location, emitTempVariableAssignment);
+            value = ensureIdentifier(value, /*reuseIdentifierExpressions*/ true, location, emitTempVariableAssignment, visitor);
         }
         else if (nodeIsSynthesized(node)) {
             // Generally, the source map location for a destructuring assignment is the root
@@ -48,7 +48,7 @@ namespace ts {
             // However, if the root expression is synthesized (as in the case
             // of the initializer when transforming a ForOfStatement), then the source map
             // location should point to the right-hand value of the expression.
-            location = node.right;
+            location = value;
         }
 
         flattenDestructuring(context, node, value, location, emitAssignment, emitTempVariableAssignment, visitor);
@@ -397,16 +397,22 @@ namespace ts {
      *                                   false if it is necessary to always emit an identifier.
      * @param location The location to use for source maps and comments.
      * @param emitTempVariableAssignment A callback used to emit a temporary variable.
+     * @param visitor An optional callback used to visit the value.
      */
     function ensureIdentifier(
         value: Expression,
         reuseIdentifierExpressions: boolean,
         location: TextRange,
-        emitTempVariableAssignment: (value: Expression, location: TextRange) => Identifier) {
+        emitTempVariableAssignment: (value: Expression, location: TextRange) => Identifier,
+        visitor?: (node: Node) => VisitResult<Node>) {
         if (isIdentifier(value) && reuseIdentifierExpressions) {
             return value;
         }
         else {
+            if (visitor) {
+                value = visitNode(value, visitor, isExpression);
+            }
+
             return emitTempVariableAssignment(value, location);
         }
     }

--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -148,12 +148,10 @@ namespace ts {
         } = context;
 
         const resolver = context.getEmitResolver();
-        const previousIdentifierSubstitution = context.identifierSubstitution;
-        const previousExpressionSubstitution = context.expressionSubstitution;
+        const previousOnSubstituteNode = context.onSubstituteNode;
         const previousOnEmitNode = context.onEmitNode;
         context.onEmitNode = onEmitNode;
-        context.identifierSubstitution = substituteIdentifier;
-        context.expressionSubstitution = substituteExpression;
+        context.onSubstituteNode = onSubstituteNode;
 
         let currentSourceFile: SourceFile;
         let currentText: string;
@@ -2667,7 +2665,7 @@ namespace ts {
         function enableSubstitutionsForBlockScopedBindings() {
             if ((enabledSubstitutions & ES6SubstitutionFlags.BlockScopedBindings) === 0) {
                 enabledSubstitutions |= ES6SubstitutionFlags.BlockScopedBindings;
-                context.enableExpressionSubstitution(SyntaxKind.Identifier);
+                context.enableSubstitution(SyntaxKind.Identifier);
             }
         }
 
@@ -2678,7 +2676,7 @@ namespace ts {
         function enableSubstitutionsForCapturedThis() {
             if ((enabledSubstitutions & ES6SubstitutionFlags.CapturedThis) === 0) {
                 enabledSubstitutions |= ES6SubstitutionFlags.CapturedThis;
-                context.enableExpressionSubstitution(SyntaxKind.ThisKeyword);
+                context.enableSubstitution(SyntaxKind.ThisKeyword);
                 context.enableEmitNotification(SyntaxKind.Constructor);
                 context.enableEmitNotification(SyntaxKind.MethodDeclaration);
                 context.enableEmitNotification(SyntaxKind.GetAccessor);
@@ -2690,11 +2688,30 @@ namespace ts {
         }
 
         /**
+         * Hooks node substitutions.
+         *
+         * @param node The node to substitute.
+         * @param isExpression A value indicating whether the node is to be used in an expression
+         *                     position.
+         */
+        function onSubstituteNode(node: Node, isExpression: boolean) {
+            node = previousOnSubstituteNode(node, isExpression);
+
+            if (isExpression) {
+                return substituteExpression(node);
+            }
+
+            if (isIdentifier(node)) {
+                return substituteIdentifier(node);
+            }
+
+            return node;
+        }
+
+        /**
          * Hooks substitutions for non-expression identifiers.
          */
         function substituteIdentifier(node: Identifier) {
-            node = previousIdentifierSubstitution(node);
-
             // Only substitute the identifier if we have enabled substitutions for block-scoped
             // bindings.
             if (enabledSubstitutions & ES6SubstitutionFlags.BlockScopedBindings) {
@@ -2732,8 +2749,7 @@ namespace ts {
          *
          * @param node An Expression node.
          */
-        function substituteExpression(node: Expression): Expression {
-            node = previousExpressionSubstitution(node);
+        function substituteExpression(node: Node) {
             switch (node.kind) {
                 case SyntaxKind.Identifier:
                     return substituteExpressionIdentifier(<Identifier>node);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2541,7 +2541,7 @@ namespace ts {
         // When options come from a config file, its path is recorded here
         configFilePath?: string;
         /* @internal */
-        // Path used to used to compute primary search locations 
+        // Path used to used to compute primary search locations
         typesRoot?: string;
         types?: string[];
 
@@ -2969,28 +2969,22 @@ namespace ts {
         hoistVariableDeclaration(node: Identifier): void;
 
         /**
-         * Hook used by transformers to substitute non-expression identifiers
-         * just before theyare emitted by the pretty printer.
-         */
-        identifierSubstitution?: (node: Identifier) => Identifier;
-
-        /**
          * Enables expression substitutions in the pretty printer for
          * the provided SyntaxKind.
          */
-        enableExpressionSubstitution(kind: SyntaxKind): void;
+        enableSubstitution(kind: SyntaxKind): void;
 
         /**
          * Determines whether expression substitutions are enabled for the
          * provided node.
          */
-        isExpressionSubstitutionEnabled(node: Node): boolean;
+        isSubstitutionEnabled(node: Node): boolean;
 
         /**
          * Hook used by transformers to substitute expressions just before they
          * are emitted by the pretty printer.
          */
-        expressionSubstitution?: (node: Expression) => Expression;
+        onSubstituteNode?: (node: Node, isExpression: boolean) => Node;
 
         /**
          * Enables before/after emit notifications in the pretty printer for

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3589,6 +3589,10 @@ namespace ts {
         return node.kind === SyntaxKind.ExportSpecifier;
     }
 
+    export function isModuleOrEnumDeclaration(node: Node): node is ModuleDeclaration | EnumDeclaration {
+        return node.kind === SyntaxKind.ModuleDeclaration || node.kind === SyntaxKind.EnumDeclaration;
+    }
+
     function isDeclarationKind(kind: SyntaxKind) {
         return kind === SyntaxKind.ArrowFunction
             || kind === SyntaxKind.BindingElement

--- a/tests/baselines/reference/emptyAssignmentPatterns04_ES5.js
+++ b/tests/baselines/reference/emptyAssignmentPatterns04_ES5.js
@@ -9,8 +9,8 @@ let x, y, z, a1, a2, a3;
 //// [emptyAssignmentPatterns04_ES5.js]
 var a;
 var x, y, z, a1, a2, a3;
-(_a = {} = a, x = _a.x, y = _a.y, z = _a.z, _a);
-(_b = [] = a, a1 = _b[0], a2 = _b[1], a3 = _b[2], _b);
+(_a = a, x = _a.x, y = _a.y, z = _a.z, _a);
+(_b = a, a1 = _b[0], a2 = _b[1], a3 = _b[2], _b);
 var _a, _b;
 
 

--- a/tests/baselines/reference/invalidInstantiatedModule.js
+++ b/tests/baselines/reference/invalidInstantiatedModule.js
@@ -21,9 +21,9 @@ var M;
     var Point = (function () {
         function Point() {
         }
-        return M.Point;
+        return Point;
     }());
-    M.Point = M.Point;
+    M.Point = Point;
     M.Point = 1; // Error
 })(M || (M = {}));
 var M2;


### PR DESCRIPTION
This change revises how JIT substitution works in the printer. Previously we had two hooks for substitution on `TransformationContext`: `identifierSubstitution` and `expressionSubstitution`. Now, we instead have a single hook, `onSubstituteNode`, which adds an additional `isExpression` parameter that will be provided a value indicating whether the node to be substituted is expected to be used as an expression.

This change allows us to easily add substitutions for a node that is neither an identifier nor an expression, such as a `ShorthandPropertyAssignment`.

Fixes #7862.

Fixes the following tests:
* tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts
* tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesWithModuleES6.ts
* tests/cases/conformance/internalModules/moduleDeclarations/invalidInstantiatedModule.ts
* tests/cases/compiler/giant.ts
* tests/cases/compiler/privacyImportParseErrors.ts
* tests/cases/compiler/shorthand-property-es6-amd.ts
* tests/cases/compiler/shorthandPropertyAssignmentInES6Module.ts