### PR TITLE
Fix #8271: Add `undefined` type to index signatures

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2512,14 +2512,14 @@ namespace ts {
         types?: string[];
 
         list?: string[];
-        [option: string]: CompilerOptionsValue;
+        [option: string]: CompilerOptionsValue | undefined;
     }
 
     export interface TypingOptions {
         enableAutoDiscovery?: boolean;
         include?: string[];
         exclude?: string[];
-        [option: string]: string[] | boolean;
+        [option: string]: string[] | boolean | undefined;
     }
 
     export interface DiscoverTypingsInfo {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1027,7 +1027,7 @@ namespace ts {
         getScriptFileNames(): string[];
         getScriptKind?(fileName: string): ScriptKind;
         getScriptVersion(fileName: string): string;
-        getScriptSnapshot(fileName: string): IScriptSnapshot;
+        getScriptSnapshot(fileName: string): IScriptSnapshot | undefined;
         getLocalizedDiagnosticMessages?(): any;
         getCancellationToken?(): HostCancellationToken;
         getCurrentDirectory(): string;

--- a/tests/baselines/reference/APISample_linter.js
+++ b/tests/baselines/reference/APISample_linter.js
@@ -55,7 +55,7 @@ export function delint(sourceFile: ts.SourceFile) {
     }
 }
 
-const fileNames = process.argv.slice(2);
+const fileNames: string[] = process.argv.slice(2);
 fileNames.forEach(fileName => {
     // Parse a file
     let sourceFile = ts.createSourceFile(fileName, readFileSync(fileName).toString(), ts.ScriptTarget.ES6, /*setParentNodes */ true);

--- a/tests/baselines/reference/APISample_parseConfig.js
+++ b/tests/baselines/reference/APISample_parseConfig.js
@@ -19,7 +19,7 @@ function printError(error: ts.Diagnostic): void {
     console.log(`${error.file && error.file.fileName}: ${error.messageText}`);
 }
 
-export function createProgram(rootFiles: string[], compilerOptionsJson: string): ts.Program {
+export function createProgram(rootFiles: string[], compilerOptionsJson: string): ts.Program | undefined {
     const { config, error } = ts.parseConfigFileTextToJson("tsconfig.json", compilerOptionsJson)
     if (error) {
         printError(error);

--- a/tests/baselines/reference/APISample_watcher.js
+++ b/tests/baselines/reference/APISample_watcher.js
@@ -8,7 +8,13 @@
 
 declare var process: any;
 declare var console: any;
-declare var fs: any;
+declare var fs: {
+    existsSync(path: string): boolean;
+    readdirSync(path: string): string[];
+    readFileSync(filename: string, encoding?: string): string;
+    writeFileSync(filename: string, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): void;
+    watchFile(filename: string, options: { persistent?: boolean; interval?: number; }, listener: (curr: { mtime: Date }, prev: { mtime: Date }) => void): void;
+};
 declare var path: any;
 
 import * as ts from "typescript";

--- a/tests/cases/compiler/APISample_compile.ts
+++ b/tests/cases/compiler/APISample_compile.ts
@@ -1,6 +1,7 @@
 ﻿// @module: commonjs
 // @includebuiltfile: typescript_standalone.d.ts
-// @stripInternal:true
+// @noImplicitAny:true
+// @strictNullChecks:true
 
 /*
  * Note: This test is a public API sample. The sample sources can be found 

--- a/tests/cases/compiler/APISample_linter.ts
+++ b/tests/cases/compiler/APISample_linter.ts
@@ -1,6 +1,7 @@
 ﻿// @module: commonjs
 // @includebuiltfile: typescript_standalone.d.ts
-// @stripInternal:true
+// @noImplicitAny:true
+// @strictNullChecks:true
 
 /*
  * Note: This test is a public API sample. The sample sources can be found 
@@ -57,7 +58,7 @@ export function delint(sourceFile: ts.SourceFile) {
     }
 }
 
-const fileNames = process.argv.slice(2);
+const fileNames: string[] = process.argv.slice(2);
 fileNames.forEach(fileName => {
     // Parse a file
     let sourceFile = ts.createSourceFile(fileName, readFileSync(fileName).toString(), ts.ScriptTarget.ES6, /*setParentNodes */ true);

--- a/tests/cases/compiler/APISample_parseConfig.ts
+++ b/tests/cases/compiler/APISample_parseConfig.ts
@@ -1,6 +1,7 @@
 // @module: commonjs
 // @includebuiltfile: typescript_standalone.d.ts
-// @stripInternal:true
+// @noImplicitAny:true
+// @strictNullChecks:true
 
 /*
  * Note: This test is a public API sample. The sample sources can be found 
@@ -21,7 +22,7 @@ function printError(error: ts.Diagnostic): void {
     console.log(`${error.file && error.file.fileName}: ${error.messageText}`);
 }
 
-export function createProgram(rootFiles: string[], compilerOptionsJson: string): ts.Program {
+export function createProgram(rootFiles: string[], compilerOptionsJson: string): ts.Program | undefined {
     const { config, error } = ts.parseConfigFileTextToJson("tsconfig.json", compilerOptionsJson)
     if (error) {
         printError(error);

--- a/tests/cases/compiler/APISample_transform.ts
+++ b/tests/cases/compiler/APISample_transform.ts
@@ -1,6 +1,7 @@
 ﻿// @module: commonjs
 // @includebuiltfile: typescript_standalone.d.ts
-// @stripInternal:true
+// @noImplicitAny:true
+// @strictNullChecks:true
 
 /*
  * Note: This test is a public API sample. The sample sources can be found 

--- a/tests/cases/compiler/APISample_watcher.ts
+++ b/tests/cases/compiler/APISample_watcher.ts
@@ -1,6 +1,7 @@
 ﻿// @module: commonjs
 // @includebuiltfile: typescript_standalone.d.ts
-// @stripInternal:true
+// @noImplicitAny:true
+// @strictNullChecks:true
 
 /*
  * Note: This test is a public API sample. The sample sources can be found 
@@ -10,7 +11,13 @@
 
 declare var process: any;
 declare var console: any;
-declare var fs: any;
+declare var fs: {
+    existsSync(path: string): boolean;
+    readdirSync(path: string): string[];
+    readFileSync(filename: string, encoding?: string): string;
+    writeFileSync(filename: string, data: any, options?: { encoding?: string; mode?: number; flag?: string; }): void;
+    watchFile(filename: string, options: { persistent?: boolean; interval?: number; }, listener: (curr: { mtime: Date }, prev: { mtime: Date }) => void): void;
+};
 declare var path: any;
 
 import * as ts from "typescript";


### PR DESCRIPTION
Fixes #8271

Also making sure our API tests would catch these issues as well as noImplicitAny issues,