### PR TITLE
Control flow cache fix

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -645,6 +645,13 @@ namespace ts {
             };
         }
 
+        function createFlowLoopLabel(): FlowLabel {
+            return {
+                kind: FlowKind.LoopLabel,
+                antecedents: undefined
+            };
+        }
+
         function addAntecedent(label: FlowLabel, antecedent: FlowNode): void {
             if (antecedent.kind !== FlowKind.Unreachable && !contains(label.antecedents, antecedent)) {
                 (label.antecedents || (label.antecedents = [])).push(antecedent);
@@ -755,7 +762,7 @@ namespace ts {
         }
 
         function bindWhileStatement(node: WhileStatement): void {
-            const preWhileLabel = createFlowLabel();
+            const preWhileLabel = createFlowLoopLabel();
             const preBodyLabel = createFlowLabel();
             const postWhileLabel = createFlowLabel();
             addAntecedent(preWhileLabel, currentFlow);
@@ -768,7 +775,7 @@ namespace ts {
         }
 
         function bindDoStatement(node: DoStatement): void {
-            const preDoLabel = createFlowLabel();
+            const preDoLabel = createFlowLoopLabel();
             const preConditionLabel = createFlowLabel();
             const postDoLabel = createFlowLabel();
             addAntecedent(preDoLabel, currentFlow);
@@ -781,7 +788,7 @@ namespace ts {
         }
 
         function bindForStatement(node: ForStatement): void {
-            const preLoopLabel = createFlowLabel();
+            const preLoopLabel = createFlowLoopLabel();
             const preBodyLabel = createFlowLabel();
             const postLoopLabel = createFlowLabel();
             bind(node.initializer);
@@ -796,7 +803,7 @@ namespace ts {
         }
 
         function bindForInOrForOfStatement(node: ForInStatement | ForOfStatement): void {
-            const preLoopLabel = createFlowLabel();
+            const preLoopLabel = createFlowLoopLabel();
             const postLoopLabel = createFlowLabel();
             addAntecedent(preLoopLabel, currentFlow);
             currentFlow = preLoopLabel;
@@ -943,7 +950,7 @@ namespace ts {
         }
 
         function bindLabeledStatement(node: LabeledStatement): void {
-            const preStatementLabel = createFlowLabel();
+            const preStatementLabel = createFlowLoopLabel();
             const postStatementLabel = createFlowLabel();
             bind(node.label);
             addAntecedent(preStatementLabel, currentFlow);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1519,6 +1519,7 @@ namespace ts {
         Unreachable,
         Start,
         Label,
+        LoopLabel,
         Assignment,
         Condition
     }

--- a/tests/baselines/reference/controlFlowIteration.js
+++ b/tests/baselines/reference/controlFlowIteration.js
@@ -1,0 +1,40 @@
+//// [controlFlowIteration.ts]
+
+let cond: boolean;
+
+function ff() {
+    let x: string | undefined;
+    while (true) {
+        if (cond) {
+            x = "";
+        }
+        else {
+            if (x) {
+                x.length;
+            }
+            if (x) {
+                x.length;
+            }
+        }
+    }
+}
+
+
+//// [controlFlowIteration.js]
+var cond;
+function ff() {
+    var x;
+    while (true) {
+        if (cond) {
+            x = "";
+        }
+        else {
+            if (x) {
+                x.length;
+            }
+            if (x) {
+                x.length;
+            }
+        }
+    }
+}

--- a/tests/baselines/reference/controlFlowIteration.symbols
+++ b/tests/baselines/reference/controlFlowIteration.symbols
@@ -1,0 +1,39 @@
+=== tests/cases/conformance/controlFlow/controlFlowIteration.ts ===
+
+let cond: boolean;
+>cond : Symbol(cond, Decl(controlFlowIteration.ts, 1, 3))
+
+function ff() {
+>ff : Symbol(ff, Decl(controlFlowIteration.ts, 1, 18))
+
+    let x: string | undefined;
+>x : Symbol(x, Decl(controlFlowIteration.ts, 4, 7))
+
+    while (true) {
+        if (cond) {
+>cond : Symbol(cond, Decl(controlFlowIteration.ts, 1, 3))
+
+            x = "";
+>x : Symbol(x, Decl(controlFlowIteration.ts, 4, 7))
+        }
+        else {
+            if (x) {
+>x : Symbol(x, Decl(controlFlowIteration.ts, 4, 7))
+
+                x.length;
+>x.length : Symbol(String.length, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(controlFlowIteration.ts, 4, 7))
+>length : Symbol(String.length, Decl(lib.d.ts, --, --))
+            }
+            if (x) {
+>x : Symbol(x, Decl(controlFlowIteration.ts, 4, 7))
+
+                x.length;
+>x.length : Symbol(String.length, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(controlFlowIteration.ts, 4, 7))
+>length : Symbol(String.length, Decl(lib.d.ts, --, --))
+            }
+        }
+    }
+}
+

--- a/tests/baselines/reference/controlFlowIteration.types
+++ b/tests/baselines/reference/controlFlowIteration.types
@@ -1,0 +1,43 @@
+=== tests/cases/conformance/controlFlow/controlFlowIteration.ts ===
+
+let cond: boolean;
+>cond : boolean
+
+function ff() {
+>ff : () => void
+
+    let x: string | undefined;
+>x : string | undefined
+
+    while (true) {
+>true : boolean
+
+        if (cond) {
+>cond : boolean
+
+            x = "";
+>x = "" : string
+>x : string | undefined
+>"" : string
+        }
+        else {
+            if (x) {
+>x : string | undefined
+
+                x.length;
+>x.length : number
+>x : string
+>length : number
+            }
+            if (x) {
+>x : string | undefined
+
+                x.length;
+>x.length : number
+>x : string
+>length : number
+            }
+        }
+    }
+}
+

--- a/tests/cases/conformance/controlFlow/controlFlowIteration.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowIteration.ts
@@ -1,0 +1,20 @@
+// @strictNullChecks: true
+
+let cond: boolean;
+
+function ff() {
+    let x: string | undefined;
+    while (true) {
+        if (cond) {
+            x = "";
+        }
+        else {
+            if (x) {
+                x.length;
+            }
+            if (x) {
+                x.length;
+            }
+        }
+    }
+}


### PR DESCRIPTION
With this PR we only cache control flow type information in loop-back junction labels. Previously we'd cache in all junction labels, but that would sometimes prevent evolving types from being observed. For example:

```typescript
let x: string | undefined;
while (true) {
    if (cond) {
        x = "";
    }
    else {
        if (x) {
            x.length;
        }
        if (x) {
            x.length;  // Would previously error here
        }
    }
}
```

Previously we'd error in the code above because we would have cached the type `undefined` for `x` in the junction label of following the preceding `if` statement.