### PR TITLE
Variable of type any has initial type any in control flow analysis

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7972,7 +7972,7 @@ namespace ts {
                 return type;
             }
             const declaration = localOrExportSymbol.valueDeclaration;
-            const defaultsToDeclaredType = !strictNullChecks || !declaration ||
+            const defaultsToDeclaredType = !strictNullChecks || type.flags & TypeFlags.Any || !declaration ||
                 declaration.kind === SyntaxKind.Parameter || isInAmbientContext(declaration) ||
                 getContainingFunctionOrModule(declaration) !== getContainingFunctionOrModule(node);
             if (defaultsToDeclaredType && !(type.flags & TypeFlags.Narrowable)) {

--- a/tests/baselines/reference/defaultOfAnyInStrictNullChecks.js
+++ b/tests/baselines/reference/defaultOfAnyInStrictNullChecks.js
@@ -1,0 +1,22 @@
+//// [defaultOfAnyInStrictNullChecks.ts]
+
+// Regression test for #8295
+
+function foo() {
+    try {
+    }
+    catch (e) {
+        let s = e.message; 
+    }
+}
+
+
+//// [defaultOfAnyInStrictNullChecks.js]
+// Regression test for #8295
+function foo() {
+    try {
+    }
+    catch (e) {
+        var s = e.message;
+    }
+}

--- a/tests/baselines/reference/defaultOfAnyInStrictNullChecks.symbols
+++ b/tests/baselines/reference/defaultOfAnyInStrictNullChecks.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/compiler/defaultOfAnyInStrictNullChecks.ts ===
+
+// Regression test for #8295
+
+function foo() {
+>foo : Symbol(foo, Decl(defaultOfAnyInStrictNullChecks.ts, 0, 0))
+
+    try {
+    }
+    catch (e) {
+>e : Symbol(e, Decl(defaultOfAnyInStrictNullChecks.ts, 6, 11))
+
+        let s = e.message; 
+>s : Symbol(s, Decl(defaultOfAnyInStrictNullChecks.ts, 7, 11))
+>e : Symbol(e, Decl(defaultOfAnyInStrictNullChecks.ts, 6, 11))
+    }
+}
+

--- a/tests/baselines/reference/defaultOfAnyInStrictNullChecks.types
+++ b/tests/baselines/reference/defaultOfAnyInStrictNullChecks.types
@@ -1,0 +1,20 @@
+=== tests/cases/compiler/defaultOfAnyInStrictNullChecks.ts ===
+
+// Regression test for #8295
+
+function foo() {
+>foo : () => void
+
+    try {
+    }
+    catch (e) {
+>e : any
+
+        let s = e.message; 
+>s : any
+>e.message : any
+>e : any
+>message : any
+    }
+}
+

--- a/tests/cases/compiler/defaultOfAnyInStrictNullChecks.ts
+++ b/tests/cases/compiler/defaultOfAnyInStrictNullChecks.ts
@@ -1,0 +1,11 @@
+// @strictNullChecks: true
+
+// Regression test for #8295
+
+function foo() {
+    try {
+    }
+    catch (e) {
+        let s = e.message; 
+    }
+}


### PR DESCRIPTION
Fixes the following scenario that would previously produce an error:

```typescript
function foo() {
    try {
    }
    catch (e) {
        console.log(e.message); // e should be of type any, not undefined 
    }
}
```
