### PR TITLE
Properly display narrowed types when hovering in IDE

### DIFF
--- a/tests/cases/fourslash/quickInfoOnNarrowedType.ts
+++ b/tests/cases/fourslash/quickInfoOnNarrowedType.ts
@@ -1,5 +1,7 @@
 /// <reference path='fourslash.ts'/>
 
+// @strictNullChecks: true
+
 ////function foo(strOrNum: string | number) {
 ////    if (typeof /*1*/strOrNum === "number") {
 ////        return /*2*/strOrNum; 
@@ -7,6 +9,13 @@
 ////    else {
 ////        return /*3*/strOrNum.length;
 ////    }
+////}
+
+////function bar() {
+////   let s: string | undefined;
+////   /*4*/s;
+////   /*5*/s = "abc";
+////   /*6*/s;
 ////}
 
 goTo.marker('1');
@@ -20,3 +29,15 @@ verify.completionListContains("strOrNum", "(parameter) strOrNum: number");
 goTo.marker('3');
 verify.quickInfoIs('(parameter) strOrNum: string');
 verify.completionListContains("strOrNum", "(parameter) strOrNum: string");
+
+goTo.marker('4');
+verify.quickInfoIs('let s: undefined');
+verify.completionListContains("s", "let s: undefined");
+
+goTo.marker('5');
+verify.quickInfoIs('let s: string | undefined');
+verify.completionListContains("s", "let s: string | undefined");
+
+goTo.marker('6');
+verify.quickInfoIs('let s: string');
+verify.completionListContains("s", "let s: string");


### PR DESCRIPTION
This PR corrects the type information displayed when hovering over variables in the IDE. Specifically, the `getTypeOfSymbolAtLocation` function used by the language service now consistently returns the narrowed type of a variable unless the variable is the target of an assignment. The PR also removes the old (and shimmed) `getNarrowedTypeOfReference` function and replaces all usages with calls to the new `getFlowTypeOfReference` function.