### PR TITLE
Display 'nothing' for the empty union type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2014,7 +2014,12 @@ namespace ts {
                         writeUnionOrIntersectionType(<UnionOrIntersectionType>type, flags);
                     }
                     else if (type.flags & TypeFlags.Anonymous) {
-                        writeAnonymousType(<ObjectType>type, flags);
+                        if (type === emptyUnionType) {
+                            writer.writeKeyword("nothing");
+                        }
+                        else {
+                            writeAnonymousType(<ObjectType>type, flags);
+                        }
                     }
                     else if (type.flags & TypeFlags.StringLiteral) {
                         writer.writeStringLiteral(`"${escapeString((<StringLiteralType>type).text)}"`);
@@ -4247,7 +4252,9 @@ namespace ts {
                         propTypes.push(getTypeOfSymbol(prop));
                     }
                 }
-                return getUnionType(propTypes);
+                if (propTypes.length) {
+                    return getUnionType(propTypes);
+                }
             }
             return undefined;
         }

--- a/tests/baselines/reference/instanceOfAssignability.types
+++ b/tests/baselines/reference/instanceOfAssignability.types
@@ -133,8 +133,8 @@ function fn5(x: Derived1) {
 		// 1.5: y: Derived1
 		// Want: ???
 		let y = x;
->y : {}
->x : {}
+>y : nothing
+>x : nothing
 	}
 }
 

--- a/tests/baselines/reference/stringLiteralTypesAsTags01.types
+++ b/tests/baselines/reference/stringLiteralTypesAsTags01.types
@@ -116,6 +116,6 @@ if (!hasKind(x, "B")) {
 }
 else {
     let d = x;
->d : {}
->x : {}
+>d : nothing
+>x : nothing
 }

--- a/tests/baselines/reference/stringLiteralTypesAsTags02.types
+++ b/tests/baselines/reference/stringLiteralTypesAsTags02.types
@@ -110,6 +110,6 @@ if (!hasKind(x, "B")) {
 }
 else {
     let d = x;
->d : {}
->x : {}
+>d : nothing
+>x : nothing
 }

--- a/tests/baselines/reference/stringLiteralTypesAsTags03.types
+++ b/tests/baselines/reference/stringLiteralTypesAsTags03.types
@@ -113,6 +113,6 @@ if (!hasKind(x, "B")) {
 }
 else {
     let d = x;
->d : {}
->x : {}
+>d : nothing
+>x : nothing
 }

--- a/tests/baselines/reference/typeGuardOfFormTypeOfBoolean.types
+++ b/tests/baselines/reference/typeGuardOfFormTypeOfBoolean.types
@@ -121,7 +121,7 @@ if (typeof strOrNum === "boolean") {
 
     let z1: {} = strOrNum; // {}
 >z1 : {}
->strOrNum : {}
+>strOrNum : nothing
 }
 else {
     let z2: string | number = strOrNum; // string | number
@@ -215,6 +215,6 @@ if (typeof strOrNum !== "boolean") {
 else {
     let z2: {} = strOrNum; // {}
 >z2 : {}
->strOrNum : {}
+>strOrNum : nothing
 }
 

--- a/tests/baselines/reference/typeGuardOfFormTypeOfNumber.types
+++ b/tests/baselines/reference/typeGuardOfFormTypeOfNumber.types
@@ -120,7 +120,7 @@ if (typeof strOrBool === "number") {
 
     let y1: {} = strOrBool; // {}
 >y1 : {}
->strOrBool : {}
+>strOrBool : nothing
 }
 else {
     let y2: string | boolean = strOrBool; // string | boolean
@@ -212,6 +212,6 @@ if (typeof strOrBool !== "number") {
 else {
     let y2: {} = strOrBool; // {}
 >y2 : {}
->strOrBool : {}
+>strOrBool : nothing
 }
 

--- a/tests/baselines/reference/typeGuardOfFormTypeOfOther.types
+++ b/tests/baselines/reference/typeGuardOfFormTypeOfOther.types
@@ -105,7 +105,7 @@ if (typeof strOrNumOrBool === "Object") {
 
     let q1: {} = strOrNumOrBool; // {}
 >q1 : {}
->strOrNumOrBool : {}
+>strOrNumOrBool : nothing
 }
 else {
     let q2: string | number | boolean = strOrNumOrBool; // string | number | boolean
@@ -178,6 +178,6 @@ if (typeof strOrNumOrBool !== "Object") {
 else {
     let q2: {} = strOrNumOrBool; // {}
 >q2 : {}
->strOrNumOrBool : {}
+>strOrNumOrBool : nothing
 }
 

--- a/tests/baselines/reference/typeGuardOfFormTypeOfString.types
+++ b/tests/baselines/reference/typeGuardOfFormTypeOfString.types
@@ -121,7 +121,7 @@ if (typeof numOrBool === "string") {
 
     let x1: {} = numOrBool; // {}
 >x1 : {}
->numOrBool : {}
+>numOrBool : nothing
 }
 else {
     let x2: number | boolean = numOrBool; // number | boolean
@@ -214,6 +214,6 @@ if (typeof numOrBool !== "string") {
 else {
     let x2: {} = numOrBool; // {}
 >x2 : {}
->numOrBool : {}
+>numOrBool : nothing
 }
 

--- a/tests/baselines/reference/typeGuardTautologicalConsistiency.types
+++ b/tests/baselines/reference/typeGuardTautologicalConsistiency.types
@@ -15,7 +15,7 @@ if (typeof stringOrNumber === "number") {
 >"number" : string
 
         stringOrNumber;
->stringOrNumber : {}
+>stringOrNumber : nothing
     }
 }
 
@@ -31,6 +31,6 @@ if (typeof stringOrNumber === "number" && typeof stringOrNumber !== "number") {
 >"number" : string
 
     stringOrNumber;
->stringOrNumber : {}
+>stringOrNumber : nothing
 }
 

--- a/tests/baselines/reference/typeGuardTypeOfUndefined.types
+++ b/tests/baselines/reference/typeGuardTypeOfUndefined.types
@@ -47,7 +47,7 @@ function test2(a: any) {
 >"boolean" : string
 
             a;
->a : {}
+>a : nothing
         }
         else {
             a;
@@ -129,7 +129,7 @@ function test5(a: boolean | void) {
         }
         else {
             a;
->a : {}
+>a : nothing
         }
     }
     else {
@@ -188,7 +188,7 @@ function test7(a: boolean | void) {
     }
     else {
         a;
->a : {}
+>a : nothing
     }
 }
 

--- a/tests/baselines/reference/typeGuardsWithInstanceOf.errors.txt
+++ b/tests/baselines/reference/typeGuardsWithInstanceOf.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOf.ts(7,20): error TS2339: Property 'global' does not exist on type '{}'.
+tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOf.ts(7,20): error TS2339: Property 'global' does not exist on type 'nothing'.
 
 
 ==== tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOf.ts (1 errors) ====
@@ -10,5 +10,5 @@ tests/cases/conformance/expressions/typeGuards/typeGuardsWithInstanceOf.ts(7,20)
         result = result2;
     } else if (!result.global) {
                        ~~~~~~
-!!! error TS2339: Property 'global' does not exist on type '{}'.
+!!! error TS2339: Property 'global' does not exist on type 'nothing'.
     }


### PR DESCRIPTION
With this PR we display the name 'nothing' for empty union types. Empty union types can occur when control flow type analysis concludes that there is no possible type for a variable that matches the preceding type guards in a particular code path. For example:

```typescript
function foo(x: string | number) {
    if (typeof x === "string") {
        x;  // x is of type string here
    }
    else if (typeof x === "number") {
        x;  // x is of type number here
    }
    else {
        x;  // x is of type nothing here
    }
}
```

The 'nothing' type cannot be explicitly named, it has no members, and no other types are compatible with it.