### PR TITLE
Make `this` in object literal always of type `any`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8206,15 +8206,6 @@ namespace ts {
                 if (signature.thisType) {
                     return signature.thisType;
                 }
-                const parentObject = container.parent && container.parent.kind === SyntaxKind.PropertyAssignment ? container.parent.parent : container.parent;
-                if (parentObject && parentObject.kind === SyntaxKind.ObjectLiteralExpression) {
-                    // Note: this works because object literal methods are deferred,
-                    // which means that the type of the containing object literal is already known.
-                    const type = checkExpressionCached(<ObjectLiteralExpression>parentObject);
-                    if (type) {
-                        return type;
-                    }
-                }
             }
             if (isClassLike(container.parent)) {
                 const symbol = getSymbolOfNode(container.parent);
@@ -8454,10 +8445,7 @@ namespace ts {
             if (isContextSensitiveFunctionOrObjectLiteralMethod(func) && func.kind !== SyntaxKind.ArrowFunction) {
                 const contextualSignature = getContextualSignature(func);
                 if (contextualSignature) {
-                    return contextualSignature.thisType || anyType;
-                }
-                else if (getContextualTypeForFunctionLikeDeclaration(func) === anyType) {
-                    return anyType;
+                    return contextualSignature.thisType;
                 }
             }
 

--- a/tests/baselines/reference/commentsOnObjectLiteral2.errors.txt
+++ b/tests/baselines/reference/commentsOnObjectLiteral2.errors.txt
@@ -1,8 +1,7 @@
 tests/cases/compiler/commentsOnObjectLiteral2.ts(1,14): error TS2304: Cannot find name 'makeClass'.
-tests/cases/compiler/commentsOnObjectLiteral2.ts(9,17): error TS2339: Property 'name' does not exist on type '{ initialize: (name: any) => void; }'.
 
 
-==== tests/cases/compiler/commentsOnObjectLiteral2.ts (2 errors) ====
+==== tests/cases/compiler/commentsOnObjectLiteral2.ts (1 errors) ====
     var Person = makeClass( 
                  ~~~~~~~~~
 !!! error TS2304: Cannot find name 'makeClass'.
@@ -14,8 +13,6 @@ tests/cases/compiler/commentsOnObjectLiteral2.ts(9,17): error TS2339: Property '
             */ 
            initialize: function(name) { 
                this.name = name; 
-                    ~~~~
-!!! error TS2339: Property 'name' does not exist on type '{ initialize: (name: any) => void; }'.
            } /* trailing comment 1*/, 
        } 
     );

--- a/tests/baselines/reference/commentsOnObjectLiteral3.symbols
+++ b/tests/baselines/reference/commentsOnObjectLiteral3.symbols
@@ -21,10 +21,6 @@ var v = {
 >a : Symbol(a, Decl(commentsOnObjectLiteral3.ts, 8, 13), Decl(commentsOnObjectLiteral3.ts, 12, 18))
 
   return this.prop;
->this.prop : Symbol(prop, Decl(commentsOnObjectLiteral3.ts, 1, 9))
->this : Symbol(, Decl(commentsOnObjectLiteral3.ts, 1, 7))
->prop : Symbol(prop, Decl(commentsOnObjectLiteral3.ts, 1, 9))
-
  } /*trailing 1*/,
  //setter
  set a(value) {
@@ -32,9 +28,6 @@ var v = {
 >value : Symbol(value, Decl(commentsOnObjectLiteral3.ts, 14, 7))
 
   this.prop = value;
->this.prop : Symbol(prop, Decl(commentsOnObjectLiteral3.ts, 1, 9))
->this : Symbol(, Decl(commentsOnObjectLiteral3.ts, 1, 7))
->prop : Symbol(prop, Decl(commentsOnObjectLiteral3.ts, 1, 9))
 >value : Symbol(value, Decl(commentsOnObjectLiteral3.ts, 14, 7))
 
  } // trailing 2

--- a/tests/baselines/reference/commentsOnObjectLiteral3.types
+++ b/tests/baselines/reference/commentsOnObjectLiteral3.types
@@ -24,9 +24,9 @@ var v = {
 >a : any
 
   return this.prop;
->this.prop : number
->this : { prop: number; func: () => void; func1(): void; a: any; }
->prop : number
+>this.prop : any
+>this : any
+>prop : any
 
  } /*trailing 1*/,
  //setter
@@ -36,9 +36,9 @@ var v = {
 
   this.prop = value;
 >this.prop = value : any
->this.prop : number
->this : { prop: number; func: () => void; func1(): void; a: any; }
->prop : number
+>this.prop : any
+>this : any
+>prop : any
 >value : any
 
  } // trailing 2

--- a/tests/baselines/reference/declFileObjectLiteralWithAccessors.symbols
+++ b/tests/baselines/reference/declFileObjectLiteralWithAccessors.symbols
@@ -15,9 +15,6 @@ function /*1*/makePoint(x: number) {
         set x(a: number) { this.b = a; }
 >x : Symbol(x, Decl(declFileObjectLiteralWithAccessors.ts, 3, 14), Decl(declFileObjectLiteralWithAccessors.ts, 4, 30))
 >a : Symbol(a, Decl(declFileObjectLiteralWithAccessors.ts, 5, 14))
->this.b : Symbol(b, Decl(declFileObjectLiteralWithAccessors.ts, 2, 12))
->this : Symbol(, Decl(declFileObjectLiteralWithAccessors.ts, 2, 10))
->b : Symbol(b, Decl(declFileObjectLiteralWithAccessors.ts, 2, 12))
 >a : Symbol(a, Decl(declFileObjectLiteralWithAccessors.ts, 5, 14))
 
     };

--- a/tests/baselines/reference/declFileObjectLiteralWithAccessors.types
+++ b/tests/baselines/reference/declFileObjectLiteralWithAccessors.types
@@ -19,9 +19,9 @@ function /*1*/makePoint(x: number) {
 >x : number
 >a : number
 >this.b = a : number
->this.b : number
->this : { b: number; x: number; }
->b : number
+>this.b : any
+>this : any
+>b : any
 >a : number
 
     };

--- a/tests/baselines/reference/declFileObjectLiteralWithOnlySetter.symbols
+++ b/tests/baselines/reference/declFileObjectLiteralWithOnlySetter.symbols
@@ -11,9 +11,6 @@ function /*1*/makePoint(x: number) {
         set x(a: number) { this.b = a; }
 >x : Symbol(x, Decl(declFileObjectLiteralWithOnlySetter.ts, 3, 14))
 >a : Symbol(a, Decl(declFileObjectLiteralWithOnlySetter.ts, 4, 14))
->this.b : Symbol(b, Decl(declFileObjectLiteralWithOnlySetter.ts, 2, 12))
->this : Symbol(, Decl(declFileObjectLiteralWithOnlySetter.ts, 2, 10))
->b : Symbol(b, Decl(declFileObjectLiteralWithOnlySetter.ts, 2, 12))
 >a : Symbol(a, Decl(declFileObjectLiteralWithOnlySetter.ts, 4, 14))
 
     };

--- a/tests/baselines/reference/declFileObjectLiteralWithOnlySetter.types
+++ b/tests/baselines/reference/declFileObjectLiteralWithOnlySetter.types
@@ -15,9 +15,9 @@ function /*1*/makePoint(x: number) {
 >x : number
 >a : number
 >this.b = a : number
->this.b : number
->this : { b: number; x: number; }
->b : number
+>this.b : any
+>this : any
+>b : any
 >a : number
 
     };

--- a/tests/baselines/reference/declarationEmitThisPredicates02.errors.txt
+++ b/tests/baselines/reference/declarationEmitThisPredicates02.errors.txt
@@ -1,9 +1,7 @@
 tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates02.ts(9,10): error TS2526: A 'this' type is available only in a non-static member of a class or interface.
-tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates02.ts(10,19): error TS2352: Type '{ m(): this is Foo; }' cannot be converted to type 'Foo'.
-  Property 'a' is missing in type '{ m(): this is Foo; }'.
 
 
-==== tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates02.ts (2 errors) ====
+==== tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicates02.ts (1 errors) ====
     
     export interface Foo {
         a: string;
@@ -16,9 +14,6 @@ tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredic
              ~~~~
 !!! error TS2526: A 'this' type is available only in a non-static member of a class or interface.
             let dis = this as Foo;
-                      ~~~~~~~~~~~
-!!! error TS2352: Type '{ m(): this is Foo; }' cannot be converted to type 'Foo'.
-!!! error TS2352:   Property 'a' is missing in type '{ m(): this is Foo; }'.
             return dis.a != null && dis.b != null && dis.c != null;
         }
     }

--- a/tests/baselines/reference/declarationEmitThisPredicatesWithPrivateName02.errors.txt
+++ b/tests/baselines/reference/declarationEmitThisPredicatesWithPrivateName02.errors.txt
@@ -1,10 +1,8 @@
 tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName02.ts(8,14): error TS4025: Exported variable 'obj' has or is using private name 'Foo'.
 tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName02.ts(9,10): error TS2526: A 'this' type is available only in a non-static member of a class or interface.
-tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName02.ts(10,19): error TS2352: Type '{ m(): this is Foo; }' cannot be converted to type 'Foo'.
-  Property 'a' is missing in type '{ m(): this is Foo; }'.
 
 
-==== tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName02.ts (3 errors) ====
+==== tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredicatesWithPrivateName02.ts (2 errors) ====
     
     interface Foo {
         a: string;
@@ -19,9 +17,6 @@ tests/cases/conformance/declarationEmit/typePredicates/declarationEmitThisPredic
              ~~~~
 !!! error TS2526: A 'this' type is available only in a non-static member of a class or interface.
             let dis = this as Foo;
-                      ~~~~~~~~~~~
-!!! error TS2352: Type '{ m(): this is Foo; }' cannot be converted to type 'Foo'.
-!!! error TS2352:   Property 'a' is missing in type '{ m(): this is Foo; }'.
             return dis.a != null && dis.b != null && dis.c != null;
         }
     }

--- a/tests/baselines/reference/emitCompoundExponentiationAssignmentWithIndexingOnLHS3.symbols
+++ b/tests/baselines/reference/emitCompoundExponentiationAssignmentWithIndexingOnLHS3.symbols
@@ -8,18 +8,11 @@ var object = {
 
     get 0() {
         return this._0;
->this._0 : Symbol(_0, Decl(emitCompoundExponentiationAssignmentWithIndexingOnLHS3.ts, 1, 14))
->this : Symbol(, Decl(emitCompoundExponentiationAssignmentWithIndexingOnLHS3.ts, 1, 12))
->_0 : Symbol(_0, Decl(emitCompoundExponentiationAssignmentWithIndexingOnLHS3.ts, 1, 14))
-
     },
     set 0(x: number) {
 >x : Symbol(x, Decl(emitCompoundExponentiationAssignmentWithIndexingOnLHS3.ts, 6, 10))
 
         this._0 = x;
->this._0 : Symbol(_0, Decl(emitCompoundExponentiationAssignmentWithIndexingOnLHS3.ts, 1, 14))
->this : Symbol(, Decl(emitCompoundExponentiationAssignmentWithIndexingOnLHS3.ts, 1, 12))
->_0 : Symbol(_0, Decl(emitCompoundExponentiationAssignmentWithIndexingOnLHS3.ts, 1, 14))
 >x : Symbol(x, Decl(emitCompoundExponentiationAssignmentWithIndexingOnLHS3.ts, 6, 10))
 
     },

--- a/tests/baselines/reference/emitCompoundExponentiationAssignmentWithIndexingOnLHS3.types
+++ b/tests/baselines/reference/emitCompoundExponentiationAssignmentWithIndexingOnLHS3.types
@@ -10,9 +10,9 @@ var object = {
 
     get 0() {
         return this._0;
->this._0 : number
->this : { 0: number; _0: number; }
->_0 : number
+>this._0 : any
+>this : any
+>_0 : any
 
     },
     set 0(x: number) {
@@ -20,9 +20,9 @@ var object = {
 
         this._0 = x;
 >this._0 = x : number
->this._0 : number
->this : { 0: number; _0: number; }
->_0 : number
+>this._0 : any
+>this : any
+>_0 : any
 >x : number
 
     },

--- a/tests/baselines/reference/fatarrowfunctions.symbols
+++ b/tests/baselines/reference/fatarrowfunctions.symbols
@@ -163,11 +163,6 @@ var messenger = {
 
         setTimeout(() => { this.message.toString(); }, 3000);
 >setTimeout : Symbol(setTimeout, Decl(fatarrowfunctions.ts, 34, 1))
->this.message.toString : Symbol(String.toString, Decl(lib.d.ts, --, --))
->this.message : Symbol(message, Decl(fatarrowfunctions.ts, 38, 17))
->this : Symbol(, Decl(fatarrowfunctions.ts, 38, 15))
->message : Symbol(message, Decl(fatarrowfunctions.ts, 38, 17))
->toString : Symbol(String.toString, Decl(lib.d.ts, --, --))
     }
 };
 

--- a/tests/baselines/reference/fatarrowfunctions.types
+++ b/tests/baselines/reference/fatarrowfunctions.types
@@ -234,12 +234,12 @@ var messenger = {
 >setTimeout(() => { this.message.toString(); }, 3000) : number
 >setTimeout : (expression: any, msec?: number, language?: any) => number
 >() => { this.message.toString(); } : () => void
->this.message.toString() : string
->this.message.toString : () => string
->this.message : string
->this : { message: string; start: () => void; }
->message : string
->toString : () => string
+>this.message.toString() : any
+>this.message.toString : any
+>this.message : any
+>this : any
+>message : any
+>toString : any
 >3000 : number
     }
 };

--- a/tests/baselines/reference/fatarrowfunctionsInFunctions.symbols
+++ b/tests/baselines/reference/fatarrowfunctionsInFunctions.symbols
@@ -16,17 +16,12 @@ var messenger = {
 
         var _self = this;
 >_self : Symbol(_self, Decl(fatarrowfunctionsInFunctions.ts, 5, 11))
->this : Symbol(, Decl(fatarrowfunctionsInFunctions.ts, 2, 15))
 
         setTimeout(function() {
 >setTimeout : Symbol(setTimeout, Decl(fatarrowfunctionsInFunctions.ts, 0, 0))
 
             _self.message.toString(); 
->_self.message.toString : Symbol(String.toString, Decl(lib.d.ts, --, --))
->_self.message : Symbol(message, Decl(fatarrowfunctionsInFunctions.ts, 2, 17))
 >_self : Symbol(_self, Decl(fatarrowfunctionsInFunctions.ts, 5, 11))
->message : Symbol(message, Decl(fatarrowfunctionsInFunctions.ts, 2, 17))
->toString : Symbol(String.toString, Decl(lib.d.ts, --, --))
 
         }, 3000); 
     }

--- a/tests/baselines/reference/fatarrowfunctionsInFunctions.types
+++ b/tests/baselines/reference/fatarrowfunctionsInFunctions.types
@@ -18,8 +18,8 @@ var messenger = {
 >function() {        var _self = this;        setTimeout(function() {            _self.message.toString();         }, 3000);     } : () => void
 
         var _self = this;
->_self : { message: string; start: () => void; }
->this : { message: string; start: () => void; }
+>_self : any
+>this : any
 
         setTimeout(function() {
 >setTimeout(function() {            _self.message.toString();         }, 3000) : number
@@ -27,12 +27,12 @@ var messenger = {
 >function() {            _self.message.toString();         } : () => void
 
             _self.message.toString(); 
->_self.message.toString() : string
->_self.message.toString : () => string
->_self.message : string
->_self : { message: string; start: () => void; }
->message : string
->toString : () => string
+>_self.message.toString() : any
+>_self.message.toString : any
+>_self.message : any
+>_self : any
+>message : any
+>toString : any
 
         }, 3000); 
 >3000 : number

--- a/tests/baselines/reference/looseThisTypeInFunctions.errors.txt
+++ b/tests/baselines/reference/looseThisTypeInFunctions.errors.txt
@@ -1,13 +1,12 @@
 tests/cases/conformance/types/thisType/looseThisTypeInFunctions.ts(21,1): error TS2322: Type '(this: C, m: number) => number' is not assignable to type '(this: void, m: number) => number'.
   The 'this' types of each signature are incompatible.
     Type 'void' is not assignable to type 'C'.
-tests/cases/conformance/types/thisType/looseThisTypeInFunctions.ts(25,27): error TS2339: Property 'length' does not exist on type 'number'.
 tests/cases/conformance/types/thisType/looseThisTypeInFunctions.ts(33,28): error TS2339: Property 'length' does not exist on type 'number'.
 tests/cases/conformance/types/thisType/looseThisTypeInFunctions.ts(37,9): error TS2684: The 'this' context of type 'void' is not assignable to method's 'this' of type 'I'.
 tests/cases/conformance/types/thisType/looseThisTypeInFunctions.ts(46,20): error TS2339: Property 'length' does not exist on type 'number'.
 
 
-==== tests/cases/conformance/types/thisType/looseThisTypeInFunctions.ts (5 errors) ====
+==== tests/cases/conformance/types/thisType/looseThisTypeInFunctions.ts (4 errors) ====
     interface I {
         n: number;
         explicitThis(this: this, m: number): number;
@@ -37,8 +36,6 @@ tests/cases/conformance/types/thisType/looseThisTypeInFunctions.ts(46,20): error
         n: 101,
         explicitThis: function (m: number) {
             return m + this.n.length; // error, 'length' does not exist on 'number'
-                              ~~~~~~
-!!! error TS2339: Property 'length' does not exist on type 'number'.
         },
         implicitThis(m: number): number { return m; }
     };

--- a/tests/baselines/reference/noImplicitThisObjectLiterals.errors.txt
+++ b/tests/baselines/reference/noImplicitThisObjectLiterals.errors.txt
@@ -1,0 +1,22 @@
+tests/cases/compiler/noImplicitThisObjectLiterals.ts(2,8): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
+tests/cases/compiler/noImplicitThisObjectLiterals.ts(4,16): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
+tests/cases/compiler/noImplicitThisObjectLiterals.ts(7,16): error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
+
+
+==== tests/cases/compiler/noImplicitThisObjectLiterals.ts (3 errors) ====
+    let o = {
+        d: this, // error, this: any
+           ~~~~
+!!! error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
+        m() {
+            return this.d.length; // error, this: any
+                   ~~~~
+!!! error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
+        },
+        f: function() {
+            return this.d.length; // error, this: any
+                   ~~~~
+!!! error TS2683: 'this' implicitly has type 'any' because it does not have a type annotation.
+        }
+    }
+    

--- a/tests/baselines/reference/noImplicitThisObjectLiterals.js
+++ b/tests/baselines/reference/noImplicitThisObjectLiterals.js
@@ -1,0 +1,22 @@
+//// [noImplicitThisObjectLiterals.ts]
+let o = {
+    d: this, // error, this: any
+    m() {
+        return this.d.length; // error, this: any
+    },
+    f: function() {
+        return this.d.length; // error, this: any
+    }
+}
+
+
+//// [noImplicitThisObjectLiterals.js]
+var o = {
+    d: this,
+    m: function () {
+        return this.d.length; // error, this: any
+    },
+    f: function () {
+        return this.d.length; // error, this: any
+    }
+};

--- a/tests/baselines/reference/selfInLambdas.symbols
+++ b/tests/baselines/reference/selfInLambdas.symbols
@@ -37,15 +37,8 @@ var o = {
 >onmousemove : Symbol(Window.onmousemove, Decl(selfInLambdas.ts, 6, 18))
 
             this.counter++
->this.counter : Symbol(counter, Decl(selfInLambdas.ts, 10, 9))
->this : Symbol(, Decl(selfInLambdas.ts, 10, 7))
->counter : Symbol(counter, Decl(selfInLambdas.ts, 10, 9))
-
             var f = () => this.counter;
 >f : Symbol(f, Decl(selfInLambdas.ts, 18, 15))
->this.counter : Symbol(counter, Decl(selfInLambdas.ts, 10, 9))
->this : Symbol(, Decl(selfInLambdas.ts, 10, 7))
->counter : Symbol(counter, Decl(selfInLambdas.ts, 10, 9))
 
         }
 

--- a/tests/baselines/reference/selfInLambdas.types
+++ b/tests/baselines/reference/selfInLambdas.types
@@ -43,16 +43,16 @@ var o = {
 
             this.counter++
 >this.counter++ : number
->this.counter : number
->this : { counter: number; start: () => void; }
->counter : number
+>this.counter : any
+>this : any
+>counter : any
 
             var f = () => this.counter;
->f : () => number
->() => this.counter : () => number
->this.counter : number
->this : { counter: number; start: () => void; }
->counter : number
+>f : () => any
+>() => this.counter : () => any
+>this.counter : any
+>this : any
+>counter : any
 
         }
 

--- a/tests/baselines/reference/thisBinding2.symbols
+++ b/tests/baselines/reference/thisBinding2.symbols
@@ -50,9 +50,6 @@ var messenger = {
         return setTimeout(() => { var x = this.message; }, 3000);
 >setTimeout : Symbol(setTimeout, Decl(thisBinding2.ts, 12, 1))
 >x : Symbol(x, Decl(thisBinding2.ts, 17, 37))
->this.message : Symbol(message, Decl(thisBinding2.ts, 14, 17))
->this : Symbol(, Decl(thisBinding2.ts, 14, 15))
->message : Symbol(message, Decl(thisBinding2.ts, 14, 17))
     }
 };
 

--- a/tests/baselines/reference/thisBinding2.types
+++ b/tests/baselines/reference/thisBinding2.types
@@ -67,10 +67,10 @@ var messenger = {
 >setTimeout(() => { var x = this.message; }, 3000) : number
 >setTimeout : (expression: any, msec?: number, language?: any) => number
 >() => { var x = this.message; } : () => void
->x : string
->this.message : string
->this : { message: string; start: () => number; }
->message : string
+>x : any
+>this.message : any
+>this : any
+>message : any
 >3000 : number
     }
 };

--- a/tests/baselines/reference/thisInObjectLiterals.errors.txt
+++ b/tests/baselines/reference/thisInObjectLiterals.errors.txt
@@ -1,8 +1,7 @@
 tests/cases/conformance/expressions/thisKeyword/thisInObjectLiterals.ts(7,13): error TS2403: Subsequent variable declarations must have the same type.  Variable 't' must be of type '{ x: this; y: number; }', but here has type '{ x: MyClass; y: number; }'.
-tests/cases/conformance/expressions/thisKeyword/thisInObjectLiterals.ts(14,21): error TS2339: Property 'spaaace' does not exist on type '{ f(): any; }'.
 
 
-==== tests/cases/conformance/expressions/thisKeyword/thisInObjectLiterals.ts (2 errors) ====
+==== tests/cases/conformance/expressions/thisKeyword/thisInObjectLiterals.ts (1 errors) ====
     class MyClass {
         t: number;
     
@@ -19,8 +18,6 @@ tests/cases/conformance/expressions/thisKeyword/thisInObjectLiterals.ts(14,21): 
     var obj = {
         f() {
             return this.spaaace;
-                        ~~~~~~~
-!!! error TS2339: Property 'spaaace' does not exist on type '{ f(): any; }'.
         }
     };
     var obj: { f: () => any; };

--- a/tests/baselines/reference/thisInPropertyBoundDeclarations.symbols
+++ b/tests/baselines/reference/thisInPropertyBoundDeclarations.symbols
@@ -70,7 +70,6 @@ class A {
 
         a: function() { return this; },
 >a : Symbol(a, Decl(thisInPropertyBoundDeclarations.ts, 33, 13))
->this : Symbol(, Decl(thisInPropertyBoundDeclarations.ts, 33, 11))
 
     };
 
@@ -80,7 +79,6 @@ class A {
         return {
             a: function() { return this; },
 >a : Symbol(a, Decl(thisInPropertyBoundDeclarations.ts, 38, 16))
->this : Symbol(, Decl(thisInPropertyBoundDeclarations.ts, 38, 14))
 
         };
     };

--- a/tests/baselines/reference/thisInPropertyBoundDeclarations.types
+++ b/tests/baselines/reference/thisInPropertyBoundDeclarations.types
@@ -84,9 +84,9 @@ class A {
 >{        a: function() { return this; },    } : { a: () => any; }
 
         a: function() { return this; },
->a : () => { a: any; }
->function() { return this; } : () => { a: any; }
->this : { a: () => any; }
+>a : () => any
+>function() { return this; } : () => any
+>this : any
 
     };
 
@@ -98,9 +98,9 @@ class A {
 >{            a: function() { return this; },        } : { a: () => any; }
 
             a: function() { return this; },
->a : () => { a: any; }
->function() { return this; } : () => { a: any; }
->this : { a: () => any; }
+>a : () => any
+>function() { return this; } : () => any
+>this : any
 
         };
     };

--- a/tests/baselines/reference/thisTypeInObjectLiterals.symbols
+++ b/tests/baselines/reference/thisTypeInObjectLiterals.symbols
@@ -9,22 +9,11 @@ let o = {
 >m : Symbol(m, Decl(thisTypeInObjectLiterals.ts, 1, 13))
 
         return this.d.length;
->this.d.length : Symbol(String.length, Decl(lib.d.ts, --, --))
->this.d : Symbol(d, Decl(thisTypeInObjectLiterals.ts, 0, 9))
->this : Symbol(, Decl(thisTypeInObjectLiterals.ts, 0, 7))
->d : Symbol(d, Decl(thisTypeInObjectLiterals.ts, 0, 9))
->length : Symbol(String.length, Decl(lib.d.ts, --, --))
-
     },
     f: function() {
 >f : Symbol(f, Decl(thisTypeInObjectLiterals.ts, 4, 6))
 
         return this.d.length;
->this.d.length : Symbol(String.length, Decl(lib.d.ts, --, --))
->this.d : Symbol(d, Decl(thisTypeInObjectLiterals.ts, 0, 9))
->this : Symbol(, Decl(thisTypeInObjectLiterals.ts, 0, 7))
->d : Symbol(d, Decl(thisTypeInObjectLiterals.ts, 0, 9))
->length : Symbol(String.length, Decl(lib.d.ts, --, --))
     }
 }
 
@@ -38,22 +27,12 @@ let mutuallyRecursive = {
 >start : Symbol(start, Decl(thisTypeInObjectLiterals.ts, 11, 11))
 
         return this.passthrough(this.a);
->this.passthrough : Symbol(passthrough, Decl(thisTypeInObjectLiterals.ts, 14, 6))
->this : Symbol(, Decl(thisTypeInObjectLiterals.ts, 10, 23))
->passthrough : Symbol(passthrough, Decl(thisTypeInObjectLiterals.ts, 14, 6))
->this.a : Symbol(a, Decl(thisTypeInObjectLiterals.ts, 10, 25))
->this : Symbol(, Decl(thisTypeInObjectLiterals.ts, 10, 23))
->a : Symbol(a, Decl(thisTypeInObjectLiterals.ts, 10, 25))
-
     },
     passthrough(n: number) {
 >passthrough : Symbol(passthrough, Decl(thisTypeInObjectLiterals.ts, 14, 6))
 >n : Symbol(n, Decl(thisTypeInObjectLiterals.ts, 15, 16))
 
         return this.sub1(n);
->this.sub1 : Symbol(sub1, Decl(thisTypeInObjectLiterals.ts, 17, 6))
->this : Symbol(, Decl(thisTypeInObjectLiterals.ts, 10, 23))
->sub1 : Symbol(sub1, Decl(thisTypeInObjectLiterals.ts, 17, 6))
 >n : Symbol(n, Decl(thisTypeInObjectLiterals.ts, 15, 16))
 
     },
@@ -65,9 +44,6 @@ let mutuallyRecursive = {
 >n : Symbol(n, Decl(thisTypeInObjectLiterals.ts, 18, 9))
 
             return this.passthrough(n - 1);
->this.passthrough : Symbol(passthrough, Decl(thisTypeInObjectLiterals.ts, 14, 6))
->this : Symbol(, Decl(thisTypeInObjectLiterals.ts, 10, 23))
->passthrough : Symbol(passthrough, Decl(thisTypeInObjectLiterals.ts, 14, 6))
 >n : Symbol(n, Decl(thisTypeInObjectLiterals.ts, 18, 9))
         }
         return n;

--- a/tests/baselines/reference/thisTypeInObjectLiterals.types
+++ b/tests/baselines/reference/thisTypeInObjectLiterals.types
@@ -1,66 +1,66 @@
 === tests/cases/conformance/types/thisType/thisTypeInObjectLiterals.ts ===
 let o = {
->o : { d: string; m(): number; f: () => number; }
->{    d: "bar",    m() {        return this.d.length;    },    f: function() {        return this.d.length;    }} : { d: string; m(): number; f: () => number; }
+>o : { d: string; m(): any; f: () => any; }
+>{    d: "bar",    m() {        return this.d.length;    },    f: function() {        return this.d.length;    }} : { d: string; m(): any; f: () => any; }
 
     d: "bar",
 >d : string
 >"bar" : string
 
     m() {
->m : () => number
+>m : () => any
 
         return this.d.length;
->this.d.length : number
->this.d : string
->this : { d: string; m(): number; f: () => number; }
->d : string
->length : number
+>this.d.length : any
+>this.d : any
+>this : any
+>d : any
+>length : any
 
     },
     f: function() {
->f : () => number
->function() {        return this.d.length;    } : () => number
+>f : () => any
+>function() {        return this.d.length;    } : () => any
 
         return this.d.length;
->this.d.length : number
->this.d : string
->this : { d: string; m(): number; f: () => number; }
->d : string
->length : number
+>this.d.length : any
+>this.d : any
+>this : any
+>d : any
+>length : any
     }
 }
 
 let mutuallyRecursive = {
->mutuallyRecursive : { a: number; start(): number; passthrough(n: number): number; sub1(n: number): number; }
->{    a: 100,    start() {        return this.passthrough(this.a);    },    passthrough(n: number) {        return this.sub1(n);    },    sub1(n: number): number {        if (n > 0) {            return this.passthrough(n - 1);        }        return n;    }} : { a: number; start(): number; passthrough(n: number): number; sub1(n: number): number; }
+>mutuallyRecursive : { a: number; start(): any; passthrough(n: number): any; sub1(n: number): number; }
+>{    a: 100,    start() {        return this.passthrough(this.a);    },    passthrough(n: number) {        return this.sub1(n);    },    sub1(n: number): number {        if (n > 0) {            return this.passthrough(n - 1);        }        return n;    }} : { a: number; start(): any; passthrough(n: number): any; sub1(n: number): number; }
 
     a: 100,
 >a : number
 >100 : number
 
     start() {
->start : () => number
+>start : () => any
 
         return this.passthrough(this.a);
->this.passthrough(this.a) : number
->this.passthrough : (n: number) => number
->this : { a: number; start(): number; passthrough(n: number): number; sub1(n: number): number; }
->passthrough : (n: number) => number
->this.a : number
->this : { a: number; start(): number; passthrough(n: number): number; sub1(n: number): number; }
->a : number
+>this.passthrough(this.a) : any
+>this.passthrough : any
+>this : any
+>passthrough : any
+>this.a : any
+>this : any
+>a : any
 
     },
     passthrough(n: number) {
->passthrough : (n: number) => number
+>passthrough : (n: number) => any
 >n : number
 
         return this.sub1(n);
->this.sub1(n) : number
->this.sub1 : (n: number) => number
->this : { a: number; start(): number; passthrough(n: number): number; sub1(n: number): number; }
->sub1 : (n: number) => number
+>this.sub1(n) : any
+>this.sub1 : any
+>this : any
+>sub1 : any
 >n : number
 
     },
@@ -74,10 +74,10 @@ let mutuallyRecursive = {
 >0 : number
 
             return this.passthrough(n - 1);
->this.passthrough(n - 1) : number
->this.passthrough : (n: number) => number
->this : { a: number; start(): number; passthrough(n: number): number; sub1(n: number): number; }
->passthrough : (n: number) => number
+>this.passthrough(n - 1) : any
+>this.passthrough : any
+>this : any
+>passthrough : any
 >n - 1 : number
 >n : number
 >1 : number
@@ -88,10 +88,10 @@ let mutuallyRecursive = {
 }
 var i: number = mutuallyRecursive.start();
 >i : number
->mutuallyRecursive.start() : number
->mutuallyRecursive.start : () => number
->mutuallyRecursive : { a: number; start(): number; passthrough(n: number): number; sub1(n: number): number; }
->start : () => number
+>mutuallyRecursive.start() : any
+>mutuallyRecursive.start : () => any
+>mutuallyRecursive : { a: number; start(): any; passthrough(n: number): any; sub1(n: number): number; }
+>start : () => any
 
 interface I {
 >I : I
@@ -113,5 +113,5 @@ interface I {
 var impl: I = mutuallyRecursive;
 >impl : I
 >I : I
->mutuallyRecursive : { a: number; start(): number; passthrough(n: number): number; sub1(n: number): number; }
+>mutuallyRecursive : { a: number; start(): any; passthrough(n: number): any; sub1(n: number): number; }
 

--- a/tests/baselines/reference/throwInEnclosingStatements.symbols
+++ b/tests/baselines/reference/throwInEnclosingStatements.symbols
@@ -89,7 +89,6 @@ var aa = {
 >biz : Symbol(biz, Decl(throwInEnclosingStatements.ts, 41, 10))
 
         throw this;
->this : Symbol(, Decl(throwInEnclosingStatements.ts, 40, 8))
     }
 }
 

--- a/tests/baselines/reference/throwInEnclosingStatements.types
+++ b/tests/baselines/reference/throwInEnclosingStatements.types
@@ -104,7 +104,7 @@ var aa = {
 >biz : () => void
 
         throw this;
->this : { id: number; biz(): void; }
+>this : any
     }
 }
 

--- a/tests/baselines/reference/underscoreTest1.symbols
+++ b/tests/baselines/reference/underscoreTest1.symbols
@@ -395,16 +395,10 @@ var buttonView = {
     onClick: function () { alert('clicked: ' + this.label); },
 >onClick : Symbol(onClick, Decl(underscoreTest1_underscoreTests.ts, 97, 24))
 >alert : Symbol(alert, Decl(underscoreTest1_underscoreTests.ts, 2, 14))
->this.label : Symbol(label, Decl(underscoreTest1_underscoreTests.ts, 96, 18))
->this : Symbol(, Decl(underscoreTest1_underscoreTests.ts, 96, 16))
->label : Symbol(label, Decl(underscoreTest1_underscoreTests.ts, 96, 18))
 
     onHover: function () { alert('hovering: ' + this.label); }
 >onHover : Symbol(onHover, Decl(underscoreTest1_underscoreTests.ts, 98, 62))
 >alert : Symbol(alert, Decl(underscoreTest1_underscoreTests.ts, 2, 14))
->this.label : Symbol(label, Decl(underscoreTest1_underscoreTests.ts, 96, 18))
->this : Symbol(, Decl(underscoreTest1_underscoreTests.ts, 96, 16))
->label : Symbol(label, Decl(underscoreTest1_underscoreTests.ts, 96, 18))
 
 };
 _.bindAll(buttonView);

--- a/tests/baselines/reference/underscoreTest1.types
+++ b/tests/baselines/reference/underscoreTest1.types
@@ -827,9 +827,9 @@ var buttonView = {
 >alert : (x: string) => void
 >'clicked: ' + this.label : string
 >'clicked: ' : string
->this.label : string
->this : { label: string; onClick: () => void; onHover: () => void; }
->label : string
+>this.label : any
+>this : any
+>label : any
 
     onHover: function () { alert('hovering: ' + this.label); }
 >onHover : () => void
@@ -838,9 +838,9 @@ var buttonView = {
 >alert : (x: string) => void
 >'hovering: ' + this.label : string
 >'hovering: ' : string
->this.label : string
->this : { label: string; onClick: () => void; onHover: () => void; }
->label : string
+>this.label : any
+>this : any
+>label : any
 
 };
 _.bindAll(buttonView);

--- a/tests/cases/compiler/noImplicitThisObjectLiterals.ts
+++ b/tests/cases/compiler/noImplicitThisObjectLiterals.ts
@@ -1,0 +1,10 @@
+// @noImplicitThis: true
+let o = {
+    d: this, // error, this: any
+    m() {
+        return this.d.length; // error, this: any
+    },
+    f: function() {
+        return this.d.length; // error, this: any
+    }
+}


### PR DESCRIPTION
Fixes #8191 again, but re-breaks #8110 and #7801.

Previously, `this` was implicitly typed by the shape of its containing object literal.
This is not correct for JavaScript-style inheritance uses of object literals, and the previous fix was not correct either.
So we're going back to `this: any` in object literals for now.