### PR TITLE
Remove name length limit in navigation bar service for function expression

### DIFF
--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -758,9 +758,6 @@ namespace ts.NavigationBar {
                 else if (fnExpr.parent.kind === SyntaxKind.BinaryExpression &&
                          (fnExpr.parent as BinaryExpression).operatorToken.kind === SyntaxKind.EqualsToken) {
                     fnName = (fnExpr.parent as BinaryExpression).left.getText();
-                    if (fnName.length > 20) {
-                        fnName = fnName.substring(0, 17) + "...";
-                    }
                 }
                 // See if it is a property assignment, and if so use the property name
                 else if (fnExpr.parent.kind === SyntaxKind.PropertyAssignment &&


### PR DESCRIPTION
Hi, what do you think about removing length limit in navigation bar service for function expression?

It might be very useful for example in Visual Studio Code. VSCode uses navigation bar service for "jump to symbol". And when there is a function expression with long name it shows only 17 characters.

Current behaviour:
![screen shot 2016-04-23 at 22 42 22](https://cloud.githubusercontent.com/assets/200119/14937917/cd2c31a2-0f1d-11e6-8cca-33d23fa60b7b.png)

After changes from this PR:
![screen shot 2016-04-23 at 22 43 11](https://cloud.githubusercontent.com/assets/200119/14937939/376a7f9c-0f1e-11e6-962e-1cc5c195c841.png)

Here is code on which you can check current behaviour:
```js
blocks['some-block-with-long-name'] = function(params) {}
blocks['some-block-with-long-name2'] = function(params) {}
blocks['some-block-with-long-name3'] = function(params) {}
blocks['some-block-with-long-name4-much-longer-that-i-have-ever-exptected-it-to-be-so-it-doesnt-fit-in-one-line'] = function(params) {}
```

And this limit looks a bit strange because if you put ```var``` in front of function expression you'll get whole name. So it should not break anything :).

```js

test_variable_with_very_long_name_much_longer_that_i_ve_ever_expected = function(params) {}
var test_variable_with_very_long_name_much_longer_that_i_ve_ever_expected2 = function(params) {}
```

![screen shot 2016-04-30 at 22 01 17](https://cloud.githubusercontent.com/assets/200119/14937982/1cd661cc-0f1f-11e6-97fe-7f34fca57931.png)