### PR TITLE
Declared type as initial type in control flow analysis

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7989,7 +7989,7 @@ namespace ts {
             const defaultsToDeclaredType = !strictNullChecks || type.flags & TypeFlags.Any || !declaration ||
                 getRootDeclaration(declaration).kind === SyntaxKind.Parameter || isInAmbientContext(declaration) ||
                 getContainingFunctionOrModule(declaration) !== getContainingFunctionOrModule(node);
-            const flowType = getFlowTypeOfReference(node, type, defaultsToDeclaredType ? type : undefinedType);
+            const flowType = getFlowTypeOfReference(node, type, defaultsToDeclaredType ? type : addNullableKind(type, TypeFlags.Undefined));
             if (strictNullChecks && !(type.flags & TypeFlags.Any) && !(getNullableKind(type) & TypeFlags.Undefined) && getNullableKind(flowType) & TypeFlags.Undefined) {
                 error(node, Diagnostics.Variable_0_is_used_before_being_assigned, symbolToString(symbol));
                 // Return the declared type to reduce follow-on errors

--- a/tests/cases/fourslash/quickInfoOnNarrowedType.ts
+++ b/tests/cases/fourslash/quickInfoOnNarrowedType.ts
@@ -31,8 +31,8 @@ verify.quickInfoIs('(parameter) strOrNum: string');
 verify.completionListContains("strOrNum", "(parameter) strOrNum: string");
 
 goTo.marker('4');
-verify.quickInfoIs('let s: undefined');
-verify.completionListContains("s", "let s: undefined");
+verify.quickInfoIs('let s: string | undefined');
+verify.completionListContains("s", "let s: string | undefined");
 
 goTo.marker('5');
 verify.quickInfoIs('let s: string | undefined');


### PR DESCRIPTION
With this PR we consider the initial type of a variable to be a union of its declared type and `undefined`. This makes control flow based type analysis less aggressive in cases where the checker is unable to see assignments to a variable because they exclusively occur in nested functions (which aren't included in the analysis). For example:

```typescript
let result: Foo | undefined;
scanForResult();
if (result) {
    // Do something with result
}

function scanForResult() {
    // Logic that possibly assigns to result
}
```

With the PR we consider the initial type of `result` to be `Foo | undefined`, which narrows to `Foo` in the type guard. Previously we considered the initial type to be `undefined` which would narrow to `nothing` and cause errors.