### PR TITLE
Fix 8262: allow unparenthesized parameter in async arrow-function

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2704,7 +2704,7 @@ namespace ts {
             // Production (1) of AsyncArrowFunctionExpression is parsed in "tryParseAsyncSimpleArrowFunctionExpression".
             // And production (2) is parsed in "tryParseParenthesizedArrowFunctionExpression". 
             //
-            // If we do successfully parse arrow-function, we must * not * recurse for productions 1, 2 or 3. An ArrowFunction is
+            // If we do successfully parse arrow-function, we must *not* recurse for productions 1, 2 or 3. An ArrowFunction is
             // not a  LeftHandSideExpression, nor does it start a ConditionalExpression.  So we are done
             // with AssignmentExpression if we see one.
             const arrowExpression = tryParseParenthesizedArrowFunctionExpression() || tryParseAsyncSimpleArrowFunctionExpression();
@@ -2820,7 +2820,7 @@ namespace ts {
             node.parameters.end = parameter.end;
 
             node.equalsGreaterThanToken = parseExpectedToken(SyntaxKind.EqualsGreaterThanToken, /*reportAtCurrentPosition*/ false, Diagnostics._0_expected, "=>");
-            node.body = parseArrowFunctionExpressionBody(/*isAsync*/ asyncModifier ? true : false);
+            node.body = parseArrowFunctionExpressionBody(/*isAsync*/ !!asyncModifier);
 
             return finishNode(node);
         }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2696,8 +2696,15 @@ namespace ts {
                 return parseYieldExpression();
             }
 
-            // Then, check if we have an arrow function (production '4') that starts with a parenthesized
-            // parameter list. If we do, we must *not* recurse for productions 1, 2 or 3. An ArrowFunction is
+            // Then, check if we have an arrow function (production '4' and '5') that starts with a parenthesized
+            // parameter list or is an async arrow function.
+            // AsyncArrowFunctionExpression:
+            //      1) async[no LineTerminator here]AsyncArrowBindingIdentifier[?Yield][no LineTerminator here]=>AsyncConciseBody[?In]
+            //      2) CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await][no LineTerminator here]=>AsyncConciseBody[?In]
+            // Production (1) of AsyncArrowFunctionExpression is parsed in "tryParseAsyncSimpleArrowFunctionExpression".
+            // And production (2) is parsed in "tryParseParenthesizedArrowFunctionExpression". 
+            //
+            // If we do successfully parse arrow-function, we must * not * recurse for productions 1, 2 or 3. An ArrowFunction is
             // not a  LeftHandSideExpression, nor does it start a ConditionalExpression.  So we are done
             // with AssignmentExpression if we see one.
             const arrowExpression = tryParseParenthesizedArrowFunctionExpression() || tryParseAsyncSimpleArrowFunctionExpression();

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2707,10 +2707,10 @@ namespace ts {
             // From ES6 spec:
             // AsyncArrowFunction[In, Yield, Await]::
             //      async[no LineTerminator here]AsyncArrowBindingIdentifier[?Yield][no LineTerminator here]=>AsyncConciseBody[?In]
-            const unParenthesizedAsyncArrowFunction = tryParseUnParenthesizedAsyncArrowFunctionExpressionWorker();
+            const unparenthensizedAsyncArrowFunction = tryParseUnparenthesizedAsyncArrowFunctionExpressionWorker();
 
-            if (unParenthesizedAsyncArrowFunction) {
-                return unParenthesizedAsyncArrowFunction;
+            if (unparenthensizedAsyncArrowFunction ) {
+                return unparenthensizedAsyncArrowFunction ;
             }
             // Now try to see if we're in production '1', '2' or '3'.  A conditional expression can
             // start with a LogicalOrExpression, while the assignment productions can only start with
@@ -2981,7 +2981,7 @@ namespace ts {
             return parseParenthesizedArrowFunctionExpressionHead(/*allowAmbiguity*/ false);
         }
 
-        function tryParseUnParenthesizedAsyncArrowFunctionExpressionWorker(): ArrowFunction {
+        function tryParseUnparenthesizedAsyncArrowFunctionExpressionWorker(): ArrowFunction {
             const isUnParenthesizedAsyncArrowFunction = lookAhead(isUnParenthesizedAsyncArrowFunctionWorker);
             if (isUnParenthesizedAsyncArrowFunction === Tristate.True) {
                 const node = <ArrowFunction>createNode(SyntaxKind.ArrowFunction);

--- a/tests/baselines/reference/asyncUnParenthesizedArrowFunction_es6.js
+++ b/tests/baselines/reference/asyncUnParenthesizedArrowFunction_es6.js
@@ -1,0 +1,9 @@
+//// [asyncUnParenthesizedArrowFunction_es6.ts]
+
+declare function someOtherFunction(i: any): Promise<void>;
+const x = async i => await someOtherFunction(i)
+const x1 = async (i) => await someOtherFunction(i);
+
+//// [asyncUnParenthesizedArrowFunction_es6.js]
+const x = (i) => __awaiter(this, void 0, void 0, function* () { return yield someOtherFunction(i); });
+const x1 = (i) => __awaiter(this, void 0, void 0, function* () { return yield someOtherFunction(i); });

--- a/tests/baselines/reference/asyncUnParenthesizedArrowFunction_es6.symbols
+++ b/tests/baselines/reference/asyncUnParenthesizedArrowFunction_es6.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/conformance/async/es6/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es6.ts ===
+
+declare function someOtherFunction(i: any): Promise<void>;
+>someOtherFunction : Symbol(someOtherFunction, Decl(asyncUnParenthesizedArrowFunction_es6.ts, 0, 0))
+>i : Symbol(i, Decl(asyncUnParenthesizedArrowFunction_es6.ts, 1, 35))
+>Promise : Symbol(Promise, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+
+const x = async i => await someOtherFunction(i)
+>x : Symbol(x, Decl(asyncUnParenthesizedArrowFunction_es6.ts, 2, 5))
+>i : Symbol(i, Decl(asyncUnParenthesizedArrowFunction_es6.ts, 2, 15))
+>someOtherFunction : Symbol(someOtherFunction, Decl(asyncUnParenthesizedArrowFunction_es6.ts, 0, 0))
+>i : Symbol(i, Decl(asyncUnParenthesizedArrowFunction_es6.ts, 2, 15))
+
+const x1 = async (i) => await someOtherFunction(i);
+>x1 : Symbol(x1, Decl(asyncUnParenthesizedArrowFunction_es6.ts, 3, 5))
+>i : Symbol(i, Decl(asyncUnParenthesizedArrowFunction_es6.ts, 3, 18))
+>someOtherFunction : Symbol(someOtherFunction, Decl(asyncUnParenthesizedArrowFunction_es6.ts, 0, 0))
+>i : Symbol(i, Decl(asyncUnParenthesizedArrowFunction_es6.ts, 3, 18))
+

--- a/tests/baselines/reference/asyncUnParenthesizedArrowFunction_es6.types
+++ b/tests/baselines/reference/asyncUnParenthesizedArrowFunction_es6.types
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/async/es6/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es6.ts ===
+
+declare function someOtherFunction(i: any): Promise<void>;
+>someOtherFunction : (i: any) => Promise<void>
+>i : any
+>Promise : Promise<T>
+
+const x = async i => await someOtherFunction(i)
+>x : (i: any) => Promise<void>
+>async i => await someOtherFunction(i) : (i: any) => Promise<void>
+>i : any
+>await someOtherFunction(i) : void
+>someOtherFunction(i) : Promise<void>
+>someOtherFunction : (i: any) => Promise<void>
+>i : any
+
+const x1 = async (i) => await someOtherFunction(i);
+>x1 : (i: any) => Promise<void>
+>async (i) => await someOtherFunction(i) : (i: any) => Promise<void>
+>i : any
+>await someOtherFunction(i) : void
+>someOtherFunction(i) : Promise<void>
+>someOtherFunction : (i: any) => Promise<void>
+>i : any
+

--- a/tests/cases/conformance/async/es6/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es6.ts
+++ b/tests/cases/conformance/async/es6/asyncArrowFunction/asyncUnParenthesizedArrowFunction_es6.ts
@@ -1,0 +1,6 @@
+// @target: ES6
+// @noEmitHelpers: true
+
+declare function someOtherFunction(i: any): Promise<void>;
+const x = async i => await someOtherFunction(i)
+const x1 = async (i) => await someOtherFunction(i);


### PR DESCRIPTION
Fix #8262