### PR TITLE
Fix #8357: Remove optionality for the definition of `IteratorResult`

### DIFF
--- a/src/lib/es2015.iterable.d.ts
+++ b/src/lib/es2015.iterable.d.ts
@@ -2,7 +2,7 @@
 
 interface IteratorResult<T> {
     done: boolean;
-    value?: T;
+    value: T;
 }
 
 interface Iterator<T> {

--- a/tests/baselines/reference/iteratorsAndStrictNullChecks.js
+++ b/tests/baselines/reference/iteratorsAndStrictNullChecks.js
@@ -1,0 +1,22 @@
+//// [iteratorsAndStrictNullChecks.ts]
+
+// for..of
+for (const x of ["a", "b"]) {
+    x.substring;
+}
+
+// Spread
+const xs = [1, 2, 3];
+const ys = [4, 5];
+xs.push(...ys);
+
+
+//// [iteratorsAndStrictNullChecks.js]
+// for..of
+for (const x of ["a", "b"]) {
+    x.substring;
+}
+// Spread
+const xs = [1, 2, 3];
+const ys = [4, 5];
+xs.push(...ys);

--- a/tests/baselines/reference/iteratorsAndStrictNullChecks.symbols
+++ b/tests/baselines/reference/iteratorsAndStrictNullChecks.symbols
@@ -1,0 +1,25 @@
+=== tests/cases/compiler/iteratorsAndStrictNullChecks.ts ===
+
+// for..of
+for (const x of ["a", "b"]) {
+>x : Symbol(x, Decl(iteratorsAndStrictNullChecks.ts, 2, 10))
+
+    x.substring;
+>x.substring : Symbol(String.substring, Decl(lib.es5.d.ts, --, --))
+>x : Symbol(x, Decl(iteratorsAndStrictNullChecks.ts, 2, 10))
+>substring : Symbol(String.substring, Decl(lib.es5.d.ts, --, --))
+}
+
+// Spread
+const xs = [1, 2, 3];
+>xs : Symbol(xs, Decl(iteratorsAndStrictNullChecks.ts, 7, 5))
+
+const ys = [4, 5];
+>ys : Symbol(ys, Decl(iteratorsAndStrictNullChecks.ts, 8, 5))
+
+xs.push(...ys);
+>xs.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>xs : Symbol(xs, Decl(iteratorsAndStrictNullChecks.ts, 7, 5))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>ys : Symbol(ys, Decl(iteratorsAndStrictNullChecks.ts, 8, 5))
+

--- a/tests/baselines/reference/iteratorsAndStrictNullChecks.types
+++ b/tests/baselines/reference/iteratorsAndStrictNullChecks.types
@@ -1,0 +1,37 @@
+=== tests/cases/compiler/iteratorsAndStrictNullChecks.ts ===
+
+// for..of
+for (const x of ["a", "b"]) {
+>x : string
+>["a", "b"] : string[]
+>"a" : string
+>"b" : string
+
+    x.substring;
+>x.substring : (start: number, end?: number | undefined) => string
+>x : string
+>substring : (start: number, end?: number | undefined) => string
+}
+
+// Spread
+const xs = [1, 2, 3];
+>xs : number[]
+>[1, 2, 3] : number[]
+>1 : number
+>2 : number
+>3 : number
+
+const ys = [4, 5];
+>ys : number[]
+>[4, 5] : number[]
+>4 : number
+>5 : number
+
+xs.push(...ys);
+>xs.push(...ys) : number
+>xs.push : (...items: number[]) => number
+>xs : number[]
+>push : (...items: number[]) => number
+>...ys : number
+>ys : number[]
+

--- a/tests/cases/compiler/iteratorsAndStrictNullChecks.ts
+++ b/tests/cases/compiler/iteratorsAndStrictNullChecks.ts
@@ -1,0 +1,12 @@
+// @target : ES6
+// @strictNullChecks: true
+
+// for..of
+for (const x of ["a", "b"]) {
+    x.substring;
+}
+
+// Spread
+const xs = [1, 2, 3];
+const ys = [4, 5];
+xs.push(...ys);


### PR DESCRIPTION
Fixes #8357