### PR TITLE
Check that token is AsyncKeyword before calling lookAhead

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2991,7 +2991,7 @@ namespace ts {
         function tryParseAsyncSimpleArrowFunctionExpression(): ArrowFunction {
             // We do a check here so that we won't be doing unnecessarily call to "lookAhead"
             if (token === SyntaxKind.AsyncKeyword) {
-                const isUnParenthesizedAsyncArrowFunction = lookAhead(isUnParenthesizedAsyncArrowFunctionWorker);           
+                const isUnParenthesizedAsyncArrowFunction = lookAhead(isUnParenthesizedAsyncArrowFunctionWorker);
                 if (isUnParenthesizedAsyncArrowFunction === Tristate.True) {
                     const asyncModifier = parseModifiersForArrowFunction();
                     const expr = parseBinaryExpressionOrHigher(/*precedence*/ 0);

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2989,11 +2989,14 @@ namespace ts {
         }
 
         function tryParseAsyncSimpleArrowFunctionExpression(): ArrowFunction {
-            const isUnParenthesizedAsyncArrowFunction = lookAhead(isUnParenthesizedAsyncArrowFunctionWorker);
-            if (isUnParenthesizedAsyncArrowFunction === Tristate.True) {
-                const asyncModifier = parseModifiersForArrowFunction();
-                const expr = parseBinaryExpressionOrHigher(/*precedence*/ 0);
-                return parseSimpleArrowFunctionExpression(<Identifier>expr, asyncModifier);
+            // We do a check here so that we won't be doing unnecessarily call to "lookAhead"
+            if (token === SyntaxKind.AsyncKeyword) {
+                const isUnParenthesizedAsyncArrowFunction = lookAhead(isUnParenthesizedAsyncArrowFunctionWorker);           
+                if (isUnParenthesizedAsyncArrowFunction === Tristate.True) {
+                    const asyncModifier = parseModifiersForArrowFunction();
+                    const expr = parseBinaryExpressionOrHigher(/*precedence*/ 0);
+                    return parseSimpleArrowFunctionExpression(<Identifier>expr, asyncModifier);
+                }
             }
             return undefined;
         }


### PR DESCRIPTION
Before calling lookAhead function check that the current toke is AsyncKeyword because lookAHead is an expensive operation