### PR TITLE
Fix #8470: use ts.normalizePath before checking filename idenity

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1921,7 +1921,7 @@ namespace ts {
 
         // Create a compilerHost object to allow the compiler to read and write files
         const compilerHost: CompilerHost = {
-            getSourceFile: (fileName, target) => fileName === normalizeSlashes(inputFileName) ? sourceFile : undefined,
+            getSourceFile: (fileName, target) => fileName === normalizePath(inputFileName) ? sourceFile : undefined,
             writeFile: (name, text, writeByteOrderMark) => {
                 if (fileExtensionIs(name, ".map")) {
                     Debug.assert(sourceMapText === undefined, `Unexpected multiple source map outputs for the file '${name}'`);

--- a/tests/cases/unittests/transpile.ts
+++ b/tests/cases/unittests/transpile.ts
@@ -277,7 +277,7 @@ var x = 0;`,
         it("Supports backslashes in file name", () => {
             test("var x", { expectedOutput: `"use strict";\r\nvar x;\r\n`, options: { fileName: "a\\b.ts" }});
         });
-        
+
         it("transpile file as 'tsx' if 'jsx' is specified", () => {
             let input = `var x = <div/>`;
             let output = `"use strict";\nvar x = React.createElement("div", null);\n`;
@@ -286,6 +286,7 @@ var x = 0;`,
                 options: { compilerOptions: { jsx: JsxEmit.React, newLine: NewLineKind.LineFeed } }
             })
         });
+
         it("transpile .js files", () => {
             const input = "const a = 10;";
             const output = `"use strict";\nvar a = 10;\n`;
@@ -295,5 +296,9 @@ var x = 0;`,
                 expectedDiagnosticCodes: []
             });
         })
+
+        it("Supports urls in file name", () => {
+            test("var x", { expectedOutput: `"use strict";\r\nvar x;\r\n`, options: { fileName: "http://somewhere/directory//directory2/file.ts" } });
+        });
     });
 }


### PR DESCRIPTION
Fixes #8470.

//CC @vladima 