### PR TITLE
Contextually type IIFE params by their arguments

### DIFF
--- a/tests/baselines/reference/contextuallyTypedIife.js
+++ b/tests/baselines/reference/contextuallyTypedIife.js
@@ -1,0 +1,90 @@
+//// [contextuallyTypedIife.ts]
+// arrow
+(jake => { })("build");
+// function expression
+(function (cats) { })("lol");
+// multiple arguments
+((a, b, c) => { })("foo", 101, false);
+// contextually typed parameters.
+(f => f(1))(i => i + 1);
+// default parameters
+((m = 10) => m + 1)(12);
+((n = 10) => n + 1)();
+// optional parameters
+((j?) => j + 1)(12);
+((k?) => k + 1)();
+((l, o?) => l + o)(12); // o should be any
+// rest parameters
+((...numbers) => numbers.every(n => n > 0))(5,6,7);
+((...noNumbers) => noNumbers.some(n => n > 0))();
+((first, ...rest) => first ? [] : rest.map(n => n > 0))(8,9,10);
+// destructuring parameters (with defaults too!)
+(({ q }) => q)({ q : 13 });
+(({ p = 14 }) => p)({ p : 15 });
+(({ r = 17 } = { r: 18 }) => r)({r : 19});
+(({ u = 22 } = { u: 23 }) => u)();
+
+
+
+
+//// [contextuallyTypedIife.js]
+// arrow
+(function (jake) { })("build");
+// function expression
+(function (cats) { })("lol");
+// multiple arguments
+(function (a, b, c) { })("foo", 101, false);
+// contextually typed parameters.
+(function (f) { return f(1); })(function (i) { return i + 1; });
+// default parameters
+(function (m) {
+    if (m === void 0) { m = 10; }
+    return m + 1;
+})(12);
+(function (n) {
+    if (n === void 0) { n = 10; }
+    return n + 1;
+})();
+// optional parameters
+(function (j) { return j + 1; })(12);
+(function (k) { return k + 1; })();
+(function (l, o) { return l + o; })(12); // o should be any
+// rest parameters
+(function () {
+    var numbers = [];
+    for (var _i = 0; _i < arguments.length; _i++) {
+        numbers[_i - 0] = arguments[_i];
+    }
+    return numbers.every(function (n) { return n > 0; });
+})(5, 6, 7);
+(function () {
+    var noNumbers = [];
+    for (var _i = 0; _i < arguments.length; _i++) {
+        noNumbers[_i - 0] = arguments[_i];
+    }
+    return noNumbers.some(function (n) { return n > 0; });
+})();
+(function (first) {
+    var rest = [];
+    for (var _i = 1; _i < arguments.length; _i++) {
+        rest[_i - 1] = arguments[_i];
+    }
+    return first ? [] : rest.map(function (n) { return n > 0; });
+})(8, 9, 10);
+// destructuring parameters (with defaults too!)
+(function (_a) {
+    var q = _a.q;
+    return q;
+})({ q: 13 });
+(function (_a) {
+    var _b = _a.p, p = _b === void 0 ? 14 : _b;
+    return p;
+})({ p: 15 });
+(function (_a) {
+    var _b = (_a === void 0 ? { r: 18 } : _a).r, r = _b === void 0 ? 17 : _b;
+    return r;
+})({ r: 19 });
+(function (_a) {
+    var _b = (_a === void 0 ? { u: 23 } : _a).u, u = _b === void 0 ? 22 : _b;
+    return u;
+})();

--- a/tests/baselines/reference/contextuallyTypedIife.js
+++ b/tests/baselines/reference/contextuallyTypedIife.js
@@ -3,10 +3,11 @@
 (jake => { })("build");
 // function expression
 (function (cats) { })("lol");
+// Lots of Irritating Superfluous Parentheses
+(function (x) { } ("!"));
+((((function (y) { }))))("-");
 // multiple arguments
 ((a, b, c) => { })("foo", 101, false);
-// contextually typed parameters.
-(f => f(1))(i => i + 1);
 // default parameters
 ((m = 10) => m + 1)(12);
 ((n = 10) => n + 1)();
@@ -16,6 +17,7 @@
 ((l, o?) => l + o)(12); // o should be any
 // rest parameters
 ((...numbers) => numbers.every(n => n > 0))(5,6,7);
+((...mixed) => mixed.every(n => !!n))(5,'oops','oh no');
 ((...noNumbers) => noNumbers.some(n => n > 0))();
 ((first, ...rest) => first ? [] : rest.map(n => n > 0))(8,9,10);
 // destructuring parameters (with defaults too!)
@@ -23,8 +25,9 @@
 (({ p = 14 }) => p)({ p : 15 });
 (({ r = 17 } = { r: 18 }) => r)({r : 19});
 (({ u = 22 } = { u: 23 }) => u)();
-
-
+// contextually typed parameters.
+let twelve = (f => f(12))(i => i);
+let eleven = (o => o.a(11))({ a: function(n) { return n; } });
 
 
 //// [contextuallyTypedIife.js]
@@ -32,10 +35,11 @@
 (function (jake) { })("build");
 // function expression
 (function (cats) { })("lol");
+// Lots of Irritating Superfluous Parentheses
+(function (x) { }("!"));
+((((function (y) { }))))("-");
 // multiple arguments
 (function (a, b, c) { })("foo", 101, false);
-// contextually typed parameters.
-(function (f) { return f(1); })(function (i) { return i + 1; });
 // default parameters
 (function (m) {
     if (m === void 0) { m = 10; }
@@ -57,6 +61,13 @@
     }
     return numbers.every(function (n) { return n > 0; });
 })(5, 6, 7);
+(function () {
+    var mixed = [];
+    for (var _i = 0; _i < arguments.length; _i++) {
+        mixed[_i - 0] = arguments[_i];
+    }
+    return mixed.every(function (n) { return !!n; });
+})(5, 'oops', 'oh no');
 (function () {
     var noNumbers = [];
     for (var _i = 0; _i < arguments.length; _i++) {
@@ -88,3 +99,6 @@
     var _b = (_a === void 0 ? { u: 23 } : _a).u, u = _b === void 0 ? 22 : _b;
     return u;
 })();
+// contextually typed parameters.
+var twelve = (function (f) { return f(12); })(function (i) { return i; });
+var eleven = (function (o) { return o.a(11); })({ a: function (n) { return n; } });

--- a/tests/baselines/reference/contextuallyTypedIife.symbols
+++ b/tests/baselines/reference/contextuallyTypedIife.symbols
@@ -1,0 +1,97 @@
+=== tests/cases/conformance/expressions/functions/contextuallyTypedIife.ts ===
+// arrow
+(jake => { })("build");
+>jake : Symbol(jake, Decl(contextuallyTypedIife.ts, 1, 1))
+
+// function expression
+(function (cats) { })("lol");
+>cats : Symbol(cats, Decl(contextuallyTypedIife.ts, 3, 11))
+
+// multiple arguments
+((a, b, c) => { })("foo", 101, false);
+>a : Symbol(a, Decl(contextuallyTypedIife.ts, 5, 2))
+>b : Symbol(b, Decl(contextuallyTypedIife.ts, 5, 4))
+>c : Symbol(c, Decl(contextuallyTypedIife.ts, 5, 7))
+
+// contextually typed parameters.
+(f => f(1))(i => i + 1);
+>f : Symbol(f, Decl(contextuallyTypedIife.ts, 7, 1))
+>f : Symbol(f, Decl(contextuallyTypedIife.ts, 7, 1))
+>i : Symbol(i, Decl(contextuallyTypedIife.ts, 7, 12))
+>i : Symbol(i, Decl(contextuallyTypedIife.ts, 7, 12))
+
+// default parameters
+((m = 10) => m + 1)(12);
+>m : Symbol(m, Decl(contextuallyTypedIife.ts, 9, 2))
+>m : Symbol(m, Decl(contextuallyTypedIife.ts, 9, 2))
+
+((n = 10) => n + 1)();
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 10, 2))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 10, 2))
+
+// optional parameters
+((j?) => j + 1)(12);
+>j : Symbol(j, Decl(contextuallyTypedIife.ts, 12, 2))
+>j : Symbol(j, Decl(contextuallyTypedIife.ts, 12, 2))
+
+((k?) => k + 1)();
+>k : Symbol(k, Decl(contextuallyTypedIife.ts, 13, 2))
+>k : Symbol(k, Decl(contextuallyTypedIife.ts, 13, 2))
+
+((l, o?) => l + o)(12); // o should be any
+>l : Symbol(l, Decl(contextuallyTypedIife.ts, 14, 2))
+>o : Symbol(o, Decl(contextuallyTypedIife.ts, 14, 4))
+>l : Symbol(l, Decl(contextuallyTypedIife.ts, 14, 2))
+>o : Symbol(o, Decl(contextuallyTypedIife.ts, 14, 4))
+
+// rest parameters
+((...numbers) => numbers.every(n => n > 0))(5,6,7);
+>numbers : Symbol(numbers, Decl(contextuallyTypedIife.ts, 16, 2))
+>numbers.every : Symbol(Array.every, Decl(lib.d.ts, --, --))
+>numbers : Symbol(numbers, Decl(contextuallyTypedIife.ts, 16, 2))
+>every : Symbol(Array.every, Decl(lib.d.ts, --, --))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 16, 31))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 16, 31))
+
+((...noNumbers) => noNumbers.some(n => n > 0))();
+>noNumbers : Symbol(noNumbers, Decl(contextuallyTypedIife.ts, 17, 2))
+>noNumbers.some : Symbol(Array.some, Decl(lib.d.ts, --, --))
+>noNumbers : Symbol(noNumbers, Decl(contextuallyTypedIife.ts, 17, 2))
+>some : Symbol(Array.some, Decl(lib.d.ts, --, --))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 17, 34))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 17, 34))
+
+((first, ...rest) => first ? [] : rest.map(n => n > 0))(8,9,10);
+>first : Symbol(first, Decl(contextuallyTypedIife.ts, 18, 2))
+>rest : Symbol(rest, Decl(contextuallyTypedIife.ts, 18, 8))
+>first : Symbol(first, Decl(contextuallyTypedIife.ts, 18, 2))
+>rest.map : Symbol(Array.map, Decl(lib.d.ts, --, --))
+>rest : Symbol(rest, Decl(contextuallyTypedIife.ts, 18, 8))
+>map : Symbol(Array.map, Decl(lib.d.ts, --, --))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 18, 43))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 18, 43))
+
+// destructuring parameters (with defaults too!)
+(({ q }) => q)({ q : 13 });
+>q : Symbol(q, Decl(contextuallyTypedIife.ts, 20, 3))
+>q : Symbol(q, Decl(contextuallyTypedIife.ts, 20, 3))
+>q : Symbol(q, Decl(contextuallyTypedIife.ts, 20, 16))
+
+(({ p = 14 }) => p)({ p : 15 });
+>p : Symbol(p, Decl(contextuallyTypedIife.ts, 21, 3))
+>p : Symbol(p, Decl(contextuallyTypedIife.ts, 21, 3))
+>p : Symbol(p, Decl(contextuallyTypedIife.ts, 21, 21))
+
+(({ r = 17 } = { r: 18 }) => r)({r : 19});
+>r : Symbol(r, Decl(contextuallyTypedIife.ts, 22, 3))
+>r : Symbol(r, Decl(contextuallyTypedIife.ts, 22, 16))
+>r : Symbol(r, Decl(contextuallyTypedIife.ts, 22, 3))
+>r : Symbol(r, Decl(contextuallyTypedIife.ts, 22, 33))
+
+(({ u = 22 } = { u: 23 }) => u)();
+>u : Symbol(u, Decl(contextuallyTypedIife.ts, 23, 3))
+>u : Symbol(u, Decl(contextuallyTypedIife.ts, 23, 16))
+>u : Symbol(u, Decl(contextuallyTypedIife.ts, 23, 3))
+
+
+

--- a/tests/baselines/reference/contextuallyTypedIife.symbols
+++ b/tests/baselines/reference/contextuallyTypedIife.symbols
@@ -7,91 +7,115 @@
 (function (cats) { })("lol");
 >cats : Symbol(cats, Decl(contextuallyTypedIife.ts, 3, 11))
 
+// Lots of Irritating Superfluous Parentheses
+(function (x) { } ("!"));
+>x : Symbol(x, Decl(contextuallyTypedIife.ts, 5, 11))
+
+((((function (y) { }))))("-");
+>y : Symbol(y, Decl(contextuallyTypedIife.ts, 6, 14))
+
 // multiple arguments
 ((a, b, c) => { })("foo", 101, false);
->a : Symbol(a, Decl(contextuallyTypedIife.ts, 5, 2))
->b : Symbol(b, Decl(contextuallyTypedIife.ts, 5, 4))
->c : Symbol(c, Decl(contextuallyTypedIife.ts, 5, 7))
-
-// contextually typed parameters.
-(f => f(1))(i => i + 1);
->f : Symbol(f, Decl(contextuallyTypedIife.ts, 7, 1))
->f : Symbol(f, Decl(contextuallyTypedIife.ts, 7, 1))
->i : Symbol(i, Decl(contextuallyTypedIife.ts, 7, 12))
->i : Symbol(i, Decl(contextuallyTypedIife.ts, 7, 12))
+>a : Symbol(a, Decl(contextuallyTypedIife.ts, 8, 2))
+>b : Symbol(b, Decl(contextuallyTypedIife.ts, 8, 4))
+>c : Symbol(c, Decl(contextuallyTypedIife.ts, 8, 7))
 
 // default parameters
 ((m = 10) => m + 1)(12);
->m : Symbol(m, Decl(contextuallyTypedIife.ts, 9, 2))
->m : Symbol(m, Decl(contextuallyTypedIife.ts, 9, 2))
+>m : Symbol(m, Decl(contextuallyTypedIife.ts, 10, 2))
+>m : Symbol(m, Decl(contextuallyTypedIife.ts, 10, 2))
 
 ((n = 10) => n + 1)();
->n : Symbol(n, Decl(contextuallyTypedIife.ts, 10, 2))
->n : Symbol(n, Decl(contextuallyTypedIife.ts, 10, 2))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 11, 2))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 11, 2))
 
 // optional parameters
 ((j?) => j + 1)(12);
->j : Symbol(j, Decl(contextuallyTypedIife.ts, 12, 2))
->j : Symbol(j, Decl(contextuallyTypedIife.ts, 12, 2))
+>j : Symbol(j, Decl(contextuallyTypedIife.ts, 13, 2))
+>j : Symbol(j, Decl(contextuallyTypedIife.ts, 13, 2))
 
 ((k?) => k + 1)();
->k : Symbol(k, Decl(contextuallyTypedIife.ts, 13, 2))
->k : Symbol(k, Decl(contextuallyTypedIife.ts, 13, 2))
+>k : Symbol(k, Decl(contextuallyTypedIife.ts, 14, 2))
+>k : Symbol(k, Decl(contextuallyTypedIife.ts, 14, 2))
 
 ((l, o?) => l + o)(12); // o should be any
->l : Symbol(l, Decl(contextuallyTypedIife.ts, 14, 2))
->o : Symbol(o, Decl(contextuallyTypedIife.ts, 14, 4))
->l : Symbol(l, Decl(contextuallyTypedIife.ts, 14, 2))
->o : Symbol(o, Decl(contextuallyTypedIife.ts, 14, 4))
+>l : Symbol(l, Decl(contextuallyTypedIife.ts, 15, 2))
+>o : Symbol(o, Decl(contextuallyTypedIife.ts, 15, 4))
+>l : Symbol(l, Decl(contextuallyTypedIife.ts, 15, 2))
+>o : Symbol(o, Decl(contextuallyTypedIife.ts, 15, 4))
 
 // rest parameters
 ((...numbers) => numbers.every(n => n > 0))(5,6,7);
->numbers : Symbol(numbers, Decl(contextuallyTypedIife.ts, 16, 2))
+>numbers : Symbol(numbers, Decl(contextuallyTypedIife.ts, 17, 2))
 >numbers.every : Symbol(Array.every, Decl(lib.d.ts, --, --))
->numbers : Symbol(numbers, Decl(contextuallyTypedIife.ts, 16, 2))
+>numbers : Symbol(numbers, Decl(contextuallyTypedIife.ts, 17, 2))
 >every : Symbol(Array.every, Decl(lib.d.ts, --, --))
->n : Symbol(n, Decl(contextuallyTypedIife.ts, 16, 31))
->n : Symbol(n, Decl(contextuallyTypedIife.ts, 16, 31))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 17, 31))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 17, 31))
+
+((...mixed) => mixed.every(n => !!n))(5,'oops','oh no');
+>mixed : Symbol(mixed, Decl(contextuallyTypedIife.ts, 18, 2))
+>mixed.every : Symbol(Array.every, Decl(lib.d.ts, --, --))
+>mixed : Symbol(mixed, Decl(contextuallyTypedIife.ts, 18, 2))
+>every : Symbol(Array.every, Decl(lib.d.ts, --, --))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 18, 27))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 18, 27))
 
 ((...noNumbers) => noNumbers.some(n => n > 0))();
->noNumbers : Symbol(noNumbers, Decl(contextuallyTypedIife.ts, 17, 2))
+>noNumbers : Symbol(noNumbers, Decl(contextuallyTypedIife.ts, 19, 2))
 >noNumbers.some : Symbol(Array.some, Decl(lib.d.ts, --, --))
->noNumbers : Symbol(noNumbers, Decl(contextuallyTypedIife.ts, 17, 2))
+>noNumbers : Symbol(noNumbers, Decl(contextuallyTypedIife.ts, 19, 2))
 >some : Symbol(Array.some, Decl(lib.d.ts, --, --))
->n : Symbol(n, Decl(contextuallyTypedIife.ts, 17, 34))
->n : Symbol(n, Decl(contextuallyTypedIife.ts, 17, 34))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 19, 34))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 19, 34))
 
 ((first, ...rest) => first ? [] : rest.map(n => n > 0))(8,9,10);
->first : Symbol(first, Decl(contextuallyTypedIife.ts, 18, 2))
->rest : Symbol(rest, Decl(contextuallyTypedIife.ts, 18, 8))
->first : Symbol(first, Decl(contextuallyTypedIife.ts, 18, 2))
+>first : Symbol(first, Decl(contextuallyTypedIife.ts, 20, 2))
+>rest : Symbol(rest, Decl(contextuallyTypedIife.ts, 20, 8))
+>first : Symbol(first, Decl(contextuallyTypedIife.ts, 20, 2))
 >rest.map : Symbol(Array.map, Decl(lib.d.ts, --, --))
->rest : Symbol(rest, Decl(contextuallyTypedIife.ts, 18, 8))
+>rest : Symbol(rest, Decl(contextuallyTypedIife.ts, 20, 8))
 >map : Symbol(Array.map, Decl(lib.d.ts, --, --))
->n : Symbol(n, Decl(contextuallyTypedIife.ts, 18, 43))
->n : Symbol(n, Decl(contextuallyTypedIife.ts, 18, 43))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 20, 43))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 20, 43))
 
 // destructuring parameters (with defaults too!)
 (({ q }) => q)({ q : 13 });
->q : Symbol(q, Decl(contextuallyTypedIife.ts, 20, 3))
->q : Symbol(q, Decl(contextuallyTypedIife.ts, 20, 3))
->q : Symbol(q, Decl(contextuallyTypedIife.ts, 20, 16))
+>q : Symbol(q, Decl(contextuallyTypedIife.ts, 22, 3))
+>q : Symbol(q, Decl(contextuallyTypedIife.ts, 22, 3))
+>q : Symbol(q, Decl(contextuallyTypedIife.ts, 22, 16))
 
 (({ p = 14 }) => p)({ p : 15 });
->p : Symbol(p, Decl(contextuallyTypedIife.ts, 21, 3))
->p : Symbol(p, Decl(contextuallyTypedIife.ts, 21, 3))
->p : Symbol(p, Decl(contextuallyTypedIife.ts, 21, 21))
+>p : Symbol(p, Decl(contextuallyTypedIife.ts, 23, 3))
+>p : Symbol(p, Decl(contextuallyTypedIife.ts, 23, 3))
+>p : Symbol(p, Decl(contextuallyTypedIife.ts, 23, 21))
 
 (({ r = 17 } = { r: 18 }) => r)({r : 19});
->r : Symbol(r, Decl(contextuallyTypedIife.ts, 22, 3))
->r : Symbol(r, Decl(contextuallyTypedIife.ts, 22, 16))
->r : Symbol(r, Decl(contextuallyTypedIife.ts, 22, 3))
->r : Symbol(r, Decl(contextuallyTypedIife.ts, 22, 33))
+>r : Symbol(r, Decl(contextuallyTypedIife.ts, 24, 3))
+>r : Symbol(r, Decl(contextuallyTypedIife.ts, 24, 16))
+>r : Symbol(r, Decl(contextuallyTypedIife.ts, 24, 3))
+>r : Symbol(r, Decl(contextuallyTypedIife.ts, 24, 33))
 
 (({ u = 22 } = { u: 23 }) => u)();
->u : Symbol(u, Decl(contextuallyTypedIife.ts, 23, 3))
->u : Symbol(u, Decl(contextuallyTypedIife.ts, 23, 16))
->u : Symbol(u, Decl(contextuallyTypedIife.ts, 23, 3))
+>u : Symbol(u, Decl(contextuallyTypedIife.ts, 25, 3))
+>u : Symbol(u, Decl(contextuallyTypedIife.ts, 25, 16))
+>u : Symbol(u, Decl(contextuallyTypedIife.ts, 25, 3))
 
+// contextually typed parameters.
+let twelve = (f => f(12))(i => i);
+>twelve : Symbol(twelve, Decl(contextuallyTypedIife.ts, 27, 3))
+>f : Symbol(f, Decl(contextuallyTypedIife.ts, 27, 14))
+>f : Symbol(f, Decl(contextuallyTypedIife.ts, 27, 14))
+>i : Symbol(i, Decl(contextuallyTypedIife.ts, 27, 26))
+>i : Symbol(i, Decl(contextuallyTypedIife.ts, 27, 26))
 
+let eleven = (o => o.a(11))({ a: function(n) { return n; } });
+>eleven : Symbol(eleven, Decl(contextuallyTypedIife.ts, 28, 3))
+>o : Symbol(o, Decl(contextuallyTypedIife.ts, 28, 14))
+>o.a : Symbol(a, Decl(contextuallyTypedIife.ts, 28, 29))
+>o : Symbol(o, Decl(contextuallyTypedIife.ts, 28, 14))
+>a : Symbol(a, Decl(contextuallyTypedIife.ts, 28, 29))
+>a : Symbol(a, Decl(contextuallyTypedIife.ts, 28, 29))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 28, 42))
+>n : Symbol(n, Decl(contextuallyTypedIife.ts, 28, 42))
 

--- a/tests/baselines/reference/contextuallyTypedIife.types
+++ b/tests/baselines/reference/contextuallyTypedIife.types
@@ -223,26 +223,26 @@
 let twelve = (f => f(12))(i => i);
 >twelve : any
 >(f => f(12))(i => i) : any
->(f => f(12)) : (f: {}) => any
->f => f(12) : (f: {}) => any
->f : {}
+>(f => f(12)) : (f: (i: any) => any) => any
+>f => f(12) : (f: (i: any) => any) => any
+>f : (i: any) => any
 >f(12) : any
->f : {}
+>f : (i: any) => any
 >12 : number
->i => i : (i: {}) => {}
->i : {}
->i : {}
+>i => i : (i: any) => any
+>i : any
+>i : any
 
 let eleven = (o => o.a(11))({ a: function(n) { return n; } });
 >eleven : any
 >(o => o.a(11))({ a: function(n) { return n; } }) : any
->(o => o.a(11)) : (o: { a: {}; }) => any
->o => o.a(11) : (o: { a: {}; }) => any
->o : { a: {}; }
+>(o => o.a(11)) : (o: { a: (n: any) => any; }) => any
+>o => o.a(11) : (o: { a: (n: any) => any; }) => any
+>o : { a: (n: any) => any; }
 >o.a(11) : any
->o.a : {}
->o : { a: {}; }
->a : {}
+>o.a : (n: any) => any
+>o : { a: (n: any) => any; }
+>a : (n: any) => any
 >11 : number
 >{ a: function(n) { return n; } } : { a: (n: any) => any; }
 >a : (n: any) => any

--- a/tests/baselines/reference/contextuallyTypedIife.types
+++ b/tests/baselines/reference/contextuallyTypedIife.types
@@ -1,0 +1,202 @@
+=== tests/cases/conformance/expressions/functions/contextuallyTypedIife.ts ===
+// arrow
+(jake => { })("build");
+>(jake => { })("build") : void
+>(jake => { }) : (jake: string) => void
+>jake => { } : (jake: string) => void
+>jake : string
+>"build" : string
+
+// function expression
+(function (cats) { })("lol");
+>(function (cats) { })("lol") : void
+>(function (cats) { }) : (cats: string) => void
+>function (cats) { } : (cats: string) => void
+>cats : string
+>"lol" : string
+
+// multiple arguments
+((a, b, c) => { })("foo", 101, false);
+>((a, b, c) => { })("foo", 101, false) : void
+>((a, b, c) => { }) : (a: string, b: number, c: boolean) => void
+>(a, b, c) => { } : (a: string, b: number, c: boolean) => void
+>a : string
+>b : number
+>c : boolean
+>"foo" : string
+>101 : number
+>false : boolean
+
+// contextually typed parameters.
+(f => f(1))(i => i + 1);
+>(f => f(1))(i => i + 1) : any
+>(f => f(1)) : (f: (i: any) => any) => any
+>f => f(1) : (f: (i: any) => any) => any
+>f : (i: any) => any
+>f(1) : any
+>f : (i: any) => any
+>1 : number
+>i => i + 1 : (i: any) => any
+>i : any
+>i + 1 : any
+>i : any
+>1 : number
+
+// default parameters
+((m = 10) => m + 1)(12);
+>((m = 10) => m + 1)(12) : number
+>((m = 10) => m + 1) : (m?: number) => number
+>(m = 10) => m + 1 : (m?: number) => number
+>m : number
+>10 : number
+>m + 1 : number
+>m : number
+>1 : number
+>12 : number
+
+((n = 10) => n + 1)();
+>((n = 10) => n + 1)() : number
+>((n = 10) => n + 1) : (n?: number) => number
+>(n = 10) => n + 1 : (n?: number) => number
+>n : number
+>10 : number
+>n + 1 : number
+>n : number
+>1 : number
+
+// optional parameters
+((j?) => j + 1)(12);
+>((j?) => j + 1)(12) : number
+>((j?) => j + 1) : (j?: number) => number
+>(j?) => j + 1 : (j?: number) => number
+>j : number
+>j + 1 : number
+>j : number
+>1 : number
+>12 : number
+
+((k?) => k + 1)();
+>((k?) => k + 1)() : any
+>((k?) => k + 1) : (k?: any) => any
+>(k?) => k + 1 : (k?: any) => any
+>k : any
+>k + 1 : any
+>k : any
+>1 : number
+
+((l, o?) => l + o)(12); // o should be any
+>((l, o?) => l + o)(12) : any
+>((l, o?) => l + o) : (l: number, o?: any) => any
+>(l, o?) => l + o : (l: number, o?: any) => any
+>l : number
+>o : any
+>l + o : any
+>l : number
+>o : any
+>12 : number
+
+// rest parameters
+((...numbers) => numbers.every(n => n > 0))(5,6,7);
+>((...numbers) => numbers.every(n => n > 0))(5,6,7) : boolean
+>((...numbers) => numbers.every(n => n > 0)) : (...numbers: number[]) => boolean
+>(...numbers) => numbers.every(n => n > 0) : (...numbers: number[]) => boolean
+>numbers : number[]
+>numbers.every(n => n > 0) : boolean
+>numbers.every : (callbackfn: (value: number, index: number, array: number[]) => boolean, thisArg?: any) => boolean
+>numbers : number[]
+>every : (callbackfn: (value: number, index: number, array: number[]) => boolean, thisArg?: any) => boolean
+>n => n > 0 : (n: number) => boolean
+>n : number
+>n > 0 : boolean
+>n : number
+>0 : number
+>5 : number
+>6 : number
+>7 : number
+
+((...noNumbers) => noNumbers.some(n => n > 0))();
+>((...noNumbers) => noNumbers.some(n => n > 0))() : boolean
+>((...noNumbers) => noNumbers.some(n => n > 0)) : (...noNumbers: any[]) => boolean
+>(...noNumbers) => noNumbers.some(n => n > 0) : (...noNumbers: any[]) => boolean
+>noNumbers : any[]
+>noNumbers.some(n => n > 0) : boolean
+>noNumbers.some : (callbackfn: (value: any, index: number, array: any[]) => boolean, thisArg?: any) => boolean
+>noNumbers : any[]
+>some : (callbackfn: (value: any, index: number, array: any[]) => boolean, thisArg?: any) => boolean
+>n => n > 0 : (n: any) => boolean
+>n : any
+>n > 0 : boolean
+>n : any
+>0 : number
+
+((first, ...rest) => first ? [] : rest.map(n => n > 0))(8,9,10);
+>((first, ...rest) => first ? [] : rest.map(n => n > 0))(8,9,10) : boolean[]
+>((first, ...rest) => first ? [] : rest.map(n => n > 0)) : (first: number, ...rest: number[]) => boolean[]
+>(first, ...rest) => first ? [] : rest.map(n => n > 0) : (first: number, ...rest: number[]) => boolean[]
+>first : number
+>rest : number[]
+>first ? [] : rest.map(n => n > 0) : boolean[]
+>first : number
+>[] : undefined[]
+>rest.map(n => n > 0) : boolean[]
+>rest.map : <U>(callbackfn: (value: number, index: number, array: number[]) => U, thisArg?: any) => U[]
+>rest : number[]
+>map : <U>(callbackfn: (value: number, index: number, array: number[]) => U, thisArg?: any) => U[]
+>n => n > 0 : (n: number) => boolean
+>n : number
+>n > 0 : boolean
+>n : number
+>0 : number
+>8 : number
+>9 : number
+>10 : number
+
+// destructuring parameters (with defaults too!)
+(({ q }) => q)({ q : 13 });
+>(({ q }) => q)({ q : 13 }) : number
+>(({ q }) => q) : ({q}: { q: number; }) => number
+>({ q }) => q : ({q}: { q: number; }) => number
+>q : number
+>q : number
+>{ q : 13 } : { q: number; }
+>q : number
+>13 : number
+
+(({ p = 14 }) => p)({ p : 15 });
+>(({ p = 14 }) => p)({ p : 15 }) : number
+>(({ p = 14 }) => p) : ({p}: { p: number; }) => number
+>({ p = 14 }) => p : ({p}: { p: number; }) => number
+>p : number
+>14 : number
+>p : number
+>{ p : 15 } : { p: number; }
+>p : number
+>15 : number
+
+(({ r = 17 } = { r: 18 }) => r)({r : 19});
+>(({ r = 17 } = { r: 18 }) => r)({r : 19}) : number
+>(({ r = 17 } = { r: 18 }) => r) : ({r}?: { r: number; }) => number
+>({ r = 17 } = { r: 18 }) => r : ({r}?: { r: number; }) => number
+>r : number
+>17 : number
+>{ r: 18 } : { r: number; }
+>r : number
+>18 : number
+>r : number
+>{r : 19} : { r: number; }
+>r : number
+>19 : number
+
+(({ u = 22 } = { u: 23 }) => u)();
+>(({ u = 22 } = { u: 23 }) => u)() : number
+>(({ u = 22 } = { u: 23 }) => u) : ({u}?: { u?: number; }) => number
+>({ u = 22 } = { u: 23 }) => u : ({u}?: { u?: number; }) => number
+>u : number
+>22 : number
+>{ u: 23 } : { u?: number; }
+>u : number
+>23 : number
+>u : number
+
+
+

--- a/tests/baselines/reference/contextuallyTypedIife.types
+++ b/tests/baselines/reference/contextuallyTypedIife.types
@@ -15,6 +15,24 @@
 >cats : string
 >"lol" : string
 
+// Lots of Irritating Superfluous Parentheses
+(function (x) { } ("!"));
+>(function (x) { } ("!")) : void
+>function (x) { } ("!") : void
+>function (x) { } : (x: string) => void
+>x : string
+>"!" : string
+
+((((function (y) { }))))("-");
+>((((function (y) { }))))("-") : void
+>((((function (y) { })))) : (y: string) => void
+>(((function (y) { }))) : (y: string) => void
+>((function (y) { })) : (y: string) => void
+>(function (y) { }) : (y: string) => void
+>function (y) { } : (y: string) => void
+>y : string
+>"-" : string
+
 // multiple arguments
 ((a, b, c) => { })("foo", 101, false);
 >((a, b, c) => { })("foo", 101, false) : void
@@ -26,21 +44,6 @@
 >"foo" : string
 >101 : number
 >false : boolean
-
-// contextually typed parameters.
-(f => f(1))(i => i + 1);
->(f => f(1))(i => i + 1) : any
->(f => f(1)) : (f: (i: any) => any) => any
->f => f(1) : (f: (i: any) => any) => any
->f : (i: any) => any
->f(1) : any
->f : (i: any) => any
->1 : number
->i => i + 1 : (i: any) => any
->i : any
->i + 1 : any
->i : any
->1 : number
 
 // default parameters
 ((m = 10) => m + 1)(12);
@@ -113,6 +116,24 @@
 >5 : number
 >6 : number
 >7 : number
+
+((...mixed) => mixed.every(n => !!n))(5,'oops','oh no');
+>((...mixed) => mixed.every(n => !!n))(5,'oops','oh no') : boolean
+>((...mixed) => mixed.every(n => !!n)) : (...mixed: (number | string)[]) => boolean
+>(...mixed) => mixed.every(n => !!n) : (...mixed: (number | string)[]) => boolean
+>mixed : (number | string)[]
+>mixed.every(n => !!n) : boolean
+>mixed.every : (callbackfn: (value: number | string, index: number, array: (number | string)[]) => boolean, thisArg?: any) => boolean
+>mixed : (number | string)[]
+>every : (callbackfn: (value: number | string, index: number, array: (number | string)[]) => boolean, thisArg?: any) => boolean
+>n => !!n : (n: number | string) => boolean
+>n : number | string
+>!!n : boolean
+>!n : boolean
+>n : number | string
+>5 : number
+>'oops' : string
+>'oh no' : string
 
 ((...noNumbers) => noNumbers.some(n => n > 0))();
 >((...noNumbers) => noNumbers.some(n => n > 0))() : boolean
@@ -198,5 +219,34 @@
 >23 : number
 >u : number
 
+// contextually typed parameters.
+let twelve = (f => f(12))(i => i);
+>twelve : any
+>(f => f(12))(i => i) : any
+>(f => f(12)) : (f: {}) => any
+>f => f(12) : (f: {}) => any
+>f : {}
+>f(12) : any
+>f : {}
+>12 : number
+>i => i : (i: {}) => {}
+>i : {}
+>i : {}
 
+let eleven = (o => o.a(11))({ a: function(n) { return n; } });
+>eleven : any
+>(o => o.a(11))({ a: function(n) { return n; } }) : any
+>(o => o.a(11)) : (o: { a: {}; }) => any
+>o => o.a(11) : (o: { a: {}; }) => any
+>o : { a: {}; }
+>o.a(11) : any
+>o.a : {}
+>o : { a: {}; }
+>a : {}
+>11 : number
+>{ a: function(n) { return n; } } : { a: (n: any) => any; }
+>a : (n: any) => any
+>function(n) { return n; } : (n: any) => any
+>n : any
+>n : any
 

--- a/tests/cases/conformance/expressions/functions/contextuallyTypedIife.ts
+++ b/tests/cases/conformance/expressions/functions/contextuallyTypedIife.ts
@@ -1,0 +1,26 @@
+// arrow
+(jake => { })("build");
+// function expression
+(function (cats) { })("lol");
+// multiple arguments
+((a, b, c) => { })("foo", 101, false);
+// contextually typed parameters.
+(f => f(1))(i => i + 1);
+// default parameters
+((m = 10) => m + 1)(12);
+((n = 10) => n + 1)();
+// optional parameters
+((j?) => j + 1)(12);
+((k?) => k + 1)();
+((l, o?) => l + o)(12); // o should be any
+// rest parameters
+((...numbers) => numbers.every(n => n > 0))(5,6,7);
+((...noNumbers) => noNumbers.some(n => n > 0))();
+((first, ...rest) => first ? [] : rest.map(n => n > 0))(8,9,10);
+// destructuring parameters (with defaults too!)
+(({ q }) => q)({ q : 13 });
+(({ p = 14 }) => p)({ p : 15 });
+(({ r = 17 } = { r: 18 }) => r)({r : 19});
+(({ u = 22 } = { u: 23 }) => u)();
+
+

--- a/tests/cases/conformance/expressions/functions/contextuallyTypedIife.ts
+++ b/tests/cases/conformance/expressions/functions/contextuallyTypedIife.ts
@@ -2,10 +2,11 @@
 (jake => { })("build");
 // function expression
 (function (cats) { })("lol");
+// Lots of Irritating Superfluous Parentheses
+(function (x) { } ("!"));
+((((function (y) { }))))("-");
 // multiple arguments
 ((a, b, c) => { })("foo", 101, false);
-// contextually typed parameters.
-(f => f(1))(i => i + 1);
 // default parameters
 ((m = 10) => m + 1)(12);
 ((n = 10) => n + 1)();
@@ -15,6 +16,7 @@
 ((l, o?) => l + o)(12); // o should be any
 // rest parameters
 ((...numbers) => numbers.every(n => n > 0))(5,6,7);
+((...mixed) => mixed.every(n => !!n))(5,'oops','oh no');
 ((...noNumbers) => noNumbers.some(n => n > 0))();
 ((first, ...rest) => first ? [] : rest.map(n => n > 0))(8,9,10);
 // destructuring parameters (with defaults too!)
@@ -22,5 +24,6 @@
 (({ p = 14 }) => p)({ p : 15 });
 (({ r = 17 } = { r: 18 }) => r)({r : 19});
 (({ u = 22 } = { u: 23 }) => u)();
-
-
+// contextually typed parameters.
+let twelve = (f => f(12))(i => i);
+let eleven = (o => o.a(11))({ a: function(n) { return n; } });


### PR DESCRIPTION
Fixes #4142.

Right now rest parameters look at the first matching argument to get their contextual type. This might be wrong.