### PR TITLE
getSymbolAtLocation now returns symbol for external modules

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16587,6 +16587,9 @@ namespace ts {
         }
 
         function getSymbolAtLocation(node: Node) {
+            if (node.kind === SyntaxKind.SourceFile) {
+                return isExternalModule(<SourceFile>node) ? getMergedSymbol(node.symbol) : undefined;
+            }
             if (isInsideWithStatementBody(node)) {
                 // We cannot answer semantic questions within a with block, do not proceed any further
                 return undefined;


### PR DESCRIPTION
without this bit `TypeChecker.getExportsOfModule` is effectively unusable