### PR TITLE
Add test for explicitly added dotted files

### DIFF
--- a/tests/cases/unittests/tsconfigParsing.ts
+++ b/tests/cases/unittests/tsconfigParsing.ts
@@ -157,6 +157,18 @@ namespace ts {
                 ["/apath/test.ts", "/apath/.git/a.ts", "/apath/.b.ts", "/apath/..c.ts"],
                 ["/apath/test.ts"]
             )
-        })
+        });
+
+        it("allow dotted files and folders when explicitly requested", () => {
+            assertParseFileList(
+                `{
+                    "files": ["/apath/.git/a.ts", "/apath/.b.ts", "/apath/..c.ts"]
+                }`,
+                "tsconfig.json",
+                "/apath",
+                ["/apath/test.ts", "/apath/.git/a.ts", "/apath/.b.ts", "/apath/..c.ts"],
+                ["/apath/.git/a.ts", "/apath/.b.ts", "/apath/..c.ts"]
+            )
+        });
     });
 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Per comment at https://github.com/Microsoft/TypeScript/pull/8484#discussion_r62305459
Adding a test for allowing dotted files / folders when explicitly request.

