### PR TITLE
Fix #8507: Consider UnknownSymbols values for import/export purposes

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2629,7 +2629,7 @@ namespace ts {
                         const internalModuleReference = <Identifier | QualifiedName>(<ImportEqualsDeclaration>declaration).moduleReference;
                         const firstIdentifier = getFirstIdentifier(internalModuleReference);
                         const importSymbol = resolveName(declaration, firstIdentifier.text, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace,
-                            Diagnostics.Cannot_find_name_0, firstIdentifier);
+                            undefined, undefined);
                         if (importSymbol) {
                             buildVisibleNodeList(importSymbol.declarations);
                         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1133,9 +1133,8 @@ namespace ts {
             const symbol = getSymbolOfNode(node);
             const target = resolveAlias(symbol);
             if (target) {
-                const markAlias =
-                    (target === unknownSymbol && compilerOptions.isolatedModules) ||
-                    (target !== unknownSymbol && (target.flags & SymbolFlags.Value) && !isConstEnumOrConstEnumOnlyModule(target));
+                const markAlias = target === unknownSymbol ||
+                    ((target.flags & SymbolFlags.Value) && !isConstEnumOrConstEnumOnlyModule(target));
 
                 if (markAlias) {
                     markAliasSymbolAsReferenced(symbol);
@@ -16983,14 +16982,12 @@ namespace ts {
 
         function isAliasResolvedToValue(symbol: Symbol): boolean {
             const target = resolveAlias(symbol);
-            if (target === unknownSymbol && compilerOptions.isolatedModules) {
+            if (target === unknownSymbol) {
                 return true;
             }
             // const enums and modules that contain only const enums are not considered values from the emit perspective
             // unless 'preserveConstEnums' option is set to true
-            return target !== unknownSymbol &&
-                target &&
-                target.flags & SymbolFlags.Value &&
+            return target.flags & SymbolFlags.Value &&
                 (compilerOptions.preserveConstEnums || !isConstEnumOrConstEnumOnlyModule(target));
         }
 

--- a/tests/baselines/reference/ExportAssignment7.js
+++ b/tests/baselines/reference/ExportAssignment7.js
@@ -12,3 +12,4 @@ var C = (function () {
     return C;
 }());
 exports.C = C;
+module.exports = B;

--- a/tests/baselines/reference/ExportAssignment8.js
+++ b/tests/baselines/reference/ExportAssignment8.js
@@ -12,3 +12,4 @@ var C = (function () {
     return C;
 }());
 exports.C = C;
+module.exports = B;

--- a/tests/baselines/reference/aliasErrors.js
+++ b/tests/baselines/reference/aliasErrors.js
@@ -55,9 +55,12 @@ var foo;
 var provide = foo;
 var booz = foo.bar.baz;
 var beez = foo.bar;
+var m = no;
+var m2 = no.mod;
 5;
 "s";
 null;
+var r = undefined;
 var p = new provide.Provide();
 function use() {
     beez.baz.boo;

--- a/tests/baselines/reference/blockScopedFunctionDeclarationInStrictModule.js
+++ b/tests/baselines/reference/blockScopedFunctionDeclarationInStrictModule.js
@@ -13,4 +13,5 @@ define(["require", "exports"], function (require, exports) {
         function foo() { }
         foo(); // ok
     }
+    return foo;
 });

--- a/tests/baselines/reference/classAbstractManyKeywords.js
+++ b/tests/baselines/reference/classAbstractManyKeywords.js
@@ -6,6 +6,8 @@ import abstract class D {}
 
 //// [classAbstractManyKeywords.js]
 "use strict";
+exports.__esModule = true;
+exports["default"] = abstract;
 var A = (function () {
     function A() {
     }
@@ -22,6 +24,7 @@ var C = (function () {
     }
     return C;
 }());
+var abstract = ;
 var D = (function () {
     function D() {
     }

--- a/tests/baselines/reference/declarationEmit_UnknownImport.errors.txt
+++ b/tests/baselines/reference/declarationEmit_UnknownImport.errors.txt
@@ -1,14 +1,11 @@
-tests/cases/compiler/declarationEmit_UnknownImport.ts(2,1): error TS2304: Cannot find name 'SomeNonExistingName'.
 tests/cases/compiler/declarationEmit_UnknownImport.ts(2,14): error TS2304: Cannot find name 'SomeNonExistingName'.
 tests/cases/compiler/declarationEmit_UnknownImport.ts(2,14): error TS2503: Cannot find namespace 'SomeNonExistingName'.
 tests/cases/compiler/declarationEmit_UnknownImport.ts(2,14): error TS4000: Import declaration 'Foo' is using private name 'SomeNonExistingName'.
 
 
-==== tests/cases/compiler/declarationEmit_UnknownImport.ts (4 errors) ====
+==== tests/cases/compiler/declarationEmit_UnknownImport.ts (3 errors) ====
     
     import Foo = SomeNonExistingName
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2304: Cannot find name 'SomeNonExistingName'.
                  ~~~~~~~~~~~~~~~~~~~
 !!! error TS2304: Cannot find name 'SomeNonExistingName'.
                  ~~~~~~~~~~~~~~~~~~~

--- a/tests/baselines/reference/declarationEmit_UnknownImport.errors.txt
+++ b/tests/baselines/reference/declarationEmit_UnknownImport.errors.txt
@@ -1,12 +1,15 @@
 tests/cases/compiler/declarationEmit_UnknownImport.ts(2,1): error TS2304: Cannot find name 'SomeNonExistingName'.
+tests/cases/compiler/declarationEmit_UnknownImport.ts(2,14): error TS2304: Cannot find name 'SomeNonExistingName'.
 tests/cases/compiler/declarationEmit_UnknownImport.ts(2,14): error TS2503: Cannot find namespace 'SomeNonExistingName'.
 tests/cases/compiler/declarationEmit_UnknownImport.ts(2,14): error TS4000: Import declaration 'Foo' is using private name 'SomeNonExistingName'.
 
 
-==== tests/cases/compiler/declarationEmit_UnknownImport.ts (3 errors) ====
+==== tests/cases/compiler/declarationEmit_UnknownImport.ts (4 errors) ====
     
     import Foo = SomeNonExistingName
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2304: Cannot find name 'SomeNonExistingName'.
+                 ~~~~~~~~~~~~~~~~~~~
 !!! error TS2304: Cannot find name 'SomeNonExistingName'.
                  ~~~~~~~~~~~~~~~~~~~
 !!! error TS2503: Cannot find namespace 'SomeNonExistingName'.

--- a/tests/baselines/reference/declarationEmit_UnknownImport.js
+++ b/tests/baselines/reference/declarationEmit_UnknownImport.js
@@ -5,3 +5,5 @@ export {Foo}
 
 //// [declarationEmit_UnknownImport.js]
 "use strict";
+var Foo = SomeNonExistingName;
+exports.Foo = Foo;

--- a/tests/baselines/reference/declarationEmit_UnknownImport2.errors.txt
+++ b/tests/baselines/reference/declarationEmit_UnknownImport2.errors.txt
@@ -1,4 +1,3 @@
-tests/cases/compiler/declarationEmit_UnknownImport2.ts(2,1): error TS2304: Cannot find name 'From'.
 tests/cases/compiler/declarationEmit_UnknownImport2.ts(2,12): error TS1005: '=' expected.
 tests/cases/compiler/declarationEmit_UnknownImport2.ts(2,12): error TS2304: Cannot find name 'From'.
 tests/cases/compiler/declarationEmit_UnknownImport2.ts(2,12): error TS2503: Cannot find namespace 'From'.
@@ -6,11 +5,9 @@ tests/cases/compiler/declarationEmit_UnknownImport2.ts(2,12): error TS4000: Impo
 tests/cases/compiler/declarationEmit_UnknownImport2.ts(2,17): error TS1005: ';' expected.
 
 
-==== tests/cases/compiler/declarationEmit_UnknownImport2.ts (6 errors) ====
+==== tests/cases/compiler/declarationEmit_UnknownImport2.ts (5 errors) ====
     
     import Foo From './Foo'; // Syntax error
-    ~~~~~~~~~~~~~~~
-!!! error TS2304: Cannot find name 'From'.
                ~~~~
 !!! error TS1005: '=' expected.
                ~~~~

--- a/tests/baselines/reference/declarationEmit_UnknownImport2.errors.txt
+++ b/tests/baselines/reference/declarationEmit_UnknownImport2.errors.txt
@@ -1,17 +1,20 @@
 tests/cases/compiler/declarationEmit_UnknownImport2.ts(2,1): error TS2304: Cannot find name 'From'.
 tests/cases/compiler/declarationEmit_UnknownImport2.ts(2,12): error TS1005: '=' expected.
+tests/cases/compiler/declarationEmit_UnknownImport2.ts(2,12): error TS2304: Cannot find name 'From'.
 tests/cases/compiler/declarationEmit_UnknownImport2.ts(2,12): error TS2503: Cannot find namespace 'From'.
 tests/cases/compiler/declarationEmit_UnknownImport2.ts(2,12): error TS4000: Import declaration 'Foo' is using private name 'From'.
 tests/cases/compiler/declarationEmit_UnknownImport2.ts(2,17): error TS1005: ';' expected.
 
 
-==== tests/cases/compiler/declarationEmit_UnknownImport2.ts (5 errors) ====
+==== tests/cases/compiler/declarationEmit_UnknownImport2.ts (6 errors) ====
     
     import Foo From './Foo'; // Syntax error
     ~~~~~~~~~~~~~~~
 !!! error TS2304: Cannot find name 'From'.
                ~~~~
 !!! error TS1005: '=' expected.
+               ~~~~
+!!! error TS2304: Cannot find name 'From'.
                ~~~~
 !!! error TS2503: Cannot find namespace 'From'.
                ~~~~

--- a/tests/baselines/reference/declarationEmit_UnknownImport2.js
+++ b/tests/baselines/reference/declarationEmit_UnknownImport2.js
@@ -5,4 +5,7 @@ export default Foo
 
 //// [declarationEmit_UnknownImport2.js]
 "use strict";
+var Foo = From;
 './Foo'; // Syntax error
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = Foo;

--- a/tests/baselines/reference/es6ExportEqualsInterop.js
+++ b/tests/baselines/reference/es6ExportEqualsInterop.js
@@ -275,6 +275,8 @@ function_module_1.a;
 class_1.a;
 class_module_1.a;
 // named export
+var interface_2 = require("interface");
+exports.a1 = interface_2.a;
 var variable_2 = require("variable");
 exports.a2 = variable_2.a;
 var interface_variable_2 = require("interface-variable");
@@ -285,8 +287,12 @@ var interface_module_2 = require("interface-module");
 exports.a5 = interface_module_2.a;
 var variable_module_2 = require("variable-module");
 exports.a6 = variable_module_2.a;
+var function_2 = require("function");
+exports.a7 = function_2.a;
 var function_module_2 = require("function-module");
 exports.a8 = function_module_2.a;
+var class_2 = require("class");
+exports.a9 = class_2.a;
 var class_module_2 = require("class-module");
 exports.a0 = class_module_2.a;
 // export-star

--- a/tests/baselines/reference/importDeclWithClassModifiers.errors.txt
+++ b/tests/baselines/reference/importDeclWithClassModifiers.errors.txt
@@ -1,12 +1,15 @@
 tests/cases/compiler/importDeclWithClassModifiers.ts(5,8): error TS1044: 'public' modifier cannot appear on a module or namespace element.
+tests/cases/compiler/importDeclWithClassModifiers.ts(5,26): error TS2304: Cannot find name 'x'.
 tests/cases/compiler/importDeclWithClassModifiers.ts(5,28): error TS2305: Module 'x' has no exported member 'c'.
 tests/cases/compiler/importDeclWithClassModifiers.ts(6,8): error TS1044: 'private' modifier cannot appear on a module or namespace element.
+tests/cases/compiler/importDeclWithClassModifiers.ts(6,27): error TS2304: Cannot find name 'x'.
 tests/cases/compiler/importDeclWithClassModifiers.ts(6,29): error TS2305: Module 'x' has no exported member 'c'.
 tests/cases/compiler/importDeclWithClassModifiers.ts(7,8): error TS1044: 'static' modifier cannot appear on a module or namespace element.
+tests/cases/compiler/importDeclWithClassModifiers.ts(7,26): error TS2304: Cannot find name 'x'.
 tests/cases/compiler/importDeclWithClassModifiers.ts(7,28): error TS2305: Module 'x' has no exported member 'c'.
 
 
-==== tests/cases/compiler/importDeclWithClassModifiers.ts (6 errors) ====
+==== tests/cases/compiler/importDeclWithClassModifiers.ts (9 errors) ====
     module x {
         interface c {
         }
@@ -14,16 +17,22 @@ tests/cases/compiler/importDeclWithClassModifiers.ts(7,28): error TS2305: Module
     export public import a = x.c;
            ~~~~~~
 !!! error TS1044: 'public' modifier cannot appear on a module or namespace element.
+                             ~
+!!! error TS2304: Cannot find name 'x'.
                                ~
 !!! error TS2305: Module 'x' has no exported member 'c'.
     export private import b = x.c;
            ~~~~~~~
 !!! error TS1044: 'private' modifier cannot appear on a module or namespace element.
+                              ~
+!!! error TS2304: Cannot find name 'x'.
                                 ~
 !!! error TS2305: Module 'x' has no exported member 'c'.
     export static import c = x.c;
            ~~~~~~
 !!! error TS1044: 'static' modifier cannot appear on a module or namespace element.
+                             ~
+!!! error TS2304: Cannot find name 'x'.
                                ~
 !!! error TS2305: Module 'x' has no exported member 'c'.
     var b: a;

--- a/tests/baselines/reference/importDeclWithClassModifiers.js
+++ b/tests/baselines/reference/importDeclWithClassModifiers.js
@@ -12,5 +12,8 @@ var b: a;
 //// [importDeclWithClassModifiers.js]
 define(["require", "exports"], function (require, exports) {
     "use strict";
+    exports.a = x.c;
+    exports.b = x.c;
+    exports.c = x.c;
     var b;
 });

--- a/tests/baselines/reference/importDeclWithDeclareModifier.errors.txt
+++ b/tests/baselines/reference/importDeclWithDeclareModifier.errors.txt
@@ -1,8 +1,9 @@
 tests/cases/compiler/importDeclWithDeclareModifier.ts(5,9): error TS1029: 'export' modifier must precede 'declare' modifier.
+tests/cases/compiler/importDeclWithDeclareModifier.ts(5,27): error TS2304: Cannot find name 'x'.
 tests/cases/compiler/importDeclWithDeclareModifier.ts(5,29): error TS2305: Module 'x' has no exported member 'c'.
 
 
-==== tests/cases/compiler/importDeclWithDeclareModifier.ts (2 errors) ====
+==== tests/cases/compiler/importDeclWithDeclareModifier.ts (3 errors) ====
     module x {
         interface c {
         }
@@ -10,6 +11,8 @@ tests/cases/compiler/importDeclWithDeclareModifier.ts(5,29): error TS2305: Modul
     declare export import a = x.c;
             ~~~~~~
 !!! error TS1029: 'export' modifier must precede 'declare' modifier.
+                              ~
+!!! error TS2304: Cannot find name 'x'.
                                 ~
 !!! error TS2305: Module 'x' has no exported member 'c'.
     var b: a;

--- a/tests/baselines/reference/importDeclWithExportModifier.errors.txt
+++ b/tests/baselines/reference/importDeclWithExportModifier.errors.txt
@@ -1,12 +1,15 @@
+tests/cases/compiler/importDeclWithExportModifier.ts(5,19): error TS2304: Cannot find name 'x'.
 tests/cases/compiler/importDeclWithExportModifier.ts(5,21): error TS2305: Module 'x' has no exported member 'c'.
 
 
-==== tests/cases/compiler/importDeclWithExportModifier.ts (1 errors) ====
+==== tests/cases/compiler/importDeclWithExportModifier.ts (2 errors) ====
     module x {
         interface c {
         }
     }
     export import a = x.c;
+                      ~
+!!! error TS2304: Cannot find name 'x'.
                         ~
 !!! error TS2305: Module 'x' has no exported member 'c'.
     var b: a;

--- a/tests/baselines/reference/importDeclWithExportModifier.js
+++ b/tests/baselines/reference/importDeclWithExportModifier.js
@@ -10,5 +10,6 @@ var b: a;
 //// [importDeclWithExportModifier.js]
 define(["require", "exports"], function (require, exports) {
     "use strict";
+    exports.a = x.c;
     var b;
 });

--- a/tests/baselines/reference/importDeclWithExportModifierAndExportAssignment.errors.txt
+++ b/tests/baselines/reference/importDeclWithExportModifierAndExportAssignment.errors.txt
@@ -1,13 +1,16 @@
+tests/cases/compiler/importDeclWithExportModifierAndExportAssignment.ts(5,19): error TS2304: Cannot find name 'x'.
 tests/cases/compiler/importDeclWithExportModifierAndExportAssignment.ts(5,21): error TS2305: Module 'x' has no exported member 'c'.
 tests/cases/compiler/importDeclWithExportModifierAndExportAssignment.ts(6,1): error TS2309: An export assignment cannot be used in a module with other exported elements.
 
 
-==== tests/cases/compiler/importDeclWithExportModifierAndExportAssignment.ts (2 errors) ====
+==== tests/cases/compiler/importDeclWithExportModifierAndExportAssignment.ts (3 errors) ====
     module x {
         interface c {
         }
     }
     export import a = x.c;
+                      ~
+!!! error TS2304: Cannot find name 'x'.
                         ~
 !!! error TS2305: Module 'x' has no exported member 'c'.
     export = x;

--- a/tests/baselines/reference/importDeclWithExportModifierAndExportAssignment.js
+++ b/tests/baselines/reference/importDeclWithExportModifierAndExportAssignment.js
@@ -8,3 +8,4 @@ export = x;
 
 //// [importDeclWithExportModifierAndExportAssignment.js]
 "use strict";
+exports.a = x.c;

--- a/tests/baselines/reference/invalidImportAliasIdentifiers.js
+++ b/tests/baselines/reference/invalidImportAliasIdentifiers.js
@@ -27,13 +27,17 @@ import i = I;
 //// [invalidImportAliasIdentifiers.js]
 // none of these should work, since non are actually modules
 var V = 12;
+var v = V;
 var C = (function () {
     function C() {
     }
     return C;
 }());
+var c = C;
 var E;
 (function (E) {
     E[E["Red"] = 0] = "Red";
     E[E["Blue"] = 1] = "Blue";
 })(E || (E = {}));
+var e = E;
+var i = I;

--- a/tests/baselines/reference/moduleElementsInWrongContext.js
+++ b/tests/baselines/reference/moduleElementsInWrongContext.js
@@ -34,6 +34,8 @@
 {
     var v;
     function foo() { }
+    var ambient_2 = require("ambient");
+    exports.b = ambient_2.baz;
     exports["default"] = v;
     var C = (function () {
         function C() {

--- a/tests/baselines/reference/moduleElementsInWrongContext2.js
+++ b/tests/baselines/reference/moduleElementsInWrongContext2.js
@@ -34,6 +34,8 @@ function blah () {
 function blah() {
     var v;
     function foo() { }
+    var ambient_2 = require("ambient");
+    exports.b = ambient_2.baz;
     exports["default"] = v;
     var C = (function () {
         function C() {

--- a/tests/baselines/reference/moduleElementsInWrongContext3.js
+++ b/tests/baselines/reference/moduleElementsInWrongContext3.js
@@ -37,6 +37,8 @@ var P;
     {
         var v;
         function foo() { }
+        var ambient_2 = require("ambient");
+        P.b = ambient_2.baz;
         P["default"] = v;
         var C = (function () {
             function C() {

--- a/tests/baselines/reference/parserExportAssignment1.js
+++ b/tests/baselines/reference/parserExportAssignment1.js
@@ -3,3 +3,4 @@ export = foo
 
 //// [parserExportAssignment1.js]
 "use strict";
+module.exports = foo;

--- a/tests/baselines/reference/parserExportAssignment2.js
+++ b/tests/baselines/reference/parserExportAssignment2.js
@@ -3,3 +3,4 @@ export = foo;
 
 //// [parserExportAssignment2.js]
 "use strict";
+module.exports = foo;

--- a/tests/baselines/reference/parserExportAssignment3.js
+++ b/tests/baselines/reference/parserExportAssignment3.js
@@ -3,3 +3,4 @@ export =
 
 //// [parserExportAssignment3.js]
 "use strict";
+module.exports = ;

--- a/tests/baselines/reference/parserExportAssignment4.js
+++ b/tests/baselines/reference/parserExportAssignment4.js
@@ -3,3 +3,4 @@ export = ;
 
 //// [parserExportAssignment4.js]
 "use strict";
+module.exports = ;

--- a/tests/baselines/reference/parserExportAssignment7.js
+++ b/tests/baselines/reference/parserExportAssignment7.js
@@ -12,3 +12,4 @@ var C = (function () {
     return C;
 }());
 exports.C = C;
+module.exports = B;

--- a/tests/baselines/reference/parserExportAssignment8.js
+++ b/tests/baselines/reference/parserExportAssignment8.js
@@ -12,3 +12,4 @@ var C = (function () {
     return C;
 }());
 exports.C = C;
+module.exports = B;

--- a/tests/baselines/reference/parserImportDeclaration1.js
+++ b/tests/baselines/reference/parserImportDeclaration1.js
@@ -2,3 +2,4 @@
 import TypeScript = TypeScriptServices.TypeScript;
 
 //// [parserImportDeclaration1.js]
+var TypeScript = TypeScriptServices.TypeScript;

--- a/tests/baselines/reference/privacyImportParseErrors.js
+++ b/tests/baselines/reference/privacyImportParseErrors.js
@@ -560,6 +560,8 @@ var glo_im4_private_v4_private = glo_im4_private.f1();
 // Parse error to export module
 exports.glo_im1_public = glo_M1_public;
 exports.glo_im2_public = glo_M3_private;
+exports.glo_im3_public = require("glo_M2_public");
+exports.glo_im4_public = require("glo_M4_private");
 var m2;
 (function (m2_1) {
     var m4;

--- a/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType4.js
+++ b/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType4.js
@@ -14,8 +14,9 @@ import ClassB = require("recursiveExportAssignmentAndFindAliasedType4_moduleB");
 export var b: ClassB; // This should result in type ClassB
 
 //// [recursiveExportAssignmentAndFindAliasedType4_moduleC.js]
-define(["require", "exports"], function (require, exports) {
+define(["require", "exports", "recursiveExportAssignmentAndFindAliasedType4_moduleC"], function (require, exports, self) {
     "use strict";
+    return self;
 });
 //// [recursiveExportAssignmentAndFindAliasedType4_moduleB.js]
 define(["require", "exports"], function (require, exports) {

--- a/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType5.js
+++ b/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType5.js
@@ -18,12 +18,14 @@ import ClassB = require("recursiveExportAssignmentAndFindAliasedType5_moduleB");
 export var b: ClassB; // This should result in type ClassB
 
 //// [recursiveExportAssignmentAndFindAliasedType5_moduleD.js]
-define(["require", "exports"], function (require, exports) {
+define(["require", "exports", "recursiveExportAssignmentAndFindAliasedType5_moduleC"], function (require, exports, self) {
     "use strict";
+    return self;
 });
 //// [recursiveExportAssignmentAndFindAliasedType5_moduleC.js]
-define(["require", "exports"], function (require, exports) {
+define(["require", "exports", "recursiveExportAssignmentAndFindAliasedType5_moduleD"], function (require, exports, self) {
     "use strict";
+    return self;
 });
 //// [recursiveExportAssignmentAndFindAliasedType5_moduleB.js]
 define(["require", "exports"], function (require, exports) {

--- a/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType6.js
+++ b/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType6.js
@@ -22,16 +22,19 @@ import ClassB = require("recursiveExportAssignmentAndFindAliasedType6_moduleB");
 export var b: ClassB; // This should result in type ClassB
 
 //// [recursiveExportAssignmentAndFindAliasedType6_moduleE.js]
-define(["require", "exports"], function (require, exports) {
+define(["require", "exports", "recursiveExportAssignmentAndFindAliasedType6_moduleC"], function (require, exports, self) {
     "use strict";
+    return self;
 });
 //// [recursiveExportAssignmentAndFindAliasedType6_moduleD.js]
-define(["require", "exports"], function (require, exports) {
+define(["require", "exports", "recursiveExportAssignmentAndFindAliasedType6_moduleE"], function (require, exports, self) {
     "use strict";
+    return self;
 });
 //// [recursiveExportAssignmentAndFindAliasedType6_moduleC.js]
-define(["require", "exports"], function (require, exports) {
+define(["require", "exports", "recursiveExportAssignmentAndFindAliasedType6_moduleD"], function (require, exports, self) {
     "use strict";
+    return self;
 });
 //// [recursiveExportAssignmentAndFindAliasedType6_moduleB.js]
 define(["require", "exports"], function (require, exports) {

--- a/tests/baselines/reference/scannerImportDeclaration1.js
+++ b/tests/baselines/reference/scannerImportDeclaration1.js
@@ -2,3 +2,4 @@
 import TypeScript = TypeScriptServices.TypeScript;
 
 //// [scannerImportDeclaration1.js]
+var TypeScript = TypeScriptServices.TypeScript;

--- a/tests/baselines/reference/unclosedExportClause01.js
+++ b/tests/baselines/reference/unclosedExportClause01.js
@@ -23,13 +23,18 @@ exports.x = "x";
 "use strict";
 var t1_1 = require("./t1");
 exports.x = t1_1.x;
+exports.from = t1_1.from;
 //// [t3.js]
 "use strict";
+var t1_1 = require("./t1");
+exports.from = t1_1.from;
 //// [t4.js]
 "use strict";
 var t1_1 = require("./t1");
 exports.a = t1_1.x;
+exports.from = t1_1.from;
 //// [t5.js]
 "use strict";
 var t1_1 = require("./t1");
 exports.a = t1_1.x;
+exports.from = t1_1.from;


### PR DESCRIPTION
Fixes #8507

This is important for JS files. regardless if we found the module or not, we should be always emitting the import/export to grantee valid transpilation. Also note that this is the same behavior for `--isolatedModules`, and it is currently an error case anyways, so there should not be any breaks from changing this behavior to working code.
