### PR TITLE
`this`-related changes + new String.normalize overload

### DIFF
--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -4,7 +4,7 @@ interface Map<K, V> {
     forEach(callbackfn: (value: V, index: K, map: Map<K, V>) => void, thisArg?: any): void;
     get(key: K): V | undefined;
     has(key: K): boolean;
-    set(key: K, value?: V): Map<K, V>;
+    set(key: K, value?: V): this;
     readonly size: number;
 }
 
@@ -20,8 +20,7 @@ interface WeakMap<K, V> {
     delete(key: K): boolean;
     get(key: K): V | undefined;
     has(key: K): boolean;
-    set(key: K, value?: V): WeakMap<K, V>;
-
+    set(key: K, value?: V): this;
 }
 
 interface WeakMapConstructor {
@@ -32,7 +31,7 @@ interface WeakMapConstructor {
 declare var WeakMap: WeakMapConstructor;
 
 interface Set<T> {
-    add(value: T): Set<T>;
+    add(value: T): this;
     clear(): void;
     delete(value: T): boolean;
     forEach(callbackfn: (value: T, index: T, set: Set<T>) => void, thisArg?: any): void;
@@ -48,11 +47,10 @@ interface SetConstructor {
 declare var Set: SetConstructor;
 
 interface WeakSet<T> {
-    add(value: T): WeakSet<T>;
+    add(value: T): this;
     clear(): void;
     delete(value: T): boolean;
     has(value: T): boolean;
-
 }
 
 interface WeakSetConstructor {

--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -31,7 +31,7 @@ interface Array<T> {
       * @param end index to stop filling the array at. If end is negative, it is treated as
       * length+end.
       */
-    fill(value: T, start?: number, end?: number): T[];
+    fill(value: T, start?: number, end?: number): this;
 
     /**
       * Returns the this object after copying a section of the array identified by start and end
@@ -42,7 +42,7 @@ interface Array<T> {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value.
       */
-    copyWithin(target: number, start: number, end?: number): T[];
+    copyWithin(target: number, start: number, end?: number): this;
 }
 
 interface ArrayConstructor {

--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -408,6 +408,14 @@ interface String {
       * @param form Applicable values: "NFC", "NFD", "NFKC", or "NFKD", If not specified default
       * is "NFC"
       */
+    normalize(form: "NFC" | "NFD" | "NFKC" | "NFKD"): string;
+
+    /**
+      * Returns the String value result of normalizing the string into the normalization form
+      * named by form as specified in Unicode Standard Annex #15, Unicode Normalization Forms.
+      * @param form Applicable values: "NFC", "NFD", "NFKC", or "NFKD", If not specified default
+      * is "NFC"
+      */
     normalize(form?: string): string;
 
     /**

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1139,7 +1139,7 @@ interface Array<T> {
       * Sorts an array.
       * @param compareFn The name of the function used to determine the order of the elements. If omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: T, b: T) => number): T[];
+    sort(compareFn?: (a: T, b: T) => number): this;
     /**
       * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
       * @param start The zero-based location in the array from which to start removing elements.
@@ -1481,7 +1481,7 @@ interface Int8Array {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value.
       */
-    copyWithin(target: number, start: number, end?: number): Int8Array;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -1501,7 +1501,7 @@ interface Int8Array {
         * @param end index to stop filling the array at. If end is negative, it is treated as
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Int8Array;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function.
@@ -1670,7 +1670,7 @@ interface Int8Array {
       * @param compareFn The name of the function used to determine the order of the elements. If
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Int8Array;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Int8Array view of the ArrayBuffer store for this array, referencing the elements
@@ -1754,7 +1754,7 @@ interface Uint8Array {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value.
       */
-    copyWithin(target: number, start: number, end?: number): Uint8Array;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -1774,7 +1774,7 @@ interface Uint8Array {
         * @param end index to stop filling the array at. If end is negative, it is treated as
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Uint8Array;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function.
@@ -1943,7 +1943,7 @@ interface Uint8Array {
       * @param compareFn The name of the function used to determine the order of the elements. If
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Uint8Array;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Uint8Array view of the ArrayBuffer store for this array, referencing the elements
@@ -2028,7 +2028,7 @@ interface Uint8ClampedArray {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value.
       */
-    copyWithin(target: number, start: number, end?: number): Uint8ClampedArray;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -2048,7 +2048,7 @@ interface Uint8ClampedArray {
         * @param end index to stop filling the array at. If end is negative, it is treated as
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Uint8ClampedArray;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function.
@@ -2217,7 +2217,7 @@ interface Uint8ClampedArray {
       * @param compareFn The name of the function used to determine the order of the elements. If
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Uint8ClampedArray;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Uint8ClampedArray view of the ArrayBuffer store for this array, referencing the elements
@@ -2301,7 +2301,7 @@ interface Int16Array {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value.
       */
-    copyWithin(target: number, start: number, end?: number): Int16Array;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -2321,7 +2321,7 @@ interface Int16Array {
         * @param end index to stop filling the array at. If end is negative, it is treated as
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Int16Array;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function.
@@ -2490,7 +2490,7 @@ interface Int16Array {
       * @param compareFn The name of the function used to determine the order of the elements. If
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Int16Array;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Int16Array view of the ArrayBuffer store for this array, referencing the elements
@@ -2575,7 +2575,7 @@ interface Uint16Array {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value.
       */
-    copyWithin(target: number, start: number, end?: number): Uint16Array;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -2595,7 +2595,7 @@ interface Uint16Array {
         * @param end index to stop filling the array at. If end is negative, it is treated as
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Uint16Array;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function.
@@ -2764,7 +2764,7 @@ interface Uint16Array {
       * @param compareFn The name of the function used to determine the order of the elements. If
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Uint16Array;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Uint16Array view of the ArrayBuffer store for this array, referencing the elements
@@ -2848,7 +2848,7 @@ interface Int32Array {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value.
       */
-    copyWithin(target: number, start: number, end?: number): Int32Array;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -2868,7 +2868,7 @@ interface Int32Array {
         * @param end index to stop filling the array at. If end is negative, it is treated as
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Int32Array;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function.
@@ -3037,7 +3037,7 @@ interface Int32Array {
       * @param compareFn The name of the function used to determine the order of the elements. If
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Int32Array;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Int32Array view of the ArrayBuffer store for this array, referencing the elements
@@ -3121,7 +3121,7 @@ interface Uint32Array {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value.
       */
-    copyWithin(target: number, start: number, end?: number): Uint32Array;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -3141,7 +3141,7 @@ interface Uint32Array {
         * @param end index to stop filling the array at. If end is negative, it is treated as
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Uint32Array;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function.
@@ -3310,7 +3310,7 @@ interface Uint32Array {
       * @param compareFn The name of the function used to determine the order of the elements. If
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Uint32Array;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Uint32Array view of the ArrayBuffer store for this array, referencing the elements
@@ -3394,7 +3394,7 @@ interface Float32Array {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value.
       */
-    copyWithin(target: number, start: number, end?: number): Float32Array;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -3414,7 +3414,7 @@ interface Float32Array {
         * @param end index to stop filling the array at. If end is negative, it is treated as
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Float32Array;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function.
@@ -3583,7 +3583,7 @@ interface Float32Array {
       * @param compareFn The name of the function used to determine the order of the elements. If
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Float32Array;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Float32Array view of the ArrayBuffer store for this array, referencing the elements
@@ -3668,7 +3668,7 @@ interface Float64Array {
       * is treated as length+end.
       * @param end If not specified, length of the this object is used as its default value.
       */
-    copyWithin(target: number, start: number, end?: number): Float64Array;
+    copyWithin(target: number, start: number, end?: number): this;
 
     /**
       * Determines whether all the members of an array satisfy the specified test.
@@ -3688,7 +3688,7 @@ interface Float64Array {
         * @param end index to stop filling the array at. If end is negative, it is treated as
         * length+end.
         */
-    fill(value: number, start?: number, end?: number): Float64Array;
+    fill(value: number, start?: number, end?: number): this;
 
     /**
       * Returns the elements of an array that meet the condition specified in a callback function.
@@ -3857,7 +3857,7 @@ interface Float64Array {
       * @param compareFn The name of the function used to determine the order of the elements. If
       * omitted, the elements are sorted in ascending, ASCII character order.
       */
-    sort(compareFn?: (a: number, b: number) => number): Float64Array;
+    sort(compareFn?: (a: number, b: number) => number): this;
 
     /**
       * Gets a new Float64Array view of the ArrayBuffer store for this array, referencing the elements

--- a/tests/baselines/reference/implementArrayInterface.js
+++ b/tests/baselines/reference/implementArrayInterface.js
@@ -10,7 +10,7 @@ declare class MyArray<T> implements Array<T> {
     reverse(): T[];
     shift(): T;
     slice(start?: number, end?: number): T[];
-    sort(compareFn?: (a: T, b: T) => number): T[];
+    sort(compareFn?: (a: T, b: T) => number): this;
     splice(start: number): T[];
     splice(start: number, deleteCount: number, ...items: T[]): T[];
     unshift(...items: T[]): number;

--- a/tests/baselines/reference/implementArrayInterface.symbols
+++ b/tests/baselines/reference/implementArrayInterface.symbols
@@ -52,22 +52,21 @@ declare class MyArray<T> implements Array<T> {
 >end : Symbol(end, Decl(implementArrayInterface.ts, 10, 25))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 
-    sort(compareFn?: (a: T, b: T) => number): T[];
+    sort(compareFn?: (a: T, b: T) => number): this;
 >sort : Symbol(MyArray.sort, Decl(implementArrayInterface.ts, 10, 45))
 >compareFn : Symbol(compareFn, Decl(implementArrayInterface.ts, 11, 9))
 >a : Symbol(a, Decl(implementArrayInterface.ts, 11, 22))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 >b : Symbol(b, Decl(implementArrayInterface.ts, 11, 27))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
->T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 
     splice(start: number): T[];
->splice : Symbol(MyArray.splice, Decl(implementArrayInterface.ts, 11, 50), Decl(implementArrayInterface.ts, 12, 31))
+>splice : Symbol(MyArray.splice, Decl(implementArrayInterface.ts, 11, 51), Decl(implementArrayInterface.ts, 12, 31))
 >start : Symbol(start, Decl(implementArrayInterface.ts, 12, 11))
 >T : Symbol(T, Decl(implementArrayInterface.ts, 0, 22))
 
     splice(start: number, deleteCount: number, ...items: T[]): T[];
->splice : Symbol(MyArray.splice, Decl(implementArrayInterface.ts, 11, 50), Decl(implementArrayInterface.ts, 12, 31))
+>splice : Symbol(MyArray.splice, Decl(implementArrayInterface.ts, 11, 51), Decl(implementArrayInterface.ts, 12, 31))
 >start : Symbol(start, Decl(implementArrayInterface.ts, 13, 11))
 >deleteCount : Symbol(deleteCount, Decl(implementArrayInterface.ts, 13, 25))
 >items : Symbol(items, Decl(implementArrayInterface.ts, 13, 46))

--- a/tests/baselines/reference/implementArrayInterface.types
+++ b/tests/baselines/reference/implementArrayInterface.types
@@ -52,13 +52,12 @@ declare class MyArray<T> implements Array<T> {
 >end : number
 >T : T
 
-    sort(compareFn?: (a: T, b: T) => number): T[];
->sort : (compareFn?: (a: T, b: T) => number) => T[]
+    sort(compareFn?: (a: T, b: T) => number): this;
+>sort : (compareFn?: (a: T, b: T) => number) => this
 >compareFn : (a: T, b: T) => number
 >a : T
 >T : T
 >b : T
->T : T
 >T : T
 
     splice(start: number): T[];

--- a/tests/cases/compiler/implementArrayInterface.ts
+++ b/tests/cases/compiler/implementArrayInterface.ts
@@ -9,7 +9,7 @@ declare class MyArray<T> implements Array<T> {
     reverse(): T[];
     shift(): T;
     slice(start?: number, end?: number): T[];
-    sort(compareFn?: (a: T, b: T) => number): T[];
+    sort(compareFn?: (a: T, b: T) => number): this;
     splice(start: number): T[];
     splice(start: number, deleteCount: number, ...items: T[]): T[];
     unshift(...items: T[]): number;


### PR DESCRIPTION
1. Array, TypedArray, Map and Set methods that are specced to return the this-object now return `this` instead of explicit type.

1. Added an overload for ES6 String.normalize's that has `form` parameter as union of the allowed string literals.

`tests/cases/compiler/implementArrayInterface` started failing until I updated it, since it is now an error to implement array methods with old callback that accepted `T[]`. Breaking change?

`jake runtests` passes.

---

Based on #7664. Since @mhegazy asked for the change to the callbacks to accept `this` be reverted, and since master split es6.d.ts into multiple files, it was cleaner to just rebase the change onto master than do reverts and merges. To preserve the comments on the diff of that PR I decided to make a new PR.

Note that, as mentioned above, `tests/cases/compiler/implementArrayInterface` still requires changes to compile (since `sort` now returns `this` instead of `T[]`). I'm not sure I see the value of not taking the callback changes since it's still a breaking change for custom `Array<T>` implementations.

cc @jods4