### PR TITLE
Fix minor comment typo

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1895,7 +1895,7 @@ namespace ts {
                     // add file to program only if:
                     // - resolution was successful
                     // - noResolve is falsy
-                    // - module name come from the list fo imports
+                    // - module name comes from the list of imports
                     const shouldAddFile = resolution &&
                         !options.noResolve &&
                         i < file.imports.length;


### PR DESCRIPTION
This PR doesn't fix any particular issue because it's a tiny typo fix I found while grepping the TypeScript source.