### PR TITLE
Type guards as assertions

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -696,23 +696,6 @@ namespace ts {
             };
         }
 
-        function skipSimpleConditionalFlow(flow: FlowNode) {
-            // We skip over simple conditional flows of the form 'x ? aaa : bbb', where 'aaa' and 'bbb' contain
-            // no constructs that affect control flow type analysis. Such simple flows have no effect on the
-            // code paths that follow and ignoring them means we'll do less work.
-            if (flow.flags & FlowFlags.BranchLabel && (<FlowLabel>flow).antecedents.length === 2) {
-                const a = (<FlowLabel>flow).antecedents[0];
-                const b = (<FlowLabel>flow).antecedents[1];
-                if ((a.flags & FlowFlags.TrueCondition && b.flags & FlowFlags.FalseCondition ||
-                    a.flags & FlowFlags.FalseCondition && b.flags & FlowFlags.TrueCondition) &&
-                    (<FlowCondition>a).antecedent === (<FlowCondition>b).antecedent &&
-                    (<FlowCondition>a).expression === (<FlowCondition>b).expression) {
-                    return (<FlowCondition>a).antecedent;
-                }
-            }
-            return flow;
-        }
-
         function finishFlowLabel(flow: FlowLabel): FlowNode {
             const antecedents = flow.antecedents;
             if (!antecedents) {
@@ -721,7 +704,7 @@ namespace ts {
             if (antecedents.length === 1) {
                 return antecedents[0];
             }
-            return skipSimpleConditionalFlow(flow);
+            return flow;
         }
 
         function isStatementCondition(node: Node) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7621,6 +7621,9 @@ namespace ts {
             const visitedFlowStart = visitedFlowCount;
             const result = getTypeAtFlowNode(reference.flowNode);
             visitedFlowCount = visitedFlowStart;
+            if (reference.parent.kind === SyntaxKind.NonNullExpression && getTypeWithFacts(result, TypeFacts.NEUndefinedOrNull) === nothingType) {
+                return declaredType;
+            }
             return result;
 
             function getTypeAtFlowNode(flow: FlowNode): Type {

--- a/tests/baselines/reference/controlFlowBinaryOrExpression.types
+++ b/tests/baselines/reference/controlFlowBinaryOrExpression.types
@@ -87,7 +87,7 @@ if (isNodeList(sourceObj)) {
 if (isHTMLCollection(sourceObj)) {
 >isHTMLCollection(sourceObj) : boolean
 >isHTMLCollection : (sourceObj: any) => sourceObj is HTMLCollection
->sourceObj : { a: string; } | HTMLCollection
+>sourceObj : HTMLCollection | { a: string; }
 
     sourceObj.length;
 >sourceObj.length : number
@@ -99,7 +99,7 @@ if (isNodeList(sourceObj) || isHTMLCollection(sourceObj)) {
 >isNodeList(sourceObj) || isHTMLCollection(sourceObj) : boolean
 >isNodeList(sourceObj) : boolean
 >isNodeList : (sourceObj: any) => sourceObj is NodeList
->sourceObj : { a: string; } | HTMLCollection
+>sourceObj : HTMLCollection | { a: string; }
 >isHTMLCollection(sourceObj) : boolean
 >isHTMLCollection : (sourceObj: any) => sourceObj is HTMLCollection
 >sourceObj : { a: string; }

--- a/tests/baselines/reference/typeGuardEnums.types
+++ b/tests/baselines/reference/typeGuardEnums.types
@@ -27,7 +27,7 @@ else {
 if (typeof x !== "number") {
 >typeof x !== "number" : boolean
 >typeof x : string
->x : number | string | E | V
+>x : number | string
 >"number" : string
 
     x; // string
@@ -35,6 +35,6 @@ if (typeof x !== "number") {
 }
 else {
     x; // number|E|V
->x : number | E | V
+>x : number
 }
 

--- a/tests/baselines/reference/typeGuardNesting.types
+++ b/tests/baselines/reference/typeGuardNesting.types
@@ -34,7 +34,7 @@ if ((typeof strOrBool === 'boolean' && !strOrBool) || typeof strOrBool === 'stri
 >(typeof strOrBool === 'boolean') : boolean
 >typeof strOrBool === 'boolean' : boolean
 >typeof strOrBool : string
->strOrBool : boolean | string
+>strOrBool : string | boolean
 >'boolean' : string
 >strOrBool : boolean
 >false : boolean
@@ -56,7 +56,7 @@ if ((typeof strOrBool === 'boolean' && !strOrBool) || typeof strOrBool === 'stri
 >(typeof strOrBool !== 'string') : boolean
 >typeof strOrBool !== 'string' : boolean
 >typeof strOrBool : string
->strOrBool : boolean | string
+>strOrBool : string | boolean
 >'string' : string
 >strOrBool : boolean
 >false : boolean
@@ -94,7 +94,7 @@ if ((typeof strOrBool !== 'string' && !strOrBool) || typeof strOrBool !== 'boole
 >(typeof strOrBool === 'boolean') : boolean
 >typeof strOrBool === 'boolean' : boolean
 >typeof strOrBool : string
->strOrBool : boolean | string
+>strOrBool : string | boolean
 >'boolean' : string
 >strOrBool : boolean
 >false : boolean
@@ -116,7 +116,7 @@ if ((typeof strOrBool !== 'string' && !strOrBool) || typeof strOrBool !== 'boole
 >(typeof strOrBool !== 'string') : boolean
 >typeof strOrBool !== 'string' : boolean
 >typeof strOrBool : string
->strOrBool : boolean | string
+>strOrBool : string | boolean
 >'string' : string
 >strOrBool : boolean
 >false : boolean

--- a/tests/baselines/reference/typeGuardTautologicalConsistiency.types
+++ b/tests/baselines/reference/typeGuardTautologicalConsistiency.types
@@ -15,7 +15,7 @@ if (typeof stringOrNumber === "number") {
 >"number" : string
 
         stringOrNumber;
->stringOrNumber : nothing
+>stringOrNumber : string
     }
 }
 
@@ -31,6 +31,6 @@ if (typeof stringOrNumber === "number" && typeof stringOrNumber !== "number") {
 >"number" : string
 
     stringOrNumber;
->stringOrNumber : nothing
+>stringOrNumber : string
 }
 

--- a/tests/baselines/reference/typeGuardTypeOfUndefined.types
+++ b/tests/baselines/reference/typeGuardTypeOfUndefined.types
@@ -47,7 +47,7 @@ function test2(a: any) {
 >"boolean" : string
 
             a;
->a : nothing
+>a : boolean
         }
         else {
             a;
@@ -129,7 +129,7 @@ function test5(a: boolean | void) {
         }
         else {
             a;
->a : nothing
+>a : void
         }
     }
     else {
@@ -188,7 +188,7 @@ function test7(a: boolean | void) {
     }
     else {
         a;
->a : nothing
+>a : void
     }
 }
 

--- a/tests/baselines/reference/typeGuardsAsAssertions.js
+++ b/tests/baselines/reference/typeGuardsAsAssertions.js
@@ -104,6 +104,23 @@ function f5(x: string | number) {
     x;  // string | number
 }
 
+function f6() {
+    let x: string | undefined | null;
+    x!.slice();
+    x = "";
+    x!.slice();
+    x = undefined;
+    x!.slice();
+    x = null;
+    x!.slice();
+    x = <undefined | null>undefined;
+    x!.slice();
+    x = <string | undefined>"";
+    x!.slice();
+    x = <string | null>"";
+    x!.slice();
+}
+
 
 //// [typeGuardsAsAssertions.js]
 // Repro from #8513
@@ -193,4 +210,20 @@ function f5(x) {
         x; // string | number
     }
     x; // string | number
+}
+function f6() {
+    var x;
+    x.slice();
+    x = "";
+    x.slice();
+    x = undefined;
+    x.slice();
+    x = null;
+    x.slice();
+    x = undefined;
+    x.slice();
+    x = "";
+    x.slice();
+    x = "";
+    x.slice();
 }

--- a/tests/baselines/reference/typeGuardsAsAssertions.js
+++ b/tests/baselines/reference/typeGuardsAsAssertions.js
@@ -1,0 +1,196 @@
+//// [typeGuardsAsAssertions.ts]
+
+// Repro from #8513
+
+let cond: boolean;
+
+export type Optional<a> = Some<a> | None;
+
+export interface None { readonly none: string; }
+export interface Some<a> { readonly some: a; }
+
+export const none : None = { none: '' };
+
+export function isSome<a>(value: Optional<a>): value is Some<a> {
+    return 'some' in value;
+}
+
+function someFrom<a>(some: a) {
+    return { some };
+}
+
+export function fn<r>(makeSome: () => r): void {
+    let result: Optional<r> = none;
+    result;  // None
+    while (cond) {
+        result;  // Some<r> | None
+        result = someFrom(isSome(result) ? result.some : makeSome());
+        result;  // Some<r>
+    }
+}
+
+function foo1() {
+    let x: string | number | boolean = 0;
+    x;  // number
+    while (cond) {
+        x;  // number, then string | number
+        x = typeof x === "string" ? x.slice() : "abc";
+        x;  // string
+    }
+    x;
+}
+
+function foo2() {
+    let x: string | number | boolean = 0;
+    x;  // number
+    while (cond) {
+        x;  // number, then string | number
+        if (typeof x === "string") {
+            x = x.slice();
+        }
+        else {
+            x = "abc";
+        }
+        x;  // string
+    }
+    x;
+}
+
+// Type guards as assertions
+
+function f1() {
+    let x: string | number | undefined = undefined;
+    x;  // undefined
+    if (x) {
+        x;  // string | number (guard as assertion)
+    }
+    x;  // string | number | undefined
+}
+
+function f2() {
+    let x: string | number | undefined = undefined;
+    x;  // undefined
+    if (typeof x === "string") {
+        x;  // string (guard as assertion)
+    }
+    x;  // string | undefined
+}
+
+function f3() {
+    let x: string | number | undefined = undefined;
+    x;  // undefined
+    if (!x) {
+        return;
+    }
+    x;  // string | number (guard as assertion)
+}
+
+function f4() {
+    let x: string | number | undefined = undefined;
+    x;  // undefined
+    if (typeof x === "boolean") {
+        x;  // nothing (boolean not in declared type)
+    }
+    x;  // undefined
+}
+
+function f5(x: string | number) {
+    if (typeof x === "string" && typeof x === "number") {
+        x;  // number (guard as assertion)
+    }
+    else {
+        x;  // string | number
+    }
+    x;  // string | number
+}
+
+
+//// [typeGuardsAsAssertions.js]
+// Repro from #8513
+"use strict";
+var cond;
+exports.none = { none: '' };
+function isSome(value) {
+    return 'some' in value;
+}
+exports.isSome = isSome;
+function someFrom(some) {
+    return { some: some };
+}
+function fn(makeSome) {
+    var result = exports.none;
+    result; // None
+    while (cond) {
+        result; // Some<r> | None
+        result = someFrom(isSome(result) ? result.some : makeSome());
+        result; // Some<r>
+    }
+}
+exports.fn = fn;
+function foo1() {
+    var x = 0;
+    x; // number
+    while (cond) {
+        x; // number, then string | number
+        x = typeof x === "string" ? x.slice() : "abc";
+        x; // string
+    }
+    x;
+}
+function foo2() {
+    var x = 0;
+    x; // number
+    while (cond) {
+        x; // number, then string | number
+        if (typeof x === "string") {
+            x = x.slice();
+        }
+        else {
+            x = "abc";
+        }
+        x; // string
+    }
+    x;
+}
+// Type guards as assertions
+function f1() {
+    var x = undefined;
+    x; // undefined
+    if (x) {
+        x; // string | number (guard as assertion)
+    }
+    x; // string | number | undefined
+}
+function f2() {
+    var x = undefined;
+    x; // undefined
+    if (typeof x === "string") {
+        x; // string (guard as assertion)
+    }
+    x; // string | undefined
+}
+function f3() {
+    var x = undefined;
+    x; // undefined
+    if (!x) {
+        return;
+    }
+    x; // string | number (guard as assertion)
+}
+function f4() {
+    var x = undefined;
+    x; // undefined
+    if (typeof x === "boolean") {
+        x; // nothing (boolean not in declared type)
+    }
+    x; // undefined
+}
+function f5(x) {
+    if (typeof x === "string" && typeof x === "number") {
+        x; // number (guard as assertion)
+    }
+    else {
+        x; // string | number
+    }
+    x; // string | number
+}

--- a/tests/baselines/reference/typeGuardsAsAssertions.symbols
+++ b/tests/baselines/reference/typeGuardsAsAssertions.symbols
@@ -251,3 +251,65 @@ function f5(x: string | number) {
 >x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 95, 12))
 }
 
+function f6() {
+>f6 : Symbol(f6, Decl(typeGuardsAsAssertions.ts, 103, 1))
+
+    let x: string | undefined | null;
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 106, 7))
+
+    x!.slice();
+>x!.slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 106, 7))
+>slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+
+    x = "";
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 106, 7))
+
+    x!.slice();
+>x!.slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 106, 7))
+>slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+
+    x = undefined;
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 106, 7))
+>undefined : Symbol(undefined)
+
+    x!.slice();
+>x!.slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 106, 7))
+>slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+
+    x = null;
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 106, 7))
+
+    x!.slice();
+>x!.slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 106, 7))
+>slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+
+    x = <undefined | null>undefined;
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 106, 7))
+>undefined : Symbol(undefined)
+
+    x!.slice();
+>x!.slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 106, 7))
+>slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+
+    x = <string | undefined>"";
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 106, 7))
+
+    x!.slice();
+>x!.slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 106, 7))
+>slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+
+    x = <string | null>"";
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 106, 7))
+
+    x!.slice();
+>x!.slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 106, 7))
+>slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+}
+

--- a/tests/baselines/reference/typeGuardsAsAssertions.symbols
+++ b/tests/baselines/reference/typeGuardsAsAssertions.symbols
@@ -1,0 +1,253 @@
+=== tests/cases/conformance/controlFlow/typeGuardsAsAssertions.ts ===
+
+// Repro from #8513
+
+let cond: boolean;
+>cond : Symbol(cond, Decl(typeGuardsAsAssertions.ts, 3, 3))
+
+export type Optional<a> = Some<a> | None;
+>Optional : Symbol(Optional, Decl(typeGuardsAsAssertions.ts, 3, 18))
+>a : Symbol(a, Decl(typeGuardsAsAssertions.ts, 5, 21))
+>Some : Symbol(Some, Decl(typeGuardsAsAssertions.ts, 7, 48))
+>a : Symbol(a, Decl(typeGuardsAsAssertions.ts, 5, 21))
+>None : Symbol(None, Decl(typeGuardsAsAssertions.ts, 5, 41))
+
+export interface None { readonly none: string; }
+>None : Symbol(None, Decl(typeGuardsAsAssertions.ts, 5, 41))
+>none : Symbol(None.none, Decl(typeGuardsAsAssertions.ts, 7, 23))
+
+export interface Some<a> { readonly some: a; }
+>Some : Symbol(Some, Decl(typeGuardsAsAssertions.ts, 7, 48))
+>a : Symbol(a, Decl(typeGuardsAsAssertions.ts, 8, 22))
+>some : Symbol(Some.some, Decl(typeGuardsAsAssertions.ts, 8, 26))
+>a : Symbol(a, Decl(typeGuardsAsAssertions.ts, 8, 22))
+
+export const none : None = { none: '' };
+>none : Symbol(none, Decl(typeGuardsAsAssertions.ts, 10, 12))
+>None : Symbol(None, Decl(typeGuardsAsAssertions.ts, 5, 41))
+>none : Symbol(none, Decl(typeGuardsAsAssertions.ts, 10, 28))
+
+export function isSome<a>(value: Optional<a>): value is Some<a> {
+>isSome : Symbol(isSome, Decl(typeGuardsAsAssertions.ts, 10, 40))
+>a : Symbol(a, Decl(typeGuardsAsAssertions.ts, 12, 23))
+>value : Symbol(value, Decl(typeGuardsAsAssertions.ts, 12, 26))
+>Optional : Symbol(Optional, Decl(typeGuardsAsAssertions.ts, 3, 18))
+>a : Symbol(a, Decl(typeGuardsAsAssertions.ts, 12, 23))
+>value : Symbol(value, Decl(typeGuardsAsAssertions.ts, 12, 26))
+>Some : Symbol(Some, Decl(typeGuardsAsAssertions.ts, 7, 48))
+>a : Symbol(a, Decl(typeGuardsAsAssertions.ts, 12, 23))
+
+    return 'some' in value;
+>value : Symbol(value, Decl(typeGuardsAsAssertions.ts, 12, 26))
+}
+
+function someFrom<a>(some: a) {
+>someFrom : Symbol(someFrom, Decl(typeGuardsAsAssertions.ts, 14, 1))
+>a : Symbol(a, Decl(typeGuardsAsAssertions.ts, 16, 18))
+>some : Symbol(some, Decl(typeGuardsAsAssertions.ts, 16, 21))
+>a : Symbol(a, Decl(typeGuardsAsAssertions.ts, 16, 18))
+
+    return { some };
+>some : Symbol(some, Decl(typeGuardsAsAssertions.ts, 17, 12))
+}
+
+export function fn<r>(makeSome: () => r): void {
+>fn : Symbol(fn, Decl(typeGuardsAsAssertions.ts, 18, 1))
+>r : Symbol(r, Decl(typeGuardsAsAssertions.ts, 20, 19))
+>makeSome : Symbol(makeSome, Decl(typeGuardsAsAssertions.ts, 20, 22))
+>r : Symbol(r, Decl(typeGuardsAsAssertions.ts, 20, 19))
+
+    let result: Optional<r> = none;
+>result : Symbol(result, Decl(typeGuardsAsAssertions.ts, 21, 7))
+>Optional : Symbol(Optional, Decl(typeGuardsAsAssertions.ts, 3, 18))
+>r : Symbol(r, Decl(typeGuardsAsAssertions.ts, 20, 19))
+>none : Symbol(none, Decl(typeGuardsAsAssertions.ts, 10, 12))
+
+    result;  // None
+>result : Symbol(result, Decl(typeGuardsAsAssertions.ts, 21, 7))
+
+    while (cond) {
+>cond : Symbol(cond, Decl(typeGuardsAsAssertions.ts, 3, 3))
+
+        result;  // Some<r> | None
+>result : Symbol(result, Decl(typeGuardsAsAssertions.ts, 21, 7))
+
+        result = someFrom(isSome(result) ? result.some : makeSome());
+>result : Symbol(result, Decl(typeGuardsAsAssertions.ts, 21, 7))
+>someFrom : Symbol(someFrom, Decl(typeGuardsAsAssertions.ts, 14, 1))
+>isSome : Symbol(isSome, Decl(typeGuardsAsAssertions.ts, 10, 40))
+>result : Symbol(result, Decl(typeGuardsAsAssertions.ts, 21, 7))
+>result.some : Symbol(Some.some, Decl(typeGuardsAsAssertions.ts, 8, 26))
+>result : Symbol(result, Decl(typeGuardsAsAssertions.ts, 21, 7))
+>some : Symbol(Some.some, Decl(typeGuardsAsAssertions.ts, 8, 26))
+>makeSome : Symbol(makeSome, Decl(typeGuardsAsAssertions.ts, 20, 22))
+
+        result;  // Some<r>
+>result : Symbol(result, Decl(typeGuardsAsAssertions.ts, 21, 7))
+    }
+}
+
+function foo1() {
+>foo1 : Symbol(foo1, Decl(typeGuardsAsAssertions.ts, 28, 1))
+
+    let x: string | number | boolean = 0;
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 31, 7))
+
+    x;  // number
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 31, 7))
+
+    while (cond) {
+>cond : Symbol(cond, Decl(typeGuardsAsAssertions.ts, 3, 3))
+
+        x;  // number, then string | number
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 31, 7))
+
+        x = typeof x === "string" ? x.slice() : "abc";
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 31, 7))
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 31, 7))
+>x.slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 31, 7))
+>slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+
+        x;  // string
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 31, 7))
+    }
+    x;
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 31, 7))
+}
+
+function foo2() {
+>foo2 : Symbol(foo2, Decl(typeGuardsAsAssertions.ts, 39, 1))
+
+    let x: string | number | boolean = 0;
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 42, 7))
+
+    x;  // number
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 42, 7))
+
+    while (cond) {
+>cond : Symbol(cond, Decl(typeGuardsAsAssertions.ts, 3, 3))
+
+        x;  // number, then string | number
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 42, 7))
+
+        if (typeof x === "string") {
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 42, 7))
+
+            x = x.slice();
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 42, 7))
+>x.slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 42, 7))
+>slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+        }
+        else {
+            x = "abc";
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 42, 7))
+        }
+        x;  // string
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 42, 7))
+    }
+    x;
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 42, 7))
+}
+
+// Type guards as assertions
+
+function f1() {
+>f1 : Symbol(f1, Decl(typeGuardsAsAssertions.ts, 55, 1))
+
+    let x: string | number | undefined = undefined;
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 60, 7))
+>undefined : Symbol(undefined)
+
+    x;  // undefined
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 60, 7))
+
+    if (x) {
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 60, 7))
+
+        x;  // string | number (guard as assertion)
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 60, 7))
+    }
+    x;  // string | number | undefined
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 60, 7))
+}
+
+function f2() {
+>f2 : Symbol(f2, Decl(typeGuardsAsAssertions.ts, 66, 1))
+
+    let x: string | number | undefined = undefined;
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 69, 7))
+>undefined : Symbol(undefined)
+
+    x;  // undefined
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 69, 7))
+
+    if (typeof x === "string") {
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 69, 7))
+
+        x;  // string (guard as assertion)
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 69, 7))
+    }
+    x;  // string | undefined
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 69, 7))
+}
+
+function f3() {
+>f3 : Symbol(f3, Decl(typeGuardsAsAssertions.ts, 75, 1))
+
+    let x: string | number | undefined = undefined;
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 78, 7))
+>undefined : Symbol(undefined)
+
+    x;  // undefined
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 78, 7))
+
+    if (!x) {
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 78, 7))
+
+        return;
+    }
+    x;  // string | number (guard as assertion)
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 78, 7))
+}
+
+function f4() {
+>f4 : Symbol(f4, Decl(typeGuardsAsAssertions.ts, 84, 1))
+
+    let x: string | number | undefined = undefined;
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 87, 7))
+>undefined : Symbol(undefined)
+
+    x;  // undefined
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 87, 7))
+
+    if (typeof x === "boolean") {
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 87, 7))
+
+        x;  // nothing (boolean not in declared type)
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 87, 7))
+    }
+    x;  // undefined
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 87, 7))
+}
+
+function f5(x: string | number) {
+>f5 : Symbol(f5, Decl(typeGuardsAsAssertions.ts, 93, 1))
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 95, 12))
+
+    if (typeof x === "string" && typeof x === "number") {
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 95, 12))
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 95, 12))
+
+        x;  // number (guard as assertion)
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 95, 12))
+    }
+    else {
+        x;  // string | number
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 95, 12))
+    }
+    x;  // string | number
+>x : Symbol(x, Decl(typeGuardsAsAssertions.ts, 95, 12))
+}
+

--- a/tests/baselines/reference/typeGuardsAsAssertions.types
+++ b/tests/baselines/reference/typeGuardsAsAssertions.types
@@ -291,3 +291,95 @@ function f5(x: string | number) {
 >x : number | string
 }
 
+function f6() {
+>f6 : () => void
+
+    let x: string | undefined | null;
+>x : string | null | undefined
+>null : null
+
+    x!.slice();
+>x!.slice() : string
+>x!.slice : (start?: number | undefined, end?: number | undefined) => string
+>x! : string
+>x : string | null | undefined
+>slice : (start?: number | undefined, end?: number | undefined) => string
+
+    x = "";
+>x = "" : string
+>x : string | null | undefined
+>"" : string
+
+    x!.slice();
+>x!.slice() : string
+>x!.slice : (start?: number | undefined, end?: number | undefined) => string
+>x! : string
+>x : string
+>slice : (start?: number | undefined, end?: number | undefined) => string
+
+    x = undefined;
+>x = undefined : undefined
+>x : string | null | undefined
+>undefined : undefined
+
+    x!.slice();
+>x!.slice() : string
+>x!.slice : (start?: number | undefined, end?: number | undefined) => string
+>x! : string
+>x : string | null | undefined
+>slice : (start?: number | undefined, end?: number | undefined) => string
+
+    x = null;
+>x = null : null
+>x : string | null | undefined
+>null : null
+
+    x!.slice();
+>x!.slice() : string
+>x!.slice : (start?: number | undefined, end?: number | undefined) => string
+>x! : string
+>x : string | null | undefined
+>slice : (start?: number | undefined, end?: number | undefined) => string
+
+    x = <undefined | null>undefined;
+>x = <undefined | null>undefined : null | undefined
+>x : string | null | undefined
+><undefined | null>undefined : null | undefined
+>null : null
+>undefined : undefined
+
+    x!.slice();
+>x!.slice() : string
+>x!.slice : (start?: number | undefined, end?: number | undefined) => string
+>x! : string
+>x : string | null | undefined
+>slice : (start?: number | undefined, end?: number | undefined) => string
+
+    x = <string | undefined>"";
+>x = <string | undefined>"" : string | undefined
+>x : string | null | undefined
+><string | undefined>"" : string | undefined
+>"" : string
+
+    x!.slice();
+>x!.slice() : string
+>x!.slice : (start?: number | undefined, end?: number | undefined) => string
+>x! : string
+>x : string | undefined
+>slice : (start?: number | undefined, end?: number | undefined) => string
+
+    x = <string | null>"";
+>x = <string | null>"" : string | null
+>x : string | null | undefined
+><string | null>"" : string | null
+>null : null
+>"" : string
+
+    x!.slice();
+>x!.slice() : string
+>x!.slice : (start?: number | undefined, end?: number | undefined) => string
+>x! : string
+>x : string | null
+>slice : (start?: number | undefined, end?: number | undefined) => string
+}
+

--- a/tests/baselines/reference/typeGuardsAsAssertions.types
+++ b/tests/baselines/reference/typeGuardsAsAssertions.types
@@ -1,0 +1,293 @@
+=== tests/cases/conformance/controlFlow/typeGuardsAsAssertions.ts ===
+
+// Repro from #8513
+
+let cond: boolean;
+>cond : boolean
+
+export type Optional<a> = Some<a> | None;
+>Optional : Some<a> | None
+>a : a
+>Some : Some<a>
+>a : a
+>None : None
+
+export interface None { readonly none: string; }
+>None : None
+>none : string
+
+export interface Some<a> { readonly some: a; }
+>Some : Some<a>
+>a : a
+>some : a
+>a : a
+
+export const none : None = { none: '' };
+>none : None
+>None : None
+>{ none: '' } : { none: string; }
+>none : string
+>'' : string
+
+export function isSome<a>(value: Optional<a>): value is Some<a> {
+>isSome : <a>(value: Some<a> | None) => value is Some<a>
+>a : a
+>value : Some<a> | None
+>Optional : Some<a> | None
+>a : a
+>value : any
+>Some : Some<a>
+>a : a
+
+    return 'some' in value;
+>'some' in value : boolean
+>'some' : string
+>value : Some<a> | None
+}
+
+function someFrom<a>(some: a) {
+>someFrom : <a>(some: a) => { some: a; }
+>a : a
+>some : a
+>a : a
+
+    return { some };
+>{ some } : { some: a; }
+>some : a
+}
+
+export function fn<r>(makeSome: () => r): void {
+>fn : <r>(makeSome: () => r) => void
+>r : r
+>makeSome : () => r
+>r : r
+
+    let result: Optional<r> = none;
+>result : Some<r> | None
+>Optional : Some<a> | None
+>r : r
+>none : None
+
+    result;  // None
+>result : None
+
+    while (cond) {
+>cond : boolean
+
+        result;  // Some<r> | None
+>result : None | Some<r>
+
+        result = someFrom(isSome(result) ? result.some : makeSome());
+>result = someFrom(isSome(result) ? result.some : makeSome()) : { some: r; }
+>result : Some<r> | None
+>someFrom(isSome(result) ? result.some : makeSome()) : { some: r; }
+>someFrom : <a>(some: a) => { some: a; }
+>isSome(result) ? result.some : makeSome() : r
+>isSome(result) : boolean
+>isSome : <a>(value: Some<a> | None) => value is Some<a>
+>result : None | Some<r>
+>result.some : r
+>result : Some<r>
+>some : r
+>makeSome() : r
+>makeSome : () => r
+
+        result;  // Some<r>
+>result : Some<r>
+    }
+}
+
+function foo1() {
+>foo1 : () => void
+
+    let x: string | number | boolean = 0;
+>x : string | number | boolean
+>0 : number
+
+    x;  // number
+>x : number
+
+    while (cond) {
+>cond : boolean
+
+        x;  // number, then string | number
+>x : number | string
+
+        x = typeof x === "string" ? x.slice() : "abc";
+>x = typeof x === "string" ? x.slice() : "abc" : string
+>x : string | number | boolean
+>typeof x === "string" ? x.slice() : "abc" : string
+>typeof x === "string" : boolean
+>typeof x : string
+>x : number | string
+>"string" : string
+>x.slice() : string
+>x.slice : (start?: number | undefined, end?: number | undefined) => string
+>x : string
+>slice : (start?: number | undefined, end?: number | undefined) => string
+>"abc" : string
+
+        x;  // string
+>x : string
+    }
+    x;
+>x : number | string
+}
+
+function foo2() {
+>foo2 : () => void
+
+    let x: string | number | boolean = 0;
+>x : string | number | boolean
+>0 : number
+
+    x;  // number
+>x : number
+
+    while (cond) {
+>cond : boolean
+
+        x;  // number, then string | number
+>x : number | string
+
+        if (typeof x === "string") {
+>typeof x === "string" : boolean
+>typeof x : string
+>x : number | string
+>"string" : string
+
+            x = x.slice();
+>x = x.slice() : string
+>x : string | number | boolean
+>x.slice() : string
+>x.slice : (start?: number | undefined, end?: number | undefined) => string
+>x : string
+>slice : (start?: number | undefined, end?: number | undefined) => string
+        }
+        else {
+            x = "abc";
+>x = "abc" : string
+>x : string | number | boolean
+>"abc" : string
+        }
+        x;  // string
+>x : string
+    }
+    x;
+>x : number | string
+}
+
+// Type guards as assertions
+
+function f1() {
+>f1 : () => void
+
+    let x: string | number | undefined = undefined;
+>x : string | number | undefined
+>undefined : undefined
+
+    x;  // undefined
+>x : undefined
+
+    if (x) {
+>x : undefined
+
+        x;  // string | number (guard as assertion)
+>x : string | number
+    }
+    x;  // string | number | undefined
+>x : string | number | undefined
+}
+
+function f2() {
+>f2 : () => void
+
+    let x: string | number | undefined = undefined;
+>x : string | number | undefined
+>undefined : undefined
+
+    x;  // undefined
+>x : undefined
+
+    if (typeof x === "string") {
+>typeof x === "string" : boolean
+>typeof x : string
+>x : undefined
+>"string" : string
+
+        x;  // string (guard as assertion)
+>x : string
+    }
+    x;  // string | undefined
+>x : string | undefined
+}
+
+function f3() {
+>f3 : () => void
+
+    let x: string | number | undefined = undefined;
+>x : string | number | undefined
+>undefined : undefined
+
+    x;  // undefined
+>x : undefined
+
+    if (!x) {
+>!x : boolean
+>x : undefined
+
+        return;
+    }
+    x;  // string | number (guard as assertion)
+>x : string | number
+}
+
+function f4() {
+>f4 : () => void
+
+    let x: string | number | undefined = undefined;
+>x : string | number | undefined
+>undefined : undefined
+
+    x;  // undefined
+>x : undefined
+
+    if (typeof x === "boolean") {
+>typeof x === "boolean" : boolean
+>typeof x : string
+>x : undefined
+>"boolean" : string
+
+        x;  // nothing (boolean not in declared type)
+>x : nothing
+    }
+    x;  // undefined
+>x : undefined
+}
+
+function f5(x: string | number) {
+>f5 : (x: string | number) => void
+>x : string | number
+
+    if (typeof x === "string" && typeof x === "number") {
+>typeof x === "string" && typeof x === "number" : boolean
+>typeof x === "string" : boolean
+>typeof x : string
+>x : string | number
+>"string" : string
+>typeof x === "number" : boolean
+>typeof x : string
+>x : string
+>"number" : string
+
+        x;  // number (guard as assertion)
+>x : number
+    }
+    else {
+        x;  // string | number
+>x : number | string
+    }
+    x;  // string | number
+>x : number | string
+}
+

--- a/tests/cases/conformance/controlFlow/typeGuardsAsAssertions.ts
+++ b/tests/cases/conformance/controlFlow/typeGuardsAsAssertions.ts
@@ -103,3 +103,20 @@ function f5(x: string | number) {
     }
     x;  // string | number
 }
+
+function f6() {
+    let x: string | undefined | null;
+    x!.slice();
+    x = "";
+    x!.slice();
+    x = undefined;
+    x!.slice();
+    x = null;
+    x!.slice();
+    x = <undefined | null>undefined;
+    x!.slice();
+    x = <string | undefined>"";
+    x!.slice();
+    x = <string | null>"";
+    x!.slice();
+}

--- a/tests/cases/conformance/controlFlow/typeGuardsAsAssertions.ts
+++ b/tests/cases/conformance/controlFlow/typeGuardsAsAssertions.ts
@@ -1,0 +1,105 @@
+// @strictNullChecks: true
+
+// Repro from #8513
+
+let cond: boolean;
+
+export type Optional<a> = Some<a> | None;
+
+export interface None { readonly none: string; }
+export interface Some<a> { readonly some: a; }
+
+export const none : None = { none: '' };
+
+export function isSome<a>(value: Optional<a>): value is Some<a> {
+    return 'some' in value;
+}
+
+function someFrom<a>(some: a) {
+    return { some };
+}
+
+export function fn<r>(makeSome: () => r): void {
+    let result: Optional<r> = none;
+    result;  // None
+    while (cond) {
+        result;  // Some<r> | None
+        result = someFrom(isSome(result) ? result.some : makeSome());
+        result;  // Some<r>
+    }
+}
+
+function foo1() {
+    let x: string | number | boolean = 0;
+    x;  // number
+    while (cond) {
+        x;  // number, then string | number
+        x = typeof x === "string" ? x.slice() : "abc";
+        x;  // string
+    }
+    x;
+}
+
+function foo2() {
+    let x: string | number | boolean = 0;
+    x;  // number
+    while (cond) {
+        x;  // number, then string | number
+        if (typeof x === "string") {
+            x = x.slice();
+        }
+        else {
+            x = "abc";
+        }
+        x;  // string
+    }
+    x;
+}
+
+// Type guards as assertions
+
+function f1() {
+    let x: string | number | undefined = undefined;
+    x;  // undefined
+    if (x) {
+        x;  // string | number (guard as assertion)
+    }
+    x;  // string | number | undefined
+}
+
+function f2() {
+    let x: string | number | undefined = undefined;
+    x;  // undefined
+    if (typeof x === "string") {
+        x;  // string (guard as assertion)
+    }
+    x;  // string | undefined
+}
+
+function f3() {
+    let x: string | number | undefined = undefined;
+    x;  // undefined
+    if (!x) {
+        return;
+    }
+    x;  // string | number (guard as assertion)
+}
+
+function f4() {
+    let x: string | number | undefined = undefined;
+    x;  // undefined
+    if (typeof x === "boolean") {
+        x;  // nothing (boolean not in declared type)
+    }
+    x;  // undefined
+}
+
+function f5(x: string | number) {
+    if (typeof x === "string" && typeof x === "number") {
+        x;  // number (guard as assertion)
+    }
+    else {
+        x;  // string | number
+    }
+    x;  // string | number
+}


### PR DESCRIPTION
This PR fixes several of the issues we've had around `nothing` types in control flows. We previously took the view that when the current control flow based type of a variable is disjoint with the type implied by a type guard, we produce type `nothing`. Effectively, we'd trust that the control flow based type is right and therefore conclude that the type guard must be wrong.

This PR changes the reasoning in favor of the type guard instead. We now say that if narrowing the current *control flow type* produces `nothing`, but narrowing the *declared type* would produce an actual type, then the type guard must be there for a reason (and consequently we must have missed something in the reasoning about the control flow). Therefore, instead of producing `nothing`, we revert to the declared type and narrow that. Effectively we treat the type guard as an *assertion* that the condition could be true and respect it if it actually could be true according to the declared type.

Things that could cause the control flow reasoning to disagree with the type guard include an invalid argument passed for a parameter or an assignment to local variable by a nested function. For example:

```typescript
function foo() {
    let s: string | undefined = undefined
    function inner() {
        // Possibly assign to s
    }
    inner();
    if (s) {
        // Treat s as string instead of nothing
    }
}
```

Fixes #8513.
Fixes #8429.