### PR TITLE
expose code path that will use Path type to avoid redundant string conversions

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1039,6 +1039,7 @@ namespace ts {
         program = {
             getRootFileNames: () => rootNames,
             getSourceFile,
+            getSourceFileByPath,
             getSourceFiles: () => files,
             getCompilerOptions: () => options,
             getSyntacticDiagnostics,
@@ -1115,7 +1116,11 @@ namespace ts {
                 (oldOptions.allowJs !== options.allowJs) ||
                 (oldOptions.rootDir !== options.rootDir) ||
                 (oldOptions.typesSearchPaths !== options.typesSearchPaths) ||
-                (oldOptions.configFilePath !== options.configFilePath)) {
+                (oldOptions.configFilePath !== options.configFilePath) ||
+                (oldOptions.baseUrl !== options.baseUrl) ||
+                (oldOptions.typesRoot !== options.typesRoot) ||
+                !arrayIsEqualTo(oldOptions.rootDirs, options.rootDirs) ||
+                !mapIsEqualTo(oldOptions.paths, options.paths)) {
                 return false;
             }
 
@@ -1137,7 +1142,10 @@ namespace ts {
             const modifiedSourceFiles: SourceFile[] = [];
 
             for (const oldSourceFile of oldProgram.getSourceFiles()) {
-                let newSourceFile = host.getSourceFile(oldSourceFile.fileName, options.target);
+                let newSourceFile = host.getSourceFileByPath
+                    ? host.getSourceFileByPath(oldSourceFile.fileName, oldSourceFile.path, options.target)
+                    : host.getSourceFile(oldSourceFile.fileName, options.target);
+
                 if (!newSourceFile) {
                     return false;
                 }
@@ -1232,6 +1240,7 @@ namespace ts {
                 getCurrentDirectory: () => currentDirectory,
                 getNewLine: () => host.getNewLine(),
                 getSourceFile: program.getSourceFile,
+                getSourceFileByPath: program.getSourceFileByPath,
                 getSourceFiles: program.getSourceFiles,
                 writeFile: writeFileCallback || (
                     (fileName, data, writeByteOrderMark, onError, sourceFiles) => host.writeFile(fileName, data, writeByteOrderMark, onError, sourceFiles)),
@@ -1307,7 +1316,11 @@ namespace ts {
         }
 
         function getSourceFile(fileName: string): SourceFile {
-            return filesByName.get(toPath(fileName, currentDirectory, getCanonicalFileName));
+            return getSourceFileByPath(toPath(fileName, currentDirectory, getCanonicalFileName));
+        }
+
+        function getSourceFileByPath(path: Path): SourceFile {
+            return filesByName.get(path);
         }
 
         function getDiagnosticsHelper(

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1627,6 +1627,7 @@ namespace ts {
     export interface ScriptReferenceHost {
         getCompilerOptions(): CompilerOptions;
         getSourceFile(fileName: string): SourceFile;
+        getSourceFileByPath(path: Path): SourceFile;
         getCurrentDirectory(): string;
     }
 
@@ -2813,6 +2814,7 @@ namespace ts {
 
     export interface CompilerHost extends ModuleResolutionHost {
         getSourceFile(fileName: string, languageVersion: ScriptTarget, onError?: (message: string) => void): SourceFile;
+        getSourceFileByPath?(fileName: string, path: Path, languageVersion: ScriptTarget, onError?: (message: string) => void): SourceFile;
         getCancellationToken?(): CancellationToken;
         getDefaultLibFileName(options: CompilerOptions): string;
         getDefaultLibLocation?(): string;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -84,6 +84,25 @@ namespace ts {
         return node.end - node.pos;
     }
 
+    export function mapIsEqualTo<T>(map1: Map<T>, map2: Map<T>): boolean {
+        if (!map1 || !map2) {
+            return map1 === map2;
+        }
+        return containsAll(map1, map2) && containsAll(map2, map1);
+    }
+
+    function containsAll<T>(map: Map<T>, other: Map<T>): boolean {
+        for (const key in map) {
+            if (!hasProperty(map, key)) {
+                continue;
+            }
+            if (!hasProperty(other, key) || map[key] !== other[key]) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     export function arrayIsEqualTo<T>(array1: T[], array2: T[], equaler?: (a: T, b: T) => boolean): boolean {
         if (!array1 || !array2) {
             return array1 === array2;


### PR DESCRIPTION
reduces amount of allocations on a happy path in language service when we can reuse program structure