### PR TITLE
Include delete operator in control flow analysis

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -580,6 +580,9 @@ namespace ts {
                 case SyntaxKind.BinaryExpression:
                     bindBinaryExpressionFlow(<BinaryExpression>node);
                     break;
+                case SyntaxKind.DeleteExpression:
+                    bindDeleteExpressionFlow(<DeleteExpression>node);
+                    break;
                 case SyntaxKind.ConditionalExpression:
                     bindConditionalExpressionFlow(<ConditionalExpression>node);
                     break;
@@ -1052,6 +1055,13 @@ namespace ts {
                 if (operator === SyntaxKind.EqualsToken && !isAssignmentTarget(node)) {
                     bindAssignmentTargetFlow(node.left);
                 }
+            }
+        }
+
+        function bindDeleteExpressionFlow(node: DeleteExpression) {
+            forEachChild(node, bind);
+            if (node.expression.kind === SyntaxKind.PropertyAccessExpression) {
+                bindAssignmentTargetFlow(node.expression);
             }
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7563,6 +7563,8 @@ namespace ts {
                     return checkRightHandSideOfForOf((<ForOfStatement>parent).expression) || unknownType;
                 case SyntaxKind.BinaryExpression:
                     return getAssignedTypeOfBinaryExpression(<BinaryExpression>parent);
+                case SyntaxKind.DeleteExpression:
+                    return undefinedType;
                 case SyntaxKind.ArrayLiteralExpression:
                     return getAssignedTypeOfArrayLiteralElement(<ArrayLiteralExpression>parent, node);
                 case SyntaxKind.SpreadElementExpression:

--- a/tests/baselines/reference/controlFlowDeleteOperator.js
+++ b/tests/baselines/reference/controlFlowDeleteOperator.js
@@ -1,0 +1,36 @@
+//// [controlFlowDeleteOperator.ts]
+
+function f() {
+    let x: { a?: number | string, b: number | string } = { b: 1 };
+    x.a;
+    x.b;
+    x.a = 1;
+    x.b = 1;
+    x.a;
+    x.b;
+    delete x.a;
+    delete x.b;
+    x.a;
+    x.b;
+    x;
+    delete x;  // No effect
+    x;
+}
+
+//// [controlFlowDeleteOperator.js]
+function f() {
+    var x = { b: 1 };
+    x.a;
+    x.b;
+    x.a = 1;
+    x.b = 1;
+    x.a;
+    x.b;
+    delete x.a;
+    delete x.b;
+    x.a;
+    x.b;
+    x;
+    delete x; // No effect
+    x;
+}

--- a/tests/baselines/reference/controlFlowDeleteOperator.symbols
+++ b/tests/baselines/reference/controlFlowDeleteOperator.symbols
@@ -1,0 +1,70 @@
+=== tests/cases/conformance/controlFlow/controlFlowDeleteOperator.ts ===
+
+function f() {
+>f : Symbol(f, Decl(controlFlowDeleteOperator.ts, 0, 0))
+
+    let x: { a?: number | string, b: number | string } = { b: 1 };
+>x : Symbol(x, Decl(controlFlowDeleteOperator.ts, 2, 7))
+>a : Symbol(a, Decl(controlFlowDeleteOperator.ts, 2, 12))
+>b : Symbol(b, Decl(controlFlowDeleteOperator.ts, 2, 33))
+>b : Symbol(b, Decl(controlFlowDeleteOperator.ts, 2, 58))
+
+    x.a;
+>x.a : Symbol(a, Decl(controlFlowDeleteOperator.ts, 2, 12))
+>x : Symbol(x, Decl(controlFlowDeleteOperator.ts, 2, 7))
+>a : Symbol(a, Decl(controlFlowDeleteOperator.ts, 2, 12))
+
+    x.b;
+>x.b : Symbol(b, Decl(controlFlowDeleteOperator.ts, 2, 33))
+>x : Symbol(x, Decl(controlFlowDeleteOperator.ts, 2, 7))
+>b : Symbol(b, Decl(controlFlowDeleteOperator.ts, 2, 33))
+
+    x.a = 1;
+>x.a : Symbol(a, Decl(controlFlowDeleteOperator.ts, 2, 12))
+>x : Symbol(x, Decl(controlFlowDeleteOperator.ts, 2, 7))
+>a : Symbol(a, Decl(controlFlowDeleteOperator.ts, 2, 12))
+
+    x.b = 1;
+>x.b : Symbol(b, Decl(controlFlowDeleteOperator.ts, 2, 33))
+>x : Symbol(x, Decl(controlFlowDeleteOperator.ts, 2, 7))
+>b : Symbol(b, Decl(controlFlowDeleteOperator.ts, 2, 33))
+
+    x.a;
+>x.a : Symbol(a, Decl(controlFlowDeleteOperator.ts, 2, 12))
+>x : Symbol(x, Decl(controlFlowDeleteOperator.ts, 2, 7))
+>a : Symbol(a, Decl(controlFlowDeleteOperator.ts, 2, 12))
+
+    x.b;
+>x.b : Symbol(b, Decl(controlFlowDeleteOperator.ts, 2, 33))
+>x : Symbol(x, Decl(controlFlowDeleteOperator.ts, 2, 7))
+>b : Symbol(b, Decl(controlFlowDeleteOperator.ts, 2, 33))
+
+    delete x.a;
+>x.a : Symbol(a, Decl(controlFlowDeleteOperator.ts, 2, 12))
+>x : Symbol(x, Decl(controlFlowDeleteOperator.ts, 2, 7))
+>a : Symbol(a, Decl(controlFlowDeleteOperator.ts, 2, 12))
+
+    delete x.b;
+>x.b : Symbol(b, Decl(controlFlowDeleteOperator.ts, 2, 33))
+>x : Symbol(x, Decl(controlFlowDeleteOperator.ts, 2, 7))
+>b : Symbol(b, Decl(controlFlowDeleteOperator.ts, 2, 33))
+
+    x.a;
+>x.a : Symbol(a, Decl(controlFlowDeleteOperator.ts, 2, 12))
+>x : Symbol(x, Decl(controlFlowDeleteOperator.ts, 2, 7))
+>a : Symbol(a, Decl(controlFlowDeleteOperator.ts, 2, 12))
+
+    x.b;
+>x.b : Symbol(b, Decl(controlFlowDeleteOperator.ts, 2, 33))
+>x : Symbol(x, Decl(controlFlowDeleteOperator.ts, 2, 7))
+>b : Symbol(b, Decl(controlFlowDeleteOperator.ts, 2, 33))
+
+    x;
+>x : Symbol(x, Decl(controlFlowDeleteOperator.ts, 2, 7))
+
+    delete x;  // No effect
+>x : Symbol(x, Decl(controlFlowDeleteOperator.ts, 2, 7))
+
+    x;
+>x : Symbol(x, Decl(controlFlowDeleteOperator.ts, 2, 7))
+}

--- a/tests/baselines/reference/controlFlowDeleteOperator.types
+++ b/tests/baselines/reference/controlFlowDeleteOperator.types
@@ -1,0 +1,79 @@
+=== tests/cases/conformance/controlFlow/controlFlowDeleteOperator.ts ===
+
+function f() {
+>f : () => void
+
+    let x: { a?: number | string, b: number | string } = { b: 1 };
+>x : { a?: number | string | undefined; b: number | string; }
+>a : number | string | undefined
+>b : number | string
+>{ b: 1 } : { b: number; }
+>b : number
+>1 : number
+
+    x.a;
+>x.a : number | string | undefined
+>x : { a?: number | string | undefined; b: number | string; }
+>a : number | string | undefined
+
+    x.b;
+>x.b : number | string
+>x : { a?: number | string | undefined; b: number | string; }
+>b : number | string
+
+    x.a = 1;
+>x.a = 1 : number
+>x.a : number | string | undefined
+>x : { a?: number | string | undefined; b: number | string; }
+>a : number | string | undefined
+>1 : number
+
+    x.b = 1;
+>x.b = 1 : number
+>x.b : number | string
+>x : { a?: number | string | undefined; b: number | string; }
+>b : number | string
+>1 : number
+
+    x.a;
+>x.a : number
+>x : { a?: number | string | undefined; b: number | string; }
+>a : number
+
+    x.b;
+>x.b : number
+>x : { a?: number | string | undefined; b: number | string; }
+>b : number
+
+    delete x.a;
+>delete x.a : boolean
+>x.a : number
+>x : { a?: number | string | undefined; b: number | string; }
+>a : number
+
+    delete x.b;
+>delete x.b : boolean
+>x.b : number
+>x : { a?: number | string | undefined; b: number | string; }
+>b : number
+
+    x.a;
+>x.a : undefined
+>x : { a?: number | string | undefined; b: number | string; }
+>a : undefined
+
+    x.b;
+>x.b : number | string
+>x : { a?: number | string | undefined; b: number | string; }
+>b : number | string
+
+    x;
+>x : { a?: number | string | undefined; b: number | string; }
+
+    delete x;  // No effect
+>delete x : boolean
+>x : { a?: number | string | undefined; b: number | string; }
+
+    x;
+>x : { a?: number | string | undefined; b: number | string; }
+}

--- a/tests/cases/conformance/controlFlow/controlFlowDeleteOperator.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowDeleteOperator.ts
@@ -1,0 +1,18 @@
+// @strictNullChecks: true
+
+function f() {
+    let x: { a?: number | string, b: number | string } = { b: 1 };
+    x.a;
+    x.b;
+    x.a = 1;
+    x.b = 1;
+    x.a;
+    x.b;
+    delete x.a;
+    delete x.b;
+    x.a;
+    x.b;
+    x;
+    delete x;  // No effect
+    x;
+}


### PR DESCRIPTION
Fixes #8398. The operation `delete x.y` has the same control flow effect as `x.y = undefined`.