### PR TITLE
Fix #7966: A non-anonymous type can still fail to have a symbol.

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -4349,7 +4349,7 @@ namespace ts {
                                         displayParts.push(keywordPart(SyntaxKind.NewKeyword));
                                         displayParts.push(spacePart());
                                     }
-                                    if (!(type.flags & TypeFlags.Anonymous)) {
+                                    if (!(type.flags & TypeFlags.Anonymous) && type.symbol) {
                                         addRange(displayParts, symbolToDisplayParts(typeChecker, type.symbol, enclosingDeclaration, /*meaning*/ undefined, SymbolFormatFlags.WriteTypeParametersOrArguments));
                                     }
                                     addSignatureDisplayParts(signature, allSignatures, TypeFormatFlags.WriteArrowStyleSignature);

--- a/tests/cases/fourslash/getQuickInfoForIntersectionTypes.ts
+++ b/tests/cases/fourslash/getQuickInfoForIntersectionTypes.ts
@@ -1,0 +1,8 @@
+////function f(): string & {(): any} {
+////	return <any>{};
+////}
+////let x = f();
+////x/**/();
+
+goTo.marker();
+verify.quickInfoIs("let x: () => any");


### PR DESCRIPTION
Fixes #7966.