### PR TITLE
Use NodeFlags.ParameterPropertyModifier rather than NodeFlags.AccessibilityModifier to detect parameter properties

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -961,8 +961,8 @@ namespace ts {
                         break;
 
                     case SyntaxKind.Parameter:
-                        // Only consider properties defined as constructor parameters
-                        if (!(node.flags & NodeFlags.AccessibilityModifier)) {
+                        // Only consider parameter properties
+                        if (!(node.flags & NodeFlags.ParameterPropertyModifier)) {
                             break;
                         }
                     // fall through
@@ -2795,7 +2795,7 @@ namespace ts {
             case SyntaxKind.Constructor: return ScriptElementKind.constructorImplementationElement;
             case SyntaxKind.TypeParameter: return ScriptElementKind.typeParameterElement;
             case SyntaxKind.EnumMember: return ScriptElementKind.variableElement;
-            case SyntaxKind.Parameter: return (node.flags & NodeFlags.AccessibilityModifier) ? ScriptElementKind.memberVariableElement : ScriptElementKind.parameterElement;
+            case SyntaxKind.Parameter: return (node.flags & NodeFlags.ParameterPropertyModifier) ? ScriptElementKind.memberVariableElement : ScriptElementKind.parameterElement;
             case SyntaxKind.ImportEqualsDeclaration:
             case SyntaxKind.ImportSpecifier:
             case SyntaxKind.ImportClause:

--- a/tests/cases/fourslash/navigationItemsInConstructorsExactMatch.ts
+++ b/tests/cases/fourslash/navigationItemsInConstructorsExactMatch.ts
@@ -2,7 +2,7 @@
 
 ////class Test {
 ////    private search1: number;
-////    constructor(public search2: boolean, search3: string) {
+////    constructor(public search2: boolean, readonly search3: string, search4: string) {
 ////    }
 ////}
 
@@ -10,3 +10,4 @@
 var searchValue = "search";
 verify.navigationItemsListContains("search1", "property", searchValue, "prefix");
 verify.navigationItemsListContains("search2", "property", searchValue, "prefix");
+verify.navigationItemsListContains("search3", "property", searchValue, "prefix");


### PR DESCRIPTION
This is a continuation of #8555.