### PR TITLE
Recursively mark object literals as non-fresh when checking assignability to intersections

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6834,45 +6834,42 @@ namespace ts {
             return symbol;
         }
 
+        function updateTypeOfMembers(type: Type, update: (propertyType: Type) => Type) {
+            const members: SymbolTable = {};
+            for (const property of getPropertiesOfObjectType(type)) {
+                const original = getTypeOfSymbol(property);
+                const updated = update(original);
+                members[property.name] = updated === original ? property : createTransientSymbol(property, updated);
+            };
+            return members;
+        }
+
         function getRegularTypeOfObjectLiteral(type: Type): Type {
-            if (type.flags & TypeFlags.FreshObjectLiteral) {
-                let regularType = (<FreshObjectLiteralType>type).regularType;
-                if (!regularType) {
-                    regularType = <ResolvedType>createType((<ResolvedType>type).flags & ~TypeFlags.FreshObjectLiteral);
-                    regularType.symbol = (<ResolvedType>type).symbol;
-                    const members: SymbolTable = {};
-                    const properties: Symbol[] = [];
-                    for (let p of (<ResolvedType>type).properties) {
-                        const propType = getTypeOfSymbol(p);
-                        if (propType.flags & TypeFlags.FreshObjectLiteral) {
-                            p = createTransientSymbol(p, getRegularTypeOfObjectLiteral(propType));
-                        }
-                        members[p.name] = p;
-                        properties.push(p);
-                    };
-                    regularType.properties = properties;
-                    regularType.members = members;
-                    regularType.callSignatures = (<ResolvedType>type).callSignatures;
-                    regularType.constructSignatures = (<ResolvedType>type).constructSignatures;
-                    regularType.stringIndexInfo = (<ResolvedType>type).stringIndexInfo;
-                    regularType.numberIndexInfo = (<ResolvedType>type).numberIndexInfo;
-                    (<FreshObjectLiteralType>type).regularType = regularType;
-                }
+            if (!(type.flags & TypeFlags.FreshObjectLiteral)) {
+                return type;
+            }
+            const regularType = (<FreshObjectLiteralType>type).regularType;
+            if (regularType) {
                 return regularType;
             }
-            return type;
+
+            const resolved = <ResolvedType>type;
+            const members = updateTypeOfMembers(type, prop => prop.flags & TypeFlags.FreshObjectLiteral ? getRegularTypeOfObjectLiteral(prop) : prop);
+            const regularNew = createAnonymousType(resolved.symbol,
+                                                   members,
+                                                   resolved.callSignatures,
+                                                   resolved.constructSignatures,
+                                                   resolved.stringIndexInfo,
+                                                   resolved.numberIndexInfo);
+            regularNew.flags = resolved.flags & ~TypeFlags.FreshObjectLiteral;
+            (<FreshObjectLiteralType>type).regularType = regularNew;
+            return regularNew;
         }
 
         function getWidenedTypeOfObjectLiteral(type: Type): Type {
-            const properties = getPropertiesOfObjectType(type);
-            const members: SymbolTable = {};
-            forEach(properties, p => {
-                const propType = getTypeOfSymbol(p);
-                const widenedType = getWidenedType(propType);
-                if (propType !== widenedType) {
-                    p = createTransientSymbol(p, widenedType);
-                }
-                members[p.name] = p;
+            const members = updateTypeOfMembers(type, prop => {
+                const widened = getWidenedType(prop);
+                return prop === widened ? prop : widened;
             });
             const stringIndexInfo = getIndexInfoOfType(type, IndexKind.String);
             const numberIndexInfo = getIndexInfoOfType(type, IndexKind.Number);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6846,9 +6846,10 @@ namespace ts {
             return members;
         }
 
-        /** Mark an object literal as exempt from the excess properties check.
-         *  Recursively mark object literal members as exempt.
-         *  Leave signatures alone since they are not subject to the check.
+        /**
+         * If the the provided object literal is subject to the excess properties check,
+         * create a new that is exempt. Recursively mark object literal members as exempt.
+         * Leave signatures alone since they are not subject to the check.
          */
         function getRegularTypeOfObjectLiteral(type: Type): Type {
             if (!(type.flags & TypeFlags.FreshObjectLiteral)) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6860,7 +6860,7 @@ namespace ts {
             }
 
             const resolved = <ResolvedType>type;
-            const members = transformTypeOfMembers(type, prop => prop.flags & TypeFlags.FreshObjectLiteral ? getRegularTypeOfObjectLiteral(prop) : prop);
+            const members = transformTypeOfMembers(type, getRegularTypeOfObjectLiteral);
             const regularNew = createAnonymousType(resolved.symbol,
                                                    members,
                                                    resolved.callSignatures,

--- a/tests/baselines/reference/intersectionTypeMembers.js
+++ b/tests/baselines/reference/intersectionTypeMembers.js
@@ -27,6 +27,19 @@ var f: F1 & F2;
 var s = f("hello");
 var n = f(42);
 
+interface D {
+    nested: {d: string;};
+}
+interface E {
+    nested: { e: string; };
+}
+const de: D & E = {
+    nested: {
+        d: 'yes',
+        e: 'no'
+    }
+}
+
 
 //// [intersectionTypeMembers.js]
 // An intersection type has those members that are present in any of its constituent types,
@@ -42,3 +55,9 @@ xyz.x.c = "hello";
 var f;
 var s = f("hello");
 var n = f(42);
+var de = {
+    nested: {
+        d: 'yes',
+        e: 'no'
+    }
+};

--- a/tests/baselines/reference/intersectionTypeMembers.js
+++ b/tests/baselines/reference/intersectionTypeMembers.js
@@ -28,15 +28,19 @@ var s = f("hello");
 var n = f(42);
 
 interface D {
-    nested: {d: string;};
+    nested: { doublyNested: { d: string; }, different: { e: number } };
 }
 interface E {
-    nested: { e: string; };
+    nested: { doublyNested: { f: string; }, other: {g: number } };
 }
 const de: D & E = {
     nested: {
-        d: 'yes',
-        e: 'no'
+        doublyNested: {
+            d: 'yes',
+            f: 'no'
+        },
+        different: { e: 12 },
+        other: { g: 101 }
     }
 }
 
@@ -57,7 +61,11 @@ var s = f("hello");
 var n = f(42);
 var de = {
     nested: {
-        d: 'yes',
-        e: 'no'
+        doublyNested: {
+            d: 'yes',
+            f: 'no'
+        },
+        different: { e: 12 },
+        other: { g: 101 }
     }
 };

--- a/tests/baselines/reference/intersectionTypeMembers.symbols
+++ b/tests/baselines/reference/intersectionTypeMembers.symbols
@@ -98,3 +98,33 @@ var n = f(42);
 >n : Symbol(n, Decl(intersectionTypeMembers.ts, 26, 3))
 >f : Symbol(f, Decl(intersectionTypeMembers.ts, 24, 3))
 
+interface D {
+>D : Symbol(D, Decl(intersectionTypeMembers.ts, 26, 14))
+
+    nested: {d: string;};
+>nested : Symbol(D.nested, Decl(intersectionTypeMembers.ts, 28, 13))
+>d : Symbol(d, Decl(intersectionTypeMembers.ts, 29, 13))
+}
+interface E {
+>E : Symbol(E, Decl(intersectionTypeMembers.ts, 30, 1))
+
+    nested: { e: string; };
+>nested : Symbol(E.nested, Decl(intersectionTypeMembers.ts, 31, 13))
+>e : Symbol(e, Decl(intersectionTypeMembers.ts, 32, 13))
+}
+const de: D & E = {
+>de : Symbol(de, Decl(intersectionTypeMembers.ts, 34, 5))
+>D : Symbol(D, Decl(intersectionTypeMembers.ts, 26, 14))
+>E : Symbol(E, Decl(intersectionTypeMembers.ts, 30, 1))
+
+    nested: {
+>nested : Symbol(nested, Decl(intersectionTypeMembers.ts, 34, 19))
+
+        d: 'yes',
+>d : Symbol(d, Decl(intersectionTypeMembers.ts, 35, 13))
+
+        e: 'no'
+>e : Symbol(e, Decl(intersectionTypeMembers.ts, 36, 17))
+    }
+}
+

--- a/tests/baselines/reference/intersectionTypeMembers.symbols
+++ b/tests/baselines/reference/intersectionTypeMembers.symbols
@@ -101,16 +101,22 @@ var n = f(42);
 interface D {
 >D : Symbol(D, Decl(intersectionTypeMembers.ts, 26, 14))
 
-    nested: {d: string;};
+    nested: { doublyNested: { d: string; }, different: { e: number } };
 >nested : Symbol(D.nested, Decl(intersectionTypeMembers.ts, 28, 13))
->d : Symbol(d, Decl(intersectionTypeMembers.ts, 29, 13))
+>doublyNested : Symbol(doublyNested, Decl(intersectionTypeMembers.ts, 29, 13))
+>d : Symbol(d, Decl(intersectionTypeMembers.ts, 29, 29))
+>different : Symbol(different, Decl(intersectionTypeMembers.ts, 29, 43))
+>e : Symbol(e, Decl(intersectionTypeMembers.ts, 29, 56))
 }
 interface E {
 >E : Symbol(E, Decl(intersectionTypeMembers.ts, 30, 1))
 
-    nested: { e: string; };
+    nested: { doublyNested: { f: string; }, other: {g: number } };
 >nested : Symbol(E.nested, Decl(intersectionTypeMembers.ts, 31, 13))
->e : Symbol(e, Decl(intersectionTypeMembers.ts, 32, 13))
+>doublyNested : Symbol(doublyNested, Decl(intersectionTypeMembers.ts, 32, 13))
+>f : Symbol(f, Decl(intersectionTypeMembers.ts, 32, 29))
+>other : Symbol(other, Decl(intersectionTypeMembers.ts, 32, 43))
+>g : Symbol(g, Decl(intersectionTypeMembers.ts, 32, 52))
 }
 const de: D & E = {
 >de : Symbol(de, Decl(intersectionTypeMembers.ts, 34, 5))
@@ -120,11 +126,23 @@ const de: D & E = {
     nested: {
 >nested : Symbol(nested, Decl(intersectionTypeMembers.ts, 34, 19))
 
-        d: 'yes',
->d : Symbol(d, Decl(intersectionTypeMembers.ts, 35, 13))
+        doublyNested: {
+>doublyNested : Symbol(doublyNested, Decl(intersectionTypeMembers.ts, 35, 13))
 
-        e: 'no'
->e : Symbol(e, Decl(intersectionTypeMembers.ts, 36, 17))
+            d: 'yes',
+>d : Symbol(d, Decl(intersectionTypeMembers.ts, 36, 23))
+
+            f: 'no'
+>f : Symbol(f, Decl(intersectionTypeMembers.ts, 37, 21))
+
+        },
+        different: { e: 12 },
+>different : Symbol(different, Decl(intersectionTypeMembers.ts, 39, 10))
+>e : Symbol(e, Decl(intersectionTypeMembers.ts, 40, 20))
+
+        other: { g: 101 }
+>other : Symbol(other, Decl(intersectionTypeMembers.ts, 40, 29))
+>g : Symbol(g, Decl(intersectionTypeMembers.ts, 41, 16))
     }
 }
 

--- a/tests/baselines/reference/intersectionTypeMembers.types
+++ b/tests/baselines/reference/intersectionTypeMembers.types
@@ -117,34 +117,57 @@ var n = f(42);
 interface D {
 >D : D
 
-    nested: {d: string;};
->nested : { d: string; }
+    nested: { doublyNested: { d: string; }, different: { e: number } };
+>nested : { doublyNested: { d: string; }; different: { e: number; }; }
+>doublyNested : { d: string; }
 >d : string
+>different : { e: number; }
+>e : number
 }
 interface E {
 >E : E
 
-    nested: { e: string; };
->nested : { e: string; }
->e : string
+    nested: { doublyNested: { f: string; }, other: {g: number } };
+>nested : { doublyNested: { f: string; }; other: { g: number; }; }
+>doublyNested : { f: string; }
+>f : string
+>other : { g: number; }
+>g : number
 }
 const de: D & E = {
 >de : D & E
 >D : D
 >E : E
->{    nested: {        d: 'yes',        e: 'no'    }} : { nested: { d: string; e: string; }; }
+>{    nested: {        doublyNested: {            d: 'yes',            f: 'no'        },        different: { e: 12 },        other: { g: 101 }    }} : { nested: { doublyNested: { d: string; f: string; }; different: { e: number; }; other: { g: number; }; }; }
 
     nested: {
->nested : { d: string; e: string; }
->{        d: 'yes',        e: 'no'    } : { d: string; e: string; }
+>nested : { doublyNested: { d: string; f: string; }; different: { e: number; }; other: { g: number; }; }
+>{        doublyNested: {            d: 'yes',            f: 'no'        },        different: { e: 12 },        other: { g: 101 }    } : { doublyNested: { d: string; f: string; }; different: { e: number; }; other: { g: number; }; }
 
-        d: 'yes',
+        doublyNested: {
+>doublyNested : { d: string; f: string; }
+>{            d: 'yes',            f: 'no'        } : { d: string; f: string; }
+
+            d: 'yes',
 >d : string
 >'yes' : string
 
-        e: 'no'
->e : string
+            f: 'no'
+>f : string
 >'no' : string
+
+        },
+        different: { e: 12 },
+>different : { e: number; }
+>{ e: 12 } : { e: number; }
+>e : number
+>12 : number
+
+        other: { g: 101 }
+>other : { g: number; }
+>{ g: 101 } : { g: number; }
+>g : number
+>101 : number
     }
 }
 

--- a/tests/baselines/reference/intersectionTypeMembers.types
+++ b/tests/baselines/reference/intersectionTypeMembers.types
@@ -114,3 +114,37 @@ var n = f(42);
 >f : ((x: string) => string) & ((x: number) => number)
 >42 : number
 
+interface D {
+>D : D
+
+    nested: {d: string;};
+>nested : { d: string; }
+>d : string
+}
+interface E {
+>E : E
+
+    nested: { e: string; };
+>nested : { e: string; }
+>e : string
+}
+const de: D & E = {
+>de : D & E
+>D : D
+>E : E
+>{    nested: {        d: 'yes',        e: 'no'    }} : { nested: { d: string; e: string; }; }
+
+    nested: {
+>nested : { d: string; e: string; }
+>{        d: 'yes',        e: 'no'    } : { d: string; e: string; }
+
+        d: 'yes',
+>d : string
+>'yes' : string
+
+        e: 'no'
+>e : string
+>'no' : string
+    }
+}
+

--- a/tests/cases/conformance/types/intersection/intersectionTypeMembers.ts
+++ b/tests/cases/conformance/types/intersection/intersectionTypeMembers.ts
@@ -27,14 +27,18 @@ var s = f("hello");
 var n = f(42);
 
 interface D {
-    nested: {d: string;};
+    nested: { doublyNested: { d: string; }, different: { e: number } };
 }
 interface E {
-    nested: { e: string; };
+    nested: { doublyNested: { f: string; }, other: {g: number } };
 }
 const de: D & E = {
     nested: {
-        d: 'yes',
-        e: 'no'
+        doublyNested: {
+            d: 'yes',
+            f: 'no'
+        },
+        different: { e: 12 },
+        other: { g: 101 }
     }
 }

--- a/tests/cases/conformance/types/intersection/intersectionTypeMembers.ts
+++ b/tests/cases/conformance/types/intersection/intersectionTypeMembers.ts
@@ -25,3 +25,16 @@ type F2 = (x: number) => number;
 var f: F1 & F2;
 var s = f("hello");
 var n = f(42);
+
+interface D {
+    nested: {d: string;};
+}
+interface E {
+    nested: { e: string; };
+}
+const de: D & E = {
+    nested: {
+        d: 'yes',
+        e: 'no'
+    }
+}


### PR DESCRIPTION
Fixes #7649 
