### PR TITLE
Use binding pattern for type inference result `{}`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11455,6 +11455,12 @@ namespace ts {
             const links = getSymbolLinks(parameter);
             if (!links.type) {
                 links.type = instantiateType(contextualType, mapper);
+                // if inference didn't come up with anything but {}, fall back to the binding pattern if present.
+                if (links.type === emptyObjectType &&
+                    (parameter.valueDeclaration.name.kind === SyntaxKind.ObjectBindingPattern ||
+                     parameter.valueDeclaration.name.kind === SyntaxKind.ArrayBindingPattern)) {
+                    links.type = getTypeFromBindingPattern(<BindingPattern>parameter.valueDeclaration.name);
+                }
                 assignBindingElementTypes(<ParameterDeclaration>parameter.valueDeclaration);
             }
             else if (isInferentialContext(mapper)) {

--- a/tests/baselines/reference/fallbackToBindingPatternForTypeInference.js
+++ b/tests/baselines/reference/fallbackToBindingPatternForTypeInference.js
@@ -1,0 +1,25 @@
+//// [fallbackToBindingPatternForTypeInference.ts]
+declare function trans<T>(f: (x: T) => string): number;
+trans(({a}) => a);
+trans(([b,c]) => 'foo');
+trans(({d: [e,f]}) => 'foo');
+trans(([{g},{h}]) => 'foo');
+
+
+//// [fallbackToBindingPatternForTypeInference.js]
+trans(function (_a) {
+    var a = _a.a;
+    return a;
+});
+trans(function (_a) {
+    var b = _a[0], c = _a[1];
+    return 'foo';
+});
+trans(function (_a) {
+    var _b = _a.d, e = _b[0], f = _b[1];
+    return 'foo';
+});
+trans(function (_a) {
+    var g = _a[0].g, h = _a[1].h;
+    return 'foo';
+});

--- a/tests/baselines/reference/fallbackToBindingPatternForTypeInference.js
+++ b/tests/baselines/reference/fallbackToBindingPatternForTypeInference.js
@@ -4,6 +4,7 @@ trans(({a}) => a);
 trans(([b,c]) => 'foo');
 trans(({d: [e,f]}) => 'foo');
 trans(([{g},{h}]) => 'foo');
+trans(({a, b = 10}) => a);
 
 
 //// [fallbackToBindingPatternForTypeInference.js]
@@ -22,4 +23,8 @@ trans(function (_a) {
 trans(function (_a) {
     var g = _a[0].g, h = _a[1].h;
     return 'foo';
+});
+trans(function (_a) {
+    var a = _a.a, _b = _a.b, b = _b === void 0 ? 10 : _b;
+    return a;
 });

--- a/tests/baselines/reference/fallbackToBindingPatternForTypeInference.symbols
+++ b/tests/baselines/reference/fallbackToBindingPatternForTypeInference.symbols
@@ -26,3 +26,9 @@ trans(([{g},{h}]) => 'foo');
 >g : Symbol(g, Decl(fallbackToBindingPatternForTypeInference.ts, 4, 9))
 >h : Symbol(h, Decl(fallbackToBindingPatternForTypeInference.ts, 4, 13))
 
+trans(({a, b = 10}) => a);
+>trans : Symbol(trans, Decl(fallbackToBindingPatternForTypeInference.ts, 0, 0))
+>a : Symbol(a, Decl(fallbackToBindingPatternForTypeInference.ts, 5, 8))
+>b : Symbol(b, Decl(fallbackToBindingPatternForTypeInference.ts, 5, 10))
+>a : Symbol(a, Decl(fallbackToBindingPatternForTypeInference.ts, 5, 8))
+

--- a/tests/baselines/reference/fallbackToBindingPatternForTypeInference.symbols
+++ b/tests/baselines/reference/fallbackToBindingPatternForTypeInference.symbols
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/fallbackToBindingPatternForTypeInference.ts ===
+declare function trans<T>(f: (x: T) => string): number;
+>trans : Symbol(trans, Decl(fallbackToBindingPatternForTypeInference.ts, 0, 0))
+>T : Symbol(T, Decl(fallbackToBindingPatternForTypeInference.ts, 0, 23))
+>f : Symbol(f, Decl(fallbackToBindingPatternForTypeInference.ts, 0, 26))
+>x : Symbol(x, Decl(fallbackToBindingPatternForTypeInference.ts, 0, 30))
+>T : Symbol(T, Decl(fallbackToBindingPatternForTypeInference.ts, 0, 23))
+
+trans(({a}) => a);
+>trans : Symbol(trans, Decl(fallbackToBindingPatternForTypeInference.ts, 0, 0))
+>a : Symbol(a, Decl(fallbackToBindingPatternForTypeInference.ts, 1, 8))
+>a : Symbol(a, Decl(fallbackToBindingPatternForTypeInference.ts, 1, 8))
+
+trans(([b,c]) => 'foo');
+>trans : Symbol(trans, Decl(fallbackToBindingPatternForTypeInference.ts, 0, 0))
+>b : Symbol(b, Decl(fallbackToBindingPatternForTypeInference.ts, 2, 8))
+>c : Symbol(c, Decl(fallbackToBindingPatternForTypeInference.ts, 2, 10))
+
+trans(({d: [e,f]}) => 'foo');
+>trans : Symbol(trans, Decl(fallbackToBindingPatternForTypeInference.ts, 0, 0))
+>e : Symbol(e, Decl(fallbackToBindingPatternForTypeInference.ts, 3, 12))
+>f : Symbol(f, Decl(fallbackToBindingPatternForTypeInference.ts, 3, 14))
+
+trans(([{g},{h}]) => 'foo');
+>trans : Symbol(trans, Decl(fallbackToBindingPatternForTypeInference.ts, 0, 0))
+>g : Symbol(g, Decl(fallbackToBindingPatternForTypeInference.ts, 4, 9))
+>h : Symbol(h, Decl(fallbackToBindingPatternForTypeInference.ts, 4, 13))
+

--- a/tests/baselines/reference/fallbackToBindingPatternForTypeInference.types
+++ b/tests/baselines/reference/fallbackToBindingPatternForTypeInference.types
@@ -1,0 +1,40 @@
+=== tests/cases/compiler/fallbackToBindingPatternForTypeInference.ts ===
+declare function trans<T>(f: (x: T) => string): number;
+>trans : <T>(f: (x: T) => string) => number
+>T : T
+>f : (x: T) => string
+>x : T
+>T : T
+
+trans(({a}) => a);
+>trans(({a}) => a) : number
+>trans : <T>(f: (x: T) => string) => number
+>({a}) => a : ({a}: { a: any; }) => any
+>a : any
+>a : any
+
+trans(([b,c]) => 'foo');
+>trans(([b,c]) => 'foo') : number
+>trans : <T>(f: (x: T) => string) => number
+>([b,c]) => 'foo' : ([b, c]: [any, any]) => string
+>b : any
+>c : any
+>'foo' : string
+
+trans(({d: [e,f]}) => 'foo');
+>trans(({d: [e,f]}) => 'foo') : number
+>trans : <T>(f: (x: T) => string) => number
+>({d: [e,f]}) => 'foo' : ({d: [e, f]}: { d: [any, any]; }) => string
+>d : any
+>e : any
+>f : any
+>'foo' : string
+
+trans(([{g},{h}]) => 'foo');
+>trans(([{g},{h}]) => 'foo') : number
+>trans : <T>(f: (x: T) => string) => number
+>([{g},{h}]) => 'foo' : ([{g}, {h}]: [{ g: any; }, { h: any; }]) => string
+>g : any
+>h : any
+>'foo' : string
+

--- a/tests/baselines/reference/fallbackToBindingPatternForTypeInference.types
+++ b/tests/baselines/reference/fallbackToBindingPatternForTypeInference.types
@@ -38,3 +38,12 @@ trans(([{g},{h}]) => 'foo');
 >h : any
 >'foo' : string
 
+trans(({a, b = 10}) => a);
+>trans(({a, b = 10}) => a) : number
+>trans : <T>(f: (x: T) => string) => number
+>({a, b = 10}) => a : ({a, b}: { a: any; b?: number; }) => any
+>a : any
+>b : number
+>10 : number
+>a : any
+

--- a/tests/cases/compiler/fallbackToBindingPatternForTypeInference.ts
+++ b/tests/cases/compiler/fallbackToBindingPatternForTypeInference.ts
@@ -3,3 +3,4 @@ trans(({a}) => a);
 trans(([b,c]) => 'foo');
 trans(({d: [e,f]}) => 'foo');
 trans(([{g},{h}]) => 'foo');
+trans(({a, b = 10}) => a);

--- a/tests/cases/compiler/fallbackToBindingPatternForTypeInference.ts
+++ b/tests/cases/compiler/fallbackToBindingPatternForTypeInference.ts
@@ -1,0 +1,5 @@
+declare function trans<T>(f: (x: T) => string): number;
+trans(({a}) => a);
+trans(([b,c]) => 'foo');
+trans(({d: [e,f]}) => 'foo');
+trans(([{g},{h}]) => 'foo');


### PR DESCRIPTION
Fixes #7679.

The binding pattern provides additional information when the contextual type is not found and would otherwise fix a type parameter to `{}`. I'm not sure this fix is worth it. It's ad-hoc and doesn't provide too much value. But it does squash another difference between contextual typing vs separate declaration of arrows.