### PR TITLE
Extra test for #8364 - non-breaking of one-liners

### DIFF
--- a/tests/cases/fourslash/formatArrayLiteralExpression.ts
+++ b/tests/cases/fourslash/formatArrayLiteralExpression.ts
@@ -18,9 +18,9 @@
 ////}/*6*/,
 ////    {
 ////        Salad: 'salad', /*7*/
-////        Burrito: 'burrito',
+////        Burrito: ['burrito', 'carne asada', 'tinga de res', 'tinga de pollo'], /*8*/
 ////        Pie: 'pie'
-////    }];/*8*/
+////    }];/*9*/
 
 format.document();
 
@@ -40,4 +40,6 @@ verify.currentLineContentIs("    },");
 goTo.marker("7");
 verify.currentLineContentIs("        Salad: 'salad',");
 goTo.marker("8");
+verify.currentLineContentIs("        Burrito: ['burrito', 'carne asada', 'tinga de res', 'tinga de pollo'],");
+goTo.marker("9");
 verify.currentLineContentIs("    }];");


### PR DESCRIPTION
On the back of **#8364 Fix indentation for array items**

This guards one-line arrays from being broken into lines by any formatting changes.

(formatting of multi-line function signatures, also [discussed](https://github.com/Microsoft/TypeScript/pull/8364#discussion_r61663104) in that PR — is a personal taste, I'm leaving that argument out of this PR)