### PR TITLE
Unescape string literal types starting with double underscore.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5138,20 +5138,19 @@ namespace ts {
         }
 
         function getStringLiteralTypeForText(text: string): StringLiteralType {
-            const unescaped = unescapeIdentifier(text);
-            if (hasProperty(stringLiteralTypes, unescaped)) {
-                return stringLiteralTypes[unescaped];
+            if (hasProperty(stringLiteralTypes, text)) {
+                return stringLiteralTypes[text];
             }
 
-            const type = stringLiteralTypes[unescaped] = <StringLiteralType>createType(TypeFlags.StringLiteral);
-            type.text = unescaped;
+            const type = stringLiteralTypes[text] = <StringLiteralType>createType(TypeFlags.StringLiteral);
+            type.text = text;
             return type;
         }
 
         function getTypeFromStringLiteralTypeNode(node: StringLiteralTypeNode): Type {
             const links = getNodeLinks(node);
             if (!links.resolvedType) {
-                links.resolvedType = getStringLiteralTypeForText(node.text);
+                links.resolvedType = getStringLiteralTypeForText(unescapeIdentifier(node.text));
             }
             return links.resolvedType;
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5138,12 +5138,13 @@ namespace ts {
         }
 
         function getStringLiteralTypeForText(text: string): StringLiteralType {
-            if (hasProperty(stringLiteralTypes, text)) {
-                return stringLiteralTypes[text];
+            const unescaped = unescapeIdentifier(text);
+            if (hasProperty(stringLiteralTypes, unescaped)) {
+                return stringLiteralTypes[unescaped];
             }
 
-            const type = stringLiteralTypes[text] = <StringLiteralType>createType(TypeFlags.StringLiteral);
-            type.text = text;
+            const type = stringLiteralTypes[unescaped] = <StringLiteralType>createType(TypeFlags.StringLiteral);
+            type.text = unescaped;
             return type;
         }
 

--- a/tests/baselines/reference/doubleUnderStringLiteralAssignability.errors.txt
+++ b/tests/baselines/reference/doubleUnderStringLiteralAssignability.errors.txt
@@ -6,4 +6,6 @@ tests/cases/compiler/doubleUnderStringLiteralAssignability.ts(2,5): error TS2322
     var bad: '__dunder' = 'no_dunder';
         ~~~
 !!! error TS2322: Type '"no_dunder"' is not assignable to type '"__dunder"'.
+    var okok: '___thunder' = '___thunder';
+    var alsoOk: '_sunder' = '_sunder';
     

--- a/tests/baselines/reference/doubleUnderStringLiteralAssignability.errors.txt
+++ b/tests/baselines/reference/doubleUnderStringLiteralAssignability.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/compiler/doubleUnderStringLiteralAssignability.ts(2,5): error TS2322: Type '"no_dunder"' is not assignable to type '"__dunder"'.
+
+
+==== tests/cases/compiler/doubleUnderStringLiteralAssignability.ts (1 errors) ====
+    var shouldBeOk: '__dunder' = '__dunder';
+    var bad: '__dunder' = 'no_dunder';
+        ~~~
+!!! error TS2322: Type '"no_dunder"' is not assignable to type '"__dunder"'.
+    

--- a/tests/baselines/reference/doubleUnderStringLiteralAssignability.js
+++ b/tests/baselines/reference/doubleUnderStringLiteralAssignability.js
@@ -1,0 +1,8 @@
+//// [doubleUnderStringLiteralAssignability.ts]
+var shouldBeOk: '__dunder' = '__dunder';
+var bad: '__dunder' = 'no_dunder';
+
+
+//// [doubleUnderStringLiteralAssignability.js]
+var shouldBeOk = '__dunder';
+var bad = 'no_dunder';

--- a/tests/baselines/reference/doubleUnderStringLiteralAssignability.js
+++ b/tests/baselines/reference/doubleUnderStringLiteralAssignability.js
@@ -1,8 +1,12 @@
 //// [doubleUnderStringLiteralAssignability.ts]
 var shouldBeOk: '__dunder' = '__dunder';
 var bad: '__dunder' = 'no_dunder';
+var okok: '___thunder' = '___thunder';
+var alsoOk: '_sunder' = '_sunder';
 
 
 //// [doubleUnderStringLiteralAssignability.js]
 var shouldBeOk = '__dunder';
 var bad = 'no_dunder';
+var okok = '___thunder';
+var alsoOk = '_sunder';

--- a/tests/cases/compiler/doubleUnderStringLiteralAssignability.ts
+++ b/tests/cases/compiler/doubleUnderStringLiteralAssignability.ts
@@ -1,0 +1,2 @@
+var shouldBeOk: '__dunder' = '__dunder';
+var bad: '__dunder' = 'no_dunder';

--- a/tests/cases/compiler/doubleUnderStringLiteralAssignability.ts
+++ b/tests/cases/compiler/doubleUnderStringLiteralAssignability.ts
@@ -1,2 +1,4 @@
 var shouldBeOk: '__dunder' = '__dunder';
 var bad: '__dunder' = 'no_dunder';
+var okok: '___thunder' = '___thunder';
+var alsoOk: '_sunder' = '_sunder';


### PR DESCRIPTION
Fixes #8614

String literal types starting with double underscore are escaped in the parser and need to be unescaped before the type is given the string literal as its name.