### PR TITLE
Mark IIFE signature with `anySignature` during contextual typing

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8606,7 +8606,12 @@ namespace ts {
                             }
                             return createArrayType(getUnionType(restTypes));
                         }
-                        return checkExpression(iife.arguments[indexOfParameter]);
+                        const links = getNodeLinks(iife);
+                        const cached = links.resolvedSignature;
+                        links.resolvedSignature = anySignature;
+                        const type = checkExpression(iife.arguments[indexOfParameter]);
+                        links.resolvedSignature = cached;
+                        return type;
                     }
                 }
                 const contextualSignature = getContextualSignature(func);

--- a/tests/cases/fourslash/quickInfoForContextuallyTypedIife.ts
+++ b/tests/cases/fourslash/quickInfoForContextuallyTypedIife.ts
@@ -1,0 +1,38 @@
+/// <reference path='fourslash.ts' />
+
+////(({ q/*1*/, qq/*2*/ }, x/*3*/, { p/*4*/ }) => {
+////    var s: number = q/*5*/;
+////    var t: number = qq/*6*/;
+////    var u: number = p/*7*/;
+////    var v: number = x/*8*/;
+////    return q; })({ q: 13, qq: 12 }, 1, { p: 14 });
+////((a/*9*/, b/*10*/, c/*11*/) => [a/*12*/,b/*13*/,c/*14*/])("foo", 101, false);
+
+goTo.marker('1');
+verify.quickInfoIs("var q: number");
+goTo.marker('2');
+verify.quickInfoIs("var qq: number");
+goTo.marker('3');
+verify.quickInfoIs("(parameter) x: number");
+goTo.marker('4');
+verify.quickInfoIs("var p: number");
+goTo.marker('5');
+verify.quickInfoIs("var q: number");
+goTo.marker('6');
+verify.quickInfoIs("var qq: number");
+goTo.marker('7');
+verify.quickInfoIs("var p: number");
+goTo.marker('8');
+verify.quickInfoIs("(parameter) x: number");
+goTo.marker('9');
+verify.quickInfoIs("(parameter) a: string");
+goTo.marker('10');
+verify.quickInfoIs("(parameter) b: number");
+goTo.marker('11');
+verify.quickInfoIs("(parameter) c: boolean");
+goTo.marker('12');
+verify.quickInfoIs("(parameter) a: string");
+goTo.marker('13');
+verify.quickInfoIs("(parameter) b: number");
+goTo.marker('14');
+verify.quickInfoIs("(parameter) c: boolean");


### PR DESCRIPTION
Fixes #8661

Avoids recursion -- during batch compilation, `checkCallExpression` already sets the signature to `anySignature` as a sentinel value, the services layer calls directly into `checkParameter`, skipping `checkCallExpression` entirely. So `getContextuallyTypedParameterType` also needs to set this
sentinel value.