### PR TITLE
runtests-parallel does not fail when a single bucket fails

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -729,8 +729,11 @@ function runConsoleTests(defaultReporter, defaultSubsets) {
         tests = subsetRegex ? ' -g "' + subsetRegex + '"' : '';
         var cmd = "mocha" + (debug ? " --debug-brk" : "") + " -R " + reporter + tests + colors + ' -t ' + testTimeout + ' ' + run;
         console.log(cmd);
-        exec(cmd, function () {
+        function finish() {
             deleteTemporaryProjectOutput();
+            complete();
+        }
+        exec(cmd, function () {
             if (lintFlag && i === 0) {
                 var lint = jake.Task['lint'];
                 lint.addListener('complete', function () {
@@ -738,10 +741,8 @@ function runConsoleTests(defaultReporter, defaultSubsets) {
                 });
                 lint.invoke();
             }
-            else {
-                complete();
-            }
-        });
+            finish();
+        }, finish);
     });
 }
 


### PR DESCRIPTION
Fixes the problem that runtests-parallel has when tests from different buckets would fail -- only the failures from the first bucket would survive because Jake would fail when the first bucket failed.

Now all buckets run to completion, allowing you to see all failures at the end.