### PR TITLE
Optional symbols keep their declared type

### DIFF
--- a/tests/baselines/reference/asyncFunctionsAndStrictNullChecks.types
+++ b/tests/baselines/reference/asyncFunctionsAndStrictNullChecks.types
@@ -9,78 +9,78 @@ declare namespace Windows.Foundation {
 >TResult : TResult
 
         then<U>(success?: (value: TResult) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>;
->then : { <U>(success?: ((value: TResult) => IPromise<U>) | undefined, error?: ((error: any) => IPromise<U>) | undefined, progress?: ((progress: any) => void) | undefined): IPromise<U>; <U>(success?: ((value: TResult) => IPromise<U>) | undefined, error?: ((error: any) => U) | undefined, progress?: ((progress: any) => void) | undefined): IPromise<U>; <U>(success?: ((value: TResult) => U) | undefined, error?: ((error: any) => IPromise<U>) | undefined, progress?: ((progress: any) => void) | undefined): IPromise<U>; <U>(success?: ((value: TResult) => U) | undefined, error?: ((error: any) => U) | undefined, progress?: ((progress: any) => void) | undefined): IPromise<U>; }
+>then : { <U>(success?: (value: TResult) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: TResult) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: TResult) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: TResult) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }
 >U : U
->success : ((value: TResult) => IPromise<U>) | undefined
+>success : (value: TResult) => IPromise<U>
 >value : TResult
 >TResult : TResult
 >IPromise : IPromise<TResult>
 >U : U
->error : ((error: any) => IPromise<U>) | undefined
+>error : (error: any) => IPromise<U>
 >error : any
 >IPromise : IPromise<TResult>
 >U : U
->progress : ((progress: any) => void) | undefined
+>progress : (progress: any) => void
 >progress : any
 >IPromise : IPromise<TResult>
 >U : U
 
         then<U>(success?: (value: TResult) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>;
->then : { <U>(success?: ((value: TResult) => IPromise<U>) | undefined, error?: ((error: any) => IPromise<U>) | undefined, progress?: ((progress: any) => void) | undefined): IPromise<U>; <U>(success?: ((value: TResult) => IPromise<U>) | undefined, error?: ((error: any) => U) | undefined, progress?: ((progress: any) => void) | undefined): IPromise<U>; <U>(success?: ((value: TResult) => U) | undefined, error?: ((error: any) => IPromise<U>) | undefined, progress?: ((progress: any) => void) | undefined): IPromise<U>; <U>(success?: ((value: TResult) => U) | undefined, error?: ((error: any) => U) | undefined, progress?: ((progress: any) => void) | undefined): IPromise<U>; }
+>then : { <U>(success?: (value: TResult) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: TResult) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: TResult) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: TResult) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }
 >U : U
->success : ((value: TResult) => IPromise<U>) | undefined
+>success : (value: TResult) => IPromise<U>
 >value : TResult
 >TResult : TResult
 >IPromise : IPromise<TResult>
 >U : U
->error : ((error: any) => U) | undefined
+>error : (error: any) => U
 >error : any
 >U : U
->progress : ((progress: any) => void) | undefined
+>progress : (progress: any) => void
 >progress : any
 >IPromise : IPromise<TResult>
 >U : U
 
         then<U>(success?: (value: TResult) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>;
->then : { <U>(success?: ((value: TResult) => IPromise<U>) | undefined, error?: ((error: any) => IPromise<U>) | undefined, progress?: ((progress: any) => void) | undefined): IPromise<U>; <U>(success?: ((value: TResult) => IPromise<U>) | undefined, error?: ((error: any) => U) | undefined, progress?: ((progress: any) => void) | undefined): IPromise<U>; <U>(success?: ((value: TResult) => U) | undefined, error?: ((error: any) => IPromise<U>) | undefined, progress?: ((progress: any) => void) | undefined): IPromise<U>; <U>(success?: ((value: TResult) => U) | undefined, error?: ((error: any) => U) | undefined, progress?: ((progress: any) => void) | undefined): IPromise<U>; }
+>then : { <U>(success?: (value: TResult) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: TResult) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: TResult) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: TResult) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }
 >U : U
->success : ((value: TResult) => U) | undefined
+>success : (value: TResult) => U
 >value : TResult
 >TResult : TResult
 >U : U
->error : ((error: any) => IPromise<U>) | undefined
+>error : (error: any) => IPromise<U>
 >error : any
 >IPromise : IPromise<TResult>
 >U : U
->progress : ((progress: any) => void) | undefined
+>progress : (progress: any) => void
 >progress : any
 >IPromise : IPromise<TResult>
 >U : U
 
         then<U>(success?: (value: TResult) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>;
->then : { <U>(success?: ((value: TResult) => IPromise<U>) | undefined, error?: ((error: any) => IPromise<U>) | undefined, progress?: ((progress: any) => void) | undefined): IPromise<U>; <U>(success?: ((value: TResult) => IPromise<U>) | undefined, error?: ((error: any) => U) | undefined, progress?: ((progress: any) => void) | undefined): IPromise<U>; <U>(success?: ((value: TResult) => U) | undefined, error?: ((error: any) => IPromise<U>) | undefined, progress?: ((progress: any) => void) | undefined): IPromise<U>; <U>(success?: ((value: TResult) => U) | undefined, error?: ((error: any) => U) | undefined, progress?: ((progress: any) => void) | undefined): IPromise<U>; }
+>then : { <U>(success?: (value: TResult) => IPromise<U>, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: TResult) => IPromise<U>, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: TResult) => U, error?: (error: any) => IPromise<U>, progress?: (progress: any) => void): IPromise<U>; <U>(success?: (value: TResult) => U, error?: (error: any) => U, progress?: (progress: any) => void): IPromise<U>; }
 >U : U
->success : ((value: TResult) => U) | undefined
+>success : (value: TResult) => U
 >value : TResult
 >TResult : TResult
 >U : U
->error : ((error: any) => U) | undefined
+>error : (error: any) => U
 >error : any
 >U : U
->progress : ((progress: any) => void) | undefined
+>progress : (progress: any) => void
 >progress : any
 >IPromise : IPromise<TResult>
 >U : U
 
         done<U>(success?: (value: TResult) => any, error?: (error: any) => any, progress?: (progress: any) => void): void;
->done : <U>(success?: ((value: TResult) => any) | undefined, error?: ((error: any) => any) | undefined, progress?: ((progress: any) => void) | undefined) => void
+>done : <U>(success?: (value: TResult) => any, error?: (error: any) => any, progress?: (progress: any) => void) => void
 >U : U
->success : ((value: TResult) => any) | undefined
+>success : (value: TResult) => any
 >value : TResult
 >TResult : TResult
->error : ((error: any) => any) | undefined
+>error : (error: any) => any
 >error : any
->progress : ((progress: any) => void) | undefined
+>progress : (progress: any) => void
 >progress : any
 
         cancel(): void;
@@ -121,8 +121,8 @@ declare function resolve2<T>(value: T): Windows.Foundation.IPromise<T>;
 >T : T
 
 async function sample2(x?: number) {
->sample2 : (x?: number | undefined) => Promise<void>
->x : number | undefined
+>sample2 : (x?: number) => Promise<void>
+>x : number
 
     let x1 = await resolve1(x);
 >x1 : number | undefined

--- a/tests/baselines/reference/controlFlowDeleteOperator.types
+++ b/tests/baselines/reference/controlFlowDeleteOperator.types
@@ -4,8 +4,8 @@ function f() {
 >f : () => void
 
     let x: { a?: number | string, b: number | string } = { b: 1 };
->x : { a?: number | string | undefined; b: number | string; }
->a : number | string | undefined
+>x : { a?: number | string; b: number | string; }
+>a : number | string
 >b : number | string
 >{ b: 1 } : { b: number; }
 >b : number
@@ -13,67 +13,67 @@ function f() {
 
     x.a;
 >x.a : number | string | undefined
->x : { a?: number | string | undefined; b: number | string; }
+>x : { a?: number | string; b: number | string; }
 >a : number | string | undefined
 
     x.b;
 >x.b : number | string
->x : { a?: number | string | undefined; b: number | string; }
+>x : { a?: number | string; b: number | string; }
 >b : number | string
 
     x.a = 1;
 >x.a = 1 : number
->x.a : number | string | undefined
->x : { a?: number | string | undefined; b: number | string; }
->a : number | string | undefined
+>x.a : number | string
+>x : { a?: number | string; b: number | string; }
+>a : number | string
 >1 : number
 
     x.b = 1;
 >x.b = 1 : number
 >x.b : number | string
->x : { a?: number | string | undefined; b: number | string; }
+>x : { a?: number | string; b: number | string; }
 >b : number | string
 >1 : number
 
     x.a;
 >x.a : number
->x : { a?: number | string | undefined; b: number | string; }
+>x : { a?: number | string; b: number | string; }
 >a : number
 
     x.b;
 >x.b : number
->x : { a?: number | string | undefined; b: number | string; }
+>x : { a?: number | string; b: number | string; }
 >b : number
 
     delete x.a;
 >delete x.a : boolean
 >x.a : number
->x : { a?: number | string | undefined; b: number | string; }
+>x : { a?: number | string; b: number | string; }
 >a : number
 
     delete x.b;
 >delete x.b : boolean
 >x.b : number
->x : { a?: number | string | undefined; b: number | string; }
+>x : { a?: number | string; b: number | string; }
 >b : number
 
     x.a;
 >x.a : undefined
->x : { a?: number | string | undefined; b: number | string; }
+>x : { a?: number | string; b: number | string; }
 >a : undefined
 
     x.b;
 >x.b : number | string
->x : { a?: number | string | undefined; b: number | string; }
+>x : { a?: number | string; b: number | string; }
 >b : number | string
 
     x;
->x : { a?: number | string | undefined; b: number | string; }
+>x : { a?: number | string; b: number | string; }
 
     delete x;  // No effect
 >delete x : boolean
->x : { a?: number | string | undefined; b: number | string; }
+>x : { a?: number | string; b: number | string; }
 
     x;
->x : { a?: number | string | undefined; b: number | string; }
+>x : { a?: number | string; b: number | string; }
 }

--- a/tests/baselines/reference/controlFlowDestructuringDeclaration.types
+++ b/tests/baselines/reference/controlFlowDestructuringDeclaration.types
@@ -115,8 +115,8 @@ function f5() {
 >f5 : () => void
 
     let { x }: { x?: string | number } = { x: 1 };
->x : string | number | undefined
->x : string | number | undefined
+>x : string | number
+>x : string | number
 >{ x: 1 } : { x: number; }
 >x : number
 >1 : number
@@ -150,12 +150,12 @@ function f6() {
 >f6 : () => void
 
     let { x }: { x?: string | number } = {};
->x : string | number | undefined
->x : string | number | undefined
+>x : string | number
+>x : string | number
 >{} : {}
 
     x;
->x : string | number | undefined
+>x : string | number
 
     let { y }: { y?: string | undefined } = {};
 >y : string | undefined

--- a/tests/baselines/reference/iteratorsAndStrictNullChecks.types
+++ b/tests/baselines/reference/iteratorsAndStrictNullChecks.types
@@ -8,9 +8,9 @@ for (const x of ["a", "b"]) {
 >"b" : string
 
     x.substring;
->x.substring : (start: number, end?: number | undefined) => string
+>x.substring : (start: number, end?: number) => string
 >x : string
->substring : (start: number, end?: number | undefined) => string
+>substring : (start: number, end?: number) => string
 }
 
 // Spread

--- a/tests/baselines/reference/optionalMethods.js
+++ b/tests/baselines/reference/optionalMethods.js
@@ -130,7 +130,7 @@ declare class Bar {
     e: number;
     a: number;
     b?: number;
-    c?: number | undefined;
+    c?: number;
     constructor(d?: number, e?: number);
     f(): number;
     g?(): number;

--- a/tests/baselines/reference/optionalMethods.types
+++ b/tests/baselines/reference/optionalMethods.types
@@ -7,13 +7,13 @@ interface Foo {
 >a : number
 
     b?: number;
->b : number | undefined
+>b : number
 
     f(): number;
 >f : () => number
 
     g?(): number;
->g : (() => number) | undefined
+>g : () => number
 }
 
 function test1(x: Foo) {
@@ -79,14 +79,14 @@ class Bar {
 >a : number
 
     b?: number;
->b : number | undefined
+>b : number
 
     c? = 2;
->c : number | undefined
+>c : number
 >2 : number
 
     constructor(public d?: number, public e = 10) {}
->d : number | undefined
+>d : number
 >e : number
 >10 : number
 
@@ -97,10 +97,10 @@ class Bar {
 >1 : number
     }
     g?(): number;  // Body of optional method can be omitted
->g : (() => number) | undefined
+>g : () => number
 
     h?() {
->h : (() => number) | undefined
+>h : () => number
 
         return 2;
 >2 : number
@@ -128,9 +128,9 @@ function test2(x: Bar) {
 >c : number | undefined
 
     x.d;
->x.d : number | undefined
+>x.d : number
 >x : Bar
->d : number | undefined
+>d : number
 
     x.e;
 >x.e : number
@@ -205,10 +205,10 @@ class Base {
 >Base : Base
 
     a?: number;
->a : number | undefined
+>a : number
 
     f?(): number;
->f : (() => number) | undefined
+>f : () => number
 }
 
 class Derived extends Base {

--- a/tests/baselines/reference/optionalParameterDestructuring.js
+++ b/tests/baselines/reference/optionalParameterDestructuring.js
@@ -1,0 +1,55 @@
+//// [optionalParameterDestructuring.ts]
+
+declare function f1({ a, b }?: { a: number, b: string }): string;
+
+function f2({ a, b }: { a: number, b: number } = { a: 0, b: 0 }) {
+}
+
+// Repro from #8681
+
+interface Type { t: void }
+interface QueryMetadata { q: void }
+
+interface QueryMetadataFactory {
+    (selector: Type | string, {descendants, read}?: {
+        descendants?: boolean;
+        read?: any;
+    }): ParameterDecorator;
+    new (selector: Type | string, {descendants, read}?: {
+        descendants?: boolean;
+        read?: any;
+    }): QueryMetadata;
+}
+
+
+//// [optionalParameterDestructuring.js]
+function f2(_a) {
+    var _b = _a === void 0 ? { a: 0, b: 0 } : _a, a = _b.a, b = _b.b;
+}
+
+
+//// [optionalParameterDestructuring.d.ts]
+declare function f1({a, b}?: {
+    a: number;
+    b: string;
+}): string;
+declare function f2({a, b}?: {
+    a: number;
+    b: number;
+}): void;
+interface Type {
+    t: void;
+}
+interface QueryMetadata {
+    q: void;
+}
+interface QueryMetadataFactory {
+    (selector: Type | string, {descendants, read}?: {
+        descendants?: boolean;
+        read?: any;
+    }): ParameterDecorator;
+    new (selector: Type | string, {descendants, read}?: {
+        descendants?: boolean;
+        read?: any;
+    }): QueryMetadata;
+}

--- a/tests/baselines/reference/optionalParameterDestructuring.symbols
+++ b/tests/baselines/reference/optionalParameterDestructuring.symbols
@@ -1,0 +1,63 @@
+=== tests/cases/compiler/optionalParameterDestructuring.ts ===
+
+declare function f1({ a, b }?: { a: number, b: string }): string;
+>f1 : Symbol(f1, Decl(optionalParameterDestructuring.ts, 0, 0))
+>a : Symbol(a, Decl(optionalParameterDestructuring.ts, 1, 21))
+>b : Symbol(b, Decl(optionalParameterDestructuring.ts, 1, 24))
+>a : Symbol(a, Decl(optionalParameterDestructuring.ts, 1, 32))
+>b : Symbol(b, Decl(optionalParameterDestructuring.ts, 1, 43))
+
+function f2({ a, b }: { a: number, b: number } = { a: 0, b: 0 }) {
+>f2 : Symbol(f2, Decl(optionalParameterDestructuring.ts, 1, 65))
+>a : Symbol(a, Decl(optionalParameterDestructuring.ts, 3, 13))
+>b : Symbol(b, Decl(optionalParameterDestructuring.ts, 3, 16))
+>a : Symbol(a, Decl(optionalParameterDestructuring.ts, 3, 23))
+>b : Symbol(b, Decl(optionalParameterDestructuring.ts, 3, 34))
+>a : Symbol(a, Decl(optionalParameterDestructuring.ts, 3, 50))
+>b : Symbol(b, Decl(optionalParameterDestructuring.ts, 3, 56))
+}
+
+// Repro from #8681
+
+interface Type { t: void }
+>Type : Symbol(Type, Decl(optionalParameterDestructuring.ts, 4, 1))
+>t : Symbol(Type.t, Decl(optionalParameterDestructuring.ts, 8, 16))
+
+interface QueryMetadata { q: void }
+>QueryMetadata : Symbol(QueryMetadata, Decl(optionalParameterDestructuring.ts, 8, 26))
+>q : Symbol(QueryMetadata.q, Decl(optionalParameterDestructuring.ts, 9, 25))
+
+interface QueryMetadataFactory {
+>QueryMetadataFactory : Symbol(QueryMetadataFactory, Decl(optionalParameterDestructuring.ts, 9, 35))
+
+    (selector: Type | string, {descendants, read}?: {
+>selector : Symbol(selector, Decl(optionalParameterDestructuring.ts, 12, 5))
+>Type : Symbol(Type, Decl(optionalParameterDestructuring.ts, 4, 1))
+>descendants : Symbol(descendants, Decl(optionalParameterDestructuring.ts, 12, 31))
+>read : Symbol(read, Decl(optionalParameterDestructuring.ts, 12, 43))
+
+        descendants?: boolean;
+>descendants : Symbol(descendants, Decl(optionalParameterDestructuring.ts, 12, 53))
+
+        read?: any;
+>read : Symbol(read, Decl(optionalParameterDestructuring.ts, 13, 30))
+
+    }): ParameterDecorator;
+>ParameterDecorator : Symbol(ParameterDecorator, Decl(lib.d.ts, --, --))
+
+    new (selector: Type | string, {descendants, read}?: {
+>selector : Symbol(selector, Decl(optionalParameterDestructuring.ts, 16, 9))
+>Type : Symbol(Type, Decl(optionalParameterDestructuring.ts, 4, 1))
+>descendants : Symbol(descendants, Decl(optionalParameterDestructuring.ts, 16, 35))
+>read : Symbol(read, Decl(optionalParameterDestructuring.ts, 16, 47))
+
+        descendants?: boolean;
+>descendants : Symbol(descendants, Decl(optionalParameterDestructuring.ts, 16, 57))
+
+        read?: any;
+>read : Symbol(read, Decl(optionalParameterDestructuring.ts, 17, 30))
+
+    }): QueryMetadata;
+>QueryMetadata : Symbol(QueryMetadata, Decl(optionalParameterDestructuring.ts, 8, 26))
+}
+

--- a/tests/baselines/reference/optionalParameterDestructuring.types
+++ b/tests/baselines/reference/optionalParameterDestructuring.types
@@ -1,0 +1,66 @@
+=== tests/cases/compiler/optionalParameterDestructuring.ts ===
+
+declare function f1({ a, b }?: { a: number, b: string }): string;
+>f1 : ({a, b}?: { a: number; b: string; }) => string
+>a : number
+>b : string
+>a : number
+>b : string
+
+function f2({ a, b }: { a: number, b: number } = { a: 0, b: 0 }) {
+>f2 : ({a, b}?: { a: number; b: number; }) => void
+>a : number
+>b : number
+>a : number
+>b : number
+>{ a: 0, b: 0 } : { a: number; b: number; }
+>a : number
+>0 : number
+>b : number
+>0 : number
+}
+
+// Repro from #8681
+
+interface Type { t: void }
+>Type : Type
+>t : void
+
+interface QueryMetadata { q: void }
+>QueryMetadata : QueryMetadata
+>q : void
+
+interface QueryMetadataFactory {
+>QueryMetadataFactory : QueryMetadataFactory
+
+    (selector: Type | string, {descendants, read}?: {
+>selector : Type | string
+>Type : Type
+>descendants : boolean
+>read : any
+
+        descendants?: boolean;
+>descendants : boolean
+
+        read?: any;
+>read : any
+
+    }): ParameterDecorator;
+>ParameterDecorator : (target: Object, propertyKey: string | symbol, parameterIndex: number) => void
+
+    new (selector: Type | string, {descendants, read}?: {
+>selector : Type | string
+>Type : Type
+>descendants : boolean
+>read : any
+
+        descendants?: boolean;
+>descendants : boolean
+
+        read?: any;
+>read : any
+
+    }): QueryMetadata;
+>QueryMetadata : QueryMetadata
+}
+

--- a/tests/baselines/reference/typeGuardsAsAssertions.types
+++ b/tests/baselines/reference/typeGuardsAsAssertions.types
@@ -122,9 +122,9 @@ function foo1() {
 >x : number | string
 >"string" : string
 >x.slice() : string
->x.slice : (start?: number | undefined, end?: number | undefined) => string
+>x.slice : (start?: number, end?: number) => string
 >x : string
->slice : (start?: number | undefined, end?: number | undefined) => string
+>slice : (start?: number, end?: number) => string
 >"abc" : string
 
         x;  // string
@@ -160,9 +160,9 @@ function foo2() {
 >x = x.slice() : string
 >x : string | number | boolean
 >x.slice() : string
->x.slice : (start?: number | undefined, end?: number | undefined) => string
+>x.slice : (start?: number, end?: number) => string
 >x : string
->slice : (start?: number | undefined, end?: number | undefined) => string
+>slice : (start?: number, end?: number) => string
         }
         else {
             x = "abc";
@@ -300,10 +300,10 @@ function f6() {
 
     x!.slice();
 >x!.slice() : string
->x!.slice : (start?: number | undefined, end?: number | undefined) => string
+>x!.slice : (start?: number, end?: number) => string
 >x! : string
 >x : string | null | undefined
->slice : (start?: number | undefined, end?: number | undefined) => string
+>slice : (start?: number, end?: number) => string
 
     x = "";
 >x = "" : string
@@ -312,10 +312,10 @@ function f6() {
 
     x!.slice();
 >x!.slice() : string
->x!.slice : (start?: number | undefined, end?: number | undefined) => string
+>x!.slice : (start?: number, end?: number) => string
 >x! : string
 >x : string
->slice : (start?: number | undefined, end?: number | undefined) => string
+>slice : (start?: number, end?: number) => string
 
     x = undefined;
 >x = undefined : undefined
@@ -324,10 +324,10 @@ function f6() {
 
     x!.slice();
 >x!.slice() : string
->x!.slice : (start?: number | undefined, end?: number | undefined) => string
+>x!.slice : (start?: number, end?: number) => string
 >x! : string
 >x : string | null | undefined
->slice : (start?: number | undefined, end?: number | undefined) => string
+>slice : (start?: number, end?: number) => string
 
     x = null;
 >x = null : null
@@ -336,10 +336,10 @@ function f6() {
 
     x!.slice();
 >x!.slice() : string
->x!.slice : (start?: number | undefined, end?: number | undefined) => string
+>x!.slice : (start?: number, end?: number) => string
 >x! : string
 >x : string | null | undefined
->slice : (start?: number | undefined, end?: number | undefined) => string
+>slice : (start?: number, end?: number) => string
 
     x = <undefined | null>undefined;
 >x = <undefined | null>undefined : null | undefined
@@ -350,10 +350,10 @@ function f6() {
 
     x!.slice();
 >x!.slice() : string
->x!.slice : (start?: number | undefined, end?: number | undefined) => string
+>x!.slice : (start?: number, end?: number) => string
 >x! : string
 >x : string | null | undefined
->slice : (start?: number | undefined, end?: number | undefined) => string
+>slice : (start?: number, end?: number) => string
 
     x = <string | undefined>"";
 >x = <string | undefined>"" : string | undefined
@@ -363,10 +363,10 @@ function f6() {
 
     x!.slice();
 >x!.slice() : string
->x!.slice : (start?: number | undefined, end?: number | undefined) => string
+>x!.slice : (start?: number, end?: number) => string
 >x! : string
 >x : string | undefined
->slice : (start?: number | undefined, end?: number | undefined) => string
+>slice : (start?: number, end?: number) => string
 
     x = <string | null>"";
 >x = <string | null>"" : string | null
@@ -377,9 +377,9 @@ function f6() {
 
     x!.slice();
 >x!.slice() : string
->x!.slice : (start?: number | undefined, end?: number | undefined) => string
+>x!.slice : (start?: number, end?: number) => string
 >x! : string
 >x : string | null
->slice : (start?: number | undefined, end?: number | undefined) => string
+>slice : (start?: number, end?: number) => string
 }
 

--- a/tests/cases/compiler/optionalParameterDestructuring.ts
+++ b/tests/cases/compiler/optionalParameterDestructuring.ts
@@ -1,0 +1,23 @@
+// @strictNullChecks: true
+// @declaration: true
+
+declare function f1({ a, b }?: { a: number, b: string }): string;
+
+function f2({ a, b }: { a: number, b: number } = { a: 0, b: 0 }) {
+}
+
+// Repro from #8681
+
+interface Type { t: void }
+interface QueryMetadata { q: void }
+
+interface QueryMetadataFactory {
+    (selector: Type | string, {descendants, read}?: {
+        descendants?: boolean;
+        read?: any;
+    }): ParameterDecorator;
+    new (selector: Type | string, {descendants, read}?: {
+        descendants?: boolean;
+        read?: any;
+    }): QueryMetadata;
+}


### PR DESCRIPTION
With this PR, symbols for optional parameters, properties, and methods keep their actual declared type instead of having `undefined` added to the type when in `--strictNullChecks` mode. The `undefined` is added to the type in a later phase when checking expressions involving the parameter or property (specifically by `checkIdentifier` and `checkPropertyAccessExpression`). This change allows us to better preserve fidelity in declaration file emitting and also makes it possible to have different behavior for reading vs. writing of optional parameters and properties. For example, the following is now an error:

```typescript
function foo(x?: number) {
    x = undefined;  // Error, declared type doesn't include undefined
}
```

Fixes ##8681.