### PR TITLE
Fix #8729: Make JSON.stringify accept `null` and `undefined` replacers

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -952,35 +952,19 @@ interface JSON {
     /**
       * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
       * @param value A JavaScript value, usually an object or array, to be converted.
-      */
-    stringify(value: any): string;
-    /**
-      * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
-      * @param value A JavaScript value, usually an object or array, to be converted.
-      * @param replacer A function that transforms the results.
-      */
-    stringify(value: any, replacer: (key: string, value: any) => any): string;
-    /**
-      * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
-      * @param value A JavaScript value, usually an object or array, to be converted.
-      * @param replacer Array that transforms the results.
-      */
-    stringify(value: any, replacer: any[]): string;
-    /**
-      * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
-      * @param value A JavaScript value, usually an object or array, to be converted.
       * @param replacer A function that transforms the results.
       * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
       */
-    stringify(value: any, replacer: (key: string, value: any) => any, space: string | number): string;
+    stringify(value: any, replacer?: (key: string, value: any) => any, space?: string | number): string;
     /**
       * Converts a JavaScript value to a JavaScript Object Notation (JSON) string.
       * @param value A JavaScript value, usually an object or array, to be converted.
-      * @param replacer Array that transforms the results.
+      * @param replacer An array of strings and numbers that acts as a white list for selecting the object properties that will be stringified.
       * @param space Adds indentation, white space, and line break characters to the return-value JSON text to make it easier to read.
       */
-    stringify(value: any, replacer: any[], space: string | number): string;
+    stringify(value: any, replacer?: (number | string)[] | null, space?: string | number): string;
 }
+
 /**
   * An intrinsic object that provides functions to convert JavaScript values to and from the JavaScript Object Notation (JSON) format.
   */

--- a/tests/baselines/reference/json.stringify.js
+++ b/tests/baselines/reference/json.stringify.js
@@ -1,0 +1,16 @@
+//// [json.stringify.ts]
+
+var value = null;
+JSON.stringify(value, undefined, 2);
+JSON.stringify(value, null, 2);
+JSON.stringify(value, ["a", 1], 2);
+JSON.stringify(value, (k) => undefined, 2);
+JSON.stringify(value, undefined, 2);
+
+//// [json.stringify.js]
+var value = null;
+JSON.stringify(value, undefined, 2);
+JSON.stringify(value, null, 2);
+JSON.stringify(value, ["a", 1], 2);
+JSON.stringify(value, function (k) { return undefined; }, 2);
+JSON.stringify(value, undefined, 2);

--- a/tests/baselines/reference/json.stringify.symbols
+++ b/tests/baselines/reference/json.stringify.symbols
@@ -1,0 +1,39 @@
+=== tests/cases/compiler/json.stringify.ts ===
+
+var value = null;
+>value : Symbol(value, Decl(json.stringify.ts, 1, 3))
+
+JSON.stringify(value, undefined, 2);
+>JSON.stringify : Symbol(JSON.stringify, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>JSON : Symbol(JSON, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>stringify : Symbol(JSON.stringify, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>value : Symbol(value, Decl(json.stringify.ts, 1, 3))
+>undefined : Symbol(undefined)
+
+JSON.stringify(value, null, 2);
+>JSON.stringify : Symbol(JSON.stringify, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>JSON : Symbol(JSON, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>stringify : Symbol(JSON.stringify, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>value : Symbol(value, Decl(json.stringify.ts, 1, 3))
+
+JSON.stringify(value, ["a", 1], 2);
+>JSON.stringify : Symbol(JSON.stringify, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>JSON : Symbol(JSON, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>stringify : Symbol(JSON.stringify, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>value : Symbol(value, Decl(json.stringify.ts, 1, 3))
+
+JSON.stringify(value, (k) => undefined, 2);
+>JSON.stringify : Symbol(JSON.stringify, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>JSON : Symbol(JSON, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>stringify : Symbol(JSON.stringify, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>value : Symbol(value, Decl(json.stringify.ts, 1, 3))
+>k : Symbol(k, Decl(json.stringify.ts, 5, 23))
+>undefined : Symbol(undefined)
+
+JSON.stringify(value, undefined, 2);
+>JSON.stringify : Symbol(JSON.stringify, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>JSON : Symbol(JSON, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>stringify : Symbol(JSON.stringify, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>value : Symbol(value, Decl(json.stringify.ts, 1, 3))
+>undefined : Symbol(undefined)
+

--- a/tests/baselines/reference/json.stringify.types
+++ b/tests/baselines/reference/json.stringify.types
@@ -1,0 +1,55 @@
+=== tests/cases/compiler/json.stringify.ts ===
+
+var value = null;
+>value : null
+>null : null
+
+JSON.stringify(value, undefined, 2);
+>JSON.stringify(value, undefined, 2) : string
+>JSON.stringify : { (value: any, replacer?: ((key: string, value: any) => any) | undefined, space?: string | number | undefined): string; (value: any, replacer?: (number | string)[] | null | undefined, space?: string | number | undefined): string; }
+>JSON : JSON
+>stringify : { (value: any, replacer?: ((key: string, value: any) => any) | undefined, space?: string | number | undefined): string; (value: any, replacer?: (number | string)[] | null | undefined, space?: string | number | undefined): string; }
+>value : null
+>undefined : undefined
+>2 : number
+
+JSON.stringify(value, null, 2);
+>JSON.stringify(value, null, 2) : string
+>JSON.stringify : { (value: any, replacer?: ((key: string, value: any) => any) | undefined, space?: string | number | undefined): string; (value: any, replacer?: (number | string)[] | null | undefined, space?: string | number | undefined): string; }
+>JSON : JSON
+>stringify : { (value: any, replacer?: ((key: string, value: any) => any) | undefined, space?: string | number | undefined): string; (value: any, replacer?: (number | string)[] | null | undefined, space?: string | number | undefined): string; }
+>value : null
+>null : null
+>2 : number
+
+JSON.stringify(value, ["a", 1], 2);
+>JSON.stringify(value, ["a", 1], 2) : string
+>JSON.stringify : { (value: any, replacer?: ((key: string, value: any) => any) | undefined, space?: string | number | undefined): string; (value: any, replacer?: (number | string)[] | null | undefined, space?: string | number | undefined): string; }
+>JSON : JSON
+>stringify : { (value: any, replacer?: ((key: string, value: any) => any) | undefined, space?: string | number | undefined): string; (value: any, replacer?: (number | string)[] | null | undefined, space?: string | number | undefined): string; }
+>value : null
+>["a", 1] : (string | number)[]
+>"a" : string
+>1 : number
+>2 : number
+
+JSON.stringify(value, (k) => undefined, 2);
+>JSON.stringify(value, (k) => undefined, 2) : string
+>JSON.stringify : { (value: any, replacer?: ((key: string, value: any) => any) | undefined, space?: string | number | undefined): string; (value: any, replacer?: (number | string)[] | null | undefined, space?: string | number | undefined): string; }
+>JSON : JSON
+>stringify : { (value: any, replacer?: ((key: string, value: any) => any) | undefined, space?: string | number | undefined): string; (value: any, replacer?: (number | string)[] | null | undefined, space?: string | number | undefined): string; }
+>value : null
+>(k) => undefined : (k: string) => undefined
+>k : string
+>undefined : undefined
+>2 : number
+
+JSON.stringify(value, undefined, 2);
+>JSON.stringify(value, undefined, 2) : string
+>JSON.stringify : { (value: any, replacer?: ((key: string, value: any) => any) | undefined, space?: string | number | undefined): string; (value: any, replacer?: (number | string)[] | null | undefined, space?: string | number | undefined): string; }
+>JSON : JSON
+>stringify : { (value: any, replacer?: ((key: string, value: any) => any) | undefined, space?: string | number | undefined): string; (value: any, replacer?: (number | string)[] | null | undefined, space?: string | number | undefined): string; }
+>value : null
+>undefined : undefined
+>2 : number
+

--- a/tests/cases/compiler/json.stringify.ts
+++ b/tests/cases/compiler/json.stringify.ts
@@ -1,0 +1,8 @@
+// @strictNullChecks: true
+
+var value = null;
+JSON.stringify(value, undefined, 2);
+JSON.stringify(value, null, 2);
+JSON.stringify(value, ["a", 1], 2);
+JSON.stringify(value, (k) => undefined, 2);
+JSON.stringify(value, undefined, 2);


### PR DESCRIPTION
Spec: http://www.ecma-international.org/ecma-262/6.0/#sec-json.stringify

split into two signatures for better parameter help experience on the replacer.