### PR TITLE
Fix #8738: Handles Re-assignment of Exported Clause Member

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2812,8 +2812,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     if (languageVersion === ScriptTarget.ES3 && name.text === "default") {
                         write('["default"]');
                     }
-                    write(".");
-                    emitNodeWithCommentsAndWithoutSourcemap(specifier.name);
+                    else {
+                        write(".");
+                        emitNodeWithCommentsAndWithoutSourcemap(specifier.name);
+                    }
                     emitEnd(specifier.name);
                     write(" = ");
                 }

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2622,10 +2622,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
             }
 
             function emitPrefixUnaryExpression(node: PrefixUnaryExpression) {
-                const exportChanged = (node.operator === SyntaxKind.PlusPlusToken || node.operator === SyntaxKind.MinusMinusToken) &&
+                const isPlusPlusOrMinusMinus = (node.operator === SyntaxKind.PlusPlusToken
+                    || node.operator === SyntaxKind.MinusMinusToken);
+                const externalExportChanged = isPlusPlusOrMinusMinus &&
                     isNameOfExportedSourceLevelDeclarationInSystemExternalModule(node.operand);
 
-                if (exportChanged) {
+                if (externalExportChanged) {
                     // emit
                     // ++x
                     // as
@@ -2633,6 +2635,12 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     write(`${exportFunctionForFile}("`);
                     emitNodeWithoutSourceMap(node.operand);
                     write(`", `);
+                }
+                const internalExportChanged = isPlusPlusOrMinusMinus &&
+                    isNameOfExportedSourceLevelDeclarationInClauseModule(node.operand);
+
+                if (internalExportChanged) {
+                    emitAliasEqual(<Identifier> node.operand);
                 }
 
                 write(tokenToString(node.operator));
@@ -2659,14 +2667,16 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 }
                 emit(node.operand);
 
-                if (exportChanged) {
+                if (externalExportChanged) {
                     write(")");
                 }
             }
 
             function emitPostfixUnaryExpression(node: PostfixUnaryExpression) {
-                const exportChanged = isNameOfExportedSourceLevelDeclarationInSystemExternalModule(node.operand);
-                if (exportChanged) {
+                const externalExportChanged = isNameOfExportedSourceLevelDeclarationInSystemExternalModule(node.operand);
+                const internalExportChanged = isNameOfExportedSourceLevelDeclarationInClauseModule(node.operand);
+
+                if (externalExportChanged) {
                     // export function returns the value that was passes as the second argument
                     // however for postfix unary expressions result value should be the value before modification.
                     // emit 'x++' as '(export('x', ++x) - 1)' and 'x--' as '(export('x', --x) + 1)'
@@ -2682,6 +2692,16 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     }
                     else {
                         write(") + 1)");
+                    }
+                }
+                else if (internalExportChanged) {
+                    emitAliasEqual(<Identifier> node.operand);
+                    emit(node.operand);
+                    if (node.operator === SyntaxKind.PlusPlusToken) {
+                        write(" += 1");
+                    }
+                    else {
+                        write(" -= 1");
                     }
                 }
                 else {
@@ -2785,6 +2805,18 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 }
             }
 
+            function emitAliasEqual(name: Identifier): boolean {
+                for (const specifier of exportSpecifiers[name.text]) {
+                    emitStart(specifier.name);
+                    emitContainingModuleName(specifier);
+                    write(".");
+                    emitNodeWithCommentsAndWithoutSourcemap(specifier.name);
+                    emitEnd(specifier.name);
+                    write(" = ");
+                }
+                return true;
+            }
+
             function emitBinaryExpression(node: BinaryExpression) {
                 if (languageVersion < ScriptTarget.ES6 && node.operatorToken.kind === SyntaxKind.EqualsToken &&
                     (node.left.kind === SyntaxKind.ObjectLiteralExpression || node.left.kind === SyntaxKind.ArrayLiteralExpression)) {
@@ -2803,18 +2835,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                         write(`", `);
                     }
 
-                    const internalExportClauseMemberChanged = isAssignment &&
+                    const internalExportChanged = isAssignment &&
                         isNameOfExportedSourceLevelDeclarationInClauseModule(node.left);
 
-                    if (internalExportClauseMemberChanged) {
-                        for (const specifier of exportSpecifiers[(<Identifier>node.left).text]) {
-                            emitStart(specifier.name);
-                            emitContainingModuleName(specifier);
-                            write(".");
-                            emitNodeWithCommentsAndWithoutSourcemap(specifier.name);
-                            emitEnd(specifier.name);
-                            write(" = ");
-                        }
+                    if (internalExportChanged) {
+                        // export { foo }
+                        // emit foo = 2 as exports.foo = foo = 2
+                        emitAliasEqual(<Identifier>node.left);
                     }
 
                     if (node.operatorToken.kind === SyntaxKind.AsteriskAsteriskToken || node.operatorToken.kind === SyntaxKind.AsteriskAsteriskEqualsToken) {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2809,6 +2809,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 for (const specifier of exportSpecifiers[name.text]) {
                     emitStart(specifier.name);
                     emitContainingModuleName(specifier);
+                    if (languageVersion === ScriptTarget.ES3 && name.text === "default") {
+                        write('["default"]');
+                    }
                     write(".");
                     emitNodeWithCommentsAndWithoutSourcemap(specifier.name);
                     emitEnd(specifier.name);

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2613,7 +2613,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 return isSourceFileLevelDeclarationInSystemJsModule(targetDeclaration, /*isExported*/ true);
             }
 
-            function isNameOfExportedSourceLevelDeclarationInClauseModule(node: Node): boolean {
+            function isNameOfExportedDeclarationInNonES6Module(node: Node): boolean {
                 if (modulekind === ModuleKind.System || node.kind !== SyntaxKind.Identifier || nodeIsSynthesized(node)) {
                     return false;
                 }
@@ -2637,7 +2637,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     write(`", `);
                 }
                 const internalExportChanged = isPlusPlusOrMinusMinus &&
-                    isNameOfExportedSourceLevelDeclarationInClauseModule(node.operand);
+                    isNameOfExportedDeclarationInNonES6Module(node.operand);
 
                 if (internalExportChanged) {
                     emitAliasEqual(<Identifier> node.operand);
@@ -2674,7 +2674,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 
             function emitPostfixUnaryExpression(node: PostfixUnaryExpression) {
                 const externalExportChanged = isNameOfExportedSourceLevelDeclarationInSystemExternalModule(node.operand);
-                const internalExportChanged = isNameOfExportedSourceLevelDeclarationInClauseModule(node.operand);
+                const internalExportChanged = isNameOfExportedDeclarationInNonES6Module(node.operand);
 
                 if (externalExportChanged) {
                     // export function returns the value that was passes as the second argument
@@ -2841,7 +2841,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     }
 
                     const internalExportChanged = isAssignment &&
-                        isNameOfExportedSourceLevelDeclarationInClauseModule(node.left);
+                        isNameOfExportedDeclarationInNonES6Module(node.left);
 
                     if (internalExportChanged) {
                         // export { foo }
@@ -5464,7 +5464,7 @@ const _super = (function (geti, seti) {
                         //
 
                         // NOTE: we reuse the same rewriting logic for cases when targeting ES6 and module kind is System.
-                        // Because of hoisting top level class declaration need to be emitted as class expressions. 
+                        // Because of hoisting top level class declaration need to be emitted as class expressions.
                         // Double bind case is only required if node is decorated.
                         if (isDecorated && resolver.getNodeCheckFlags(node) & NodeCheckFlags.ClassWithBodyScopedClassBinding) {
                             decoratedClassAlias = unescapeIdentifier(makeUniqueName(node.name ? node.name.text : "default"));

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2791,9 +2791,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     emitDestructuring(node, node.parent.kind === SyntaxKind.ExpressionStatement);
                 }
                 else {
-                    const externalExportChanged =
-                        node.operatorToken.kind >= SyntaxKind.FirstAssignment &&
-                        node.operatorToken.kind <= SyntaxKind.LastAssignment &&
+                    const isAssignment = isAssignmentOperator(node.operatorToken.kind);
+
+                    const externalExportChanged = isAssignment &&
                         isNameOfExportedSourceLevelDeclarationInSystemExternalModule(node.left);
 
                     if (externalExportChanged) {
@@ -2803,9 +2803,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                         write(`", `);
                     }
 
-                    const internalExportClauseMemberChanged =
-                        node.operatorToken.kind >= SyntaxKind.FirstAssignment &&
-                        node.operatorToken.kind <= SyntaxKind.LastAssignment &&
+                    const internalExportClauseMemberChanged = isAssignment &&
                         isNameOfExportedSourceLevelDeclarationInClauseModule(node.left);
 
                     if (internalExportClauseMemberChanged) {

--- a/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.js
+++ b/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.js
@@ -6,7 +6,10 @@ foo = 3;
 var baz = 3;
 baz = 4;
 
-export { foo, baz, baz as quux };
+var buzz = 10;
+buzz += 3;
+
+export { foo, baz, baz as quux, buzz };
 
 
 //// [server.js]
@@ -18,3 +21,6 @@ var baz = 3;
 exports.baz = baz;
 exports.quux = baz;
 exports.baz = exports.quux = baz = 4;
+var buzz = 10;
+exports.buzz = buzz;
+exports.buzz = buzz += 3;

--- a/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.js
+++ b/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.js
@@ -9,7 +9,12 @@ baz = 4;
 var buzz = 10;
 buzz += 3;
 
-export { foo, baz, baz as quux, buzz };
+var bizz = 8;
+bizz++; // compiles to exports.bizz = bizz += 1
+bizz--; // similarly
+++bizz; // compiles to exports.bizz = ++bizz
+
+export { foo, baz, baz as quux, buzz, bizz };
 
 
 //// [server.js]
@@ -24,3 +29,8 @@ exports.baz = exports.quux = baz = 4;
 var buzz = 10;
 exports.buzz = buzz;
 exports.buzz = buzz += 3;
+var bizz = 8;
+exports.bizz = bizz;
+exports.bizz = bizz += 1; // compiles to exports.bizz = bizz += 1
+exports.bizz = bizz -= 1; // similarly
+exports.bizz = ++bizz; // compiles to exports.bizz = ++bizz

--- a/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.js
+++ b/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.js
@@ -17,4 +17,4 @@ exports.foo = foo = 3;
 var baz = 3;
 exports.baz = baz;
 exports.quux = baz;
-exports.quux = exports.baz = baz = 4;
+exports.baz = exports.quux = baz = 4;

--- a/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.js
+++ b/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.js
@@ -1,0 +1,20 @@
+//// [server.ts]
+
+var foo = 2;
+foo = 3;
+
+var baz = 3;
+baz = 4;
+
+export { foo, baz, baz as quux };
+
+
+//// [server.js]
+"use strict";
+var foo = 2;
+exports.foo = foo;
+exports.foo = foo = 3;
+var baz = 3;
+exports.baz = baz;
+exports.quux = baz;
+exports.quux = exports.baz = baz = 4;

--- a/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.symbols
+++ b/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.symbols
@@ -18,10 +18,23 @@ var buzz = 10;
 buzz += 3;
 >buzz : Symbol(buzz, Decl(server.ts, 7, 3))
 
-export { foo, baz, baz as quux, buzz };
->foo : Symbol(foo, Decl(server.ts, 10, 8))
->baz : Symbol(baz, Decl(server.ts, 10, 13))
->baz : Symbol(quux, Decl(server.ts, 10, 18))
->quux : Symbol(quux, Decl(server.ts, 10, 18))
->buzz : Symbol(buzz, Decl(server.ts, 10, 31))
+var bizz = 8;
+>bizz : Symbol(bizz, Decl(server.ts, 10, 3))
+
+bizz++; // compiles to exports.bizz = bizz += 1
+>bizz : Symbol(bizz, Decl(server.ts, 10, 3))
+
+bizz--; // similarly
+>bizz : Symbol(bizz, Decl(server.ts, 10, 3))
+
+++bizz; // compiles to exports.bizz = ++bizz
+>bizz : Symbol(bizz, Decl(server.ts, 10, 3))
+
+export { foo, baz, baz as quux, buzz, bizz };
+>foo : Symbol(foo, Decl(server.ts, 15, 8))
+>baz : Symbol(baz, Decl(server.ts, 15, 13))
+>baz : Symbol(quux, Decl(server.ts, 15, 18))
+>quux : Symbol(quux, Decl(server.ts, 15, 18))
+>buzz : Symbol(buzz, Decl(server.ts, 15, 31))
+>bizz : Symbol(bizz, Decl(server.ts, 15, 37))
 

--- a/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.symbols
+++ b/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.symbols
@@ -12,9 +12,16 @@ var baz = 3;
 baz = 4;
 >baz : Symbol(baz, Decl(server.ts, 4, 3))
 
-export { foo, baz, baz as quux };
->foo : Symbol(foo, Decl(server.ts, 7, 8))
->baz : Symbol(baz, Decl(server.ts, 7, 13))
->baz : Symbol(quux, Decl(server.ts, 7, 18))
->quux : Symbol(quux, Decl(server.ts, 7, 18))
+var buzz = 10;
+>buzz : Symbol(buzz, Decl(server.ts, 7, 3))
+
+buzz += 3;
+>buzz : Symbol(buzz, Decl(server.ts, 7, 3))
+
+export { foo, baz, baz as quux, buzz };
+>foo : Symbol(foo, Decl(server.ts, 10, 8))
+>baz : Symbol(baz, Decl(server.ts, 10, 13))
+>baz : Symbol(quux, Decl(server.ts, 10, 18))
+>quux : Symbol(quux, Decl(server.ts, 10, 18))
+>buzz : Symbol(buzz, Decl(server.ts, 10, 31))
 

--- a/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.symbols
+++ b/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.symbols
@@ -1,0 +1,20 @@
+=== tests/cases/compiler/server.ts ===
+
+var foo = 2;
+>foo : Symbol(foo, Decl(server.ts, 1, 3))
+
+foo = 3;
+>foo : Symbol(foo, Decl(server.ts, 1, 3))
+
+var baz = 3;
+>baz : Symbol(baz, Decl(server.ts, 4, 3))
+
+baz = 4;
+>baz : Symbol(baz, Decl(server.ts, 4, 3))
+
+export { foo, baz, baz as quux };
+>foo : Symbol(foo, Decl(server.ts, 7, 8))
+>baz : Symbol(baz, Decl(server.ts, 7, 13))
+>baz : Symbol(quux, Decl(server.ts, 7, 18))
+>quux : Symbol(quux, Decl(server.ts, 7, 18))
+

--- a/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.types
+++ b/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.types
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/server.ts ===
+
+var foo = 2;
+>foo : number
+>2 : number
+
+foo = 3;
+>foo = 3 : number
+>foo : number
+>3 : number
+
+var baz = 3;
+>baz : number
+>3 : number
+
+baz = 4;
+>baz = 4 : number
+>baz : number
+>4 : number
+
+export { foo, baz, baz as quux };
+>foo : number
+>baz : number
+>baz : number
+>quux : number
+

--- a/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.types
+++ b/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.types
@@ -18,9 +18,19 @@ baz = 4;
 >baz : number
 >4 : number
 
-export { foo, baz, baz as quux };
+var buzz = 10;
+>buzz : number
+>10 : number
+
+buzz += 3;
+>buzz += 3 : number
+>buzz : number
+>3 : number
+
+export { foo, baz, baz as quux, buzz };
 >foo : number
 >baz : number
 >baz : number
 >quux : number
+>buzz : number
 

--- a/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.types
+++ b/tests/baselines/reference/es6ExportClauseWithAssignmentInEs5.types
@@ -27,10 +27,27 @@ buzz += 3;
 >buzz : number
 >3 : number
 
-export { foo, baz, baz as quux, buzz };
+var bizz = 8;
+>bizz : number
+>8 : number
+
+bizz++; // compiles to exports.bizz = bizz += 1
+>bizz++ : number
+>bizz : number
+
+bizz--; // similarly
+>bizz-- : number
+>bizz : number
+
+++bizz; // compiles to exports.bizz = ++bizz
+>++bizz : number
+>bizz : number
+
+export { foo, baz, baz as quux, buzz, bizz };
 >foo : number
 >baz : number
 >baz : number
 >quux : number
 >buzz : number
+>bizz : number
 

--- a/tests/cases/compiler/es6ExportClauseWithAssignmentInEs5.ts
+++ b/tests/cases/compiler/es6ExportClauseWithAssignmentInEs5.ts
@@ -8,4 +8,7 @@ foo = 3;
 var baz = 3;
 baz = 4;
 
-export { foo, baz, baz as quux };
+var buzz = 10;
+buzz += 3;
+
+export { foo, baz, baz as quux, buzz };

--- a/tests/cases/compiler/es6ExportClauseWithAssignmentInEs5.ts
+++ b/tests/cases/compiler/es6ExportClauseWithAssignmentInEs5.ts
@@ -1,0 +1,11 @@
+// @target: es5
+// @module: commonjs
+
+// @filename: server.ts
+var foo = 2;
+foo = 3;
+
+var baz = 3;
+baz = 4;
+
+export { foo, baz, baz as quux };

--- a/tests/cases/compiler/es6ExportClauseWithAssignmentInEs5.ts
+++ b/tests/cases/compiler/es6ExportClauseWithAssignmentInEs5.ts
@@ -11,4 +11,9 @@ baz = 4;
 var buzz = 10;
 buzz += 3;
 
-export { foo, baz, baz as quux, buzz };
+var bizz = 8;
+bizz++; // compiles to exports.bizz = bizz += 1
+bizz--; // similarly
+++bizz; // compiles to exports.bizz = ++bizz
+
+export { foo, baz, baz as quux, buzz, bizz };


### PR DESCRIPTION
This Pull Request Fixes #8738.

When exporting a clause directly, TypeScript emits the member assignment to `exports` after the variable declaration of the member. This ignores all assignment statement afterwards.

Patch Summary:
When there is assignment operator expression `=, +=, etc`, check if the target is a member of export clause. If it is, make sure that the export clause is updated.

Behaviour before patch:
```
var foo = 2;
foo = 3;
export { foo }
```
compiles to
```
var foo = 2;
exports.foo = 2;
foo = 3;
```

Compile result after patch:
```
var foo = 2;
exports.foo = 2;
exports.foo = foo = 3;
```

Export alias are updated as well, I use the same code for variable declaration.
