### PR TITLE
[Transforms] Accept .js baselines when there are compiler's errors

### DIFF
--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -698,9 +698,6 @@ namespace ts {
         function visitClassDeclaration(node: ClassDeclaration): VisitResult<Statement> {
             const statements: Statement[] = [];
             const name = node.name || getGeneratedNameForNode(node);
-            // Set emitFlags on the name of the classDeclaration
-            // This is so that when printer will not substitute the identifier
-            setNodeEmitFlags(name, NodeEmitFlags.NoSubstitution);
             if (hasModifier(node, ModifierFlags.Export)) {
                 statements.push(
                     setOriginalNode(

--- a/tests/baselines/reference/defaultExportsCannotMerge02.js
+++ b/tests/baselines/reference/defaultExportsCannotMerge02.js
@@ -33,7 +33,7 @@ var Decl = (function () {
     return Decl;
 }());
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.default = Decl;
+exports.default = exports.Decl;
 //// [m2.js]
 "use strict";
 var m1_1 = require("m1");

--- a/tests/baselines/reference/defaultExportsCannotMerge04.js
+++ b/tests/baselines/reference/defaultExportsCannotMerge04.js
@@ -18,7 +18,7 @@ export interface Foo {
 function Foo() {
 }
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.default = Foo;
+exports.default = exports.Foo;
 var Foo;
 (function (Foo) {
-})(Foo || (Foo = {}));
+})(exports.Foo || (exports.Foo = {}));


### PR DESCRIPTION
Fix #8722 