### PR TITLE
Don't include imports in navigateTo if the imported declaration is also in the items and has the same name

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -6601,8 +6601,8 @@ namespace ts {
         /// NavigateTo
         function getNavigateToItems(searchValue: string, maxResultCount?: number): NavigateToItem[] {
             synchronizeHostData();
-
-            return ts.NavigateTo.getNavigateToItems(program, cancellationToken, searchValue, maxResultCount);
+            const checker = getProgram().getTypeChecker();
+            return ts.NavigateTo.getNavigateToItems(program, checker, cancellationToken, searchValue, maxResultCount);
         }
 
         function getEmitOutput(fileName: string): EmitOutput {

--- a/tests/cases/fourslash/navigateToImport.ts
+++ b/tests/cases/fourslash/navigateToImport.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: library.ts
+////export function foo() {}
+////export function bar() {}
+// @Filename: user.ts
+////import {foo, bar as baz} from './library';
+
+verify.navigationItemsListCount(1, "foo");
+verify.navigationItemsListContains("foo", "function", "foo", "exact");
+verify.navigationItemsListCount(1, "bar");
+verify.navigationItemsListContains("bar", "function", "bar", "exact");
+verify.navigationItemsListCount(1, "baz");
+verify.navigationItemsListContains("baz", "alias", "baz", "exact");


### PR DESCRIPTION
Fixes #6939