### PR TITLE
Make fourslash tests actually test parentName for navbar items

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1989,36 +1989,36 @@ namespace FourSlash {
             return result;
         }
 
-        public verifyNavigationBarContains(name: string, kind: string) {
-            const items = this.languageService.getNavigationBarItems(this.activeFile.fileName);
+        public verifyNavigationBarContains(name: string, kind: string, fileName?: string, parentName?: string, isAdditionalSpan?: boolean, markerPosition?: number) {
+            fileName = fileName || this.activeFile.fileName;
+            const items = this.languageService.getNavigationBarItems(fileName);
 
             if (!items || items.length === 0) {
                 this.raiseError("verifyNavigationBarContains failed - found 0 navigation items, expected at least one.");
             }
 
-            if (this.navigationBarItemsContains(items, name, kind)) {
+            if (this.navigationBarItemsContains(items, name, kind, parentName)) {
                 return;
             }
 
-            const missingItem = { name, kind };
+            const missingItem = { name, kind, parentName };
             this.raiseError(`verifyNavigationBarContains failed - could not find the item: ${JSON.stringify(missingItem, undefined, 2)} in the returned list: (${JSON.stringify(items, undefined, 2)})`);
         }
 
-        private navigationBarItemsContains(items: ts.NavigationBarItem[], name: string, kind: string) {
-            if (items) {
+        private navigationBarItemsContains(items: ts.NavigationBarItem[], name: string, kind: string, parentName?: string) {
+            function recur(items: ts.NavigationBarItem[], curParentName: string) {
                 for (let i = 0; i < items.length; i++) {
                     const item = items[i];
-                    if (item && item.text === name && item.kind === kind) {
+                    if (item && item.text === name && item.kind === kind && (!parentName || curParentName === parentName)) {
                         return true;
                     }
-
-                    if (this.navigationBarItemsContains(item.childItems, name, kind)) {
+                    if (recur(item.childItems, item.text)) {
                         return true;
                     }
                 }
+                return false;
             }
-
-            return false;
+            return recur(items, "");
         }
 
         public verifyNavigationBarChildItem(parent: string, name: string, kind: string) {
@@ -3055,7 +3055,7 @@ namespace FourSlashInterface {
             parentName?: string,
             isAdditionalSpan?: boolean,
             markerPosition?: number) {
-            this.state.verifyNavigationBarContains(name, kind);
+            this.state.verifyNavigationBarContains(name, kind, fileName, parentName, isAdditionalSpan, markerPosition);
         }
 
         public navigationBarChildItem(parent: string, name: string, kind: string) {

--- a/tests/cases/fourslash/navbar_const.ts
+++ b/tests/cases/fourslash/navbar_const.ts
@@ -1,6 +1,6 @@
 /// <reference path="fourslash.ts" />
 
-//// {| "itemName": "c", "kind": "const", "parentName": "" |}const c = 0;
+//// {| "itemName": "c", "kind": "const", "parentName": "<global>" |}const c = 0;
 
 test.markers().forEach(marker => {
     verify.navigationBarContains(

--- a/tests/cases/fourslash/navbar_contains-no-duplicates.ts
+++ b/tests/cases/fourslash/navbar_contains-no-duplicates.ts
@@ -1,6 +1,6 @@
 /// <reference path="fourslash.ts" />
 //// {| "itemName": "Windows", "kind": "module", "parentName": "" |}declare module Windows {
-////     {| "itemName": "Foundation", "kind": "module", "parentName": "Windows" |}export module Foundation {
+////     {| "itemName": "Foundation", "kind": "module", "parentName": "" |}export module Foundation {
 ////         export var {| "itemName": "A", "kind": "var" |}A;
 ////         {| "itemName": "Test", "kind": "class" |}export class Test {
 ////             {| "itemName": "wow", "kind": "method" |}public wow();
@@ -9,7 +9,7 @@
 //// }
 //// 
 //// {| "itemName": "Windows", "kind": "module", "parentName": "", "isAdditionalRange": true |}declare module Windows {
-////     {| "itemName": "Foundation", "kind": "module", "parentName": "Windows", "isAdditionalRange": true |}export module Foundation {
+////     {| "itemName": "Foundation", "kind": "module", "parentName": "", "isAdditionalRange": true |}export module Foundation {
 ////         export var {| "itemName": "B", "kind": "var" |}B;
 ////         {| "itemName": "Test", "kind": "module" |}export module Test {
 ////             {| "itemName": "Boom", "kind": "function" |}export function Boom(): number;

--- a/tests/cases/fourslash/navigationBarItemsInsideMethodsAndConstructors.ts
+++ b/tests/cases/fourslash/navigationBarItemsInsideMethodsAndConstructors.ts
@@ -2,11 +2,11 @@
 
 ////class Class {
 ////    constructor() {
-////        {| "itemName": "LocalFunctionInConstructor", "kind": "function", "parentName": "Class"|}function LocalFunctionInConstructor() {
+////        {| "itemName": "LocalFunctionInConstructor", "kind": "function", "parentName": "constructor"|}function LocalFunctionInConstructor() {
 ////
 ////        }
 ////
-////        {| "itemName": "LocalInterfaceInConstrcutor", "kind": "interface", "parentName": "foo"|}interface LocalInterfaceInConstrcutor {
+////        {| "itemName": "LocalInterfaceInConstrcutor", "kind": "interface", "parentName": ""|}interface LocalInterfaceInConstrcutor {
 ////        }
 ////
 ////        enum LocalEnumInConstructor {
@@ -15,17 +15,17 @@
 ////    }
 ////
 ////    method() {
-////        {| "itemName": "LocalFunctionInMethod", "kind": "function", "parentName": "foo"|}function LocalFunctionInMethod() {
-////            {| "itemName": "LocalFunctionInLocalFunctionInMethod", "kind": "function", "parentName": "bar"|}function LocalFunctionInLocalFunctionInMethod() {
+////        {| "itemName": "LocalFunctionInMethod", "kind": "function", "parentName": "method"|}function LocalFunctionInMethod() {
+////            {| "itemName": "LocalFunctionInLocalFunctionInMethod", "kind": "function", "parentName": "LocalFunctionInMethod"|}function LocalFunctionInLocalFunctionInMethod() {
 ////
 ////            }
 ////        }
 ////
-////        {| "itemName": "LocalInterfaceInMethod", "kind": "interface", "parentName": "foo"|}interface LocalInterfaceInMethod {
+////        {| "itemName": "LocalInterfaceInMethod", "kind": "interface", "parentName": ""|}interface LocalInterfaceInMethod {
 ////        }
 ////
-////        enum LocalEnumInMethod {
-////            {| "itemName": "LocalEnumMemberInMethod", "kind": "property", "parentName": "foo"|}LocalEnumMemberInMethod,
+////        {| "itemName": "LocalEnumInMethod", "kind": "enum", "parentName": ""|}enum LocalEnumInMethod {
+////            {| "itemName": "LocalEnumMemberInMethod", "kind": "property", "parentName": "LocalEnumInMethod"|}LocalEnumMemberInMethod,
 ////        }
 ////    }
 ////

--- a/tests/cases/fourslash/navigationBarItemsItems.ts
+++ b/tests/cases/fourslash/navigationBarItemsItems.ts
@@ -13,28 +13,28 @@
 ////{| "itemName": "Shapes", "kind": "module", "parentName": "" |}module Shapes {
 ////
 ////    // Class
-////    {| "itemName": "Point", "kind": "class", "parentName": "Shapes" |}export class Point implements IPoint {
-////        {| "itemName": "constructor", "kind": "constructor", "parentName": "Shapes.Point" |}constructor (public x: number, public y: number) { }
+////    {| "itemName": "Point", "kind": "class", "parentName": "" |}export class Point implements IPoint {
+////        {| "itemName": "constructor", "kind": "constructor", "parentName": "Point" |}constructor (public x: number, public y: number) { }
 ////
 ////        // Instance member
-////        {| "itemName": "getDist", "kind": "method", "parentName": "Shapes.Point" |}getDist() { return Math.sqrt(this.x * this.x + this.y * this.y); }
+////        {| "itemName": "getDist", "kind": "method", "parentName": "Point" |}getDist() { return Math.sqrt(this.x * this.x + this.y * this.y); }
 ////
 ////        // Getter
-////        {| "itemName": "value", "kind": "getter", "parentName": "Shapes.Point" |}get value(): number { return 0; }
+////        {| "itemName": "value", "kind": "getter", "parentName": "Point" |}get value(): number { return 0; }
 ////
 ////        // Setter
-////        {| "itemName": "value", "kind": "setter", "parentName": "Shapes.Point" |}set value(newValue: number) { return; }
+////        {| "itemName": "value", "kind": "setter", "parentName": "Point" |}set value(newValue: number) { return; }
 ////
 ////        // Static member
-////        {| "itemName": "origin", "kind": "property", "parentName": "Shapes.Point" |}static origin = new Point(0, 0);
+////        {| "itemName": "origin", "kind": "property", "parentName": "Point" |}static origin = new Point(0, 0);
 ////
 ////        // Static method
-////        {| "itemName": "getOrigin", "kind": "method", "parentName": "Shapes.Point" |}private static getOrigin() { return Point.origin;}
+////        {| "itemName": "getOrigin", "kind": "method", "parentName": "Point" |}private static getOrigin() { return Point.origin;}
 ////    }
 ////
-////    {| "itemName": "Values", "kind": "enum", "parentName": "Shapes" |}enum Values {
+////    {| "itemName": "Values", "kind": "enum", "parentName": "" |}enum Values {
 ////        value1,
-////        {| "itemName": "value2", "kind": "property", "parentName": "Shapes.Values" |}value2,
+////        {| "itemName": "value2", "kind": "property", "parentName": "Values" |}value2,
 ////        value3,
 ////    }
 ////}

--- a/tests/cases/fourslash/navigationBarItemsItemsExternalModules3.ts
+++ b/tests/cases/fourslash/navigationBarItemsItemsExternalModules3.ts
@@ -5,7 +5,7 @@
 ////    {| "itemName": "s", "kind": "property", "parentName": "Bar" |}public s: string;
 ////}
 ////{| "itemName": "\"my fil\\\"e\"", "kind": "module" |}
-////{| "itemName": "x", "kind": "var", "parentName": "\"file\"" |}
+////{| "itemName": "x", "kind": "var", "parentName": "\"my fil\\\"e\"" |}
 ////export var x: number;
 
 test.markers().forEach((marker) => {

--- a/tests/cases/fourslash/navigationBarItemsModules.ts
+++ b/tests/cases/fourslash/navigationBarItemsModules.ts
@@ -27,9 +27,9 @@
 ////
 ////{| "itemName": "A", "kind": "module" |}
 ////module A {
-////    {| "itemName": "B", "kind": "module", "parentName": "E" |}
+////    {| "itemName": "B", "kind": "module", "parentName": "" |}
 ////    module B {
-////        {| "itemName": "C", "kind": "module", "parentName": "F" |}
+////        {| "itemName": "C", "kind": "module", "parentName": "" |}
 ////        module C {
 ////            {| "itemName": "x", "kind": "var", "parentName": "C" |}
 ////            declare var x;

--- a/tests/cases/fourslash/server/navbar01.ts
+++ b/tests/cases/fourslash/server/navbar01.ts
@@ -13,28 +13,28 @@
 ////{| "itemName": "Shapes", "kind": "module", "parentName": "" |}module Shapes {
 ////
 ////    // Class
-////    {| "itemName": "Point", "kind": "class", "parentName": "Shapes" |}export class Point implements IPoint {
-////        {| "itemName": "constructor", "kind": "constructor", "parentName": "Shapes.Point" |}constructor (public x: number, public y: number) { }
+////    {| "itemName": "Point", "kind": "class", "parentName": "" |}export class Point implements IPoint {
+////        {| "itemName": "constructor", "kind": "constructor", "parentName": "Point" |}constructor (public x: number, public y: number) { }
 ////
 ////        // Instance member
-////        {| "itemName": "getDist", "kind": "method", "parentName": "Shapes.Point" |}getDist() { return Math.sqrt(this.x * this.x + this.y * this.y); }
+////        {| "itemName": "getDist", "kind": "method", "parentName": "Point" |}getDist() { return Math.sqrt(this.x * this.x + this.y * this.y); }
 ////
 ////        // Getter
-////        {| "itemName": "value", "kind": "getter", "parentName": "Shapes.Point" |}get value(): number { return 0; }
+////        {| "itemName": "value", "kind": "getter", "parentName": "Point" |}get value(): number { return 0; }
 ////
 ////        // Setter
-////        {| "itemName": "value", "kind": "setter", "parentName": "Shapes.Point" |}set value(newValue: number) { return; }
+////        {| "itemName": "value", "kind": "setter", "parentName": "Point" |}set value(newValue: number) { return; }
 ////
 ////        // Static member
-////        {| "itemName": "origin", "kind": "property", "parentName": "Shapes.Point" |}static origin = new Point(0, 0);
+////        {| "itemName": "origin", "kind": "property", "parentName": "Point" |}static origin = new Point(0, 0);
 ////
 ////        // Static method
-////        {| "itemName": "getOrigin", "kind": "method", "parentName": "Shapes.Point" |}private static getOrigin() { return Point.origin;}
+////        {| "itemName": "getOrigin", "kind": "method", "parentName": "Point" |}private static getOrigin() { return Point.origin;}
 ////    }
 ////
-////    {| "itemName": "Values", "kind": "enum", "parentName": "Shapes" |}enum Values {
+////    {| "itemName": "Values", "kind": "enum", "parentName": "" |}enum Values {
 ////        value1,
-////        {| "itemName": "value2", "kind": "property", "parentName": "Shapes.Values" |}value2,
+////        {| "itemName": "value2", "kind": "property", "parentName": "Values" |}value2,
 ////        value3,
 ////    }
 ////}


### PR DESCRIPTION
4 out of 6 parameters of `verify.navigationBarContains` were being ignored. Now we only ignore 2.
This highlights a few more issues that should be made:

1 Modules should have module children
    For example, see the 'Foundation' module in navbar_contains-no-duplicates
    and module B and module C in navibationBarItemsModules

2 Interfaces should be childItems
    For example, see LocalInterfaceInConstructor and LocalInterfaceInMethod in navigationBarItemsInsideMethodsAndConstructors

3 enums should be childItems
    For example, see LocalEnumInMethod in navigationBarItemsInsideMethodsAndConstructors
    and Values in navigationBarItemsItems
    and Values in navbar01

4 classes should be childItems
    See class Point in navigationBarItemsItems
    and Point in navbar01

5 Use (or get rid of) isAdditionalSpan and markerPosition
    isAdditionalSpan: not sure what this is supposed to mean.
    markerPosition: The value passed in is the index of the marker used, but not sure if it could be useful. Navigation bar items get sorted by name, not position.

