### PR TITLE
do not emit double assignment of class expressions.

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -5359,17 +5359,17 @@ const _super = (function (geti, seti) {
                         //
                         //  TypeScript                      | Javascript
                         //  --------------------------------|------------------------------------
-                        //  @dec                            | let C_1;
-                        //  class C {                       | let C = C_1 = class C {
-                        //    static x() { return C.y; }    |   static x() { return C_1.y; }
-                        //    static y = 1;                 | }
+                        //  @dec                            | let C_1 = class C {
+                        //  class C {                       |   static x() { return C_1.y; }
+                        //    static x() { return C.y; }    | }
+                        //    static y = 1;                 | let C = C_1;
                         //  }                               | C.y = 1;
                         //                                  | C = C_1 = __decorate([dec], C);
                         //  --------------------------------|------------------------------------
-                        //  @dec                            | let C_1;
-                        //  export class C {                | export let C = C_1 = class C {
-                        //    static x() { return C.y; }    |   static x() { return C_1.y; }
-                        //    static y = 1;                 | }
+                        //  @dec                            | let C_1 = class C {
+                        //  export class C {                |   static x() { return C_1.y; }
+                        //    static x() { return C.y; }    | }
+                        //    static y = 1;                 | export let C = C_1;
                         //  }                               | C.y = 1;
                         //                                  | C = C_1 = __decorate([dec], C);
                         //  ---------------------------------------------------------------------
@@ -5398,10 +5398,10 @@ const _super = (function (geti, seti) {
                         //
                         //  TypeScript                      | Javascript
                         //  --------------------------------|------------------------------------
-                        //  @dec                            | let C_1;
-                        //  export default class C {        | let C = C_1 = class C {
-                        //    static x() { return C.y; }    |   static x() { return C_1.y; }
-                        //    static y = 1;                 | }
+                        //  @dec                            | let C_1 = class C {
+                        //  export default class C {        |   static x() { return C_1.y; }
+                        //    static x() { return C.y; }    | };
+                        //    static y = 1;                 | let C = C_1;
                         //  }                               | C.y = 1;
                         //                                  | C = C_1 = __decorate([dec], C);
                         //                                  | export default C;
@@ -5410,25 +5410,25 @@ const _super = (function (geti, seti) {
                         //
 
                         // NOTE: we reuse the same rewriting logic for cases when targeting ES6 and module kind is System.
-                        // Because of hoisting top level class declaration need to be emitted as class expressions. 
+                        // Because of hoisting top level class declaration need to be emitted as class expressions.
                         // Double bind case is only required if node is decorated.
                         if (isDecorated && resolver.getNodeCheckFlags(node) & NodeCheckFlags.ClassWithBodyScopedClassBinding) {
                             decoratedClassAlias = unescapeIdentifier(makeUniqueName(node.name ? node.name.text : "default"));
                             decoratedClassAliases[getNodeId(node)] = decoratedClassAlias;
-                            write(`let ${decoratedClassAlias};`);
-                            writeLine();
                         }
 
-                        if (isES6ExportedDeclaration(node) && !(node.flags & NodeFlags.Default)) {
+                        if (isES6ExportedDeclaration(node) && !(node.flags & NodeFlags.Default) && decoratedClassAlias === undefined) {
                             write("export ");
                         }
 
                         if (!isHoistedDeclarationInSystemModule) {
                             write("let ");
                         }
-                        emitDeclarationName(node);
                         if (decoratedClassAlias !== undefined) {
-                            write(` = ${decoratedClassAlias}`);
+                            write(`${decoratedClassAlias}`);
+                        }
+                        else {
+                            emitDeclarationName(node);
                         }
 
                         write(" = ");
@@ -5490,6 +5490,16 @@ const _super = (function (geti, seti) {
                 emitToken(SyntaxKind.CloseBraceToken, node.members.end);
 
                 if (rewriteAsClassExpression) {
+                    if (decoratedClassAlias !== undefined) {
+                        write(";");
+                        writeLine();
+                        if (isES6ExportedDeclaration(node) && !(node.flags & NodeFlags.Default)) {
+                            write("export ");
+                        }
+                        write("let ");
+                        emitDeclarationName(node);
+                        write(` = ${decoratedClassAlias}`);
+                    }
                     decoratedClassAliases[getNodeId(node)] = undefined;
                     write(";");
                 }

--- a/tests/baselines/reference/decoratorOnClass5.es6.js
+++ b/tests/baselines/reference/decoratorOnClass5.es6.js
@@ -16,10 +16,10 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-let C_1;
-let C = C_1 = class C {
+let C_1 = class C {
     static x() { return C_1.y; }
 };
+let C = C_1;
 C.y = 1;
 C = C_1 = __decorate([
     dec

--- a/tests/baselines/reference/decoratorOnClass6.es6.js
+++ b/tests/baselines/reference/decoratorOnClass6.es6.js
@@ -16,10 +16,10 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-let C_1;
-export let C = C_1 = class C {
+let C_1 = class C {
     static x() { return C_1.y; }
 };
+export let C = C_1;
 C.y = 1;
 C = C_1 = __decorate([
     dec

--- a/tests/baselines/reference/decoratorOnClass7.es6.js
+++ b/tests/baselines/reference/decoratorOnClass7.es6.js
@@ -16,10 +16,10 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-let C_1;
-let C = C_1 = class C {
+let C_1 = class C {
     static x() { return C_1.y; }
 };
+let C = C_1;
 C.y = 1;
 C = C_1 = __decorate([
     dec


### PR DESCRIPTION
Closure compiler ES6 support rejects expressions of the form `let A = B
= class {}`

With a small rewriting of the emitted code the case of decorated and
statically referenced classes, TypeScript ES6 emit satisfies this
requirement.

Before:
let C_1;
let C = C_1 = class C {};

After:
let C_1 = class C {};
let C = C_1;