### PR TITLE
Recognize '-?' / '--?' in tsc

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -38,6 +38,11 @@ namespace ts {
             description: Diagnostics.Print_this_message,
         },
         {
+            name: "help",
+            shortName: "?",
+            type: "boolean"
+        },
+        {
             name: "init",
             type: "boolean",
             description: Diagnostics.Initializes_a_TypeScript_project_and_creates_a_tsconfig_json_file,


### PR DESCRIPTION
Once a week this happens to me

> `> tsc --?`
>   `error TS5023: Unknown compiler option '?'.`

:rage: 

> `> tsc --help`