### PR TITLE
Do not resolve alias when getting symbol of import equal's right hand side

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1154,11 +1154,7 @@ namespace ts {
         }
 
         // This function is only for imports with entity names
-        function getSymbolOfPartOfRightHandSideOfImportEquals(entityName: EntityName, importDeclaration?: ImportEqualsDeclaration): Symbol {
-            if (!importDeclaration) {
-                importDeclaration = <ImportEqualsDeclaration>getAncestor(entityName, SyntaxKind.ImportEqualsDeclaration);
-                Debug.assert(importDeclaration !== undefined);
-            }
+        function getSymbolOfPartOfRightHandSideOfImportEquals(entityName: EntityName, importDeclaration: ImportEqualsDeclaration, dontResolveAlias?: boolean): Symbol {
             // There are three things we might try to look for. In the following examples,
             // the search term is enclosed in |...|:
             //
@@ -1170,13 +1166,13 @@ namespace ts {
             }
             // Check for case 1 and 3 in the above example
             if (entityName.kind === SyntaxKind.Identifier || entityName.parent.kind === SyntaxKind.QualifiedName) {
-                return resolveEntityName(entityName, SymbolFlags.Namespace);
+                return resolveEntityName(entityName, SymbolFlags.Namespace, /*ignoreErrors*/ false, dontResolveAlias);
             }
             else {
                 // Case 2 in above example
                 // entityName.kind could be a QualifiedName or a Missing identifier
                 Debug.assert(entityName.parent.kind === SyntaxKind.ImportEqualsDeclaration);
-                return resolveEntityName(entityName, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace);
+                return resolveEntityName(entityName, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace, /*ignoreErrors*/ false, dontResolveAlias);
             }
         }
 
@@ -1185,7 +1181,7 @@ namespace ts {
         }
 
         // Resolves a qualified name and any involved aliases
-        function resolveEntityName(name: EntityName | Expression, meaning: SymbolFlags, ignoreErrors?: boolean): Symbol {
+        function resolveEntityName(name: EntityName | Expression, meaning: SymbolFlags, ignoreErrors?: boolean, dontResolveAlias?: boolean): Symbol {
             if (nodeIsMissing(name)) {
                 return undefined;
             }
@@ -1219,7 +1215,7 @@ namespace ts {
                 Debug.fail("Unknown entity name kind.");
             }
             Debug.assert((symbol.flags & SymbolFlags.Instantiated) === 0, "Should never get an instantiated symbol here.");
-            return symbol.flags & meaning ? symbol : resolveAlias(symbol);
+            return (symbol.flags & meaning) || dontResolveAlias ? symbol : resolveAlias(symbol);
         }
 
         function resolveExternalModuleName(location: Node, moduleReferenceExpression: Expression): Symbol {
@@ -16441,7 +16437,9 @@ namespace ts {
             if (entityName.kind !== SyntaxKind.PropertyAccessExpression) {
                 if (isInRightSideOfImportOrExportAssignment(<EntityName>entityName)) {
                     // Since we already checked for ExportAssignment, this really could only be an Import
-                    return getSymbolOfPartOfRightHandSideOfImportEquals(<EntityName>entityName);
+                    const importEqualsDeclaration = <ImportEqualsDeclaration>getAncestor(entityName, SyntaxKind.ImportEqualsDeclaration);
+                    Debug.assert(importEqualsDeclaration !== undefined);
+                    return getSymbolOfPartOfRightHandSideOfImportEquals(<EntityName>entityName, importEqualsDeclaration, /*dontResolveAlias*/ true);
                 }
             }
 
@@ -16531,9 +16529,7 @@ namespace ts {
 
             if (node.kind === SyntaxKind.Identifier) {
                 if (isInRightSideOfImportOrExportAssignment(<Identifier>node)) {
-                    return node.parent.kind === SyntaxKind.ExportAssignment
-                        ? getSymbolOfEntityNameOrPropertyAccessExpression(<Identifier>node)
-                        : getSymbolOfPartOfRightHandSideOfImportEquals(<Identifier>node);
+                    return getSymbolOfEntityNameOrPropertyAccessExpression(<Identifier>node);
                 }
                 else if (node.parent.kind === SyntaxKind.BindingElement &&
                     node.parent.parent.kind === SyntaxKind.ObjectBindingPattern &&

--- a/tests/baselines/reference/acceptableAlias1.symbols
+++ b/tests/baselines/reference/acceptableAlias1.symbols
@@ -13,5 +13,5 @@ module M {
 import r = M.X;
 >r : Symbol(r, Decl(acceptableAlias1.ts, 4, 1))
 >M : Symbol(M, Decl(acceptableAlias1.ts, 0, 0))
->X : Symbol(r, Decl(acceptableAlias1.ts, 0, 10))
+>X : Symbol(M.X, Decl(acceptableAlias1.ts, 2, 5))
 

--- a/tests/baselines/reference/amdImportNotAsPrimaryExpression.symbols
+++ b/tests/baselines/reference/amdImportNotAsPrimaryExpression.symbols
@@ -5,7 +5,7 @@ import foo = require("./foo_0");
 // None of the below should cause a runtime dependency on foo_0
 import f = foo.M1;
 >f : Symbol(f, Decl(foo_1.ts, 0, 32))
->foo : Symbol(foo, Decl(foo_0.ts, 0, 0))
+>foo : Symbol(foo, Decl(foo_1.ts, 0, 0))
 >M1 : Symbol(foo.M1, Decl(foo_0.ts, 8, 1))
 
 var i: f.I2;

--- a/tests/baselines/reference/chainedImportAlias.symbols
+++ b/tests/baselines/reference/chainedImportAlias.symbols
@@ -4,7 +4,7 @@ import x = require('./chainedImportAlias_file0');
 
 import y = x;
 >y : Symbol(y, Decl(chainedImportAlias_file1.ts, 0, 49))
->x : Symbol(x, Decl(chainedImportAlias_file0.ts, 0, 0))
+>x : Symbol(x, Decl(chainedImportAlias_file1.ts, 0, 0))
 
 y.m.foo();
 >y.m.foo : Symbol(x.m.foo, Decl(chainedImportAlias_file0.ts, 0, 17))

--- a/tests/baselines/reference/commonJSImportNotAsPrimaryExpression.symbols
+++ b/tests/baselines/reference/commonJSImportNotAsPrimaryExpression.symbols
@@ -5,7 +5,7 @@ import foo = require("./foo_0");
 // None of the below should cause a runtime dependency on foo_0
 import f = foo.M1;
 >f : Symbol(f, Decl(foo_1.ts, 0, 32))
->foo : Symbol(foo, Decl(foo_0.ts, 0, 0))
+>foo : Symbol(foo, Decl(foo_1.ts, 0, 0))
 >M1 : Symbol(foo.M1, Decl(foo_0.ts, 8, 1))
 
 var i: f.I2;

--- a/tests/baselines/reference/declFileForExportedImport.symbols
+++ b/tests/baselines/reference/declFileForExportedImport.symbols
@@ -11,7 +11,7 @@ var y = a.x;
 
 export import b = a;
 >b : Symbol(b, Decl(declFileForExportedImport_1.ts, 2, 12))
->a : Symbol(a, Decl(declFileForExportedImport_0.ts, 0, 0))
+>a : Symbol(a, Decl(declFileForExportedImport_1.ts, 0, 0))
 
 var z = b.x;
 >z : Symbol(z, Decl(declFileForExportedImport_1.ts, 5, 3))

--- a/tests/baselines/reference/declFileImportChainInExportAssignment.symbols
+++ b/tests/baselines/reference/declFileImportChainInExportAssignment.symbols
@@ -17,7 +17,7 @@ import a = m.c;
 
 import b = a;
 >b : Symbol(b, Decl(declFileImportChainInExportAssignment.ts, 6, 15))
->a : Symbol(a, Decl(declFileImportChainInExportAssignment.ts, 0, 10))
+>a : Symbol(a, Decl(declFileImportChainInExportAssignment.ts, 5, 1))
 
 export = b;
 >b : Symbol(b, Decl(declFileImportChainInExportAssignment.ts, 6, 15))

--- a/tests/baselines/reference/declarationEmit_nameConflicts.symbols
+++ b/tests/baselines/reference/declarationEmit_nameConflicts.symbols
@@ -37,7 +37,7 @@ export module M {
 
     export import d = im;
 >d : Symbol(d, Decl(declarationEmit_nameConflicts_0.ts, 11, 24))
->im : Symbol(d, Decl(declarationEmit_nameConflicts_1.ts, 0, 0))
+>im : Symbol(im, Decl(declarationEmit_nameConflicts_0.ts, 0, 0))
 }
 
 export module M.P {

--- a/tests/baselines/reference/dependencyViaImportAlias.symbols
+++ b/tests/baselines/reference/dependencyViaImportAlias.symbols
@@ -4,7 +4,7 @@ import a = require('A');
 
 import A = a.A;
 >A : Symbol(A, Decl(B.ts, 0, 24))
->a : Symbol(a, Decl(A.ts, 0, 0))
+>a : Symbol(a, Decl(B.ts, 0, 0))
 >A : Symbol(a.A, Decl(A.ts, 0, 0))
 
 export = A;

--- a/tests/baselines/reference/es6ImportNamedImportInIndirectExportAssignment.symbols
+++ b/tests/baselines/reference/es6ImportNamedImportInIndirectExportAssignment.symbols
@@ -14,7 +14,7 @@ import { a } from "./es6ImportNamedImportInIndirectExportAssignment_0";
 
 import x = a;
 >x : Symbol(x, Decl(es6ImportNamedImportInIndirectExportAssignment_1.ts, 0, 71))
->a : Symbol(a, Decl(es6ImportNamedImportInIndirectExportAssignment_0.ts, 0, 0))
+>a : Symbol(a, Decl(es6ImportNamedImportInIndirectExportAssignment_1.ts, 0, 8))
 
 export = x;
 >x : Symbol(x, Decl(es6ImportNamedImportInIndirectExportAssignment_1.ts, 0, 71))

--- a/tests/baselines/reference/externalModuleReferenceDoubleUnderscore1.symbols
+++ b/tests/baselines/reference/externalModuleReferenceDoubleUnderscore1.symbols
@@ -5,7 +5,7 @@ declare module 'timezonecomplete' {
 
     export import TimeUnit = basics.TimeUnit;
 >TimeUnit : Symbol(TimeUnit, Decl(externalModuleReferenceDoubleUnderscore1.ts, 1, 57))
->basics : Symbol(basics, Decl(externalModuleReferenceDoubleUnderscore1.ts, 3, 1))
+>basics : Symbol(basics, Decl(externalModuleReferenceDoubleUnderscore1.ts, 0, 35))
 >TimeUnit : Symbol(basics.TimeUnit, Decl(externalModuleReferenceDoubleUnderscore1.ts, 5, 44))
 }
 

--- a/tests/baselines/reference/importAliasAnExternalModuleInsideAnInternalModule.symbols
+++ b/tests/baselines/reference/importAliasAnExternalModuleInsideAnInternalModule.symbols
@@ -8,7 +8,7 @@ module m_private {
     //import r2 = require('m'); // would be error
     export import C = r; // no error
 >C : Symbol(C, Decl(importAliasAnExternalModuleInsideAnInternalModule_file1.ts, 1, 18))
->r : Symbol(C, Decl(importAliasAnExternalModuleInsideAnInternalModule_file0.ts, 0, 0))
+>r : Symbol(r, Decl(importAliasAnExternalModuleInsideAnInternalModule_file1.ts, 0, 0))
 
     C.m.foo();
 >C.m.foo : Symbol(C.m.foo, Decl(importAliasAnExternalModuleInsideAnInternalModule_file0.ts, 0, 17))

--- a/tests/baselines/reference/import_reference-exported-alias.symbols
+++ b/tests/baselines/reference/import_reference-exported-alias.symbols
@@ -4,12 +4,12 @@ import appJs = require("file1");
 
 import Services = appJs.Services;
 >Services : Symbol(Services, Decl(file2.ts, 0, 32))
->appJs : Symbol(appJs, Decl(file1.ts, 0, 0))
+>appJs : Symbol(appJs, Decl(file2.ts, 0, 0))
 >Services : Symbol(appJs.Services, Decl(file1.ts, 0, 12))
 
 import UserServices = Services.UserServices;
 >UserServices : Symbol(UserServices, Decl(file2.ts, 1, 33))
->Services : Symbol(appJs.Services, Decl(file1.ts, 0, 12))
+>Services : Symbol(Services, Decl(file2.ts, 0, 32))
 >UserServices : Symbol(Services.UserServices, Decl(file1.ts, 1, 28))
 
 var x = new UserServices().getUserName();

--- a/tests/baselines/reference/import_reference-to-type-alias.symbols
+++ b/tests/baselines/reference/import_reference-to-type-alias.symbols
@@ -4,7 +4,7 @@ import appJs = require("file1");
 
 import Services = appJs.App.Services;
 >Services : Symbol(Services, Decl(file2.ts, 0, 32))
->appJs : Symbol(appJs, Decl(file1.ts, 0, 0))
+>appJs : Symbol(appJs, Decl(file2.ts, 0, 0))
 >App : Symbol(appJs.App, Decl(file1.ts, 0, 0))
 >Services : Symbol(Services, Decl(file1.ts, 0, 19))
 

--- a/tests/baselines/reference/importedAliasesInTypePositions.symbols
+++ b/tests/baselines/reference/importedAliasesInTypePositions.symbols
@@ -4,7 +4,7 @@ import RT_ALIAS = require("file1");
 
 import ReferredTo = RT_ALIAS.elaborate.nested.mod.name.ReferredTo;
 >ReferredTo : Symbol(ReferredTo, Decl(file2.ts, 0, 35))
->RT_ALIAS : Symbol(RT_ALIAS, Decl(file1.ts, 0, 0))
+>RT_ALIAS : Symbol(RT_ALIAS, Decl(file2.ts, 0, 0))
 >elaborate : Symbol(RT_ALIAS.elaborate, Decl(file1.ts, 0, 0))
 >nested : Symbol(RT_ALIAS.elaborate.nested, Decl(file1.ts, 0, 24))
 >mod : Symbol(RT_ALIAS.elaborate.nested.mod, Decl(file1.ts, 0, 31))

--- a/tests/baselines/reference/tsxPreserveEmit1.symbols
+++ b/tests/baselines/reference/tsxPreserveEmit1.symbols
@@ -8,7 +8,7 @@ import ReactRouter = require('react-router');
 
 import Route = ReactRouter.Route;
 >Route : Symbol(Route, Decl(test.tsx, 2, 45))
->ReactRouter : Symbol(ReactRouter, Decl(react.d.ts, 4, 1))
+>ReactRouter : Symbol(ReactRouter, Decl(test.tsx, 1, 32))
 >Route : Symbol(ReactRouter.Route, Decl(react.d.ts, 7, 4))
 
 var routes1 = <Route />;

--- a/tests/cases/fourslash/renameAlias.ts
+++ b/tests/cases/fourslash/renameAlias.ts
@@ -1,0 +1,11 @@
+/// <reference path='fourslash.ts'/>
+
+////module SomeModule { export class SomeClass { } }
+////import [|M|] = SomeModule;
+////import C = [|M|].SomeClass;
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}

--- a/tests/cases/fourslash/renameAlias2.ts
+++ b/tests/cases/fourslash/renameAlias2.ts
@@ -1,0 +1,11 @@
+/// <reference path='fourslash.ts'/>
+
+////module [|SomeModule|] { export class SomeClass { } }
+////import M = [|SomeModule|];
+////import C = M.SomeClass;
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}

--- a/tests/cases/fourslash/renameAlias3.ts
+++ b/tests/cases/fourslash/renameAlias3.ts
@@ -1,0 +1,11 @@
+/// <reference path='fourslash.ts'/>
+
+////module SomeModule { export class [|SomeClass|] { } }
+////import M = SomeModule;
+////import C = M.[|SomeClass|];
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}

--- a/tests/cases/fourslash/renameAliasExternalModule.ts
+++ b/tests/cases/fourslash/renameAliasExternalModule.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts'/>
+
+// @Filename: a.ts
+////module SomeModule { export class SomeClass { } }
+////export = SomeModule;
+
+// @Filename: b.ts
+////import [|M|] = require("./a");
+////import C = [|M|].SomeClass;
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.file(range.fileName);
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}

--- a/tests/cases/fourslash/renameAliasExternalModule2.ts
+++ b/tests/cases/fourslash/renameAliasExternalModule2.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts'/>
+
+// @Filename: a.ts
+////module [|SomeModule|] { export class SomeClass { } }
+////export = [|SomeModule|];
+
+// @Filename: b.ts
+////import M = require("./a");
+////import C = M.SomeClass;
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.file(range.fileName);
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}

--- a/tests/cases/fourslash/renameAliasExternalModule3.ts
+++ b/tests/cases/fourslash/renameAliasExternalModule3.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts'/>
+
+// @Filename: a.ts
+////module SomeModule { export class [|SomeClass|] { } }
+////export = SomeModule;
+
+// @Filename: b.ts
+////import M = require("./a");
+////import C = M.[|SomeClass|];
+
+let ranges = test.ranges()
+for (let range of ranges) {
+    goTo.file(range.fileName);
+    goTo.position(range.start);
+    verify.renameLocations(/*findInStrings*/ false, /*findInComments*/ false);
+}


### PR DESCRIPTION
This helps searching correct symbols when renaming.
Fixes #5501