### PR TITLE
[Transforms] Fix incorrect emit of capture block scoped variables in static properties of classExpression

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -907,9 +907,10 @@ function runConsoleTests(defaultReporter, defaultSubsets, dirty) {
         tests = subsetRegex ? ' -g "' + subsetRegex + '"' : '';
         var cmd = "mocha" + (debug ? " --debug-brk" : "") + " -R " + reporter + tests + colors + ' -t ' + testTimeout + ' ' + run;
         console.log(cmd);
+        var start = new Date();
         exec(cmd, function () {
             deleteTemporaryProjectOutput();
-            if (i === 0 && !dirty) {
+            /*if (i === 0 && !dirty) {
                 var lint = jake.Task['lint'];
                 lint.addListener('complete', function () {
                     complete();
@@ -918,8 +919,11 @@ function runConsoleTests(defaultReporter, defaultSubsets, dirty) {
             }
             else {
                 complete();
-            }
+            }*/
+            var finish = new Date();
+            console.log("Execution time of", subsetRegex, ":", (finish.getTime() - start.getTime()), "ms");
         });
+
     });
 }
 

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -711,16 +711,61 @@ namespace ts {
             );
 
             if (staticProperties.length > 0) {
-                const expressions: Expression[] = [];
-                const temp = createTempVariable(hoistVariableDeclaration);
+                /* If classExpression contains static properties that capture block-scoped binding, we will need to
+                 * wrap classExpression and its static properties initializers in an IIFE. Transforms this:
+                 * for (let i = 0; i < 3; i++) {
+                 *    arr.push(class C {
+                 *        static x = i;
+                 *        static y = () => C.x * 2;
+                 *    });
+                 * }
+                 * Into this:
+                 * for (let i = 0; i < 3; i++) {
+                 *     arr.push((() => {
+                 *         let _a = class C {
+                 *            };
+                 *        _a.x = i;
+                 *        _a.y = () => _a.x * 2;
+                 *        return _a;
+                 *     })());
+                 * }
+                 */
+                if (resolver.getNodeCheckFlags(classExpression) & NodeCheckFlags.ClassExpressionWithCapturedBlockScopedBinding) {
+                    const statements: Statement[] = [];
+                    const temp = createTempVariable(/*recordTempVariable*/ undefined);
+                    setNodeEmitFlags(classExpression, NodeEmitFlags.Indented | getNodeEmitFlags(classExpression));
+                    addNode(statements,
+                        createVariableStatement(
+                            /*modifier*/ undefined,
+                            createLetDeclarationList([createVariableDeclaration(temp, /*initializer*/ classExpression)])
+                        ),
+                        /*startOnNewLine*/ true
+                    );
+                    const staticPropertiesInitializedExpressions = generateInitializedPropertyExpressions(node, staticProperties, temp);
+                    for (let expression of staticPropertiesInitializedExpressions) {
+                        addNode(statements, createStatement(expression), /*startOnNewLine*/ true);
+                    }
+                    addNode(statements, createReturn(temp), /*startOnNewLine*/ true);
+                    return createCall(
+                            createArrowFunction(
+                                /*parameters*/[],
+                                createBlock(statements)
+                            ),
+                            /*argumentsArray*/[]
+                        )
+                }
+                else {
+                    const expressions: Expression[] = [];
+                    const temp = createTempVariable(hoistVariableDeclaration);
 
-                // To preserve the behavior of the old emitter, we explicitly indent
-                // the body of a class with static initializers.
-                setNodeEmitFlags(classExpression, NodeEmitFlags.Indented | getNodeEmitFlags(classExpression));
-                addNode(expressions, createAssignment(temp, classExpression), true);
-                addNodes(expressions, generateInitializedPropertyExpressions(node, staticProperties, temp), true);
-                addNode(expressions, temp, true);
-                return inlineExpressions(expressions);
+                    // To preserve the behavior of the old emitter, we explicitly indent
+                    // the body of a class with static initializers.
+                    setNodeEmitFlags(classExpression, NodeEmitFlags.Indented | getNodeEmitFlags(classExpression));
+                    addNode(expressions, createAssignment(temp, classExpression), /*startOnNewLine*/ true);
+                    addNodes(expressions, generateInitializedPropertyExpressions(node, staticProperties, temp), /*startOnNewLine*/ true);
+                    addNode(expressions, temp, /*startOnNewLine*/ true);
+                    return inlineExpressions(expressions);
+                }
             }
 
             return classExpression;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2141,6 +2141,7 @@ namespace ts {
         DecoratedClassWithSelfReference     = 0x00080000, // Decorated class that contains a binding to itself inside of the class body.
         SelfReferenceInDecoratedClass       = 0x00100000, // Binding to a decorated class inside of the class's body.
         NeedsLoopOutParameter               = 0x00200000, // Block scoped binding whose value should be explicitly copied outside of the converted loop
+        ClassExpressionWithCapturedBlockScopedBinding = 0x00400000, // ClassExpression that contains block scoped variables
     }
 
     /* @internal */

--- a/tests/baselines/reference/classExpressionWithStaticPropertiesES63.js
+++ b/tests/baselines/reference/classExpressionWithStaticPropertiesES63.js
@@ -1,0 +1,23 @@
+//// [classExpressionWithStaticPropertiesES63.ts]
+declare var console: any;
+const arr: any[] = [];
+for (let i = 0; i < 3; i++) {
+    arr.push(class C {
+        static x = i;
+        static y = () => C.x * 2;
+    });
+}
+arr.forEach(C => console.log(C.y()));
+
+//// [classExpressionWithStaticPropertiesES63.js]
+const arr = [];
+for (let i = 0; i < 3; i++) {
+    arr.push((() => {
+        let _a = class C {
+            };
+        _a.x = i;
+        _a.y = () => C.x * 2;
+        return _a;
+    })());
+}
+arr.forEach(C => console.log(C.y()));

--- a/tests/baselines/reference/classExpressionWithStaticPropertiesES63.symbols
+++ b/tests/baselines/reference/classExpressionWithStaticPropertiesES63.symbols
@@ -1,0 +1,38 @@
+=== tests/cases/compiler/classExpressionWithStaticPropertiesES63.ts ===
+declare var console: any;
+>console : Symbol(console, Decl(classExpressionWithStaticPropertiesES63.ts, 0, 11))
+
+const arr: any[] = [];
+>arr : Symbol(arr, Decl(classExpressionWithStaticPropertiesES63.ts, 1, 5))
+
+for (let i = 0; i < 3; i++) {
+>i : Symbol(i, Decl(classExpressionWithStaticPropertiesES63.ts, 2, 8))
+>i : Symbol(i, Decl(classExpressionWithStaticPropertiesES63.ts, 2, 8))
+>i : Symbol(i, Decl(classExpressionWithStaticPropertiesES63.ts, 2, 8))
+
+    arr.push(class C {
+>arr.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(classExpressionWithStaticPropertiesES63.ts, 1, 5))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>C : Symbol(C, Decl(classExpressionWithStaticPropertiesES63.ts, 3, 13))
+
+        static x = i;
+>x : Symbol(C.x, Decl(classExpressionWithStaticPropertiesES63.ts, 3, 22))
+>i : Symbol(i, Decl(classExpressionWithStaticPropertiesES63.ts, 2, 8))
+
+        static y = () => C.x * 2;
+>y : Symbol(C.y, Decl(classExpressionWithStaticPropertiesES63.ts, 4, 21))
+>C.x : Symbol(C.x, Decl(classExpressionWithStaticPropertiesES63.ts, 3, 22))
+>C : Symbol(C, Decl(classExpressionWithStaticPropertiesES63.ts, 3, 13))
+>x : Symbol(C.x, Decl(classExpressionWithStaticPropertiesES63.ts, 3, 22))
+
+    });
+}
+arr.forEach(C => console.log(C.y()));
+>arr.forEach : Symbol(Array.forEach, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(classExpressionWithStaticPropertiesES63.ts, 1, 5))
+>forEach : Symbol(Array.forEach, Decl(lib.es5.d.ts, --, --))
+>C : Symbol(C, Decl(classExpressionWithStaticPropertiesES63.ts, 8, 12))
+>console : Symbol(console, Decl(classExpressionWithStaticPropertiesES63.ts, 0, 11))
+>C : Symbol(C, Decl(classExpressionWithStaticPropertiesES63.ts, 8, 12))
+

--- a/tests/baselines/reference/classExpressionWithStaticPropertiesES63.types
+++ b/tests/baselines/reference/classExpressionWithStaticPropertiesES63.types
@@ -1,0 +1,56 @@
+=== tests/cases/compiler/classExpressionWithStaticPropertiesES63.ts ===
+declare var console: any;
+>console : any
+
+const arr: any[] = [];
+>arr : any[]
+>[] : undefined[]
+
+for (let i = 0; i < 3; i++) {
+>i : number
+>0 : number
+>i < 3 : boolean
+>i : number
+>3 : number
+>i++ : number
+>i : number
+
+    arr.push(class C {
+>arr.push(class C {        static x = i;        static y = () => C.x * 2;    }) : number
+>arr.push : (...items: any[]) => number
+>arr : any[]
+>push : (...items: any[]) => number
+>class C {        static x = i;        static y = () => C.x * 2;    } : typeof C
+>C : typeof C
+
+        static x = i;
+>x : number
+>i : number
+
+        static y = () => C.x * 2;
+>y : () => number
+>() => C.x * 2 : () => number
+>C.x * 2 : number
+>C.x : number
+>C : typeof C
+>x : number
+>2 : number
+
+    });
+}
+arr.forEach(C => console.log(C.y()));
+>arr.forEach(C => console.log(C.y())) : void
+>arr.forEach : (callbackfn: (value: any, index: number, array: any[]) => void, thisArg?: any) => void
+>arr : any[]
+>forEach : (callbackfn: (value: any, index: number, array: any[]) => void, thisArg?: any) => void
+>C => console.log(C.y()) : (C: any) => any
+>C : any
+>console.log(C.y()) : any
+>console.log : any
+>console : any
+>log : any
+>C.y() : any
+>C.y : any
+>C : any
+>y : any
+

--- a/tests/baselines/reference/classExpressionWithStaticPropertiesES64.js
+++ b/tests/baselines/reference/classExpressionWithStaticPropertiesES64.js
@@ -1,0 +1,23 @@
+//// [classExpressionWithStaticPropertiesES64.ts]
+declare var console: any;
+const arr: any[] = [];
+for (let i = 0; i < 3; i++) {
+    arr.push((class C {
+        static x = i;
+        static y = () => C.x * 2;
+    }), i);
+}
+arr.forEach(C => console.log(C.y()));
+
+//// [classExpressionWithStaticPropertiesES64.js]
+const arr = [];
+for (let i = 0; i < 3; i++) {
+    arr.push(((() => {
+        let _a = class C {
+            };
+        _a.x = i;
+        _a.y = () => C.x * 2;
+        return _a;
+    })()), i);
+}
+arr.forEach(C => console.log(C.y()));

--- a/tests/baselines/reference/classExpressionWithStaticPropertiesES64.symbols
+++ b/tests/baselines/reference/classExpressionWithStaticPropertiesES64.symbols
@@ -1,0 +1,39 @@
+=== tests/cases/compiler/classExpressionWithStaticPropertiesES64.ts ===
+declare var console: any;
+>console : Symbol(console, Decl(classExpressionWithStaticPropertiesES64.ts, 0, 11))
+
+const arr: any[] = [];
+>arr : Symbol(arr, Decl(classExpressionWithStaticPropertiesES64.ts, 1, 5))
+
+for (let i = 0; i < 3; i++) {
+>i : Symbol(i, Decl(classExpressionWithStaticPropertiesES64.ts, 2, 8))
+>i : Symbol(i, Decl(classExpressionWithStaticPropertiesES64.ts, 2, 8))
+>i : Symbol(i, Decl(classExpressionWithStaticPropertiesES64.ts, 2, 8))
+
+    arr.push((class C {
+>arr.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(classExpressionWithStaticPropertiesES64.ts, 1, 5))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>C : Symbol(C, Decl(classExpressionWithStaticPropertiesES64.ts, 3, 14))
+
+        static x = i;
+>x : Symbol(C.x, Decl(classExpressionWithStaticPropertiesES64.ts, 3, 23))
+>i : Symbol(i, Decl(classExpressionWithStaticPropertiesES64.ts, 2, 8))
+
+        static y = () => C.x * 2;
+>y : Symbol(C.y, Decl(classExpressionWithStaticPropertiesES64.ts, 4, 21))
+>C.x : Symbol(C.x, Decl(classExpressionWithStaticPropertiesES64.ts, 3, 23))
+>C : Symbol(C, Decl(classExpressionWithStaticPropertiesES64.ts, 3, 14))
+>x : Symbol(C.x, Decl(classExpressionWithStaticPropertiesES64.ts, 3, 23))
+
+    }), i);
+>i : Symbol(i, Decl(classExpressionWithStaticPropertiesES64.ts, 2, 8))
+}
+arr.forEach(C => console.log(C.y()));
+>arr.forEach : Symbol(Array.forEach, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(classExpressionWithStaticPropertiesES64.ts, 1, 5))
+>forEach : Symbol(Array.forEach, Decl(lib.es5.d.ts, --, --))
+>C : Symbol(C, Decl(classExpressionWithStaticPropertiesES64.ts, 8, 12))
+>console : Symbol(console, Decl(classExpressionWithStaticPropertiesES64.ts, 0, 11))
+>C : Symbol(C, Decl(classExpressionWithStaticPropertiesES64.ts, 8, 12))
+

--- a/tests/baselines/reference/classExpressionWithStaticPropertiesES64.types
+++ b/tests/baselines/reference/classExpressionWithStaticPropertiesES64.types
@@ -1,0 +1,58 @@
+=== tests/cases/compiler/classExpressionWithStaticPropertiesES64.ts ===
+declare var console: any;
+>console : any
+
+const arr: any[] = [];
+>arr : any[]
+>[] : undefined[]
+
+for (let i = 0; i < 3; i++) {
+>i : number
+>0 : number
+>i < 3 : boolean
+>i : number
+>3 : number
+>i++ : number
+>i : number
+
+    arr.push((class C {
+>arr.push((class C {        static x = i;        static y = () => C.x * 2;    }), i) : number
+>arr.push : (...items: any[]) => number
+>arr : any[]
+>push : (...items: any[]) => number
+>(class C {        static x = i;        static y = () => C.x * 2;    }) : typeof C
+>class C {        static x = i;        static y = () => C.x * 2;    } : typeof C
+>C : typeof C
+
+        static x = i;
+>x : number
+>i : number
+
+        static y = () => C.x * 2;
+>y : () => number
+>() => C.x * 2 : () => number
+>C.x * 2 : number
+>C.x : number
+>C : typeof C
+>x : number
+>2 : number
+
+    }), i);
+>i : number
+}
+arr.forEach(C => console.log(C.y()));
+>arr.forEach(C => console.log(C.y())) : void
+>arr.forEach : (callbackfn: (value: any, index: number, array: any[]) => void, thisArg?: any) => void
+>arr : any[]
+>forEach : (callbackfn: (value: any, index: number, array: any[]) => void, thisArg?: any) => void
+>C => console.log(C.y()) : (C: any) => any
+>C : any
+>console.log(C.y()) : any
+>console.log : any
+>console : any
+>log : any
+>C.y() : any
+>C.y : any
+>C : any
+>y : any
+

--- a/tests/baselines/reference/classExpressionWithStaticPropertiesES65.js
+++ b/tests/baselines/reference/classExpressionWithStaticPropertiesES65.js
@@ -1,0 +1,23 @@
+//// [classExpressionWithStaticPropertiesES65.ts]
+declare var console: any;
+const arr: any[] = [];
+for (let i = 0; i < 3; i++) {
+    arr.push(class C {
+        static x = i;
+        static y = function() { return C.x * 2; };
+    });
+}
+arr.forEach(C => console.log(C.y()));
+
+//// [classExpressionWithStaticPropertiesES65.js]
+const arr = [];
+for (let i = 0; i < 3; i++) {
+    arr.push((() => {
+        let _a = class C {
+            };
+        _a.x = i;
+        _a.y = function () { return C.x * 2; };
+        return _a;
+    })());
+}
+arr.forEach(C => console.log(C.y()));

--- a/tests/baselines/reference/classExpressionWithStaticPropertiesES65.symbols
+++ b/tests/baselines/reference/classExpressionWithStaticPropertiesES65.symbols
@@ -1,0 +1,38 @@
+=== tests/cases/compiler/classExpressionWithStaticPropertiesES65.ts ===
+declare var console: any;
+>console : Symbol(console, Decl(classExpressionWithStaticPropertiesES65.ts, 0, 11))
+
+const arr: any[] = [];
+>arr : Symbol(arr, Decl(classExpressionWithStaticPropertiesES65.ts, 1, 5))
+
+for (let i = 0; i < 3; i++) {
+>i : Symbol(i, Decl(classExpressionWithStaticPropertiesES65.ts, 2, 8))
+>i : Symbol(i, Decl(classExpressionWithStaticPropertiesES65.ts, 2, 8))
+>i : Symbol(i, Decl(classExpressionWithStaticPropertiesES65.ts, 2, 8))
+
+    arr.push(class C {
+>arr.push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(classExpressionWithStaticPropertiesES65.ts, 1, 5))
+>push : Symbol(Array.push, Decl(lib.es5.d.ts, --, --))
+>C : Symbol(C, Decl(classExpressionWithStaticPropertiesES65.ts, 3, 13))
+
+        static x = i;
+>x : Symbol(C.x, Decl(classExpressionWithStaticPropertiesES65.ts, 3, 22))
+>i : Symbol(i, Decl(classExpressionWithStaticPropertiesES65.ts, 2, 8))
+
+        static y = function() { return C.x * 2; };
+>y : Symbol(C.y, Decl(classExpressionWithStaticPropertiesES65.ts, 4, 21))
+>C.x : Symbol(C.x, Decl(classExpressionWithStaticPropertiesES65.ts, 3, 22))
+>C : Symbol(C, Decl(classExpressionWithStaticPropertiesES65.ts, 3, 13))
+>x : Symbol(C.x, Decl(classExpressionWithStaticPropertiesES65.ts, 3, 22))
+
+    });
+}
+arr.forEach(C => console.log(C.y()));
+>arr.forEach : Symbol(Array.forEach, Decl(lib.es5.d.ts, --, --))
+>arr : Symbol(arr, Decl(classExpressionWithStaticPropertiesES65.ts, 1, 5))
+>forEach : Symbol(Array.forEach, Decl(lib.es5.d.ts, --, --))
+>C : Symbol(C, Decl(classExpressionWithStaticPropertiesES65.ts, 8, 12))
+>console : Symbol(console, Decl(classExpressionWithStaticPropertiesES65.ts, 0, 11))
+>C : Symbol(C, Decl(classExpressionWithStaticPropertiesES65.ts, 8, 12))
+

--- a/tests/baselines/reference/classExpressionWithStaticPropertiesES65.types
+++ b/tests/baselines/reference/classExpressionWithStaticPropertiesES65.types
@@ -1,0 +1,56 @@
+=== tests/cases/compiler/classExpressionWithStaticPropertiesES65.ts ===
+declare var console: any;
+>console : any
+
+const arr: any[] = [];
+>arr : any[]
+>[] : undefined[]
+
+for (let i = 0; i < 3; i++) {
+>i : number
+>0 : number
+>i < 3 : boolean
+>i : number
+>3 : number
+>i++ : number
+>i : number
+
+    arr.push(class C {
+>arr.push(class C {        static x = i;        static y = function() { return C.x * 2; };    }) : number
+>arr.push : (...items: any[]) => number
+>arr : any[]
+>push : (...items: any[]) => number
+>class C {        static x = i;        static y = function() { return C.x * 2; };    } : typeof C
+>C : typeof C
+
+        static x = i;
+>x : number
+>i : number
+
+        static y = function() { return C.x * 2; };
+>y : () => number
+>function() { return C.x * 2; } : () => number
+>C.x * 2 : number
+>C.x : number
+>C : typeof C
+>x : number
+>2 : number
+
+    });
+}
+arr.forEach(C => console.log(C.y()));
+>arr.forEach(C => console.log(C.y())) : void
+>arr.forEach : (callbackfn: (value: any, index: number, array: any[]) => void, thisArg?: any) => void
+>arr : any[]
+>forEach : (callbackfn: (value: any, index: number, array: any[]) => void, thisArg?: any) => void
+>C => console.log(C.y()) : (C: any) => any
+>C : any
+>console.log(C.y()) : any
+>console.log : any
+>console : any
+>log : any
+>C.y() : any
+>C.y : any
+>C : any
+>y : any
+

--- a/tests/cases/compiler/classExpressionWithStaticPropertiesES63.ts
+++ b/tests/cases/compiler/classExpressionWithStaticPropertiesES63.ts
@@ -1,0 +1,10 @@
+//@target: es6
+declare var console: any;
+const arr: any[] = [];
+for (let i = 0; i < 3; i++) {
+    arr.push(class C {
+        static x = i;
+        static y = () => C.x * 2;
+    });
+}
+arr.forEach(C => console.log(C.y()));

--- a/tests/cases/compiler/classExpressionWithStaticPropertiesES64.ts
+++ b/tests/cases/compiler/classExpressionWithStaticPropertiesES64.ts
@@ -1,0 +1,10 @@
+//@target: es6
+declare var console: any;
+const arr: any[] = [];
+for (let i = 0; i < 3; i++) {
+    arr.push((class C {
+        static x = i;
+        static y = () => C.x * 2;
+    }), i);
+}
+arr.forEach(C => console.log(C.y()));

--- a/tests/cases/compiler/classExpressionWithStaticPropertiesES65.ts
+++ b/tests/cases/compiler/classExpressionWithStaticPropertiesES65.ts
@@ -1,0 +1,10 @@
+//@target: es6
+declare var console: any;
+const arr: any[] = [];
+for (let i = 0; i < 3; i++) {
+    arr.push(class C {
+        static x = i;
+        static y = function() { return C.x * 2; };
+    });
+}
+arr.forEach(C => console.log(C.y()));


### PR DESCRIPTION
Fix #8579 

TODO: address similar issue for down-level