### PR TITLE
Excess property check numeric indexers

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6034,10 +6034,13 @@ namespace ts {
             function isKnownProperty(type: Type, name: string): boolean {
                 if (type.flags & TypeFlags.ObjectType) {
                     const resolved = resolveStructuredTypeMembers(type);
-                    if ((relation === assignableRelation || relation === comparableRelation) &&
-                        (type === globalObjectType || isEmptyObjectType(resolved)) ||
-                        resolved.stringIndexInfo || resolved.numberIndexInfo || getPropertyOfType(type, name)) {
+                    if ((relation === assignableRelation || relation === comparableRelation) && (type === globalObjectType || isEmptyObjectType(resolved)) ||
+                        resolved.stringIndexInfo ||
+                        getPropertyOfType(type, name)) {
                         return true;
+                    }
+                    if (resolved.numberIndexInfo) {
+                        return isNumericLiteralName(name);
                     }
                 }
                 else if (type.flags & TypeFlags.UnionOrIntersection) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6036,11 +6036,9 @@ namespace ts {
                     const resolved = resolveStructuredTypeMembers(type);
                     if ((relation === assignableRelation || relation === comparableRelation) && (type === globalObjectType || isEmptyObjectType(resolved)) ||
                         resolved.stringIndexInfo ||
+                        (resolved.numberIndexInfo && isNumericLiteralName(name)) ||
                         getPropertyOfType(type, name)) {
                         return true;
-                    }
-                    if (resolved.numberIndexInfo) {
-                        return isNumericLiteralName(name);
                     }
                 }
                 else if (type.flags & TypeFlags.UnionOrIntersection) {

--- a/tests/baselines/reference/computedPropertyNamesContextualType7_ES5.js
+++ b/tests/baselines/reference/computedPropertyNamesContextualType7_ES5.js
@@ -6,16 +6,17 @@ interface I<T> {
 declare function foo<T>(obj: I<T>): T
 
 foo({
-    p: "",
+    101: "",
     0: () => { },
     ["hi" + "bye"]: true,
     [0 + 1]: 0,
     [+"hi"]: [0]
 });
 
+
 //// [computedPropertyNamesContextualType7_ES5.js]
 foo((_a = {
-        p: "",
+        101: "",
         0: function () { }
     },
     _a["hi" + "bye"] = true,

--- a/tests/baselines/reference/computedPropertyNamesContextualType7_ES5.js
+++ b/tests/baselines/reference/computedPropertyNamesContextualType7_ES5.js
@@ -1,22 +1,26 @@
 //// [computedPropertyNamesContextualType7_ES5.ts]
 interface I<T> {
-    [s: number]: T;
+    [n: number]: T;
+}
+interface J<T> {
+    [s: string]: T;
 }
 
-declare function foo<T>(obj: I<T>): T
+declare function foo<T>(obj: I<T>): T;
+declare function g<T>(obj: J<T>): T;
 
 foo({
-    101: "",
     0: () => { },
     ["hi" + "bye"]: true,
     [0 + 1]: 0,
     [+"hi"]: [0]
 });
 
+g({ p: "" });
+
 
 //// [computedPropertyNamesContextualType7_ES5.js]
 foo((_a = {
-        101: "",
         0: function () { }
     },
     _a["hi" + "bye"] = true,
@@ -24,4 +28,5 @@ foo((_a = {
     _a[+"hi"] = [0],
     _a
 ));
+g({ p: "" });
 var _a;

--- a/tests/baselines/reference/computedPropertyNamesContextualType7_ES5.symbols
+++ b/tests/baselines/reference/computedPropertyNamesContextualType7_ES5.symbols
@@ -3,26 +3,45 @@ interface I<T> {
 >I : Symbol(I, Decl(computedPropertyNamesContextualType7_ES5.ts, 0, 0))
 >T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES5.ts, 0, 12))
 
-    [s: number]: T;
->s : Symbol(s, Decl(computedPropertyNamesContextualType7_ES5.ts, 1, 5))
+    [n: number]: T;
+>n : Symbol(n, Decl(computedPropertyNamesContextualType7_ES5.ts, 1, 5))
 >T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES5.ts, 0, 12))
 }
+interface J<T> {
+>J : Symbol(J, Decl(computedPropertyNamesContextualType7_ES5.ts, 2, 1))
+>T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES5.ts, 3, 12))
 
-declare function foo<T>(obj: I<T>): T
->foo : Symbol(foo, Decl(computedPropertyNamesContextualType7_ES5.ts, 2, 1))
->T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES5.ts, 4, 21))
->obj : Symbol(obj, Decl(computedPropertyNamesContextualType7_ES5.ts, 4, 24))
+    [s: string]: T;
+>s : Symbol(s, Decl(computedPropertyNamesContextualType7_ES5.ts, 4, 5))
+>T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES5.ts, 3, 12))
+}
+
+declare function foo<T>(obj: I<T>): T;
+>foo : Symbol(foo, Decl(computedPropertyNamesContextualType7_ES5.ts, 5, 1))
+>T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES5.ts, 7, 21))
+>obj : Symbol(obj, Decl(computedPropertyNamesContextualType7_ES5.ts, 7, 24))
 >I : Symbol(I, Decl(computedPropertyNamesContextualType7_ES5.ts, 0, 0))
->T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES5.ts, 4, 21))
->T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES5.ts, 4, 21))
+>T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES5.ts, 7, 21))
+>T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES5.ts, 7, 21))
+
+declare function g<T>(obj: J<T>): T;
+>g : Symbol(g, Decl(computedPropertyNamesContextualType7_ES5.ts, 7, 38))
+>T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES5.ts, 8, 19))
+>obj : Symbol(obj, Decl(computedPropertyNamesContextualType7_ES5.ts, 8, 22))
+>J : Symbol(J, Decl(computedPropertyNamesContextualType7_ES5.ts, 2, 1))
+>T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES5.ts, 8, 19))
+>T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES5.ts, 8, 19))
 
 foo({
->foo : Symbol(foo, Decl(computedPropertyNamesContextualType7_ES5.ts, 2, 1))
+>foo : Symbol(foo, Decl(computedPropertyNamesContextualType7_ES5.ts, 5, 1))
 
-    101: "",
     0: () => { },
     ["hi" + "bye"]: true,
     [0 + 1]: 0,
     [+"hi"]: [0]
 });
+
+g({ p: "" });
+>g : Symbol(g, Decl(computedPropertyNamesContextualType7_ES5.ts, 7, 38))
+>p : Symbol(p, Decl(computedPropertyNamesContextualType7_ES5.ts, 17, 3))
 

--- a/tests/baselines/reference/computedPropertyNamesContextualType7_ES5.symbols
+++ b/tests/baselines/reference/computedPropertyNamesContextualType7_ES5.symbols
@@ -19,11 +19,10 @@ declare function foo<T>(obj: I<T>): T
 foo({
 >foo : Symbol(foo, Decl(computedPropertyNamesContextualType7_ES5.ts, 2, 1))
 
-    p: "",
->p : Symbol(p, Decl(computedPropertyNamesContextualType7_ES5.ts, 6, 5))
-
+    101: "",
     0: () => { },
     ["hi" + "bye"]: true,
     [0 + 1]: 0,
     [+"hi"]: [0]
 });
+

--- a/tests/baselines/reference/computedPropertyNamesContextualType7_ES5.types
+++ b/tests/baselines/reference/computedPropertyNamesContextualType7_ES5.types
@@ -17,12 +17,11 @@ declare function foo<T>(obj: I<T>): T
 >T : T
 
 foo({
->foo({    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]}) : (() => void) | number | number[]
+>foo({    101: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]}) : string | (() => void) | number | number[]
 >foo : <T>(obj: I<T>) => T
->{    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: string | (() => void) | boolean | number | number[]; [x: number]: (() => void) | number | number[]; 0: () => void; p: string; }
+>{    101: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: string | (() => void) | boolean | number | number[]; [x: number]: string | (() => void) | number | number[]; 0: () => void; 101: string; }
 
-    p: "",
->p : string
+    101: "",
 >"" : string
 
     0: () => { },
@@ -47,3 +46,4 @@ foo({
 >0 : number
 
 });
+

--- a/tests/baselines/reference/computedPropertyNamesContextualType7_ES5.types
+++ b/tests/baselines/reference/computedPropertyNamesContextualType7_ES5.types
@@ -3,12 +3,20 @@ interface I<T> {
 >I : I<T>
 >T : T
 
-    [s: number]: T;
->s : number
+    [n: number]: T;
+>n : number
+>T : T
+}
+interface J<T> {
+>J : J<T>
+>T : T
+
+    [s: string]: T;
+>s : string
 >T : T
 }
 
-declare function foo<T>(obj: I<T>): T
+declare function foo<T>(obj: I<T>): T;
 >foo : <T>(obj: I<T>) => T
 >T : T
 >obj : I<T>
@@ -16,13 +24,18 @@ declare function foo<T>(obj: I<T>): T
 >T : T
 >T : T
 
-foo({
->foo({    101: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]}) : string | (() => void) | number | number[]
->foo : <T>(obj: I<T>) => T
->{    101: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: string | (() => void) | boolean | number | number[]; [x: number]: string | (() => void) | number | number[]; 0: () => void; 101: string; }
+declare function g<T>(obj: J<T>): T;
+>g : <T>(obj: J<T>) => T
+>T : T
+>obj : J<T>
+>J : J<T>
+>T : T
+>T : T
 
-    101: "",
->"" : string
+foo({
+>foo({    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]}) : (() => void) | number | number[]
+>foo : <T>(obj: I<T>) => T
+>{    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: (() => void) | boolean | number | number[]; [x: number]: (() => void) | number | number[]; 0: () => void; }
 
     0: () => { },
 >() => { } : () => void
@@ -46,4 +59,11 @@ foo({
 >0 : number
 
 });
+
+g({ p: "" });
+>g({ p: "" }) : string
+>g : <T>(obj: J<T>) => T
+>{ p: "" } : { p: string; }
+>p : string
+>"" : string
 

--- a/tests/baselines/reference/computedPropertyNamesContextualType7_ES6.js
+++ b/tests/baselines/reference/computedPropertyNamesContextualType7_ES6.js
@@ -1,24 +1,29 @@
 //// [computedPropertyNamesContextualType7_ES6.ts]
 interface I<T> {
-    [s: number]: T;
+    [n: number]: T;
+}
+interface J<T> {
+    [s: string]: T;
 }
 
-declare function foo<T>(obj: I<T>): T
+declare function foo<T>(obj: I<T>): T;
+declare function g<T>(obj: J<T>): T;
 
 foo({
-    101: "",
     0: () => { },
     ["hi" + "bye"]: true,
     [0 + 1]: 0,
     [+"hi"]: [0]
 });
+
+g({ p: "" });
 
 
 //// [computedPropertyNamesContextualType7_ES6.js]
 foo({
-    101: "",
     0: () => { },
     ["hi" + "bye"]: true,
     [0 + 1]: 0,
     [+"hi"]: [0]
 });
+g({ p: "" });

--- a/tests/baselines/reference/computedPropertyNamesContextualType7_ES6.js
+++ b/tests/baselines/reference/computedPropertyNamesContextualType7_ES6.js
@@ -6,16 +6,17 @@ interface I<T> {
 declare function foo<T>(obj: I<T>): T
 
 foo({
-    p: "",
+    101: "",
     0: () => { },
     ["hi" + "bye"]: true,
     [0 + 1]: 0,
     [+"hi"]: [0]
 });
 
+
 //// [computedPropertyNamesContextualType7_ES6.js]
 foo({
-    p: "",
+    101: "",
     0: () => { },
     ["hi" + "bye"]: true,
     [0 + 1]: 0,

--- a/tests/baselines/reference/computedPropertyNamesContextualType7_ES6.symbols
+++ b/tests/baselines/reference/computedPropertyNamesContextualType7_ES6.symbols
@@ -19,11 +19,10 @@ declare function foo<T>(obj: I<T>): T
 foo({
 >foo : Symbol(foo, Decl(computedPropertyNamesContextualType7_ES6.ts, 2, 1))
 
-    p: "",
->p : Symbol(p, Decl(computedPropertyNamesContextualType7_ES6.ts, 6, 5))
-
+    101: "",
     0: () => { },
     ["hi" + "bye"]: true,
     [0 + 1]: 0,
     [+"hi"]: [0]
 });
+

--- a/tests/baselines/reference/computedPropertyNamesContextualType7_ES6.symbols
+++ b/tests/baselines/reference/computedPropertyNamesContextualType7_ES6.symbols
@@ -3,26 +3,45 @@ interface I<T> {
 >I : Symbol(I, Decl(computedPropertyNamesContextualType7_ES6.ts, 0, 0))
 >T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES6.ts, 0, 12))
 
-    [s: number]: T;
->s : Symbol(s, Decl(computedPropertyNamesContextualType7_ES6.ts, 1, 5))
+    [n: number]: T;
+>n : Symbol(n, Decl(computedPropertyNamesContextualType7_ES6.ts, 1, 5))
 >T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES6.ts, 0, 12))
 }
+interface J<T> {
+>J : Symbol(J, Decl(computedPropertyNamesContextualType7_ES6.ts, 2, 1))
+>T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES6.ts, 3, 12))
 
-declare function foo<T>(obj: I<T>): T
->foo : Symbol(foo, Decl(computedPropertyNamesContextualType7_ES6.ts, 2, 1))
->T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES6.ts, 4, 21))
->obj : Symbol(obj, Decl(computedPropertyNamesContextualType7_ES6.ts, 4, 24))
+    [s: string]: T;
+>s : Symbol(s, Decl(computedPropertyNamesContextualType7_ES6.ts, 4, 5))
+>T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES6.ts, 3, 12))
+}
+
+declare function foo<T>(obj: I<T>): T;
+>foo : Symbol(foo, Decl(computedPropertyNamesContextualType7_ES6.ts, 5, 1))
+>T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES6.ts, 7, 21))
+>obj : Symbol(obj, Decl(computedPropertyNamesContextualType7_ES6.ts, 7, 24))
 >I : Symbol(I, Decl(computedPropertyNamesContextualType7_ES6.ts, 0, 0))
->T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES6.ts, 4, 21))
->T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES6.ts, 4, 21))
+>T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES6.ts, 7, 21))
+>T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES6.ts, 7, 21))
+
+declare function g<T>(obj: J<T>): T;
+>g : Symbol(g, Decl(computedPropertyNamesContextualType7_ES6.ts, 7, 38))
+>T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES6.ts, 8, 19))
+>obj : Symbol(obj, Decl(computedPropertyNamesContextualType7_ES6.ts, 8, 22))
+>J : Symbol(J, Decl(computedPropertyNamesContextualType7_ES6.ts, 2, 1))
+>T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES6.ts, 8, 19))
+>T : Symbol(T, Decl(computedPropertyNamesContextualType7_ES6.ts, 8, 19))
 
 foo({
->foo : Symbol(foo, Decl(computedPropertyNamesContextualType7_ES6.ts, 2, 1))
+>foo : Symbol(foo, Decl(computedPropertyNamesContextualType7_ES6.ts, 5, 1))
 
-    101: "",
     0: () => { },
     ["hi" + "bye"]: true,
     [0 + 1]: 0,
     [+"hi"]: [0]
 });
+
+g({ p: "" });
+>g : Symbol(g, Decl(computedPropertyNamesContextualType7_ES6.ts, 7, 38))
+>p : Symbol(p, Decl(computedPropertyNamesContextualType7_ES6.ts, 17, 3))
 

--- a/tests/baselines/reference/computedPropertyNamesContextualType7_ES6.types
+++ b/tests/baselines/reference/computedPropertyNamesContextualType7_ES6.types
@@ -17,12 +17,11 @@ declare function foo<T>(obj: I<T>): T
 >T : T
 
 foo({
->foo({    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]}) : (() => void) | number | number[]
+>foo({    101: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]}) : string | (() => void) | number | number[]
 >foo : <T>(obj: I<T>) => T
->{    p: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: string | (() => void) | boolean | number | number[]; [x: number]: (() => void) | number | number[]; 0: () => void; p: string; }
+>{    101: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: string | (() => void) | boolean | number | number[]; [x: number]: string | (() => void) | number | number[]; 0: () => void; 101: string; }
 
-    p: "",
->p : string
+    101: "",
 >"" : string
 
     0: () => { },
@@ -47,3 +46,4 @@ foo({
 >0 : number
 
 });
+

--- a/tests/baselines/reference/computedPropertyNamesContextualType7_ES6.types
+++ b/tests/baselines/reference/computedPropertyNamesContextualType7_ES6.types
@@ -3,12 +3,20 @@ interface I<T> {
 >I : I<T>
 >T : T
 
-    [s: number]: T;
->s : number
+    [n: number]: T;
+>n : number
+>T : T
+}
+interface J<T> {
+>J : J<T>
+>T : T
+
+    [s: string]: T;
+>s : string
 >T : T
 }
 
-declare function foo<T>(obj: I<T>): T
+declare function foo<T>(obj: I<T>): T;
 >foo : <T>(obj: I<T>) => T
 >T : T
 >obj : I<T>
@@ -16,13 +24,18 @@ declare function foo<T>(obj: I<T>): T
 >T : T
 >T : T
 
-foo({
->foo({    101: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]}) : string | (() => void) | number | number[]
->foo : <T>(obj: I<T>) => T
->{    101: "",    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: string | (() => void) | boolean | number | number[]; [x: number]: string | (() => void) | number | number[]; 0: () => void; 101: string; }
+declare function g<T>(obj: J<T>): T;
+>g : <T>(obj: J<T>) => T
+>T : T
+>obj : J<T>
+>J : J<T>
+>T : T
+>T : T
 
-    101: "",
->"" : string
+foo({
+>foo({    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]}) : (() => void) | number | number[]
+>foo : <T>(obj: I<T>) => T
+>{    0: () => { },    ["hi" + "bye"]: true,    [0 + 1]: 0,    [+"hi"]: [0]} : { [x: string]: (() => void) | boolean | number | number[]; [x: number]: (() => void) | number | number[]; 0: () => void; }
 
     0: () => { },
 >() => { } : () => void
@@ -46,4 +59,11 @@ foo({
 >0 : number
 
 });
+
+g({ p: "" });
+>g({ p: "" }) : string
+>g : <T>(obj: J<T>) => T
+>{ p: "" } : { p: string; }
+>p : string
+>"" : string
 

--- a/tests/baselines/reference/indexSignaturesInferentialTyping.js
+++ b/tests/baselines/reference/indexSignaturesInferentialTyping.js
@@ -3,15 +3,13 @@ function foo<T>(items: { [index: number]: T }): T { return undefined; }
 function bar<T>(items: { [index: string]: T }): T { return undefined; }
 
 var x1 = foo({ 0: 0, 1: 1 });       // type should be number
-var x2 = foo({ zero: 0, one: 1 });
-var x3 = bar({ 0: 0, 1: 1 });
-var x4 = bar({ zero: 0, one: 1 });  // type should be number
+var x2 = bar({ 0: 0, 1: 1 });
+var x3 = bar({ zero: 0, one: 1 });  // type should be number
 
 
 //// [indexSignaturesInferentialTyping.js]
 function foo(items) { return undefined; }
 function bar(items) { return undefined; }
 var x1 = foo({ 0: 0, 1: 1 }); // type should be number
-var x2 = foo({ zero: 0, one: 1 });
-var x3 = bar({ 0: 0, 1: 1 });
-var x4 = bar({ zero: 0, one: 1 }); // type should be number
+var x2 = bar({ 0: 0, 1: 1 });
+var x3 = bar({ zero: 0, one: 1 }); // type should be number

--- a/tests/baselines/reference/indexSignaturesInferentialTyping.symbols
+++ b/tests/baselines/reference/indexSignaturesInferentialTyping.symbols
@@ -21,19 +21,13 @@ var x1 = foo({ 0: 0, 1: 1 });       // type should be number
 >x1 : Symbol(x1, Decl(indexSignaturesInferentialTyping.ts, 3, 3))
 >foo : Symbol(foo, Decl(indexSignaturesInferentialTyping.ts, 0, 0))
 
-var x2 = foo({ zero: 0, one: 1 });
+var x2 = bar({ 0: 0, 1: 1 });
 >x2 : Symbol(x2, Decl(indexSignaturesInferentialTyping.ts, 4, 3))
->foo : Symbol(foo, Decl(indexSignaturesInferentialTyping.ts, 0, 0))
->zero : Symbol(zero, Decl(indexSignaturesInferentialTyping.ts, 4, 14))
->one : Symbol(one, Decl(indexSignaturesInferentialTyping.ts, 4, 23))
+>bar : Symbol(bar, Decl(indexSignaturesInferentialTyping.ts, 0, 71))
 
-var x3 = bar({ 0: 0, 1: 1 });
+var x3 = bar({ zero: 0, one: 1 });  // type should be number
 >x3 : Symbol(x3, Decl(indexSignaturesInferentialTyping.ts, 5, 3))
 >bar : Symbol(bar, Decl(indexSignaturesInferentialTyping.ts, 0, 71))
-
-var x4 = bar({ zero: 0, one: 1 });  // type should be number
->x4 : Symbol(x4, Decl(indexSignaturesInferentialTyping.ts, 6, 3))
->bar : Symbol(bar, Decl(indexSignaturesInferentialTyping.ts, 0, 71))
->zero : Symbol(zero, Decl(indexSignaturesInferentialTyping.ts, 6, 14))
->one : Symbol(one, Decl(indexSignaturesInferentialTyping.ts, 6, 23))
+>zero : Symbol(zero, Decl(indexSignaturesInferentialTyping.ts, 5, 14))
+>one : Symbol(one, Decl(indexSignaturesInferentialTyping.ts, 5, 23))
 

--- a/tests/baselines/reference/indexSignaturesInferentialTyping.types
+++ b/tests/baselines/reference/indexSignaturesInferentialTyping.types
@@ -25,26 +25,16 @@ var x1 = foo({ 0: 0, 1: 1 });       // type should be number
 >0 : number
 >1 : number
 
-var x2 = foo({ zero: 0, one: 1 });
->x2 : {}
->foo({ zero: 0, one: 1 }) : {}
->foo : <T>(items: { [index: number]: T; }) => T
->{ zero: 0, one: 1 } : { zero: number; one: number; }
->zero : number
->0 : number
->one : number
->1 : number
-
-var x3 = bar({ 0: 0, 1: 1 });
->x3 : number
+var x2 = bar({ 0: 0, 1: 1 });
+>x2 : number
 >bar({ 0: 0, 1: 1 }) : number
 >bar : <T>(items: { [index: string]: T; }) => T
 >{ 0: 0, 1: 1 } : { 0: number; 1: number; }
 >0 : number
 >1 : number
 
-var x4 = bar({ zero: 0, one: 1 });  // type should be number
->x4 : number
+var x3 = bar({ zero: 0, one: 1 });  // type should be number
+>x3 : number
 >bar({ zero: 0, one: 1 }) : number
 >bar : <T>(items: { [index: string]: T; }) => T
 >{ zero: 0, one: 1 } : { zero: number; one: number; }

--- a/tests/baselines/reference/numericIndexerConstrainsPropertyDeclarations.errors.txt
+++ b/tests/baselines/reference/numericIndexerConstrainsPropertyDeclarations.errors.txt
@@ -5,9 +5,8 @@ tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerCo
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations.ts(36,16): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations.ts(50,5): error TS2412: Property '2.0' of type 'number' is not assignable to numeric index type 'string'.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations.ts(68,5): error TS2412: Property '2.0' of type 'number' is not assignable to numeric index type 'string'.
-tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations.ts(78,5): error TS2322: Type '{ 1.0: string; 2.0: number; a: string; b: number; c: () => void; "d": string; "e": number; "3.0": string; "4.0": number; f: any; X: string; foo(): string; }' is not assignable to type '{ [x: number]: string; }'.
-  Property '2.0' is incompatible with index signature.
-    Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations.ts(79,5): error TS2322: Type '{ 1.0: string; 2.0: number; a: string; b: number; c: () => void; "d": string; "e": number; "3.0": string; "4.0": number; f: any; X: string; foo(): string; }' is not assignable to type '{ [x: number]: string; }'.
+  Object literal may only specify known properties, and 'a' does not exist in type '{ [x: number]: string; }'.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations.ts(88,9): error TS2304: Cannot find name 'Myn'.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations.ts(90,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations.ts(93,9): error TS1056: Accessors are only available when targeting ECMAScript 5 and higher.
@@ -106,11 +105,10 @@ tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerCo
     
     // error
     var b: { [x: number]: string; } = {
-        ~
-!!! error TS2322: Type '{ 1.0: string; 2.0: number; a: string; b: number; c: () => void; "d": string; "e": number; "3.0": string; "4.0": number; f: any; X: string; foo(): string; }' is not assignable to type '{ [x: number]: string; }'.
-!!! error TS2322:   Property '2.0' is incompatible with index signature.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
         a: '',
+        ~~~~~
+!!! error TS2322: Type '{ 1.0: string; 2.0: number; a: string; b: number; c: () => void; "d": string; "e": number; "3.0": string; "4.0": number; f: any; X: string; foo(): string; }' is not assignable to type '{ [x: number]: string; }'.
+!!! error TS2322:   Object literal may only specify known properties, and 'a' does not exist in type '{ [x: number]: string; }'.
         b: 1, 
         c: () => { }, 
         "d": '', 

--- a/tests/baselines/reference/numericIndexerConstrainsPropertyDeclarations2.errors.txt
+++ b/tests/baselines/reference/numericIndexerConstrainsPropertyDeclarations2.errors.txt
@@ -1,9 +1,8 @@
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations2.ts(16,5): error TS2412: Property '3.0' of type 'number' is not assignable to numeric index type 'A'.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations2.ts(25,5): error TS2412: Property '3.0' of type 'number' is not assignable to numeric index type 'A'.
 tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations2.ts(34,5): error TS2412: Property '3.0' of type 'number' is not assignable to numeric index type 'A'.
-tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations2.ts(39,5): error TS2322: Type '{ 1.0: A; 2.0: B; 3.0: number; "2.5": B; "4.0": string; }' is not assignable to type '{ [x: number]: A; }'.
-  Property '3.0' is incompatible with index signature.
-    Type 'number' is not assignable to type 'A'.
+tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations2.ts(44,5): error TS2322: Type '{ 1.0: A; 2.0: B; 3.0: number; "2.5": B; "4.0": string; }' is not assignable to type '{ [x: number]: A; }'.
+  Object literal may only specify known properties, and '"4.0"' does not exist in type '{ [x: number]: A; }'.
 
 
 ==== tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerConstrainsPropertyDeclarations2.ts (4 errors) ====
@@ -52,13 +51,12 @@ tests/cases/conformance/types/objectTypeLiteral/indexSignatures/numericIndexerCo
     
     // error
     var b: { [x: number]: A } = {
-        ~
-!!! error TS2322: Type '{ 1.0: A; 2.0: B; 3.0: number; "2.5": B; "4.0": string; }' is not assignable to type '{ [x: number]: A; }'.
-!!! error TS2322:   Property '3.0' is incompatible with index signature.
-!!! error TS2322:     Type 'number' is not assignable to type 'A'.
         1.0: new A(), 
         2.0: new B(), 
         "2.5": new B(),
         3.0: 1,
         "4.0": ''
+        ~~~~~~~~~
+!!! error TS2322: Type '{ 1.0: A; 2.0: B; 3.0: number; "2.5": B; "4.0": string; }' is not assignable to type '{ [x: number]: A; }'.
+!!! error TS2322:   Object literal may only specify known properties, and '"4.0"' does not exist in type '{ [x: number]: A; }'.
     }

--- a/tests/baselines/reference/numericIndexerConstraint4.js
+++ b/tests/baselines/reference/numericIndexerConstraint4.js
@@ -9,7 +9,8 @@ class B extends A {
 
 var x: {
     [idx: number]: A;
-} = { data: new B() }
+} = { 0: new B() }
+
 
 //// [numericIndexerConstraint4.js]
 var __extends = (this && this.__extends) || function (d, b) {
@@ -29,4 +30,4 @@ var B = (function (_super) {
     }
     return B;
 }(A));
-var x = { data: new B() };
+var x = { 0: new B() };

--- a/tests/baselines/reference/numericIndexerConstraint4.symbols
+++ b/tests/baselines/reference/numericIndexerConstraint4.symbols
@@ -21,7 +21,6 @@ var x: {
 >idx : Symbol(idx, Decl(numericIndexerConstraint4.ts, 9, 5))
 >A : Symbol(A, Decl(numericIndexerConstraint4.ts, 0, 0))
 
-} = { data: new B() }
->data : Symbol(data, Decl(numericIndexerConstraint4.ts, 10, 5))
+} = { 0: new B() }
 >B : Symbol(B, Decl(numericIndexerConstraint4.ts, 2, 1))
 

--- a/tests/baselines/reference/numericIndexerConstraint4.types
+++ b/tests/baselines/reference/numericIndexerConstraint4.types
@@ -21,9 +21,8 @@ var x: {
 >idx : number
 >A : A
 
-} = { data: new B() }
->{ data: new B() } : { data: B; }
->data : B
+} = { 0: new B() }
+>{ 0: new B() } : { 0: B; }
 >new B() : B
 >B : typeof B
 

--- a/tests/baselines/reference/objectLitIndexerContextualType.errors.txt
+++ b/tests/baselines/reference/objectLitIndexerContextualType.errors.txt
@@ -2,11 +2,13 @@ tests/cases/compiler/objectLitIndexerContextualType.ts(12,13): error TS2362: The
 tests/cases/compiler/objectLitIndexerContextualType.ts(12,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/compiler/objectLitIndexerContextualType.ts(15,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/compiler/objectLitIndexerContextualType.ts(15,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/compiler/objectLitIndexerContextualType.ts(18,5): error TS2322: Type '{ s: (t: any) => number; }' is not assignable to type 'J'.
+  Object literal may only specify known properties, and 's' does not exist in type 'J'.
 tests/cases/compiler/objectLitIndexerContextualType.ts(21,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/compiler/objectLitIndexerContextualType.ts(21,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 
 
-==== tests/cases/compiler/objectLitIndexerContextualType.ts (6 errors) ====
+==== tests/cases/compiler/objectLitIndexerContextualType.ts (7 errors) ====
     interface I {
         [s: string]: (s: string) => number;
     }
@@ -32,7 +34,10 @@ tests/cases/compiler/objectLitIndexerContextualType.ts(21,17): error TS2363: The
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     };
     y = {
-        s: t => t * t, // Should not error
+        s: t => t * t, // Should error
+        ~~~~~~~~~~~~~
+!!! error TS2322: Type '{ s: (t: any) => number; }' is not assignable to type 'J'.
+!!! error TS2322:   Object literal may only specify known properties, and 's' does not exist in type 'J'.
     };
     y = {
         0: t => t * t, // Should error
@@ -41,3 +46,4 @@ tests/cases/compiler/objectLitIndexerContextualType.ts(21,17): error TS2363: The
                     ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     };
+    

--- a/tests/baselines/reference/objectLitIndexerContextualType.js
+++ b/tests/baselines/reference/objectLitIndexerContextualType.js
@@ -16,11 +16,12 @@ x = {
     0: t => t * t, // Should error
 };
 y = {
-    s: t => t * t, // Should not error
+    s: t => t * t, // Should error
 };
 y = {
     0: t => t * t, // Should error
 };
+
 
 //// [objectLitIndexerContextualType.js]
 var x;

--- a/tests/baselines/reference/objectLiteralExcessProperties.errors.txt
+++ b/tests/baselines/reference/objectLiteralExcessProperties.errors.txt
@@ -15,9 +15,13 @@ tests/cases/compiler/objectLiteralExcessProperties.ts(19,57): error TS2322: Type
   Object literal may only specify known properties, and 'price' does not exist in type 'Book & Cover'.
 tests/cases/compiler/objectLiteralExcessProperties.ts(21,43): error TS2322: Type '{ foreword: string; price: number; }' is not assignable to type 'Book & number'.
   Object literal may only specify known properties, and 'price' does not exist in type 'Book & number'.
+tests/cases/compiler/objectLiteralExcessProperties.ts(23,29): error TS2322: Type '{ couleur: string; }' is not assignable to type 'Cover | Cover[]'.
+  Object literal may only specify known properties, and 'couleur' does not exist in type 'Cover | Cover[]'.
+tests/cases/compiler/objectLiteralExcessProperties.ts(25,27): error TS2322: Type '{ forewarned: string; }' is not assignable to type 'Book | Book[]'.
+  Object literal may only specify known properties, and 'forewarned' does not exist in type 'Book | Book[]'.
 
 
-==== tests/cases/compiler/objectLiteralExcessProperties.ts (7 errors) ====
+==== tests/cases/compiler/objectLiteralExcessProperties.ts (9 errors) ====
     interface Book {
         foreword: string;
     }
@@ -63,4 +67,14 @@ tests/cases/compiler/objectLiteralExcessProperties.ts(21,43): error TS2322: Type
                                               ~~~~~~~~~~~~
 !!! error TS2322: Type '{ foreword: string; price: number; }' is not assignable to type 'Book & number'.
 !!! error TS2322:   Object literal may only specify known properties, and 'price' does not exist in type 'Book & number'.
+    
+    var b8: Cover | Cover[] = { couleur : "non" };
+                                ~~~~~~~~~~~~~~~
+!!! error TS2322: Type '{ couleur: string; }' is not assignable to type 'Cover | Cover[]'.
+!!! error TS2322:   Object literal may only specify known properties, and 'couleur' does not exist in type 'Cover | Cover[]'.
+    
+    var b9: Book | Book[] = { forewarned: "still no" };
+                              ~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type '{ forewarned: string; }' is not assignable to type 'Book | Book[]'.
+!!! error TS2322:   Object literal may only specify known properties, and 'forewarned' does not exist in type 'Book | Book[]'.
     

--- a/tests/baselines/reference/objectLiteralExcessProperties.errors.txt
+++ b/tests/baselines/reference/objectLiteralExcessProperties.errors.txt
@@ -19,9 +19,13 @@ tests/cases/compiler/objectLiteralExcessProperties.ts(23,29): error TS2322: Type
   Object literal may only specify known properties, and 'couleur' does not exist in type 'Cover | Cover[]'.
 tests/cases/compiler/objectLiteralExcessProperties.ts(25,27): error TS2322: Type '{ forewarned: string; }' is not assignable to type 'Book | Book[]'.
   Object literal may only specify known properties, and 'forewarned' does not exist in type 'Book | Book[]'.
+tests/cases/compiler/objectLiteralExcessProperties.ts(33,27): error TS2322: Type '{ 0: { colour: string; }; }' is not assignable to type 'Indexed'.
+  Property '0' is incompatible with index signature.
+    Type '{ colour: string; }' is not assignable to type 'Cover'.
+      Object literal may only specify known properties, and 'colour' does not exist in type 'Cover'.
 
 
-==== tests/cases/compiler/objectLiteralExcessProperties.ts (9 errors) ====
+==== tests/cases/compiler/objectLiteralExcessProperties.ts (10 errors) ====
     interface Book {
         foreword: string;
     }
@@ -77,4 +81,17 @@ tests/cases/compiler/objectLiteralExcessProperties.ts(25,27): error TS2322: Type
                               ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ forewarned: string; }' is not assignable to type 'Book | Book[]'.
 !!! error TS2322:   Object literal may only specify known properties, and 'forewarned' does not exist in type 'Book | Book[]'.
+    
+    interface Indexed {
+        [n: number]: Cover;
+    }
+    
+    var b10: Indexed = { 0: { }, '1': { } }; // ok
+    
+    var b11: Indexed = { 0: { colour: "blue" } }; // nested object literal still errors
+                              ~~~~~~~~~~~~~~
+!!! error TS2322: Type '{ 0: { colour: string; }; }' is not assignable to type 'Indexed'.
+!!! error TS2322:   Property '0' is incompatible with index signature.
+!!! error TS2322:     Type '{ colour: string; }' is not assignable to type 'Cover'.
+!!! error TS2322:       Object literal may only specify known properties, and 'colour' does not exist in type 'Cover'.
     

--- a/tests/baselines/reference/objectLiteralExcessProperties.js
+++ b/tests/baselines/reference/objectLiteralExcessProperties.js
@@ -21,6 +21,10 @@ var b6: Book & Cover = { foreword: "hi", color: "blue", price: 10.99 };
 
 var b7: Book & number = { foreword: "hi", price: 10.99 };
 
+var b8: Cover | Cover[] = { couleur : "non" };
+
+var b9: Book | Book[] = { forewarned: "still no" };
+
 
 //// [objectLiteralExcessProperties.js]
 var b1 = { forword: "oops" };
@@ -30,3 +34,5 @@ var b4 = { foreword: "hi", colour: "blue" };
 var b5 = { foreward: "hi", color: "blue" };
 var b6 = { foreword: "hi", color: "blue", price: 10.99 };
 var b7 = { foreword: "hi", price: 10.99 };
+var b8 = { couleur: "non" };
+var b9 = { forewarned: "still no" };

--- a/tests/baselines/reference/objectLiteralExcessProperties.js
+++ b/tests/baselines/reference/objectLiteralExcessProperties.js
@@ -25,6 +25,14 @@ var b8: Cover | Cover[] = { couleur : "non" };
 
 var b9: Book | Book[] = { forewarned: "still no" };
 
+interface Indexed {
+    [n: number]: Cover;
+}
+
+var b10: Indexed = { 0: { }, '1': { } }; // ok
+
+var b11: Indexed = { 0: { colour: "blue" } }; // nested object literal still errors
+
 
 //// [objectLiteralExcessProperties.js]
 var b1 = { forword: "oops" };
@@ -36,3 +44,5 @@ var b6 = { foreword: "hi", color: "blue", price: 10.99 };
 var b7 = { foreword: "hi", price: 10.99 };
 var b8 = { couleur: "non" };
 var b9 = { forewarned: "still no" };
+var b10 = { 0: {}, '1': {} }; // ok
+var b11 = { 0: { colour: "blue" } }; // nested object literal still errors

--- a/tests/baselines/reference/objectTypesIdentityWithNumericIndexers1.js
+++ b/tests/baselines/reference/objectTypesIdentityWithNumericIndexers1.js
@@ -26,7 +26,7 @@ class PB extends B {
 var a: {
     [x: number]: string;
 }
-var b: { [x: number]: string; } = { foo: '' };
+var b: { [x: number]: string; } = { 0: '' };
 
 function foo1(x: A);
 function foo1(x: A); // error
@@ -159,7 +159,7 @@ var PB = (function (_super) {
     return PB;
 }(B));
 var a;
-var b = { foo: '' };
+var b = { 0: '' };
 function foo1(x) { }
 function foo1b(x) { }
 function foo1c(x) { }

--- a/tests/baselines/reference/objectTypesIdentityWithNumericIndexers1.symbols
+++ b/tests/baselines/reference/objectTypesIdentityWithNumericIndexers1.symbols
@@ -47,23 +47,22 @@ var a: {
     [x: number]: string;
 >x : Symbol(x, Decl(objectTypesIdentityWithNumericIndexers1.ts, 25, 5))
 }
-var b: { [x: number]: string; } = { foo: '' };
+var b: { [x: number]: string; } = { 0: '' };
 >b : Symbol(b, Decl(objectTypesIdentityWithNumericIndexers1.ts, 27, 3))
 >x : Symbol(x, Decl(objectTypesIdentityWithNumericIndexers1.ts, 27, 10))
->foo : Symbol(foo, Decl(objectTypesIdentityWithNumericIndexers1.ts, 27, 35))
 
 function foo1(x: A);
->foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers1.ts, 27, 46), Decl(objectTypesIdentityWithNumericIndexers1.ts, 29, 20), Decl(objectTypesIdentityWithNumericIndexers1.ts, 30, 20))
+>foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers1.ts, 27, 44), Decl(objectTypesIdentityWithNumericIndexers1.ts, 29, 20), Decl(objectTypesIdentityWithNumericIndexers1.ts, 30, 20))
 >x : Symbol(x, Decl(objectTypesIdentityWithNumericIndexers1.ts, 29, 14))
 >A : Symbol(A, Decl(objectTypesIdentityWithNumericIndexers1.ts, 0, 0))
 
 function foo1(x: A); // error
->foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers1.ts, 27, 46), Decl(objectTypesIdentityWithNumericIndexers1.ts, 29, 20), Decl(objectTypesIdentityWithNumericIndexers1.ts, 30, 20))
+>foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers1.ts, 27, 44), Decl(objectTypesIdentityWithNumericIndexers1.ts, 29, 20), Decl(objectTypesIdentityWithNumericIndexers1.ts, 30, 20))
 >x : Symbol(x, Decl(objectTypesIdentityWithNumericIndexers1.ts, 30, 14))
 >A : Symbol(A, Decl(objectTypesIdentityWithNumericIndexers1.ts, 0, 0))
 
 function foo1(x: any) { }
->foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers1.ts, 27, 46), Decl(objectTypesIdentityWithNumericIndexers1.ts, 29, 20), Decl(objectTypesIdentityWithNumericIndexers1.ts, 30, 20))
+>foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers1.ts, 27, 44), Decl(objectTypesIdentityWithNumericIndexers1.ts, 29, 20), Decl(objectTypesIdentityWithNumericIndexers1.ts, 30, 20))
 >x : Symbol(x, Decl(objectTypesIdentityWithNumericIndexers1.ts, 31, 14))
 
 function foo1b(x: B);

--- a/tests/baselines/reference/objectTypesIdentityWithNumericIndexers1.types
+++ b/tests/baselines/reference/objectTypesIdentityWithNumericIndexers1.types
@@ -47,11 +47,10 @@ var a: {
     [x: number]: string;
 >x : number
 }
-var b: { [x: number]: string; } = { foo: '' };
+var b: { [x: number]: string; } = { 0: '' };
 >b : { [x: number]: string; }
 >x : number
->{ foo: '' } : { foo: string; }
->foo : string
+>{ 0: '' } : { 0: string; }
 >'' : string
 
 function foo1(x: A);

--- a/tests/baselines/reference/objectTypesIdentityWithNumericIndexers2.js
+++ b/tests/baselines/reference/objectTypesIdentityWithNumericIndexers2.js
@@ -29,7 +29,7 @@ class PB extends B {
 var a: {
     [x: number]: Base;
 }
-var b: { [x: number]: Derived; } = { foo: <Derived>null };
+var b: { [x: number]: Derived; } = { 0: <Derived>null };
 
 function foo1(x: A);
 function foo1(x: A); // error
@@ -174,7 +174,7 @@ var PB = (function (_super) {
     return PB;
 }(B));
 var a;
-var b = { foo: null };
+var b = { 0: null };
 function foo1(x) { }
 function foo1b(x) { }
 function foo1c(x) { }

--- a/tests/baselines/reference/objectTypesIdentityWithNumericIndexers2.symbols
+++ b/tests/baselines/reference/objectTypesIdentityWithNumericIndexers2.symbols
@@ -60,25 +60,24 @@ var a: {
 >x : Symbol(x, Decl(objectTypesIdentityWithNumericIndexers2.ts, 28, 5))
 >Base : Symbol(Base, Decl(objectTypesIdentityWithNumericIndexers2.ts, 0, 0))
 }
-var b: { [x: number]: Derived; } = { foo: <Derived>null };
+var b: { [x: number]: Derived; } = { 0: <Derived>null };
 >b : Symbol(b, Decl(objectTypesIdentityWithNumericIndexers2.ts, 30, 3))
 >x : Symbol(x, Decl(objectTypesIdentityWithNumericIndexers2.ts, 30, 10))
 >Derived : Symbol(Derived, Decl(objectTypesIdentityWithNumericIndexers2.ts, 2, 27))
->foo : Symbol(foo, Decl(objectTypesIdentityWithNumericIndexers2.ts, 30, 36))
 >Derived : Symbol(Derived, Decl(objectTypesIdentityWithNumericIndexers2.ts, 2, 27))
 
 function foo1(x: A);
->foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers2.ts, 30, 58), Decl(objectTypesIdentityWithNumericIndexers2.ts, 32, 20), Decl(objectTypesIdentityWithNumericIndexers2.ts, 33, 20))
+>foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers2.ts, 30, 56), Decl(objectTypesIdentityWithNumericIndexers2.ts, 32, 20), Decl(objectTypesIdentityWithNumericIndexers2.ts, 33, 20))
 >x : Symbol(x, Decl(objectTypesIdentityWithNumericIndexers2.ts, 32, 14))
 >A : Symbol(A, Decl(objectTypesIdentityWithNumericIndexers2.ts, 3, 43))
 
 function foo1(x: A); // error
->foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers2.ts, 30, 58), Decl(objectTypesIdentityWithNumericIndexers2.ts, 32, 20), Decl(objectTypesIdentityWithNumericIndexers2.ts, 33, 20))
+>foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers2.ts, 30, 56), Decl(objectTypesIdentityWithNumericIndexers2.ts, 32, 20), Decl(objectTypesIdentityWithNumericIndexers2.ts, 33, 20))
 >x : Symbol(x, Decl(objectTypesIdentityWithNumericIndexers2.ts, 33, 14))
 >A : Symbol(A, Decl(objectTypesIdentityWithNumericIndexers2.ts, 3, 43))
 
 function foo1(x: any) { }
->foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers2.ts, 30, 58), Decl(objectTypesIdentityWithNumericIndexers2.ts, 32, 20), Decl(objectTypesIdentityWithNumericIndexers2.ts, 33, 20))
+>foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers2.ts, 30, 56), Decl(objectTypesIdentityWithNumericIndexers2.ts, 32, 20), Decl(objectTypesIdentityWithNumericIndexers2.ts, 33, 20))
 >x : Symbol(x, Decl(objectTypesIdentityWithNumericIndexers2.ts, 34, 14))
 
 function foo1b(x: B);

--- a/tests/baselines/reference/objectTypesIdentityWithNumericIndexers2.types
+++ b/tests/baselines/reference/objectTypesIdentityWithNumericIndexers2.types
@@ -60,12 +60,11 @@ var a: {
 >x : number
 >Base : Base
 }
-var b: { [x: number]: Derived; } = { foo: <Derived>null };
+var b: { [x: number]: Derived; } = { 0: <Derived>null };
 >b : { [x: number]: Derived; }
 >x : number
 >Derived : Derived
->{ foo: <Derived>null } : { foo: Derived; }
->foo : Derived
+>{ 0: <Derived>null } : { 0: Derived; }
 ><Derived>null : Derived
 >Derived : Derived
 >null : null

--- a/tests/baselines/reference/objectTypesIdentityWithNumericIndexers3.js
+++ b/tests/baselines/reference/objectTypesIdentityWithNumericIndexers3.js
@@ -26,7 +26,7 @@ class PB extends B {
 var a: {
     [x: string]: string;
 }
-var b: { [x: number]: string; } = { foo: '' };
+var b: { [x: number]: string; } = { 0: '' };
 
 function foo1(x: A);
 function foo1(x: A); // error
@@ -159,7 +159,7 @@ var PB = (function (_super) {
     return PB;
 }(B));
 var a;
-var b = { foo: '' };
+var b = { 0: '' };
 function foo1(x) { }
 function foo1b(x) { }
 function foo1c(x) { }

--- a/tests/baselines/reference/objectTypesIdentityWithNumericIndexers3.symbols
+++ b/tests/baselines/reference/objectTypesIdentityWithNumericIndexers3.symbols
@@ -47,23 +47,22 @@ var a: {
     [x: string]: string;
 >x : Symbol(x, Decl(objectTypesIdentityWithNumericIndexers3.ts, 25, 5))
 }
-var b: { [x: number]: string; } = { foo: '' };
+var b: { [x: number]: string; } = { 0: '' };
 >b : Symbol(b, Decl(objectTypesIdentityWithNumericIndexers3.ts, 27, 3))
 >x : Symbol(x, Decl(objectTypesIdentityWithNumericIndexers3.ts, 27, 10))
->foo : Symbol(foo, Decl(objectTypesIdentityWithNumericIndexers3.ts, 27, 35))
 
 function foo1(x: A);
->foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers3.ts, 27, 46), Decl(objectTypesIdentityWithNumericIndexers3.ts, 29, 20), Decl(objectTypesIdentityWithNumericIndexers3.ts, 30, 20))
+>foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers3.ts, 27, 44), Decl(objectTypesIdentityWithNumericIndexers3.ts, 29, 20), Decl(objectTypesIdentityWithNumericIndexers3.ts, 30, 20))
 >x : Symbol(x, Decl(objectTypesIdentityWithNumericIndexers3.ts, 29, 14))
 >A : Symbol(A, Decl(objectTypesIdentityWithNumericIndexers3.ts, 0, 0))
 
 function foo1(x: A); // error
->foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers3.ts, 27, 46), Decl(objectTypesIdentityWithNumericIndexers3.ts, 29, 20), Decl(objectTypesIdentityWithNumericIndexers3.ts, 30, 20))
+>foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers3.ts, 27, 44), Decl(objectTypesIdentityWithNumericIndexers3.ts, 29, 20), Decl(objectTypesIdentityWithNumericIndexers3.ts, 30, 20))
 >x : Symbol(x, Decl(objectTypesIdentityWithNumericIndexers3.ts, 30, 14))
 >A : Symbol(A, Decl(objectTypesIdentityWithNumericIndexers3.ts, 0, 0))
 
 function foo1(x: any) { }
->foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers3.ts, 27, 46), Decl(objectTypesIdentityWithNumericIndexers3.ts, 29, 20), Decl(objectTypesIdentityWithNumericIndexers3.ts, 30, 20))
+>foo1 : Symbol(foo1, Decl(objectTypesIdentityWithNumericIndexers3.ts, 27, 44), Decl(objectTypesIdentityWithNumericIndexers3.ts, 29, 20), Decl(objectTypesIdentityWithNumericIndexers3.ts, 30, 20))
 >x : Symbol(x, Decl(objectTypesIdentityWithNumericIndexers3.ts, 31, 14))
 
 function foo1b(x: B);

--- a/tests/baselines/reference/objectTypesIdentityWithNumericIndexers3.types
+++ b/tests/baselines/reference/objectTypesIdentityWithNumericIndexers3.types
@@ -47,11 +47,10 @@ var a: {
     [x: string]: string;
 >x : string
 }
-var b: { [x: number]: string; } = { foo: '' };
+var b: { [x: number]: string; } = { 0: '' };
 >b : { [x: number]: string; }
 >x : number
->{ foo: '' } : { foo: string; }
->foo : string
+>{ 0: '' } : { 0: string; }
 >'' : string
 
 function foo1(x: A);

--- a/tests/baselines/reference/propertyAccess.errors.txt
+++ b/tests/baselines/reference/propertyAccess.errors.txt
@@ -1,10 +1,12 @@
+tests/cases/conformance/expressions/propertyAccess/propertyAccess.ts(11,55): error TS2322: Type '{ 3: string; 'three': string; }' is not assignable to type '{ [n: number]: string; }'.
+  Object literal may only specify known properties, and ''three'' does not exist in type '{ [n: number]: string; }'.
 tests/cases/conformance/expressions/propertyAccess/propertyAccess.ts(45,14): error TS2339: Property 'qqq' does not exist on type '{ 10: string; x: string; y: number; z: { n: string; m: number; o: () => boolean; }; 'literal property': number; }'.
 tests/cases/conformance/expressions/propertyAccess/propertyAccess.ts(80,10): error TS2342: An index expression argument must be of type 'string', 'number', 'symbol', or 'any'.
 tests/cases/conformance/expressions/propertyAccess/propertyAccess.ts(117,10): error TS2342: An index expression argument must be of type 'string', 'number', 'symbol', or 'any'.
 tests/cases/conformance/expressions/propertyAccess/propertyAccess.ts(140,12): error TS2342: An index expression argument must be of type 'string', 'number', 'symbol', or 'any'.
 
 
-==== tests/cases/conformance/expressions/propertyAccess/propertyAccess.ts (4 errors) ====
+==== tests/cases/conformance/expressions/propertyAccess/propertyAccess.ts (5 errors) ====
     class A {
         a: number;
     }
@@ -16,6 +18,9 @@ tests/cases/conformance/expressions/propertyAccess/propertyAccess.ts(140,12): er
     }
     
     var numIndex: { [n: number]: string } = { 3: 'three', 'three': 'three' };
+                                                          ~~~~~~~~~~~~~~~~
+!!! error TS2322: Type '{ 3: string; 'three': string; }' is not assignable to type '{ [n: number]: string; }'.
+!!! error TS2322:   Object literal may only specify known properties, and ''three'' does not exist in type '{ [n: number]: string; }'.
     var strIndex: { [n: string]: Compass } = { 'N': Compass.North, 'E': Compass.East };
     var bothIndex:
         {

--- a/tests/cases/compiler/indexSignaturesInferentialTyping.ts
+++ b/tests/cases/compiler/indexSignaturesInferentialTyping.ts
@@ -2,6 +2,5 @@ function foo<T>(items: { [index: number]: T }): T { return undefined; }
 function bar<T>(items: { [index: string]: T }): T { return undefined; }
 
 var x1 = foo({ 0: 0, 1: 1 });       // type should be number
-var x2 = foo({ zero: 0, one: 1 });
-var x3 = bar({ 0: 0, 1: 1 });
-var x4 = bar({ zero: 0, one: 1 });  // type should be number
+var x2 = bar({ 0: 0, 1: 1 });
+var x3 = bar({ zero: 0, one: 1 });  // type should be number

--- a/tests/cases/compiler/numericIndexerConstraint4.ts
+++ b/tests/cases/compiler/numericIndexerConstraint4.ts
@@ -8,4 +8,4 @@ class B extends A {
 
 var x: {
     [idx: number]: A;
-} = { data: new B() }
+} = { 0: new B() }

--- a/tests/cases/compiler/objectLitIndexerContextualType.ts
+++ b/tests/cases/compiler/objectLitIndexerContextualType.ts
@@ -15,7 +15,7 @@ x = {
     0: t => t * t, // Should error
 };
 y = {
-    s: t => t * t, // Should not error
+    s: t => t * t, // Should error
 };
 y = {
     0: t => t * t, // Should error

--- a/tests/cases/compiler/objectLiteralExcessProperties.ts
+++ b/tests/cases/compiler/objectLiteralExcessProperties.ts
@@ -23,3 +23,11 @@ var b7: Book & number = { foreword: "hi", price: 10.99 };
 var b8: Cover | Cover[] = { couleur : "non" };
 
 var b9: Book | Book[] = { forewarned: "still no" };
+
+interface Indexed {
+    [n: number]: Cover;
+}
+
+var b10: Indexed = { 0: { }, '1': { } }; // ok
+
+var b11: Indexed = { 0: { colour: "blue" } }; // nested object literal still errors

--- a/tests/cases/compiler/objectLiteralExcessProperties.ts
+++ b/tests/cases/compiler/objectLiteralExcessProperties.ts
@@ -19,3 +19,7 @@ var b5: Book & Cover = { foreward: "hi", color: "blue" };
 var b6: Book & Cover = { foreword: "hi", color: "blue", price: 10.99 };
 
 var b7: Book & number = { foreword: "hi", price: 10.99 };
+
+var b8: Cover | Cover[] = { couleur : "non" };
+
+var b9: Book | Book[] = { forewarned: "still no" };

--- a/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType7_ES5.ts
+++ b/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType7_ES5.ts
@@ -6,7 +6,7 @@ interface I<T> {
 declare function foo<T>(obj: I<T>): T
 
 foo({
-    p: "",
+    101: "",
     0: () => { },
     ["hi" + "bye"]: true,
     [0 + 1]: 0,

--- a/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType7_ES5.ts
+++ b/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType7_ES5.ts
@@ -1,14 +1,19 @@
 // @target: es5
 interface I<T> {
-    [s: number]: T;
+    [n: number]: T;
+}
+interface J<T> {
+    [s: string]: T;
 }
 
-declare function foo<T>(obj: I<T>): T
+declare function foo<T>(obj: I<T>): T;
+declare function g<T>(obj: J<T>): T;
 
 foo({
-    101: "",
     0: () => { },
     ["hi" + "bye"]: true,
     [0 + 1]: 0,
     [+"hi"]: [0]
 });
+
+g({ p: "" });

--- a/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType7_ES6.ts
+++ b/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType7_ES6.ts
@@ -1,14 +1,19 @@
 // @target: es6
 interface I<T> {
-    [s: number]: T;
+    [n: number]: T;
+}
+interface J<T> {
+    [s: string]: T;
 }
 
-declare function foo<T>(obj: I<T>): T
+declare function foo<T>(obj: I<T>): T;
+declare function g<T>(obj: J<T>): T;
 
 foo({
-    101: "",
     0: () => { },
     ["hi" + "bye"]: true,
     [0 + 1]: 0,
     [+"hi"]: [0]
 });
+
+g({ p: "" });

--- a/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType7_ES6.ts
+++ b/tests/cases/conformance/es6/computedProperties/computedPropertyNamesContextualType7_ES6.ts
@@ -6,7 +6,7 @@ interface I<T> {
 declare function foo<T>(obj: I<T>): T
 
 foo({
-    p: "",
+    101: "",
     0: () => { },
     ["hi" + "bye"]: true,
     [0 + 1]: 0,

--- a/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers1.ts
+++ b/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers1.ts
@@ -25,7 +25,7 @@ class PB extends B {
 var a: {
     [x: number]: string;
 }
-var b: { [x: number]: string; } = { foo: '' };
+var b: { [x: number]: string; } = { 0: '' };
 
 function foo1(x: A);
 function foo1(x: A); // error

--- a/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers2.ts
+++ b/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers2.ts
@@ -28,7 +28,7 @@ class PB extends B {
 var a: {
     [x: number]: Base;
 }
-var b: { [x: number]: Derived; } = { foo: <Derived>null };
+var b: { [x: number]: Derived; } = { 0: <Derived>null };
 
 function foo1(x: A);
 function foo1(x: A); // error

--- a/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers3.ts
+++ b/tests/cases/conformance/types/typeRelationships/typeAndMemberIdentity/objectTypesIdentityWithNumericIndexers3.ts
@@ -25,7 +25,7 @@ class PB extends B {
 var a: {
     [x: string]: string;
 }
-var b: { [x: number]: string; } = { foo: '' };
+var b: { [x: number]: string; } = { 0: '' };
 
 function foo1(x: A);
 function foo1(x: A); // error


### PR DESCRIPTION
Fixes #8768.

A lot of tests used non-numeric property names for object literals that are contextually typed only by a numeric indexer. I changed the tests to use numeric names after reading them. I don't think any of them depended on the non-numeric names.