### PR TITLE
Symbol for property assignments in Salsa/ES6 constructors

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1880,12 +1880,20 @@ namespace ts {
         }
 
         function bindThisPropertyAssignment(node: BinaryExpression) {
-            // Declare a 'member' in case it turns out the container was an ES5 class
-            if (container.kind === SyntaxKind.FunctionExpression || container.kind === SyntaxKind.FunctionDeclaration) {
-                container.symbol.members = container.symbol.members || {};
-                // It's acceptable for multiple 'this' assignments of the same identifier to occur
-                declareSymbol(container.symbol.members, container.symbol, node, SymbolFlags.Property, SymbolFlags.PropertyExcludes & ~SymbolFlags.Property);
+            // Declare a 'member' in case it turns out the container was an ES5 class or ES6 constructor
+            let assignee: Node;
+            if (container.kind === SyntaxKind.FunctionDeclaration || container.kind === SyntaxKind.FunctionDeclaration) {
+                assignee = container;
             }
+            else if (container.kind === SyntaxKind.Constructor) {
+                assignee = container.parent;
+            }
+            else {
+                return;
+            }
+            assignee.symbol.members = assignee.symbol.members || {};
+            // It's acceptable for multiple 'this' assignments of the same identifier to occur
+            declareSymbol(assignee.symbol.members, assignee.symbol, node, SymbolFlags.Property, SymbolFlags.PropertyExcludes & ~SymbolFlags.Property);
         }
 
         function bindPrototypePropertyAssignment(node: BinaryExpression) {

--- a/tests/cases/fourslash/renameJsThisProperty03.ts
+++ b/tests/cases/fourslash/renameJsThisProperty03.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts'/>
+
+// @allowJs: true
+// @Filename: a.js
+////class C {
+////  constructor(y) {
+////    this./**/[|x|] = y;
+////  }
+////}
+////var t = new C(12);
+////t.[|x|] = 11;
+
+goTo.marker();
+verify.renameLocations( /*findInStrings*/ false, /*findInComments*/ false);

--- a/tests/cases/fourslash/renameJsThisProperty04.ts
+++ b/tests/cases/fourslash/renameJsThisProperty04.ts
@@ -1,0 +1,14 @@
+/// <reference path='fourslash.ts'/>
+
+// @allowJs: true
+// @Filename: a.js
+////class C {
+////  constructor(y) {
+////    this.[|x|] = y;
+////  }
+////}
+////var t = new C(12);
+////t./**/[|x|] = 11;
+
+goTo.marker();
+verify.renameLocations( /*findInStrings*/ false, /*findInComments*/ false);


### PR DESCRIPTION
Fixes #8777

Previously no symbol at all was created, meaning that Salsa didn't track properties in ES6 code.