### PR TITLE
Improve control flow analysis in function expressions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7695,11 +7695,11 @@ namespace ts {
                             getTypeAtFlowLoopLabel(<FlowLabel>flow);
                     }
                     else if (flow.flags & FlowFlags.Start) {
-                        let container = (<FlowStart>flow).container;
+                        const container = (<FlowStart>flow).container;
                         if (container) {
                             // If container is an IIFE continue with the control flow associated with the
                             // call expression node.
-                            let iife = getImmediatelyInvokedFunctionExpression(<FunctionExpression>container);
+                            const iife = getImmediatelyInvokedFunctionExpression(<FunctionExpression>container);
                             if (iife && iife.flowNode) {
                                 flow = iife.flowNode;
                                 continue;
@@ -8084,16 +8084,6 @@ namespace ts {
                 expression = (expression as ParenthesizedExpression).expression;
             }
             return expression;
-        }
-
-        function getControlFlowContainer(node: Identifier, declarationContainer: Node, skipFunctionExpressions: boolean) {
-            let container = getContainingFunctionOrModule(node);
-            while (container !== declarationContainer &&
-                (container.kind === SyntaxKind.FunctionExpression || container.kind === SyntaxKind.ArrowFunction) &&
-                (skipFunctionExpressions || getImmediatelyInvokedFunctionExpression(<FunctionExpression>container))) {
-                container = getContainingFunctionOrModule(container);
-            }
-            return container;
         }
 
         function isDeclarationIncludedInFlow(reference: Node, declaration: Declaration, includeOuterFunctions: boolean) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8643,25 +8643,23 @@ namespace ts {
         function getContextuallyTypedParameterType(parameter: ParameterDeclaration): Type {
             const func = parameter.parent;
             if (isContextSensitiveFunctionOrObjectLiteralMethod(func)) {
-                if (func.kind === SyntaxKind.FunctionExpression || func.kind === SyntaxKind.ArrowFunction) {
-                    const iife = getImmediatelyInvokedFunctionExpression(func);
-                    if (iife) {
-                        const indexOfParameter = indexOf(func.parameters, parameter);
-                        if (iife.arguments && indexOfParameter < iife.arguments.length) {
-                            if (parameter.dotDotDotToken) {
-                                const restTypes: Type[] = [];
-                                for (let i = indexOfParameter; i < iife.arguments.length; i++) {
-                                    restTypes.push(getTypeOfExpression(iife.arguments[i]));
-                                }
-                                return createArrayType(getUnionType(restTypes));
+                const iife = getImmediatelyInvokedFunctionExpression(func);
+                if (iife) {
+                    const indexOfParameter = indexOf(func.parameters, parameter);
+                    if (iife.arguments && indexOfParameter < iife.arguments.length) {
+                        if (parameter.dotDotDotToken) {
+                            const restTypes: Type[] = [];
+                            for (let i = indexOfParameter; i < iife.arguments.length; i++) {
+                                restTypes.push(getTypeOfExpression(iife.arguments[i]));
                             }
-                            const links = getNodeLinks(iife);
-                            const cached = links.resolvedSignature;
-                            links.resolvedSignature = anySignature;
-                            const type = checkExpression(iife.arguments[indexOfParameter]);
-                            links.resolvedSignature = cached;
-                            return type;
+                            return createArrayType(getUnionType(restTypes));
                         }
+                        const links = getNodeLinks(iife);
+                        const cached = links.resolvedSignature;
+                        links.resolvedSignature = anySignature;
+                        const type = checkExpression(iife.arguments[indexOfParameter]);
+                        links.resolvedSignature = cached;
+                        return type;
                     }
                 }
                 const contextualSignature = getContextualSignature(func);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1537,6 +1537,13 @@ namespace ts {
         id?: number;     // Node id used by flow type cache in checker
     }
 
+    // FlowStart represents the start of a control flow. For a function expression or arrow
+    // function, the container property references the function (which in turn has a flowNode
+    // property for the containing control flow).
+    export interface FlowStart extends FlowNode {
+        container?: FunctionExpression | ArrowFunction;
+    }
+
     // FlowLabel represents a junction with multiple possible preceding control flows.
     export interface FlowLabel extends FlowNode {
         antecedents: FlowNode[];

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -416,6 +416,7 @@ namespace ts {
 
         ReachabilityCheckFlags = HasImplicitReturn | HasExplicitReturn,
         EmitHelperFlags = HasClassExtends | HasDecorators | HasParamDecorators | HasAsyncFunctions,
+        ReachabilityAndEmitFlags = ReachabilityCheckFlags | EmitHelperFlags,
 
         // Parsing context flags
         ContextFlags = DisallowInContext | YieldContext | DecoratorContext | AwaitContext | JavaScriptFile,

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -987,6 +987,20 @@ namespace ts {
         }
     }
 
+    export function getImmediatelyInvokedFunctionExpression(func: Node): CallExpression {
+        if (func.kind === SyntaxKind.FunctionExpression || func.kind === SyntaxKind.ArrowFunction) {
+            let prev = func;
+            let parent = func.parent;
+            while (parent.kind === SyntaxKind.ParenthesizedExpression) {
+                prev = parent;
+                parent = parent.parent;
+            }
+            if (parent.kind === SyntaxKind.CallExpression && (parent as CallExpression).expression === prev) {
+                return parent as CallExpression;
+            }
+        }
+    }
+
     /**
      * Determines whether a node is a property or element access expression for super.
      */

--- a/tests/baselines/reference/constLocalsInFunctionExpressions.js
+++ b/tests/baselines/reference/constLocalsInFunctionExpressions.js
@@ -1,0 +1,73 @@
+//// [constLocalsInFunctionExpressions.ts]
+declare function getStringOrNumber(): string | number;
+
+function f1() {
+    const x = getStringOrNumber();
+    if (typeof x === "string") {
+        const f = () => x.length;
+    }
+}
+
+function f2() {
+    const x = getStringOrNumber();
+    if (typeof x !== "string") {
+        return;
+    }
+    const f = () => x.length;
+}
+
+function f3() {
+    const x = getStringOrNumber();
+    if (typeof x === "string") {
+        const f = function() { return x.length; };
+    }
+}
+
+function f4() {
+    const x = getStringOrNumber();
+    if (typeof x !== "string") {
+        return;
+    }
+    const f = function() { return x.length; };
+}
+
+function f5() {
+    const x = getStringOrNumber();
+    if (typeof x === "string") {
+        const f = () => () => x.length;
+    }
+}
+
+//// [constLocalsInFunctionExpressions.js]
+function f1() {
+    var x = getStringOrNumber();
+    if (typeof x === "string") {
+        var f = function () { return x.length; };
+    }
+}
+function f2() {
+    var x = getStringOrNumber();
+    if (typeof x !== "string") {
+        return;
+    }
+    var f = function () { return x.length; };
+}
+function f3() {
+    var x = getStringOrNumber();
+    if (typeof x === "string") {
+        var f = function () { return x.length; };
+    }
+}
+function f4() {
+    var x = getStringOrNumber();
+    if (typeof x !== "string") {
+        return;
+    }
+    var f = function () { return x.length; };
+}
+function f5() {
+    var x = getStringOrNumber();
+    if (typeof x === "string") {
+        var f = function () { return function () { return x.length; }; };
+    }
+}

--- a/tests/baselines/reference/constLocalsInFunctionExpressions.symbols
+++ b/tests/baselines/reference/constLocalsInFunctionExpressions.symbols
@@ -1,0 +1,95 @@
+=== tests/cases/conformance/controlFlow/constLocalsInFunctionExpressions.ts ===
+declare function getStringOrNumber(): string | number;
+>getStringOrNumber : Symbol(getStringOrNumber, Decl(constLocalsInFunctionExpressions.ts, 0, 0))
+
+function f1() {
+>f1 : Symbol(f1, Decl(constLocalsInFunctionExpressions.ts, 0, 54))
+
+    const x = getStringOrNumber();
+>x : Symbol(x, Decl(constLocalsInFunctionExpressions.ts, 3, 9))
+>getStringOrNumber : Symbol(getStringOrNumber, Decl(constLocalsInFunctionExpressions.ts, 0, 0))
+
+    if (typeof x === "string") {
+>x : Symbol(x, Decl(constLocalsInFunctionExpressions.ts, 3, 9))
+
+        const f = () => x.length;
+>f : Symbol(f, Decl(constLocalsInFunctionExpressions.ts, 5, 13))
+>x.length : Symbol(String.length, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(constLocalsInFunctionExpressions.ts, 3, 9))
+>length : Symbol(String.length, Decl(lib.d.ts, --, --))
+    }
+}
+
+function f2() {
+>f2 : Symbol(f2, Decl(constLocalsInFunctionExpressions.ts, 7, 1))
+
+    const x = getStringOrNumber();
+>x : Symbol(x, Decl(constLocalsInFunctionExpressions.ts, 10, 9))
+>getStringOrNumber : Symbol(getStringOrNumber, Decl(constLocalsInFunctionExpressions.ts, 0, 0))
+
+    if (typeof x !== "string") {
+>x : Symbol(x, Decl(constLocalsInFunctionExpressions.ts, 10, 9))
+
+        return;
+    }
+    const f = () => x.length;
+>f : Symbol(f, Decl(constLocalsInFunctionExpressions.ts, 14, 9))
+>x.length : Symbol(String.length, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(constLocalsInFunctionExpressions.ts, 10, 9))
+>length : Symbol(String.length, Decl(lib.d.ts, --, --))
+}
+
+function f3() {
+>f3 : Symbol(f3, Decl(constLocalsInFunctionExpressions.ts, 15, 1))
+
+    const x = getStringOrNumber();
+>x : Symbol(x, Decl(constLocalsInFunctionExpressions.ts, 18, 9))
+>getStringOrNumber : Symbol(getStringOrNumber, Decl(constLocalsInFunctionExpressions.ts, 0, 0))
+
+    if (typeof x === "string") {
+>x : Symbol(x, Decl(constLocalsInFunctionExpressions.ts, 18, 9))
+
+        const f = function() { return x.length; };
+>f : Symbol(f, Decl(constLocalsInFunctionExpressions.ts, 20, 13))
+>x.length : Symbol(String.length, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(constLocalsInFunctionExpressions.ts, 18, 9))
+>length : Symbol(String.length, Decl(lib.d.ts, --, --))
+    }
+}
+
+function f4() {
+>f4 : Symbol(f4, Decl(constLocalsInFunctionExpressions.ts, 22, 1))
+
+    const x = getStringOrNumber();
+>x : Symbol(x, Decl(constLocalsInFunctionExpressions.ts, 25, 9))
+>getStringOrNumber : Symbol(getStringOrNumber, Decl(constLocalsInFunctionExpressions.ts, 0, 0))
+
+    if (typeof x !== "string") {
+>x : Symbol(x, Decl(constLocalsInFunctionExpressions.ts, 25, 9))
+
+        return;
+    }
+    const f = function() { return x.length; };
+>f : Symbol(f, Decl(constLocalsInFunctionExpressions.ts, 29, 9))
+>x.length : Symbol(String.length, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(constLocalsInFunctionExpressions.ts, 25, 9))
+>length : Symbol(String.length, Decl(lib.d.ts, --, --))
+}
+
+function f5() {
+>f5 : Symbol(f5, Decl(constLocalsInFunctionExpressions.ts, 30, 1))
+
+    const x = getStringOrNumber();
+>x : Symbol(x, Decl(constLocalsInFunctionExpressions.ts, 33, 9))
+>getStringOrNumber : Symbol(getStringOrNumber, Decl(constLocalsInFunctionExpressions.ts, 0, 0))
+
+    if (typeof x === "string") {
+>x : Symbol(x, Decl(constLocalsInFunctionExpressions.ts, 33, 9))
+
+        const f = () => () => x.length;
+>f : Symbol(f, Decl(constLocalsInFunctionExpressions.ts, 35, 13))
+>x.length : Symbol(String.length, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(constLocalsInFunctionExpressions.ts, 33, 9))
+>length : Symbol(String.length, Decl(lib.d.ts, --, --))
+    }
+}

--- a/tests/baselines/reference/constLocalsInFunctionExpressions.types
+++ b/tests/baselines/reference/constLocalsInFunctionExpressions.types
@@ -1,0 +1,121 @@
+=== tests/cases/conformance/controlFlow/constLocalsInFunctionExpressions.ts ===
+declare function getStringOrNumber(): string | number;
+>getStringOrNumber : () => string | number
+
+function f1() {
+>f1 : () => void
+
+    const x = getStringOrNumber();
+>x : string | number
+>getStringOrNumber() : string | number
+>getStringOrNumber : () => string | number
+
+    if (typeof x === "string") {
+>typeof x === "string" : boolean
+>typeof x : string
+>x : string | number
+>"string" : string
+
+        const f = () => x.length;
+>f : () => number
+>() => x.length : () => number
+>x.length : number
+>x : string
+>length : number
+    }
+}
+
+function f2() {
+>f2 : () => void
+
+    const x = getStringOrNumber();
+>x : string | number
+>getStringOrNumber() : string | number
+>getStringOrNumber : () => string | number
+
+    if (typeof x !== "string") {
+>typeof x !== "string" : boolean
+>typeof x : string
+>x : string | number
+>"string" : string
+
+        return;
+    }
+    const f = () => x.length;
+>f : () => number
+>() => x.length : () => number
+>x.length : number
+>x : string
+>length : number
+}
+
+function f3() {
+>f3 : () => void
+
+    const x = getStringOrNumber();
+>x : string | number
+>getStringOrNumber() : string | number
+>getStringOrNumber : () => string | number
+
+    if (typeof x === "string") {
+>typeof x === "string" : boolean
+>typeof x : string
+>x : string | number
+>"string" : string
+
+        const f = function() { return x.length; };
+>f : () => number
+>function() { return x.length; } : () => number
+>x.length : number
+>x : string
+>length : number
+    }
+}
+
+function f4() {
+>f4 : () => void
+
+    const x = getStringOrNumber();
+>x : string | number
+>getStringOrNumber() : string | number
+>getStringOrNumber : () => string | number
+
+    if (typeof x !== "string") {
+>typeof x !== "string" : boolean
+>typeof x : string
+>x : string | number
+>"string" : string
+
+        return;
+    }
+    const f = function() { return x.length; };
+>f : () => number
+>function() { return x.length; } : () => number
+>x.length : number
+>x : string
+>length : number
+}
+
+function f5() {
+>f5 : () => void
+
+    const x = getStringOrNumber();
+>x : string | number
+>getStringOrNumber() : string | number
+>getStringOrNumber : () => string | number
+
+    if (typeof x === "string") {
+>typeof x === "string" : boolean
+>typeof x : string
+>x : string | number
+>"string" : string
+
+        const f = () => () => x.length;
+>f : () => () => number
+>() => () => x.length : () => () => number
+>() => x.length : () => number
+>x.length : number
+>x : string
+>length : number
+    }
+}

--- a/tests/baselines/reference/controlFlowIIFE.js
+++ b/tests/baselines/reference/controlFlowIIFE.js
@@ -34,6 +34,7 @@ let maybeNumber: number | undefined;
 (function () {
     maybeNumber = 1;
 })();
+maybeNumber++;
 if (maybeNumber !== undefined) {
     maybeNumber++;
 }
@@ -75,6 +76,7 @@ var maybeNumber;
 (function () {
     maybeNumber = 1;
 })();
+maybeNumber++;
 if (maybeNumber !== undefined) {
     maybeNumber++;
 }

--- a/tests/baselines/reference/controlFlowIIFE.js
+++ b/tests/baselines/reference/controlFlowIIFE.js
@@ -1,0 +1,87 @@
+//// [controlFlowIIFE.ts]
+
+declare function getStringOrNumber(): string | number;
+
+function f1() {
+    let x = getStringOrNumber();
+    if (typeof x === "string") {
+        let n = function() {
+            return x.length;
+        }();
+    }
+}
+
+function f2() {
+    let x = getStringOrNumber();
+    if (typeof x === "string") {
+        let n = (function() {
+            return x.length;
+        })();
+    }
+}
+
+function f3() {
+    let x = getStringOrNumber();
+    let y: number;
+    if (typeof x === "string") {
+        let n = (z => x.length + y + z)(y = 1);
+    }
+}
+
+// Repros from #8381
+
+let maybeNumber: number | undefined;
+(function () {
+    maybeNumber = 1;
+})();
+if (maybeNumber !== undefined) {
+    maybeNumber++;
+}
+
+let test: string | undefined;
+if (!test) {
+    throw new Error('Test is not defined');
+}
+(() => {
+    test.slice(1); // No error
+})();
+
+//// [controlFlowIIFE.js]
+function f1() {
+    var x = getStringOrNumber();
+    if (typeof x === "string") {
+        var n = function () {
+            return x.length;
+        }();
+    }
+}
+function f2() {
+    var x = getStringOrNumber();
+    if (typeof x === "string") {
+        var n = (function () {
+            return x.length;
+        })();
+    }
+}
+function f3() {
+    var x = getStringOrNumber();
+    var y;
+    if (typeof x === "string") {
+        var n = (function (z) { return x.length + y + z; })(y = 1);
+    }
+}
+// Repros from #8381
+var maybeNumber;
+(function () {
+    maybeNumber = 1;
+})();
+if (maybeNumber !== undefined) {
+    maybeNumber++;
+}
+var test;
+if (!test) {
+    throw new Error('Test is not defined');
+}
+(function () {
+    test.slice(1); // No error
+})();

--- a/tests/baselines/reference/controlFlowIIFE.symbols
+++ b/tests/baselines/reference/controlFlowIIFE.symbols
@@ -1,0 +1,108 @@
+=== tests/cases/conformance/controlFlow/controlFlowIIFE.ts ===
+
+declare function getStringOrNumber(): string | number;
+>getStringOrNumber : Symbol(getStringOrNumber, Decl(controlFlowIIFE.ts, 0, 0))
+
+function f1() {
+>f1 : Symbol(f1, Decl(controlFlowIIFE.ts, 1, 54))
+
+    let x = getStringOrNumber();
+>x : Symbol(x, Decl(controlFlowIIFE.ts, 4, 7))
+>getStringOrNumber : Symbol(getStringOrNumber, Decl(controlFlowIIFE.ts, 0, 0))
+
+    if (typeof x === "string") {
+>x : Symbol(x, Decl(controlFlowIIFE.ts, 4, 7))
+
+        let n = function() {
+>n : Symbol(n, Decl(controlFlowIIFE.ts, 6, 11))
+
+            return x.length;
+>x.length : Symbol(String.length, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(controlFlowIIFE.ts, 4, 7))
+>length : Symbol(String.length, Decl(lib.d.ts, --, --))
+
+        }();
+    }
+}
+
+function f2() {
+>f2 : Symbol(f2, Decl(controlFlowIIFE.ts, 10, 1))
+
+    let x = getStringOrNumber();
+>x : Symbol(x, Decl(controlFlowIIFE.ts, 13, 7))
+>getStringOrNumber : Symbol(getStringOrNumber, Decl(controlFlowIIFE.ts, 0, 0))
+
+    if (typeof x === "string") {
+>x : Symbol(x, Decl(controlFlowIIFE.ts, 13, 7))
+
+        let n = (function() {
+>n : Symbol(n, Decl(controlFlowIIFE.ts, 15, 11))
+
+            return x.length;
+>x.length : Symbol(String.length, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(controlFlowIIFE.ts, 13, 7))
+>length : Symbol(String.length, Decl(lib.d.ts, --, --))
+
+        })();
+    }
+}
+
+function f3() {
+>f3 : Symbol(f3, Decl(controlFlowIIFE.ts, 19, 1))
+
+    let x = getStringOrNumber();
+>x : Symbol(x, Decl(controlFlowIIFE.ts, 22, 7))
+>getStringOrNumber : Symbol(getStringOrNumber, Decl(controlFlowIIFE.ts, 0, 0))
+
+    let y: number;
+>y : Symbol(y, Decl(controlFlowIIFE.ts, 23, 7))
+
+    if (typeof x === "string") {
+>x : Symbol(x, Decl(controlFlowIIFE.ts, 22, 7))
+
+        let n = (z => x.length + y + z)(y = 1);
+>n : Symbol(n, Decl(controlFlowIIFE.ts, 25, 11))
+>z : Symbol(z, Decl(controlFlowIIFE.ts, 25, 17))
+>x.length : Symbol(String.length, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(controlFlowIIFE.ts, 22, 7))
+>length : Symbol(String.length, Decl(lib.d.ts, --, --))
+>y : Symbol(y, Decl(controlFlowIIFE.ts, 23, 7))
+>z : Symbol(z, Decl(controlFlowIIFE.ts, 25, 17))
+>y : Symbol(y, Decl(controlFlowIIFE.ts, 23, 7))
+    }
+}
+
+// Repros from #8381
+
+let maybeNumber: number | undefined;
+>maybeNumber : Symbol(maybeNumber, Decl(controlFlowIIFE.ts, 31, 3))
+
+(function () {
+    maybeNumber = 1;
+>maybeNumber : Symbol(maybeNumber, Decl(controlFlowIIFE.ts, 31, 3))
+
+})();
+if (maybeNumber !== undefined) {
+>maybeNumber : Symbol(maybeNumber, Decl(controlFlowIIFE.ts, 31, 3))
+>undefined : Symbol(undefined)
+
+    maybeNumber++;
+>maybeNumber : Symbol(maybeNumber, Decl(controlFlowIIFE.ts, 31, 3))
+}
+
+let test: string | undefined;
+>test : Symbol(test, Decl(controlFlowIIFE.ts, 39, 3))
+
+if (!test) {
+>test : Symbol(test, Decl(controlFlowIIFE.ts, 39, 3))
+
+    throw new Error('Test is not defined');
+>Error : Symbol(Error, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+}
+(() => {
+    test.slice(1); // No error
+>test.slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+>test : Symbol(test, Decl(controlFlowIIFE.ts, 39, 3))
+>slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
+
+})();

--- a/tests/baselines/reference/controlFlowIIFE.symbols
+++ b/tests/baselines/reference/controlFlowIIFE.symbols
@@ -82,6 +82,9 @@ let maybeNumber: number | undefined;
 >maybeNumber : Symbol(maybeNumber, Decl(controlFlowIIFE.ts, 31, 3))
 
 })();
+maybeNumber++;
+>maybeNumber : Symbol(maybeNumber, Decl(controlFlowIIFE.ts, 31, 3))
+
 if (maybeNumber !== undefined) {
 >maybeNumber : Symbol(maybeNumber, Decl(controlFlowIIFE.ts, 31, 3))
 >undefined : Symbol(undefined)
@@ -91,10 +94,10 @@ if (maybeNumber !== undefined) {
 }
 
 let test: string | undefined;
->test : Symbol(test, Decl(controlFlowIIFE.ts, 39, 3))
+>test : Symbol(test, Decl(controlFlowIIFE.ts, 40, 3))
 
 if (!test) {
->test : Symbol(test, Decl(controlFlowIIFE.ts, 39, 3))
+>test : Symbol(test, Decl(controlFlowIIFE.ts, 40, 3))
 
     throw new Error('Test is not defined');
 >Error : Symbol(Error, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
@@ -102,7 +105,7 @@ if (!test) {
 (() => {
     test.slice(1); // No error
 >test.slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
->test : Symbol(test, Decl(controlFlowIIFE.ts, 39, 3))
+>test : Symbol(test, Decl(controlFlowIIFE.ts, 40, 3))
 >slice : Symbol(String.slice, Decl(lib.d.ts, --, --))
 
 })();

--- a/tests/baselines/reference/controlFlowIIFE.types
+++ b/tests/baselines/reference/controlFlowIIFE.types
@@ -1,0 +1,149 @@
+=== tests/cases/conformance/controlFlow/controlFlowIIFE.ts ===
+
+declare function getStringOrNumber(): string | number;
+>getStringOrNumber : () => string | number
+
+function f1() {
+>f1 : () => void
+
+    let x = getStringOrNumber();
+>x : string | number
+>getStringOrNumber() : string | number
+>getStringOrNumber : () => string | number
+
+    if (typeof x === "string") {
+>typeof x === "string" : boolean
+>typeof x : string
+>x : string | number
+>"string" : string
+
+        let n = function() {
+>n : number
+>function() {            return x.length;        }() : number
+>function() {            return x.length;        } : () => number
+
+            return x.length;
+>x.length : number
+>x : string
+>length : number
+
+        }();
+    }
+}
+
+function f2() {
+>f2 : () => void
+
+    let x = getStringOrNumber();
+>x : string | number
+>getStringOrNumber() : string | number
+>getStringOrNumber : () => string | number
+
+    if (typeof x === "string") {
+>typeof x === "string" : boolean
+>typeof x : string
+>x : string | number
+>"string" : string
+
+        let n = (function() {
+>n : number
+>(function() {            return x.length;        })() : number
+>(function() {            return x.length;        }) : () => number
+>function() {            return x.length;        } : () => number
+
+            return x.length;
+>x.length : number
+>x : string
+>length : number
+
+        })();
+    }
+}
+
+function f3() {
+>f3 : () => void
+
+    let x = getStringOrNumber();
+>x : string | number
+>getStringOrNumber() : string | number
+>getStringOrNumber : () => string | number
+
+    let y: number;
+>y : number
+
+    if (typeof x === "string") {
+>typeof x === "string" : boolean
+>typeof x : string
+>x : string | number
+>"string" : string
+
+        let n = (z => x.length + y + z)(y = 1);
+>n : number
+>(z => x.length + y + z)(y = 1) : number
+>(z => x.length + y + z) : (z: number) => number
+>z => x.length + y + z : (z: number) => number
+>z : number
+>x.length + y + z : number
+>x.length + y : number
+>x.length : number
+>x : string
+>length : number
+>y : number
+>z : number
+>y = 1 : number
+>y : number
+>1 : number
+    }
+}
+
+// Repros from #8381
+
+let maybeNumber: number | undefined;
+>maybeNumber : number | undefined
+
+(function () {
+>(function () {    maybeNumber = 1;})() : void
+>(function () {    maybeNumber = 1;}) : () => void
+>function () {    maybeNumber = 1;} : () => void
+
+    maybeNumber = 1;
+>maybeNumber = 1 : number
+>maybeNumber : number | undefined
+>1 : number
+
+})();
+if (maybeNumber !== undefined) {
+>maybeNumber !== undefined : boolean
+>maybeNumber : number | undefined
+>undefined : undefined
+
+    maybeNumber++;
+>maybeNumber++ : number
+>maybeNumber : number
+}
+
+let test: string | undefined;
+>test : string | undefined
+
+if (!test) {
+>!test : boolean
+>test : string | undefined
+
+    throw new Error('Test is not defined');
+>new Error('Test is not defined') : Error
+>Error : ErrorConstructor
+>'Test is not defined' : string
+}
+(() => {
+>(() => {    test.slice(1); // No error})() : void
+>(() => {    test.slice(1); // No error}) : () => void
+>() => {    test.slice(1); // No error} : () => void
+
+    test.slice(1); // No error
+>test.slice(1) : string
+>test.slice : (start?: number | undefined, end?: number | undefined) => string
+>test : string
+>slice : (start?: number | undefined, end?: number | undefined) => string
+>1 : number
+
+})();

--- a/tests/baselines/reference/controlFlowIIFE.types
+++ b/tests/baselines/reference/controlFlowIIFE.types
@@ -112,9 +112,13 @@ let maybeNumber: number | undefined;
 >1 : number
 
 })();
+maybeNumber++;
+>maybeNumber++ : number
+>maybeNumber : number
+
 if (maybeNumber !== undefined) {
 >maybeNumber !== undefined : boolean
->maybeNumber : number | undefined
+>maybeNumber : number
 >undefined : undefined
 
     maybeNumber++;

--- a/tests/baselines/reference/typeGuardsInFunctionAndModuleBlock.js
+++ b/tests/baselines/reference/typeGuardsInFunctionAndModuleBlock.js
@@ -41,7 +41,7 @@ function foo4(x: number | string | boolean) {
                 : x.toString(); // number
         })(x); // x here is narrowed to number | boolean
 }
-// Type guards affect nested function expressions and nested function declarations
+// Type guards do not affect nested function declarations
 function foo5(x: number | string | boolean) {
     if (typeof x === "string") {
         var y = x; // string;
@@ -121,7 +121,7 @@ function foo4(x) {
                 : x.toString(); // number
         })(x); // x here is narrowed to number | boolean
 }
-// Type guards affect nested function expressions and nested function declarations
+// Type guards do not affect nested function declarations
 function foo5(x) {
     if (typeof x === "string") {
         var y = x; // string;

--- a/tests/baselines/reference/typeGuardsInFunctionAndModuleBlock.symbols
+++ b/tests/baselines/reference/typeGuardsInFunctionAndModuleBlock.symbols
@@ -27,9 +27,9 @@ function foo(x: number | string | boolean) {
 >toString : Symbol(Object.toString, Decl(lib.d.ts, --, --))
 
                 : x.toString(); // number
->x.toString : Symbol(toString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>x.toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
 >x : Symbol(x, Decl(typeGuardsInFunctionAndModuleBlock.ts, 2, 13))
->toString : Symbol(toString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
 
         } ();
 }
@@ -60,9 +60,9 @@ function foo2(x: number | string | boolean) {
 >toString : Symbol(Object.toString, Decl(lib.d.ts, --, --))
 
                 : x.toString(); // number
->x.toString : Symbol(toString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>x.toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
 >x : Symbol(x, Decl(typeGuardsInFunctionAndModuleBlock.ts, 12, 14))
->toString : Symbol(toString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
 
         } (x); // x here is narrowed to number | boolean
 >x : Symbol(x, Decl(typeGuardsInFunctionAndModuleBlock.ts, 12, 14))
@@ -91,9 +91,9 @@ function foo3(x: number | string | boolean) {
 >toString : Symbol(Object.toString, Decl(lib.d.ts, --, --))
 
                 : x.toString(); // number
->x.toString : Symbol(toString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>x.toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
 >x : Symbol(x, Decl(typeGuardsInFunctionAndModuleBlock.ts, 22, 14))
->toString : Symbol(toString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
 
         })();
 }
@@ -123,14 +123,14 @@ function foo4(x: number | string | boolean) {
 >toString : Symbol(Object.toString, Decl(lib.d.ts, --, --))
 
                 : x.toString(); // number
->x.toString : Symbol(toString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>x.toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
 >x : Symbol(x, Decl(typeGuardsInFunctionAndModuleBlock.ts, 32, 14))
->toString : Symbol(toString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
 
         })(x); // x here is narrowed to number | boolean
 >x : Symbol(x, Decl(typeGuardsInFunctionAndModuleBlock.ts, 32, 14))
 }
-// Type guards affect nested function expressions and nested function declarations
+// Type guards do not affect nested function declarations
 function foo5(x: number | string | boolean) {
 >foo5 : Symbol(foo5, Decl(typeGuardsInFunctionAndModuleBlock.ts, 41, 1))
 >x : Symbol(x, Decl(typeGuardsInFunctionAndModuleBlock.ts, 43, 14))

--- a/tests/baselines/reference/typeGuardsInFunctionAndModuleBlock.types
+++ b/tests/baselines/reference/typeGuardsInFunctionAndModuleBlock.types
@@ -21,14 +21,14 @@ function foo(x: number | string | boolean) {
 >f : () => string
 
             var b = x; // number | boolean
->b : number | string | boolean
->x : number | string | boolean
+>b : number | boolean
+>x : number | boolean
 
             return typeof x === "boolean"
 >typeof x === "boolean"                ? x.toString() // boolean                : x.toString() : string
 >typeof x === "boolean" : boolean
 >typeof x : string
->x : number | string | boolean
+>x : number | boolean
 >"boolean" : string
 
                 ? x.toString() // boolean
@@ -40,7 +40,7 @@ function foo(x: number | string | boolean) {
                 : x.toString(); // number
 >x.toString() : string
 >x.toString : (radix?: number) => string
->x : number | string
+>x : number
 >toString : (radix?: number) => string
 
         } ();
@@ -66,14 +66,14 @@ function foo2(x: number | string | boolean) {
 >a : number | boolean
 
             var b = x; // new scope - number | boolean
->b : number | string | boolean
->x : number | string | boolean
+>b : number | boolean
+>x : number | boolean
 
             return typeof x === "boolean"
 >typeof x === "boolean"                ? x.toString() // boolean                : x.toString() : string
 >typeof x === "boolean" : boolean
 >typeof x : string
->x : number | string | boolean
+>x : number | boolean
 >"boolean" : string
 
                 ? x.toString() // boolean
@@ -85,7 +85,7 @@ function foo2(x: number | string | boolean) {
                 : x.toString(); // number
 >x.toString() : string
 >x.toString : (radix?: number) => string
->x : number | string
+>x : number
 >toString : (radix?: number) => string
 
         } (x); // x here is narrowed to number | boolean
@@ -111,14 +111,14 @@ function foo3(x: number | string | boolean) {
 >() => {            var b = x; // new scope - number | boolean            return typeof x === "boolean"                ? x.toString() // boolean                : x.toString(); // number        } : () => string
 
             var b = x; // new scope - number | boolean
->b : number | string | boolean
->x : number | string | boolean
+>b : number | boolean
+>x : number | boolean
 
             return typeof x === "boolean"
 >typeof x === "boolean"                ? x.toString() // boolean                : x.toString() : string
 >typeof x === "boolean" : boolean
 >typeof x : string
->x : number | string | boolean
+>x : number | boolean
 >"boolean" : string
 
                 ? x.toString() // boolean
@@ -130,7 +130,7 @@ function foo3(x: number | string | boolean) {
                 : x.toString(); // number
 >x.toString() : string
 >x.toString : (radix?: number) => string
->x : number | string
+>x : number
 >toString : (radix?: number) => string
 
         })();
@@ -156,14 +156,14 @@ function foo4(x: number | string | boolean) {
 >a : number | boolean
 
             var b = x; // new scope - number | boolean
->b : number | string | boolean
->x : number | string | boolean
+>b : number | boolean
+>x : number | boolean
 
             return typeof x === "boolean"
 >typeof x === "boolean"                ? x.toString() // boolean                : x.toString() : string
 >typeof x === "boolean" : boolean
 >typeof x : string
->x : number | string | boolean
+>x : number | boolean
 >"boolean" : string
 
                 ? x.toString() // boolean
@@ -175,13 +175,13 @@ function foo4(x: number | string | boolean) {
                 : x.toString(); // number
 >x.toString() : string
 >x.toString : (radix?: number) => string
->x : number | string
+>x : number
 >toString : (radix?: number) => string
 
         })(x); // x here is narrowed to number | boolean
 >x : number | boolean
 }
-// Type guards affect nested function expressions and nested function declarations
+// Type guards do not affect nested function declarations
 function foo5(x: number | string | boolean) {
 >foo5 : (x: number | string | boolean) => void
 >x : number | string | boolean

--- a/tests/cases/conformance/controlFlow/constLocalsInFunctionExpressions.ts
+++ b/tests/cases/conformance/controlFlow/constLocalsInFunctionExpressions.ts
@@ -1,0 +1,38 @@
+declare function getStringOrNumber(): string | number;
+
+function f1() {
+    const x = getStringOrNumber();
+    if (typeof x === "string") {
+        const f = () => x.length;
+    }
+}
+
+function f2() {
+    const x = getStringOrNumber();
+    if (typeof x !== "string") {
+        return;
+    }
+    const f = () => x.length;
+}
+
+function f3() {
+    const x = getStringOrNumber();
+    if (typeof x === "string") {
+        const f = function() { return x.length; };
+    }
+}
+
+function f4() {
+    const x = getStringOrNumber();
+    if (typeof x !== "string") {
+        return;
+    }
+    const f = function() { return x.length; };
+}
+
+function f5() {
+    const x = getStringOrNumber();
+    if (typeof x === "string") {
+        const f = () => () => x.length;
+    }
+}

--- a/tests/cases/conformance/controlFlow/controlFlowIIFE.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowIIFE.ts
@@ -1,0 +1,47 @@
+// @strictNullChecks: true
+
+declare function getStringOrNumber(): string | number;
+
+function f1() {
+    let x = getStringOrNumber();
+    if (typeof x === "string") {
+        let n = function() {
+            return x.length;
+        }();
+    }
+}
+
+function f2() {
+    let x = getStringOrNumber();
+    if (typeof x === "string") {
+        let n = (function() {
+            return x.length;
+        })();
+    }
+}
+
+function f3() {
+    let x = getStringOrNumber();
+    let y: number;
+    if (typeof x === "string") {
+        let n = (z => x.length + y + z)(y = 1);
+    }
+}
+
+// Repros from #8381
+
+let maybeNumber: number | undefined;
+(function () {
+    maybeNumber = 1;
+})();
+if (maybeNumber !== undefined) {
+    maybeNumber++;
+}
+
+let test: string | undefined;
+if (!test) {
+    throw new Error('Test is not defined');
+}
+(() => {
+    test.slice(1); // No error
+})();

--- a/tests/cases/conformance/controlFlow/controlFlowIIFE.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowIIFE.ts
@@ -34,6 +34,7 @@ let maybeNumber: number | undefined;
 (function () {
     maybeNumber = 1;
 })();
+maybeNumber++;
 if (maybeNumber !== undefined) {
     maybeNumber++;
 }

--- a/tests/cases/conformance/expressions/typeGuards/typeGuardsInFunctionAndModuleBlock.ts
+++ b/tests/cases/conformance/expressions/typeGuards/typeGuardsInFunctionAndModuleBlock.ts
@@ -40,7 +40,7 @@ function foo4(x: number | string | boolean) {
                 : x.toString(); // number
         })(x); // x here is narrowed to number | boolean
 }
-// Type guards affect nested function expressions and nested function declarations
+// Type guards do not affect nested function declarations
 function foo5(x: number | string | boolean) {
     if (typeof x === "string") {
         var y = x; // string;


### PR DESCRIPTION
This PR improves control flow analysis as follows:

* Immediately invoked function expressions (IIFEs) are considered part of the surrounding control flow. Effectively, IIFEs act just like statement blocks for purposes of control flow analysis.
* Type guards for captured `const` locals are in effect within nested function expressions and arrow functions. Although it is not known when (or even whether) a function expression or arrow function will be invoked, it *is* known that once proven true a type guard for a captured `const` local will remain true (because the `const` local can't be reassigned).

Some examples:

```typescript
declare function getStringOrNumber(): string | number;

// The type guard for x remains in effect in the arrow function because x is a const local.
// Had x been declared using let or var, the type guard would not be in effect.
function f1() {
    const x = getStringOrNumber();
    if (typeof x === "string") {
        const f = () => x.length;  // Ok
    }
}

// Type guard for x remains in effect in the IIFE.
function f2() {
    let x = getStringOrNumber();
    if (typeof x === "string") {
        let n = function() {
            return x.length;  // Ok
        }();
    }
}

// Type guard for x remains in effect and assignment to y is known to
// have executed before IIFE is invoked.
function f3() {
    let x = getStringOrNumber();
    let y: number;
    if (typeof x === "string") {
        let n = (z => x.length + y + z)(y = 1);
    }
}
```

Fixes #8381.