### PR TITLE
Improve error elaboration for types that have a property that references the type recursively

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6194,12 +6194,9 @@ namespace ts {
                 const id = relation !== identityRelation || source.id < target.id ? source.id + "," + target.id : target.id + "," + source.id;
                 const related = relation[id];
                 if (related !== undefined) {
-                    if (reportErrors && related === RelationComparisonResult.Failed) {
-                        // We are elaborating errors and the cached result is an unreported failure. Record the result as a reported
-                        // failure and continue computing the relation such that errors get reported.
-                        relation[id] = RelationComparisonResult.FailedAndReported;
-                    }
-                    else {
+                    // If we computed this relation already and it was failed and reported, or if we're not being asked to elaborate
+                    // errors, we can use the cached value. Otherwise, recompute the relation.
+                    if (!reportErrors || related === RelationComparisonResult.FailedAndReported) {
                         return related === RelationComparisonResult.Succeeded ? Ternary.True : Ternary.False;
                     }
                 }

--- a/tests/baselines/reference/promisePermutations3.errors.txt
+++ b/tests/baselines/reference/promisePermutations3.errors.txt
@@ -80,9 +80,7 @@ tests/cases/compiler/promisePermutations3.ts(159,21): error TS2345: Argument of 
               Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of type '{ <T>(x: T): IPromise<T>; <T>(x: T, y: T): Promise<T>; }' is not assignable to parameter of type '(value: (x: any) => any) => Promise<any>'.
   Type 'IPromise<any>' is not assignable to type 'Promise<any>'.
-    Types of property 'then' are incompatible.
-      Type '<U>(success?: (value: any) => U, error?: (error: any) => U, progress?: (progress: any) => void) => IPromise<U>' is not assignable to type '{ <U>(success?: (value: any) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: any) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: any) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: any) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
-        Type 'IPromise<any>' is not assignable to type 'Promise<any>'.
+    Property 'done' is optional in type 'IPromise<any>' but required in type 'Promise<any>'.
 
 
 ==== tests/cases/compiler/promisePermutations3.ts (35 errors) ====
@@ -368,7 +366,5 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
                         ~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '{ <T>(x: T): IPromise<T>; <T>(x: T, y: T): Promise<T>; }' is not assignable to parameter of type '(value: (x: any) => any) => Promise<any>'.
 !!! error TS2345:   Type 'IPromise<any>' is not assignable to type 'Promise<any>'.
-!!! error TS2345:     Types of property 'then' are incompatible.
-!!! error TS2345:       Type '<U>(success?: (value: any) => U, error?: (error: any) => U, progress?: (progress: any) => void) => IPromise<U>' is not assignable to type '{ <U>(success?: (value: any) => Promise<U>, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: any) => Promise<U>, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: any) => U, error?: (error: any) => Promise<U>, progress?: (progress: any) => void): Promise<U>; <U>(success?: (value: any) => U, error?: (error: any) => U, progress?: (progress: any) => void): Promise<U>; }'.
-!!! error TS2345:         Type 'IPromise<any>' is not assignable to type 'Promise<any>'.
+!!! error TS2345:     Property 'done' is optional in type 'IPromise<any>' but required in type 'Promise<any>'.
     var s12c = s12.then(testFunction12P, testFunction12, testFunction12); // ok


### PR DESCRIPTION
Revert commit 4beedcf from #5761.
It is no longer needed to prevent a crash in cases/compiler/elaborateErrors, and makes errors worse with properties that reference the containing type.

Fixes #7269 and doesn't re-break #5712 (as checked by the regression test/cases/compiler/elaborateErrors).

@ahejlsberg can you take a look? I understand why the change made the errors worse, but I don't understand why it was supposed to prevent the crash in #5712. I guess that some other, later change also fixed the source of the crash.
