### PR TITLE
Add option to bail out of `jake runtests` when a test fails

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -755,13 +755,18 @@ function runConsoleTests(defaultReporter, runInParallel) {
             // schedule work for chunks
             configFiles.forEach(function (f) {
                 var configPath = path.join(taskConfigsFolder, f);
-                var workerCmd = "mocha" + " -t " + testTimeout + " -R " + reporter + " " + colors + " " + run + " --config='" + configPath + "'";
+                var workerCmd = "mocha" + " -t " + testTimeout + " -R " + reporter + " " + colors + bail + " " + run + " --config='" + configPath + "'";
                 console.log(workerCmd);
                 exec(workerCmd,  finishWorker, finishWorker) 
             });
             
             function finishWorker(e, errorStatus) {
                 counter--;
+
+                if (bail && errorStatus !== undefined) {
+                    failWithStatus(firstErrorStatus);
+                }
+
                 if (firstErrorStatus === undefined && errorStatus !== undefined) {
                     firstErrorStatus = errorStatus;
                 }
@@ -810,7 +815,7 @@ function runConsoleTests(defaultReporter, runInParallel) {
 }
 
 var testTimeout = 20000;
-desc("Runs all the tests in parallel using the built run.js file. Optional arguments are: t[ests]=category1|category2|... d[ebug]=true.");
+desc("Runs all the tests in parallel using the built run.js file. Optional arguments are: t[ests]=category1|category2|... d[ebug]=true bail=false.");
 task("runtests-parallel", ["build-rules", "tests", builtLocalDirectory], function() {
     runConsoleTests('min', /*runInParallel*/ true);
 }, {async: true});

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -726,13 +726,14 @@ function runConsoleTests(defaultReporter, runInParallel) {
     colors = process.env.colors || process.env.color;
     colors = colors ? ' --no-colors ' : ' --colors ';
     reporter = process.env.reporter || process.env.r || defaultReporter;
+    var bail = (process.env.bail || process.env.b) ? "--bail" : "";
     var lintFlag = process.env.lint !== 'false';
 
     // timeout normally isn't necessary but Travis-CI has been timing out on compiler baselines occasionally
     // default timeout is 2sec which really should be enough, but maybe we just need a small amount longer
     if(!runInParallel) {
         tests = tests ? ' -g "' + tests + '"' : '';
-        var cmd = "mocha" + (debug ? " --debug-brk" : "") + " -R " + reporter + tests + colors + ' -t ' + testTimeout + ' ' + run;
+        var cmd = "mocha" + (debug ? " --debug-brk" : "") + " -R " + reporter + tests + colors + bail + ' -t ' + testTimeout + ' ' + run;
         console.log(cmd);
         exec(cmd, function () {
             runLinter();
@@ -814,7 +815,7 @@ task("runtests-parallel", ["build-rules", "tests", builtLocalDirectory], functio
     runConsoleTests('min', /*runInParallel*/ true);
 }, {async: true});
 
-desc("Runs the tests using the built run.js file. Optional arguments are: t[ests]=regex r[eporter]=[list|spec|json|<more>] d[ebug]=true color[s]=false lint=true.");
+desc("Runs the tests using the built run.js file. Optional arguments are: t[ests]=regex r[eporter]=[list|spec|json|<more>] d[ebug]=true color[s]=false lint=true bail=false.");
 task("runtests", ["build-rules", "tests", builtLocalDirectory], function() {
     runConsoleTests('mocha-fivemat-progress-reporter', /*runInParallel*/ false);
 }, {async: true});

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -764,7 +764,7 @@ function runConsoleTests(defaultReporter, runInParallel) {
                 counter--;
 
                 if (bail && errorStatus !== undefined) {
-                    failWithStatus(firstErrorStatus);
+                    failWithStatus(errorStatus);
                 }
 
                 if (firstErrorStatus === undefined && errorStatus !== undefined) {


### PR DESCRIPTION
Currently serial only. For parallel we would need a way to notify all other running processes to stop.