### PR TITLE
Add `integrity` property to SRI-enabled DOM elements

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -5884,6 +5884,10 @@ interface HTMLLinkElement extends HTMLElement, LinkStyle {
       */
     hreflang: string;
     /**
+     * Sets or retrieves the Subresource Integrity metadata.
+    */
+    integrity: string;
+    /**
       * Sets or retrieves the media type.
       */
     media: string;
@@ -6753,6 +6757,10 @@ interface HTMLScriptElement extends HTMLElement {
       * Sets or retrieves the object that is bound to the event script.
       */
     htmlFor: string;
+    /**
+      * Sets or retrieves the Subresource Integrity metadata.
+      */
+    integrity: string;
     /**
       * Retrieves the URL to an external file that contains the source code or data.
       */


### PR DESCRIPTION
Related to #8955. This adds properties `integrity: string` to HTMLScriptElement and HTMLLinkElement.