### PR TITLE
Include indent in navigation bar protocol

### DIFF
--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -459,7 +459,7 @@ namespace ts.server {
                 kindModifiers: item.kindModifiers || "",
                 spans: item.spans.map(span => createTextSpanFromBounds(this.lineOffsetToPosition(fileName, span.start), this.lineOffsetToPosition(fileName, span.end))),
                 childItems: this.decodeNavigationBarItems(item.childItems, fileName),
-                indent: 0,
+                indent: item.indent,
                 bolded: false,
                 grayed: false
             }));

--- a/src/server/protocol.d.ts
+++ b/src/server/protocol.d.ts
@@ -1242,6 +1242,11 @@ declare namespace ts.server.protocol {
           * Optional children.
           */
         childItems?: NavigationBarItem[];
+
+        /**
+          * Number of levels deep this item should appear.
+          */
+        indent: number;
     }
 
     export interface NavBarResponse extends Response {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -872,7 +872,8 @@ namespace ts.server {
                     start: compilerService.host.positionToLineOffset(fileName, span.start),
                     end: compilerService.host.positionToLineOffset(fileName, ts.textSpanEnd(span))
                 })),
-                childItems: this.decorateNavigationBarItem(project, fileName, item.childItems)
+                childItems: this.decorateNavigationBarItem(project, fileName, item.childItems),
+                indent: item.indent
             }));
         }
 

--- a/tests/cases/fourslash/server/navbar01.ts
+++ b/tests/cases/fourslash/server/navbar01.ts
@@ -85,7 +85,8 @@ verify.navigationBar([
                 "text": "prop",
                 "kind": "property"
             }
-        ]
+        ],
+        "indent": 1
     },
     {
         "text": "Shapes",
@@ -100,7 +101,8 @@ verify.navigationBar([
                 "text": "Values",
                 "kind": "enum"
             }
-        ]
+        ],
+        "indent": 1
     },
     {
         "text": "Point",
@@ -143,7 +145,8 @@ verify.navigationBar([
                 "kind": "property",
                 "kindModifiers": "public"
             }
-        ]
+        ],
+        "indent": 2
     },
     {
         "text": "Values",
@@ -161,6 +164,7 @@ verify.navigationBar([
                 "text": "value3",
                 "kind": "property"
             }
-        ]
+        ],
+        "indent": 2
     }
 ]);


### PR DESCRIPTION
Previously navbar01 test had indents when run in the browser but not when run from node. Now they run the same.