### PR TITLE
Support using string values in enums for CompilerOptions in transpile

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -6,7 +6,7 @@
 
 namespace ts {
     /* @internal */
-    export let optionDeclarations: CommandLineOption[] = [
+    export const optionDeclarations: CommandLineOption[] = [
         {
             name: "charset",
             type: "string",

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1920,11 +1920,15 @@ namespace ts {
         sourceMapText?: string;
     }
 
+    const commandLineOptions_stringToEnum = <CommandLineOptionOfCustomType[]>filter(optionDeclarations, o => {
+        return typeof o.type === "object" && !forEachValue(<Map<any>> o.type, v => typeof v !== "number");
+    });
+
     /** JS users may pass in string values for enum compiler options (such as ModuleKind), so convert. */
     function fixupCompilerOptions(options: CompilerOptions, diagnostics: Diagnostic[]) {
         options = clone(options);
 
-        for (const opt of stringValuedEnums) {
+        for (const opt of commandLineOptions_stringToEnum) {
             if (!hasProperty(options, opt.name)) {
                 continue;
             }
@@ -1945,10 +1949,6 @@ namespace ts {
 
         return options;
     }
-
-    const stringValuedEnums = <CommandLineOptionOfCustomType[]>filter(optionDeclarations, o => {
-        return typeof o.type === "object" && !forEachValue(<Map<any>> o.type, v => typeof v !== "number");
-    });
 
     /*
      * This function will compile source text from 'input' argument using specified compiler options.

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1920,12 +1920,16 @@ namespace ts {
         sourceMapText?: string;
     }
 
-    const commandLineOptions_stringToEnum = <CommandLineOptionOfCustomType[]>filter(optionDeclarations, o => {
-        return typeof o.type === "object" && !forEachValue(<Map<any>> o.type, v => typeof v !== "number");
-    });
+
+
+    let commandLineOptions_stringToEnum: CommandLineOptionOfCustomType[];
 
     /** JS users may pass in string values for enum compiler options (such as ModuleKind), so convert. */
-    function fixupCompilerOptions(options: CompilerOptions, diagnostics: Diagnostic[]) {
+    function fixupCompilerOptions(options: CompilerOptions, diagnostics: Diagnostic[]): CompilerOptions {
+        // Lazily create this value to fix module loading errors.
+        commandLineOptions_stringToEnum = commandLineOptions_stringToEnum || <CommandLineOptionOfCustomType[]>filter(optionDeclarations, o =>
+            typeof o.type === "object" && !forEachValue(<Map<any>> o.type, v => typeof v !== "number"));
+
         options = clone(options);
 
         for (const opt of commandLineOptions_stringToEnum) {

--- a/tests/cases/unittests/transpile.ts
+++ b/tests/cases/unittests/transpile.ts
@@ -7,13 +7,17 @@ namespace ts {
             options?: TranspileOptions;
             expectedOutput?: string;
             expectedDiagnosticCodes?: number[];
+            expectedDiagnosticTexts?: string[];
         }
 
-        function checkDiagnostics(diagnostics: Diagnostic[], expectedDiagnosticCodes: number[] = []) {
-            for (let i = 0; i < expectedDiagnosticCodes.length; i++) {
-                assert.equal(expectedDiagnosticCodes[i], diagnostics[i] && diagnostics[i].code, `Could not find expeced diagnostic.`);
+        function checkDiagnostics(diagnostics: Diagnostic[], expectedDiagnosticCodes: number[] = [], expectedDiagnosticTexts: string[] = []) {
+            const n = expectedDiagnosticCodes.length;
+            assert.equal(n, expectedDiagnosticTexts.length);
+            for (let i = 0; i < n; i++) {
+                assert.equal(expectedDiagnosticCodes[i], diagnostics[i] && diagnostics[i].code, `Could not find expected diagnostic.`);
+                assert.equal(expectedDiagnosticTexts[i], diagnostics[i] && diagnostics[i].messageText);
             }
-            assert.equal(diagnostics.length, expectedDiagnosticCodes.length, "Resuting diagnostics count does not match expected");
+            assert.equal(diagnostics.length, n, "Resuting diagnostics count does not match expected");
         }
 
         function test(input: string, testSettings: TranspileTestSettings): void {
@@ -32,7 +36,7 @@ namespace ts {
             transpileOptions.reportDiagnostics = true;
             const transpileModuleResult = transpileModule(input, transpileOptions);
 
-            checkDiagnostics(transpileModuleResult.diagnostics, testSettings.expectedDiagnosticCodes);
+            checkDiagnostics(transpileModuleResult.diagnostics, testSettings.expectedDiagnosticCodes, testSettings.expectedDiagnosticTexts);
 
             if (testSettings.expectedOutput !== undefined) {
                 assert.equal(transpileModuleResult.outputText, testSettings.expectedOutput);
@@ -41,7 +45,7 @@ namespace ts {
             if (canUseOldTranspile) {
                 const diagnostics: Diagnostic[] = [];
                 const transpileResult = transpile(input, transpileOptions.compilerOptions, transpileOptions.fileName, diagnostics, transpileOptions.moduleName);
-                checkDiagnostics(diagnostics, testSettings.expectedDiagnosticCodes);
+                checkDiagnostics(diagnostics, testSettings.expectedDiagnosticCodes, testSettings.expectedDiagnosticTexts);
                 if (testSettings.expectedOutput) {
                     assert.equal(transpileResult, testSettings.expectedOutput);
                 }
@@ -313,7 +317,8 @@ var x = 0;`,
             it("Fails on bad value", () => {
                 test(``, {
                     options: { compilerOptions: { module: <ModuleKind><any>{} } },
-                    expectedDiagnosticCodes: [6046]
+                    expectedDiagnosticCodes: [6046],
+                    expectedDiagnosticTexts: ["Argument for '--module' option must be:  'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015'"]
                 });
             });
         });

--- a/tests/cases/unittests/transpile.ts
+++ b/tests/cases/unittests/transpile.ts
@@ -10,12 +10,16 @@ namespace ts {
             expectedDiagnosticTexts?: string[];
         }
 
-        function checkDiagnostics(diagnostics: Diagnostic[], expectedDiagnosticCodes: number[] = [], expectedDiagnosticTexts: string[] = []) {
+        function checkDiagnostics(diagnostics: Diagnostic[], expectedDiagnosticCodes: number[] = [], expectedDiagnosticTexts?: string[]) {
             const n = expectedDiagnosticCodes.length;
-            assert.equal(n, expectedDiagnosticTexts.length);
+            if (expectedDiagnosticTexts) {
+                assert.equal(n, expectedDiagnosticTexts.length);
+            }
             for (let i = 0; i < n; i++) {
                 assert.equal(expectedDiagnosticCodes[i], diagnostics[i] && diagnostics[i].code, `Could not find expected diagnostic.`);
-                assert.equal(expectedDiagnosticTexts[i], diagnostics[i] && diagnostics[i].messageText);
+                if (expectedDiagnosticTexts) {
+                    assert.equal(expectedDiagnosticTexts[i], diagnostics[i] && diagnostics[i].messageText);
+                }
             }
             assert.equal(diagnostics.length, n, "Resuting diagnostics count does not match expected");
         }

--- a/tests/cases/unittests/transpile.ts
+++ b/tests/cases/unittests/transpile.ts
@@ -20,7 +20,7 @@ namespace ts {
                 if (expectedDiagnosticTexts) {
                     assert.equal(expectedDiagnosticTexts[i], diagnostics[i] && diagnostics[i].messageText);
                 }
-            }
+            };
             assert.equal(diagnostics.length, n, "Resuting diagnostics count does not match expected");
         }
 
@@ -319,11 +319,13 @@ var x = 0;`,
             });
 
             it("Fails on bad value", () => {
-                test(``, {
-                    options: { compilerOptions: { module: <ModuleKind><any>{} } },
-                    expectedDiagnosticCodes: [6046],
-                    expectedDiagnosticTexts: ["Argument for '--module' option must be:  'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015'"]
-                });
+                for (const value in [123, {}, ""]) {
+                    test(``, {
+                        options: { compilerOptions: { module: <ModuleKind><any>value } },
+                        expectedDiagnosticCodes: [6046],
+                        expectedDiagnosticTexts: ["Argument for '--module' option must be:  'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015'"]
+                    });
+                }
             });
         });
     });

--- a/tests/cases/unittests/transpile.ts
+++ b/tests/cases/unittests/transpile.ts
@@ -9,11 +9,7 @@ namespace ts {
             expectedDiagnosticCodes?: number[];
         }
 
-        function checkDiagnostics(diagnostics: Diagnostic[], expectedDiagnosticCodes?: number[]) {
-            if (!expectedDiagnosticCodes) {
-                return;
-            }
-
+        function checkDiagnostics(diagnostics: Diagnostic[], expectedDiagnosticCodes: number[] = []) {
             for (let i = 0; i < expectedDiagnosticCodes.length; i++) {
                 assert.equal(expectedDiagnosticCodes[i], diagnostics[i] && diagnostics[i].code, `Could not find expeced diagnostic.`);
             }
@@ -26,7 +22,7 @@ namespace ts {
             if (!transpileOptions.compilerOptions) {
                 transpileOptions.compilerOptions = {};
             }
-            if (transpileOptions.compilerOptions.newLine === undefined) { // 
+            if (transpileOptions.compilerOptions.newLine === undefined) {
                 // use \r\n as default new line
                 transpileOptions.compilerOptions.newLine = ts.NewLineKind.CarriageReturnLineFeed;
             }
@@ -292,13 +288,34 @@ var x = 0;`,
             const output = `"use strict";\nvar a = 10;\n`;
             test(input, {
                 expectedOutput: output,
-                options: { compilerOptions: { newLine: NewLineKind.LineFeed, module: ModuleKind.CommonJS }, fileName: "input.js", reportDiagnostics: true },
-                expectedDiagnosticCodes: []
+                options: { compilerOptions: { newLine: NewLineKind.LineFeed, module: ModuleKind.CommonJS }, fileName: "input.js", reportDiagnostics: true }
             });
         });
 
         it("Supports urls in file name", () => {
             test("var x", { expectedOutput: `"use strict";\r\nvar x;\r\n`, options: { fileName: "http://somewhere/directory//directory2/file.ts" } });
+        });
+
+        describe("String values for enums", () => {
+            it("Accepts strings instead of enum values", () => {
+                test(`export const x = 0`, {
+                    options: {
+                        compilerOptions: {
+                            module: <ModuleKind><any>"es6",
+                            // Capitalization and spaces ignored
+                            target: <ScriptTarget><any>" Es6 "
+                        }
+                    },
+                    expectedOutput: "export const x = 0;\r\n"
+                });
+            });
+
+            it("Fails on bad value", () => {
+                test(``, {
+                    options: { compilerOptions: { module: <ModuleKind><any>{} } },
+                    expectedDiagnosticCodes: [6046]
+                });
+            });
         });
     });
 }


### PR DESCRIPTION
Fixes #7980
This doesn't change the CompilerOptions type, so only JS consumers can use strings.