### PR TITLE
Remove Completed TODO

### DIFF
--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1692,6 +1692,3 @@ namespace Harness {
 
     if (Error) (<any>Error).stackTraceLimit = 1;
 }
-
-// TODO: not sure why Utils.evalFile isn't working with this, eventually will concat it like old compiler instead of eval
-eval(Harness.tcServicesFile);


### PR DESCRIPTION
AFAIK, the harness sources have been concatenated into `run.js` for as long as I've known. This stops executing them twice (and in turn makes debugging tests much easier, since you no longer have to debug into eval'd code).