### PR TITLE
Fix this resolution in parameter initializers

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8392,7 +8392,10 @@ namespace ts {
             if (needToCaptureLexicalThis) {
                 captureLexicalThis(node, container);
             }
-            if (isFunctionLike(container) && !isInParameterInitializerBeforeContainingFunction(node)) {
+            if (isFunctionLike(container) &&
+                (!isInParameterInitializerBeforeContainingFunction(node) || getFunctionLikeThisParameter(container))) {
+                // Note: a parameter initializer should refer to class-this unless function-this is explicitly annotated.
+
                 // If this is a function in a JS file, it might be a class method. Check if it's the RHS
                 // of a x.prototype.y = function [name]() { .... }
                 if (container.kind === SyntaxKind.FunctionExpression &&
@@ -18470,6 +18473,14 @@ namespace ts {
                 accessor.parameters[0].name.kind === SyntaxKind.Identifier &&
                 (<Identifier>accessor.parameters[0].name).originalKeywordKind === SyntaxKind.ThisKeyword) {
                 return accessor.parameters[0];
+            }
+        }
+
+        function getFunctionLikeThisParameter(func: FunctionLikeDeclaration) {
+            if (func.parameters.length &&
+                func.parameters[0].name.kind === SyntaxKind.Identifier &&
+                (<Identifier>func.parameters[0].name).originalKeywordKind === SyntaxKind.ThisKeyword) {
+                return func.parameters[0];
             }
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8392,7 +8392,7 @@ namespace ts {
             if (needToCaptureLexicalThis) {
                 captureLexicalThis(node, container);
             }
-            if (isFunctionLike(container)) {
+            if (isFunctionLike(container) && !isInParameterInitializerBeforeContainingFunction(node)) {
                 // If this is a function in a JS file, it might be a class method. Check if it's the RHS
                 // of a x.prototype.y = function [name]() { .... }
                 if (container.kind === SyntaxKind.FunctionExpression &&

--- a/tests/baselines/reference/inferParameterWithMethodCallInitializer.js
+++ b/tests/baselines/reference/inferParameterWithMethodCallInitializer.js
@@ -10,6 +10,14 @@ class Example {
         return a;
     }
 }
+function weird(this: Example, a = this.getNumber()) {
+    return a;
+}
+class Weird {
+    doSomething(this: Example, a = this.getNumber()) {
+        return a;
+    }
+}
 
 
 //// [inferParameterWithMethodCallInitializer.js]
@@ -27,4 +35,17 @@ var Example = (function () {
         return a;
     };
     return Example;
+}());
+function weird(a) {
+    if (a === void 0) { a = this.getNumber(); }
+    return a;
+}
+var Weird = (function () {
+    function Weird() {
+    }
+    Weird.prototype.doSomething = function (a) {
+        if (a === void 0) { a = this.getNumber(); }
+        return a;
+    };
+    return Weird;
 }());

--- a/tests/baselines/reference/inferParameterWithMethodCallInitializer.js
+++ b/tests/baselines/reference/inferParameterWithMethodCallInitializer.js
@@ -1,0 +1,30 @@
+//// [inferParameterWithMethodCallInitializer.ts]
+function getNumber(): number {
+    return 1;
+}
+class Example {
+    getNumber(): number {
+        return 1;
+    }
+    doSomething(a = this.getNumber()): typeof a {
+        return a;
+    }
+}
+
+
+//// [inferParameterWithMethodCallInitializer.js]
+function getNumber() {
+    return 1;
+}
+var Example = (function () {
+    function Example() {
+    }
+    Example.prototype.getNumber = function () {
+        return 1;
+    };
+    Example.prototype.doSomething = function (a) {
+        if (a === void 0) { a = this.getNumber(); }
+        return a;
+    };
+    return Example;
+}());

--- a/tests/baselines/reference/inferParameterWithMethodCallInitializer.symbols
+++ b/tests/baselines/reference/inferParameterWithMethodCallInitializer.symbols
@@ -24,4 +24,32 @@ class Example {
 >a : Symbol(a, Decl(inferParameterWithMethodCallInitializer.ts, 7, 16))
     }
 }
+function weird(this: Example, a = this.getNumber()) {
+>weird : Symbol(weird, Decl(inferParameterWithMethodCallInitializer.ts, 10, 1))
+>this : Symbol(this, Decl(inferParameterWithMethodCallInitializer.ts, 11, 15))
+>Example : Symbol(Example, Decl(inferParameterWithMethodCallInitializer.ts, 2, 1))
+>a : Symbol(a, Decl(inferParameterWithMethodCallInitializer.ts, 11, 29))
+>this.getNumber : Symbol(Example.getNumber, Decl(inferParameterWithMethodCallInitializer.ts, 3, 15))
+>this : Symbol(Example, Decl(inferParameterWithMethodCallInitializer.ts, 2, 1))
+>getNumber : Symbol(Example.getNumber, Decl(inferParameterWithMethodCallInitializer.ts, 3, 15))
+
+    return a;
+>a : Symbol(a, Decl(inferParameterWithMethodCallInitializer.ts, 11, 29))
+}
+class Weird {
+>Weird : Symbol(Weird, Decl(inferParameterWithMethodCallInitializer.ts, 13, 1))
+
+    doSomething(this: Example, a = this.getNumber()) {
+>doSomething : Symbol(Weird.doSomething, Decl(inferParameterWithMethodCallInitializer.ts, 14, 13))
+>this : Symbol(this, Decl(inferParameterWithMethodCallInitializer.ts, 15, 16))
+>Example : Symbol(Example, Decl(inferParameterWithMethodCallInitializer.ts, 2, 1))
+>a : Symbol(a, Decl(inferParameterWithMethodCallInitializer.ts, 15, 30))
+>this.getNumber : Symbol(Example.getNumber, Decl(inferParameterWithMethodCallInitializer.ts, 3, 15))
+>this : Symbol(Example, Decl(inferParameterWithMethodCallInitializer.ts, 2, 1))
+>getNumber : Symbol(Example.getNumber, Decl(inferParameterWithMethodCallInitializer.ts, 3, 15))
+
+        return a;
+>a : Symbol(a, Decl(inferParameterWithMethodCallInitializer.ts, 15, 30))
+    }
+}
 

--- a/tests/baselines/reference/inferParameterWithMethodCallInitializer.symbols
+++ b/tests/baselines/reference/inferParameterWithMethodCallInitializer.symbols
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/inferParameterWithMethodCallInitializer.ts ===
+function getNumber(): number {
+>getNumber : Symbol(getNumber, Decl(inferParameterWithMethodCallInitializer.ts, 0, 0))
+
+    return 1;
+}
+class Example {
+>Example : Symbol(Example, Decl(inferParameterWithMethodCallInitializer.ts, 2, 1))
+
+    getNumber(): number {
+>getNumber : Symbol(Example.getNumber, Decl(inferParameterWithMethodCallInitializer.ts, 3, 15))
+
+        return 1;
+    }
+    doSomething(a = this.getNumber()): typeof a {
+>doSomething : Symbol(Example.doSomething, Decl(inferParameterWithMethodCallInitializer.ts, 6, 5))
+>a : Symbol(a, Decl(inferParameterWithMethodCallInitializer.ts, 7, 16))
+>this.getNumber : Symbol(Example.getNumber, Decl(inferParameterWithMethodCallInitializer.ts, 3, 15))
+>this : Symbol(Example, Decl(inferParameterWithMethodCallInitializer.ts, 2, 1))
+>getNumber : Symbol(Example.getNumber, Decl(inferParameterWithMethodCallInitializer.ts, 3, 15))
+>a : Symbol(a, Decl(inferParameterWithMethodCallInitializer.ts, 7, 16))
+
+        return a;
+>a : Symbol(a, Decl(inferParameterWithMethodCallInitializer.ts, 7, 16))
+    }
+}
+

--- a/tests/baselines/reference/inferParameterWithMethodCallInitializer.types
+++ b/tests/baselines/reference/inferParameterWithMethodCallInitializer.types
@@ -27,4 +27,34 @@ class Example {
 >a : number
     }
 }
+function weird(this: Example, a = this.getNumber()) {
+>weird : (this: Example, a?: number) => number
+>this : Example
+>Example : Example
+>a : number
+>this.getNumber() : number
+>this.getNumber : () => number
+>this : Example
+>getNumber : () => number
+
+    return a;
+>a : number
+}
+class Weird {
+>Weird : Weird
+
+    doSomething(this: Example, a = this.getNumber()) {
+>doSomething : (this: Example, a?: number) => number
+>this : Example
+>Example : Example
+>a : number
+>this.getNumber() : number
+>this.getNumber : () => number
+>this : Example
+>getNumber : () => number
+
+        return a;
+>a : number
+    }
+}
 

--- a/tests/baselines/reference/inferParameterWithMethodCallInitializer.types
+++ b/tests/baselines/reference/inferParameterWithMethodCallInitializer.types
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/inferParameterWithMethodCallInitializer.ts ===
+function getNumber(): number {
+>getNumber : () => number
+
+    return 1;
+>1 : number
+}
+class Example {
+>Example : Example
+
+    getNumber(): number {
+>getNumber : () => number
+
+        return 1;
+>1 : number
+    }
+    doSomething(a = this.getNumber()): typeof a {
+>doSomething : (a?: number) => number
+>a : number
+>this.getNumber() : number
+>this.getNumber : () => number
+>this : this
+>getNumber : () => number
+>a : number
+
+        return a;
+>a : number
+    }
+}
+

--- a/tests/cases/compiler/inferParameterWithMethodCallInitializer.ts
+++ b/tests/cases/compiler/inferParameterWithMethodCallInitializer.ts
@@ -1,0 +1,12 @@
+// @noImplicitAny: true
+function getNumber(): number {
+    return 1;
+}
+class Example {
+    getNumber(): number {
+        return 1;
+    }
+    doSomething(a = this.getNumber()): typeof a {
+        return a;
+    }
+}

--- a/tests/cases/compiler/inferParameterWithMethodCallInitializer.ts
+++ b/tests/cases/compiler/inferParameterWithMethodCallInitializer.ts
@@ -10,3 +10,11 @@ class Example {
         return a;
     }
 }
+function weird(this: Example, a = this.getNumber()) {
+    return a;
+}
+class Weird {
+    doSomething(this: Example, a = this.getNumber()) {
+        return a;
+    }
+}


### PR DESCRIPTION
Fixes #8647

The new code to resolve this-function types should not apply to parameter initializers, eg

```ts
class C {
  m(a = this.m2()) {
  }
  m2() { return 12; }
}
```