### PR TITLE
Normalize basepath in parseJsonConfigFileContent()

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -675,7 +675,7 @@ namespace ts {
       * @param basePath A root directory to resolve relative path entries in the config
       *    file to. e.g. outDir
       */
-    export function parseJsonConfigFileContent(json: any, host: ParseConfigHost, basePath: string, existingOptions: CompilerOptions = {}, configFileName?: string): ParsedCommandLine
+    export function parseJsonConfigFileContent(json: any, host: ParseConfigHost, basePath: string, existingOptions: CompilerOptions = {}, configFileName?: string): ParsedCommandLine {
         basePath = normalizeSlashes(basePath);
         const errors: Diagnostic[] = [];
         const compilerOptions: CompilerOptions = convertCompilerOptionsFromJsonWorker(json["compilerOptions"], basePath, errors, configFileName);

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -676,7 +676,6 @@ namespace ts {
       *    file to. e.g. outDir
       */
     export function parseJsonConfigFileContent(json: any, host: ParseConfigHost, basePath: string, existingOptions: CompilerOptions = {}, configFileName?: string): ParsedCommandLine {
-        basePath = normalizeSlashes(basePath);
         const errors: Diagnostic[] = [];
         const compilerOptions: CompilerOptions = convertCompilerOptionsFromJsonWorker(json["compilerOptions"], basePath, errors, configFileName);
         const options = extend(existingOptions, compilerOptions);

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -675,7 +675,8 @@ namespace ts {
       * @param basePath A root directory to resolve relative path entries in the config
       *    file to. e.g. outDir
       */
-    export function parseJsonConfigFileContent(json: any, host: ParseConfigHost, basePath: string, existingOptions: CompilerOptions = {}, configFileName?: string): ParsedCommandLine {
+    export function parseJsonConfigFileContent(json: any, host: ParseConfigHost, basePath: string, existingOptions: CompilerOptions = {}, configFileName?: string): ParsedCommandLine
+        basePath = normalizeSlashes(basePath);
         const errors: Diagnostic[] = [];
         const compilerOptions: CompilerOptions = convertCompilerOptionsFromJsonWorker(json["compilerOptions"], basePath, errors, configFileName);
         const options = extend(existingOptions, compilerOptions);

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -170,6 +170,7 @@ namespace ts {
 
             function readDirectory(path: string, extension?: string, exclude?: string[]): string[] {
                 const result: string[] = [];
+                path = normalizePath(path);
                 exclude = map(exclude, s => getCanonicalPath(combinePaths(path, s)));
                 visitDirectory(path);
                 return result;
@@ -416,6 +417,7 @@ namespace ts {
 
             function readDirectory(path: string, extension?: string, exclude?: string[]): string[] {
                 const result: string[] = [];
+                path = normalizePath(path);
                 exclude = map(exclude, s => getCanonicalPath(combinePaths(path, s)));
                 visitDirectory(path);
                 return result;


### PR DESCRIPTION
This PR fixes #9123 by normalizing the path with `normalizeSlashes()`. 
Im not sure if this enough, please review :)
