### PR TITLE
Add isDefinition to references

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -728,7 +728,7 @@ namespace FourSlash {
             }
         }
 
-        public verifyReferencesAtPositionListContains(fileName: string, start: number, end: number, isWriteAccess?: boolean) {
+        public verifyReferencesAtPositionListContains(fileName: string, start: number, end: number, isWriteAccess?: boolean, isDefinition?: boolean) {
             const references = this.getReferencesAtCaret();
 
             if (!references || references.length === 0) {
@@ -741,11 +741,14 @@ namespace FourSlash {
                     if (typeof isWriteAccess !== "undefined" && reference.isWriteAccess !== isWriteAccess) {
                         this.raiseError(`verifyReferencesAtPositionListContains failed - item isWriteAccess value does not match, actual: ${reference.isWriteAccess}, expected: ${isWriteAccess}.`);
                     }
+                    if (typeof isDefinition !== "undefined" && reference.isDefinition !== isDefinition) {
+                        this.raiseError(`verifyReferencesAtPositionListContains failed - item isDefinition value does not match, actual: ${reference.isDefinition}, expected: ${isDefinition}.`);
+                    }
                     return;
                 }
             }
 
-            const missingItem = { fileName: fileName, start: start, end: end, isWriteAccess: isWriteAccess };
+            const missingItem = { fileName, start, end, isWriteAccess, isDefinition };
             this.raiseError(`verifyReferencesAtPositionListContains failed - could not find the item: ${stringify(missingItem)} in the returned list: (${stringify(references)})`);
         }
 
@@ -2835,8 +2838,8 @@ namespace FourSlashInterface {
             this.state.verifyReferencesCountIs(count, /*localFilesOnly*/ false);
         }
 
-        public referencesAtPositionContains(range: FourSlash.Range, isWriteAccess?: boolean) {
-            this.state.verifyReferencesAtPositionListContains(range.fileName, range.start, range.end, isWriteAccess);
+        public referencesAtPositionContains(range: FourSlash.Range, isWriteAccess?: boolean, isDefinition?: boolean) {
+            this.state.verifyReferencesAtPositionListContains(range.fileName, range.start, range.end, isWriteAccess, isDefinition);
         }
 
         public signatureHelpPresent() {

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -537,6 +537,7 @@ namespace ts.server {
                     fileName,
                     textSpan: ts.createTextSpanFromBounds(start, end),
                     isWriteAccess: entry.isWriteAccess,
+                    isDefinition: false
                 };
             });
         }

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -376,6 +376,7 @@ namespace ts.server {
                     fileName: fileName,
                     textSpan: ts.createTextSpanFromBounds(start, end),
                     isWriteAccess: entry.isWriteAccess,
+                    isDefinition: entry.isDefinition,
                 };
             });
         }

--- a/src/server/protocol.d.ts
+++ b/src/server/protocol.d.ts
@@ -308,7 +308,7 @@ declare namespace ts.server.protocol {
         /**
          * True if reference is a definition, false otherwise.
          */
-        isDefinition?: boolean;
+        isDefinition: boolean;
     }
 
     /**

--- a/src/server/protocol.d.ts
+++ b/src/server/protocol.d.ts
@@ -304,6 +304,11 @@ declare namespace ts.server.protocol {
           * True if reference is a write location, false otherwise.
           */
         isWriteAccess: boolean;
+
+        /**
+         * True if reference is a definition, false otherwise.
+         */
+        isDefinition?: boolean;
     }
 
     /**

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -379,7 +379,7 @@ namespace ts.server {
                     start,
                     end,
                     file: fileName,
-                    isWriteAccess
+                    isWriteAccess,
                 };
             });
         }
@@ -555,7 +555,8 @@ namespace ts.server {
                             start: start,
                             lineText: lineText,
                             end: compilerService.host.positionToLineOffset(ref.fileName, ts.textSpanEnd(ref.textSpan)),
-                            isWriteAccess: ref.isWriteAccess
+                            isWriteAccess: ref.isWriteAccess,
+                            isDefinition: ref.isDefinition
                         };
                     });
                 },

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -6741,7 +6741,7 @@ namespace ts {
                 fileName: node.getSourceFile().fileName,
                 textSpan: createTextSpanFromBounds(start, end),
                 isWriteAccess: isWriteAccess(node),
-                isDefinition: isDeclarationName(node)
+                isDefinition: isDeclarationName(node) || node.parent.kind === SyntaxKind.ComputedPropertyName
             };
         }
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -6741,7 +6741,7 @@ namespace ts {
                 fileName: node.getSourceFile().fileName,
                 textSpan: createTextSpanFromBounds(start, end),
                 isWriteAccess: isWriteAccess(node),
-                isDefinition: isDeclarationName(node) || node.parent.kind === SyntaxKind.ComputedPropertyName
+                isDefinition: isDeclarationName(node) || isLiteralComputedPropertyDeclarationName(node)
             };
         }
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1208,6 +1208,7 @@ namespace ts {
         textSpan: TextSpan;
         fileName: string;
         isWriteAccess: boolean;
+        isDefinition?: boolean;
     }
 
     export interface DocumentHighlights {
@@ -6183,7 +6184,8 @@ namespace ts {
                                     references: [{
                                         fileName: sourceFile.fileName,
                                         textSpan: createTextSpan(position, searchText.length),
-                                        isWriteAccess: false
+                                        isWriteAccess: false,
+                                        isDefinition: false
                                     }]
                                 });
                             }
@@ -6737,7 +6739,8 @@ namespace ts {
             return {
                 fileName: node.getSourceFile().fileName,
                 textSpan: createTextSpanFromBounds(start, end),
-                isWriteAccess: isWriteAccess(node)
+                isWriteAccess: isWriteAccess(node),
+                isDefinition: isDeclarationName(node)
             };
         }
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1208,7 +1208,7 @@ namespace ts {
         textSpan: TextSpan;
         fileName: string;
         isWriteAccess: boolean;
-        isDefinition?: boolean;
+        isDefinition: boolean;
     }
 
     export interface DocumentHighlights {
@@ -5750,7 +5750,8 @@ namespace ts {
                         result.push({
                             fileName: entry.fileName,
                             textSpan: highlightSpan.textSpan,
-                            isWriteAccess: highlightSpan.kind === HighlightSpanKind.writtenReference
+                            isWriteAccess: highlightSpan.kind === HighlightSpanKind.writtenReference,
+                            isDefinition: false
                         });
                     }
                 }

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -164,7 +164,7 @@ namespace ts {
 
         /**
          * Returns a JSON-encoded value of the type:
-         * { fileName: string; textSpan: { start: number; length: number}; isWriteAccess: boolean }[]
+         * { fileName: string; textSpan: { start: number; length: number}; isWriteAccess: boolean, isDefinition?: boolean }[]
          */
         getReferencesAtPosition(fileName: string, position: number): string;
 

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -125,7 +125,7 @@ declare namespace FourSlashInterface {
         completionListAllowsNewIdentifier(): void;
         memberListIsEmpty(): void;
         referencesCountIs(count: number): void;
-        referencesAtPositionContains(range: Range, isWriteAccess?: boolean): void;
+        referencesAtPositionContains(range: Range, isWriteAccess?: boolean, isDefinition?: boolean): void;
         signatureHelpPresent(): void;
         errorExistsBetweenMarkers(startMarker: string, endMarker: string): void;
         errorExistsAfterMarker(markerName?: string): void;

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfArrowFunction.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfArrowFunction.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+////var [|{| "isDefinition": true |}f|] = x => x + 1;
+////[|{| "isDefinition": false |}f|](12);
+var firstRange = test.ranges()[0];
+goTo.position(firstRange.start, firstRange.fileName);
+test.ranges().forEach(range => {
+    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
+});

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfBindingPattern.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfBindingPattern.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+////const { [|{| "isDefinition": true |}x|], y } = { x: 1, y: 2 };
+////const z = [|{| "isDefinition": false |}x|];
+var firstRange = test.ranges()[0];
+goTo.position(firstRange.start, firstRange.fileName);
+test.ranges().forEach(range => {
+    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
+});

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfClass.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfClass.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+////class [|{| "isDefinition": true |}C|] {
+////    n: number;
+////    constructor() {
+////        this.n = 12;
+////    }
+////}
+////let c = new [|{| "isDefinition": false |}C|]();
+var firstRange = test.ranges()[0];
+goTo.position(firstRange.start, firstRange.fileName);
+test.ranges().forEach(range => {
+    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
+});

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfComputedProperty.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfComputedProperty.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts' />
+////let o = { ["[|{| "isDefinition": true |}foo|]"]: 12 };
+////let y = o.[|{| "isDefinition": false |}foo|];
+////let z = o['[|{| "isDefinition": false |}foo|]'];
+var firstRange = test.ranges()[0];
+goTo.position(firstRange.start, firstRange.fileName);
+test.ranges().forEach(range => {
+    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
+});

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfEnum.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfEnum.ts
@@ -1,0 +1,11 @@
+/// <reference path='fourslash.ts' />
+////enum [|{| "isDefinition": true |}E|] {
+////    First,
+////    Second
+////}
+////let first = [|{| "isDefinition": false |}E|].First;
+var firstRange = test.ranges()[0];
+goTo.position(firstRange.start, firstRange.fileName);
+test.ranges().forEach(range => {
+    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
+});

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfExport.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfExport.ts
@@ -1,0 +1,11 @@
+/// <reference path='fourslash.ts' />
+// @Filename: m.ts
+////export var [|{| "isDefinition": true |}x|] = 12;
+// @Filename: main.ts
+////import { [|{| "isDefinition": true |}x|] } from "./m";
+////const y = [|{| "isDefinition": false |}x|];
+var firstRange = test.ranges()[0];
+goTo.position(firstRange.start, firstRange.fileName);
+test.ranges().forEach(range => {
+    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
+});

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfFunction.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfFunction.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts' />
+////function [|{| "isDefinition": true |}func|](x: number) {
+////}
+////[|{| "isDefinition": false |}func|](x)
+var firstRange = test.ranges()[0];
+goTo.position(firstRange.start, firstRange.fileName);
+test.ranges().forEach(range => {
+    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
+});

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfInterface.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfInterface.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts' />
+////interface [|{| "isDefinition": true |}I|] {
+////    p: number;
+////}
+////let i: [|{| "isDefinition": false |}I|] = { p: 12 };
+var firstRange = test.ranges()[0];
+goTo.position(firstRange.start, firstRange.fileName);
+test.ranges().forEach(range => {
+    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
+});

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfInterfaceClassMerge.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfInterfaceClassMerge.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts' />
+////interface [|{| "isDefinition": true |}Numbers|] {
+////    p: number;
+////}
+////interface [|{| "isDefinition": true |}Numbers|] {
+////    m: number;
+////}
+////class [|{| "isDefinition": true |}Numbers|] {
+////    f(n: number) {
+////        return this.p + this.m + n;
+////    }
+////}
+////let i: [|{| "isDefinition": false |}Numbers|] = new [|{| "isDefinition": false |}Numbers|]();
+////let x = i.f(i.p + i.m);
+var firstRange = test.ranges()[0];
+goTo.position(firstRange.start, firstRange.fileName);
+test.ranges().forEach(range => {
+    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
+});

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfNamespace.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfNamespace.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts' />
+////namespace [|{| "isDefinition": true |}Numbers|] {
+////    export var n = 12;
+////}
+////let x = [|{| "isDefinition": false |}Numbers|].n + 1;
+var firstRange = test.ranges()[0];
+goTo.position(firstRange.start, firstRange.fileName);
+test.ranges().forEach(range => {
+    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
+});

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfNumberNamedProperty.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfNumberNamedProperty.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+////let o = { [|{| "isDefinition": true |}1|]: 12 };
+////let y = o[[|{| "isDefinition": false |}1|]];
+var firstRange = test.ranges()[0];
+goTo.position(firstRange.start, firstRange.fileName);
+test.ranges().forEach(range => {
+    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
+});

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfParameter.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfParameter.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts' />
+////function f([|{| "isDefinition": true |}x|]: number) {
+////  return [|{| "isDefinition": false |}x|] + 1
+////}
+var firstRange = test.ranges()[0];
+goTo.position(firstRange.start, firstRange.fileName);
+test.ranges().forEach(range => {
+    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
+});

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfStringNamedProperty.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfStringNamedProperty.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+////let o = { "[|{| "isDefinition": true |}x|]": 12 };
+////let y = o.[|{| "isDefinition": false |}x|];
+var firstRange = test.ranges()[0];
+goTo.position(firstRange.start, firstRange.fileName);
+test.ranges().forEach(range => {
+    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
+});

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfTypeAlias.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfTypeAlias.ts
@@ -1,0 +1,8 @@
+/// <reference path='fourslash.ts' />
+////type [|{| "isDefinition": true |}Alias|]= number;
+////let n: [|{| "isDefinition": false |}Alias|] = 12;
+var firstRange = test.ranges()[0];
+goTo.position(firstRange.start, firstRange.fileName);
+test.ranges().forEach(range => {
+    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
+});

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfVariable.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfVariable.ts
@@ -1,0 +1,23 @@
+/// <reference path='fourslash.ts' />
+////var [|{| "isDefinition": true |}x|] = 0;
+////var assignmentRightHandSide = [|{| "isDefinition": false |}x|];
+////var assignmentRightHandSide2 = 1 + [|{| "isDefinition": false |}x|];
+////
+////[|{| "isDefinition": false |}x|] = 1;
+////[|{| "isDefinition": false |}x|] = [|{| "isDefinition": false |}x|] + [|{| "isDefinition": false |}x|];
+////
+////[|{| "isDefinition": false |}x|] == 1;
+////[|{| "isDefinition": false |}x|] <= 1;
+////
+////var preIncrement = ++[|{| "isDefinition": false |}x|];
+////var postIncrement = [|{| "isDefinition": false |}x|]++;
+////var preDecrement = --[|{| "isDefinition": false |}x|];
+////var postDecrement = [|{| "isDefinition": false |}x|]--;
+////
+////[|{| "isDefinition": false |}x|] += 1;
+////[|{| "isDefinition": false |}x|] <<= 1;
+var firstRange = test.ranges()[0];
+goTo.position(firstRange.start, firstRange.fileName);
+test.ranges().forEach(range => {
+    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
+});


### PR DESCRIPTION
This allows clients to distinguish definitions from usages. I used this [to change tide to behave more like  Resharper](https://github.com/sandersn/tide/compare/typescript-2.0...sandersn:jump-to-single-reference?expand=1): tide-references now jumps directly to a single usage if only one usage and one definition exist. For example,

```ts
function f() {
  const once/*1*/ = 12;
  const twice/*2*/ = 13;
  const thrice/*3*/ = twice + 1;
  return once + twice + thrice + thrice + thrice;
}
```

If you get all references at /*1*/, you'll jump straight to the `return` line. If you get all references at /*2*/, you'll get the normal buffer listing references. Because of the deduping logic I wrote for tide, /*3*/ will behave the same as /*1*/ since all references are on the same line. But that's not necessarily the right thing.

@andy-ms I believe you were interested in this for Sublime too. @zhengbli, can you look at this and say whether it's the right approach?