### PR TITLE
Fix emit for shorthand properties when they refer to CommonJS exports.

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2150,9 +2150,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
             }
 
             // Return true if identifier resolves to an exported member of a namespace
-            function isNamespaceExportReference(node: Identifier) {
+            function isExportReference(node: Identifier) {
                 const container = resolver.getReferencedExportContainer(node);
-                return container && container.kind !== SyntaxKind.SourceFile;
+                return !!container;
             }
 
             // Return true if identifier resolves to an imported identifier
@@ -2185,10 +2185,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 //   const foo_1 = require('./foo');
                 //   exports.baz = { foo: foo_1.foo };
                 //
-                if (languageVersion < ScriptTarget.ES6 || (modulekind !== ModuleKind.ES6 && isImportedReference(node.name)) || isNamespaceExportReference(node.name) ) {
+                if (languageVersion < ScriptTarget.ES6 || (modulekind !== ModuleKind.ES6 && isImportedReference(node.name)) || isExportReference(node.name)) {
                     // Emit identifier as an identifier
                     write(": ");
-                    emit(node.name);
+                    emitExpressionIdentifier(node.name);
                 }
 
                 if (languageVersion >= ScriptTarget.ES6 && node.objectAssignmentInitializer) {

--- a/tests/baselines/reference/shorthandOfExportedEntity01_targetES2015_CommonJS.js
+++ b/tests/baselines/reference/shorthandOfExportedEntity01_targetES2015_CommonJS.js
@@ -11,7 +11,7 @@ export function foo () {
 "use strict";
 exports.test = "test";
 function foo() {
-    const x = { test };
+    const x = { test: exports.test };
 }
 exports.foo = foo;
 

--- a/tests/baselines/reference/shorthandOfExportedEntity01_targetES2015_CommonJS.js
+++ b/tests/baselines/reference/shorthandOfExportedEntity01_targetES2015_CommonJS.js
@@ -1,0 +1,21 @@
+//// [shorthandOfExportedEntity01_targetES2015_CommonJS.ts]
+
+export const test = "test";
+
+export function foo () {
+  const x = { test };
+}
+
+
+//// [shorthandOfExportedEntity01_targetES2015_CommonJS.js]
+"use strict";
+exports.test = "test";
+function foo() {
+    const x = { test };
+}
+exports.foo = foo;
+
+
+//// [shorthandOfExportedEntity01_targetES2015_CommonJS.d.ts]
+export declare const test: string;
+export declare function foo(): void;

--- a/tests/baselines/reference/shorthandOfExportedEntity01_targetES2015_CommonJS.symbols
+++ b/tests/baselines/reference/shorthandOfExportedEntity01_targetES2015_CommonJS.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/shorthandOfExportedEntity01_targetES2015_CommonJS.ts ===
+
+export const test = "test";
+>test : Symbol(test, Decl(shorthandOfExportedEntity01_targetES2015_CommonJS.ts, 1, 12))
+
+export function foo () {
+>foo : Symbol(foo, Decl(shorthandOfExportedEntity01_targetES2015_CommonJS.ts, 1, 27))
+
+  const x = { test };
+>x : Symbol(x, Decl(shorthandOfExportedEntity01_targetES2015_CommonJS.ts, 4, 7))
+>test : Symbol(test, Decl(shorthandOfExportedEntity01_targetES2015_CommonJS.ts, 4, 13))
+}
+

--- a/tests/baselines/reference/shorthandOfExportedEntity01_targetES2015_CommonJS.types
+++ b/tests/baselines/reference/shorthandOfExportedEntity01_targetES2015_CommonJS.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/shorthandOfExportedEntity01_targetES2015_CommonJS.ts ===
+
+export const test = "test";
+>test : string
+>"test" : string
+
+export function foo () {
+>foo : () => void
+
+  const x = { test };
+>x : { test: string; }
+>{ test } : { test: string; }
+>test : string
+}
+

--- a/tests/baselines/reference/shorthandOfExportedEntity02_targetES5_CommonJS.js
+++ b/tests/baselines/reference/shorthandOfExportedEntity02_targetES5_CommonJS.js
@@ -1,0 +1,21 @@
+//// [shorthandOfExportedEntity02_targetES5_CommonJS.ts]
+
+export const test = "test";
+
+export function foo () {
+  const x = { test };
+}
+
+
+//// [shorthandOfExportedEntity02_targetES5_CommonJS.js]
+"use strict";
+exports.test = "test";
+function foo() {
+    var x = { test: exports.test };
+}
+exports.foo = foo;
+
+
+//// [shorthandOfExportedEntity02_targetES5_CommonJS.d.ts]
+export declare const test: string;
+export declare function foo(): void;

--- a/tests/baselines/reference/shorthandOfExportedEntity02_targetES5_CommonJS.symbols
+++ b/tests/baselines/reference/shorthandOfExportedEntity02_targetES5_CommonJS.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/shorthandOfExportedEntity02_targetES5_CommonJS.ts ===
+
+export const test = "test";
+>test : Symbol(test, Decl(shorthandOfExportedEntity02_targetES5_CommonJS.ts, 1, 12))
+
+export function foo () {
+>foo : Symbol(foo, Decl(shorthandOfExportedEntity02_targetES5_CommonJS.ts, 1, 27))
+
+  const x = { test };
+>x : Symbol(x, Decl(shorthandOfExportedEntity02_targetES5_CommonJS.ts, 4, 7))
+>test : Symbol(test, Decl(shorthandOfExportedEntity02_targetES5_CommonJS.ts, 4, 13))
+}
+

--- a/tests/baselines/reference/shorthandOfExportedEntity02_targetES5_CommonJS.types
+++ b/tests/baselines/reference/shorthandOfExportedEntity02_targetES5_CommonJS.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/shorthandOfExportedEntity02_targetES5_CommonJS.ts ===
+
+export const test = "test";
+>test : string
+>"test" : string
+
+export function foo () {
+>foo : () => void
+
+  const x = { test };
+>x : { test: string; }
+>{ test } : { test: string; }
+>test : string
+}
+

--- a/tests/cases/compiler/shorthandOfExportedEntity01_targetES2015_CommonJS.ts
+++ b/tests/cases/compiler/shorthandOfExportedEntity01_targetES2015_CommonJS.ts
@@ -1,0 +1,9 @@
+// @target: ES2015
+// @module: commonjs
+// @declaration: true
+
+export const test = "test";
+
+export function foo () {
+  const x = { test };
+}

--- a/tests/cases/compiler/shorthandOfExportedEntity02_targetES5_CommonJS.ts
+++ b/tests/cases/compiler/shorthandOfExportedEntity02_targetES5_CommonJS.ts
@@ -1,0 +1,9 @@
+// @target: ES5
+// @module: commonjs
+// @declaration: true
+
+export const test = "test";
+
+export function foo () {
+  const x = { test };
+}


### PR DESCRIPTION
Fixes #8826 so Yui can be more productive.