### PR TITLE
Emit 'Promise' decorator metadata return type for async methods

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -6157,12 +6157,11 @@ const _super = (function (geti, seti) {
             /** Serializes the return type of function. Used by the __metadata decorator for a method. */
             function emitSerializedReturnTypeOfNode(node: Node) {
                 if (node && isFunctionLike(node)) {
-                    const fn = <FunctionLikeDeclaration>node;
-                    if (fn.type) {
+                    if ((<FunctionLikeDeclaration>node).type) {
                         emitSerializedTypeNode((<FunctionLikeDeclaration>node).type);
                         return;
                     }
-                    else if (isAsyncFunctionLike(fn)) {
+                    else if (isAsyncFunctionLike(<FunctionLikeDeclaration>node)) {
                         write("Promise");
                         return;
                     }

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -6156,9 +6156,16 @@ const _super = (function (geti, seti) {
 
             /** Serializes the return type of function. Used by the __metadata decorator for a method. */
             function emitSerializedReturnTypeOfNode(node: Node) {
-                if (node && isFunctionLike(node) && (<FunctionLikeDeclaration>node).type) {
-                    emitSerializedTypeNode((<FunctionLikeDeclaration>node).type);
-                    return;
+                if (node && isFunctionLike(node)) {
+                    const fn = <FunctionLikeDeclaration>node;
+                    if (fn.type) {
+                        emitSerializedTypeNode((<FunctionLikeDeclaration>node).type);
+                        return;
+                    }
+                    else if (isAsyncFunctionLike(fn)) {
+                        write("Promise");
+                        return;
+                    }
                 }
 
                 write("void 0");

--- a/tests/baselines/reference/decoratorMetadataPromise.js
+++ b/tests/baselines/reference/decoratorMetadataPromise.js
@@ -1,0 +1,59 @@
+//// [decoratorMetadataPromise.ts]
+
+declare const decorator: MethodDecorator;
+
+class A {
+    @decorator
+    async foo() {}
+    @decorator
+    async bar(): Promise<number> { return 0; }
+    @decorator
+    baz(n: Promise<number>): Promise<number> { return n; }
+}
+
+
+//// [decoratorMetadataPromise.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments)).next());
+    });
+};
+class A {
+    foo() {
+        return __awaiter(this, void 0, void 0, function* () { });
+    }
+    bar() {
+        return __awaiter(this, void 0, void 0, function* () { return 0; });
+    }
+    baz(n) { return n; }
+}
+__decorate([
+    decorator, 
+    __metadata('design:type', Function), 
+    __metadata('design:paramtypes', []), 
+    __metadata('design:returntype', Promise)
+], A.prototype, "foo", null);
+__decorate([
+    decorator, 
+    __metadata('design:type', Function), 
+    __metadata('design:paramtypes', []), 
+    __metadata('design:returntype', Promise)
+], A.prototype, "bar", null);
+__decorate([
+    decorator, 
+    __metadata('design:type', Function), 
+    __metadata('design:paramtypes', [Promise]), 
+    __metadata('design:returntype', Promise)
+], A.prototype, "baz", null);

--- a/tests/baselines/reference/decoratorMetadataPromise.symbols
+++ b/tests/baselines/reference/decoratorMetadataPromise.symbols
@@ -1,0 +1,33 @@
+=== tests/cases/compiler/decoratorMetadataPromise.ts ===
+
+declare const decorator: MethodDecorator;
+>decorator : Symbol(decorator, Decl(decoratorMetadataPromise.ts, 1, 13))
+>MethodDecorator : Symbol(MethodDecorator, Decl(lib.es5.d.ts, --, --))
+
+class A {
+>A : Symbol(A, Decl(decoratorMetadataPromise.ts, 1, 41))
+
+    @decorator
+>decorator : Symbol(decorator, Decl(decoratorMetadataPromise.ts, 1, 13))
+
+    async foo() {}
+>foo : Symbol(A.foo, Decl(decoratorMetadataPromise.ts, 3, 9))
+
+    @decorator
+>decorator : Symbol(decorator, Decl(decoratorMetadataPromise.ts, 1, 13))
+
+    async bar(): Promise<number> { return 0; }
+>bar : Symbol(A.bar, Decl(decoratorMetadataPromise.ts, 5, 18))
+>Promise : Symbol(Promise, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+
+    @decorator
+>decorator : Symbol(decorator, Decl(decoratorMetadataPromise.ts, 1, 13))
+
+    baz(n: Promise<number>): Promise<number> { return n; }
+>baz : Symbol(A.baz, Decl(decoratorMetadataPromise.ts, 7, 46))
+>n : Symbol(n, Decl(decoratorMetadataPromise.ts, 9, 8))
+>Promise : Symbol(Promise, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>n : Symbol(n, Decl(decoratorMetadataPromise.ts, 9, 8))
+}
+

--- a/tests/baselines/reference/decoratorMetadataPromise.types
+++ b/tests/baselines/reference/decoratorMetadataPromise.types
@@ -1,0 +1,34 @@
+=== tests/cases/compiler/decoratorMetadataPromise.ts ===
+
+declare const decorator: MethodDecorator;
+>decorator : <T>(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T> | void
+>MethodDecorator : <T>(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T> | void
+
+class A {
+>A : A
+
+    @decorator
+>decorator : <T>(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T> | void
+
+    async foo() {}
+>foo : () => Promise<void>
+
+    @decorator
+>decorator : <T>(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T> | void
+
+    async bar(): Promise<number> { return 0; }
+>bar : () => Promise<number>
+>Promise : Promise<T>
+>0 : number
+
+    @decorator
+>decorator : <T>(target: Object, propertyKey: string | symbol, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T> | void
+
+    baz(n: Promise<number>): Promise<number> { return n; }
+>baz : (n: Promise<number>) => Promise<number>
+>n : Promise<number>
+>Promise : Promise<T>
+>Promise : Promise<T>
+>n : Promise<number>
+}
+

--- a/tests/cases/compiler/decoratorMetadataPromise.ts
+++ b/tests/cases/compiler/decoratorMetadataPromise.ts
@@ -1,0 +1,14 @@
+// @experimentaldecorators: true
+// @emitdecoratormetadata: true
+// @target: es6
+
+declare const decorator: MethodDecorator;
+
+class A {
+    @decorator
+    async foo() {}
+    @decorator
+    async bar(): Promise<number> { return 0; }
+    @decorator
+    baz(n: Promise<number>): Promise<number> { return n; }
+}


### PR DESCRIPTION
Fixes #8351
