### PR TITLE
Unions and intersections of readonly properties are now also readonly

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11975,6 +11975,10 @@ namespace ts {
             // Variables declared with 'const'
             // Get accessors without matching set accessors
             // Enum members
+            // Unions and intersections of the above
+            if (symbol.flags & SymbolFlags.SyntheticProperty) {
+                return forEach(symbol.declarations, decl => isReadonlySymbol(getSymbolOfNode(decl)));
+            }
             return symbol.flags & SymbolFlags.Property && (getDeclarationFlagsFromSymbol(symbol) & NodeFlags.Readonly) !== 0 ||
                 symbol.flags & SymbolFlags.Variable && (getDeclarationFlagsFromSymbol(symbol) & NodeFlags.Const) !== 0 ||
                 symbol.flags & SymbolFlags.Accessor && !(symbol.flags & SymbolFlags.SetAccessor) ||

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2104,6 +2104,7 @@ namespace ts {
         members?: SymbolTable;                  // Class, interface or literal instance members
         exports?: SymbolTable;                  // Module exports
         globalExports?: SymbolTable;            // Conditional global UMD exports
+        /* @internal */ isReadonly?: boolean;   // readonly? (set only for intersections and unions)
         /* @internal */ id?: number;            // Unique id (used to look up SymbolLinks)
         /* @internal */ mergeId?: number;       // Merge id (used to look up merged symbol)
         /* @internal */ parent?: Symbol;        // Parent symbol

--- a/tests/baselines/reference/intersectionTypeReadonly.errors.txt
+++ b/tests/baselines/reference/intersectionTypeReadonly.errors.txt
@@ -1,0 +1,44 @@
+tests/cases/conformance/types/intersection/intersectionTypeReadonly.ts(17,1): error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+tests/cases/conformance/types/intersection/intersectionTypeReadonly.ts(19,1): error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+tests/cases/conformance/types/intersection/intersectionTypeReadonly.ts(21,1): error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+tests/cases/conformance/types/intersection/intersectionTypeReadonly.ts(23,1): error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+tests/cases/conformance/types/intersection/intersectionTypeReadonly.ts(25,1): error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+
+
+==== tests/cases/conformance/types/intersection/intersectionTypeReadonly.ts (5 errors) ====
+    interface Base {
+        readonly value: number;
+    }
+    interface Identical {
+        readonly value: number;
+    }
+    interface Mutable {
+        value: number;
+    }
+    interface DifferentType {
+        readonly value: string;
+    }
+    interface DifferentName {
+        readonly other: number;
+    }
+    let base: Base;
+    base.value = 12 // error, lhs can't be a readonly property
+    ~~~~~~~~~~
+!!! error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+    let identical: Base & Identical;
+    identical.value = 12; // error, lhs can't be a readonly property
+    ~~~~~~~~~~~~~~~
+!!! error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+    let mutable: Base & Mutable;
+    mutable.value = 12; // error, lhs can't be a readonly property
+    ~~~~~~~~~~~~~
+!!! error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+    let differentType: Base & DifferentType;
+    differentType.value = 12; // error, lhs can't be a readonly property
+    ~~~~~~~~~~~~~~~~~~~
+!!! error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+    let differentName: Base & DifferentName;
+    differentName.value = 12; // error, property 'value' doesn't exist
+    ~~~~~~~~~~~~~~~~~~~
+!!! error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+    

--- a/tests/baselines/reference/intersectionTypeReadonly.js
+++ b/tests/baselines/reference/intersectionTypeReadonly.js
@@ -1,0 +1,39 @@
+//// [intersectionTypeReadonly.ts]
+interface Base {
+    readonly value: number;
+}
+interface Identical {
+    readonly value: number;
+}
+interface Mutable {
+    value: number;
+}
+interface DifferentType {
+    readonly value: string;
+}
+interface DifferentName {
+    readonly other: number;
+}
+let base: Base;
+base.value = 12 // error, lhs can't be a readonly property
+let identical: Base & Identical;
+identical.value = 12; // error, lhs can't be a readonly property
+let mutable: Base & Mutable;
+mutable.value = 12; // error, lhs can't be a readonly property
+let differentType: Base & DifferentType;
+differentType.value = 12; // error, lhs can't be a readonly property
+let differentName: Base & DifferentName;
+differentName.value = 12; // error, property 'value' doesn't exist
+
+
+//// [intersectionTypeReadonly.js]
+var base;
+base.value = 12; // error, lhs can't be a readonly property
+var identical;
+identical.value = 12; // error, lhs can't be a readonly property
+var mutable;
+mutable.value = 12; // error, lhs can't be a readonly property
+var differentType;
+differentType.value = 12; // error, lhs can't be a readonly property
+var differentName;
+differentName.value = 12; // error, property 'value' doesn't exist

--- a/tests/baselines/reference/unionTypeReadonly.errors.txt
+++ b/tests/baselines/reference/unionTypeReadonly.errors.txt
@@ -1,0 +1,45 @@
+tests/cases/conformance/types/union/unionTypeReadonly.ts(17,1): error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+tests/cases/conformance/types/union/unionTypeReadonly.ts(19,1): error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+tests/cases/conformance/types/union/unionTypeReadonly.ts(21,1): error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+tests/cases/conformance/types/union/unionTypeReadonly.ts(23,1): error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+tests/cases/conformance/types/union/unionTypeReadonly.ts(25,15): error TS2339: Property 'value' does not exist on type 'Base | DifferentName'.
+
+
+==== tests/cases/conformance/types/union/unionTypeReadonly.ts (5 errors) ====
+    interface Base {
+        readonly value: number;
+    }
+    interface Identical {
+        readonly value: number;
+    }
+    interface Mutable {
+        value: number;
+    }
+    interface DifferentType {
+        readonly value: string;
+    }
+    interface DifferentName {
+        readonly other: number;
+    }
+    let base: Base;
+    base.value = 12 // error, lhs can't be a readonly property
+    ~~~~~~~~~~
+!!! error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+    let identical: Base | Identical;
+    identical.value = 12; // error, lhs can't be a readonly property
+    ~~~~~~~~~~~~~~~
+!!! error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+    let mutable: Base | Mutable;
+    mutable.value = 12; // error, lhs can't be a readonly property
+    ~~~~~~~~~~~~~
+!!! error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+    let differentType: Base | DifferentType;
+    differentType.value = 12; // error, lhs can't be a readonly property
+    ~~~~~~~~~~~~~~~~~~~
+!!! error TS2450: Left-hand side of assignment expression cannot be a constant or a read-only property.
+    let differentName: Base | DifferentName;
+    differentName.value = 12; // error, property 'value' doesn't exist
+                  ~~~~~
+!!! error TS2339: Property 'value' does not exist on type 'Base | DifferentName'.
+    
+    

--- a/tests/baselines/reference/unionTypeReadonly.js
+++ b/tests/baselines/reference/unionTypeReadonly.js
@@ -1,0 +1,40 @@
+//// [unionTypeReadonly.ts]
+interface Base {
+    readonly value: number;
+}
+interface Identical {
+    readonly value: number;
+}
+interface Mutable {
+    value: number;
+}
+interface DifferentType {
+    readonly value: string;
+}
+interface DifferentName {
+    readonly other: number;
+}
+let base: Base;
+base.value = 12 // error, lhs can't be a readonly property
+let identical: Base | Identical;
+identical.value = 12; // error, lhs can't be a readonly property
+let mutable: Base | Mutable;
+mutable.value = 12; // error, lhs can't be a readonly property
+let differentType: Base | DifferentType;
+differentType.value = 12; // error, lhs can't be a readonly property
+let differentName: Base | DifferentName;
+differentName.value = 12; // error, property 'value' doesn't exist
+
+
+
+//// [unionTypeReadonly.js]
+var base;
+base.value = 12; // error, lhs can't be a readonly property
+var identical;
+identical.value = 12; // error, lhs can't be a readonly property
+var mutable;
+mutable.value = 12; // error, lhs can't be a readonly property
+var differentType;
+differentType.value = 12; // error, lhs can't be a readonly property
+var differentName;
+differentName.value = 12; // error, property 'value' doesn't exist

--- a/tests/cases/conformance/types/intersection/intersectionTypeReadonly.ts
+++ b/tests/cases/conformance/types/intersection/intersectionTypeReadonly.ts
@@ -1,0 +1,25 @@
+interface Base {
+    readonly value: number;
+}
+interface Identical {
+    readonly value: number;
+}
+interface Mutable {
+    value: number;
+}
+interface DifferentType {
+    readonly value: string;
+}
+interface DifferentName {
+    readonly other: number;
+}
+let base: Base;
+base.value = 12 // error, lhs can't be a readonly property
+let identical: Base & Identical;
+identical.value = 12; // error, lhs can't be a readonly property
+let mutable: Base & Mutable;
+mutable.value = 12; // error, lhs can't be a readonly property
+let differentType: Base & DifferentType;
+differentType.value = 12; // error, lhs can't be a readonly property
+let differentName: Base & DifferentName;
+differentName.value = 12; // error, property 'value' doesn't exist

--- a/tests/cases/conformance/types/union/unionTypeReadonly.ts
+++ b/tests/cases/conformance/types/union/unionTypeReadonly.ts
@@ -1,0 +1,26 @@
+interface Base {
+    readonly value: number;
+}
+interface Identical {
+    readonly value: number;
+}
+interface Mutable {
+    value: number;
+}
+interface DifferentType {
+    readonly value: string;
+}
+interface DifferentName {
+    readonly other: number;
+}
+let base: Base;
+base.value = 12 // error, lhs can't be a readonly property
+let identical: Base | Identical;
+identical.value = 12; // error, lhs can't be a readonly property
+let mutable: Base | Mutable;
+mutable.value = 12; // error, lhs can't be a readonly property
+let differentType: Base | DifferentType;
+differentType.value = 12; // error, lhs can't be a readonly property
+let differentName: Base | DifferentName;
+differentName.value = 12; // error, property 'value' doesn't exist
+


### PR DESCRIPTION
Fixes #9108 

@ahejlsberg can you take a look to confirm that this is how readonly should work with unions and intersections of properties?
