### PR TITLE
Prevent renaming `this` parameters

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -7999,7 +7999,7 @@ namespace ts {
 
             // Can only rename an identifier.
             if (node) {
-                if (node.kind === SyntaxKind.Identifier ||
+                if ((node.kind === SyntaxKind.Identifier && (node as Identifier).originalKeywordKind !== SyntaxKind.ThisKeyword) ||
                     node.kind === SyntaxKind.StringLiteral ||
                     isLiteralNameOfPropertyDeclarationOrIndexAccess(node)) {
                     const symbol = typeChecker.getSymbolAtLocation(node);

--- a/tests/cases/fourslash/noRenameOfThisParameter.ts
+++ b/tests/cases/fourslash/noRenameOfThisParameter.ts
@@ -1,0 +1,6 @@
+/// <reference path="fourslash.ts" />
+////function f(this/**/: string, x: number) {
+////    return this.length + x;
+////}
+goTo.marker();
+verify.renameInfoFailed();


### PR DESCRIPTION
Fixes #9037 

I'm going to look into making the parser allow a ThisKeyword as a ParameterDeclaration, but I think this will turn out to be the right fix.

