### PR TITLE
[Fix #9004] Improve error message for extending interface

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -955,7 +955,7 @@ namespace ts {
                 return false;
             }
             const expression = (<ExpressionWithTypeArguments>parentClassExpression).expression;
-            if (resolveEntityName(expression, SymbolFlags.Interface, true)) {
+            if (resolveEntityName(expression, SymbolFlags.Interface, /*ignoreErrors*/ true)) {
                 error(errorLocation, Diagnostics.Cannot_extend_an_interface_0_Did_you_mean_implements, getTextOfNode(expression));
                 return true;
             }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1935,6 +1935,10 @@
         "category": "Error",
         "code": 2688
     },
+    "Cannot extend an interface '{0}'. Did you mean 'implements'?": {
+        "category": "Error",
+        "code": 2689
+    },
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",
         "code": 4000

--- a/tests/baselines/reference/classExtendingClassLikeType.errors.txt
+++ b/tests/baselines/reference/classExtendingClassLikeType.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/classes/classDeclarations/classExtendingClassLikeType.ts(7,18): error TS2304: Cannot find name 'Base'.
+tests/cases/conformance/classes/classDeclarations/classExtendingClassLikeType.ts(7,18): error TS2689: Cannot extend an interface 'Base'. Did you mean 'implements'?
 tests/cases/conformance/classes/classDeclarations/classExtendingClassLikeType.ts(45,18): error TS2508: No base constructor has the specified number of type arguments.
 tests/cases/conformance/classes/classDeclarations/classExtendingClassLikeType.ts(56,18): error TS2510: Base constructors must all have the same return type.
 
@@ -12,7 +12,7 @@ tests/cases/conformance/classes/classDeclarations/classExtendingClassLikeType.ts
     // Error, no Base constructor function
     class D0 extends Base<string, string> {
                      ~~~~
-!!! error TS2304: Cannot find name 'Base'.
+!!! error TS2689: Cannot extend an interface 'Base'. Did you mean 'implements'?
     }
     
     interface BaseConstructor {

--- a/tests/baselines/reference/classExtendsEveryObjectType.errors.txt
+++ b/tests/baselines/reference/classExtendsEveryObjectType.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsEveryObjectType.ts(4,17): error TS2304: Cannot find name 'I'.
+tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsEveryObjectType.ts(4,17): error TS2689: Cannot extend an interface 'I'. Did you mean 'implements'?
 tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsEveryObjectType.ts(6,18): error TS2507: Type '{ foo: any; }' is not a constructor function type.
 tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsEveryObjectType.ts(6,25): error TS2304: Cannot find name 'string'.
 tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/classExtendsEveryObjectType.ts(6,31): error TS1005: ',' expected.
@@ -14,7 +14,7 @@ tests/cases/conformance/classes/classDeclarations/classHeritageSpecification/cla
     }
     class C extends I { } // error
                     ~
-!!! error TS2304: Cannot find name 'I'.
+!!! error TS2689: Cannot extend an interface 'I'. Did you mean 'implements'?
     
     class C2 extends { foo: string; } { } // error
                      ~~~~~~~~~~~~~~~~

--- a/tests/baselines/reference/classExtendsInterface.errors.txt
+++ b/tests/baselines/reference/classExtendsInterface.errors.txt
@@ -1,17 +1,17 @@
-tests/cases/compiler/classExtendsInterface.ts(2,17): error TS2304: Cannot find name 'Comparable'.
-tests/cases/compiler/classExtendsInterface.ts(6,21): error TS2304: Cannot find name 'Comparable2'.
+tests/cases/compiler/classExtendsInterface.ts(2,17): error TS2689: Cannot extend an interface 'Comparable'. Did you mean 'implements'?
+tests/cases/compiler/classExtendsInterface.ts(6,21): error TS2689: Cannot extend an interface 'Comparable2'. Did you mean 'implements'?
 
 
 ==== tests/cases/compiler/classExtendsInterface.ts (2 errors) ====
     interface Comparable {}
     class A extends Comparable {}
                     ~~~~~~~~~~
-!!! error TS2304: Cannot find name 'Comparable'.
+!!! error TS2689: Cannot extend an interface 'Comparable'. Did you mean 'implements'?
     class B implements Comparable {}
      
     interface Comparable2<T> {}
     class A2<T> extends Comparable2<T> {}
                         ~~~~~~~~~~~
-!!! error TS2304: Cannot find name 'Comparable2'.
+!!! error TS2689: Cannot extend an interface 'Comparable2'. Did you mean 'implements'?
     class B2<T> implements Comparable2<T> {}
     

--- a/tests/baselines/reference/classExtendsInterface.errors.txt
+++ b/tests/baselines/reference/classExtendsInterface.errors.txt
@@ -8,7 +8,7 @@ tests/cases/compiler/classExtendsInterface.ts(6,21): error TS2689: Cannot extend
                     ~~~~~~~~~~
 !!! error TS2689: Cannot extend an interface 'Comparable'. Did you mean 'implements'?
     class B implements Comparable {}
-     
+    
     interface Comparable2<T> {}
     class A2<T> extends Comparable2<T> {}
                         ~~~~~~~~~~~

--- a/tests/baselines/reference/classExtendsInterface.js
+++ b/tests/baselines/reference/classExtendsInterface.js
@@ -2,7 +2,7 @@
 interface Comparable {}
 class A extends Comparable {}
 class B implements Comparable {}
- 
+
 interface Comparable2<T> {}
 class A2<T> extends Comparable2<T> {}
 class B2<T> implements Comparable2<T> {}

--- a/tests/baselines/reference/classExtendsInterfaceInExpression.errors.txt
+++ b/tests/baselines/reference/classExtendsInterfaceInExpression.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/classExtendsInterfaceInExpression.ts(7,25): error TS2304: Cannot find name 'A'.
+
+
+==== tests/cases/compiler/classExtendsInterfaceInExpression.ts (1 errors) ====
+    interface A {}
+    
+    function factory(a: any): {new(): Object} {
+      return null
+    }
+    
+    class C extends factory(A) {}
+                            ~
+!!! error TS2304: Cannot find name 'A'.
+    

--- a/tests/baselines/reference/classExtendsInterfaceInExpression.errors.txt
+++ b/tests/baselines/reference/classExtendsInterfaceInExpression.errors.txt
@@ -5,7 +5,7 @@ tests/cases/compiler/classExtendsInterfaceInExpression.ts(7,25): error TS2304: C
     interface A {}
     
     function factory(a: any): {new(): Object} {
-      return null
+      return null;
     }
     
     class C extends factory(A) {}

--- a/tests/baselines/reference/classExtendsInterfaceInExpression.js
+++ b/tests/baselines/reference/classExtendsInterfaceInExpression.js
@@ -2,7 +2,7 @@
 interface A {}
 
 function factory(a: any): {new(): Object} {
-  return null
+  return null;
 }
 
 class C extends factory(A) {}

--- a/tests/baselines/reference/classExtendsInterfaceInExpression.js
+++ b/tests/baselines/reference/classExtendsInterfaceInExpression.js
@@ -1,0 +1,26 @@
+//// [classExtendsInterfaceInExpression.ts]
+interface A {}
+
+function factory(a: any): {new(): Object} {
+  return null
+}
+
+class C extends factory(A) {}
+
+
+//// [classExtendsInterfaceInExpression.js]
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+function factory(a) {
+    return null;
+}
+var C = (function (_super) {
+    __extends(C, _super);
+    function C() {
+        _super.apply(this, arguments);
+    }
+    return C;
+}(factory(A)));

--- a/tests/baselines/reference/classExtendsInterfaceInModule.errors.txt
+++ b/tests/baselines/reference/classExtendsInterfaceInModule.errors.txt
@@ -1,0 +1,27 @@
+tests/cases/compiler/classExtendsInterfaceInModule.ts(5,18): error TS2689: Cannot extend an interface 'M.I1'. Did you mean 'implements'?
+tests/cases/compiler/classExtendsInterfaceInModule.ts(6,21): error TS2689: Cannot extend an interface 'M.I2'. Did you mean 'implements'?
+tests/cases/compiler/classExtendsInterfaceInModule.ts(14,17): error TS2689: Cannot extend an interface 'Mod.Nested.I'. Did you mean 'implements'?
+
+
+==== tests/cases/compiler/classExtendsInterfaceInModule.ts (3 errors) ====
+    module M {
+      export interface I1 {}
+      export interface I2<T> {}
+    }
+    class C1 extends M.I1 {}
+                     ~
+!!! error TS2689: Cannot extend an interface 'M.I1'. Did you mean 'implements'?
+    class C2<T> extends M.I2<T> {}
+                        ~
+!!! error TS2689: Cannot extend an interface 'M.I2'. Did you mean 'implements'?
+    
+    module Mod {
+    	export namespace Nested {
+    		export interface I {}
+    	}
+    }
+    
+    class D extends Mod.Nested.I {}
+                    ~~~
+!!! error TS2689: Cannot extend an interface 'Mod.Nested.I'. Did you mean 'implements'?
+    

--- a/tests/baselines/reference/classExtendsInterfaceInModule.js
+++ b/tests/baselines/reference/classExtendsInterfaceInModule.js
@@ -1,0 +1,44 @@
+//// [classExtendsInterfaceInModule.ts]
+module M {
+  export interface I1 {}
+  export interface I2<T> {}
+}
+class C1 extends M.I1 {}
+class C2<T> extends M.I2<T> {}
+
+module Mod {
+	export namespace Nested {
+		export interface I {}
+	}
+}
+
+class D extends Mod.Nested.I {}
+
+
+//// [classExtendsInterfaceInModule.js]
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var C1 = (function (_super) {
+    __extends(C1, _super);
+    function C1() {
+        _super.apply(this, arguments);
+    }
+    return C1;
+}(M.I1));
+var C2 = (function (_super) {
+    __extends(C2, _super);
+    function C2() {
+        _super.apply(this, arguments);
+    }
+    return C2;
+}(M.I2));
+var D = (function (_super) {
+    __extends(D, _super);
+    function D() {
+        _super.apply(this, arguments);
+    }
+    return D;
+}(Mod.Nested.I));

--- a/tests/baselines/reference/genericTypeReferenceWithoutTypeArgument2.errors.txt
+++ b/tests/baselines/reference/genericTypeReferenceWithoutTypeArgument2.errors.txt
@@ -13,7 +13,7 @@ tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenc
 tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenceWithoutTypeArgument2.ts(18,23): error TS2314: Generic type 'I<T>' requires 1 type argument(s).
 tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenceWithoutTypeArgument2.ts(18,27): error TS2314: Generic type 'I<T>' requires 1 type argument(s).
 tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenceWithoutTypeArgument2.ts(18,38): error TS2314: Generic type 'I<T>' requires 1 type argument(s).
-tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenceWithoutTypeArgument2.ts(20,17): error TS2304: Cannot find name 'I'.
+tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenceWithoutTypeArgument2.ts(20,17): error TS2689: Cannot extend an interface 'I'. Did you mean 'implements'?
 tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenceWithoutTypeArgument2.ts(23,21): error TS2314: Generic type 'I<T>' requires 1 type argument(s).
 tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenceWithoutTypeArgument2.ts(29,18): error TS2304: Cannot find name 'M'.
 tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenceWithoutTypeArgument2.ts(30,24): error TS2314: Generic type 'E<T>' requires 1 type argument(s).
@@ -76,7 +76,7 @@ tests/cases/conformance/types/specifyingTypes/typeReferences/genericTypeReferenc
     
     class D extends I {
                     ~
-!!! error TS2304: Cannot find name 'I'.
+!!! error TS2689: Cannot extend an interface 'I'. Did you mean 'implements'?
     }
     
     interface U extends I {}

--- a/tests/cases/compiler/classExtendsInterface.ts
+++ b/tests/cases/compiler/classExtendsInterface.ts
@@ -5,24 +5,3 @@ class B implements Comparable {}
 interface Comparable2<T> {}
 class A2<T> extends Comparable2<T> {}
 class B2<T> implements Comparable2<T> {}
-
-function Factory(a: any): {new()} {
-  return null
-}
-
-class C extends Factory(Comparable) {}
-
-module M {
-  export interface I1 {}
-  export interface I2<T> {}
-}
-class C1 extends M.I1 {}
-class C2<T> extends M.I2<T> {}
-
-namespace N {
-  export interface I1 {}
-  export interface I2<T> {}
-}
-
-class D1 extends N.I1 {}
-class D2<T> extends N.I2<T> {}

--- a/tests/cases/compiler/classExtendsInterface.ts
+++ b/tests/cases/compiler/classExtendsInterface.ts
@@ -1,7 +1,28 @@
 interface Comparable {}
 class A extends Comparable {}
 class B implements Comparable {}
- 
+
 interface Comparable2<T> {}
 class A2<T> extends Comparable2<T> {}
 class B2<T> implements Comparable2<T> {}
+
+function Factory(a: any): {new()} {
+  return null
+}
+
+class C extends Factory(Comparable) {}
+
+module M {
+  export interface I1 {}
+  export interface I2<T> {}
+}
+class C1 extends M.I1 {}
+class C2<T> extends M.I2<T> {}
+
+namespace N {
+  export interface I1 {}
+  export interface I2<T> {}
+}
+
+class D1 extends N.I1 {}
+class D2<T> extends N.I2<T> {}

--- a/tests/cases/compiler/classExtendsInterfaceInExpression.ts
+++ b/tests/cases/compiler/classExtendsInterfaceInExpression.ts
@@ -1,0 +1,7 @@
+interface A {}
+
+function factory(a: any): {new(): Object} {
+  return null
+}
+
+class C extends factory(A) {}

--- a/tests/cases/compiler/classExtendsInterfaceInExpression.ts
+++ b/tests/cases/compiler/classExtendsInterfaceInExpression.ts
@@ -1,7 +1,7 @@
 interface A {}
 
 function factory(a: any): {new(): Object} {
-  return null
+  return null;
 }
 
 class C extends factory(A) {}

--- a/tests/cases/compiler/classExtendsInterfaceInModule.ts
+++ b/tests/cases/compiler/classExtendsInterfaceInModule.ts
@@ -1,0 +1,14 @@
+module M {
+  export interface I1 {}
+  export interface I2<T> {}
+}
+class C1 extends M.I1 {}
+class C2<T> extends M.I2<T> {}
+
+module Mod {
+	export namespace Nested {
+		export interface I {}
+	}
+}
+
+class D extends Mod.Nested.I {}


### PR DESCRIPTION
Fixes #9004

I found it had more to do with checker than diagnostics.json. We have to first check whether it is a valid base class before reporting `cannot extending an interface`.  So I put the error reporting in `resolveName` and `checkPropertyAccessExpressionOrQualifiedName`, like `checkAndReportErrorForMissingPrefix`.

New baseline is accepted, and no new tests are added because current testcases are enough for this change.