### PR TITLE
Use helper functions to simplify range tests

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -730,30 +730,6 @@ namespace FourSlash {
             }
         }
 
-        public verifyReferencesAtPositionListContains(fileName: string, start: number, end: number, isWriteAccess?: boolean, isDefinition?: boolean) {
-            const references = this.getReferencesAtCaret();
-
-            if (!references || references.length === 0) {
-                this.raiseError("verifyReferencesAtPositionListContains failed - found 0 references, expected at least one.");
-            }
-
-            for (let i = 0; i < references.length; i++) {
-                const reference = references[i];
-                if (reference && reference.fileName === fileName && reference.textSpan.start === start && ts.textSpanEnd(reference.textSpan) === end) {
-                    if (typeof isWriteAccess !== "undefined" && reference.isWriteAccess !== isWriteAccess) {
-                        this.raiseError(`verifyReferencesAtPositionListContains failed - item isWriteAccess value does not match, actual: ${reference.isWriteAccess}, expected: ${isWriteAccess}.`);
-                    }
-                    if (typeof isDefinition !== "undefined" && reference.isDefinition !== isDefinition) {
-                        this.raiseError(`verifyReferencesAtPositionListContains failed - item isDefinition value does not match, actual: ${reference.isDefinition}, expected: ${isDefinition}.`);
-                    }
-                    return;
-                }
-            }
-
-            const missingItem = { fileName, start, end, isWriteAccess, isDefinition };
-            this.raiseError(`verifyReferencesAtPositionListContains failed - could not find the item: ${stringify(missingItem)} in the returned list: (${stringify(references)})`);
-        }
-
         public verifyReferencesCountIs(count: number, localFilesOnly = true) {
             const references = this.getReferencesAtCaret();
             let referencesCount = 0;
@@ -775,6 +751,73 @@ namespace FourSlash {
                 const condition = localFilesOnly ? "excluding libs" : "including libs";
                 this.raiseError("Expected references count (" + condition + ") to be " + count + ", but is actually " + referencesCount);
             }
+        }
+
+        public verifyReferencesAre(expectedReferences: Range[]) {
+            const actualReferences = this.getReferencesAtCaret() || [];
+
+            if (actualReferences.length > expectedReferences.length) {
+                // Find the unaccounted-for reference.
+                for (const actual of actualReferences) {
+                    if (!ts.forEach(expectedReferences, r => r.start === actual.textSpan.start)) {
+                        this.raiseError(`A reference ${actual} is unaccounted for.`);
+                    }
+                }
+                // Probably will never reach here.
+                this.raiseError(`There are ${actualReferences.length} references but only ${expectedReferences.length} were expected.`);
+            }
+
+            for (const reference of expectedReferences) {
+                const {fileName, start, end} = reference;
+                if (reference.marker) {
+                    const {isWriteAccess, isDefinition} = reference.marker.data;
+                    this.verifyReferencesWorker(actualReferences, fileName, start, end, isWriteAccess, isDefinition);
+                }
+                else {
+                    this.verifyReferencesWorker(actualReferences, fileName, start, end);
+                }
+            }
+        }
+
+        public verifyReferencesOf({fileName, start}: Range, references: Range[]) {
+            this.openFile(fileName);
+            this.goToPosition(start);
+            this.verifyReferencesAre(references);
+        }
+
+        public verifyRangesReferenceEachOther(ranges?: Range[]) {
+            ranges = ranges || this.getRanges();
+            assert(ranges.length);
+            for (const range of ranges) {
+                this.verifyReferencesOf(range, ranges);
+            }
+        }
+
+        public verifyReferencesAtPositionListContains(fileName: string, start: number, end: number, isWriteAccess?: boolean, isDefinition?: boolean) {
+            const references = this.getReferencesAtCaret();
+            if (!references || references.length === 0) {
+                this.raiseError("verifyReferencesAtPositionListContains failed - found 0 references, expected at least one.");
+            }
+            this.verifyReferencesWorker(references, fileName, start, end, isWriteAccess, isDefinition);
+        }
+
+        private verifyReferencesWorker(references: ts.ReferenceEntry[], fileName: string, start: number, end: number, isWriteAccess?: boolean, isDefinition?: boolean) {
+            for (let i = 0; i < references.length; i++) {
+                const reference = references[i];
+                if (reference && reference.fileName === fileName && reference.textSpan.start === start && ts.textSpanEnd(reference.textSpan) === end) {
+                    if (typeof isWriteAccess !== "undefined" && reference.isWriteAccess !== isWriteAccess) {
+                        this.raiseError(`verifyReferencesAtPositionListContains failed - item isWriteAccess value does not match, actual: ${reference.isWriteAccess}, expected: ${isWriteAccess}.`);
+                    }
+                    if (typeof isDefinition !== "undefined" && reference.isDefinition !== isDefinition) {
+                        this.raiseError(`verifyReferencesAtPositionListContains failed - item isDefinition value does not match, actual: ${reference.isDefinition}, expected: ${isDefinition}.`);
+                    }
+                    return;
+                }
+            }
+
+            const missingItem = { fileName, start, end, isWriteAccess, isDefinition };
+            this.raiseError(`verifyReferencesAtPositionListContains failed - could not find the item: ${stringify(missingItem)} in the returned list: (${stringify(references)})`);
+
         }
 
         private getMemberListAtCaret() {
@@ -2836,14 +2879,6 @@ namespace FourSlashInterface {
             this.state.verifyMemberListIsEmpty(this.negative);
         }
 
-        public referencesCountIs(count: number) {
-            this.state.verifyReferencesCountIs(count, /*localFilesOnly*/ false);
-        }
-
-        public referencesAtPositionContains(range: FourSlash.Range, isWriteAccess?: boolean, isDefinition?: boolean) {
-            this.state.verifyReferencesAtPositionListContains(range.fileName, range.start, range.end, isWriteAccess, isDefinition);
-        }
-
         public signatureHelpPresent() {
             this.state.verifySignatureHelpPresent(!this.negative);
         }
@@ -2933,6 +2968,22 @@ namespace FourSlashInterface {
 
         public verifyGetEmitOutputContentsForCurrentFile(expected: ts.OutputFile[]): void {
             this.state.verifyGetEmitOutputContentsForCurrentFile(expected);
+        }
+
+        public referencesCountIs(count: number) {
+            this.state.verifyReferencesCountIs(count, /*localFilesOnly*/ false);
+        }
+
+        public referencesAre(ranges: FourSlash.Range[]) {
+            this.state.verifyReferencesAre(ranges);
+        }
+
+        public referencesOf(start: FourSlash.Range, references: FourSlash.Range[]) {
+            this.state.verifyReferencesOf(start, references);
+        }
+
+        public rangesReferenceEachOther(ranges?: FourSlash.Range[]) {
+            this.state.verifyRangesReferenceEachOther(ranges);
         }
 
         public currentParameterHelpArgumentNameIs(name: string) {

--- a/tests/cases/fourslash/ambientShorthandFindAllRefs.ts
+++ b/tests/cases/fourslash/ambientShorthandFindAllRefs.ts
@@ -9,13 +9,4 @@
 // @Filename: user2.ts
 ////import {[|x|]} from "jquery";
 
-let ranges = test.ranges();
-for (let range of ranges) {
-    goTo.file(range.fileName);
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedRange of ranges) {
-        verify.referencesAtPositionContains(expectedRange);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsForComputedProperties.ts
+++ b/tests/cases/fourslash/findAllRefsForComputedProperties.ts
@@ -13,12 +13,4 @@
 ////    ["[|prop1|]"]: function () { },
 ////}
 
-let ranges = test.ranges();
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedReference of ranges) {
-        verify.referencesAtPositionContains(expectedReference);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsForComputedProperties2.ts
+++ b/tests/cases/fourslash/findAllRefsForComputedProperties2.ts
@@ -12,12 +12,4 @@
 ////    ["[|42|]"]: function () { }
 ////}
 
-let ranges = test.ranges();
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedReference of ranges) {
-        verify.referencesAtPositionContains(expectedReference);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsForDefaultExport01.ts
+++ b/tests/cases/fourslash/findAllRefsForDefaultExport01.ts
@@ -7,12 +7,4 @@
 ////
 ////var y = new [|DefaultExportedClass|];
 
-let ranges = test.ranges()
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedReference of ranges) {
-        verify.referencesAtPositionContains(expectedReference);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsForDefaultExport02.ts
+++ b/tests/cases/fourslash/findAllRefsForDefaultExport02.ts
@@ -8,12 +8,4 @@
 ////
 ////var y = [|DefaultExportedFunction|]();
 
-let ranges = test.ranges()
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedReference of ranges) {
-        verify.referencesAtPositionContains(expectedReference);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsForDefaultExport03.ts
+++ b/tests/cases/fourslash/findAllRefsForDefaultExport03.ts
@@ -14,12 +14,4 @@
 ////    var local = 100;
 ////}
 
-let ranges = test.ranges()
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedReference of ranges) {
-        verify.referencesAtPositionContains(expectedReference);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsForDefaultExport04.ts
+++ b/tests/cases/fourslash/findAllRefsForDefaultExport04.ts
@@ -20,9 +20,4 @@
 // site is included in the references to the namespace.
 
 goTo.marker();
-let ranges = test.ranges();
-verify.referencesCountIs(ranges.length);
-
-for (let expectedReference of ranges) {
-    verify.referencesAtPositionContains(expectedReference);
-}
+verify.referencesAre(test.ranges());

--- a/tests/cases/fourslash/findAllRefsForDefaultExport05.ts
+++ b/tests/cases/fourslash/findAllRefsForDefaultExport05.ts
@@ -20,9 +20,4 @@
 // and all value-uses of 'f' are included in the references to the function.
 
 goTo.marker();
-let ranges = test.ranges();
-verify.referencesCountIs(ranges.length);
-
-for (let expectedReference of ranges) {
-    verify.referencesAtPositionContains(expectedReference);
-}
+verify.referencesAre(test.ranges());

--- a/tests/cases/fourslash/findAllRefsForDefaultExport06.ts
+++ b/tests/cases/fourslash/findAllRefsForDefaultExport06.ts
@@ -20,9 +20,4 @@
 // and all value-uses of 'f' are included in the references to the function.
 
 goTo.marker();
-let ranges = test.ranges();
-verify.referencesCountIs(ranges.length);
-
-for (let expectedReference of ranges) {
-    verify.referencesAtPositionContains(expectedReference);
-}
+verify.referencesAre(test.ranges());

--- a/tests/cases/fourslash/findAllRefsForFunctionExpression01.ts
+++ b/tests/cases/fourslash/findAllRefsForFunctionExpression01.ts
@@ -9,13 +9,4 @@
 /////// <reference path="file1.ts" />
 ////foo();
 
-
-let ranges = test.ranges()
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedReference of ranges) {
-        verify.referencesAtPositionContains(expectedReference);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsForObjectLiteralProperties.ts
+++ b/tests/cases/fourslash/findAllRefsForObjectLiteralProperties.ts
@@ -8,13 +8,4 @@
 ////
 ////let {[|property|]: pVar} = x;
 
-
-let ranges = test.ranges();
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedReference of ranges) {
-        verify.referencesAtPositionContains(expectedReference);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsForStringLiteralTypes.ts
+++ b/tests/cases/fourslash/findAllRefsForStringLiteralTypes.ts
@@ -3,12 +3,4 @@
 ////type Options = "[|option 1|]" | "option 2";
 ////let myOption: Options = "[|option 1|]";
 
-let ranges = test.ranges();
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedReference of ranges) {
-        verify.referencesAtPositionContains(expectedReference);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsForVariableInExtendsClause01.ts
+++ b/tests/cases/fourslash/findAllRefsForVariableInExtendsClause01.ts
@@ -1,15 +1,6 @@
 ﻿/// <reference path="fourslash.ts"/>
 
-
 ////var [|Base|] = class { };
 ////class C extends [|Base|] { }
 
-let ranges = test.ranges();
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedReference of ranges) {
-        verify.referencesAtPositionContains(expectedReference);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsForVariableInExtendsClause02.ts
+++ b/tests/cases/fourslash/findAllRefsForVariableInExtendsClause02.ts
@@ -6,12 +6,4 @@
 ////    interface I extends [|Base|] { }
 ////}
 
-let ranges = test.ranges();
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedReference of ranges) {
-        verify.referencesAtPositionContains(expectedReference);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsInClassExpression.ts
+++ b/tests/cases/fourslash/findAllRefsInClassExpression.ts
@@ -5,12 +5,4 @@
 ////   [|boom|](){}
 ////}
 
-let ranges = test.ranges()
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedReference of ranges) {
-        verify.referencesAtPositionContains(expectedReference);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsInheritedProperties1.ts
+++ b/tests/cases/fourslash/findAllRefsInheritedProperties1.ts
@@ -9,17 +9,8 @@
 //// v.[|doStuff|]();
 //// v.[|propName|];
 
-function verifyReferences(query: FourSlashInterface.Range, references: FourSlashInterface.Range[]) {
-    goTo.position(query.start);
-    for (const ref of references) {
-        verify.referencesAtPositionContains(ref);
-    }
-}
-
-const ranges = test.ranges();
-verify.assertHasRanges(ranges);
-const [r0, r1, r2, r3] = ranges;
-verifyReferences(r0, [r0, r2]);
-verifyReferences(r1, [r1, r3]);
-verifyReferences(r2, [r0, r2]);
-verifyReferences(r3, [r1, r3]);
+const [r0, r1, r2, r3] = test.ranges();
+verify.referencesOf(r0, [r0, r2]);
+verify.referencesOf(r1, [r1, r3]);
+verify.referencesOf(r2, [r0, r2]);
+verify.referencesOf(r3, [r1, r3]);

--- a/tests/cases/fourslash/findAllRefsInheritedProperties2.ts
+++ b/tests/cases/fourslash/findAllRefsInheritedProperties2.ts
@@ -9,17 +9,8 @@
 //// v.[|doStuff|]();  // r2
 //// v.[|propName|];   // r3
 
-function verifyReferences(query: FourSlashInterface.Range, references: FourSlashInterface.Range[]) {
-    goTo.position(query.start);
-    for (const ref of references) {
-        verify.referencesAtPositionContains(ref);
-    }
-}
-
-const ranges = test.ranges();
-verify.assertHasRanges(ranges);
-const [r0, r1, r2, r3] = ranges;
-verifyReferences(r0, [r0, r2]);
-verifyReferences(r1, [r1, r3]);
-verifyReferences(r2, [r0, r2]);
-verifyReferences(r3, [r1, r3]);
+const [r0, r1, r2, r3] = test.ranges();
+verify.referencesOf(r0, [r0, r2]);
+verify.referencesOf(r1, [r1, r3]);
+verify.referencesOf(r2, [r0, r2]);
+verify.referencesOf(r3, [r1, r3]);

--- a/tests/cases/fourslash/findAllRefsInheritedProperties3.ts
+++ b/tests/cases/fourslash/findAllRefsInheritedProperties3.ts
@@ -17,21 +17,12 @@
 //// v.[|propName|];   // r6
 //// v.[|doStuff|]();  // r7
 
-function verifyReferences(query: FourSlashInterface.Range, references: FourSlashInterface.Range[]) {
-    goTo.position(query.start);
-    for (const ref of references) {
-        verify.referencesAtPositionContains(ref);
-    }
-}
-
-const ranges = test.ranges();
-verify.assertHasRanges(ranges);
-const [r0, r1, r2, r3, r4, r5, r6, r7] = ranges;
-verifyReferences(r0, [r0]);
-verifyReferences(r1, [r1, r5, r6]);
-verifyReferences(r2, [r2, r4, r7]);
-verifyReferences(r3, [r3, r5, r6]);
-verifyReferences(r4, [r2, r4, r7]);
-verifyReferences(r5, [r1, r3, r5, r6]);
-verifyReferences(r6, [r1, r3, r5, r6]);
-verifyReferences(r7, [r2, r4, r7]);
+const [r0, r1, r2, r3, r4, r5, r6, r7] = test.ranges();
+verify.referencesOf(r0, [r0, r4, r7]);
+verify.referencesOf(r1, [r1, r5, r6]);
+verify.referencesOf(r2, [r2, r4, r7]);
+verify.referencesOf(r3, [r3, r5, r6]);
+verify.referencesOf(r4, [r0, r2, r4, r7]);
+verify.referencesOf(r5, [r1, r3, r5, r6]);
+verify.referencesOf(r6, [r1, r3, r5, r6]);
+verify.referencesOf(r7, [r0, r2, r4, r7]);

--- a/tests/cases/fourslash/findAllRefsInheritedProperties4.ts
+++ b/tests/cases/fourslash/findAllRefsInheritedProperties4.ts
@@ -13,18 +13,9 @@
 //// d.[|prop0|];  // r3
 //// d.[|prop1|];  // r4
 
-function verifyReferences(query: FourSlashInterface.Range, references: FourSlashInterface.Range[]) {
-    goTo.position(query.start);
-    for (const ref of references) {
-        verify.referencesAtPositionContains(ref);
-    }
-}
-
-const ranges = test.ranges();
-verify.assertHasRanges(ranges);
-const [r0, r1, r2, r3, r4] = ranges;
-verifyReferences(r0, [r0, r2, r3]);
-verifyReferences(r1, [r1]);
-verifyReferences(r2, [r0, r2, r3]);
-verifyReferences(r3, [r0, r2, r3]);
-verifyReferences(r4, []);
+const [r0, r1, r2, r3, r4] = test.ranges();
+verify.referencesOf(r0, [r0, r2, r3]);
+verify.referencesOf(r1, [r1]);
+verify.referencesOf(r2, [r0, r2, r3]);
+verify.referencesOf(r3, [r0, r2, r3]);
+verify.referencesOf(r4, []);

--- a/tests/cases/fourslash/findAllRefsInheritedProperties5.ts
+++ b/tests/cases/fourslash/findAllRefsInheritedProperties5.ts
@@ -13,18 +13,9 @@
 //// d.[|prop0|];  // r3
 //// d.[|prop1|];  // r4
 
-function verifyReferences(query: FourSlashInterface.Range, references: FourSlashInterface.Range[]) {
-    goTo.position(query.start);
-    for (const ref of references) {
-        verify.referencesAtPositionContains(ref);
-    }
-}
-
-const ranges = test.ranges();
-verify.assertHasRanges(ranges);
-const [r0, r1, r2, r3, r4] = ranges;
-verifyReferences(r0, [r0]);
-verifyReferences(r1, [r1]);
-verifyReferences(r2, [r2, r3]);
-verifyReferences(r3, [r2, r3]);
-verifyReferences(r4, []);
+const [r0, r1, r2, r3, r4] = test.ranges();
+verify.referencesOf(r0, [r0]);
+verify.referencesOf(r1, [r1]);
+verify.referencesOf(r2, [r2, r3]);
+verify.referencesOf(r3, [r2, r3]);
+verify.referencesOf(r4, []);

--- a/tests/cases/fourslash/findAllRefsInsideTemplates1.ts
+++ b/tests/cases/fourslash/findAllRefsInsideTemplates1.ts
@@ -3,10 +3,4 @@
 ////var [|x|] = 10;
 ////var y = `${ [|x|] } ${ [|x|] }`
 
-test.ranges().forEach(targetRange => {
-    goTo.position(targetRange.start);
-
-    test.ranges().forEach(range => {
-        verify.referencesAtPositionContains(range);
-    });
-});
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsInsideTemplates2.ts
+++ b/tests/cases/fourslash/findAllRefsInsideTemplates2.ts
@@ -3,10 +3,4 @@
 ////function [|f|](...rest: any[]) { }
 ////[|f|] `${ [|f|] } ${ [|f|] }`
 
-test.ranges().forEach(targetRange => {
-    goTo.position(targetRange.start);
-
-    test.ranges().forEach(range => {
-        verify.referencesAtPositionContains(range);
-    });
-});
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName01.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName01.ts
@@ -8,12 +8,4 @@
 ////var foo: I;
 ////var { [|property1|]: prop1 } = foo;
 
-let ranges = test.ranges();
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedRange of ranges) {
-        verify.referencesAtPositionContains(expectedRange);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName02.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName02.ts
@@ -8,12 +8,4 @@
 ////var foo: I;
 ////var { [|property1|]: {} } = foo;
 
-let ranges = test.ranges();
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedRange of ranges) {
-        verify.referencesAtPositionContains(expectedRange);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName03.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName03.ts
@@ -8,12 +8,4 @@
 ////var foo: I;
 ////var [{ [|property1|]: prop1 }, { [|property1|], property2 } ] = [foo, foo];
 
-let ranges = test.ranges();
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedRange of ranges) {
-        verify.referencesAtPositionContains(expectedRange);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName04.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName04.ts
@@ -5,17 +5,11 @@
 ////    property2: string;
 ////}
 ////
-////function f({ /**/[|property1|]: p1 }: I,
+////function f({ [|property1|]: p1 }: I,
 ////           { [|property1|] }: I,
 ////           { property1: p2 }) {
 ////
 ////    return [|property1|] + 1;
 ////}
 
-goTo.marker();
-
-let ranges = test.ranges();
-verify.referencesCountIs(ranges.length);
-for (let expectedRange of ranges) {
-    verify.referencesAtPositionContains(expectedRange);
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName06.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName06.ts
@@ -19,12 +19,4 @@
 // Note: if this test ever changes, consider updating
 //       'quickInfoForObjectBindingElementPropertyName05.ts'
 
-let ranges = test.ranges();
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedRange of ranges) {
-        verify.referencesAtPositionContains(expectedRange);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName07.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName07.ts
@@ -4,12 +4,4 @@
 ////
 ////p, [{ [|a|]: p, b }] = [{ [|a|]: 10, b: true }];
 
-let ranges = test.ranges();
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedRange of ranges) {
-        verify.referencesAtPositionContains(expectedRange);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName09.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName09.ts
@@ -6,16 +6,10 @@
 ////}
 ////
 ////function f({ [|property1|]: p1 }: I,
-////           { /**/[|property1|] }: I,
+////           { [|property1|] }: I,
 ////           { property1: p2 }) {
 ////
 ////    return [|property1|] + 1;
 ////}
 
-goTo.marker();
-
-let ranges = test.ranges();
-verify.referencesCountIs(ranges.length);
-for (let expectedRange of ranges) {
-    verify.referencesAtPositionContains(expectedRange);
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName10.ts
+++ b/tests/cases/fourslash/findAllRefsObjectBindingElementPropertyName10.ts
@@ -8,12 +8,4 @@
 ////function f ({ [|next|]: { [|next|]: x} }: Recursive) {
 ////}
 
-let ranges = test.ranges();
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedRange of ranges) {
-        verify.referencesAtPositionContains(expectedRange);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsOnPrivateParameterProperty1.ts
+++ b/tests/cases/fourslash/findAllRefsOnPrivateParameterProperty1.ts
@@ -9,10 +9,4 @@
 ////    }
 ////}
 
-test.ranges().forEach(r => {
-    goTo.position(r.start);
-
-    test.ranges().forEach(range => {
-        verify.referencesAtPositionContains(range);
-    });
-});
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsParameterPropertyDeclaration1.ts
+++ b/tests/cases/fourslash/findAllRefsParameterPropertyDeclaration1.ts
@@ -7,15 +7,4 @@
 ////     }
 //// }
 
-const ranges = test.ranges();
-verify.assertHasRanges(ranges);
-for (const range of ranges) {
-    goTo.position(range.start);
-
-    if (ranges.length) {
-        verify.referencesCountIs(ranges.length);
-        for (const expectedRange of ranges) {
-            verify.referencesAtPositionContains(expectedRange);
-        }
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsParameterPropertyDeclaration2.ts
+++ b/tests/cases/fourslash/findAllRefsParameterPropertyDeclaration2.ts
@@ -7,13 +7,4 @@
 ////     }
 //// }
 
-let ranges = test.ranges();
-verify.assertHasRanges(ranges);
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedRange of ranges) {
-        verify.referencesAtPositionContains(expectedRange);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsParameterPropertyDeclaration3.ts
+++ b/tests/cases/fourslash/findAllRefsParameterPropertyDeclaration3.ts
@@ -7,13 +7,4 @@
 ////     }
 //// }
 
-const ranges = test.ranges();
-verify.assertHasRanges(ranges);
-for (const range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (const expectedRange of ranges) {
-        verify.referencesAtPositionContains(expectedRange);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsPropertyContextuallyTypedByTypeParam01.ts
+++ b/tests/cases/fourslash/findAllRefsPropertyContextuallyTypedByTypeParam01.ts
@@ -17,12 +17,4 @@
 ////    [|a|]: "ss"
 ////};
 
-let ranges = test.ranges()
-for (let range of ranges) {
-    goTo.position(range.start);
-
-    verify.referencesCountIs(ranges.length);
-    for (let expectedReference of ranges) {
-        verify.referencesAtPositionContains(expectedReference);
-    }
-}
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames1.ts
+++ b/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames1.ts
@@ -7,12 +7,4 @@
 ////var x: Foo;
 ////x.[|_bar|];
 
-
-test.ranges().forEach(r1 => {
-    goTo.position(r1.start);
-    verify.referencesCountIs(2);
-
-    test.ranges().forEach(r2 => {
-        verify.referencesAtPositionContains(r2);
-    });
-});
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames2.ts
+++ b/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames2.ts
@@ -7,12 +7,4 @@
 ////var x: Foo;
 ////x.[|__bar|];
 
-
-test.ranges().forEach(r1 => {
-    goTo.position(r1.start);
-    verify.referencesCountIs(2);
-
-    test.ranges().forEach(r2 => {
-        verify.referencesAtPositionContains(r2);
-    });
-});
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames3.ts
+++ b/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames3.ts
@@ -7,12 +7,4 @@
 ////var x: Foo;
 ////x.[|___bar|];
 
-
-test.ranges().forEach(r1 => {
-    goTo.position(r1.start);
-    verify.referencesCountIs(2);
-
-    test.ranges().forEach(r2 => {
-        verify.referencesAtPositionContains(r2);
-    });
-});
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames4.ts
+++ b/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames4.ts
@@ -7,12 +7,4 @@
 ////var x: Foo;
 ////x.[|____bar|];
 
-
-test.ranges().forEach(r1 => {
-    goTo.position(r1.start);
-    verify.referencesCountIs(2);
-
-    test.ranges().forEach(r2 => {
-        verify.referencesAtPositionContains(r2);
-    });
-});
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames5.ts
+++ b/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames5.ts
@@ -13,12 +13,4 @@
 ////x.[|___bar|];
 ////x.____bar;
 
-
-test.ranges().forEach(r1 => {
-    goTo.position(r1.start);
-    verify.referencesCountIs(2);
-
-    test.ranges().forEach(r2 => {
-        verify.referencesAtPositionContains(r2);
-    });
-});
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames6.ts
+++ b/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames6.ts
@@ -13,12 +13,4 @@
 ////x.___bar;
 ////x.____bar;
 
-
-test.ranges().forEach(r1 => {
-    goTo.position(r1.start);
-    verify.referencesCountIs(2);
-
-    test.ranges().forEach(r2 => {
-        verify.referencesAtPositionContains(r2);
-    });
-});
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames7.ts
+++ b/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames7.ts
@@ -4,11 +4,4 @@
 ////    [|__foo|]();
 ////}
 
-test.ranges().forEach(r => {
-    goTo.position(r.start);
-    verify.referencesCountIs(2);
-
-    test.ranges().forEach(range => {
-        verify.referencesAtPositionContains(range);
-    });
-});
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames8.ts
+++ b/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames8.ts
@@ -4,11 +4,4 @@
 ////    [|__foo|]();
 ////})
 
-test.ranges().forEach(r => {
-    goTo.position(r.start);
-    verify.referencesCountIs(2);
-
-    test.ranges().forEach(range => {
-        verify.referencesAtPositionContains(range);
-    });
-});
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames9.ts
+++ b/tests/cases/fourslash/findAllRefsWithLeadingUnderscoreNames9.ts
@@ -4,11 +4,4 @@
 ////    [|___foo|]();
 ////})
 
-test.ranges().forEach(r => {
-    goTo.position(r.start);
-    verify.referencesCountIs(2);
-
-    test.ranges().forEach(range => {
-        verify.referencesAtPositionContains(range);
-    });
-});
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -124,8 +124,6 @@ declare namespace FourSlashInterface {
         completionListIsEmpty(): void;
         completionListAllowsNewIdentifier(): void;
         memberListIsEmpty(): void;
-        referencesCountIs(count: number): void;
-        referencesAtPositionContains(range: Range, isWriteAccess?: boolean, isDefinition?: boolean): void;
         signatureHelpPresent(): void;
         errorExistsBetweenMarkers(startMarker: string, endMarker: string): void;
         errorExistsAfterMarker(markerName?: string): void;
@@ -154,6 +152,24 @@ declare namespace FourSlashInterface {
         currentFileContentIs(text: string): void;
         verifyGetEmitOutputForCurrentFile(expected: string): void;
         verifyGetEmitOutputContentsForCurrentFile(expected: ts.OutputFile[]): void;
+        referencesCountIs(count: number): void;
+        /**
+         * Asserts that the given ranges are the references from the current position.
+         * If ranges have markers, those markers may have "isDefinition" and "isWriteAccess" data
+         * (otherwise these properties pf the reference are not tested).
+         * Order of ranges does not matter.
+         */
+        referencesAre(ranges: Range[]): void;
+        /**
+         * Like `referencesAre`, but goes to `start` first.
+         * `start` should be included in `references`.
+         */
+        referencesOf(start: Range, references: Range[]): void;
+        /**
+         * Performs `referencesOf` for every range on the whole set.
+         * If `ranges` is omitted, this is `test.ranges()`.
+         */
+        rangesReferenceEachOther(ranges?: Range[]): void;
         currentParameterHelpArgumentNameIs(name: string): void;
         currentParameterSpanIs(parameter: string): void;
         currentParameterHelpArgumentDocCommentIs(docComment: string): void;

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfArrowFunction.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfArrowFunction.ts
@@ -1,8 +1,5 @@
 /// <reference path='fourslash.ts' />
 ////var [|{| "isDefinition": true |}f|] = x => x + 1;
 ////[|{| "isDefinition": false |}f|](12);
-var firstRange = test.ranges()[0];
-goTo.position(firstRange.start, firstRange.fileName);
-test.ranges().forEach(range => {
-    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
-});
+
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfBindingPattern.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfBindingPattern.ts
@@ -1,8 +1,5 @@
 /// <reference path='fourslash.ts' />
 ////const { [|{| "isDefinition": true |}x|], y } = { x: 1, y: 2 };
 ////const z = [|{| "isDefinition": false |}x|];
-var firstRange = test.ranges()[0];
-goTo.position(firstRange.start, firstRange.fileName);
-test.ranges().forEach(range => {
-    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
-});
+
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfClass.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfClass.ts
@@ -6,8 +6,5 @@
 ////    }
 ////}
 ////let c = new [|{| "isDefinition": false |}C|]();
-var firstRange = test.ranges()[0];
-goTo.position(firstRange.start, firstRange.fileName);
-test.ranges().forEach(range => {
-    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
-});
+
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfComputedProperty.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfComputedProperty.ts
@@ -1,9 +1,7 @@
 /// <reference path='fourslash.ts' />
-////let o = { ["[|{| "isDefinition": true |}foo|]"]: 12 };
+////let o = { ["/**/[|{| "isDefinition": true |}foo|]"]: 12 };
 ////let y = o.[|{| "isDefinition": false |}foo|];
 ////let z = o['[|{| "isDefinition": false |}foo|]'];
-var firstRange = test.ranges()[0];
-goTo.position(firstRange.start, firstRange.fileName);
-test.ranges().forEach(range => {
-    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
-});
+
+goTo.marker();
+verify.referencesAre(test.ranges());

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfEnum.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfEnum.ts
@@ -4,8 +4,5 @@
 ////    Second
 ////}
 ////let first = [|{| "isDefinition": false |}E|].First;
-var firstRange = test.ranges()[0];
-goTo.position(firstRange.start, firstRange.fileName);
-test.ranges().forEach(range => {
-    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
-});
+
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfExport.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfExport.ts
@@ -4,8 +4,5 @@
 // @Filename: main.ts
 ////import { [|{| "isDefinition": true |}x|] } from "./m";
 ////const y = [|{| "isDefinition": false |}x|];
-var firstRange = test.ranges()[0];
-goTo.position(firstRange.start, firstRange.fileName);
-test.ranges().forEach(range => {
-    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
-});
+
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfFunction.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfFunction.ts
@@ -2,8 +2,5 @@
 ////function [|{| "isDefinition": true |}func|](x: number) {
 ////}
 ////[|{| "isDefinition": false |}func|](x)
-var firstRange = test.ranges()[0];
-goTo.position(firstRange.start, firstRange.fileName);
-test.ranges().forEach(range => {
-    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
-});
+
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfInterface.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfInterface.ts
@@ -3,8 +3,5 @@
 ////    p: number;
 ////}
 ////let i: [|{| "isDefinition": false |}I|] = { p: 12 };
-var firstRange = test.ranges()[0];
-goTo.position(firstRange.start, firstRange.fileName);
-test.ranges().forEach(range => {
-    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
-});
+
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfInterfaceClassMerge.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfInterfaceClassMerge.ts
@@ -12,8 +12,5 @@
 ////}
 ////let i: [|{| "isDefinition": false |}Numbers|] = new [|{| "isDefinition": false |}Numbers|]();
 ////let x = i.f(i.p + i.m);
-var firstRange = test.ranges()[0];
-goTo.position(firstRange.start, firstRange.fileName);
-test.ranges().forEach(range => {
-    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
-});
+
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfNamespace.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfNamespace.ts
@@ -3,8 +3,5 @@
 ////    export var n = 12;
 ////}
 ////let x = [|{| "isDefinition": false |}Numbers|].n + 1;
-var firstRange = test.ranges()[0];
-goTo.position(firstRange.start, firstRange.fileName);
-test.ranges().forEach(range => {
-    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
-});
+
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfNumberNamedProperty.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfNumberNamedProperty.ts
@@ -1,8 +1,5 @@
 /// <reference path='fourslash.ts' />
 ////let o = { [|{| "isDefinition": true |}1|]: 12 };
 ////let y = o[[|{| "isDefinition": false |}1|]];
-var firstRange = test.ranges()[0];
-goTo.position(firstRange.start, firstRange.fileName);
-test.ranges().forEach(range => {
-    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
-});
+
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfParameter.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfParameter.ts
@@ -2,8 +2,5 @@
 ////function f([|{| "isDefinition": true |}x|]: number) {
 ////  return [|{| "isDefinition": false |}x|] + 1
 ////}
-var firstRange = test.ranges()[0];
-goTo.position(firstRange.start, firstRange.fileName);
-test.ranges().forEach(range => {
-    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
-});
+
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfStringNamedProperty.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfStringNamedProperty.ts
@@ -1,8 +1,5 @@
 /// <reference path='fourslash.ts' />
 ////let o = { "[|{| "isDefinition": true |}x|]": 12 };
 ////let y = o.[|{| "isDefinition": false |}x|];
-var firstRange = test.ranges()[0];
-goTo.position(firstRange.start, firstRange.fileName);
-test.ranges().forEach(range => {
-    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
-});
+
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfTypeAlias.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfTypeAlias.ts
@@ -1,8 +1,5 @@
 /// <reference path='fourslash.ts' />
 ////type [|{| "isDefinition": true |}Alias|]= number;
 ////let n: [|{| "isDefinition": false |}Alias|] = 12;
-var firstRange = test.ranges()[0];
-goTo.position(firstRange.start, firstRange.fileName);
-test.ranges().forEach(range => {
-    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
-});
+
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfVariable.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfVariable.ts
@@ -16,8 +16,5 @@
 ////
 ////[|{| "isDefinition": false |}x|] += 1;
 ////[|{| "isDefinition": false |}x|] <<= 1;
-var firstRange = test.ranges()[0];
-goTo.position(firstRange.start, firstRange.fileName);
-test.ranges().forEach(range => {
-    verify.referencesAtPositionContains(range, undefined, range.marker.data.isDefinition);
-});
+
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/referenceToClass.ts
+++ b/tests/cases/fourslash/referenceToClass.ts
@@ -3,34 +3,21 @@
 // Class references should work across file and not find local variables.
 
 // @Filename: referenceToClass_1.ts
-////class /*1*/foo {
-////    public n: /*2*/foo;
+////class [|foo|] {
+////    public n: [|foo|];
 ////    public foo: number;
 ////}
 ////
 ////class bar {
-////    public n: fo/*3*/o;
-////    public k = new foo();
+////    public n: [|foo|];
+////    public k = new [|foo|]();
 ////}
 ////
 ////module mod {
-////    var k: foo = null;
+////    var k: [|foo|] = null;
 ////}
 
 // @Filename: referenceToClass_2.ts
-////var k: /*4*/foo;
+////var k: [|foo|];
 
-goTo.marker("1");
-verify.referencesCountIs(6);
-
-goTo.marker("2");
-
-verify.referencesCountIs(6);
-
-goTo.marker("3");
-
-verify.referencesCountIs(6);
-
-goTo.marker("4");
-
-verify.referencesCountIs(6);
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/referencesForStaticsAndMembersWithSameNames.ts
+++ b/tests/cases/fourslash/referencesForStaticsAndMembersWithSameNames.ts
@@ -3,12 +3,12 @@
 ////module FindRef4 {
 ////	module MixedStaticsClassTest {
 ////		export class Foo {
-////			b/*3*/ar: Foo;
-////			static b/*4*/ar: Foo;
+////			[|bar|]: Foo;
+////			static [|bar|]: Foo;
 ////
-////			public f/*1*/oo(): void {
+////			public [|foo|](): void {
 ////			}
-////			public static f/*2*/oo(): void {
+////			public static [|foo|](): void {
 ////			}
 ////		}
 ////	}
@@ -16,34 +16,25 @@
 ////	function test() {
 ////		// instance function
 ////		var x = new MixedStaticsClassTest.Foo();
-////		x.foo();
-////		x.bar;
-////
-////		var y = new MixedStaticsClassTest.Foo();
-////		y.foo();
-////		y.bar;
+////		x.[|foo|]();
+////		x.[|bar|];
 ////
 ////		// static function
-////		MixedStaticsClassTest.Foo.foo();
-////		MixedStaticsClassTest.Foo.bar;
+////		MixedStaticsClassTest.Foo.[|foo|]();
+////		MixedStaticsClassTest.Foo.[|bar|];
 ////	}
 ////}
 
-// this line triggers a semantic/syntactic error check, remove line when 788570 is fixed
-edit.insert('');
+const [fooBar, fooStaticBar, fooFoo, fooStaticFoo, xFoo, xBar, staticFoo, staticBar] = test.ranges();
 
 // References to a member method with the same name as a static.
-goTo.marker("1");
-verify.referencesCountIs(3);
+verify.referencesOf(fooFoo, [fooFoo, xFoo]);
 
 // References to a static method with the same name as a member.
-goTo.marker("2");
-verify.referencesCountIs(2);
+verify.referencesOf(fooStaticFoo, [fooStaticFoo, staticFoo]);
 
 // References to a member property with the same name as a static.
-goTo.marker("3");
-verify.referencesCountIs(3);
+verify.referencesOf(fooBar, [fooBar, xBar]);
 
 // References to a static property with the same name as a member.
-goTo.marker("4");
-verify.referencesCountIs(2);
+verify.referencesOf(fooStaticBar, [fooStaticBar, staticBar]);

--- a/tests/cases/fourslash/referencesForStringLiteralPropertyNames.ts
+++ b/tests/cases/fourslash/referencesForStringLiteralPropertyNames.ts
@@ -1,16 +1,13 @@
 /// <reference path='fourslash.ts'/>
 
 ////class Foo {
-////    public /*1*/"ss": any;
+////    public "[|ss|]": any;
 ////}
 ////
 ////var x: Foo;
-////x.ss;
-////x[/*2*/"ss"];
-////x = { "ss": 0 };
-////x = { /*3*/ss: 0 };
+////x.[|ss|];
+////x["[|ss|]"];
+////x = { "[|ss|]": 0 };
+////x = { [|ss|]: 0 };
 
-test.markers().forEach((m) => {
-    goTo.position(m.position, m.fileName);
-    verify.referencesCountIs(5);
-});
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/referencesForStringLiteralPropertyNames2.ts
+++ b/tests/cases/fourslash/referencesForStringLiteralPropertyNames2.ts
@@ -1,15 +1,10 @@
 /// <reference path='fourslash.ts'/>
 
 ////class Foo {
-////    /*1*/"blah"() { return 0; }
+////    "[|blah|]"() { return 0; }
 ////}
 ////
 ////var x: Foo;
-////x./*2*/blah;
+////x.[|blah|];
 
-
-goTo.marker("1");
-verify.referencesCountIs(2);
-
-goTo.marker("2");
-verify.referencesCountIs(2);
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/referencesForStringLiteralPropertyNames3.ts
+++ b/tests/cases/fourslash/referencesForStringLiteralPropertyNames3.ts
@@ -1,15 +1,11 @@
 /// <reference path='fourslash.ts'/>
 
 ////class Foo2 {
-////    get /*1*/"42"() { return 0; }
-////    set /*2*/42(n) { }
+////    get "[|42|]"() { return 0; }
+////    set [|42|](n) { }
 ////}
 ////
 ////var y: Foo2;
-////y[42];
+////y[[|42|]];
 
-goTo.marker("1");
-verify.referencesCountIs(3);
-
-goTo.marker("2");
-verify.referencesCountIs(3);
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/referencesForStringLiteralPropertyNames4.ts
+++ b/tests/cases/fourslash/referencesForStringLiteralPropertyNames4.ts
@@ -4,5 +4,4 @@
 ////x["[|someProperty|]"] = 3;
 ////x./*1*/[|someProperty|] = 5;
 
-goTo.marker("1");
-test.ranges().forEach(r => verify.referencesAtPositionContains(r));
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/referencesForUnionProperties.ts
+++ b/tests/cases/fourslash/referencesForUnionProperties.ts
@@ -1,16 +1,16 @@
 /// <reference path='fourslash.ts'/>
 
 ////interface One {
-////    common: { /*1*/a: number; };
+////    common: { [|a|]: number; };
 ////}
 ////
 ////interface Base {
-////    /*2*/a: string;
+////    [|a|]: string;
 ////    b: string;
 ////}
 ////
 ////interface HasAOrB extends Base {
-////    /*3*/a: string;
+////    [|a|]: string;
 ////    b: string;
 ////}
 ////
@@ -20,16 +20,10 @@
 ////
 ////var x : One | Two;
 ////
-////x.common./*4*/a;
+////x.common.[|a|];
 
-goTo.marker("1");
-verify.referencesCountIs(2); // One.common.a, x.common.a
-
-goTo.marker("2");
-verify.referencesCountIs(3); // Base.a, HasAOrB.a, x.common.a
-
-goTo.marker("3");
-verify.referencesCountIs(3); // Base.a, HasAOrB.a, x.common.a
-
-goTo.marker("4");
-verify.referencesCountIs(4); // One.common.a, Base.a, HasAOrB.a, x.common.a
+const [one, base, hasAOrB, x] = test.ranges();
+verify.referencesOf(one, [one, x]);
+verify.referencesOf(base, [base, hasAOrB, x]);
+verify.referencesOf(hasAOrB, [base, hasAOrB, x]);
+verify.referencesOf(x, [one, base, hasAOrB, x]);

--- a/tests/cases/fourslash/referencesInComment.ts
+++ b/tests/cases/fourslash/referencesInComment.ts
@@ -5,14 +5,6 @@
 ////class foo { }
 ////var bar = 0;
 
-goTo.marker("1");
-verify.referencesCountIs(0);
-
-goTo.marker("2");
-verify.referencesCountIs(0);
-
-goTo.marker("3");
-verify.referencesCountIs(0);
-
-goTo.marker("4");
-verify.referencesCountIs(0);
+for (const marker of test.markers()) {
+    verify.referencesCountIs(0);
+}

--- a/tests/cases/fourslash/renameImportAndExportInDiffFiles.ts
+++ b/tests/cases/fourslash/renameImportAndExportInDiffFiles.ts
@@ -1,18 +1,10 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: a.ts
-////export var /*1*/a;
+////export var [|a|];
 
 // @Filename: b.ts
-////import { /*2*/a } from './a';
-////export { /*3*/a };
+////import { [|a|] } from './a';
+////export { [|a|] };
 
-goTo.file("a.ts");
-goTo.marker("1");
-
-goTo.file("b.ts");
-goTo.marker("2");
-verify.referencesCountIs(3);
-
-goTo.marker("3");
-verify.referencesCountIs(3);
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/server/references01.ts
+++ b/tests/cases/fourslash/server/references01.ts
@@ -3,16 +3,13 @@
 // Global class reference.
 
 // @Filename: referencesForGlobals_1.ts
-////class /*2*/globalClass {
+////class [|globalClass|] {
 ////    public f() { }
 ////}
 
 // @Filename: referencesForGlobals_2.ts
 ///////<reference path="referencesForGlobals_1.ts" />
-////var c = /*1*/globalClass();
+////var c = [|globalClass|]();
 
-goTo.marker("1");
-verify.referencesCountIs(2);
-
-goTo.marker("2");
-verify.referencesCountIs(2);
+// Must reverse ranges so that referencesForGlobals_2 goes first -- otherwise referencesForGlobals_1 won't pick it up.
+verify.rangesReferenceEachOther(test.ranges().reverse());

--- a/tests/cases/fourslash/server/referencesInConfiguredProject.ts
+++ b/tests/cases/fourslash/server/referencesInConfiguredProject.ts
@@ -3,18 +3,14 @@
 // Global class reference.
 
 // @Filename: referencesForGlobals_1.ts
-////class /*2*/globalClass {
+////class [|globalClass|] {
 ////    public f() { }
 ////}
 
 // @Filename: referencesForGlobals_2.ts
-////var c = /*1*/globalClass();
+////var c = [|globalClass|]();
 
 // @Filename: tsconfig.json
 ////{ "files": ["referencesForGlobals_1.ts", "referencesForGlobals_2.ts"] }
 
-goTo.marker("1");
-verify.referencesCountIs(2);
-
-goTo.marker("2");
-verify.referencesCountIs(2);
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/shims-pp/getReferencesAtPosition.ts
+++ b/tests/cases/fourslash/shims-pp/getReferencesAtPosition.ts
@@ -7,7 +7,7 @@
 ////
 ////    }
 ////
-////    public /*1*/start(){
+////    public [|start|](){
 ////        return this;
 ////    }
 ////
@@ -20,10 +20,7 @@
 ////import Second = require("./findAllRefsOnDefinition-import");
 ////
 ////var second = new Second.Test()
-////second.start();
+////second.[|start|]();
 ////second.stop();
 
-goTo.file("findAllRefsOnDefinition-import.ts");
-goTo.marker("1");
-
-verify.referencesCountIs(2);
+verify.rangesReferenceEachOther();

--- a/tests/cases/fourslash/shims/getReferencesAtPosition.ts
+++ b/tests/cases/fourslash/shims/getReferencesAtPosition.ts
@@ -7,7 +7,7 @@
 ////
 ////    }
 ////
-////    public /*1*/start(){
+////    public [|start|](){
 ////        return this;
 ////    }
 ////
@@ -20,10 +20,7 @@
 ////import Second = require("./findAllRefsOnDefinition-import");
 ////
 ////var second = new Second.Test()
-////second.start();
+////second.[|start|]();
 ////second.stop();
 
-goTo.file("findAllRefsOnDefinition-import.ts");
-goTo.marker("1");
-
-verify.referencesCountIs(2);
+verify.rangesReferenceEachOther();


### PR DESCRIPTION
There remain a lot of tests that just use `verify.referencesCountIs` and don't test what those references are, but this change is big enough already.