### PR TITLE
Relax logical and

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2224,7 +2224,8 @@ namespace ts {
 
         /* @internal */
         Nullable = Undefined | Null,
-        Falsy = String | Number | Boolean | Void | Undefined | Null,
+        /* @internal */
+        Falsy = Void | Undefined | Null,       // TODO: Add false, 0, and ""
         /* @internal */
         Intrinsic = Any | String | Number | Boolean | ESSymbol | Void | Undefined | Null | Never,
         /* @internal */

--- a/tests/cases/compiler/strictNullLogicalAndOr.ts
+++ b/tests/cases/compiler/strictNullLogicalAndOr.ts
@@ -1,0 +1,15 @@
+// @strictNullChecks: true
+
+// Repro from #9113
+
+let sinOrCos = Math.random() < .5;
+let choice = sinOrCos && Math.sin || Math.cos;
+
+choice(Math.PI);
+
+function sq(n?: number): number {
+  const r = n !== undefined && n*n || 0;
+  return r;
+}
+
+sq(3);


### PR DESCRIPTION
Fixes #9113. This PR reverts most of #8949. We will reinstate the stricter typing (as described [here](https://github.com/Microsoft/TypeScript/issues/9113#issuecomment-225591381)) once we have support for numeric and boolean literal types.