### PR TITLE
Using baselines for transpile unittests

### DIFF
--- a/tests/baselines/reference/transpile/Accepts string as enum values for compile-options.js
+++ b/tests/baselines/reference/transpile/Accepts string as enum values for compile-options.js
@@ -1,0 +1,2 @@
+export const x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Does not generate semantic diagnostics.js
+++ b/tests/baselines/reference/transpile/Does not generate semantic diagnostics.js
@@ -1,0 +1,3 @@
+"use strict";
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates expected syntactic diagnostics.errors.txt
+++ b/tests/baselines/reference/transpile/Generates expected syntactic diagnostics.errors.txt
@@ -1,0 +1,7 @@
+file.ts(1,3): error TS1005: ';' expected.
+
+
+==== file.ts (1 errors) ====
+    a b
+      ~
+!!! error TS1005: ';' expected.

--- a/tests/baselines/reference/transpile/Generates expected syntactic diagnostics.js
+++ b/tests/baselines/reference/transpile/Generates expected syntactic diagnostics.js
@@ -1,0 +1,4 @@
+"use strict";
+a;
+b;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates module output.js
+++ b/tests/baselines/reference/transpile/Generates module output.js
@@ -1,0 +1,5 @@
+define(["require", "exports"], function (require, exports) {
+    "use strict";
+    var x = 0;
+});
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing file references.js
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing file references.js
@@ -1,0 +1,4 @@
+"use strict";
+/// <reference path="file2.ts" />
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing module imports.js
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing module imports.js
@@ -1,0 +1,2 @@
+"use strict";
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs.js
+++ b/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs.js
@@ -1,0 +1,3 @@
+"use strict";
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/No extra errors for file without extension.js
+++ b/tests/baselines/reference/transpile/No extra errors for file without extension.js
@@ -1,0 +1,3 @@
+"use strict";
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Rename dependencies - AMD.js
+++ b/tests/baselines/reference/transpile/Rename dependencies - AMD.js
@@ -1,0 +1,5 @@
+define(["require", "exports", "SomeOtherName"], function (require, exports, SomeName_1) {
+    "use strict";
+    use(SomeName_1.foo);
+});
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Rename dependencies - System.js
+++ b/tests/baselines/reference/transpile/Rename dependencies - System.js
@@ -1,0 +1,15 @@
+System.register(["SomeOtherName"], function(exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    var SomeName_1;
+    return {
+        setters:[
+            function (SomeName_1_1) {
+                SomeName_1 = SomeName_1_1;
+            }],
+        execute: function() {
+            use(SomeName_1.foo);
+        }
+    }
+});
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Rename dependencies - UMD.js
+++ b/tests/baselines/reference/transpile/Rename dependencies - UMD.js
@@ -1,0 +1,13 @@
+(function (factory) {
+    if (typeof module === 'object' && typeof module.exports === 'object') {
+        var v = factory(require, exports); if (v !== undefined) module.exports = v;
+    }
+    else if (typeof define === 'function' && define.amd) {
+        define(["require", "exports", "SomeOtherName"], factory);
+    }
+})(function (require, exports) {
+    "use strict";
+    var SomeName_1 = require("SomeOtherName");
+    use(SomeName_1.foo);
+});
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Report an error when compiler-options input is empty object.errors.txt
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options input is empty object.errors.txt
@@ -1,0 +1,6 @@
+error TS6046: Argument for '--module' option must be:  'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015'
+
+
+!!! error TS6046: Argument for '--module' option must be:  'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015'
+==== file.ts (0 errors) ====
+    

--- a/tests/baselines/reference/transpile/Report an error when compiler-options input is empty object.js
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options input is empty object.js
@@ -1,0 +1,2 @@
+"use strict";
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Report an error when compiler-options input is empty string.errors.txt
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options input is empty string.errors.txt
@@ -1,0 +1,6 @@
+error TS6046: Argument for '--module' option must be:  'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015'
+
+
+!!! error TS6046: Argument for '--module' option must be:  'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015'
+==== file.ts (0 errors) ====
+    

--- a/tests/baselines/reference/transpile/Report an error when compiler-options input is empty string.js
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options input is empty string.js
@@ -1,0 +1,2 @@
+"use strict";
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Report an error when compiler-options module-kind is out-of-range.errors.txt
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options module-kind is out-of-range.errors.txt
@@ -1,0 +1,6 @@
+error TS6046: Argument for '--module' option must be:  'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015'
+
+
+!!! error TS6046: Argument for '--module' option must be:  'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015'
+==== file.ts (0 errors) ====
+    

--- a/tests/baselines/reference/transpile/Report an error when compiler-options module-kind is out-of-range.js
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options module-kind is out-of-range.js
@@ -1,0 +1,2 @@
+"use strict";
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Report an error when compiler-options target-script is out-of-range.errors.txt
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options target-script is out-of-range.errors.txt
@@ -1,0 +1,6 @@
+error TS6046: Argument for '--module' option must be:  'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015'
+
+
+!!! error TS6046: Argument for '--module' option must be:  'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015'
+==== file.ts (0 errors) ====
+    

--- a/tests/baselines/reference/transpile/Report an error when compiler-options target-script is out-of-range.js
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options target-script is out-of-range.js
@@ -1,0 +1,2 @@
+"use strict";
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Sets module name.js
+++ b/tests/baselines/reference/transpile/Sets module name.js
@@ -1,0 +1,12 @@
+System.register("NamedModule", [], function(exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    var x;
+    return {
+        setters:[],
+        execute: function() {
+            var x = 1;
+        }
+    }
+});
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Support options with lib values.js
+++ b/tests/baselines/reference/transpile/Support options with lib values.js
@@ -1,0 +1,3 @@
+"use strict";
+var a = 10;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Support options with types values.js
+++ b/tests/baselines/reference/transpile/Support options with types values.js
@@ -1,0 +1,3 @@
+"use strict";
+var a = 10;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports backslashes in file name.js
+++ b/tests/baselines/reference/transpile/Supports backslashes in file name.js
@@ -1,0 +1,3 @@
+"use strict";
+var x;
+//# sourceMappingURL=b.js.map

--- a/tests/baselines/reference/transpile/Supports urls in file name.js
+++ b/tests/baselines/reference/transpile/Supports urls in file name.js
@@ -1,0 +1,3 @@
+"use strict";
+var x;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Transpile with emit decorators and emit metadata.js
+++ b/tests/baselines/reference/transpile/Transpile with emit decorators and emit metadata.js
@@ -1,0 +1,19 @@
+"use strict";
+var db_1 = require('./db');
+function someDecorator(target) {
+    return target;
+}
+var MyClass = (function () {
+    function MyClass(db) {
+        this.db = db;
+        this.db.doSomething();
+    }
+    MyClass = __decorate([
+        someDecorator, 
+        __metadata('design:paramtypes', [(typeof (_a = typeof db_1.db !== 'undefined' && db_1.db) === 'function' && _a) || Object])
+    ], MyClass);
+    return MyClass;
+    var _a;
+}());
+exports.MyClass = MyClass;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Uses correct newLine character.js
+++ b/tests/baselines/reference/transpile/Uses correct newLine character.js
@@ -1,0 +1,3 @@
+"use strict";
+var x = 0;
+//# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/transpile .js files.js
+++ b/tests/baselines/reference/transpile/transpile .js files.js
@@ -1,0 +1,3 @@
+"use strict";
+var a = 10;
+//# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/transpile file as tsx if jsx is specified.js
+++ b/tests/baselines/reference/transpile/transpile file as tsx if jsx is specified.js
@@ -1,0 +1,3 @@
+"use strict";
+var x = React.createElement("div", null);
+//# sourceMappingURL=file.js.map

--- a/tests/cases/unittests/transpile.ts
+++ b/tests/cases/unittests/transpile.ts
@@ -242,6 +242,6 @@ var x = 0;`, {
 
         transpilesCorrectly("Support options with types values", "const a = 10;", {
             options: { compilerOptions: { types: ["jquery", "typescript"], module: ModuleKind.CommonJS }, fileName: "input.js", reportDiagnostics: true }
-        })
+        });
     });
 }

--- a/tests/cases/unittests/transpile.ts
+++ b/tests/cases/unittests/transpile.ts
@@ -5,346 +5,243 @@ namespace ts {
 
         interface TranspileTestSettings {
             options?: TranspileOptions;
-            expectedOutput?: string;
-            expectedDiagnosticCodes?: number[];
-            expectedDiagnosticTexts?: string[];
         }
 
-        function checkDiagnostics(diagnostics: Diagnostic[], expectedDiagnosticCodes: number[] = [], expectedDiagnosticTexts?: string[]) {
-            const n = expectedDiagnosticCodes.length;
-            if (expectedDiagnosticTexts) {
-                assert.equal(n, expectedDiagnosticTexts.length);
-            }
-            for (let i = 0; i < n; i++) {
-                assert.equal(expectedDiagnosticCodes[i], diagnostics[i] && diagnostics[i].code, `Could not find expected diagnostic.`);
-                if (expectedDiagnosticTexts) {
-                    assert.equal(expectedDiagnosticTexts[i], diagnostics[i] && diagnostics[i].messageText);
-                }
-            };
-            assert.equal(diagnostics.length, n, "Resuting diagnostics count does not match expected");
-        }
+        function transpilesCorrectly(name: string, input: string, testSettings: TranspileTestSettings) {
+            describe(name, () => {
+                let justName: string;
+                let transpileOptions: TranspileOptions;
+                let canUseOldTranspile: boolean;
+                let toBeCompiled: Harness.Compiler.TestFile[];
+                let transpileResult: TranspileOutput;
+                let oldTranspileResult: string;
+                let oldTranspileDiagnostics: Diagnostic[];
 
-        function test(input: string, testSettings: TranspileTestSettings): void {
+                before(() => {
+                    transpileOptions = testSettings.options || {};
+                    if (!transpileOptions.compilerOptions) {
+                        transpileOptions.compilerOptions = {};
+                    }
 
-            const transpileOptions: TranspileOptions = testSettings.options || {};
-            if (!transpileOptions.compilerOptions) {
-                transpileOptions.compilerOptions = {};
-            }
-            if (transpileOptions.compilerOptions.newLine === undefined) {
-                // use \r\n as default new line
-                transpileOptions.compilerOptions.newLine = ts.NewLineKind.CarriageReturnLineFeed;
-            }
+                    if (transpileOptions.compilerOptions.newLine === undefined) {
+                        // use \r\n as default new line
+                        transpileOptions.compilerOptions.newLine = ts.NewLineKind.CarriageReturnLineFeed;
+                    }
 
-            const canUseOldTranspile = !transpileOptions.renamedDependencies;
+                    transpileOptions.compilerOptions.sourceMap = true;
 
-            transpileOptions.reportDiagnostics = true;
-            const transpileModuleResult = transpileModule(input, transpileOptions);
+                    if (!transpileOptions.fileName) {
+                        transpileOptions.fileName = transpileOptions.compilerOptions.jsx ? "file.tsx" : "file.ts";
+                    }
 
-            checkDiagnostics(transpileModuleResult.diagnostics, testSettings.expectedDiagnosticCodes, testSettings.expectedDiagnosticTexts);
+                    transpileOptions.reportDiagnostics = true;
 
-            if (testSettings.expectedOutput !== undefined) {
-                assert.equal(transpileModuleResult.outputText, testSettings.expectedOutput);
-            }
+                    justName = "transpile/" + name.replace(/[^a-z0-9\-. ]/ig, "") + (transpileOptions.compilerOptions.jsx ? ".tsx" : ".ts");
+                    toBeCompiled = [{
+                        unitName: transpileOptions.fileName,
+                        content: input
+                    }];
 
-            if (canUseOldTranspile) {
-                const diagnostics: Diagnostic[] = [];
-                const transpileResult = transpile(input, transpileOptions.compilerOptions, transpileOptions.fileName, diagnostics, transpileOptions.moduleName);
-                checkDiagnostics(diagnostics, testSettings.expectedDiagnosticCodes, testSettings.expectedDiagnosticTexts);
-                if (testSettings.expectedOutput) {
-                    assert.equal(transpileResult, testSettings.expectedOutput);
-                }
-            }
+                    canUseOldTranspile = !transpileOptions.renamedDependencies;
+                    transpileResult = transpileModule(input, transpileOptions);
 
-            // check source maps
-            if (!transpileOptions.compilerOptions) {
-                transpileOptions.compilerOptions = {};
-            }
-
-            if (!transpileOptions.fileName) {
-                transpileOptions.fileName = transpileOptions.compilerOptions.jsx ? "file.tsx" : "file.ts";
-            }
-
-            transpileOptions.compilerOptions.sourceMap = true;
-            const transpileModuleResultWithSourceMap = transpileModule(input, transpileOptions);
-            assert.isTrue(transpileModuleResultWithSourceMap.sourceMapText !== undefined);
-
-            const expectedSourceMapFileName = removeFileExtension(getBaseFileName(normalizeSlashes(transpileOptions.fileName))) + ".js.map";
-            const expectedSourceMappingUrlLine = `//# sourceMappingURL=${expectedSourceMapFileName}`;
-
-            if (testSettings.expectedOutput !== undefined) {
-                assert.equal(transpileModuleResultWithSourceMap.outputText, testSettings.expectedOutput + expectedSourceMappingUrlLine);
-            }
-            else {
-                // expected output is not set, just verify that output text has sourceMappingURL as a last line
-                const output = transpileModuleResultWithSourceMap.outputText;
-                assert.isTrue(output.length >= expectedSourceMappingUrlLine.length);
-                if (output.length === expectedSourceMappingUrlLine.length) {
-                    assert.equal(output, expectedSourceMappingUrlLine);
-                }
-                else {
-                    const suffix = getNewLineCharacter(transpileOptions.compilerOptions) + expectedSourceMappingUrlLine;
-                    assert.isTrue(output.indexOf(suffix, output.length - suffix.length) !== -1);
-                }
-            }
-
-        }
-
-        it("Generates no diagnostics with valid inputs", () => {
-            // No errors
-            test(`var x = 0;`, { options: { compilerOptions: { module: ModuleKind.CommonJS } } });
-        });
-
-        it("Generates no diagnostics for missing file references", () => {
-            test(`/// <reference path="file2.ts" />
-var x = 0;`,
-                { options: { compilerOptions: { module: ModuleKind.CommonJS } } });
-        });
-
-        it("Generates no diagnostics for missing module imports", () => {
-            test(`import {a} from "module2";`,
-                { options: { compilerOptions: { module: ModuleKind.CommonJS } } });
-        });
-
-        it("Generates expected syntactic diagnostics", () => {
-            test(`a b`,
-                { options: { compilerOptions: { module: ModuleKind.CommonJS } }, expectedDiagnosticCodes: [1005] }); /// 1005: ';' Expected
-        });
-
-        it("Does not generate semantic diagnostics", () => {
-            test(`var x: string = 0;`,
-                { options: { compilerOptions: { module: ModuleKind.CommonJS } } });
-        });
-
-        it("Generates module output", () => {
-            test(`var x = 0;`,
-                {
-                    options: { compilerOptions: { module: ModuleKind.AMD } },
-                    expectedOutput: `define(["require", "exports"], function (require, exports) {\r\n    "use strict";\r\n    var x = 0;\r\n});\r\n`
+                    if (canUseOldTranspile) {
+                        oldTranspileDiagnostics = [];
+                        oldTranspileResult = transpile(input, transpileOptions.compilerOptions, transpileOptions.fileName, oldTranspileDiagnostics, transpileOptions.moduleName);
+                    }
                 });
-        });
 
-        it("Uses correct newLine character", () => {
-            test(`var x = 0;`,
-                {
-                    options: { compilerOptions: { module: ModuleKind.CommonJS, newLine: NewLineKind.LineFeed } },
-                    expectedOutput: `"use strict";\nvar x = 0;\n`
+                after(() => {
+                    justName = undefined;
+                    transpileOptions = undefined;
+                    canUseOldTranspile = undefined;
+                    toBeCompiled = undefined;
+                    transpileResult = undefined;
+                    oldTranspileResult = undefined;
+                    oldTranspileDiagnostics = undefined;
                 });
-        });
 
-        it("Sets module name", () => {
-            const output =
-                `System.register("NamedModule", [], function(exports_1, context_1) {\n` +
-                `    "use strict";\n` +
-                `    var __moduleName = context_1 && context_1.id;\n` +
-                `    var x;\n` +
-                `    return {\n` +
-                `        setters:[],\n` +
-                `        execute: function() {\n` +
-                `            var x = 1;\n` +
-                `        }\n` +
-                `    }\n` +
-                `});\n`;
-            test("var x = 1;",
-                {
-                    options: { compilerOptions: { module: ModuleKind.System, newLine: NewLineKind.LineFeed }, moduleName: "NamedModule" },
-                    expectedOutput: output
-                });
-        });
-
-        it("No extra errors for file without extension", () => {
-            test(`"use strict";\r\nvar x = 0;`, { options: { compilerOptions: { module: ModuleKind.CommonJS }, fileName: "file" } });
-        });
-
-        it("Rename dependencies - System", () => {
-            const input =
-                `import {foo} from "SomeName";\n` +
-                `declare function use(a: any);\n` +
-                `use(foo);`;
-            const output =
-                `System.register(["SomeOtherName"], function(exports_1, context_1) {\n` +
-                `    "use strict";\n` +
-                `    var __moduleName = context_1 && context_1.id;\n` +
-                `    var SomeName_1;\n` +
-                `    return {\n` +
-                `        setters:[\n` +
-                `            function (SomeName_1_1) {\n` +
-                `                SomeName_1 = SomeName_1_1;\n` +
-                `            }],\n` +
-                `        execute: function() {\n` +
-                `            use(SomeName_1.foo);\n` +
-                `        }\n` +
-                `    }\n` +
-                `});\n`;
-
-            test(input,
-                {
-                    options: { compilerOptions: { module: ModuleKind.System, newLine: NewLineKind.LineFeed }, renamedDependencies: { "SomeName": "SomeOtherName" } },
-                    expectedOutput: output
-                });
-        });
-
-        it("Rename dependencies - AMD", () => {
-            const input =
-                `import {foo} from "SomeName";\n` +
-                `declare function use(a: any);\n` +
-                `use(foo);`;
-            const output =
-                `define(["require", "exports", "SomeOtherName"], function (require, exports, SomeName_1) {\n` +
-                `    "use strict";\n` +
-                `    use(SomeName_1.foo);\n` +
-                `});\n`;
-
-            test(input,
-                {
-                    options: { compilerOptions: { module: ModuleKind.AMD, newLine: NewLineKind.LineFeed }, renamedDependencies: { "SomeName": "SomeOtherName" } },
-                    expectedOutput: output
-                });
-        });
-
-        it("Rename dependencies - UMD", () => {
-            const input =
-                `import {foo} from "SomeName";\n` +
-                `declare function use(a: any);\n` +
-                `use(foo);`;
-            const output =
-                `(function (factory) {\n` +
-                `    if (typeof module === 'object' && typeof module.exports === 'object') {\n` +
-                `        var v = factory(require, exports); if (v !== undefined) module.exports = v;\n` +
-                `    }\n` +
-                `    else if (typeof define === 'function' && define.amd) {\n` +
-                `        define(["require", "exports", "SomeOtherName"], factory);\n` +
-                `    }\n` +
-                `})(function (require, exports) {\n` +
-                `    "use strict";\n` +
-                `    var SomeName_1 = require("SomeOtherName");\n` +
-                `    use(SomeName_1.foo);\n` +
-                `});\n`;
-
-            test(input,
-                {
-                    options: { compilerOptions: { module: ModuleKind.UMD, newLine: NewLineKind.LineFeed }, renamedDependencies: { "SomeName": "SomeOtherName" } },
-                    expectedOutput: output
-                });
-        });
-
-        it("Transpile with emit decorators and emit metadata", () => {
-            const input =
-                `import {db} from './db';\n` +
-                `function someDecorator(target) {\n` +
-                `    return target;\n` +
-                `} \n` +
-                `@someDecorator\n` +
-                `class MyClass {\n` +
-                `    db: db;\n` +
-                `    constructor(db: db) {\n` +
-                `        this.db = db;\n` +
-                `        this.db.doSomething(); \n` +
-                `    }\n` +
-                `}\n` +
-                `export {MyClass}; \n`;
-            const output =
-                `"use strict";\n` +
-                `var db_1 = require(\'./db\');\n` +
-                `function someDecorator(target) {\n` +
-                `    return target;\n` +
-                `}\n` +
-                `var MyClass = (function () {\n` +
-                `    function MyClass(db) {\n` +
-                `        this.db = db;\n` +
-                `        this.db.doSomething();\n` +
-                `    }\n` +
-                `    MyClass = __decorate([\n` +
-                `        someDecorator, \n` +
-                `        __metadata(\'design:paramtypes\', [(typeof (_a = typeof db_1.db !== \'undefined\' && db_1.db) === \'function\' && _a) || Object])\n` +
-                `    ], MyClass);\n` +
-                `    return MyClass;\n` +
-                `    var _a;\n` +
-                `}());\n` +
-                `exports.MyClass = MyClass;\n`;
-
-            test(input,
-                {
-                    options: {
-                        compilerOptions: {
-                            module: ModuleKind.CommonJS,
-                            newLine: NewLineKind.LineFeed,
-                            noEmitHelpers: true,
-                            emitDecoratorMetadata: true,
-                            experimentalDecorators: true,
-                            target: ScriptTarget.ES5,
+                it("Correct errors for " + justName, () => {
+                    Harness.Baseline.runBaseline("Correct errors", justName.replace(/\.tsx?$/, ".errors.txt"), () => {
+                        if (transpileResult.diagnostics.length === 0) {
+                            /* tslint:disable:no-null-keyword */
+                            return null;
+                            /* tslint:enable:no-null-keyword */
                         }
-                    },
-                    expectedOutput: output
+
+                        return Harness.Compiler.getErrorBaseline(toBeCompiled, transpileResult.diagnostics);
+                    });
                 });
-        });
 
-        it("Supports backslashes in file name", () => {
-            test("var x", { expectedOutput: `"use strict";\r\nvar x;\r\n`, options: { fileName: "a\\b.ts" }});
-        });
+                if (canUseOldTranspile) {
+                    it("Correct errors (old transpile) for " + justName, () => {
+                        Harness.Baseline.runBaseline("Correct errors", justName.replace(/\.tsx?$/, ".oldTranspile.errors.txt"), () => {
+                            if (oldTranspileDiagnostics.length === 0) {
+                                /* tslint:disable:no-null-keyword */
+                                return null;
+                                /* tslint:enable:no-null-keyword */
+                            }
 
-        it("transpile file as 'tsx' if 'jsx' is specified", () => {
-            const input = `var x = <div/>`;
-            const output = `"use strict";\nvar x = React.createElement("div", null);\n`;
-            test(input, {
-                expectedOutput: output,
-                options: { compilerOptions: { jsx: JsxEmit.React, newLine: NewLineKind.LineFeed } }
-            });
-        });
+                            return Harness.Compiler.getErrorBaseline(toBeCompiled, oldTranspileDiagnostics);
+                        });
+                    });
+                }
 
-        it("transpile .js files", () => {
-            const input = "const a = 10;";
-            const output = `"use strict";\nvar a = 10;\n`;
-            test(input, {
-                expectedOutput: output,
-                options: { compilerOptions: { newLine: NewLineKind.LineFeed, module: ModuleKind.CommonJS }, fileName: "input.js", reportDiagnostics: true }
-            });
-        });
-
-        it("Supports urls in file name", () => {
-            test("var x", { expectedOutput: `"use strict";\r\nvar x;\r\n`, options: { fileName: "http://somewhere/directory//directory2/file.ts" } });
-        });
-
-        it("Support options with lib values", () => {
-            const input = "const a = 10;";
-            const output = `"use strict";\r\nvar a = 10;\r\n`;
-            test(input, {
-                expectedOutput: output,
-                options: { compilerOptions: { lib: ["es6", "dom"], module: ModuleKind.CommonJS }, fileName: "input.js", reportDiagnostics: true }
-            });
-        });
-
-        it("Support options with types values", () => {
-            const input = "const a = 10;";
-            const output = `"use strict";\r\nvar a = 10;\r\n`;
-            test(input, {
-                expectedOutput: output,
-                options: { compilerOptions: { types: ["jquery", "typescript"], module: ModuleKind.CommonJS }, fileName: "input.js", reportDiagnostics: true }
-            });
-        });
-
-        describe("String values for enums", () => {
-            it("Accepts strings instead of enum values", () => {
-                test(`export const x = 0`, {
-                    options: {
-                        compilerOptions: {
-                            module: <ModuleKind><any>"es6",
-                            // Capitalization and spaces ignored
-                            target: <ScriptTarget><any>" Es6 "
+                it("Correct output for " + justName, () => {
+                    Harness.Baseline.runBaseline("Correct output", justName.replace(/\.tsx?$/, ".js"), () => {
+                        if (transpileResult.outputText) {
+                            return transpileResult.outputText;
                         }
-                    },
-                    expectedOutput: "export const x = 0;\r\n"
+                        else {
+                            // This can happen if compiler recieve invalid compiler-options
+                            /* tslint:disable:no-null-keyword */
+                            return null;
+                            /* tslint:enable:no-null-keyword */
+                        }
+                    });
                 });
-            });
 
-            it("Fails on bad value", () => {
-                for (const value in [123, {}, ""]) {
-                    test(``, {
-                        options: { compilerOptions: { module: <ModuleKind><any>value } },
-                        expectedDiagnosticCodes: [6046],
-                        expectedDiagnosticTexts: ["Argument for '--module' option must be:  'none', 'commonjs', 'amd', 'system', 'umd', 'es6', 'es2015'"]
+
+                if (canUseOldTranspile) {
+                    it("Correct output (old transpile) for " + justName, () => {
+                        Harness.Baseline.runBaseline("Correct output", justName.replace(/\.tsx?$/, ".oldTranspile.js"), () => {
+                            return oldTranspileResult;
+                        });
                     });
                 }
             });
+        }
+
+        transpilesCorrectly("Generates no diagnostics with valid inputs", `var x = 0;`, {
+            options: { compilerOptions: { module: ModuleKind.CommonJS } }
         });
+
+        transpilesCorrectly("Generates no diagnostics for missing file references", `/// <reference path="file2.ts" />
+var x = 0;`, {
+            options: { compilerOptions: { module: ModuleKind.CommonJS } }
+        });
+
+        transpilesCorrectly("Generates no diagnostics for missing module imports", `import {a} from "module2";`, {
+            options: { compilerOptions: { module: ModuleKind.CommonJS } }
+        });
+
+        transpilesCorrectly("Generates expected syntactic diagnostics", `a b`, {
+            options: { compilerOptions: { module: ModuleKind.CommonJS } }
+        });
+
+        transpilesCorrectly("Does not generate semantic diagnostics", `var x: string = 0;`, {
+            options: { compilerOptions: { module: ModuleKind.CommonJS } }
+        });
+
+        transpilesCorrectly("Generates module output", `var x = 0;`, {
+            options: { compilerOptions: { module: ModuleKind.AMD } }
+        });
+
+        transpilesCorrectly("Uses correct newLine character", `var x = 0;`, {
+            options: { compilerOptions: { module: ModuleKind.CommonJS, newLine: NewLineKind.LineFeed } }
+        });
+
+        transpilesCorrectly("Sets module name", "var x = 1;", {
+            options: { compilerOptions: { module: ModuleKind.System, newLine: NewLineKind.LineFeed }, moduleName: "NamedModule" }
+        });
+
+        transpilesCorrectly("No extra errors for file without extension", `"use strict";\r\nvar x = 0;`, {
+            options: { compilerOptions: { module: ModuleKind.CommonJS }, fileName: "file" }
+        });
+
+        transpilesCorrectly("Rename dependencies - System",
+            `import {foo} from "SomeName";\n` +
+            `declare function use(a: any);\n` +
+            `use(foo);`, {
+            options: { compilerOptions: { module: ModuleKind.System, newLine: NewLineKind.LineFeed }, renamedDependencies: { "SomeName": "SomeOtherName" } }
+        });
+
+        transpilesCorrectly("Rename dependencies - AMD",
+            `import {foo} from "SomeName";\n` +
+            `declare function use(a: any);\n` +
+            `use(foo);`, {
+            options: { compilerOptions: { module: ModuleKind.AMD, newLine: NewLineKind.LineFeed }, renamedDependencies: { "SomeName": "SomeOtherName" } }
+        });
+
+        transpilesCorrectly("Rename dependencies - UMD",
+            `import {foo} from "SomeName";\n` +
+            `declare function use(a: any);\n` +
+            `use(foo);`, {
+            options: { compilerOptions: { module: ModuleKind.UMD, newLine: NewLineKind.LineFeed }, renamedDependencies: { "SomeName": "SomeOtherName" } }
+        });
+
+        transpilesCorrectly("Transpile with emit decorators and emit metadata",
+            `import {db} from './db';\n` +
+            `function someDecorator(target) {\n` +
+            `    return target;\n` +
+            `} \n` +
+            `@someDecorator\n` +
+            `class MyClass {\n` +
+            `    db: db;\n` +
+            `    constructor(db: db) {\n` +
+            `        this.db = db;\n` +
+            `        this.db.doSomething(); \n` +
+            `    }\n` +
+            `}\n` +
+            `export {MyClass}; \n`, {
+            options: {
+                compilerOptions: {
+                    module: ModuleKind.CommonJS,
+                    newLine: NewLineKind.LineFeed,
+                    noEmitHelpers: true,
+                    emitDecoratorMetadata: true,
+                    experimentalDecorators: true,
+                    target: ScriptTarget.ES5,
+                }
+            }
+        });
+
+        transpilesCorrectly("Supports backslashes in file name", "var x", {
+            options: { fileName: "a\\b.ts" }
+        });
+
+        transpilesCorrectly("transpile file as 'tsx' if 'jsx' is specified", `var x = <div/>`, {
+            options: { compilerOptions: { jsx: JsxEmit.React, newLine: NewLineKind.LineFeed } }
+        });
+
+        transpilesCorrectly("transpile .js files", "const a = 10;", {
+            options: { compilerOptions: { newLine: NewLineKind.LineFeed, module: ModuleKind.CommonJS }, fileName: "input.js", reportDiagnostics: true }
+        });
+
+        transpilesCorrectly("Supports urls in file name", "var x", {
+            options: { fileName: "http://somewhere/directory//directory2/file.ts" }
+        });
+
+        transpilesCorrectly("Accepts string as enum values for compile-options", "export const x = 0", {
+            options: { compilerOptions: {
+                module: <ModuleKind><any>"es6",
+                 // Capitalization and spaces ignored
+                target: <ScriptTarget><any>" Es6 "
+            }}
+        });
+
+        transpilesCorrectly("Report an error when compiler-options module-kind is out-of-range", "", {
+            options: { compilerOptions: { module: <ModuleKind><any>123 }}
+        });
+
+        transpilesCorrectly("Report an error when compiler-options target-script is out-of-range", "", {
+            options: { compilerOptions: { module: <ModuleKind><any>123 }}
+        });
+
+        transpilesCorrectly("Report an error when compiler-options input is empty object", "", {
+            options: { compilerOptions: { module: <ModuleKind><any>{} }}
+        });
+
+        transpilesCorrectly("Report an error when compiler-options input is empty string", "", {
+            options: { compilerOptions: { module: <ModuleKind><any>"" }}
+        });
+
+        transpilesCorrectly("Support options with lib values", "const a = 10;", {
+            options: { compilerOptions: { lib: ["es6", "dom"], module: ModuleKind.CommonJS }, fileName: "input.js", reportDiagnostics: true }
+        });
+
+        transpilesCorrectly("Support options with types values", "const a = 10;", {
+            options: { compilerOptions: { types: ["jquery", "typescript"], module: ModuleKind.CommonJS }, fileName: "input.js", reportDiagnostics: true }
+        })
     });
 }


### PR DESCRIPTION
This is the change already existed in "transforms" branch. It used baselines for Transpile unittest.

There are couple reasons I am porting the change to master:

- making merging between "master" and "transforms" easier as currently each test has to be manually ported which can cause some tests to be missing

- making adding new Transpile tests much easier (which I will have to do to fix one of the bug)
