### PR TITLE
Add libcheck tests

### DIFF
--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1051,7 +1051,7 @@ namespace Harness {
             options.target = options.target || ts.ScriptTarget.ES3;
             options.newLine = options.newLine || ts.NewLineKind.CarriageReturnLineFeed;
             options.noErrorTruncation = true;
-            options.skipDefaultLibCheck = true;
+            options.skipDefaultLibCheck = typeof options.skipDefaultLibCheck === "undefined" ? true : options.skipDefaultLibCheck;
 
             if (typeof currentDirectory === "undefined") {
                 currentDirectory = Harness.IO.getCurrentDirectory();

--- a/tests/baselines/reference/verifyDefaultLib_dom.js
+++ b/tests/baselines/reference/verifyDefaultLib_dom.js
@@ -1,0 +1,6 @@
+//// [verifyDefaultLib_dom.ts]
+
+var x: HTMLElement;
+
+//// [verifyDefaultLib_dom.js]
+var x;

--- a/tests/baselines/reference/verifyDefaultLib_dom.symbols
+++ b/tests/baselines/reference/verifyDefaultLib_dom.symbols
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/verifyDefaultLib_dom.ts ===
+
+var x: HTMLElement;
+>x : Symbol(x, Decl(verifyDefaultLib_dom.ts, 1, 3))
+>HTMLElement : Symbol(HTMLElement, Decl(lib.dom.d.ts, --, --), Decl(lib.dom.d.ts, --, --))
+

--- a/tests/baselines/reference/verifyDefaultLib_dom.types
+++ b/tests/baselines/reference/verifyDefaultLib_dom.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/verifyDefaultLib_dom.ts ===
+
+var x: HTMLElement;
+>x : HTMLElement
+>HTMLElement : HTMLElement
+

--- a/tests/baselines/reference/verifyDefaultLib_webworker.js
+++ b/tests/baselines/reference/verifyDefaultLib_webworker.js
@@ -1,0 +1,6 @@
+//// [verifyDefaultLib_webworker.ts]
+
+var x: Worker;
+
+//// [verifyDefaultLib_webworker.js]
+var x;

--- a/tests/baselines/reference/verifyDefaultLib_webworker.symbols
+++ b/tests/baselines/reference/verifyDefaultLib_webworker.symbols
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/verifyDefaultLib_webworker.ts ===
+
+var x: Worker;
+>x : Symbol(x, Decl(verifyDefaultLib_webworker.ts, 1, 3))
+>Worker : Symbol(Worker, Decl(lib.webworker.d.ts, --, --), Decl(lib.webworker.d.ts, --, --))
+

--- a/tests/baselines/reference/verifyDefaultLib_webworker.types
+++ b/tests/baselines/reference/verifyDefaultLib_webworker.types
@@ -1,0 +1,6 @@
+=== tests/cases/compiler/verifyDefaultLib_webworker.ts ===
+
+var x: Worker;
+>x : Worker
+>Worker : Worker
+

--- a/tests/cases/compiler/verifyDefaultLib_dom.ts
+++ b/tests/cases/compiler/verifyDefaultLib_dom.ts
@@ -1,0 +1,7 @@
+// @strictNullChecks: true
+// @noImplicitAny: true
+// @noImplicitThis: true
+// @skipDefaultLibCheck: false
+// @lib: es2015,es2016,es2017,dom,scripthost
+
+var x: HTMLElement;

--- a/tests/cases/compiler/verifyDefaultLib_webworker.ts
+++ b/tests/cases/compiler/verifyDefaultLib_webworker.ts
@@ -1,0 +1,7 @@
+// @strictNullChecks: true
+// @noImplicitAny: true
+// @noImplicitThis: true
+// @skipDefaultLibCheck: false
+// @lib: es2015,es2016,es2017,webworker
+
+var x: Worker;


### PR DESCRIPTION
Adds a test to verify the library files build correctly under `--strictNullChecks`,`--noImplicitAny`, and `--noImplicitThis`. Should catch the issue reported in https://github.com/Microsoft/TypeScript/issues/9244.

Currently this is failing because of https://github.com/Microsoft/TypeScript/issues/9248.