### PR TITLE
Fix rwc-runner from breaking change in compiler

### DIFF
--- a/src/harness/loggedIO.ts
+++ b/src/harness/loggedIO.ts
@@ -224,12 +224,7 @@ namespace Playback {
                 recordLog.directoriesRead.push(logEntry);
                 return result;
             },
-            (path, extension, exclude) => findResultByPath(wrapper,
-                    replayLog.directoriesRead.filter(
-                        d => {
-                            return d.extension === extension;
-                        }
-                    ), path));
+            (path, extension, exclude) => findResultByPath(wrapper, replayLog.directoriesRead, path));
 
         wrapper.writeFile = recordReplay(wrapper.writeFile, underlying)(
             (path: string, contents: string) => callAndRecord(underlying.writeFile(path, contents), recordLog.filesWritten, { path, contents, bom: false }),


### PR DESCRIPTION
Fix RWC runner from API breaking change. The directory extension in IOLog is no longer making any sense as we are again change how the tsconfig property specified