### PR TITLE
Fix bug where `exports.` was prepended to namespace export accesses

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1125,7 +1125,7 @@ namespace ts {
             return getExternalModuleMember(<ImportDeclaration>node.parent.parent.parent, node);
         }
 
-        function getTargetOfGlobalModuleExportDeclaration(node: NamespaceExportDeclaration): Symbol {
+        function getTargetOfNamespaceExportDeclaration(node: NamespaceExportDeclaration): Symbol {
             return resolveExternalModuleSymbol(node.parent.symbol);
         }
 
@@ -1154,7 +1154,7 @@ namespace ts {
                 case SyntaxKind.ExportAssignment:
                     return getTargetOfExportAssignment(<ExportAssignment>node);
                 case SyntaxKind.NamespaceExportDeclaration:
-                    return getTargetOfGlobalModuleExportDeclaration(<NamespaceExportDeclaration>node);
+                    return getTargetOfNamespaceExportDeclaration(<NamespaceExportDeclaration>node);
             }
         }
 
@@ -17432,7 +17432,10 @@ namespace ts {
                 const parentSymbol = getParentOfSymbol(symbol);
                 if (parentSymbol) {
                     if (parentSymbol.flags & SymbolFlags.ValueModule && parentSymbol.valueDeclaration.kind === SyntaxKind.SourceFile) {
-                        return <SourceFile>parentSymbol.valueDeclaration;
+                        // If `node` accesses an export and that export isn't in the same file, then symbol is a namespace export, so return undefined.
+                        if (parentSymbol.valueDeclaration === getSourceFileOfNode(node)) {
+                            return <SourceFile>parentSymbol.valueDeclaration;
+                        }
                     }
                     for (let n = node.parent; n; n = n.parent) {
                         if ((n.kind === SyntaxKind.ModuleDeclaration || n.kind === SyntaxKind.EnumDeclaration) && getSymbolOfNode(n) === parentSymbol) {

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -753,6 +753,8 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                         return generateNameForExportDefault();
                     case SyntaxKind.ClassExpression:
                         return generateNameForClassExpression();
+                    default:
+                        Debug.fail();
                 }
             }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4699,7 +4699,7 @@ namespace ts {
                         case SyntaxKind.EqualsToken:
                             return parseExportAssignment(fullStart, decorators, modifiers);
                         case SyntaxKind.AsKeyword:
-                            return parseGlobalModuleExportDeclaration(fullStart, decorators, modifiers);
+                            return parseNamespaceExportDeclaration(fullStart, decorators, modifiers);
                         default:
                             return parseExportDeclaration(fullStart, decorators, modifiers);
                     }
@@ -5378,7 +5378,7 @@ namespace ts {
             return nextToken() === SyntaxKind.SlashToken;
         }
 
-        function parseGlobalModuleExportDeclaration(fullStart: number, decorators: NodeArray<Decorator>, modifiers: ModifiersArray): NamespaceExportDeclaration {
+        function parseNamespaceExportDeclaration(fullStart: number, decorators: NodeArray<Decorator>, modifiers: ModifiersArray): NamespaceExportDeclaration {
             const exportDeclaration = <NamespaceExportDeclaration>createNode(SyntaxKind.NamespaceExportDeclaration, fullStart);
             exportDeclaration.decorators = decorators;
             exportDeclaration.modifiers = modifiers;

--- a/tests/baselines/reference/umd-augmentation-2.js
+++ b/tests/baselines/reference/umd-augmentation-2.js
@@ -42,8 +42,8 @@ var t = p.x;
 //// [a.js]
 /// <reference path="node_modules/math2d/index.d.ts" />
 /// <reference path="math2d-augment.d.ts" />
-var v = new exports.Math2d.Vector(3, 2);
-var magnitude = exports.Math2d.getLength(v);
+var v = new Math2d.Vector(3, 2);
+var magnitude = Math2d.getLength(v);
 var p = v.translate(5, 5);
 p = v.reverse();
 var t = p.x;

--- a/tests/baselines/reference/umd-augmentation-4.js
+++ b/tests/baselines/reference/umd-augmentation-4.js
@@ -48,8 +48,8 @@ var t = p.x;
 //// [a.js]
 /// <reference path="node_modules/math2d/index.d.ts" />
 /// <reference path="math2d-augment.d.ts" />
-var v = new exports.Math2d.Vector(3, 2);
-var magnitude = exports.Math2d.getLength(v);
+var v = new Math2d.Vector(3, 2);
+var magnitude = Math2d.getLength(v);
 var p = v.translate(5, 5);
 p = v.reverse();
 var t = p.x;

--- a/tests/baselines/reference/umd1.js
+++ b/tests/baselines/reference/umd1.js
@@ -16,6 +16,6 @@ let y: number = x.n;
 
 //// [a.js]
 /// <reference path="foo.d.ts" />
-exports.Foo.fn();
+Foo.fn();
 var x;
 var y = x.n;

--- a/tests/baselines/reference/umd5.js
+++ b/tests/baselines/reference/umd5.js
@@ -23,4 +23,4 @@ Bar.fn();
 var x;
 var y = x.n;
 // should error
-var z = exports.Foo;
+var z = Foo;

--- a/tests/baselines/reference/umd6.js
+++ b/tests/baselines/reference/umd6.js
@@ -15,4 +15,4 @@ let y: number = Foo.fn();
 
 //// [a.js]
 /// <reference path="foo.d.ts" />
-var y = exports.Foo.fn();
+var y = Foo.fn();

--- a/tests/baselines/reference/umd7.js
+++ b/tests/baselines/reference/umd7.js
@@ -13,4 +13,4 @@ let y: number = Foo();
 
 //// [a.js]
 /// <reference path="foo.d.ts" />
-var y = exports.Foo();
+var y = Foo();


### PR DESCRIPTION
Fixes #9331

