### PR TITLE
[Fix #8800] Emit comments after open braces

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -2943,11 +2943,13 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 if (isSingleLineEmptyBlock(node)) {
                     emitToken(SyntaxKind.OpenBraceToken, node.pos);
                     write(" ");
+                    emitBraceTrailingComments(node);
                     emitToken(SyntaxKind.CloseBraceToken, node.statements.end);
                     return;
                 }
 
                 emitToken(SyntaxKind.OpenBraceToken, node.pos);
+                emitBraceTrailingComments(node);
                 increaseIndent();
                 if (node.kind === SyntaxKind.ModuleBlock) {
                     Debug.assert(node.parent.kind === SyntaxKind.ModuleDeclaration);
@@ -8346,6 +8348,20 @@ const _super = (function (geti, seti) {
                     write(shebang);
                     writeLine();
                 }
+            }
+
+            function emitBraceTrailingComments(block: Block) {
+                // trailing comment after block's open brace is not statements' leading comment
+                const bracePosition = skipTrivia(currentText, block.pos) + 1;
+                if (compilerOptions.removeComments) {
+                    return;
+                }
+                const trailingComments = getTrailingCommentRanges(currentText, bracePosition);
+                if (trailingComments) {
+                    write(" ");
+                }
+                // trailing comments are emitted at space/*trailing comment1 */space/*trailing comment*/
+                emitComments(currentText, currentLineMap, writer, trailingComments, /*trailingSeparator*/ true, newLine, writeComment);
             }
         }
 

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -5003,6 +5003,8 @@ const _super = (function (geti, seti) {
 
             function emitBlockFunctionBody(node: FunctionLikeDeclaration, body: Block) {
                 write(" {");
+                emitBraceTrailingComments(body);
+
                 const initialTextPos = writer.getTextPos();
 
                 increaseIndent();

--- a/tests/baselines/reference/assignToExistingClass.js
+++ b/tests/baselines/reference/assignToExistingClass.js
@@ -27,7 +27,7 @@ var Test;
         function Tester() {
         }
         Tester.prototype.willThrowError = function () {
-            Mocked = Mocked || function () {
+            Mocked = Mocked || function () { // => Error: Invalid left-hand side of assignment expression.
                 return { myProp: "test" };
             };
         };

--- a/tests/baselines/reference/augmentedTypesModules.js
+++ b/tests/baselines/reference/augmentedTypesModules.js
@@ -111,7 +111,7 @@ var m1b;
 var m1b = 1; // error
 var m1c = 1; // Should be allowed
 var m1d;
-(function (m1d) {
+(function (m1d) { // error
     var I = (function () {
         function I() {
         }

--- a/tests/baselines/reference/bestCommonTypeOfConditionalExpressions2.js
+++ b/tests/baselines/reference/bestCommonTypeOfConditionalExpressions2.js
@@ -59,7 +59,7 @@ var r9 = true ? derived : derived2;
 function foo(t, u) {
     return true ? t : u;
 }
-function foo2(t, u) {
+function foo2(t, u) { // Error for referencing own type parameter
     return true ? t : u; // Ok because BCT(T, U) = U
 }
 function foo3(t, u) {

--- a/tests/baselines/reference/callOverloads1.js
+++ b/tests/baselines/reference/callOverloads1.js
@@ -22,7 +22,7 @@ var Foo = (function () {
     function Foo(x) {
         // WScript.Echo("Constructor function has executed");
     }
-    Foo.prototype.bar1 = function () { };
+    Foo.prototype.bar1 = function () { /*WScript.Echo("bar1");*/  };
     return Foo;
 }());
 function F1(a) { return a; }

--- a/tests/baselines/reference/callOverloads2.js
+++ b/tests/baselines/reference/callOverloads2.js
@@ -30,7 +30,7 @@ var Foo = (function () {
     function Foo(x) {
         // WScript.Echo("Constructor function has executed");
     }
-    Foo.prototype.bar1 = function () { };
+    Foo.prototype.bar1 = function () { /*WScript.Echo("bar1");*/  };
     return Foo;
 }());
 function F1(s) { return s; } // error

--- a/tests/baselines/reference/callOverloads3.js
+++ b/tests/baselines/reference/callOverloads3.js
@@ -23,7 +23,7 @@ var Foo = (function () {
     function Foo(x) {
         // WScript.Echo("Constructor function has executed");
     }
-    Foo.prototype.bar1 = function () { };
+    Foo.prototype.bar1 = function () { /*WScript.Echo("bar1");*/  };
     return Foo;
 }());
 //class Foo(s: String);

--- a/tests/baselines/reference/callOverloads4.js
+++ b/tests/baselines/reference/callOverloads4.js
@@ -23,7 +23,7 @@ var Foo = (function () {
     function Foo(x) {
         // WScript.Echo("Constructor function has executed");
     }
-    Foo.prototype.bar1 = function () { };
+    Foo.prototype.bar1 = function () { /*WScript.Echo("bar1");*/  };
     return Foo;
 }());
 var f1 = new Foo("hey");

--- a/tests/baselines/reference/callOverloads5.js
+++ b/tests/baselines/reference/callOverloads5.js
@@ -24,7 +24,7 @@ var Foo = (function () {
     function Foo(x) {
         // WScript.Echo("Constructor function has executed");
     }
-    Foo.prototype.bar1 = function (a) { };
+    Foo.prototype.bar1 = function (a) { /*WScript.Echo(a);*/  };
     return Foo;
 }());
 //class Foo(s: String);

--- a/tests/baselines/reference/callSignaturesWithParameterInitializers2.js
+++ b/tests/baselines/reference/callSignaturesWithParameterInitializers2.js
@@ -45,7 +45,7 @@ var c;
 c.foo();
 c.foo(1);
 var b = {
-    foo: function (x) {
+    foo: function (x) { // error
         if (x === void 0) { x = 1; }
     },
     foo: function (x) {

--- a/tests/baselines/reference/classTypeParametersInStatics.js
+++ b/tests/baselines/reference/classTypeParametersInStatics.js
@@ -41,19 +41,19 @@ var Editor;
             this.isHead = isHead;
             this.data = data;
         }
-        List.MakeHead = function () {
+        List.MakeHead = function () { // should error
             var entry = new List(true, null);
             entry.prev = entry;
             entry.next = entry;
             return entry;
         };
-        List.MakeHead2 = function () {
+        List.MakeHead2 = function () { // should not error
             var entry = new List(true, null);
             entry.prev = entry;
             entry.next = entry;
             return entry;
         };
-        List.MakeHead3 = function () {
+        List.MakeHead3 = function () { // should not error
             var entry = new List(true, null);
             entry.prev = entry;
             entry.next = entry;

--- a/tests/baselines/reference/collisionArgumentsArrowFunctions.js
+++ b/tests/baselines/reference/collisionArgumentsArrowFunctions.js
@@ -17,21 +17,21 @@ var f2NoError = () => {
 }
 
 //// [collisionArgumentsArrowFunctions.js]
-var f1 = function (i) {
+var f1 = function (i) { //arguments is error
     var arguments = [];
     for (var _i = 1; _i < arguments.length; _i++) {
         arguments[_i - 1] = arguments[_i];
     }
     var arguments; // no error
 };
-var f12 = function (arguments) {
+var f12 = function (arguments) { //arguments is error
     var rest = [];
     for (var _i = 1; _i < arguments.length; _i++) {
         rest[_i - 1] = arguments[_i];
     }
     var arguments = 10; // no error
 };
-var f1NoError = function (arguments) {
+var f1NoError = function (arguments) { // no error
     var arguments = 10; // no error
 };
 var f2 = function () {

--- a/tests/baselines/reference/collisionArgumentsClassMethod.js
+++ b/tests/baselines/reference/collisionArgumentsClassMethod.js
@@ -52,38 +52,38 @@ class c3 {
 var c1 = (function () {
     function c1() {
     }
-    c1.prototype.foo = function (i) {
+    c1.prototype.foo = function (i) { //arguments is error
         var arguments = [];
         for (var _i = 1; _i < arguments.length; _i++) {
             arguments[_i - 1] = arguments[_i];
         }
         var arguments; // no error
     };
-    c1.prototype.foo1 = function (arguments) {
+    c1.prototype.foo1 = function (arguments) { //arguments is error
         var rest = [];
         for (var _i = 1; _i < arguments.length; _i++) {
             rest[_i - 1] = arguments[_i];
         }
         var arguments = 10; // no error
     };
-    c1.prototype.fooNoError = function (arguments) {
+    c1.prototype.fooNoError = function (arguments) { // no error
         var arguments = 10; // no error
     };
-    c1.prototype.f4 = function (i) {
+    c1.prototype.f4 = function (i) { // error
         var arguments = [];
         for (var _i = 1; _i < arguments.length; _i++) {
             arguments[_i - 1] = arguments[_i];
         }
         var arguments; // no error
     };
-    c1.prototype.f41 = function (arguments) {
+    c1.prototype.f41 = function (arguments) { // error
         var rest = [];
         for (var _i = 1; _i < arguments.length; _i++) {
             rest[_i - 1] = arguments[_i];
         }
         var arguments; // no error
     };
-    c1.prototype.f4NoError = function (arguments) {
+    c1.prototype.f4NoError = function (arguments) { // no error
         var arguments; // no error
     };
     return c1;

--- a/tests/baselines/reference/collisionArgumentsFunction.js
+++ b/tests/baselines/reference/collisionArgumentsFunction.js
@@ -46,21 +46,21 @@ declare function f6(arguments: string); // no codegen no error
 
 //// [collisionArgumentsFunction.js]
 // Functions
-function f1(arguments) {
+function f1(arguments) { //arguments is error
     var restParameters = [];
     for (var _i = 1; _i < arguments.length; _i++) {
         restParameters[_i - 1] = arguments[_i];
     }
     var arguments = 10; // no error
 }
-function f12(i) {
+function f12(i) { //arguments is error
     var arguments = [];
     for (var _i = 1; _i < arguments.length; _i++) {
         arguments[_i - 1] = arguments[_i];
     }
     var arguments; // no error
 }
-function f1NoError(arguments) {
+function f1NoError(arguments) { // no error
     var arguments = 10; // no error
 }
 function f3() {
@@ -73,20 +73,20 @@ function f3() {
 function f3NoError() {
     var arguments = 10; // no error
 }
-function f4(arguments) {
+function f4(arguments) { // error
     var rest = [];
     for (var _i = 1; _i < arguments.length; _i++) {
         rest[_i - 1] = arguments[_i];
     }
     var arguments; // No error
 }
-function f42(i) {
+function f42(i) { // error
     var arguments = [];
     for (var _i = 1; _i < arguments.length; _i++) {
         arguments[_i - 1] = arguments[_i];
     }
     var arguments; // No error
 }
-function f4NoError(arguments) {
+function f4NoError(arguments) { // no error
     var arguments; // No error
 }

--- a/tests/baselines/reference/collisionArgumentsFunctionExpressions.js
+++ b/tests/baselines/reference/collisionArgumentsFunctionExpressions.js
@@ -36,21 +36,21 @@ function foo() {
 
 //// [collisionArgumentsFunctionExpressions.js]
 function foo() {
-    function f1(arguments) {
+    function f1(arguments) { //arguments is error
         var restParameters = [];
         for (var _i = 1; _i < arguments.length; _i++) {
             restParameters[_i - 1] = arguments[_i];
         }
         var arguments = 10; // no error
     }
-    function f12(i) {
+    function f12(i) { //arguments is error
         var arguments = [];
         for (var _i = 1; _i < arguments.length; _i++) {
             arguments[_i - 1] = arguments[_i];
         }
         var arguments; // no error
     }
-    function f1NoError(arguments) {
+    function f1NoError(arguments) { // no error
         var arguments = 10; // no error
     }
     function f3() {
@@ -63,21 +63,21 @@ function foo() {
     function f3NoError() {
         var arguments = 10; // no error
     }
-    function f4(arguments) {
+    function f4(arguments) { // error
         var rest = [];
         for (var _i = 1; _i < arguments.length; _i++) {
             rest[_i - 1] = arguments[_i];
         }
         var arguments; // No error
     }
-    function f42(i) {
+    function f42(i) { // error
         var arguments = [];
         for (var _i = 1; _i < arguments.length; _i++) {
             arguments[_i - 1] = arguments[_i];
         }
         var arguments; // No error
     }
-    function f4NoError(arguments) {
+    function f4NoError(arguments) { // no error
         var arguments; // No error
     }
 }

--- a/tests/baselines/reference/collisionCodeGenModuleWithAccessorChildren.js
+++ b/tests/baselines/reference/collisionCodeGenModuleWithAccessorChildren.js
@@ -79,7 +79,7 @@ var M;
     }());
 })(M || (M = {}));
 var M;
-(function (M) {
+(function (M) { // Shouldnt be _M
     var e = (function () {
         function e() {
         }
@@ -110,7 +110,7 @@ var M;
     }());
 })(M || (M = {}));
 var M;
-(function (M) {
+(function (M) { // Shouldnt be _M
     var e = (function () {
         function e() {
         }

--- a/tests/baselines/reference/collisionCodeGenModuleWithMethodChildren.js
+++ b/tests/baselines/reference/collisionCodeGenModuleWithMethodChildren.js
@@ -71,7 +71,7 @@ var M;
     }());
 })(M || (M = {}));
 var M;
-(function (M) {
+(function (M) { // Shouldnt bn _M
     var f = (function () {
         function f() {
         }

--- a/tests/baselines/reference/collisionCodeGenModuleWithModuleChildren.js
+++ b/tests/baselines/reference/collisionCodeGenModuleWithModuleChildren.js
@@ -76,7 +76,7 @@ var M;
     })(m3 || (m3 = {}));
 })(M || (M = {}));
 var M;
-(function (M) {
+(function (M) { // shouldnt be _M
     var m3;
     (function (m3) {
         var p = M.x;

--- a/tests/baselines/reference/collisionRestParameterArrowFunctions.js
+++ b/tests/baselines/reference/collisionRestParameterArrowFunctions.js
@@ -14,14 +14,14 @@ var f2NoError = () => {
 }
 
 //// [collisionRestParameterArrowFunctions.js]
-var f1 = function (_i) {
+var f1 = function (_i) { //_i is error
     var restParameters = [];
     for (var _a = 1; _a < arguments.length; _a++) {
         restParameters[_a - 1] = arguments[_a];
     }
     var _i = 10; // no error
 };
-var f1NoError = function (_i) {
+var f1NoError = function (_i) { // no error
     var _i = 10; // no error
 };
 var f2 = function () {

--- a/tests/baselines/reference/collisionRestParameterClassMethod.js
+++ b/tests/baselines/reference/collisionRestParameterClassMethod.js
@@ -42,24 +42,24 @@ class c3 {
 var c1 = (function () {
     function c1() {
     }
-    c1.prototype.foo = function (_i) {
+    c1.prototype.foo = function (_i) { //_i is error
         var restParameters = [];
         for (var _a = 1; _a < arguments.length; _a++) {
             restParameters[_a - 1] = arguments[_a];
         }
         var _i = 10; // no error
     };
-    c1.prototype.fooNoError = function (_i) {
+    c1.prototype.fooNoError = function (_i) { // no error
         var _i = 10; // no error
     };
-    c1.prototype.f4 = function (_i) {
+    c1.prototype.f4 = function (_i) { // error
         var rest = [];
         for (var _a = 1; _a < arguments.length; _a++) {
             rest[_a - 1] = arguments[_a];
         }
         var _i; // no error
     };
-    c1.prototype.f4NoError = function (_i) {
+    c1.prototype.f4NoError = function (_i) { // no error
         var _i; // no error
     };
     return c1;

--- a/tests/baselines/reference/collisionRestParameterFunction.js
+++ b/tests/baselines/reference/collisionRestParameterFunction.js
@@ -35,14 +35,14 @@ declare function f6(_i: string); // no codegen no error
 
 //// [collisionRestParameterFunction.js]
 // Functions
-function f1(_i) {
+function f1(_i) { //_i is error
     var restParameters = [];
     for (var _a = 1; _a < arguments.length; _a++) {
         restParameters[_a - 1] = arguments[_a];
     }
     var _i = 10; // no error
 }
-function f1NoError(_i) {
+function f1NoError(_i) { // no error
     var _i = 10; // no error
 }
 function f3() {
@@ -55,11 +55,11 @@ function f3() {
 function f3NoError() {
     var _i = 10; // no error
 }
-function f4(_i) {
+function f4(_i) { // error
     var rest = [];
     for (var _a = 1; _a < arguments.length; _a++) {
         rest[_a - 1] = arguments[_a];
     }
 }
-function f4NoError(_i) {
+function f4NoError(_i) { // no error
 }

--- a/tests/baselines/reference/collisionRestParameterFunctionExpressions.js
+++ b/tests/baselines/reference/collisionRestParameterFunctionExpressions.js
@@ -26,14 +26,14 @@ function foo() {
 
 //// [collisionRestParameterFunctionExpressions.js]
 function foo() {
-    function f1(_i) {
+    function f1(_i) { //_i is error
         var restParameters = [];
         for (var _a = 1; _a < arguments.length; _a++) {
             restParameters[_a - 1] = arguments[_a];
         }
         var _i = 10; // no error
     }
-    function f1NoError(_i) {
+    function f1NoError(_i) { // no error
         var _i = 10; // no error
     }
     function f3() {
@@ -46,12 +46,12 @@ function foo() {
     function f3NoError() {
         var _i = 10; // no error
     }
-    function f4(_i) {
+    function f4(_i) { // error
         var rest = [];
         for (var _a = 1; _a < arguments.length; _a++) {
             rest[_a - 1] = arguments[_a];
         }
     }
-    function f4NoError(_i) {
+    function f4NoError(_i) { // no error
     }
 }

--- a/tests/baselines/reference/collisionSuperAndLocalFunctionInAccessors.js
+++ b/tests/baselines/reference/collisionSuperAndLocalFunctionInAccessors.js
@@ -45,19 +45,19 @@ var __extends = (this && this.__extends) || function (d, b) {
     function __() { this.constructor = d; }
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
-function _super() {
+function _super() { // No error
 }
 var Foo = (function () {
     function Foo() {
     }
     Object.defineProperty(Foo.prototype, "prop1", {
         get: function () {
-            function _super() {
+            function _super() { // No error
             }
             return 10;
         },
         set: function (val) {
-            function _super() {
+            function _super() { // No error
             }
         },
         enumerable: true,
@@ -72,12 +72,12 @@ var b = (function (_super) {
     }
     Object.defineProperty(b.prototype, "prop2", {
         get: function () {
-            function _super() {
+            function _super() { // Should be error
             }
             return 10;
         },
         set: function (val) {
-            function _super() {
+            function _super() { // Should be error
             }
         },
         enumerable: true,
@@ -93,14 +93,14 @@ var c = (function (_super) {
     Object.defineProperty(c.prototype, "prop2", {
         get: function () {
             var x = function () {
-                function _super() {
+                function _super() { // Should be error
                 }
             };
             return 10;
         },
         set: function (val) {
             var x = function () {
-                function _super() {
+                function _super() { // Should be error
                 }
             };
         },

--- a/tests/baselines/reference/collisionSuperAndLocalFunctionInConstructor.js
+++ b/tests/baselines/reference/collisionSuperAndLocalFunctionInConstructor.js
@@ -30,11 +30,11 @@ var __extends = (this && this.__extends) || function (d, b) {
     function __() { this.constructor = d; }
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
-function _super() {
+function _super() { // No error
 }
 var Foo = (function () {
     function Foo() {
-        function _super() {
+        function _super() { // No error
         }
     }
     return Foo;
@@ -43,7 +43,7 @@ var b = (function (_super) {
     __extends(b, _super);
     function b() {
         _super.call(this);
-        function _super() {
+        function _super() { // Should be error
         }
     }
     return b;
@@ -53,7 +53,7 @@ var c = (function (_super) {
     function c() {
         _super.call(this);
         var x = function () {
-            function _super() {
+            function _super() { // Should be error
             }
         };
     }

--- a/tests/baselines/reference/collisionSuperAndLocalFunctionInMethod.js
+++ b/tests/baselines/reference/collisionSuperAndLocalFunctionInMethod.js
@@ -34,16 +34,16 @@ var __extends = (this && this.__extends) || function (d, b) {
     function __() { this.constructor = d; }
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
-function _super() {
+function _super() { // No error
 }
 var Foo = (function () {
     function Foo() {
     }
     Foo.prototype.x = function () {
-        function _super() {
+        function _super() { // No error
         }
     };
-    Foo.prototype._super = function () {
+    Foo.prototype._super = function () { // No error
     };
     return Foo;
 }());
@@ -53,10 +53,10 @@ var b = (function (_super) {
         _super.apply(this, arguments);
     }
     b.prototype.foo = function () {
-        function _super() {
+        function _super() { // should be error
         }
     };
-    b.prototype._super = function () {
+    b.prototype._super = function () { // No Error
     };
     return b;
 }(Foo));
@@ -67,11 +67,11 @@ var c = (function (_super) {
     }
     c.prototype.foo = function () {
         var x = function () {
-            function _super() {
+            function _super() { // should be error
             }
         };
     };
-    c.prototype._super = function () {
+    c.prototype._super = function () { // No error
     };
     return c;
 }(Foo));

--- a/tests/baselines/reference/collisionSuperAndLocalFunctionInProperty.js
+++ b/tests/baselines/reference/collisionSuperAndLocalFunctionInProperty.js
@@ -24,13 +24,13 @@ var __extends = (this && this.__extends) || function (d, b) {
     function __() { this.constructor = d; }
     d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
 };
-function _super() {
+function _super() { // No error
 }
 var Foo = (function () {
     function Foo() {
         this.prop1 = {
             doStuff: function () {
-                function _super() {
+                function _super() { // No error
                 }
             }
         };
@@ -43,7 +43,7 @@ var b = (function (_super) {
         _super.apply(this, arguments);
         this.prop2 = {
             doStuff: function () {
-                function _super() {
+                function _super() { // error
                 }
             }
         };

--- a/tests/baselines/reference/collisionSuperAndParameter.js
+++ b/tests/baselines/reference/collisionSuperAndParameter.js
@@ -73,18 +73,18 @@ var Foo = (function () {
     }
     Foo.prototype.a = function () {
         var _this = this;
-        var lamda = function (_super) {
+        var lamda = function (_super) { // No Error 
             return function (x) { return _this; }; // New scope.  So should inject new _this capture
         };
     };
-    Foo.prototype.b = function (_super) {
+    Foo.prototype.b = function (_super) { // No Error 
         var _this = this;
         var lambda = function () {
             return function (x) { return _this; }; // New scope.  So should inject new _this capture
         };
     };
     Object.defineProperty(Foo.prototype, "c", {
-        set: function (_super) {
+        set: function (_super) { // No error
         },
         enumerable: true,
         configurable: true
@@ -96,24 +96,24 @@ var Foo2 = (function (_super) {
     function Foo2(_super) {
         _super.call(this);
         this.prop4 = {
-            doStuff: function (_super) {
+            doStuff: function (_super) { // should be error
             }
         };
     }
     Foo2.prototype.x = function () {
         var _this = this;
-        var lamda = function (_super) {
+        var lamda = function (_super) { // Error 
             return function (x) { return _this; }; // New scope.  So should inject new _this capture
         };
     };
-    Foo2.prototype.y = function (_super) {
+    Foo2.prototype.y = function (_super) { // Error 
         var _this = this;
         var lambda = function () {
             return function (x) { return _this; }; // New scope.  So should inject new _this capture
         };
     };
     Object.defineProperty(Foo2.prototype, "z", {
-        set: function (_super) {
+        set: function (_super) { // Error
         },
         enumerable: true,
         configurable: true
@@ -125,7 +125,7 @@ var Foo4 = (function (_super) {
     function Foo4(_super) {
         _super.call(this);
     }
-    Foo4.prototype.y = function (_super) {
+    Foo4.prototype.y = function (_super) { // Error 
         var _this = this;
         var lambda = function () {
             return function (x) { return _this; }; // New scope.  So should inject new _this capture

--- a/tests/baselines/reference/collisionSuperAndParameter1.js
+++ b/tests/baselines/reference/collisionSuperAndParameter1.js
@@ -26,7 +26,7 @@ var Foo2 = (function (_super) {
         _super.apply(this, arguments);
     }
     Foo2.prototype.x = function () {
-        var lambda = function (_super) {
+        var lambda = function (_super) { // Error 
         };
     };
     return Foo2;

--- a/tests/baselines/reference/collisionThisExpressionAndFunctionInGlobal.js
+++ b/tests/baselines/reference/collisionThisExpressionAndFunctionInGlobal.js
@@ -6,7 +6,7 @@ var f = () => this;
 
 //// [collisionThisExpressionAndFunctionInGlobal.js]
 var _this = this;
-function _this() {
+function _this() { //Error
     return 10;
 }
 var f = function () { return _this; };

--- a/tests/baselines/reference/collisionThisExpressionAndModuleInGlobal.js
+++ b/tests/baselines/reference/collisionThisExpressionAndModuleInGlobal.js
@@ -8,7 +8,7 @@ var f = () => this;
 //// [collisionThisExpressionAndModuleInGlobal.js]
 var _this = this;
 var _this;
-(function (_this) {
+(function (_this) { //Error
     var c = (function () {
         function c() {
         }

--- a/tests/baselines/reference/collisionThisExpressionAndParameter.js
+++ b/tests/baselines/reference/collisionThisExpressionAndParameter.js
@@ -99,18 +99,18 @@ var Foo = (function () {
     }
     Foo.prototype.x = function () {
         var _this = 10; // Local var. No this capture in x(), so no conflict.
-        function inner(_this) {
+        function inner(_this) { // Error 
             var _this = this;
             return function (x) { return _this; }; // New scope.  So should inject new _this capture into function inner
         }
     };
     Foo.prototype.y = function () {
         var _this = this;
-        var lamda = function (_this) {
+        var lamda = function (_this) { // Error 
             return function (x) { return _this; }; // New scope.  So should inject new _this capture
         };
     };
-    Foo.prototype.z = function (_this) {
+    Foo.prototype.z = function (_this) { // Error 
         var _this = this;
         var lambda = function () {
             return function (x) { return _this; }; // New scope.  So should inject new _this capture
@@ -118,14 +118,14 @@ var Foo = (function () {
     };
     Foo.prototype.x1 = function () {
         var _this = 10; // Local var. No this capture in x(), so no conflict.
-        function inner(_this) {
+        function inner(_this) { // No Error 
         }
     };
     Foo.prototype.y1 = function () {
-        var lamda = function (_this) {
+        var lamda = function (_this) { // No Error 
         };
     };
-    Foo.prototype.z1 = function (_this) {
+    Foo.prototype.z1 = function (_this) { // No Error 
         var lambda = function () {
         };
     };
@@ -155,7 +155,7 @@ var Foo3 = (function () {
             }; }
         };
     }
-    Foo3.prototype.z = function (_this) {
+    Foo3.prototype.z = function (_this) { // Error 
         var _this = this;
         var lambda = function () {
             return function (x) { return _this; }; // New scope.  So should inject new _this capture

--- a/tests/baselines/reference/constructorOverloads1.js
+++ b/tests/baselines/reference/constructorOverloads1.js
@@ -25,8 +25,8 @@ f1.bar2();
 var Foo = (function () {
     function Foo(x) {
     }
-    Foo.prototype.bar1 = function () { };
-    Foo.prototype.bar2 = function () { };
+    Foo.prototype.bar1 = function () { /*WScript.Echo("bar1");*/  };
+    Foo.prototype.bar2 = function () { /*WScript.Echo("bar1");*/  };
     return Foo;
 }());
 var f1 = new Foo("hey");

--- a/tests/baselines/reference/constructorOverloads2.js
+++ b/tests/baselines/reference/constructorOverloads2.js
@@ -34,7 +34,7 @@ var __extends = (this && this.__extends) || function (d, b) {
 var FooBase = (function () {
     function FooBase(x) {
     }
-    FooBase.prototype.bar1 = function () { };
+    FooBase.prototype.bar1 = function () { /*WScript.Echo("base bar1");*/  };
     return FooBase;
 }());
 var Foo = (function (_super) {
@@ -42,7 +42,7 @@ var Foo = (function (_super) {
     function Foo(x, y) {
         _super.call(this, x);
     }
-    Foo.prototype.bar1 = function () { };
+    Foo.prototype.bar1 = function () { /*WScript.Echo("bar1");*/  };
     return Foo;
 }(FooBase));
 var f1 = new Foo("hey");

--- a/tests/baselines/reference/constructorOverloads3.js
+++ b/tests/baselines/reference/constructorOverloads3.js
@@ -32,7 +32,7 @@ var Foo = (function (_super) {
     __extends(Foo, _super);
     function Foo(x, y) {
     }
-    Foo.prototype.bar1 = function () { };
+    Foo.prototype.bar1 = function () { /*WScript.Echo("Yo");*/  };
     return Foo;
 }(FooBase));
 var f1 = new Foo("hey");

--- a/tests/baselines/reference/declarationEmitFirstTypeArgumentGenericFunctionType.js
+++ b/tests/baselines/reference/declarationEmitFirstTypeArgumentGenericFunctionType.js
@@ -29,16 +29,16 @@ class X {
 }
 var prop11; // spaces before the first type argument
 var prop12; // spaces before the first type argument
-function f1() {
+function f1() { // Inferred return type
     return prop11;
 }
-function f2() {
+function f2() { // Inferred return type
     return prop12;
 }
-function f3() {
+function f3() { // written with space before type argument
     return prop11;
 }
-function f4() {
+function f4() { // written type with parenthesis
     return prop12;
 }
 class Y {

--- a/tests/baselines/reference/derivedTypeCallingBaseImplWithOptionalParams.js
+++ b/tests/baselines/reference/derivedTypeCallingBaseImplWithOptionalParams.js
@@ -17,7 +17,7 @@ y.myMethod(); // error
 var MyClass = (function () {
     function MyClass() {
     }
-    MyClass.prototype.myMethod = function (myList) {
+    MyClass.prototype.myMethod = function (myList) { // valid
     };
     return MyClass;
 }());

--- a/tests/baselines/reference/duplicateLocalVariable1.js
+++ b/tests/baselines/reference/duplicateLocalVariable1.js
@@ -382,7 +382,7 @@ var TestRunner = (function () {
                 exception = true;
                 testResult = false;
                 if (typeof testcase.errorMessageRegEx === "string") {
-                    if (testcase.errorMessageRegEx === "") {
+                    if (testcase.errorMessageRegEx === "") { // Any error is fine
                         testResult = true;
                     }
                     else if (e.message) {

--- a/tests/baselines/reference/duplicateSymbolsExportMatching.js
+++ b/tests/baselines/reference/duplicateSymbolsExportMatching.js
@@ -76,7 +76,7 @@ define(["require", "exports"], function (require, exports) {
             var t;
         })(inst || (inst = {}));
         var inst;
-        (function (inst) {
+        (function (inst) { // one error
             var t;
         })(inst = M.inst || (M.inst = {}));
     })(M || (M = {}));
@@ -103,7 +103,7 @@ define(["require", "exports"], function (require, exports) {
             return C;
         }());
         var C;
-        (function (C) {
+        (function (C) { // Two visibility errors (one for the clodule symbol, and one for the merged container symbol)
             var t;
         })(C = M.C || (M.C = {}));
     })(M || (M = {}));

--- a/tests/baselines/reference/emitCommentsAfterBraces.js
+++ b/tests/baselines/reference/emitCommentsAfterBraces.js
@@ -1,0 +1,15 @@
+//// [emitCommentsAfterBraces.ts]
+if (true) {//validation and tokenization
+	let a = 42;
+}
+
+if (true) {/*comment*/ let a = 42;}
+
+
+//// [emitCommentsAfterBraces.js]
+if (true) { //validation and tokenization
+    var a = 42;
+}
+if (true) { /*comment*/ 
+    var a = 42;
+}

--- a/tests/baselines/reference/emitCommentsAfterBraces.symbols
+++ b/tests/baselines/reference/emitCommentsAfterBraces.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/emitCommentsAfterBraces.ts ===
+if (true) {//validation and tokenization
+	let a = 42;
+>a : Symbol(a, Decl(emitCommentsAfterBraces.ts, 1, 4))
+}
+
+if (true) {/*comment*/ let a = 42;}
+>a : Symbol(a, Decl(emitCommentsAfterBraces.ts, 4, 26))
+

--- a/tests/baselines/reference/emitCommentsAfterBraces.types
+++ b/tests/baselines/reference/emitCommentsAfterBraces.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/emitCommentsAfterBraces.ts ===
+if (true) {//validation and tokenization
+>true : boolean
+
+	let a = 42;
+>a : number
+>42 : number
+}
+
+if (true) {/*comment*/ let a = 42;}
+>true : boolean
+>a : number
+>42 : number
+

--- a/tests/baselines/reference/exportImport.js
+++ b/tests/baselines/reference/exportImport.js
@@ -34,7 +34,7 @@ define(["require", "exports", './w1'], function (require, exports, w) {
 //// [consumer.js]
 define(["require", "exports", './exporter'], function (require, exports, e) {
     "use strict";
-    function w() {
+    function w() { // Should be OK
         return new e.w();
     }
     exports.w = w;

--- a/tests/baselines/reference/exportImportNonInstantiatedModule2.js
+++ b/tests/baselines/reference/exportImportNonInstantiatedModule2.js
@@ -26,7 +26,7 @@ define(["require", "exports"], function (require, exports) {
 //// [consumer.js]
 define(["require", "exports"], function (require, exports) {
     "use strict";
-    function w() {
+    function w() { // Should be OK
         return { name: 'value' };
     }
     exports.w = w;

--- a/tests/baselines/reference/for.js
+++ b/tests/baselines/reference/for.js
@@ -32,26 +32,26 @@ for () { // error
 }
 
 //// [for.js]
-for (var i = 0; i < 10; i++) {
+for (var i = 0; i < 10; i++) { // ok
     var x1 = i;
 }
-for (var j = 0; j < 10; j++) {
+for (var j = 0; j < 10; j++) { // ok
     var x2 = j;
 }
-for (var k = 0; k < 10;) {
+for (var k = 0; k < 10;) { // ok
     k++;
 }
-for (; i < 10;) {
+for (; i < 10;) { // ok
     i++;
 }
-for (; i > 1; i--) {
+for (; i > 1; i--) { // ok
 }
-for (var l = 0;; l++) {
+for (var l = 0;; l++) { // ok
     if (l > 10) {
         break;
     }
 }
-for (;;) {
+for (;;) { // ok
 }
-for (;;) {
+for (;;) { // error
 }

--- a/tests/baselines/reference/forIn.js
+++ b/tests/baselines/reference/forIn.js
@@ -23,16 +23,16 @@ for (var l in arr) {
 
 //// [forIn.js]
 var arr = null;
-for (var i in arr) {
+for (var i in arr) { // error
     var x1 = arr[i];
     var y1 = arr[i];
 }
-for (var j in arr) {
+for (var j in arr) { // ok
     var x2 = arr[j];
     var y2 = arr[j];
 }
 var arr2 = [];
-for (j in arr2) {
+for (j in arr2) { // ok
     var x3 = arr2[j];
     var y3 = arr2[j];
 }

--- a/tests/baselines/reference/functionImplementations.js
+++ b/tests/baselines/reference/functionImplementations.js
@@ -299,30 +299,30 @@ var AnotherClass = (function () {
 // if f is a contextually typed function expression, the inferred return type is the union type
 // of the types of the return statement expressions in the function body, 
 // ignoring return statements with no expressions.
-var f7 = function (x) {
+var f7 = function (x) { // should be (x: number) => number | string
     if (x < 0) {
         return x;
     }
     return x.toString();
 };
-var f8 = function (x) {
+var f8 = function (x) { // should be (x: number) => Base
     return new Base();
     return new Derived2();
 };
-var f9 = function (x) {
+var f9 = function (x) { // should be (x: number) => Base
     return new Base();
     return new Derived();
     return new Derived2();
 };
-var f10 = function (x) {
+var f10 = function (x) { // should be (x: number) => Derived | Derived1
     return new Derived();
     return new Derived2();
 };
-var f11 = function (x) {
+var f11 = function (x) { // should be (x: number) => Base | AnotherClass
     return new Base();
     return new AnotherClass();
 };
-var f12 = function (x) {
+var f12 = function (x) { // should be (x: number) => Base | AnotherClass
     return new Base();
     return; // should be ignored
     return new AnotherClass();

--- a/tests/baselines/reference/functionSubtypingOfVarArgs.js
+++ b/tests/baselines/reference/functionSubtypingOfVarArgs.js
@@ -34,7 +34,7 @@ var StringEvent = (function (_super) {
     function StringEvent() {
         _super.apply(this, arguments);
     }
-    StringEvent.prototype.add = function (listener) {
+    StringEvent.prototype.add = function (listener) { // valid, items is subtype of args
         _super.prototype.add.call(this, listener);
     };
     return StringEvent;

--- a/tests/baselines/reference/genericMethodOverspecialization.js
+++ b/tests/baselines/reference/genericMethodOverspecialization.js
@@ -34,6 +34,6 @@ var elements = names.map(function (name) {
 var xxx = elements.filter(function (e) {
     return !e.isDisabled;
 });
-var widths = elements.map(function (e) {
+var widths = elements.map(function (e) { // should not error
     return e.clientWidth;
 });

--- a/tests/baselines/reference/genericSpecializations2.js
+++ b/tests/baselines/reference/genericSpecializations2.js
@@ -23,7 +23,7 @@ class StringFoo3 implements IFoo<string> {
 var IFoo = (function () {
     function IFoo() {
     }
-    IFoo.prototype.foo = function (x) {
+    IFoo.prototype.foo = function (x) { // no error on implementors because IFoo's T is different from foo's T
         return null;
     };
     return IFoo;

--- a/tests/baselines/reference/implicitAnyCastedValue.js
+++ b/tests/baselines/reference/implicitAnyCastedValue.js
@@ -97,7 +97,7 @@ var C = (function () {
         enumerable: true,
         configurable: true
     });
-    C.prototype.returnBarWithCase = function () {
+    C.prototype.returnBarWithCase = function () { // this should not be an error
         return this.bar;
     };
     C.prototype.returnFooWithCase = function () {
@@ -137,7 +137,7 @@ function returnTypeBar() {
 function undefinedBar() {
     return undefined; // this should not be an error
 }
-function multipleRets1(x) {
+function multipleRets1(x) { // this should not be an error
     if (x) {
         return 0;
     }
@@ -145,7 +145,7 @@ function multipleRets1(x) {
         return null;
     }
 }
-function multipleRets2(x) {
+function multipleRets2(x) { // this should not be an error
     if (x) {
         return null;
     }

--- a/tests/baselines/reference/implicitAnyFunctionReturnNullOrUndefined.js
+++ b/tests/baselines/reference/implicitAnyFunctionReturnNullOrUndefined.js
@@ -31,10 +31,10 @@ function undefinedWidenFunction() { return undefined; } // error at "undefinedWi
 var C = (function () {
     function C() {
     }
-    C.prototype.nullWidenFuncOfC = function () {
+    C.prototype.nullWidenFuncOfC = function () { // error at "nullWidenFuncOfC"
         return null;
     };
-    C.prototype.underfinedWidenFuncOfC = function () {
+    C.prototype.underfinedWidenFuncOfC = function () { // error at "underfinedWidenFuncOfC"
         return undefined;
     };
     return C;

--- a/tests/baselines/reference/implicitAnyGetAndSetAccessorWithAnyReturnType.js
+++ b/tests/baselines/reference/implicitAnyGetAndSetAccessorWithAnyReturnType.js
@@ -30,11 +30,11 @@ var GetAndSet = (function () {
         this.getAndSet = null; // error at "getAndSet"
     }
     Object.defineProperty(GetAndSet.prototype, "haveGetAndSet", {
-        get: function () {
+        get: function () { // this should not be an error
             return this.getAndSet;
         },
         // this shouldn't be an error
-        set: function (value) {
+        set: function (value) { // error at "value"
             this.getAndSet = value;
         },
         enumerable: true,
@@ -46,7 +46,7 @@ var SetterOnly = (function () {
     function SetterOnly() {
     }
     Object.defineProperty(SetterOnly.prototype, "haveOnlySet", {
-        set: function (newXValue) {
+        set: function (newXValue) { // error at "haveOnlySet, newXValue"
         },
         enumerable: true,
         configurable: true
@@ -57,7 +57,7 @@ var GetterOnly = (function () {
     function GetterOnly() {
     }
     Object.defineProperty(GetterOnly.prototype, "haveOnlyGet", {
-        get: function () {
+        get: function () { // error at "haveOnlyGet"
             return null;
         },
         enumerable: true,

--- a/tests/baselines/reference/inferSetterParamType.js
+++ b/tests/baselines/reference/inferSetterParamType.js
@@ -26,7 +26,7 @@ var Foo = (function () {
         get: function () {
             return 0;
         },
-        set: function (n) {
+        set: function (n) { // should not be an error - infer number
         },
         enumerable: true,
         configurable: true

--- a/tests/baselines/reference/invalidTryStatements2.js
+++ b/tests/baselines/reference/invalidTryStatements2.js
@@ -32,7 +32,7 @@ function fn2() {
 function fn() {
     try {
     }
-    catch () {
+    catch () { // syntax error, missing '(x)'
     }
     try {
     }

--- a/tests/baselines/reference/invocationExpressionInFunctionParameter.js
+++ b/tests/baselines/reference/invocationExpressionInFunctionParameter.js
@@ -7,6 +7,6 @@ function foo3(x = foo1(123)) { //should error, 123 is not string
 //// [invocationExpressionInFunctionParameter.js]
 function foo1(val) {
 }
-function foo3(x) {
+function foo3(x) { //should error, 123 is not string
     if (x === void 0) { x = foo1(123); }
 }

--- a/tests/baselines/reference/moduleDuplicateIdentifiers.js
+++ b/tests/baselines/reference/moduleDuplicateIdentifiers.js
@@ -49,7 +49,7 @@ var FooBar;
     FooBar.member1 = 2;
 })(FooBar = exports.FooBar || (exports.FooBar = {}));
 var FooBar;
-(function (FooBar) {
+(function (FooBar) { // Shouldn't error
     FooBar.member2 = 42;
 })(FooBar = exports.FooBar || (exports.FooBar = {}));
 var Kettle = (function () {

--- a/tests/baselines/reference/nameCollisions.js
+++ b/tests/baselines/reference/nameCollisions.js
@@ -52,7 +52,7 @@ var T;
 (function (T) {
     var x = 2;
     var x;
-    (function (x) {
+    (function (x) { // error
         var Bar = (function () {
             function Bar() {
             }

--- a/tests/baselines/reference/noImplicitAnyDestructuringParameterDeclaration.js
+++ b/tests/baselines/reference/noImplicitAnyDestructuringParameterDeclaration.js
@@ -11,11 +11,11 @@ function f5([a1] = [undefined], {b1} = { b1: null }, c1 = undefined, d1 = null) 
 }
 
 //// [noImplicitAnyDestructuringParameterDeclaration.js]
-function f1(_a, _b, c, d) {
+function f1(_a, _b, c, d) { // error
     var a = _a[0];
     var b = _b.b;
 }
-function f2(_a, _b, c, d) {
+function f2(_a, _b, c, d) { // error
     var _c = _a[0], a = _c === void 0 ? undefined : _c;
     var _d = _b.b, b = _d === void 0 ? null : _d;
     if (c === void 0) { c = undefined; }
@@ -25,10 +25,10 @@ function f3(_a, _b, c, d) {
     var a = _a[0];
     var b = _b.b;
 }
-function f4(_a, x) {
+function f4(_a, x) { // error in type instead
     var b = _a.b;
 }
-function f5(_a, _b, c1, d1) {
+function f5(_a, _b, c1, d1) { // error
     var a1 = (_a === void 0 ? [undefined] : _a)[0];
     var b1 = (_b === void 0 ? { b1: null } : _b).b1;
     if (c1 === void 0) { c1 = undefined; }

--- a/tests/baselines/reference/noImplicitReturnsInAsync2.js
+++ b/tests/baselines/reference/noImplicitReturnsInAsync2.js
@@ -63,7 +63,7 @@ function test4(isError = true) {
 }
 // should not be error, Promise<any> currently working correctly 
 function test5(isError = true) {
-    return __awaiter(this, void 0, void 0, function* () {
+    return __awaiter(this, void 0, void 0, function* () { //should not be error
         if (isError === true) {
             return undefined;
         }

--- a/tests/baselines/reference/nonArrayRestArgs.js
+++ b/tests/baselines/reference/nonArrayRestArgs.js
@@ -5,7 +5,7 @@ function foo(...rest: number) { // error
 }
 
 //// [nonArrayRestArgs.js]
-function foo() {
+function foo() { // error
     var rest = [];
     for (var _i = 0; _i < arguments.length; _i++) {
         rest[_i - 0] = arguments[_i];

--- a/tests/baselines/reference/numericIndexerConstrainsPropertyDeclarations.js
+++ b/tests/baselines/reference/numericIndexerConstrainsPropertyDeclarations.js
@@ -103,7 +103,7 @@ var C = (function () {
     function C() {
     } // ok
     Object.defineProperty(C.prototype, "X", {
-        get: function () {
+        get: function () { // ok
             return '';
         },
         set: function (v) { } // ok
@@ -116,7 +116,7 @@ var C = (function () {
     };
     C.foo = function () { }; // ok
     Object.defineProperty(C, "X", {
-        get: function () {
+        get: function () { // ok
             return 1;
         },
         enumerable: true,

--- a/tests/baselines/reference/objectCreationExpressionInFunctionParameter.js
+++ b/tests/baselines/reference/objectCreationExpressionInFunctionParameter.js
@@ -13,6 +13,6 @@ var A = (function () {
     }
     return A;
 }());
-function foo(x) {
+function foo(x) { //should error, 123 is not string
     if (x === void 0) { x = new A(123); }
 }

--- a/tests/baselines/reference/overloadOnConstInBaseWithBadImplementationInDerived.js
+++ b/tests/baselines/reference/overloadOnConstInBaseWithBadImplementationInDerived.js
@@ -12,7 +12,7 @@ class C implements I {
 var C = (function () {
     function C() {
     }
-    C.prototype.x1 = function (a, callback) {
+    C.prototype.x1 = function (a, callback) { // error
     };
     return C;
 }());

--- a/tests/baselines/reference/overloadresolutionWithConstraintCheckingDeferred.js
+++ b/tests/baselines/reference/overloadresolutionWithConstraintCheckingDeferred.js
@@ -30,7 +30,7 @@ var G = (function () {
 }());
 var result = foo(function (x) { return new G(x); }); // x has type D, new G(x) fails, so first overload is picked.
 var result2 = foo(function (x) { return new G(x); }); // x has type D, new G(x) fails, so first overload is picked.
-var result3 = foo(function (x) {
+var result3 = foo(function (x) { // x has type D
     var y; // error that D does not satisfy constraint, y is of type G<D>, entire call to foo is an error
     return y;
 });

--- a/tests/baselines/reference/parameterInitializersForwardReferencing.js
+++ b/tests/baselines/reference/parameterInitializersForwardReferencing.js
@@ -68,7 +68,7 @@ function inside(a) {
 }
 function outside() {
     var b;
-    function inside(a) {
+    function inside(a) { // Still an error because b is declared inside the function
         if (a === void 0) { a = b; }
         var b;
     }

--- a/tests/baselines/reference/parameterReferenceInInitializer2.js
+++ b/tests/baselines/reference/parameterReferenceInInitializer2.js
@@ -4,7 +4,7 @@ function Example(x = function(x: any) { return x; }) { // Error: parameter 'x' c
 }
 
 //// [parameterReferenceInInitializer2.js]
-function Example(x) {
+function Example(x) { // Error: parameter 'x' cannot be 
     if (x === void 0) { x = function (x) { return x; }; }
     // referenced in its initializer
 }

--- a/tests/baselines/reference/parserRealSource7.js
+++ b/tests/baselines/reference/parserRealSource7.js
@@ -1369,7 +1369,7 @@ var TypeScript;
                     fgSym.declAST = ast;
                 }
             }
-            else {
+            else { // there exists a symbol with this name
                 if ((fgSym.kind() == SymbolKind.Type)) {
                     fgSym = context.checker.createFunctionSignature(funcDecl, containerSym, containerScope, fgSym, false).declAST.type.symbol;
                 }
@@ -1428,7 +1428,7 @@ var TypeScript;
                 funcDecl.accessorSymbol = context.checker.createAccessorSymbol(funcDecl, fgSym, containerSym.type, (funcDecl.isMethod() && isStatic), true, containerScope, containerSym);
             }
             funcDecl.type.symbol.declAST = ast;
-            if (funcDecl.isConstructor) {
+            if (funcDecl.isConstructor) { // REVIEW: Remove when classes completely replace oldclass
                 go = true;
             }
             ;

--- a/tests/baselines/reference/privacyAccessorDeclFile.js
+++ b/tests/baselines/reference/privacyAccessorDeclFile.js
@@ -1076,7 +1076,7 @@ var publicClassWithWithPrivateGetAccessorTypes = (function () {
     function publicClassWithWithPrivateGetAccessorTypes() {
     }
     Object.defineProperty(publicClassWithWithPrivateGetAccessorTypes, "myPublicStaticMethod", {
-        get: function () {
+        get: function () { // Error
             return null;
         },
         enumerable: true,
@@ -1090,7 +1090,7 @@ var publicClassWithWithPrivateGetAccessorTypes = (function () {
         configurable: true
     });
     Object.defineProperty(publicClassWithWithPrivateGetAccessorTypes.prototype, "myPublicMethod", {
-        get: function () {
+        get: function () { // Error
             return null;
         },
         enumerable: true,
@@ -1104,7 +1104,7 @@ var publicClassWithWithPrivateGetAccessorTypes = (function () {
         configurable: true
     });
     Object.defineProperty(publicClassWithWithPrivateGetAccessorTypes, "myPublicStaticMethod1", {
-        get: function () {
+        get: function () { // Error
             return new privateClass();
         },
         enumerable: true,
@@ -1118,7 +1118,7 @@ var publicClassWithWithPrivateGetAccessorTypes = (function () {
         configurable: true
     });
     Object.defineProperty(publicClassWithWithPrivateGetAccessorTypes.prototype, "myPublicMethod1", {
-        get: function () {
+        get: function () { // Error
             return new privateClass();
         },
         enumerable: true,
@@ -1322,7 +1322,7 @@ var publicClassWithWithPrivateSetAccessorTypes = (function () {
     function publicClassWithWithPrivateSetAccessorTypes() {
     }
     Object.defineProperty(publicClassWithWithPrivateSetAccessorTypes, "myPublicStaticMethod", {
-        set: function (param) {
+        set: function (param) { // Error
         },
         enumerable: true,
         configurable: true
@@ -1334,7 +1334,7 @@ var publicClassWithWithPrivateSetAccessorTypes = (function () {
         configurable: true
     });
     Object.defineProperty(publicClassWithWithPrivateSetAccessorTypes.prototype, "myPublicMethod", {
-        set: function (param) {
+        set: function (param) { // Error
         },
         enumerable: true,
         configurable: true
@@ -1440,28 +1440,28 @@ var publicClassWithPrivateModuleGetAccessorTypes = (function () {
     function publicClassWithPrivateModuleGetAccessorTypes() {
     }
     Object.defineProperty(publicClassWithPrivateModuleGetAccessorTypes, "myPublicStaticMethod", {
-        get: function () {
+        get: function () { // Error
             return null;
         },
         enumerable: true,
         configurable: true
     });
     Object.defineProperty(publicClassWithPrivateModuleGetAccessorTypes.prototype, "myPublicMethod", {
-        get: function () {
+        get: function () { // Error
             return null;
         },
         enumerable: true,
         configurable: true
     });
     Object.defineProperty(publicClassWithPrivateModuleGetAccessorTypes, "myPublicStaticMethod1", {
-        get: function () {
+        get: function () { // Error
             return new privateModule.publicClass();
         },
         enumerable: true,
         configurable: true
     });
     Object.defineProperty(publicClassWithPrivateModuleGetAccessorTypes.prototype, "myPublicMethod1", {
-        get: function () {
+        get: function () { // Error
             return new privateModule.publicClass();
         },
         enumerable: true,
@@ -1474,13 +1474,13 @@ var publicClassWithPrivateModuleSetAccessorTypes = (function () {
     function publicClassWithPrivateModuleSetAccessorTypes() {
     }
     Object.defineProperty(publicClassWithPrivateModuleSetAccessorTypes, "myPublicStaticMethod", {
-        set: function (param) {
+        set: function (param) { // Error
         },
         enumerable: true,
         configurable: true
     });
     Object.defineProperty(publicClassWithPrivateModuleSetAccessorTypes.prototype, "myPublicMethod", {
-        set: function (param) {
+        set: function (param) { // Error
         },
         enumerable: true,
         configurable: true
@@ -1555,7 +1555,7 @@ var publicModule;
         function publicClassWithWithPrivateGetAccessorTypes() {
         }
         Object.defineProperty(publicClassWithWithPrivateGetAccessorTypes, "myPublicStaticMethod", {
-            get: function () {
+            get: function () { // Error
                 return null;
             },
             enumerable: true,
@@ -1569,7 +1569,7 @@ var publicModule;
             configurable: true
         });
         Object.defineProperty(publicClassWithWithPrivateGetAccessorTypes.prototype, "myPublicMethod", {
-            get: function () {
+            get: function () { // Error
                 return null;
             },
             enumerable: true,
@@ -1583,7 +1583,7 @@ var publicModule;
             configurable: true
         });
         Object.defineProperty(publicClassWithWithPrivateGetAccessorTypes, "myPublicStaticMethod1", {
-            get: function () {
+            get: function () { // Error
                 return new privateClass();
             },
             enumerable: true,
@@ -1597,7 +1597,7 @@ var publicModule;
             configurable: true
         });
         Object.defineProperty(publicClassWithWithPrivateGetAccessorTypes.prototype, "myPublicMethod1", {
-            get: function () {
+            get: function () { // Error
                 return new privateClass();
             },
             enumerable: true,
@@ -1801,7 +1801,7 @@ var publicModule;
         function publicClassWithWithPrivateSetAccessorTypes() {
         }
         Object.defineProperty(publicClassWithWithPrivateSetAccessorTypes, "myPublicStaticMethod", {
-            set: function (param) {
+            set: function (param) { // Error
             },
             enumerable: true,
             configurable: true
@@ -1813,7 +1813,7 @@ var publicModule;
             configurable: true
         });
         Object.defineProperty(publicClassWithWithPrivateSetAccessorTypes.prototype, "myPublicMethod", {
-            set: function (param) {
+            set: function (param) { // Error
             },
             enumerable: true,
             configurable: true
@@ -1919,28 +1919,28 @@ var publicModule;
         function publicClassWithPrivateModuleGetAccessorTypes() {
         }
         Object.defineProperty(publicClassWithPrivateModuleGetAccessorTypes, "myPublicStaticMethod", {
-            get: function () {
+            get: function () { // Error
                 return null;
             },
             enumerable: true,
             configurable: true
         });
         Object.defineProperty(publicClassWithPrivateModuleGetAccessorTypes.prototype, "myPublicMethod", {
-            get: function () {
+            get: function () { // Error
                 return null;
             },
             enumerable: true,
             configurable: true
         });
         Object.defineProperty(publicClassWithPrivateModuleGetAccessorTypes, "myPublicStaticMethod1", {
-            get: function () {
+            get: function () { // Error
                 return new privateModule.publicClass();
             },
             enumerable: true,
             configurable: true
         });
         Object.defineProperty(publicClassWithPrivateModuleGetAccessorTypes.prototype, "myPublicMethod1", {
-            get: function () {
+            get: function () { // Error
                 return new privateModule.publicClass();
             },
             enumerable: true,
@@ -1953,13 +1953,13 @@ var publicModule;
         function publicClassWithPrivateModuleSetAccessorTypes() {
         }
         Object.defineProperty(publicClassWithPrivateModuleSetAccessorTypes, "myPublicStaticMethod", {
-            set: function (param) {
+            set: function (param) { // Error
             },
             enumerable: true,
             configurable: true
         });
         Object.defineProperty(publicClassWithPrivateModuleSetAccessorTypes.prototype, "myPublicMethod", {
-            set: function (param) {
+            set: function (param) { // Error
             },
             enumerable: true,
             configurable: true
@@ -3091,7 +3091,7 @@ var publicModuleInGlobal;
         function publicClassWithWithPrivateGetAccessorTypes() {
         }
         Object.defineProperty(publicClassWithWithPrivateGetAccessorTypes, "myPublicStaticMethod", {
-            get: function () {
+            get: function () { // Error
                 return null;
             },
             enumerable: true,
@@ -3105,7 +3105,7 @@ var publicModuleInGlobal;
             configurable: true
         });
         Object.defineProperty(publicClassWithWithPrivateGetAccessorTypes.prototype, "myPublicMethod", {
-            get: function () {
+            get: function () { // Error
                 return null;
             },
             enumerable: true,
@@ -3119,7 +3119,7 @@ var publicModuleInGlobal;
             configurable: true
         });
         Object.defineProperty(publicClassWithWithPrivateGetAccessorTypes, "myPublicStaticMethod1", {
-            get: function () {
+            get: function () { // Error
                 return new privateClass();
             },
             enumerable: true,
@@ -3133,7 +3133,7 @@ var publicModuleInGlobal;
             configurable: true
         });
         Object.defineProperty(publicClassWithWithPrivateGetAccessorTypes.prototype, "myPublicMethod1", {
-            get: function () {
+            get: function () { // Error
                 return new privateClass();
             },
             enumerable: true,
@@ -3337,7 +3337,7 @@ var publicModuleInGlobal;
         function publicClassWithWithPrivateSetAccessorTypes() {
         }
         Object.defineProperty(publicClassWithWithPrivateSetAccessorTypes, "myPublicStaticMethod", {
-            set: function (param) {
+            set: function (param) { // Error
             },
             enumerable: true,
             configurable: true
@@ -3349,7 +3349,7 @@ var publicModuleInGlobal;
             configurable: true
         });
         Object.defineProperty(publicClassWithWithPrivateSetAccessorTypes.prototype, "myPublicMethod", {
-            set: function (param) {
+            set: function (param) { // Error
             },
             enumerable: true,
             configurable: true
@@ -3455,28 +3455,28 @@ var publicModuleInGlobal;
         function publicClassWithPrivateModuleGetAccessorTypes() {
         }
         Object.defineProperty(publicClassWithPrivateModuleGetAccessorTypes, "myPublicStaticMethod", {
-            get: function () {
+            get: function () { // Error
                 return null;
             },
             enumerable: true,
             configurable: true
         });
         Object.defineProperty(publicClassWithPrivateModuleGetAccessorTypes.prototype, "myPublicMethod", {
-            get: function () {
+            get: function () { // Error
                 return null;
             },
             enumerable: true,
             configurable: true
         });
         Object.defineProperty(publicClassWithPrivateModuleGetAccessorTypes, "myPublicStaticMethod1", {
-            get: function () {
+            get: function () { // Error
                 return new privateModule.publicClass();
             },
             enumerable: true,
             configurable: true
         });
         Object.defineProperty(publicClassWithPrivateModuleGetAccessorTypes.prototype, "myPublicMethod1", {
-            get: function () {
+            get: function () { // Error
                 return new privateModule.publicClass();
             },
             enumerable: true,
@@ -3489,13 +3489,13 @@ var publicModuleInGlobal;
         function publicClassWithPrivateModuleSetAccessorTypes() {
         }
         Object.defineProperty(publicClassWithPrivateModuleSetAccessorTypes, "myPublicStaticMethod", {
-            set: function (param) {
+            set: function (param) { // Error
             },
             enumerable: true,
             configurable: true
         });
         Object.defineProperty(publicClassWithPrivateModuleSetAccessorTypes.prototype, "myPublicMethod", {
-            set: function (param) {
+            set: function (param) { // Error
             },
             enumerable: true,
             configurable: true

--- a/tests/baselines/reference/privacyCannotNameAccessorDeclFile.js
+++ b/tests/baselines/reference/privacyCannotNameAccessorDeclFile.js
@@ -192,7 +192,7 @@ var publicClassWithWithPrivateGetAccessorTypes = (function () {
     function publicClassWithWithPrivateGetAccessorTypes() {
     }
     Object.defineProperty(publicClassWithWithPrivateGetAccessorTypes, "myPublicStaticMethod", {
-        get: function () {
+        get: function () { // Error
             return exporter.createExportedWidget1();
         },
         enumerable: true,
@@ -206,7 +206,7 @@ var publicClassWithWithPrivateGetAccessorTypes = (function () {
         configurable: true
     });
     Object.defineProperty(publicClassWithWithPrivateGetAccessorTypes.prototype, "myPublicMethod", {
-        get: function () {
+        get: function () { // Error
             return exporter.createExportedWidget1();
         },
         enumerable: true,
@@ -220,7 +220,7 @@ var publicClassWithWithPrivateGetAccessorTypes = (function () {
         configurable: true
     });
     Object.defineProperty(publicClassWithWithPrivateGetAccessorTypes, "myPublicStaticMethod1", {
-        get: function () {
+        get: function () { // Error
             return exporter.createExportedWidget3();
         },
         enumerable: true,
@@ -234,7 +234,7 @@ var publicClassWithWithPrivateGetAccessorTypes = (function () {
         configurable: true
     });
     Object.defineProperty(publicClassWithWithPrivateGetAccessorTypes.prototype, "myPublicMethod1", {
-        get: function () {
+        get: function () { // Error
             return exporter.createExportedWidget3();
         },
         enumerable: true,
@@ -315,28 +315,28 @@ var publicClassWithPrivateModuleGetAccessorTypes = (function () {
     function publicClassWithPrivateModuleGetAccessorTypes() {
     }
     Object.defineProperty(publicClassWithPrivateModuleGetAccessorTypes, "myPublicStaticMethod", {
-        get: function () {
+        get: function () { // Error
             return exporter.createExportedWidget2();
         },
         enumerable: true,
         configurable: true
     });
     Object.defineProperty(publicClassWithPrivateModuleGetAccessorTypes.prototype, "myPublicMethod", {
-        get: function () {
+        get: function () { // Error
             return exporter.createExportedWidget2();
         },
         enumerable: true,
         configurable: true
     });
     Object.defineProperty(publicClassWithPrivateModuleGetAccessorTypes, "myPublicStaticMethod1", {
-        get: function () {
+        get: function () { // Error
             return exporter.createExportedWidget4();
         },
         enumerable: true,
         configurable: true
     });
     Object.defineProperty(publicClassWithPrivateModuleGetAccessorTypes.prototype, "myPublicMethod1", {
-        get: function () {
+        get: function () { // Error
             return exporter.createExportedWidget4();
         },
         enumerable: true,

--- a/tests/baselines/reference/privacyFunc.js
+++ b/tests/baselines/reference/privacyFunc.js
@@ -253,7 +253,7 @@ var m1;
         };
         C3_public.prototype.f3_private = function (m1_c3_f3_arg) {
         };
-        C3_public.prototype.f4_public = function (m1_c3_f4_arg) {
+        C3_public.prototype.f4_public = function (m1_c3_f4_arg) { // error
         };
         C3_public.prototype.f5_private = function () {
             return new C1_public();
@@ -276,7 +276,7 @@ var m1;
         C3_public.prototype.f11_private = function () {
             return new C2_private();
         };
-        C3_public.prototype.f12_public = function () {
+        C3_public.prototype.f12_public = function () { // error
             return new C2_private(); //error
         };
         return C3_public;
@@ -348,7 +348,7 @@ var m1;
     m1.f2_public = f2_public;
     function f3_public(m1_f3_arg) {
     }
-    function f4_public(m1_f4_arg) {
+    function f4_public(m1_f4_arg) { // error
     }
     m1.f4_public = f4_public;
     function f5_public() {
@@ -375,7 +375,7 @@ var m1;
     function f11_private() {
         return new C2_private();
     }
-    function f12_public() {
+    function f12_public() { // error
         return new C2_private(); //error
     }
     m1.f12_public = f12_public;

--- a/tests/baselines/reference/privacyFunctionCannotNameParameterTypeDeclFile.js
+++ b/tests/baselines/reference/privacyFunctionCannotNameParameterTypeDeclFile.js
@@ -216,13 +216,13 @@ var publicClassWithWithPrivateParmeterTypes = (function () {
         this.param1 = param1;
         this.param2 = param2;
     }
-    publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod = function (param) {
+    publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod = function (param) { // Error
         if (param === void 0) { param = exporter.createExportedWidget1(); }
     };
     publicClassWithWithPrivateParmeterTypes.myPrivateStaticMethod = function (param) {
         if (param === void 0) { param = exporter.createExportedWidget1(); }
     };
-    publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod = function (param) {
+    publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod = function (param) { // Error
         if (param === void 0) { param = exporter.createExportedWidget1(); }
     };
     publicClassWithWithPrivateParmeterTypes.prototype.myPrivateMethod = function (param) {
@@ -239,13 +239,13 @@ var publicClassWithWithPrivateParmeterTypes1 = (function () {
         this.param1 = param1;
         this.param2 = param2;
     }
-    publicClassWithWithPrivateParmeterTypes1.myPublicStaticMethod = function (param) {
+    publicClassWithWithPrivateParmeterTypes1.myPublicStaticMethod = function (param) { // Error
         if (param === void 0) { param = exporter.createExportedWidget3(); }
     };
     publicClassWithWithPrivateParmeterTypes1.myPrivateStaticMethod = function (param) {
         if (param === void 0) { param = exporter.createExportedWidget3(); }
     };
-    publicClassWithWithPrivateParmeterTypes1.prototype.myPublicMethod = function (param) {
+    publicClassWithWithPrivateParmeterTypes1.prototype.myPublicMethod = function (param) { // Error
         if (param === void 0) { param = exporter.createExportedWidget3(); }
     };
     publicClassWithWithPrivateParmeterTypes1.prototype.myPrivateMethod = function (param) {
@@ -298,14 +298,14 @@ var privateClassWithWithPrivateParmeterTypes2 = (function () {
     };
     return privateClassWithWithPrivateParmeterTypes2;
 }());
-function publicFunctionWithPrivateParmeterTypes(param) {
+function publicFunctionWithPrivateParmeterTypes(param) { // Error
     if (param === void 0) { param = exporter.createExportedWidget1(); }
 }
 exports.publicFunctionWithPrivateParmeterTypes = publicFunctionWithPrivateParmeterTypes;
 function privateFunctionWithPrivateParmeterTypes(param) {
     if (param === void 0) { param = exporter.createExportedWidget1(); }
 }
-function publicFunctionWithPrivateParmeterTypes1(param) {
+function publicFunctionWithPrivateParmeterTypes1(param) { // Error
     if (param === void 0) { param = exporter.createExportedWidget3(); }
 }
 exports.publicFunctionWithPrivateParmeterTypes1 = publicFunctionWithPrivateParmeterTypes1;
@@ -320,10 +320,10 @@ var publicClassWithPrivateModuleParameterTypes = (function () {
         this.param1 = param1;
         this.param2 = param2;
     }
-    publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod = function (param) {
+    publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod = function (param) { // Error
         if (param === void 0) { param = exporter.createExportedWidget2(); }
     };
-    publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod = function (param) {
+    publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod = function (param) { // Error
         if (param === void 0) { param = exporter.createExportedWidget2(); }
     };
     return publicClassWithPrivateModuleParameterTypes;
@@ -337,20 +337,20 @@ var publicClassWithPrivateModuleParameterTypes2 = (function () {
         this.param1 = param1;
         this.param2 = param2;
     }
-    publicClassWithPrivateModuleParameterTypes2.myPublicStaticMethod = function (param) {
+    publicClassWithPrivateModuleParameterTypes2.myPublicStaticMethod = function (param) { // Error
         if (param === void 0) { param = exporter.createExportedWidget4(); }
     };
-    publicClassWithPrivateModuleParameterTypes2.prototype.myPublicMethod = function (param) {
+    publicClassWithPrivateModuleParameterTypes2.prototype.myPublicMethod = function (param) { // Error
         if (param === void 0) { param = exporter.createExportedWidget4(); }
     };
     return publicClassWithPrivateModuleParameterTypes2;
 }());
 exports.publicClassWithPrivateModuleParameterTypes2 = publicClassWithPrivateModuleParameterTypes2;
-function publicFunctionWithPrivateModuleParameterTypes(param) {
+function publicFunctionWithPrivateModuleParameterTypes(param) { // Error
     if (param === void 0) { param = exporter.createExportedWidget2(); }
 }
 exports.publicFunctionWithPrivateModuleParameterTypes = publicFunctionWithPrivateModuleParameterTypes;
-function publicFunctionWithPrivateModuleParameterTypes1(param) {
+function publicFunctionWithPrivateModuleParameterTypes1(param) { // Error
     if (param === void 0) { param = exporter.createExportedWidget4(); }
 }
 exports.publicFunctionWithPrivateModuleParameterTypes1 = publicFunctionWithPrivateModuleParameterTypes1;

--- a/tests/baselines/reference/privacyFunctionCannotNameReturnTypeDeclFile.js
+++ b/tests/baselines/reference/privacyFunctionCannotNameReturnTypeDeclFile.js
@@ -218,14 +218,14 @@ var exporter = require("./privacyFunctionReturnTypeDeclFile_exporter");
 var publicClassWithWithPrivateParmeterTypes = (function () {
     function publicClassWithWithPrivateParmeterTypes() {
     }
-    publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod = function () {
+    publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod = function () { // Error
         return exporter.createExportedWidget1();
     };
     publicClassWithWithPrivateParmeterTypes.myPrivateStaticMethod = function () {
         return exporter.createExportedWidget1();
         ;
     };
-    publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod = function () {
+    publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod = function () { // Error
         return exporter.createExportedWidget1();
         ;
     };
@@ -233,14 +233,14 @@ var publicClassWithWithPrivateParmeterTypes = (function () {
         return exporter.createExportedWidget1();
         ;
     };
-    publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod1 = function () {
+    publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod1 = function () { // Error
         return exporter.createExportedWidget3();
     };
     publicClassWithWithPrivateParmeterTypes.myPrivateStaticMethod1 = function () {
         return exporter.createExportedWidget3();
         ;
     };
-    publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod1 = function () {
+    publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod1 = function () { // Error
         return exporter.createExportedWidget3();
         ;
     };
@@ -286,14 +286,14 @@ var privateClassWithWithPrivateParmeterTypes = (function () {
     };
     return privateClassWithWithPrivateParmeterTypes;
 }());
-function publicFunctionWithPrivateParmeterTypes() {
+function publicFunctionWithPrivateParmeterTypes() { // Error
     return exporter.createExportedWidget1();
 }
 exports.publicFunctionWithPrivateParmeterTypes = publicFunctionWithPrivateParmeterTypes;
 function privateFunctionWithPrivateParmeterTypes() {
     return exporter.createExportedWidget1();
 }
-function publicFunctionWithPrivateParmeterTypes1() {
+function publicFunctionWithPrivateParmeterTypes1() { // Error
     return exporter.createExportedWidget3();
 }
 exports.publicFunctionWithPrivateParmeterTypes1 = publicFunctionWithPrivateParmeterTypes1;
@@ -303,26 +303,26 @@ function privateFunctionWithPrivateParmeterTypes1() {
 var publicClassWithPrivateModuleReturnTypes = (function () {
     function publicClassWithPrivateModuleReturnTypes() {
     }
-    publicClassWithPrivateModuleReturnTypes.myPublicStaticMethod = function () {
+    publicClassWithPrivateModuleReturnTypes.myPublicStaticMethod = function () { // Error
         return exporter.createExportedWidget2();
     };
-    publicClassWithPrivateModuleReturnTypes.prototype.myPublicMethod = function () {
+    publicClassWithPrivateModuleReturnTypes.prototype.myPublicMethod = function () { // Error
         return exporter.createExportedWidget2();
     };
-    publicClassWithPrivateModuleReturnTypes.myPublicStaticMethod1 = function () {
+    publicClassWithPrivateModuleReturnTypes.myPublicStaticMethod1 = function () { // Error
         return exporter.createExportedWidget4();
     };
-    publicClassWithPrivateModuleReturnTypes.prototype.myPublicMethod1 = function () {
+    publicClassWithPrivateModuleReturnTypes.prototype.myPublicMethod1 = function () { // Error
         return exporter.createExportedWidget4();
     };
     return publicClassWithPrivateModuleReturnTypes;
 }());
 exports.publicClassWithPrivateModuleReturnTypes = publicClassWithPrivateModuleReturnTypes;
-function publicFunctionWithPrivateModuleReturnTypes() {
+function publicFunctionWithPrivateModuleReturnTypes() { // Error
     return exporter.createExportedWidget2();
 }
 exports.publicFunctionWithPrivateModuleReturnTypes = publicFunctionWithPrivateModuleReturnTypes;
-function publicFunctionWithPrivateModuleReturnTypes1() {
+function publicFunctionWithPrivateModuleReturnTypes1() { // Error
     return exporter.createExportedWidget4();
 }
 exports.publicFunctionWithPrivateModuleReturnTypes1 = publicFunctionWithPrivateModuleReturnTypes1;
@@ -335,10 +335,10 @@ var privateClassWithPrivateModuleReturnTypes = (function () {
     privateClassWithPrivateModuleReturnTypes.prototype.myPublicMethod = function () {
         return exporter.createExportedWidget2();
     };
-    privateClassWithPrivateModuleReturnTypes.myPublicStaticMethod1 = function () {
+    privateClassWithPrivateModuleReturnTypes.myPublicStaticMethod1 = function () { // Error
         return exporter.createExportedWidget4();
     };
-    privateClassWithPrivateModuleReturnTypes.prototype.myPublicMethod1 = function () {
+    privateClassWithPrivateModuleReturnTypes.prototype.myPublicMethod1 = function () { // Error
         return exporter.createExportedWidget4();
     };
     return privateClassWithPrivateModuleReturnTypes;

--- a/tests/baselines/reference/privacyFunctionParameterDeclFile.js
+++ b/tests/baselines/reference/privacyFunctionParameterDeclFile.js
@@ -704,11 +704,11 @@ var publicClassWithWithPrivateParmeterTypes = (function () {
         this.param1 = param1;
         this.param2 = param2;
     }
-    publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod = function (param) {
+    publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod = function (param) { // Error
     };
     publicClassWithWithPrivateParmeterTypes.myPrivateStaticMethod = function (param) {
     };
-    publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod = function (param) {
+    publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod = function (param) { // Error
     };
     publicClassWithWithPrivateParmeterTypes.prototype.myPrivateMethod = function (param) {
     };
@@ -761,7 +761,7 @@ var privateClassWithWithPublicParmeterTypes = (function () {
     };
     return privateClassWithWithPublicParmeterTypes;
 }());
-function publicFunctionWithPrivateParmeterTypes(param) {
+function publicFunctionWithPrivateParmeterTypes(param) { // Error
 }
 exports.publicFunctionWithPrivateParmeterTypes = publicFunctionWithPrivateParmeterTypes;
 function publicFunctionWithPublicParmeterTypes(param) {
@@ -776,14 +776,14 @@ var publicClassWithPrivateModuleParameterTypes = (function () {
         this.param1 = param1;
         this.param2 = param2;
     }
-    publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod = function (param) {
+    publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod = function (param) { // Error
     };
-    publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod = function (param) {
+    publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod = function (param) { // Error
     };
     return publicClassWithPrivateModuleParameterTypes;
 }());
 exports.publicClassWithPrivateModuleParameterTypes = publicClassWithPrivateModuleParameterTypes;
-function publicFunctionWithPrivateModuleParameterTypes(param) {
+function publicFunctionWithPrivateModuleParameterTypes(param) { // Error
 }
 exports.publicFunctionWithPrivateModuleParameterTypes = publicFunctionWithPrivateModuleParameterTypes;
 var privateClassWithPrivateModuleParameterTypes = (function () {
@@ -817,11 +817,11 @@ var publicModule;
             this.param1 = param1;
             this.param2 = param2;
         }
-        publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod = function (param) {
+        publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod = function (param) { // Error
         };
         publicClassWithWithPrivateParmeterTypes.myPrivateStaticMethod = function (param) {
         };
-        publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod = function (param) {
+        publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod = function (param) { // Error
         };
         publicClassWithWithPrivateParmeterTypes.prototype.myPrivateMethod = function (param) {
         };
@@ -874,7 +874,7 @@ var publicModule;
         };
         return privateClassWithWithPublicParmeterTypes;
     }());
-    function publicFunctionWithPrivateParmeterTypes(param) {
+    function publicFunctionWithPrivateParmeterTypes(param) { // Error
     }
     publicModule.publicFunctionWithPrivateParmeterTypes = publicFunctionWithPrivateParmeterTypes;
     function publicFunctionWithPublicParmeterTypes(param) {
@@ -889,14 +889,14 @@ var publicModule;
             this.param1 = param1;
             this.param2 = param2;
         }
-        publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod = function (param) {
+        publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod = function (param) { // Error
         };
-        publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod = function (param) {
+        publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod = function (param) { // Error
         };
         return publicClassWithPrivateModuleParameterTypes;
     }());
     publicModule.publicClassWithPrivateModuleParameterTypes = publicClassWithPrivateModuleParameterTypes;
-    function publicFunctionWithPrivateModuleParameterTypes(param) {
+    function publicFunctionWithPrivateModuleParameterTypes(param) { // Error
     }
     publicModule.publicFunctionWithPrivateModuleParameterTypes = publicFunctionWithPrivateModuleParameterTypes;
     var privateClassWithPrivateModuleParameterTypes = (function () {
@@ -1182,11 +1182,11 @@ var publicModuleInGlobal;
             this.param1 = param1;
             this.param2 = param2;
         }
-        publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod = function (param) {
+        publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod = function (param) { // Error
         };
         publicClassWithWithPrivateParmeterTypes.myPrivateStaticMethod = function (param) {
         };
-        publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod = function (param) {
+        publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod = function (param) { // Error
         };
         publicClassWithWithPrivateParmeterTypes.prototype.myPrivateMethod = function (param) {
         };
@@ -1239,7 +1239,7 @@ var publicModuleInGlobal;
         };
         return privateClassWithWithPublicParmeterTypes;
     }());
-    function publicFunctionWithPrivateParmeterTypes(param) {
+    function publicFunctionWithPrivateParmeterTypes(param) { // Error
     }
     publicModuleInGlobal.publicFunctionWithPrivateParmeterTypes = publicFunctionWithPrivateParmeterTypes;
     function publicFunctionWithPublicParmeterTypes(param) {
@@ -1254,14 +1254,14 @@ var publicModuleInGlobal;
             this.param1 = param1;
             this.param2 = param2;
         }
-        publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod = function (param) {
+        publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod = function (param) { // Error
         };
-        publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod = function (param) {
+        publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod = function (param) { // Error
         };
         return publicClassWithPrivateModuleParameterTypes;
     }());
     publicModuleInGlobal.publicClassWithPrivateModuleParameterTypes = publicClassWithPrivateModuleParameterTypes;
-    function publicFunctionWithPrivateModuleParameterTypes(param) {
+    function publicFunctionWithPrivateModuleParameterTypes(param) { // Error
     }
     publicModuleInGlobal.publicFunctionWithPrivateModuleParameterTypes = publicFunctionWithPrivateModuleParameterTypes;
     var privateClassWithPrivateModuleParameterTypes = (function () {

--- a/tests/baselines/reference/privacyFunctionReturnTypeDeclFile.js
+++ b/tests/baselines/reference/privacyFunctionReturnTypeDeclFile.js
@@ -1209,25 +1209,25 @@ exports.publicClass = publicClass;
 var publicClassWithWithPrivateParmeterTypes = (function () {
     function publicClassWithWithPrivateParmeterTypes() {
     }
-    publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod = function () {
+    publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod = function () { // Error
         return null;
     };
     publicClassWithWithPrivateParmeterTypes.myPrivateStaticMethod = function () {
         return null;
     };
-    publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod = function () {
+    publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod = function () { // Error
         return null;
     };
     publicClassWithWithPrivateParmeterTypes.prototype.myPrivateMethod = function () {
         return null;
     };
-    publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod1 = function () {
+    publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod1 = function () { // Error
         return new privateClass();
     };
     publicClassWithWithPrivateParmeterTypes.myPrivateStaticMethod1 = function () {
         return new privateClass();
     };
-    publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod1 = function () {
+    publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod1 = function () { // Error
         return new privateClass();
     };
     publicClassWithWithPrivateParmeterTypes.prototype.myPrivateMethod1 = function () {
@@ -1324,7 +1324,7 @@ var privateClassWithWithPublicParmeterTypes = (function () {
     };
     return privateClassWithWithPublicParmeterTypes;
 }());
-function publicFunctionWithPrivateParmeterTypes() {
+function publicFunctionWithPrivateParmeterTypes() { // Error
     return null;
 }
 exports.publicFunctionWithPrivateParmeterTypes = publicFunctionWithPrivateParmeterTypes;
@@ -1338,7 +1338,7 @@ function privateFunctionWithPrivateParmeterTypes() {
 function privateFunctionWithPublicParmeterTypes() {
     return null;
 }
-function publicFunctionWithPrivateParmeterTypes1() {
+function publicFunctionWithPrivateParmeterTypes1() { // Error
     return new privateClass();
 }
 exports.publicFunctionWithPrivateParmeterTypes1 = publicFunctionWithPrivateParmeterTypes1;
@@ -1355,26 +1355,26 @@ function privateFunctionWithPublicParmeterTypes1() {
 var publicClassWithPrivateModuleParameterTypes = (function () {
     function publicClassWithPrivateModuleParameterTypes() {
     }
-    publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod = function () {
+    publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod = function () { // Error
         return null;
     };
-    publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod = function () {
+    publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod = function () { // Error
         return null;
     };
-    publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod1 = function () {
+    publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod1 = function () { // Error
         return new privateModule.publicClass();
     };
-    publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod1 = function () {
+    publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod1 = function () { // Error
         return new privateModule.publicClass();
     };
     return publicClassWithPrivateModuleParameterTypes;
 }());
 exports.publicClassWithPrivateModuleParameterTypes = publicClassWithPrivateModuleParameterTypes;
-function publicFunctionWithPrivateModuleParameterTypes() {
+function publicFunctionWithPrivateModuleParameterTypes() { // Error
     return null;
 }
 exports.publicFunctionWithPrivateModuleParameterTypes = publicFunctionWithPrivateModuleParameterTypes;
-function publicFunctionWithPrivateModuleParameterTypes1() {
+function publicFunctionWithPrivateModuleParameterTypes1() { // Error
     return new privateModule.publicClass();
 }
 exports.publicFunctionWithPrivateModuleParameterTypes1 = publicFunctionWithPrivateModuleParameterTypes1;
@@ -1417,25 +1417,25 @@ var publicModule;
     var publicClassWithWithPrivateParmeterTypes = (function () {
         function publicClassWithWithPrivateParmeterTypes() {
         }
-        publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod = function () {
+        publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod = function () { // Error
             return null;
         };
         publicClassWithWithPrivateParmeterTypes.myPrivateStaticMethod = function () {
             return null;
         };
-        publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod = function () {
+        publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod = function () { // Error
             return null;
         };
         publicClassWithWithPrivateParmeterTypes.prototype.myPrivateMethod = function () {
             return null;
         };
-        publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod1 = function () {
+        publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod1 = function () { // Error
             return new privateClass();
         };
         publicClassWithWithPrivateParmeterTypes.myPrivateStaticMethod1 = function () {
             return new privateClass();
         };
-        publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod1 = function () {
+        publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod1 = function () { // Error
             return new privateClass();
         };
         publicClassWithWithPrivateParmeterTypes.prototype.myPrivateMethod1 = function () {
@@ -1532,7 +1532,7 @@ var publicModule;
         };
         return privateClassWithWithPublicParmeterTypes;
     }());
-    function publicFunctionWithPrivateParmeterTypes() {
+    function publicFunctionWithPrivateParmeterTypes() { // Error
         return null;
     }
     publicModule.publicFunctionWithPrivateParmeterTypes = publicFunctionWithPrivateParmeterTypes;
@@ -1546,7 +1546,7 @@ var publicModule;
     function privateFunctionWithPublicParmeterTypes() {
         return null;
     }
-    function publicFunctionWithPrivateParmeterTypes1() {
+    function publicFunctionWithPrivateParmeterTypes1() { // Error
         return new privateClass();
     }
     publicModule.publicFunctionWithPrivateParmeterTypes1 = publicFunctionWithPrivateParmeterTypes1;
@@ -1563,26 +1563,26 @@ var publicModule;
     var publicClassWithPrivateModuleParameterTypes = (function () {
         function publicClassWithPrivateModuleParameterTypes() {
         }
-        publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod = function () {
+        publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod = function () { // Error
             return null;
         };
-        publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod = function () {
+        publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod = function () { // Error
             return null;
         };
-        publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod1 = function () {
+        publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod1 = function () { // Error
             return new privateModule.publicClass();
         };
-        publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod1 = function () {
+        publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod1 = function () { // Error
             return new privateModule.publicClass();
         };
         return publicClassWithPrivateModuleParameterTypes;
     }());
     publicModule.publicClassWithPrivateModuleParameterTypes = publicClassWithPrivateModuleParameterTypes;
-    function publicFunctionWithPrivateModuleParameterTypes() {
+    function publicFunctionWithPrivateModuleParameterTypes() { // Error
         return null;
     }
     publicModule.publicFunctionWithPrivateModuleParameterTypes = publicFunctionWithPrivateModuleParameterTypes;
-    function publicFunctionWithPrivateModuleParameterTypes1() {
+    function publicFunctionWithPrivateModuleParameterTypes1() { // Error
         return new privateModule.publicClass();
     }
     publicModule.publicFunctionWithPrivateModuleParameterTypes1 = publicFunctionWithPrivateModuleParameterTypes1;
@@ -2085,25 +2085,25 @@ var publicModuleInGlobal;
     var publicClassWithWithPrivateParmeterTypes = (function () {
         function publicClassWithWithPrivateParmeterTypes() {
         }
-        publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod = function () {
+        publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod = function () { // Error
             return null;
         };
         publicClassWithWithPrivateParmeterTypes.myPrivateStaticMethod = function () {
             return null;
         };
-        publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod = function () {
+        publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod = function () { // Error
             return null;
         };
         publicClassWithWithPrivateParmeterTypes.prototype.myPrivateMethod = function () {
             return null;
         };
-        publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod1 = function () {
+        publicClassWithWithPrivateParmeterTypes.myPublicStaticMethod1 = function () { // Error
             return new privateClass();
         };
         publicClassWithWithPrivateParmeterTypes.myPrivateStaticMethod1 = function () {
             return new privateClass();
         };
-        publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod1 = function () {
+        publicClassWithWithPrivateParmeterTypes.prototype.myPublicMethod1 = function () { // Error
             return new privateClass();
         };
         publicClassWithWithPrivateParmeterTypes.prototype.myPrivateMethod1 = function () {
@@ -2200,7 +2200,7 @@ var publicModuleInGlobal;
         };
         return privateClassWithWithPublicParmeterTypes;
     }());
-    function publicFunctionWithPrivateParmeterTypes() {
+    function publicFunctionWithPrivateParmeterTypes() { // Error
         return null;
     }
     publicModuleInGlobal.publicFunctionWithPrivateParmeterTypes = publicFunctionWithPrivateParmeterTypes;
@@ -2214,7 +2214,7 @@ var publicModuleInGlobal;
     function privateFunctionWithPublicParmeterTypes() {
         return null;
     }
-    function publicFunctionWithPrivateParmeterTypes1() {
+    function publicFunctionWithPrivateParmeterTypes1() { // Error
         return new privateClass();
     }
     publicModuleInGlobal.publicFunctionWithPrivateParmeterTypes1 = publicFunctionWithPrivateParmeterTypes1;
@@ -2231,26 +2231,26 @@ var publicModuleInGlobal;
     var publicClassWithPrivateModuleParameterTypes = (function () {
         function publicClassWithPrivateModuleParameterTypes() {
         }
-        publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod = function () {
+        publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod = function () { // Error
             return null;
         };
-        publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod = function () {
+        publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod = function () { // Error
             return null;
         };
-        publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod1 = function () {
+        publicClassWithPrivateModuleParameterTypes.myPublicStaticMethod1 = function () { // Error
             return new privateModule.publicClass();
         };
-        publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod1 = function () {
+        publicClassWithPrivateModuleParameterTypes.prototype.myPublicMethod1 = function () { // Error
             return new privateModule.publicClass();
         };
         return publicClassWithPrivateModuleParameterTypes;
     }());
     publicModuleInGlobal.publicClassWithPrivateModuleParameterTypes = publicClassWithPrivateModuleParameterTypes;
-    function publicFunctionWithPrivateModuleParameterTypes() {
+    function publicFunctionWithPrivateModuleParameterTypes() { // Error
         return null;
     }
     publicModuleInGlobal.publicFunctionWithPrivateModuleParameterTypes = publicFunctionWithPrivateModuleParameterTypes;
-    function publicFunctionWithPrivateModuleParameterTypes1() {
+    function publicFunctionWithPrivateModuleParameterTypes1() { // Error
         return new privateModule.publicClass();
     }
     publicModuleInGlobal.publicFunctionWithPrivateModuleParameterTypes1 = publicFunctionWithPrivateModuleParameterTypes1;

--- a/tests/baselines/reference/privacyGetter.js
+++ b/tests/baselines/reference/privacyGetter.js
@@ -256,10 +256,10 @@ define(["require", "exports"], function (require, exports) {
                 configurable: true
             });
             Object.defineProperty(C3_public.prototype, "p4_public", {
-                get: function () {
+                get: function () { // error
                     return new C2_private(); //error
                 },
-                set: function (m1_c3_p4_arg) {
+                set: function (m1_c3_p4_arg) { // error
                 },
                 enumerable: true,
                 configurable: true
@@ -452,10 +452,10 @@ define(["require", "exports"], function (require, exports) {
             configurable: true
         });
         Object.defineProperty(C7_public.prototype, "p4_public", {
-            get: function () {
+            get: function () { // error
                 return new C5_private(); //error
             },
-            set: function (m1_c3_p4_arg) {
+            set: function (m1_c3_p4_arg) { // error
             },
             enumerable: true,
             configurable: true

--- a/tests/baselines/reference/privacyGloFunc.js
+++ b/tests/baselines/reference/privacyGloFunc.js
@@ -557,7 +557,7 @@ define(["require", "exports"], function (require, exports) {
             };
             C3_public.prototype.f3_private = function (m1_c3_f3_arg) {
             };
-            C3_public.prototype.f4_public = function (m1_c3_f4_arg) {
+            C3_public.prototype.f4_public = function (m1_c3_f4_arg) { // error
             };
             C3_public.prototype.f5_private = function () {
                 return new C1_public();
@@ -580,7 +580,7 @@ define(["require", "exports"], function (require, exports) {
             C3_public.prototype.f11_private = function () {
                 return new C2_private();
             };
-            C3_public.prototype.f12_public = function () {
+            C3_public.prototype.f12_public = function () { // error
                 return new C2_private(); //error
             };
             return C3_public;
@@ -652,7 +652,7 @@ define(["require", "exports"], function (require, exports) {
         m1.f2_public = f2_public;
         function f3_public(m1_f3_arg) {
         }
-        function f4_public(m1_f4_arg) {
+        function f4_public(m1_f4_arg) { // error
         }
         m1.f4_public = f4_public;
         function f5_public() {
@@ -679,7 +679,7 @@ define(["require", "exports"], function (require, exports) {
         function f11_private() {
             return new C2_private();
         }
-        function f12_public() {
+        function f12_public() { // error
             return new C2_private(); //error
         }
         m1.f12_public = f12_public;
@@ -857,7 +857,7 @@ define(["require", "exports"], function (require, exports) {
         };
         C7_public.prototype.f3_private = function (c7_f3_arg) {
         };
-        C7_public.prototype.f4_public = function (c7_f4_arg) {
+        C7_public.prototype.f4_public = function (c7_f4_arg) { //error
         };
         C7_public.prototype.f5_private = function () {
             return new C6_public();
@@ -880,7 +880,7 @@ define(["require", "exports"], function (require, exports) {
         C7_public.prototype.f11_private = function () {
             return new C5_private();
         };
-        C7_public.prototype.f12_public = function () {
+        C7_public.prototype.f12_public = function () { //error
             return new C5_private(); //error
         };
         return C7_public;
@@ -947,7 +947,7 @@ define(["require", "exports"], function (require, exports) {
     }());
     function f1_private(f1_arg) {
     }
-    function f2_public(f2_arg) {
+    function f2_public(f2_arg) { // error
     }
     exports.f2_public = f2_public;
     function f3_private(f3_arg) {
@@ -979,7 +979,7 @@ define(["require", "exports"], function (require, exports) {
     function f11_private() {
         return new C5_private();
     }
-    function f12_public() {
+    function f12_public() { //error 
         return new C5_private(); //error
     }
     exports.f12_public = f12_public;

--- a/tests/baselines/reference/privacyGloGetter.js
+++ b/tests/baselines/reference/privacyGloGetter.js
@@ -135,10 +135,10 @@ var m1;
             configurable: true
         });
         Object.defineProperty(C3_public.prototype, "p4_public", {
-            get: function () {
+            get: function () { // error
                 return new C2_private(); //error
             },
-            set: function (m1_c3_p4_arg) {
+            set: function (m1_c3_p4_arg) { // error
             },
             enumerable: true,
             configurable: true

--- a/tests/baselines/reference/privacyTypeParameterOfFunction.js
+++ b/tests/baselines/reference/privacyTypeParameterOfFunction.js
@@ -151,12 +151,12 @@ var publicClassWithWithPrivateTypeParameters = (function () {
     // TypeParameter_0_of_public_static_method_from_exported_class_has_or_is_using_private_type_1
     publicClassWithWithPrivateTypeParameters.myPublicStaticMethod = function () {
     };
-    publicClassWithWithPrivateTypeParameters.myPrivateStaticMethod = function () {
+    publicClassWithWithPrivateTypeParameters.myPrivateStaticMethod = function () { // No error
     };
     // TypeParameter_0_of_public_method_from_exported_class_has_or_is_using_private_type_1
     publicClassWithWithPrivateTypeParameters.prototype.myPublicMethod = function () {
     };
-    publicClassWithWithPrivateTypeParameters.prototype.myPrivateMethod = function () {
+    publicClassWithWithPrivateTypeParameters.prototype.myPrivateMethod = function () { // No error
     };
     return publicClassWithWithPrivateTypeParameters;
 }());
@@ -180,11 +180,11 @@ var privateClassWithWithPrivateTypeParameters = (function () {
     }
     privateClassWithWithPrivateTypeParameters.myPublicStaticMethod = function () {
     };
-    privateClassWithWithPrivateTypeParameters.myPrivateStaticMethod = function () {
+    privateClassWithWithPrivateTypeParameters.myPrivateStaticMethod = function () { // No error
     };
     privateClassWithWithPrivateTypeParameters.prototype.myPublicMethod = function () {
     };
-    privateClassWithWithPrivateTypeParameters.prototype.myPrivateMethod = function () {
+    privateClassWithWithPrivateTypeParameters.prototype.myPrivateMethod = function () { // No error
     };
     return privateClassWithWithPrivateTypeParameters;
 }());

--- a/tests/baselines/reference/privacyTypeParameterOfFunctionDeclFile.js
+++ b/tests/baselines/reference/privacyTypeParameterOfFunctionDeclFile.js
@@ -454,11 +454,11 @@ exports.publicClass = publicClass;
 var publicClassWithWithPrivateTypeParameters = (function () {
     function publicClassWithWithPrivateTypeParameters() {
     }
-    publicClassWithWithPrivateTypeParameters.myPublicStaticMethod = function () {
+    publicClassWithWithPrivateTypeParameters.myPublicStaticMethod = function () { // Error
     };
     publicClassWithWithPrivateTypeParameters.myPrivateStaticMethod = function () {
     };
-    publicClassWithWithPrivateTypeParameters.prototype.myPublicMethod = function () {
+    publicClassWithWithPrivateTypeParameters.prototype.myPublicMethod = function () { // Error
     };
     publicClassWithWithPrivateTypeParameters.prototype.myPrivateMethod = function () {
     };
@@ -505,7 +505,7 @@ var privateClassWithWithPublicTypeParameters = (function () {
     };
     return privateClassWithWithPublicTypeParameters;
 }());
-function publicFunctionWithPrivateTypeParameters() {
+function publicFunctionWithPrivateTypeParameters() { // Error
 }
 exports.publicFunctionWithPrivateTypeParameters = publicFunctionWithPrivateTypeParameters;
 function publicFunctionWithPublicTypeParameters() {
@@ -550,14 +550,14 @@ function privateFunctionWithPublicTypeParametersWithoutExtends() {
 var publicClassWithWithPrivateModuleTypeParameters = (function () {
     function publicClassWithWithPrivateModuleTypeParameters() {
     }
-    publicClassWithWithPrivateModuleTypeParameters.myPublicStaticMethod = function () {
+    publicClassWithWithPrivateModuleTypeParameters.myPublicStaticMethod = function () { // Error
     };
-    publicClassWithWithPrivateModuleTypeParameters.prototype.myPublicMethod = function () {
+    publicClassWithWithPrivateModuleTypeParameters.prototype.myPublicMethod = function () { // Error
     };
     return publicClassWithWithPrivateModuleTypeParameters;
 }());
 exports.publicClassWithWithPrivateModuleTypeParameters = publicClassWithWithPrivateModuleTypeParameters;
-function publicFunctionWithPrivateMopduleTypeParameters() {
+function publicFunctionWithPrivateMopduleTypeParameters() { // Error
 }
 exports.publicFunctionWithPrivateMopduleTypeParameters = publicFunctionWithPrivateMopduleTypeParameters;
 var privateClassWithWithPrivateModuleTypeParameters = (function () {
@@ -587,11 +587,11 @@ var publicModule;
     var publicClassWithWithPrivateTypeParameters = (function () {
         function publicClassWithWithPrivateTypeParameters() {
         }
-        publicClassWithWithPrivateTypeParameters.myPublicStaticMethod = function () {
+        publicClassWithWithPrivateTypeParameters.myPublicStaticMethod = function () { // Error
         };
         publicClassWithWithPrivateTypeParameters.myPrivateStaticMethod = function () {
         };
-        publicClassWithWithPrivateTypeParameters.prototype.myPublicMethod = function () {
+        publicClassWithWithPrivateTypeParameters.prototype.myPublicMethod = function () { // Error
         };
         publicClassWithWithPrivateTypeParameters.prototype.myPrivateMethod = function () {
         };
@@ -638,7 +638,7 @@ var publicModule;
         };
         return privateClassWithWithPublicTypeParameters;
     }());
-    function publicFunctionWithPrivateTypeParameters() {
+    function publicFunctionWithPrivateTypeParameters() { // Error
     }
     publicModule.publicFunctionWithPrivateTypeParameters = publicFunctionWithPrivateTypeParameters;
     function publicFunctionWithPublicTypeParameters() {
@@ -683,14 +683,14 @@ var publicModule;
     var publicClassWithWithPrivateModuleTypeParameters = (function () {
         function publicClassWithWithPrivateModuleTypeParameters() {
         }
-        publicClassWithWithPrivateModuleTypeParameters.myPublicStaticMethod = function () {
+        publicClassWithWithPrivateModuleTypeParameters.myPublicStaticMethod = function () { // Error
         };
-        publicClassWithWithPrivateModuleTypeParameters.prototype.myPublicMethod = function () {
+        publicClassWithWithPrivateModuleTypeParameters.prototype.myPublicMethod = function () { // Error
         };
         return publicClassWithWithPrivateModuleTypeParameters;
     }());
     publicModule.publicClassWithWithPrivateModuleTypeParameters = publicClassWithWithPrivateModuleTypeParameters;
-    function publicFunctionWithPrivateMopduleTypeParameters() {
+    function publicFunctionWithPrivateMopduleTypeParameters() { // Error
     }
     publicModule.publicFunctionWithPrivateMopduleTypeParameters = publicFunctionWithPrivateMopduleTypeParameters;
     var privateClassWithWithPrivateModuleTypeParameters = (function () {

--- a/tests/baselines/reference/privacyTypeParametersOfClass.js
+++ b/tests/baselines/reference/privacyTypeParametersOfClass.js
@@ -60,7 +60,7 @@ exports.publicClass = publicClass;
 var publicClassWithPrivateTypeParameters = (function () {
     function publicClassWithPrivateTypeParameters() {
     }
-    publicClassWithPrivateTypeParameters.prototype.myMethod = function (val) {
+    publicClassWithPrivateTypeParameters.prototype.myMethod = function (val) { // Error
         return val;
     };
     return publicClassWithPrivateTypeParameters;
@@ -69,7 +69,7 @@ exports.publicClassWithPrivateTypeParameters = publicClassWithPrivateTypeParamet
 var publicClassWithPublicTypeParameters = (function () {
     function publicClassWithPublicTypeParameters() {
     }
-    publicClassWithPublicTypeParameters.prototype.myMethod = function (val) {
+    publicClassWithPublicTypeParameters.prototype.myMethod = function (val) { // No Error
         return val;
     };
     return publicClassWithPublicTypeParameters;
@@ -78,7 +78,7 @@ exports.publicClassWithPublicTypeParameters = publicClassWithPublicTypeParameter
 var privateClassWithPrivateTypeParameters = (function () {
     function privateClassWithPrivateTypeParameters() {
     }
-    privateClassWithPrivateTypeParameters.prototype.myMethod = function (val) {
+    privateClassWithPrivateTypeParameters.prototype.myMethod = function (val) { // No Error
         return val;
     };
     return privateClassWithPrivateTypeParameters;
@@ -86,7 +86,7 @@ var privateClassWithPrivateTypeParameters = (function () {
 var privateClassWithPublicTypeParameters = (function () {
     function privateClassWithPublicTypeParameters() {
     }
-    privateClassWithPublicTypeParameters.prototype.myMethod = function (val) {
+    privateClassWithPublicTypeParameters.prototype.myMethod = function (val) { // No Error
         return val;
     };
     return privateClassWithPublicTypeParameters;
@@ -94,7 +94,7 @@ var privateClassWithPublicTypeParameters = (function () {
 var publicClassWithPublicTypeParametersWithoutExtends = (function () {
     function publicClassWithPublicTypeParametersWithoutExtends() {
     }
-    publicClassWithPublicTypeParametersWithoutExtends.prototype.myMethod = function (val) {
+    publicClassWithPublicTypeParametersWithoutExtends.prototype.myMethod = function (val) { // No Error
         return val;
     };
     return publicClassWithPublicTypeParametersWithoutExtends;
@@ -103,7 +103,7 @@ exports.publicClassWithPublicTypeParametersWithoutExtends = publicClassWithPubli
 var privateClassWithPublicTypeParametersWithoutExtends = (function () {
     function privateClassWithPublicTypeParametersWithoutExtends() {
     }
-    privateClassWithPublicTypeParametersWithoutExtends.prototype.myMethod = function (val) {
+    privateClassWithPublicTypeParametersWithoutExtends.prototype.myMethod = function (val) { // No Error
         return val;
     };
     return privateClassWithPublicTypeParametersWithoutExtends;

--- a/tests/baselines/reference/propertyAndAccessorWithSameName.js
+++ b/tests/baselines/reference/propertyAndAccessorWithSameName.js
@@ -24,7 +24,7 @@ var C = (function () {
     function C() {
     }
     Object.defineProperty(C.prototype, "x", {
-        get: function () {
+        get: function () { // error
             return 1;
         },
         enumerable: true,
@@ -47,7 +47,7 @@ var E = (function () {
     function E() {
     }
     Object.defineProperty(E.prototype, "x", {
-        get: function () {
+        get: function () { // error
             return 1;
         },
         set: function (v) { },

--- a/tests/baselines/reference/propertyAndFunctionWithSameName.js
+++ b/tests/baselines/reference/propertyAndFunctionWithSameName.js
@@ -15,7 +15,7 @@ class D {
 var C = (function () {
     function C() {
     }
-    C.prototype.x = function () {
+    C.prototype.x = function () { // error
         return 1;
     };
     return C;

--- a/tests/baselines/reference/staticMethodWithTypeParameterExtendsClauseDeclFile.js
+++ b/tests/baselines/reference/staticMethodWithTypeParameterExtendsClauseDeclFile.js
@@ -37,13 +37,13 @@ exports.publicClass = publicClass;
 var publicClassWithWithPrivateTypeParameters = (function () {
     function publicClassWithWithPrivateTypeParameters() {
     }
-    publicClassWithWithPrivateTypeParameters.myPrivateStaticMethod1 = function () {
+    publicClassWithWithPrivateTypeParameters.myPrivateStaticMethod1 = function () { // do not emit extends clause
     };
-    publicClassWithWithPrivateTypeParameters.prototype.myPrivateMethod1 = function () {
+    publicClassWithWithPrivateTypeParameters.prototype.myPrivateMethod1 = function () { // do not emit extends clause
     };
-    publicClassWithWithPrivateTypeParameters.myPrivateStaticMethod2 = function () {
+    publicClassWithWithPrivateTypeParameters.myPrivateStaticMethod2 = function () { // do not emit extends clause
     };
-    publicClassWithWithPrivateTypeParameters.prototype.myPrivateMethod2 = function () {
+    publicClassWithWithPrivateTypeParameters.prototype.myPrivateMethod2 = function () { // do not emit extends clause
     };
     publicClassWithWithPrivateTypeParameters.myPublicStaticMethod = function () {
     };

--- a/tests/baselines/reference/stringIndexerConstrainsPropertyDeclarations.js
+++ b/tests/baselines/reference/stringIndexerConstrainsPropertyDeclarations.js
@@ -103,7 +103,7 @@ var C = (function () {
     function C() {
     } // ok
     Object.defineProperty(C.prototype, "X", {
-        get: function () {
+        get: function () { // ok
             return '';
         },
         set: function (v) { } // ok
@@ -111,12 +111,12 @@ var C = (function () {
         enumerable: true,
         configurable: true
     });
-    C.prototype.foo = function () {
+    C.prototype.foo = function () { // error
         return '';
     };
     C.foo = function () { }; // ok
     Object.defineProperty(C, "X", {
-        get: function () {
+        get: function () { // ok
             return 1;
         },
         enumerable: true,

--- a/tests/baselines/reference/typeArgumentsInFunctionExpressions.js
+++ b/tests/baselines/reference/typeArgumentsInFunctionExpressions.js
@@ -12,11 +12,11 @@ var obj2 = function f<T>(a: T): T { // should not error
 
 
 //// [typeArgumentsInFunctionExpressions.js]
-var obj = function f(a) {
+var obj = function f(a) { // should not error
     var x;
     return a;
 };
-var obj2 = function f(a) {
+var obj2 = function f(a) { // should not error
     var x;
     return a;
 };

--- a/tests/baselines/reference/typeAssertions.js
+++ b/tests/baselines/reference/typeAssertions.js
@@ -101,11 +101,11 @@ var numOrStr;
 var str;
 if (is)
     string > (numOrStr === undefined);
-{
+{ // Error
     str = numOrStr; // Error, no narrowing occurred
 }
 if ((numOrStr === undefined))
     is;
 string;
-{
+{ // Error
 }

--- a/tests/baselines/reference/typeGuardsWithInstanceOfByConstructorSignature.js
+++ b/tests/baselines/reference/typeGuardsWithInstanceOfByConstructorSignature.js
@@ -192,89 +192,89 @@ if (obj16 instanceof H) { // can't narrow type from 'any'
 
 //// [typeGuardsWithInstanceOfByConstructorSignature.js]
 var obj1;
-if (obj1 instanceof A) {
+if (obj1 instanceof A) { // narrowed to A.
     obj1.foo;
     obj1.bar;
 }
 var obj2;
-if (obj2 instanceof A) {
+if (obj2 instanceof A) { // can't narrow type from 'any'
     obj2.foo;
     obj2.bar;
 }
 var obj3;
-if (obj3 instanceof B) {
+if (obj3 instanceof B) { // narrowed to B<number>.
     obj3.foo = 1;
     obj3.foo = "str";
     obj3.bar = "str";
 }
 var obj4;
-if (obj4 instanceof B) {
+if (obj4 instanceof B) { // can't narrow type from 'any'
     obj4.foo = "str";
     obj4.foo = 1;
     obj4.bar = "str";
 }
 var obj5;
-if (obj5 instanceof C) {
+if (obj5 instanceof C) { // narrowed to C1|C2.
     obj5.foo;
     obj5.c;
     obj5.bar1;
     obj5.bar2;
 }
 var obj6;
-if (obj6 instanceof C) {
+if (obj6 instanceof C) { // can't narrow type from 'any'
     obj6.foo;
     obj6.bar1;
     obj6.bar2;
 }
 var obj7;
-if (obj7 instanceof D) {
+if (obj7 instanceof D) { // narrowed to D.
     obj7.foo;
     obj7.bar;
 }
 var obj8;
-if (obj8 instanceof D) {
+if (obj8 instanceof D) { // can't narrow type from 'any'
     obj8.foo;
     obj8.bar;
 }
 var obj9;
-if (obj9 instanceof E) {
+if (obj9 instanceof E) { // narrowed to E1 | E2
     obj9.foo;
     obj9.bar1;
     obj9.bar2;
 }
 var obj10;
-if (obj10 instanceof E) {
+if (obj10 instanceof E) { // can't narrow type from 'any'
     obj10.foo;
     obj10.bar1;
     obj10.bar2;
 }
 var obj11;
-if (obj11 instanceof F) {
+if (obj11 instanceof F) { // can't type narrowing, construct signature returns any.
     obj11.foo;
     obj11.bar;
 }
 var obj12;
-if (obj12 instanceof F) {
+if (obj12 instanceof F) { // can't narrow type from 'any'
     obj12.foo;
     obj12.bar;
 }
 var obj13;
-if (obj13 instanceof G) {
+if (obj13 instanceof G) { // narrowed to G1. G1 is return type of prototype property.
     obj13.foo1;
     obj13.foo2;
 }
 var obj14;
-if (obj14 instanceof G) {
+if (obj14 instanceof G) { // can't narrow type from 'any'
     obj14.foo1;
     obj14.foo2;
 }
 var obj15;
-if (obj15 instanceof H) {
+if (obj15 instanceof H) { // narrowed to H.
     obj15.foo;
     obj15.bar;
 }
 var obj16;
-if (obj16 instanceof H) {
+if (obj16 instanceof H) { // can't narrow type from 'any'
     obj16.foo1;
     obj16.foo2;
 }

--- a/tests/baselines/reference/typeParameterUsedAsTypeParameterConstraint4.js
+++ b/tests/baselines/reference/typeParameterUsedAsTypeParameterConstraint4.js
@@ -65,16 +65,16 @@ var C = (function () {
     };
     return C;
 }());
-function foo(x, y) {
-    function bar() {
+function foo(x, y) { // error
+    function bar() { // error
         function baz(a, b) {
             x = y;
             return y;
         }
     }
 }
-function foo2(x, y) {
-    function bar() {
+function foo2(x, y) { // error
+    function bar() { // error
         function baz(a, b) {
             x = y;
             return y;
@@ -82,14 +82,14 @@ function foo2(x, y) {
     }
 }
 var f3 = function (x, y) {
-    function bar(r, s) {
+    function bar(r, s) { // error
         var g = function (a, b) {
             x = y;
             return y;
         };
     }
 };
-var f4 = function (x, y) {
+var f4 = function (x, y) { // error
     function bar() {
         var g = function (a, b) {
             x = y;

--- a/tests/baselines/reference/unknownSymbols2.js
+++ b/tests/baselines/reference/unknownSymbols2.js
@@ -42,7 +42,7 @@ var M;
     }
     try {
     }
-    catch (asdf) {
+    catch (asdf) { // no error
     }
     switch (asdf) {
         case qwerty:

--- a/tests/baselines/reference/withStatement.js
+++ b/tests/baselines/reference/withStatement.js
@@ -13,7 +13,7 @@ with (ooo.eee.oo.ah_ah.ting.tang.walla.walla) { // error
 
 
 //// [withStatement.js]
-with (ooo.eee.oo.ah_ah.ting.tang.walla.walla) {
+with (ooo.eee.oo.ah_ah.ting.tang.walla.walla) { // error
     bing = true; // no error
     bang = true; // no error
     function bar() { }

--- a/tests/baselines/reference/withStatementErrors.js
+++ b/tests/baselines/reference/withStatementErrors.js
@@ -19,7 +19,7 @@ with (ooo.eee.oo.ah_ah.ting.tang.walla.walla) { // error
 
 
 //// [withStatementErrors.js]
-with (ooo.eee.oo.ah_ah.ting.tang.walla.walla) {
+with (ooo.eee.oo.ah_ah.ting.tang.walla.walla) { // error
     bing = true; // no error
     bang = true; // no error
     function bar() { } // no error

--- a/tests/cases/compiler/emitCommentsAfterBraces.ts
+++ b/tests/cases/compiler/emitCommentsAfterBraces.ts
@@ -1,0 +1,5 @@
+if (true) {//validation and tokenization
+	let a = 42;
+}
+
+if (true) {/*comment*/ let a = 42;}


### PR DESCRIPTION
Fixes #8800 

Comments after open braces are neither leading comments of statments nor trailing comments of block.
This pull request compensates missing comments after writing braces.