### PR TITLE
Fix type of the disableSizeLimit option

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -423,7 +423,7 @@ namespace ts {
             description: Diagnostics.Specify_library_files_to_be_included_in_the_compilation_Colon
         },
         {
-            name: "disableProjectSizeLimit",
+            name: "disableSizeLimit",
             type: "boolean"
         },
         {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes the typo in commandLineParser for the "disableSizeLimit" compiler option.
