### PR TITLE
Fix 9363: Object destructuring broken-variables are bound to the wrong object

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -4545,8 +4545,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                                 }
 
                                 write(";");
-                                tempIndex++;
                             }
+                            // Regardless of whether we will emit a var declaration for the binding pattern, we generate the temporary
+                            // variable for the parameter (see: emitParameter)
+                            tempIndex++;
                         }
                         else if (initializer) {
                             writeLine();

--- a/tests/baselines/reference/destructuringParameterDeclaration7ES5.js
+++ b/tests/baselines/reference/destructuringParameterDeclaration7ES5.js
@@ -1,0 +1,14 @@
+//// [destructuringParameterDeclaration7ES5.ts]
+
+interface ISomething {
+    foo: string,
+    bar: string
+}
+
+function foo({}, {foo, bar}: ISomething) {}
+
+
+//// [destructuringParameterDeclaration7ES5.js]
+function foo(_a, _b) {
+    var foo = _b.foo, bar = _b.bar;
+}

--- a/tests/baselines/reference/destructuringParameterDeclaration7ES5.js
+++ b/tests/baselines/reference/destructuringParameterDeclaration7ES5.js
@@ -7,8 +7,21 @@ interface ISomething {
 
 function foo({}, {foo, bar}: ISomething) {}
 
+function baz([], {foo, bar}: ISomething) {}
+
+function one([], {}) {}
+
+function two([], [a, b, c]: number[]) {}
+
 
 //// [destructuringParameterDeclaration7ES5.js]
 function foo(_a, _b) {
     var foo = _b.foo, bar = _b.bar;
+}
+function baz(_a, _b) {
+    var foo = _b.foo, bar = _b.bar;
+}
+function one(_a, _b) { }
+function two(_a, _b) {
+    var a = _b[0], b = _b[1], c = _b[2];
 }

--- a/tests/baselines/reference/destructuringParameterDeclaration7ES5.symbols
+++ b/tests/baselines/reference/destructuringParameterDeclaration7ES5.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration7ES5.ts ===
+
+interface ISomething {
+>ISomething : Symbol(ISomething, Decl(destructuringParameterDeclaration7ES5.ts, 0, 0))
+
+    foo: string,
+>foo : Symbol(ISomething.foo, Decl(destructuringParameterDeclaration7ES5.ts, 1, 22))
+
+    bar: string
+>bar : Symbol(ISomething.bar, Decl(destructuringParameterDeclaration7ES5.ts, 2, 16))
+}
+
+function foo({}, {foo, bar}: ISomething) {}
+>foo : Symbol(foo, Decl(destructuringParameterDeclaration7ES5.ts, 4, 1))
+>foo : Symbol(foo, Decl(destructuringParameterDeclaration7ES5.ts, 6, 18))
+>bar : Symbol(bar, Decl(destructuringParameterDeclaration7ES5.ts, 6, 22))
+>ISomething : Symbol(ISomething, Decl(destructuringParameterDeclaration7ES5.ts, 0, 0))
+

--- a/tests/baselines/reference/destructuringParameterDeclaration7ES5.symbols
+++ b/tests/baselines/reference/destructuringParameterDeclaration7ES5.symbols
@@ -16,3 +16,18 @@ function foo({}, {foo, bar}: ISomething) {}
 >bar : Symbol(bar, Decl(destructuringParameterDeclaration7ES5.ts, 6, 22))
 >ISomething : Symbol(ISomething, Decl(destructuringParameterDeclaration7ES5.ts, 0, 0))
 
+function baz([], {foo, bar}: ISomething) {}
+>baz : Symbol(baz, Decl(destructuringParameterDeclaration7ES5.ts, 6, 43))
+>foo : Symbol(foo, Decl(destructuringParameterDeclaration7ES5.ts, 8, 18))
+>bar : Symbol(bar, Decl(destructuringParameterDeclaration7ES5.ts, 8, 22))
+>ISomething : Symbol(ISomething, Decl(destructuringParameterDeclaration7ES5.ts, 0, 0))
+
+function one([], {}) {}
+>one : Symbol(one, Decl(destructuringParameterDeclaration7ES5.ts, 8, 43))
+
+function two([], [a, b, c]: number[]) {}
+>two : Symbol(two, Decl(destructuringParameterDeclaration7ES5.ts, 10, 23))
+>a : Symbol(a, Decl(destructuringParameterDeclaration7ES5.ts, 12, 18))
+>b : Symbol(b, Decl(destructuringParameterDeclaration7ES5.ts, 12, 20))
+>c : Symbol(c, Decl(destructuringParameterDeclaration7ES5.ts, 12, 23))
+

--- a/tests/baselines/reference/destructuringParameterDeclaration7ES5.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration7ES5.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration7ES5.ts ===
+
+interface ISomething {
+>ISomething : ISomething
+
+    foo: string,
+>foo : string
+
+    bar: string
+>bar : string
+}
+
+function foo({}, {foo, bar}: ISomething) {}
+>foo : ({}: {}, {foo, bar}: ISomething) => void
+>foo : string
+>bar : string
+>ISomething : ISomething
+

--- a/tests/baselines/reference/destructuringParameterDeclaration7ES5.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration7ES5.types
@@ -16,3 +16,18 @@ function foo({}, {foo, bar}: ISomething) {}
 >bar : string
 >ISomething : ISomething
 
+function baz([], {foo, bar}: ISomething) {}
+>baz : ([]: any[], {foo, bar}: ISomething) => void
+>foo : string
+>bar : string
+>ISomething : ISomething
+
+function one([], {}) {}
+>one : ([]: any[], {}: {}) => void
+
+function two([], [a, b, c]: number[]) {}
+>two : ([]: any[], [a, b, c]: number[]) => void
+>a : number
+>b : number
+>c : number
+

--- a/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration7ES5.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration7ES5.ts
@@ -6,3 +6,9 @@ interface ISomething {
 }
 
 function foo({}, {foo, bar}: ISomething) {}
+
+function baz([], {foo, bar}: ISomething) {}
+
+function one([], {}) {}
+
+function two([], [a, b, c]: number[]) {}

--- a/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration7ES5.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration7ES5.ts
@@ -1,0 +1,8 @@
+﻿// @target: es5
+
+interface ISomething {
+    foo: string,
+    bar: string
+}
+
+function foo({}, {foo, bar}: ISomething) {}


### PR DESCRIPTION
Fix #9363 

TODO:

- [x] Add tests
