### PR TITLE
Check getCurrentDirectory availability in getEffectiveTypeRoots 

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -187,8 +187,22 @@ namespace ts {
     const typeReferenceExtensions = [".d.ts"];
 
     function getEffectiveTypeRoots(options: CompilerOptions, host: ModuleResolutionHost) {
-        return options.typeRoots ||
-            map(defaultTypeRoots, d => combinePaths(options.configFilePath ? getDirectoryPath(options.configFilePath) : host.getCurrentDirectory(), d));
+        if (options.typeRoots) {
+            return options.typeRoots;
+        }
+
+        let currentDirectory: string;
+        if (options.configFilePath) {
+            currentDirectory = getDirectoryPath(options.configFilePath);
+        }
+        else if (host.getCurrentDirectory) {
+            currentDirectory = host.getCurrentDirectory();
+        }
+
+        if (!currentDirectory) {
+            return undefined;
+        }
+        return map(defaultTypeRoots, d => combinePaths(currentDirectory, d));
     }
 
     /**

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -242,7 +242,7 @@ namespace ts {
         const failedLookupLocations: string[] = [];
 
         // Check primary library paths
-        if (typeRoots.length) {
+        if (typeRoots && typeRoots.length) {
             if (traceEnabled) {
                 trace(host, Diagnostics.Resolving_with_primary_search_path_0, typeRoots.join(", "));
             }
@@ -1060,9 +1060,11 @@ namespace ts {
         let result: string[] = [];
         if (host.directoryExists && host.getDirectories) {
             const typeRoots = getEffectiveTypeRoots(options, host);
-            for (const root of typeRoots) {
-                if (host.directoryExists(root)) {
-                    result = result.concat(host.getDirectories(root));
+            if (typeRoots) {
+                for (const root of typeRoots) {
+                    if (host.directoryExists(root)) {
+                        result = result.concat(host.getDirectories(root));
+                    }
                 }
             }
         }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -113,6 +113,7 @@ namespace ts.server {
             this.moduleResolutionHost = {
                 fileExists: fileName => this.fileExists(fileName),
                 readFile: fileName => this.host.readFile(fileName),
+                getCurrentDirectory: () => this.host.getCurrentDirectory(),
                 directoryExists: directoryName => this.host.directoryExists(directoryName)
             };
         }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -113,7 +113,6 @@ namespace ts.server {
             this.moduleResolutionHost = {
                 fileExists: fileName => this.fileExists(fileName),
                 readFile: fileName => this.host.readFile(fileName),
-                getCurrentDirectory: () => this.host.getCurrentDirectory(),
                 directoryExists: directoryName => this.host.directoryExists(directoryName)
             };
         }

--- a/tests/cases/fourslash/server/typeReferenceOnServer.ts
+++ b/tests/cases/fourslash/server/typeReferenceOnServer.ts
@@ -1,0 +1,9 @@
+/// <reference path='../fourslash.ts' />
+
+/////// <reference types="foo" />
+////var x: number;
+////x./*1*/
+
+goTo.marker("1");
+verify.not.completionListIsEmpty();
+


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #9186 
The crash happened because the [`getEffectiveTypeRoots`](https://github.com/Microsoft/TypeScript/blob/a91978e4435a82b8d79405958ed63c2a835df3e6/src/compiler/program.ts#L191) assumes `getCurrentDirectory` for the host. Adding to `ServerHost` solves the problem.
