### PR TITLE
Fix crash in async functions when targetting ES5.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15388,7 +15388,7 @@ namespace ts {
 
         function isUnwrappedReturnTypeVoidOrAny(func: FunctionLikeDeclaration, returnType: Type): boolean {
             const unwrappedReturnType = isAsyncFunctionLike(func) ? getPromisedType(returnType) : returnType;
-            return maybeTypeOfKind(unwrappedReturnType, TypeFlags.Void | TypeFlags.Any);
+            return unwrappedReturnType && maybeTypeOfKind(unwrappedReturnType, TypeFlags.Void | TypeFlags.Any);
         }
 
         function checkReturnStatement(node: ReturnStatement) {

--- a/tests/baselines/reference/asyncFunctionNoReturnType.errors.txt
+++ b/tests/baselines/reference/asyncFunctionNoReturnType.errors.txt
@@ -1,0 +1,25 @@
+error TS2318: Cannot find global type 'Promise'.
+tests/cases/compiler/asyncFunctionNoReturnType.ts(1,1): error TS1311: Async functions are only available when targeting ECMAScript 2015 or higher.
+tests/cases/compiler/asyncFunctionNoReturnType.ts(1,1): error TS1057: An async function or method must have a valid awaitable return type.
+tests/cases/compiler/asyncFunctionNoReturnType.ts(1,1): error TS7030: Not all code paths return a value.
+tests/cases/compiler/asyncFunctionNoReturnType.ts(2,9): error TS2304: Cannot find name 'window'.
+tests/cases/compiler/asyncFunctionNoReturnType.ts(3,9): error TS7030: Not all code paths return a value.
+
+
+!!! error TS2318: Cannot find global type 'Promise'.
+==== tests/cases/compiler/asyncFunctionNoReturnType.ts (5 errors) ====
+    async () => {
+    ~~~~~
+!!! error TS1311: Async functions are only available when targeting ECMAScript 2015 or higher.
+    ~~~~~~~~~~~~~
+!!! error TS1057: An async function or method must have a valid awaitable return type.
+    ~~~~~~~~~~~~~
+!!! error TS7030: Not all code paths return a value.
+        if (window)
+            ~~~~~~
+!!! error TS2304: Cannot find name 'window'.
+            return;
+            ~~~~~~~
+!!! error TS7030: Not all code paths return a value.
+    }
+    

--- a/tests/baselines/reference/asyncFunctionNoReturnType.js
+++ b/tests/baselines/reference/asyncFunctionNoReturnType.js
@@ -1,0 +1,20 @@
+//// [asyncFunctionNoReturnType.ts]
+async () => {
+    if (window)
+        return;
+}
+
+
+//// [asyncFunctionNoReturnType.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments)).next());
+    });
+};
+(function () __awaiter(this, void 0, void 0, function* () {
+    if (window)
+        return;
+}));

--- a/tests/cases/compiler/asyncFunctionNoReturnType.ts
+++ b/tests/cases/compiler/asyncFunctionNoReturnType.ts
@@ -1,0 +1,5 @@
+// @noImplicitReturns: true
+async () => {
+    if (window)
+        return;
+}


### PR DESCRIPTION
Fixes #9320 

When targetting ES5 and with --noImplicitReturns, an async function whose return type could not be determined would cause a compiler crash.