### PR TITLE
Fix 9363: passing undefined or null to parameter destructuring

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1943,6 +1943,10 @@
         "category": "Error",
         "code": 2689
     },
+    "'Undefined or 'null' is not assignable to a destructuring parameter.": {
+        "category": "Error",
+        "code": 2690
+    },
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",
         "code": 4000

--- a/tests/baselines/reference/destructuringParameterDeclaration8ES5.errors.txt
+++ b/tests/baselines/reference/destructuringParameterDeclaration8ES5.errors.txt
@@ -1,0 +1,52 @@
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration8ES5.ts(9,5): error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration8ES5.ts(11,5): error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration8ES5.ts(11,16): error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration8ES5.ts(13,5): error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration8ES5.ts(15,5): error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration8ES5.ts(15,11): error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration8ES5.ts(17,5): error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration8ES5.ts(17,16): error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration8ES5.ts(19,5): error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration8ES5.ts(19,11): error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+
+
+==== tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration8ES5.ts (10 errors) ====
+    
+    function one({}, {foo, bar}) {
+      // ...
+    }
+    
+    function two([], [a,b]) {}
+    
+    // should be an error
+    one(undefined, { foo: 'foo', bar: 'bar' });  
+        ~~~~~~~~~
+!!! error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+    
+    one(undefined, undefined);
+        ~~~~~~~~~
+!!! error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+                   ~~~~~~~~~
+!!! error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+    
+    one(null,  { foo: 'foo', bar: 'bar' });
+        ~~~~
+!!! error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+    
+    one(null, null);
+        ~~~~
+!!! error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+              ~~~~
+!!! error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+    
+    two(undefined, undefined);
+        ~~~~~~~~~
+!!! error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+                   ~~~~~~~~~
+!!! error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+    
+    two(null, null);
+        ~~~~
+!!! error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.
+              ~~~~
+!!! error TS2690: 'Undefined or 'null' is not assignable to a destructuring parameter.

--- a/tests/baselines/reference/destructuringParameterDeclaration8ES5.js
+++ b/tests/baselines/reference/destructuringParameterDeclaration8ES5.js
@@ -1,0 +1,36 @@
+//// [destructuringParameterDeclaration8ES5.ts]
+
+function one({}, {foo, bar}) {
+  // ...
+}
+
+function two([], [a,b]) {}
+
+// should be an error
+one(undefined, { foo: 'foo', bar: 'bar' });  
+
+one(undefined, undefined);
+
+one(null,  { foo: 'foo', bar: 'bar' });
+
+one(null, null);
+
+two(undefined, undefined);
+
+two(null, null);
+
+//// [destructuringParameterDeclaration8ES5.js]
+function one(_a, _b) {
+    var foo = _b.foo, bar = _b.bar;
+    // ...
+}
+function two(_a, _b) {
+    var a = _b[0], b = _b[1];
+}
+// should be an error
+one(undefined, { foo: 'foo', bar: 'bar' });
+one(undefined, undefined);
+one(null, { foo: 'foo', bar: 'bar' });
+one(null, null);
+two(undefined, undefined);
+two(null, null);

--- a/tests/baselines/reference/destructuringParameterDeclaration9ES5.js
+++ b/tests/baselines/reference/destructuringParameterDeclaration9ES5.js
@@ -1,0 +1,28 @@
+//// [destructuringParameterDeclaration9ES5.ts]
+
+function three({} = {}) {}
+
+function four([] = []) {}
+
+// should not be an error
+
+three(undefined);
+
+three(null);
+
+four(undefined);
+
+four(null)
+
+//// [destructuringParameterDeclaration9ES5.js]
+function three(_a) {
+    var _a = {};
+}
+function four(_a) {
+    var _a = [];
+}
+// should not be an error
+three(undefined);
+three(null);
+four(undefined);
+four(null);

--- a/tests/baselines/reference/destructuringParameterDeclaration9ES5.symbols
+++ b/tests/baselines/reference/destructuringParameterDeclaration9ES5.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration9ES5.ts ===
+
+function three({} = {}) {}
+>three : Symbol(three, Decl(destructuringParameterDeclaration9ES5.ts, 0, 0))
+
+function four([] = []) {}
+>four : Symbol(four, Decl(destructuringParameterDeclaration9ES5.ts, 1, 26))
+
+// should not be an error
+
+three(undefined);
+>three : Symbol(three, Decl(destructuringParameterDeclaration9ES5.ts, 0, 0))
+>undefined : Symbol(undefined)
+
+three(null);
+>three : Symbol(three, Decl(destructuringParameterDeclaration9ES5.ts, 0, 0))
+
+four(undefined);
+>four : Symbol(four, Decl(destructuringParameterDeclaration9ES5.ts, 1, 26))
+>undefined : Symbol(undefined)
+
+four(null)
+>four : Symbol(four, Decl(destructuringParameterDeclaration9ES5.ts, 1, 26))
+

--- a/tests/baselines/reference/destructuringParameterDeclaration9ES5.types
+++ b/tests/baselines/reference/destructuringParameterDeclaration9ES5.types
@@ -1,0 +1,32 @@
+=== tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration9ES5.ts ===
+
+function three({} = {}) {}
+>three : ({}?: {}) => void
+>{} : {}
+
+function four([] = []) {}
+>four : ([]?: any[]) => void
+>[] : undefined[]
+
+// should not be an error
+
+three(undefined);
+>three(undefined) : void
+>three : ({}?: {}) => void
+>undefined : undefined
+
+three(null);
+>three(null) : void
+>three : ({}?: {}) => void
+>null : null
+
+four(undefined);
+>four(undefined) : void
+>four : ([]?: any[]) => void
+>undefined : undefined
+
+four(null)
+>four(null) : void
+>four : ([]?: any[]) => void
+>null : null
+

--- a/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration8ES5.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration8ES5.ts
@@ -1,0 +1,20 @@
+﻿// @target: es5
+
+function one({}, {foo, bar}) {
+  // ...
+}
+
+function two([], [a,b]) {}
+
+// should be an error
+one(undefined, { foo: 'foo', bar: 'bar' });  
+
+one(undefined, undefined);
+
+one(null,  { foo: 'foo', bar: 'bar' });
+
+one(null, null);
+
+two(undefined, undefined);
+
+two(null, null);

--- a/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration9ES5.ts
+++ b/tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration9ES5.ts
@@ -1,0 +1,15 @@
+﻿// @target: es5
+
+function three({} = {}) {}
+
+function four([] = []) {}
+
+// should not be an error
+
+three(undefined);
+
+three(null);
+
+four(undefined);
+
+four(null)


### PR DESCRIPTION
Fix #9363
~~This probably should be ported to release-2.0 as well.~~
Also, technically, it is actually fine to pass undefined or null if the `--target` is es5 (at least for the empty destructing case as we won't be emit the destructuring in the body) I think it is more consistent to error regardless of the `--target`. let me know if you think it should respect the target more