### PR TITLE
Add nullcheck when calculating indentations for implort clause

### DIFF
--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -497,7 +497,7 @@ namespace ts.formatting {
                     return childKind !== SyntaxKind.NamedExports;
                 case SyntaxKind.ImportDeclaration:
                     return childKind !== SyntaxKind.ImportClause ||
-                        (<ImportClause>child).namedBindings.kind !== SyntaxKind.NamedImports;
+                        ((<ImportClause>child).namedBindings && (<ImportClause>child).namedBindings.kind !== SyntaxKind.NamedImports);
                 case SyntaxKind.JsxElement:
                     return childKind !== SyntaxKind.JsxClosingElement;
             }

--- a/tests/cases/fourslash/formattingIllegalImportClause.ts
+++ b/tests/cases/fourslash/formattingIllegalImportClause.ts
@@ -1,0 +1,26 @@
+/// <reference path='fourslash.ts' />
+
+//// var expect = require('expect.js');
+//// import React   from 'react'/*1*/;
+//// import { mount } from 'enzyme';
+//// require('../setup');
+//// var Amount = require('../../src/js/components/amount');
+
+//// describe('<Failed />', () => {
+////   var history
+////   beforeEach(() => {
+////     history = createMemoryHistory();
+////     sinon.spy(history, 'pushState');
+////   });
+
+////   afterEach(() => {
+////   })
+
+////   it('redirects to order summary', () => {
+
+////   });
+//// });
+
+format.document();
+goTo.marker("1");
+verify.currentLineContentIs("import React from 'react';")


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #9411 

