### PR TITLE
runtests-parallel skips empty buckets

### DIFF
--- a/src/harness/runner.ts
+++ b/src/harness/runner.ts
@@ -193,7 +193,7 @@ if (taskConfigsFolder) {
         for (let i = 0; i < workerCount; i++) {
             const startPos = i * chunkSize;
             const len = Math.min(chunkSize, files.length - startPos);
-            if (len !== 0) {
+            if (len > 0) {
                 workerConfigs[i].tasks.push({
                     runner: runner.kind(),
                     files: files.slice(startPos, startPos + len)
@@ -214,5 +214,5 @@ else {
 }
 if (!runUnitTests) {
     // patch `describe` to skip unit tests
-    describe = <any>describe.skip;
+    describe = <any>(function () { });
 }


### PR DESCRIPTION
`runtests-parallel` now skips empty buckets. Previously, it would enter them as buckets with no tests, which would make our test runners run *every* test.

This became obvious on machines with lots of cores because there were lots of workers running many more tests than they should, instead of just one or two.