### PR TITLE
Port #9421 to not compile files under from node_modules

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1383,7 +1383,7 @@ namespace ts {
                 getSourceFile: program.getSourceFile,
                 getSourceFileByPath: program.getSourceFileByPath,
                 getSourceFiles: program.getSourceFiles,
-                isSourceFileFromNodeModules: (file: SourceFile) => !!lookUp(sourceFilesFoundSearchingNodeModules, file.path),
+                isSourceFileFromExternalLibrary: (file: SourceFile) => !!lookUp(sourceFilesFoundSearchingNodeModules, file.path),
                 writeFile: writeFileCallback || (
                     (fileName, data, writeByteOrderMark, onError, sourceFiles) => host.writeFile(fileName, data, writeByteOrderMark, onError, sourceFiles)),
                 isEmitBlocked,

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -36,7 +36,7 @@ namespace ts {
         getSourceFiles(): SourceFile[];
 
         /* @internal */
-        getFilesFromNodeModules(): Map<boolean>;
+        isSourceFileFromNodeModules(file: SourceFile): boolean;
 
         getCommonSourceDirectory(): string;
         getCanonicalFileName(fileName: string): string;
@@ -2277,10 +2277,9 @@ namespace ts {
         }
         else {
             const sourceFiles = targetSourceFile === undefined ? host.getSourceFiles() : [targetSourceFile];
-            const nodeModulesFiles = host.getFilesFromNodeModules();
             for (const sourceFile of sourceFiles) {
                 // Don't emit if source file is a declaration file, or was located under node_modules
-                if (!isDeclarationFile(sourceFile) && !lookUp(nodeModulesFiles, sourceFile.path)) {
+                if (!isDeclarationFile(sourceFile) && !host.isSourceFileFromNodeModules(sourceFile)) {
                     onSingleFileEmit(host, sourceFile);
                 }
             }
@@ -2314,10 +2313,9 @@ namespace ts {
         function onBundledEmit(host: EmitHost) {
             // Can emit only sources that are not declaration file and are either non module code or module with
             // --module or --target es6 specified. Files included by searching under node_modules are also not emitted.
-            const nodeModulesFiles = host.getFilesFromNodeModules();
             const bundledSources = filter(host.getSourceFiles(),
                 sourceFile => !isDeclarationFile(sourceFile) &&
-                              !lookUp(nodeModulesFiles, sourceFile.path) &&
+                              !host.isSourceFileFromNodeModules(sourceFile) &&
                               (!isExternalModule(sourceFile) ||
                                !!getEmitModuleKind(options)));
             if (bundledSources.length) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -36,7 +36,7 @@ namespace ts {
         getSourceFiles(): SourceFile[];
 
         /* @internal */
-        isSourceFileFromNodeModules(file: SourceFile): boolean;
+        isSourceFileFromExternalLibrary(file: SourceFile): boolean;
 
         getCommonSourceDirectory(): string;
         getCanonicalFileName(fileName: string): string;
@@ -2279,7 +2279,7 @@ namespace ts {
             const sourceFiles = targetSourceFile === undefined ? host.getSourceFiles() : [targetSourceFile];
             for (const sourceFile of sourceFiles) {
                 // Don't emit if source file is a declaration file, or was located under node_modules
-                if (!isDeclarationFile(sourceFile) && !host.isSourceFileFromNodeModules(sourceFile)) {
+                if (!isDeclarationFile(sourceFile) && !host.isSourceFileFromExternalLibrary(sourceFile)) {
                     onSingleFileEmit(host, sourceFile);
                 }
             }
@@ -2315,7 +2315,7 @@ namespace ts {
             // --module or --target es6 specified. Files included by searching under node_modules are also not emitted.
             const bundledSources = filter(host.getSourceFiles(),
                 sourceFile => !isDeclarationFile(sourceFile) &&
-                              !host.isSourceFileFromNodeModules(sourceFile) &&
+                              !host.isSourceFileFromExternalLibrary(sourceFile) &&
                               (!isExternalModule(sourceFile) ||
                                !!getEmitModuleKind(options)));
             if (bundledSources.length) {

--- a/tests/baselines/reference/moduleAugmentationInDependency2.js
+++ b/tests/baselines/reference/moduleAugmentationInDependency2.js
@@ -8,8 +8,6 @@ export {};
 //// [app.ts]
 import "A"
 
-//// [index.js]
-"use strict";
 //// [app.js]
 "use strict";
 require("A");

--- a/tests/baselines/reference/pathMappingBasedModuleResolution5_node.js
+++ b/tests/baselines/reference/pathMappingBasedModuleResolution5_node.js
@@ -31,9 +31,6 @@ exports.x = 1;
 //// [file2.js]
 "use strict";
 exports.y = 1;
-//// [file4.js]
-"use strict";
-exports.z1 = 1;
 //// [file1.js]
 "use strict";
 var file1_1 = require("folder2/file1");

--- a/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/amd/maxDepthIncreased/root.js
+++ b/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/amd/maxDepthIncreased/root.js
@@ -1,6 +1,8 @@
-define(["require", "exports", "m1"], function (require, exports, m1) {
+define(["require", "exports", "m1", "m4"], function (require, exports, m1, m4) {
     "use strict";
     m1.f1("test");
     m1.f2.a = 10;
-    m1.f2.person.age = "10"; // Error: Should be number
+    m1.f2.person.age = "10"; // Should error if loaded the .js files correctly
+    var r1 = m4.test.charAt(2); // Should error if correctly not using the .js file but using @types info
+    var r2 = 3 + m4.foo; // Should be OK if correctly using the @types .d.ts file
 });

--- a/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/amd/maxDepthIncreased/root.js
+++ b/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/amd/maxDepthIncreased/root.js
@@ -3,6 +3,5 @@ define(["require", "exports", "m1", "m4"], function (require, exports, m1, m4) {
     m1.f1("test");
     m1.f2.a = 10;
     m1.f2.person.age = "10"; // Should error if loaded the .js files correctly
-    var r1 = m4.test.charAt(2); // Should error if correctly not using the .js file but using @types info
     var r2 = 3 + m4.foo; // Should be OK if correctly using the @types .d.ts file
 });

--- a/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/amd/nodeModulesMaxDepthIncreased.errors.txt
+++ b/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/amd/nodeModulesMaxDepthIncreased.errors.txt
@@ -1,5 +1,4 @@
 maxDepthIncreased/root.ts(7,1): error TS2322: Type 'string' is not assignable to type 'number'.
-maxDepthIncreased/root.ts(8,13): error TS2339: Property 'test' does not exist on type 'typeof "C:/src/TypeScript/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/node_modules/@...'.
 
 
 ==== index.js (0 errors) ====
@@ -32,7 +31,7 @@ maxDepthIncreased/root.ts(8,13): error TS2339: Property 'test' does not exist on
 ==== entry.d.ts (0 errors) ====
     export declare var foo: number;
     
-==== maxDepthIncreased/root.ts (2 errors) ====
+==== maxDepthIncreased/root.ts (1 errors) ====
     import * as m1 from "m1";
     import * as m4 from "m4";
     
@@ -42,9 +41,6 @@ maxDepthIncreased/root.ts(8,13): error TS2339: Property 'test' does not exist on
     m1.f2.person.age = "10";    // Should error if loaded the .js files correctly
     ~~~~~~~~~~~~~~~~
 !!! error TS2322: Type 'string' is not assignable to type 'number'.
-    let r1 = m4.test.charAt(2); // Should error if correctly not using the .js file but using @types info
-                ~~~~
-!!! error TS2339: Property 'test' does not exist on type 'typeof "C:/src/TypeScript/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/node_modules/@...'.
     
     let r2 = 3 + m4.foo; // Should be OK if correctly using the @types .d.ts file
     

--- a/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/amd/nodeModulesMaxDepthIncreased.errors.txt
+++ b/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/amd/nodeModulesMaxDepthIncreased.errors.txt
@@ -1,4 +1,5 @@
-maxDepthIncreased/root.ts(4,1): error TS2322: Type 'string' is not assignable to type 'number'.
+maxDepthIncreased/root.ts(7,1): error TS2322: Type 'string' is not assignable to type 'number'.
+maxDepthIncreased/root.ts(8,13): error TS2339: Property 'test' does not exist on type 'typeof "C:/src/TypeScript/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/node_modules/@...'.
 
 
 ==== index.js (0 errors) ====
@@ -28,11 +29,22 @@ maxDepthIncreased/root.ts(4,1): error TS2322: Type 'string' is not assignable to
     
     exports.f2 = m2;
     
-==== maxDepthIncreased/root.ts (1 errors) ====
+==== entry.d.ts (0 errors) ====
+    export declare var foo: number;
+    
+==== maxDepthIncreased/root.ts (2 errors) ====
     import * as m1 from "m1";
+    import * as m4 from "m4";
+    
     m1.f1("test");
     m1.f2.a = 10;
-    m1.f2.person.age = "10"; // Error: Should be number
+    
+    m1.f2.person.age = "10";    // Should error if loaded the .js files correctly
     ~~~~~~~~~~~~~~~~
 !!! error TS2322: Type 'string' is not assignable to type 'number'.
+    let r1 = m4.test.charAt(2); // Should error if correctly not using the .js file but using @types info
+                ~~~~
+!!! error TS2339: Property 'test' does not exist on type 'typeof "C:/src/TypeScript/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/node_modules/@...'.
+    
+    let r2 = 3 + m4.foo; // Should be OK if correctly using the @types .d.ts file
     

--- a/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/amd/nodeModulesMaxDepthIncreased.json
+++ b/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/amd/nodeModulesMaxDepthIncreased.json
@@ -10,6 +10,7 @@
         "maxDepthIncreased/node_modules/m2/node_modules/m3/index.js",
         "maxDepthIncreased/node_modules/m2/entry.js",
         "maxDepthIncreased/node_modules/m1/index.js",
+        "maxDepthIncreased/node_modules/@types/m4/entry.d.ts",
         "maxDepthIncreased/root.ts"
     ],
     "emittedFiles": [

--- a/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/node/maxDepthIncreased/root.js
+++ b/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/node/maxDepthIncreased/root.js
@@ -1,5 +1,8 @@
 "use strict";
 var m1 = require("m1");
+var m4 = require("m4");
 m1.f1("test");
 m1.f2.a = 10;
-m1.f2.person.age = "10"; // Error: Should be number
+m1.f2.person.age = "10"; // Should error if loaded the .js files correctly
+var r1 = m4.test.charAt(2); // Should error if correctly not using the .js file but using @types info
+var r2 = 3 + m4.foo; // Should be OK if correctly using the @types .d.ts file

--- a/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/node/maxDepthIncreased/root.js
+++ b/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/node/maxDepthIncreased/root.js
@@ -4,5 +4,4 @@ var m4 = require("m4");
 m1.f1("test");
 m1.f2.a = 10;
 m1.f2.person.age = "10"; // Should error if loaded the .js files correctly
-var r1 = m4.test.charAt(2); // Should error if correctly not using the .js file but using @types info
 var r2 = 3 + m4.foo; // Should be OK if correctly using the @types .d.ts file

--- a/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/node/nodeModulesMaxDepthIncreased.errors.txt
+++ b/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/node/nodeModulesMaxDepthIncreased.errors.txt
@@ -1,5 +1,4 @@
 maxDepthIncreased/root.ts(7,1): error TS2322: Type 'string' is not assignable to type 'number'.
-maxDepthIncreased/root.ts(8,13): error TS2339: Property 'test' does not exist on type 'typeof "C:/src/TypeScript/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/node_modules/@...'.
 
 
 ==== index.js (0 errors) ====
@@ -32,7 +31,7 @@ maxDepthIncreased/root.ts(8,13): error TS2339: Property 'test' does not exist on
 ==== entry.d.ts (0 errors) ====
     export declare var foo: number;
     
-==== maxDepthIncreased/root.ts (2 errors) ====
+==== maxDepthIncreased/root.ts (1 errors) ====
     import * as m1 from "m1";
     import * as m4 from "m4";
     
@@ -42,9 +41,6 @@ maxDepthIncreased/root.ts(8,13): error TS2339: Property 'test' does not exist on
     m1.f2.person.age = "10";    // Should error if loaded the .js files correctly
     ~~~~~~~~~~~~~~~~
 !!! error TS2322: Type 'string' is not assignable to type 'number'.
-    let r1 = m4.test.charAt(2); // Should error if correctly not using the .js file but using @types info
-                ~~~~
-!!! error TS2339: Property 'test' does not exist on type 'typeof "C:/src/TypeScript/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/node_modules/@...'.
     
     let r2 = 3 + m4.foo; // Should be OK if correctly using the @types .d.ts file
     

--- a/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/node/nodeModulesMaxDepthIncreased.errors.txt
+++ b/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/node/nodeModulesMaxDepthIncreased.errors.txt
@@ -1,4 +1,5 @@
-maxDepthIncreased/root.ts(4,1): error TS2322: Type 'string' is not assignable to type 'number'.
+maxDepthIncreased/root.ts(7,1): error TS2322: Type 'string' is not assignable to type 'number'.
+maxDepthIncreased/root.ts(8,13): error TS2339: Property 'test' does not exist on type 'typeof "C:/src/TypeScript/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/node_modules/@...'.
 
 
 ==== index.js (0 errors) ====
@@ -28,11 +29,22 @@ maxDepthIncreased/root.ts(4,1): error TS2322: Type 'string' is not assignable to
     
     exports.f2 = m2;
     
-==== maxDepthIncreased/root.ts (1 errors) ====
+==== entry.d.ts (0 errors) ====
+    export declare var foo: number;
+    
+==== maxDepthIncreased/root.ts (2 errors) ====
     import * as m1 from "m1";
+    import * as m4 from "m4";
+    
     m1.f1("test");
     m1.f2.a = 10;
-    m1.f2.person.age = "10"; // Error: Should be number
+    
+    m1.f2.person.age = "10";    // Should error if loaded the .js files correctly
     ~~~~~~~~~~~~~~~~
 !!! error TS2322: Type 'string' is not assignable to type 'number'.
+    let r1 = m4.test.charAt(2); // Should error if correctly not using the .js file but using @types info
+                ~~~~
+!!! error TS2339: Property 'test' does not exist on type 'typeof "C:/src/TypeScript/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/node_modules/@...'.
+    
+    let r2 = 3 + m4.foo; // Should be OK if correctly using the @types .d.ts file
     

--- a/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/node/nodeModulesMaxDepthIncreased.json
+++ b/tests/baselines/reference/project/nodeModulesMaxDepthIncreased/node/nodeModulesMaxDepthIncreased.json
@@ -10,6 +10,7 @@
         "maxDepthIncreased/node_modules/m2/node_modules/m3/index.js",
         "maxDepthIncreased/node_modules/m2/entry.js",
         "maxDepthIncreased/node_modules/m1/index.js",
+        "maxDepthIncreased/node_modules/@types/m4/entry.d.ts",
         "maxDepthIncreased/root.ts"
     ],
     "emittedFiles": [

--- a/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/node_modules/@types/m4/entry.d.ts
+++ b/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/node_modules/@types/m4/entry.d.ts
@@ -1,0 +1,1 @@
+export declare var foo: number;

--- a/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/node_modules/@types/m4/package.json
+++ b/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/node_modules/@types/m4/package.json
@@ -1,0 +1,5 @@
+{
+  "types": "entry.d.ts",
+  "name": "m4",
+  "version": "1.0.0"
+}

--- a/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/node_modules/m4/entry.js
+++ b/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/node_modules/m4/entry.js
@@ -1,0 +1,1 @@
+exports.test = "hello, world";

--- a/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/node_modules/m4/package.json
+++ b/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/node_modules/m4/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "m4",
+  "version": "1.0.0",
+  "main": "entry.js"
+}

--- a/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/root.ts
+++ b/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/root.ts
@@ -1,4 +1,10 @@
 import * as m1 from "m1";
+import * as m4 from "m4";
+
 m1.f1("test");
 m1.f2.a = 10;
-m1.f2.person.age = "10"; // Error: Should be number
+
+m1.f2.person.age = "10";    // Should error if loaded the .js files correctly
+let r1 = m4.test.charAt(2); // Should error if correctly not using the .js file but using @types info
+
+let r2 = 3 + m4.foo; // Should be OK if correctly using the @types .d.ts file

--- a/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/root.ts
+++ b/tests/cases/projects/NodeModulesSearch/maxDepthIncreased/root.ts
@@ -5,6 +5,5 @@ m1.f1("test");
 m1.f2.a = 10;
 
 m1.f2.person.age = "10";    // Should error if loaded the .js files correctly
-let r1 = m4.test.charAt(2); // Should error if correctly not using the .js file but using @types info
 
 let r2 = 3 + m4.foo; // Should be OK if correctly using the @types .d.ts file


### PR DESCRIPTION
This is a port of #9421 which stops the compiling or source code loaded from a node_modules search (#6964) and also includes the fix for the bug of preferring JavaScript files from node_modules over `@types` packages when `allowJs` is set (#9427).