### PR TITLE
Fix #9458: exclude parameters starting with underscore from unusedParamter checks

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14554,7 +14554,10 @@ namespace ts {
                         const local = node.locals[key];
                         if (!local.isReferenced) {
                             if (local.valueDeclaration && local.valueDeclaration.kind === SyntaxKind.Parameter) {
-                                if (compilerOptions.noUnusedParameters && !isParameterPropertyDeclaration(<ParameterDeclaration>local.valueDeclaration)) {
+                                const parameter = <ParameterDeclaration>local.valueDeclaration;
+                                if (compilerOptions.noUnusedParameters &&
+                                    !isParameterPropertyDeclaration(parameter) &&
+                                    !parameterNameStartsWithUnderscore(parameter)) {
                                     error(local.valueDeclaration.name, Diagnostics._0_is_declared_but_never_used, local.name);
                                 }
                             }
@@ -14565,6 +14568,10 @@ namespace ts {
                     }
                 }
             }
+        }
+
+        function parameterNameStartsWithUnderscore(parameter: ParameterDeclaration) {
+            return parameter.name && parameter.name.kind === SyntaxKind.Identifier && (<Identifier>parameter.name).text.charCodeAt(0) === CharacterCodes._;
         }
 
         function checkUnusedClassMembers(node: ClassDeclaration | ClassExpression): void {

--- a/tests/baselines/reference/unusedParametersWithUnderscore.errors.txt
+++ b/tests/baselines/reference/unusedParametersWithUnderscore.errors.txt
@@ -1,0 +1,56 @@
+tests/cases/compiler/unusedParametersWithUnderscore.ts(2,12): error TS6133: 'a' is declared but never used.
+tests/cases/compiler/unusedParametersWithUnderscore.ts(2,19): error TS6133: 'c' is declared but never used.
+tests/cases/compiler/unusedParametersWithUnderscore.ts(2,27): error TS6133: 'd' is declared but never used.
+tests/cases/compiler/unusedParametersWithUnderscore.ts(2,29): error TS6133: 'e___' is declared but never used.
+tests/cases/compiler/unusedParametersWithUnderscore.ts(6,14): error TS6133: '_a' is declared but never used.
+tests/cases/compiler/unusedParametersWithUnderscore.ts(6,18): error TS6133: '___b' is declared but never used.
+tests/cases/compiler/unusedParametersWithUnderscore.ts(9,14): error TS6133: '_a' is declared but never used.
+tests/cases/compiler/unusedParametersWithUnderscore.ts(9,19): error TS6133: '___b' is declared but never used.
+tests/cases/compiler/unusedParametersWithUnderscore.ts(12,16): error TS6133: 'arg' is declared but never used.
+tests/cases/compiler/unusedParametersWithUnderscore.ts(18,13): error TS6133: 'arg' is declared but never used.
+
+
+==== tests/cases/compiler/unusedParametersWithUnderscore.ts (10 errors) ====
+    
+    function f(a, _b, c, ___, d,e___, _f) {
+               ~
+!!! error TS6133: 'a' is declared but never used.
+                      ~
+!!! error TS6133: 'c' is declared but never used.
+                              ~
+!!! error TS6133: 'd' is declared but never used.
+                                ~~~~
+!!! error TS6133: 'e___' is declared but never used.
+    }
+    
+    
+    function f2({_a, __b}) {
+                 ~~
+!!! error TS6133: '_a' is declared but never used.
+                     ~~~
+!!! error TS6133: '___b' is declared but never used.
+    }
+    
+    function f3([_a, ,__b]) {
+                 ~~
+!!! error TS6133: '_a' is declared but never used.
+                      ~~~
+!!! error TS6133: '___b' is declared but never used.
+    }
+    
+    function f4(...arg) {
+                   ~~~
+!!! error TS6133: 'arg' is declared but never used.
+    }
+    
+    function f5(..._arg) {
+    }
+    
+    function f6(arg?, _arg?) {
+                ~~~
+!!! error TS6133: 'arg' is declared but never used.
+    }
+    
+    var f7 = _ => undefined;
+    
+    var f8 = function (_) { };

--- a/tests/baselines/reference/unusedParametersWithUnderscore.js
+++ b/tests/baselines/reference/unusedParametersWithUnderscore.js
@@ -1,0 +1,50 @@
+//// [unusedParametersWithUnderscore.ts]
+
+function f(a, _b, c, ___, d,e___, _f) {
+}
+
+
+function f2({_a, __b}) {
+}
+
+function f3([_a, ,__b]) {
+}
+
+function f4(...arg) {
+}
+
+function f5(..._arg) {
+}
+
+function f6(arg?, _arg?) {
+}
+
+var f7 = _ => undefined;
+
+var f8 = function (_) { };
+
+//// [unusedParametersWithUnderscore.js]
+function f(a, _b, c, ___, d, e___, _f) {
+}
+function f2(_c) {
+    var _a = _c._a, __b = _c.__b;
+}
+function f3(_c) {
+    var _a = _c[0], __b = _c[2];
+}
+function f4() {
+    var arg = [];
+    for (var _i = 0; _i < arguments.length; _i++) {
+        arg[_i - 0] = arguments[_i];
+    }
+}
+function f5() {
+    var _arg = [];
+    for (var _i = 0; _i < arguments.length; _i++) {
+        _arg[_i - 0] = arguments[_i];
+    }
+}
+function f6(arg, _arg) {
+}
+var f7 = function (_) { return undefined; };
+var f8 = function (_) { };

--- a/tests/cases/compiler/unusedParametersWithUnderscore.ts
+++ b/tests/cases/compiler/unusedParametersWithUnderscore.ts
@@ -1,0 +1,25 @@
+//@noUnusedLocals:true
+//@noUnusedParameters:true
+
+function f(a, _b, c, ___, d,e___, _f) {
+}
+
+
+function f2({_a, __b}) {
+}
+
+function f3([_a, ,__b]) {
+}
+
+function f4(...arg) {
+}
+
+function f5(..._arg) {
+}
+
+function f6(arg?, _arg?) {
+}
+
+var f7 = _ => undefined;
+
+var f8 = function (_) { };


### PR DESCRIPTION
Fixes #9458
