### PR TITLE
Add performance framework from transforms branch

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -34,6 +34,7 @@ if (process.env.path !== undefined) {
 
 var compilerSources = [
     "core.ts",
+    "performance.ts",
     "sys.ts",
     "types.ts",
     "scanner.ts",
@@ -54,6 +55,7 @@ var compilerSources = [
 
 var servicesSources = [
     "core.ts",
+    "performance.ts",
     "sys.ts",
     "types.ts",
     "scanner.ts",

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -3,8 +3,6 @@
 
 /* @internal */
 namespace ts {
-    export let bindTime = 0;
-
     export const enum ModuleInstanceState {
         NonInstantiated = 0,
         Instantiated = 1,
@@ -91,9 +89,9 @@ namespace ts {
     const binder = createBinder();
 
     export function bindSourceFile(file: SourceFile, options: CompilerOptions) {
-        const start = new Date().getTime();
+        const start = performance.mark();
         binder(file, options);
-        bindTime += new Date().getTime() - start;
+        performance.measure("bindTime", start);
     }
 
     function createBinder(): (file: SourceFile, options: CompilerOptions) => void {

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -91,7 +91,7 @@ namespace ts {
     export function bindSourceFile(file: SourceFile, options: CompilerOptions) {
         const start = performance.mark();
         binder(file, options);
-        performance.measure("bindTime", start);
+        performance.measure("Bind", start);
     }
 
     function createBinder(): (file: SourceFile, options: CompilerOptions) => void {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17013,7 +17013,7 @@ namespace ts {
 
             checkSourceFileWorker(node);
 
-            performance.measure("checkTime", start);
+            performance.measure("Check", start);
         }
 
         // Fully type check a source file and collect the relevant diagnostics.

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15,8 +15,6 @@ namespace ts {
         return node.id;
     }
 
-    export let checkTime = 0;
-
     export function getSymbolId(symbol: Symbol): number {
         if (!symbol.id) {
             symbol.id = nextSymbolId;
@@ -17011,11 +17009,11 @@ namespace ts {
         }
 
         function checkSourceFile(node: SourceFile) {
-            const start = new Date().getTime();
+            const start = performance.mark();
 
             checkSourceFileWorker(node);
 
-            checkTime += new Date().getTime() - start;
+            performance.measure("checkTime", start);
         }
 
         // Fully type check a source file and collect the relevant diagnostics.

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -28,6 +28,10 @@ namespace ts {
             type: "boolean",
         },
         {
+            name: "extendedDiagnostics",
+            type: "boolean",
+        },
+        {
             name: "emitBOM",
             type: "boolean"
         },

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1,4 +1,6 @@
 /// <reference path="types.ts"/>
+/// <reference path="performance.ts" />
+
 
 /* @internal */
 namespace ts {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2,8 +2,6 @@
 /// <reference path="scanner.ts"/>
 
 namespace ts {
-    /* @internal */ export let parseTime = 0;
-
     let NodeConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
     let SourceFileConstructor: new (kind: SyntaxKind, pos: number, end: number) => Node;
 
@@ -413,10 +411,10 @@ namespace ts {
     }
 
     export function createSourceFile(fileName: string, sourceText: string, languageVersion: ScriptTarget, setParentNodes = false, scriptKind?: ScriptKind): SourceFile {
-        const start = new Date().getTime();
+        const start = performance.mark();
         const result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, scriptKind);
 
-        parseTime += new Date().getTime() - start;
+        performance.measure("parseTime", start);
         return result;
     }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -414,7 +414,7 @@ namespace ts {
         const start = performance.mark();
         const result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, scriptKind);
 
-        performance.measure("parseTime", start);
+        performance.measure("Parse", start);
         return result;
     }
 

--- a/src/compiler/performance.ts
+++ b/src/compiler/performance.ts
@@ -82,13 +82,13 @@ namespace ts {
         export function enable() {
             counters = { };
             measures = {
-                programTime: 0,
-                parseTime: 0,
-                bindTime: 0,
-                checkTime: 0,
-                emitTime: 0,
-                ioReadTime: 0,
-                ioWriteTime: 0,
+                "I/O Read": 0,
+                "I/O Write": 0,
+                "Program": 0,
+                "Parse": 0,
+                "Bind": 0,
+                "Check": 0,
+                "Emit": 0,
             };
 
             profilerEvent = typeof onProfilerEvent === "function" && onProfilerEvent.profiler === true

--- a/src/compiler/performance.ts
+++ b/src/compiler/performance.ts
@@ -94,7 +94,7 @@ namespace ts {
             profilerEvent = typeof onProfilerEvent === "function" && onProfilerEvent.profiler === true
                 ? onProfilerEvent
                 : undefined;
-            markInternal = performance && performance.now ? performance.now : Date.now ? Date.now : () => +(new Date());
+            markInternal = performance && performance.now ? performance.now : Date.now ? Date.now : () => new Date().getTime();
         }
 
         /** Disables (and clears) performance measurements for the compiler. */

--- a/src/compiler/performance.ts
+++ b/src/compiler/performance.ts
@@ -1,0 +1,98 @@
+/*@internal*/
+namespace ts {
+    /** Performance measurements for the compiler. */
+    export namespace performance {
+        declare const onProfilerEvent: { (markName: string): void; profiler: boolean; };
+        declare const performance: { now?(): number } | undefined;
+        let profilerEvent: (markName: string) => void;
+        let markInternal: () => number;
+        let counters: Map<number>;
+        let measures: Map<number>;
+
+        /**
+         * Emit a performance event if ts-profiler is connected. This is primarily used
+         * to generate heap snapshots.
+         *
+         * @param eventName A name for the event.
+         */
+        export function emit(eventName: string) {
+            if (profilerEvent) {
+                profilerEvent(eventName);
+            }
+        }
+
+        /**
+         * Increments a counter with the specified name.
+         *
+         * @param counterName The name of the counter.
+         */
+        export function increment(counterName: string) {
+            if (counters) {
+                counters[counterName] = (getProperty(counters, counterName) || 0) + 1;
+            }
+        }
+
+        /**
+         * Gets the value of the counter with the specified name.
+         *
+         * @param counterName The name of the counter.
+         */
+        export function getCount(counterName: string) {
+            return counters && getProperty(counters, counterName) || 0;
+        }
+
+        /**
+         * Marks the start of a performance measurement.
+         */
+        export function mark() {
+            return measures ? markInternal() : 0;
+        }
+
+        /**
+         * Adds a performance measurement with the specified name.
+         *
+         * @param measureName The name of the performance measurement.
+         * @param marker The timestamp of the starting mark.
+         */
+        export function measure(measureName: string, marker: number) {
+            if (measures) {
+                measures[measureName] = (getProperty(measures, measureName) || 0) + (Date.now() - marker);
+            }
+        }
+
+        /**
+         * Gets the total duration of all measurements with the supplied name.
+         *
+         * @param measureName The name of the measure whose durations should be accumulated.
+         */
+        export function getDuration(measureName: string) {
+            return measures && getProperty(measures, measureName) || 0;
+        }
+
+        /** Enables (and resets) performance measurements for the compiler. */
+        export function enable() {
+            counters = { };
+            measures = {
+                programTime: 0,
+                parseTime: 0,
+                bindTime: 0,
+                checkTime: 0,
+                emitTime: 0,
+                ioReadTime: 0,
+                ioWriteTime: 0,
+            };
+
+            profilerEvent = typeof onProfilerEvent === "function" && onProfilerEvent.profiler === true
+                ? onProfilerEvent
+                : undefined;
+            markInternal = performance && performance.now ? performance.now : Date.now ? Date.now : () => +(new Date());
+        }
+
+        /** Disables (and clears) performance measurements for the compiler. */
+        export function disable() {
+            counters = undefined;
+            measures = undefined;
+            profilerEvent = undefined;
+        }
+    }
+}

--- a/src/compiler/performance.ts
+++ b/src/compiler/performance.ts
@@ -61,6 +61,15 @@ namespace ts {
         }
 
         /**
+         * Iterate over each measure, performing some action
+         * 
+         * @param cb The action to perform for each measure
+         */
+        export function forEachMeasure(cb: (measureName: string, duration: number) => void) {
+            return forEachKey(measures, key => cb(key, measures[key]));
+        }
+
+        /**
          * Gets the total duration of all measurements with the supplied name.
          *
          * @param measureName The name of the measure whose durations should be accumulated.

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -3,11 +3,6 @@
 /// <reference path="core.ts" />
 
 namespace ts {
-    /* @internal */ export let programTime = 0;
-    /* @internal */ export let emitTime = 0;
-    /* @internal */ export let ioReadTime = 0;
-    /* @internal */ export let ioWriteTime = 0;
-
     /** The version of the TypeScript compiler release */
     export const version = "2.0.0";
 
@@ -871,9 +866,9 @@ namespace ts {
         function getSourceFile(fileName: string, languageVersion: ScriptTarget, onError?: (message: string) => void): SourceFile {
             let text: string;
             try {
-                const start = new Date().getTime();
+                const start = performance.mark();
                 text = sys.readFile(fileName, options.charset);
-                ioReadTime += new Date().getTime() - start;
+                performance.measure("ioReadTime", start);
             }
             catch (e) {
                 if (onError) {
@@ -940,7 +935,7 @@ namespace ts {
 
         function writeFile(fileName: string, data: string, writeByteOrderMark: boolean, onError?: (message: string) => void) {
             try {
-                const start = new Date().getTime();
+                const start = performance.mark();
                 ensureDirectoriesExist(getDirectoryPath(normalizePath(fileName)));
 
                 if (isWatchSet(options) && sys.createHash && sys.getModifiedTime) {
@@ -950,7 +945,7 @@ namespace ts {
                     sys.writeFile(fileName, data, writeByteOrderMark);
                 }
 
-                ioWriteTime += new Date().getTime() - start;
+                performance.measure("ioWriteTime", start);
             }
             catch (e) {
                 if (onError) {
@@ -1104,7 +1099,7 @@ namespace ts {
         // Track source files that are JavaScript files found by searching under node_modules, as these shouldn't be compiled.
         const sourceFilesFoundSearchingNodeModules: Map<boolean> = {};
 
-        const start = new Date().getTime();
+        const start = performance.mark();
 
         host = host || createCompilerHost(options);
 
@@ -1203,7 +1198,7 @@ namespace ts {
 
         verifyCompilerOptions();
 
-        programTime += new Date().getTime() - start;
+        performance.measure("programTime", start);
 
         return program;
 
@@ -1446,14 +1441,14 @@ namespace ts {
             // checked is to not pass the file to getEmitResolver.
             const emitResolver = getDiagnosticsProducingTypeChecker().getEmitResolver((options.outFile || options.out) ? undefined : sourceFile);
 
-            const start = new Date().getTime();
+            const start = performance.mark();
 
             const emitResult = emitFiles(
                 emitResolver,
                 getEmitHost(writeFileCallback),
                 sourceFile);
 
-            emitTime += new Date().getTime() - start;
+            performance.measure("emitTime", start);
             return emitResult;
         }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -868,7 +868,7 @@ namespace ts {
             try {
                 const start = performance.mark();
                 text = sys.readFile(fileName, options.charset);
-                performance.measure("ioReadTime", start);
+                performance.measure("I/O Read", start);
             }
             catch (e) {
                 if (onError) {
@@ -945,7 +945,7 @@ namespace ts {
                     sys.writeFile(fileName, data, writeByteOrderMark);
                 }
 
-                performance.measure("ioWriteTime", start);
+                performance.measure("I/O Write", start);
             }
             catch (e) {
                 if (onError) {
@@ -1198,7 +1198,7 @@ namespace ts {
 
         verifyCompilerOptions();
 
-        performance.measure("programTime", start);
+        performance.measure("Program", start);
 
         return program;
 
@@ -1448,7 +1448,7 @@ namespace ts {
                 getEmitHost(writeFileCallback),
                 sourceFile);
 
-            performance.measure("emitTime", start);
+            performance.measure("Emit", start);
             return emitResult;
         }
 

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -240,6 +240,8 @@ namespace ts {
                 return;
             }
 
+            const start = performance.mark();
+
             const sourceLinePos = getLineAndCharacterOfPosition(currentSourceFile, pos);
 
             // Convert the location to be one-based.
@@ -279,6 +281,8 @@ namespace ts {
             }
 
             updateLastEncodedAndRecordedSpans();
+
+            performance.measure("Source Map", start);
         }
 
         function getStartPos(range: TextRange) {

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -579,6 +579,10 @@ namespace ts {
                 reportStatisticalValue("Memory used", Math.round(memoryUsed / 1000) + "K");
             }
 
+            const programTime = performance.getDuration("Program");
+            const bindTime = performance.getDuration("Bind");
+            const checkTime = performance.getDuration("Check");
+            const emitTime = performance.getDuration("Emit");
             if (compilerOptions.extendedDiagnostics) {
                 performance.forEachMeasure((name, duration) => reportTimeStatistic(`${name} time`, duration));
             }
@@ -589,16 +593,12 @@ namespace ts {
                 // emit time includes I/O write time. We preserve this behavior so we can accurately compare times.
                 reportTimeStatistic("I/O read", performance.getDuration("I/O Read"));
                 reportTimeStatistic("I/O write", performance.getDuration("I/O Write"));
-                const programTime = performance.getDuration("Program");
-                const bindTime = performance.getDuration("Bind");
-                const checkTime = performance.getDuration("Check");
-                const emitTime = performance.getDuration("Emit");
                 reportTimeStatistic("Parse time", programTime);
                 reportTimeStatistic("Bind time", bindTime);
                 reportTimeStatistic("Check time", checkTime);
                 reportTimeStatistic("Emit time", emitTime);
-                reportTimeStatistic("Total time", programTime + bindTime + checkTime + emitTime);
             }
+            reportTimeStatistic("Total time", programTime + bindTime + checkTime + emitTime);
 
             performance.disable();
         }

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -554,12 +554,7 @@ namespace ts {
     }
 
     function compile(fileNames: string[], compilerOptions: CompilerOptions, compilerHost: CompilerHost) {
-        ioReadTime = 0;
-        ioWriteTime = 0;
-        programTime = 0;
-        bindTime = 0;
-        checkTime = 0;
-        emitTime = 0;
+        if (compilerOptions.diagnostics) performance.enable();
 
         const program = createProgram(fileNames, compilerOptions, compilerHost);
         const exitStatus = compileProgram();
@@ -587,13 +582,13 @@ namespace ts {
             // Note: To match the behavior of previous versions of the compiler, the reported parse time includes
             // I/O read time and processing time for triple-slash references and module imports, and the reported
             // emit time includes I/O write time. We preserve this behavior so we can accurately compare times.
-            reportTimeStatistic("I/O read", ioReadTime);
-            reportTimeStatistic("I/O write", ioWriteTime);
-            reportTimeStatistic("Parse time", programTime);
-            reportTimeStatistic("Bind time", bindTime);
-            reportTimeStatistic("Check time", checkTime);
-            reportTimeStatistic("Emit time", emitTime);
-            reportTimeStatistic("Total time", programTime + bindTime + checkTime + emitTime);
+            reportTimeStatistic("I/O read", performance.getDuration("ioReadTime"));
+            reportTimeStatistic("I/O write", performance.getDuration("ioWriteTime"));
+            reportTimeStatistic("Parse time", performance.getDuration("parseTime"));
+            reportTimeStatistic("Bind time", performance.getDuration("bindTime"));
+            reportTimeStatistic("Check time", performance.getDuration("checkTime"));
+            reportTimeStatistic("Emit time", performance.getDuration("emitTime"));
+            reportTimeStatistic("Total time", performance.getDuration("programTime") + performance.getDuration("bindTime") + performance.getDuration("checkTime") + performance.getDuration("emitTime"));
         }
 
         return { program, exitStatus };

--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -10,6 +10,7 @@
     },
     "files": [
         "core.ts",
+        "performance.ts",
         "sys.ts",
         "types.ts",
         "scanner.ts",

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2535,6 +2535,7 @@ namespace ts {
         declaration?: boolean;
         declarationDir?: string;
         /* @internal */ diagnostics?: boolean;
+        /* @internal */ extendedDiagnostics?: boolean;
         disableSizeLimit?: boolean;
         emitBOM?: boolean;
         emitDecoratorMetadata?: boolean;


### PR DESCRIPTION
@rbuckton 
@mhegazy 

I was working on suspiciously similar code for doing extension profiling in #9038 - by splitting the performance tools framework from either PR, we can merge them in more quickly and start using a common framework across all PRs.

Notable differences from the original code in the transforms branch:
- When the new `extendedDiagnostics` argument is supplied, all recorded perf buckets are reported under the friendly name they use as their key (unlike before, where they used a codename and had to be explicitly printed). This is very useful since extensions are likely to add extra perf buckets on the fly (and we have no idea what they'll be named, but would still like to report them in the summary).
- The `counter` and `emit` code is presently unused - @rbuckton uses them in profiling and inspecting transformations in his branch, but I don't yet have a need to insert profiling events or replace counters elsewhere in our codebase (and I may use them for extensions, too).
- The function used to `mark` internally is now chosen as one of `performance.now`, `Date.now`, and `() => new Date().getTime()` (in that order) - this way a higher resolution/performance marker is used when available, but falls back to a universal option if they are unavailable. (And as @rbuckton explained the other day, it doesn't try to use process.hrtime since that would allocate arrays.)
- It's in its own file, rather than in `core.ts` - it's an isolated set of work and is understandable/reusable. IMO, it makes sense for it to be its own unit.