### PR TITLE
Fix #9531: account for `async` as an contextual keyword when parsing export assignments

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1184,7 +1184,8 @@ namespace ts {
 
         function nextTokenIsClassOrFunctionOrAsync(): boolean {
             nextToken();
-            return token === SyntaxKind.ClassKeyword || token === SyntaxKind.FunctionKeyword || token === SyntaxKind.AsyncKeyword;
+            return token === SyntaxKind.ClassKeyword || token === SyntaxKind.FunctionKeyword ||
+                (token === SyntaxKind.AsyncKeyword && lookAhead(nextTokenIsFunctionKeywordOnSameLine));
         }
 
         // True if positioned at the start of a list element

--- a/tests/baselines/reference/exportDefaultAsyncFunction2.js
+++ b/tests/baselines/reference/exportDefaultAsyncFunction2.js
@@ -1,0 +1,56 @@
+//// [tests/cases/compiler/exportDefaultAsyncFunction2.ts] ////
+
+//// [asyncawait.ts]
+
+export function async<T>(...args: any[]): any { }
+export function await(...args: any[]): any { }
+
+//// [a.ts]
+import { async, await } from 'asyncawait';
+export default async(() => await(Promise.resolve(1)));
+
+//// [b.ts]
+export default async () => { return 0; };
+
+//// [c.ts]
+import { async, await } from 'asyncawait';
+export default async<number>();
+
+//// [d.ts]
+import { async, await } from 'asyncawait';
+
+export default async;
+
+//// [e.ts]
+import { async, await } from 'asyncawait';
+
+export default async
+
+export function foo() { }
+
+//// [asyncawait.js]
+export function async(...args) { }
+export function await(...args) { }
+//// [a.js]
+import { async, await } from 'asyncawait';
+export default async(() => await(Promise.resolve(1)));
+//// [b.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments)).next());
+    });
+};
+export default () => __awaiter(this, void 0, void 0, function* () { return 0; });
+//// [c.js]
+import { async } from 'asyncawait';
+export default async();
+//// [d.js]
+import { async } from 'asyncawait';
+export default async;
+//// [e.js]
+import { async } from 'asyncawait';
+export default async;
+export function foo() { }

--- a/tests/baselines/reference/exportDefaultAsyncFunction2.symbols
+++ b/tests/baselines/reference/exportDefaultAsyncFunction2.symbols
@@ -1,0 +1,53 @@
+=== tests/cases/compiler/asyncawait.ts ===
+
+export function async<T>(...args: any[]): any { }
+>async : Symbol(async, Decl(asyncawait.ts, 0, 0))
+>T : Symbol(T, Decl(asyncawait.ts, 1, 22))
+>args : Symbol(args, Decl(asyncawait.ts, 1, 25))
+
+export function await(...args: any[]): any { }
+>await : Symbol(await, Decl(asyncawait.ts, 1, 49))
+>args : Symbol(args, Decl(asyncawait.ts, 2, 22))
+
+=== tests/cases/compiler/a.ts ===
+import { async, await } from 'asyncawait';
+>async : Symbol(async, Decl(a.ts, 0, 8))
+>await : Symbol(await, Decl(a.ts, 0, 15))
+
+export default async(() => await(Promise.resolve(1)));
+>async : Symbol(async, Decl(a.ts, 0, 8))
+>await : Symbol(await, Decl(a.ts, 0, 15))
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+=== tests/cases/compiler/b.ts ===
+export default async () => { return 0; };
+No type information for this code.
+No type information for this code.=== tests/cases/compiler/c.ts ===
+import { async, await } from 'asyncawait';
+>async : Symbol(async, Decl(c.ts, 0, 8))
+>await : Symbol(await, Decl(c.ts, 0, 15))
+
+export default async<number>();
+>async : Symbol(async, Decl(c.ts, 0, 8))
+
+=== tests/cases/compiler/d.ts ===
+import { async, await } from 'asyncawait';
+>async : Symbol(async, Decl(d.ts, 0, 8))
+>await : Symbol(await, Decl(d.ts, 0, 15))
+
+export default async;
+>async : Symbol(async, Decl(d.ts, 0, 8))
+
+=== tests/cases/compiler/e.ts ===
+import { async, await } from 'asyncawait';
+>async : Symbol(async, Decl(e.ts, 0, 8))
+>await : Symbol(await, Decl(e.ts, 0, 15))
+
+export default async
+>async : Symbol(async, Decl(e.ts, 0, 8))
+
+export function foo() { }
+>foo : Symbol(foo, Decl(e.ts, 2, 20))
+

--- a/tests/baselines/reference/exportDefaultAsyncFunction2.types
+++ b/tests/baselines/reference/exportDefaultAsyncFunction2.types
@@ -1,0 +1,61 @@
+=== tests/cases/compiler/asyncawait.ts ===
+
+export function async<T>(...args: any[]): any { }
+>async : <T>(...args: any[]) => any
+>T : T
+>args : any[]
+
+export function await(...args: any[]): any { }
+>await : (...args: any[]) => any
+>args : any[]
+
+=== tests/cases/compiler/a.ts ===
+import { async, await } from 'asyncawait';
+>async : <T>(...args: any[]) => any
+>await : (...args: any[]) => any
+
+export default async(() => await(Promise.resolve(1)));
+>async(() => await(Promise.resolve(1))) : any
+>async : <T>(...args: any[]) => any
+>() => await(Promise.resolve(1)) : () => any
+>await(Promise.resolve(1)) : any
+>await : (...args: any[]) => any
+>Promise.resolve(1) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>1 : number
+
+=== tests/cases/compiler/b.ts ===
+export default async () => { return 0; };
+>async () => { return 0; } : () => Promise<number>
+>0 : number
+
+=== tests/cases/compiler/c.ts ===
+import { async, await } from 'asyncawait';
+>async : <T>(...args: any[]) => any
+>await : (...args: any[]) => any
+
+export default async<number>();
+>async<number>() : any
+>async : <T>(...args: any[]) => any
+
+=== tests/cases/compiler/d.ts ===
+import { async, await } from 'asyncawait';
+>async : <T>(...args: any[]) => any
+>await : (...args: any[]) => any
+
+export default async;
+>async : <T>(...args: any[]) => any
+
+=== tests/cases/compiler/e.ts ===
+import { async, await } from 'asyncawait';
+>async : <T>(...args: any[]) => any
+>await : (...args: any[]) => any
+
+export default async
+>async : <T>(...args: any[]) => any
+
+export function foo() { }
+>foo : () => void
+

--- a/tests/cases/compiler/exportDefaultAsyncFunction2.ts
+++ b/tests/cases/compiler/exportDefaultAsyncFunction2.ts
@@ -1,0 +1,28 @@
+// @target: es6
+
+// @filename: asyncawait.ts
+export function async<T>(...args: any[]): any { }
+export function await(...args: any[]): any { }
+
+// @filename: a.ts
+import { async, await } from 'asyncawait';
+export default async(() => await(Promise.resolve(1)));
+
+// @filename: b.ts
+export default async () => { return 0; };
+
+// @filename: c.ts
+import { async, await } from 'asyncawait';
+export default async<number>();
+
+// @filename: d.ts
+import { async, await } from 'asyncawait';
+
+export default async;
+
+// @filename: e.ts
+import { async, await } from 'asyncawait';
+
+export default async
+
+export function foo() { }


### PR DESCRIPTION
Fixes #9531

