### PR TITLE
Swap q from a reference to an import

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -20,8 +20,7 @@ import * as insert from "gulp-insert";
 import * as sourcemaps from "gulp-sourcemaps";
 import Q = require("q");
 declare global {
-    // This is silly. We include Q because orchestrator (a part of gulp) depends on it, but its not included.
-    // `del` further depends on `Promise` (and is also not included), so we just, patch the global scope's Promise to Q's
+    // `del` further depends on `Promise` (and is also not included), so we just, patch the global scope's Promise to Q's (which we already include in our deps because gulp depends on it)
     type Promise<T> = Q.Promise<T>;
 }
 import del = require("del");

--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -1,6 +1,4 @@
 /// <reference path="scripts/types/ambient.d.ts" />
-/// <reference types="q" />
-
 import * as cp from "child_process";
 import * as path from "path";
 import * as fs from "fs";
@@ -20,6 +18,7 @@ declare module "gulp-typescript" {
 }
 import * as insert from "gulp-insert";
 import * as sourcemaps from "gulp-sourcemaps";
+import Q = require("q");
 declare global {
     // This is silly. We include Q because orchestrator (a part of gulp) depends on it, but its not included.
     // `del` further depends on `Promise` (and is also not included), so we just, patch the global scope's Promise to Q's


### PR DESCRIPTION
Fixes #9553

`q` has been updated to be properly importable, so our gulpfile was broken under the latest types versions.