### PR TITLE
Fix #9550: exclude 'this' type parameters from unusedParameters checks.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14563,6 +14563,7 @@ namespace ts {
                                 const parameter = <ParameterDeclaration>local.valueDeclaration;
                                 if (compilerOptions.noUnusedParameters &&
                                     !isParameterPropertyDeclaration(parameter) &&
+                                    !parameterIsThisKeyword(parameter) &&
                                     !parameterNameStartsWithUnderscore(parameter)) {
                                     error(local.valueDeclaration.name, Diagnostics._0_is_declared_but_never_used, local.name);
                                 }
@@ -14574,6 +14575,10 @@ namespace ts {
                     }
                 }
             }
+        }
+
+        function parameterIsThisKeyword(parameter: ParameterDeclaration) {
+            return parameter.name && (<Identifier>parameter.name).originalKeywordKind === SyntaxKind.ThisKeyword;
         }
 
         function parameterNameStartsWithUnderscore(parameter: ParameterDeclaration) {

--- a/tests/baselines/reference/unusedParametersThis.js
+++ b/tests/baselines/reference/unusedParametersThis.js
@@ -1,0 +1,67 @@
+//// [unusedParametersThis.ts]
+
+class A {
+    public a: number;
+
+    public method(this: this): number {
+        return this.a;
+    }
+
+    public method2(this: A): number {
+        return this.a;
+    }
+
+    public method3(this: this): number {
+        var fn = () => this.a;
+        return fn();
+    }
+
+    public method4(this: A): number {
+        var fn = () => this.a;
+        return fn();
+    }
+
+    static staticMethod(this: A): number {
+        return this.a;
+    }
+}
+
+function f(this: A): number {
+    return this.a
+}
+
+var f2 = function f2(this: A): number {
+    return this.a;
+};
+
+//// [unusedParametersThis.js]
+var A = (function () {
+    function A() {
+    }
+    A.prototype.method = function () {
+        return this.a;
+    };
+    A.prototype.method2 = function () {
+        return this.a;
+    };
+    A.prototype.method3 = function () {
+        var _this = this;
+        var fn = function () { return _this.a; };
+        return fn();
+    };
+    A.prototype.method4 = function () {
+        var _this = this;
+        var fn = function () { return _this.a; };
+        return fn();
+    };
+    A.staticMethod = function () {
+        return this.a;
+    };
+    return A;
+}());
+function f() {
+    return this.a;
+}
+var f2 = function f2() {
+    return this.a;
+};

--- a/tests/baselines/reference/unusedParametersThis.symbols
+++ b/tests/baselines/reference/unusedParametersThis.symbols
@@ -1,0 +1,93 @@
+=== tests/cases/compiler/unusedParametersThis.ts ===
+
+class A {
+>A : Symbol(A, Decl(unusedParametersThis.ts, 0, 0))
+
+    public a: number;
+>a : Symbol(A.a, Decl(unusedParametersThis.ts, 1, 9))
+
+    public method(this: this): number {
+>method : Symbol(A.method, Decl(unusedParametersThis.ts, 2, 21))
+>this : Symbol(this, Decl(unusedParametersThis.ts, 4, 18))
+
+        return this.a;
+>this.a : Symbol(A.a, Decl(unusedParametersThis.ts, 1, 9))
+>this : Symbol(this, Decl(unusedParametersThis.ts, 4, 18))
+>a : Symbol(A.a, Decl(unusedParametersThis.ts, 1, 9))
+    }
+
+    public method2(this: A): number {
+>method2 : Symbol(A.method2, Decl(unusedParametersThis.ts, 6, 5))
+>this : Symbol(this, Decl(unusedParametersThis.ts, 8, 19))
+>A : Symbol(A, Decl(unusedParametersThis.ts, 0, 0))
+
+        return this.a;
+>this.a : Symbol(A.a, Decl(unusedParametersThis.ts, 1, 9))
+>this : Symbol(this, Decl(unusedParametersThis.ts, 8, 19))
+>a : Symbol(A.a, Decl(unusedParametersThis.ts, 1, 9))
+    }
+
+    public method3(this: this): number {
+>method3 : Symbol(A.method3, Decl(unusedParametersThis.ts, 10, 5))
+>this : Symbol(this, Decl(unusedParametersThis.ts, 12, 19))
+
+        var fn = () => this.a;
+>fn : Symbol(fn, Decl(unusedParametersThis.ts, 13, 11))
+>this.a : Symbol(A.a, Decl(unusedParametersThis.ts, 1, 9))
+>this : Symbol(this, Decl(unusedParametersThis.ts, 12, 19))
+>a : Symbol(A.a, Decl(unusedParametersThis.ts, 1, 9))
+
+        return fn();
+>fn : Symbol(fn, Decl(unusedParametersThis.ts, 13, 11))
+    }
+
+    public method4(this: A): number {
+>method4 : Symbol(A.method4, Decl(unusedParametersThis.ts, 15, 5))
+>this : Symbol(this, Decl(unusedParametersThis.ts, 17, 19))
+>A : Symbol(A, Decl(unusedParametersThis.ts, 0, 0))
+
+        var fn = () => this.a;
+>fn : Symbol(fn, Decl(unusedParametersThis.ts, 18, 11))
+>this.a : Symbol(A.a, Decl(unusedParametersThis.ts, 1, 9))
+>this : Symbol(this, Decl(unusedParametersThis.ts, 17, 19))
+>a : Symbol(A.a, Decl(unusedParametersThis.ts, 1, 9))
+
+        return fn();
+>fn : Symbol(fn, Decl(unusedParametersThis.ts, 18, 11))
+    }
+
+    static staticMethod(this: A): number {
+>staticMethod : Symbol(A.staticMethod, Decl(unusedParametersThis.ts, 20, 5))
+>this : Symbol(this, Decl(unusedParametersThis.ts, 22, 24))
+>A : Symbol(A, Decl(unusedParametersThis.ts, 0, 0))
+
+        return this.a;
+>this.a : Symbol(A.a, Decl(unusedParametersThis.ts, 1, 9))
+>this : Symbol(this, Decl(unusedParametersThis.ts, 22, 24))
+>a : Symbol(A.a, Decl(unusedParametersThis.ts, 1, 9))
+    }
+}
+
+function f(this: A): number {
+>f : Symbol(f, Decl(unusedParametersThis.ts, 25, 1))
+>this : Symbol(this, Decl(unusedParametersThis.ts, 27, 11))
+>A : Symbol(A, Decl(unusedParametersThis.ts, 0, 0))
+
+    return this.a
+>this.a : Symbol(A.a, Decl(unusedParametersThis.ts, 1, 9))
+>this : Symbol(this, Decl(unusedParametersThis.ts, 27, 11))
+>a : Symbol(A.a, Decl(unusedParametersThis.ts, 1, 9))
+}
+
+var f2 = function f2(this: A): number {
+>f2 : Symbol(f2, Decl(unusedParametersThis.ts, 31, 3))
+>f2 : Symbol(f2, Decl(unusedParametersThis.ts, 31, 8))
+>this : Symbol(this, Decl(unusedParametersThis.ts, 31, 21))
+>A : Symbol(A, Decl(unusedParametersThis.ts, 0, 0))
+
+    return this.a;
+>this.a : Symbol(A.a, Decl(unusedParametersThis.ts, 1, 9))
+>this : Symbol(this, Decl(unusedParametersThis.ts, 31, 21))
+>a : Symbol(A.a, Decl(unusedParametersThis.ts, 1, 9))
+
+};

--- a/tests/baselines/reference/unusedParametersThis.types
+++ b/tests/baselines/reference/unusedParametersThis.types
@@ -1,0 +1,98 @@
+=== tests/cases/compiler/unusedParametersThis.ts ===
+
+class A {
+>A : A
+
+    public a: number;
+>a : number
+
+    public method(this: this): number {
+>method : (this: this) => number
+>this : this
+
+        return this.a;
+>this.a : number
+>this : this
+>a : number
+    }
+
+    public method2(this: A): number {
+>method2 : (this: A) => number
+>this : A
+>A : A
+
+        return this.a;
+>this.a : number
+>this : A
+>a : number
+    }
+
+    public method3(this: this): number {
+>method3 : (this: this) => number
+>this : this
+
+        var fn = () => this.a;
+>fn : () => number
+>() => this.a : () => number
+>this.a : number
+>this : this
+>a : number
+
+        return fn();
+>fn() : number
+>fn : () => number
+    }
+
+    public method4(this: A): number {
+>method4 : (this: A) => number
+>this : A
+>A : A
+
+        var fn = () => this.a;
+>fn : () => number
+>() => this.a : () => number
+>this.a : number
+>this : A
+>a : number
+
+        return fn();
+>fn() : number
+>fn : () => number
+    }
+
+    static staticMethod(this: A): number {
+>staticMethod : (this: A) => number
+>this : A
+>A : A
+
+        return this.a;
+>this.a : number
+>this : A
+>a : number
+    }
+}
+
+function f(this: A): number {
+>f : (this: A) => number
+>this : A
+>A : A
+
+    return this.a
+>this.a : number
+>this : A
+>a : number
+}
+
+var f2 = function f2(this: A): number {
+>f2 : (this: A) => number
+>function f2(this: A): number {    return this.a;} : (this: A) => number
+>f2 : (this: A) => number
+>this : A
+>A : A
+
+    return this.a;
+>this.a : number
+>this : A
+>a : number
+
+};

--- a/tests/cases/compiler/unusedParametersThis.ts
+++ b/tests/cases/compiler/unusedParametersThis.ts
@@ -1,0 +1,37 @@
+//@noImplicitThis:true
+//@noUnusedLocals:true
+//@noUnusedParameters:true
+
+class A {
+    public a: number;
+
+    public method(this: this): number {
+        return this.a;
+    }
+
+    public method2(this: A): number {
+        return this.a;
+    }
+
+    public method3(this: this): number {
+        var fn = () => this.a;
+        return fn();
+    }
+
+    public method4(this: A): number {
+        var fn = () => this.a;
+        return fn();
+    }
+
+    static staticMethod(this: A): number {
+        return this.a;
+    }
+}
+
+function f(this: A): number {
+    return this.a
+}
+
+var f2 = function f2(this: A): number {
+    return this.a;
+};


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fix #9550

