### PR TITLE
Fix: Namespace import doesn't work for modules exported with 'export=…

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1043,7 +1043,7 @@ namespace ts {
 
         function getTargetOfNamespaceImport(node: NamespaceImport): Symbol {
             const moduleSpecifier = (<ImportDeclaration>node.parent.parent).moduleSpecifier;
-            return resolveESModuleSymbol(resolveExternalModuleName(node, moduleSpecifier), moduleSpecifier);
+            return resolveExternalModuleSymbol(resolveExternalModuleName(node, moduleSpecifier));
         }
 
         // This function creates a synthetic symbol that combines the value side of one symbol with the
@@ -1097,7 +1097,7 @@ namespace ts {
 
         function getExternalModuleMember(node: ImportDeclaration | ExportDeclaration, specifier: ImportOrExportSpecifier): Symbol {
             const moduleSymbol = resolveExternalModuleName(node, node.moduleSpecifier);
-            const targetSymbol = resolveESModuleSymbol(moduleSymbol, node.moduleSpecifier);
+            const targetSymbol = resolveExternalModuleSymbol(moduleSymbol);
             if (targetSymbol) {
                 const name = specifier.propertyName || specifier.name;
                 if (name.text) {
@@ -1145,6 +1145,7 @@ namespace ts {
             return resolveEntityName(<Identifier>node.expression, SymbolFlags.Value | SymbolFlags.Type | SymbolFlags.Namespace);
         }
 
+        
         function getTargetOfAliasDeclaration(node: Declaration): Symbol {
             switch (node.kind) {
                 case SyntaxKind.ImportEqualsDeclaration:
@@ -1353,18 +1354,6 @@ namespace ts {
         // and an external module with no 'export =' declaration resolves to the module itself.
         function resolveExternalModuleSymbol(moduleSymbol: Symbol): Symbol {
             return moduleSymbol && getMergedSymbol(resolveSymbol(moduleSymbol.exports["export="])) || moduleSymbol;
-        }
-
-        // An external module with an 'export =' declaration may be referenced as an ES6 module provided the 'export ='
-        // references a symbol that is at least declared as a module or a variable. The target of the 'export =' may
-        // combine other declarations with the module or variable (e.g. a class/module, function/module, interface/variable).
-        function resolveESModuleSymbol(moduleSymbol: Symbol, moduleReferenceExpression: Expression): Symbol {
-            let symbol = resolveExternalModuleSymbol(moduleSymbol);
-            if (symbol && !(symbol.flags & (SymbolFlags.Module | SymbolFlags.Variable))) {
-                error(moduleReferenceExpression, Diagnostics.Module_0_resolves_to_a_non_module_entity_and_cannot_be_imported_using_this_construct, symbolToString(moduleSymbol));
-                symbol = undefined;
-            }
-            return symbol;
         }
 
         function hasExportAssignmentSymbol(moduleSymbol: Symbol): boolean {

--- a/tests/baselines/reference/es6ExportEqualsInterop.errors.txt
+++ b/tests/baselines/reference/es6ExportEqualsInterop.errors.txt
@@ -11,15 +11,15 @@ tests/cases/compiler/main.ts(33,8): error TS1192: Module '"function"' has no def
 tests/cases/compiler/main.ts(34,8): error TS1192: Module '"function-module"' has no default export.
 tests/cases/compiler/main.ts(35,8): error TS1192: Module '"class"' has no default export.
 tests/cases/compiler/main.ts(36,8): error TS1192: Module '"class-module"' has no default export.
-tests/cases/compiler/main.ts(39,21): error TS2497: Module '"interface"' resolves to a non-module entity and cannot be imported using this construct.
-tests/cases/compiler/main.ts(45,21): error TS2497: Module '"function"' resolves to a non-module entity and cannot be imported using this construct.
-tests/cases/compiler/main.ts(47,21): error TS2497: Module '"class"' resolves to a non-module entity and cannot be imported using this construct.
-tests/cases/compiler/main.ts(62,25): error TS2497: Module '"interface"' resolves to a non-module entity and cannot be imported using this construct.
-tests/cases/compiler/main.ts(68,25): error TS2497: Module '"function"' resolves to a non-module entity and cannot be imported using this construct.
-tests/cases/compiler/main.ts(70,25): error TS2497: Module '"class"' resolves to a non-module entity and cannot be imported using this construct.
-tests/cases/compiler/main.ts(85,25): error TS2497: Module '"interface"' resolves to a non-module entity and cannot be imported using this construct.
-tests/cases/compiler/main.ts(91,25): error TS2497: Module '"function"' resolves to a non-module entity and cannot be imported using this construct.
-tests/cases/compiler/main.ts(93,25): error TS2497: Module '"class"' resolves to a non-module entity and cannot be imported using this construct.
+tests/cases/compiler/main.ts(50,1): error TS2304: Cannot find name 'y1'.
+tests/cases/compiler/main.ts(56,4): error TS2339: Property 'a' does not exist on type '() => any'.
+tests/cases/compiler/main.ts(58,4): error TS2339: Property 'a' does not exist on type 'typeof Foo'.
+tests/cases/compiler/main.ts(62,10): error TS2305: Module '"interface"' has no exported member 'a'.
+tests/cases/compiler/main.ts(68,10): error TS2305: Module '"function"' has no exported member 'a'.
+tests/cases/compiler/main.ts(70,10): error TS2305: Module '"class"' has no exported member 'a'.
+tests/cases/compiler/main.ts(85,10): error TS2305: Module '"interface"' has no exported member 'a'.
+tests/cases/compiler/main.ts(91,10): error TS2305: Module '"function"' has no exported member 'a'.
+tests/cases/compiler/main.ts(93,10): error TS2305: Module '"class"' has no exported member 'a'.
 tests/cases/compiler/main.ts(97,15): error TS2498: Module '"interface"' uses 'export =' and cannot be used with 'export *'.
 tests/cases/compiler/main.ts(98,15): error TS2498: Module '"variable"' uses 'export =' and cannot be used with 'export *'.
 tests/cases/compiler/main.ts(99,15): error TS2498: Module '"interface-variable"' uses 'export =' and cannot be used with 'export *'.
@@ -98,49 +98,49 @@ tests/cases/compiler/main.ts(106,15): error TS2498: Module '"class-module"' uses
     
     // namespace import
     import * as y1 from "interface";
-                        ~~~~~~~~~~~
-!!! error TS2497: Module '"interface"' resolves to a non-module entity and cannot be imported using this construct.
     import * as y2 from "variable";
     import * as y3 from "interface-variable";
     import * as y4 from "module";
     import * as y5 from "interface-module";
     import * as y6 from "variable-module";
     import * as y7 from "function";
-                        ~~~~~~~~~~
-!!! error TS2497: Module '"function"' resolves to a non-module entity and cannot be imported using this construct.
     import * as y8 from "function-module";
     import * as y9 from "class";
-                        ~~~~~~~
-!!! error TS2497: Module '"class"' resolves to a non-module entity and cannot be imported using this construct.
     import * as y0 from "class-module";
     
     y1.a;
+    ~~
+!!! error TS2304: Cannot find name 'y1'.
     y2.a;
     y3.a;
     y4.a;
     y5.a;
     y6.a;
     y7.a;
+       ~
+!!! error TS2339: Property 'a' does not exist on type '() => any'.
     y8.a;
     y9.a;
+       ~
+!!! error TS2339: Property 'a' does not exist on type 'typeof Foo'.
     y0.a;
     
     // named import
     import { a as a1 } from "interface";
-                            ~~~~~~~~~~~
-!!! error TS2497: Module '"interface"' resolves to a non-module entity and cannot be imported using this construct.
+             ~
+!!! error TS2305: Module '"interface"' has no exported member 'a'.
     import { a as a2 } from "variable";
     import { a as a3 } from "interface-variable";
     import { a as a4 } from "module";
     import { a as a5 } from "interface-module";
     import { a as a6 } from "variable-module";
     import { a as a7 } from "function";
-                            ~~~~~~~~~~
-!!! error TS2497: Module '"function"' resolves to a non-module entity and cannot be imported using this construct.
+             ~
+!!! error TS2305: Module '"function"' has no exported member 'a'.
     import { a as a8 } from "function-module";
     import { a as a9 } from "class";
-                            ~~~~~~~
-!!! error TS2497: Module '"class"' resolves to a non-module entity and cannot be imported using this construct.
+             ~
+!!! error TS2305: Module '"class"' has no exported member 'a'.
     import { a as a0 } from "class-module";
     
     a1;
@@ -156,20 +156,20 @@ tests/cases/compiler/main.ts(106,15): error TS2498: Module '"class-module"' uses
     
     // named export
     export { a as a1 } from "interface";
-                            ~~~~~~~~~~~
-!!! error TS2497: Module '"interface"' resolves to a non-module entity and cannot be imported using this construct.
+             ~
+!!! error TS2305: Module '"interface"' has no exported member 'a'.
     export { a as a2 } from "variable";
     export { a as a3 } from "interface-variable";
     export { a as a4 } from "module";
     export { a as a5 } from "interface-module";
     export { a as a6 } from "variable-module";
     export { a as a7 } from "function";
-                            ~~~~~~~~~~
-!!! error TS2497: Module '"function"' resolves to a non-module entity and cannot be imported using this construct.
+             ~
+!!! error TS2305: Module '"function"' has no exported member 'a'.
     export { a as a8 } from "function-module";
     export { a as a9 } from "class";
-                            ~~~~~~~
-!!! error TS2497: Module '"class"' resolves to a non-module entity and cannot be imported using this construct.
+             ~
+!!! error TS2305: Module '"class"' has no exported member 'a'.
     export { a as a0 } from "class-module";
     
     // export-star

--- a/tests/baselines/reference/es6ExportEqualsInterop.js
+++ b/tests/baselines/reference/es6ExportEqualsInterop.js
@@ -232,8 +232,6 @@ z7.a;
 z8.a;
 z9.a;
 z0.a;
-// namespace import
-var y1 = require("interface");
 var y2 = require("variable");
 var y3 = require("interface-variable");
 var y4 = require("module");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #7454
