### PR TITLE
Fix typedef parsing issue

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6374,6 +6374,9 @@ namespace ts {
                                 case SyntaxKind.AtToken:
                                     if (canParseTag) {
                                         parentTagTerminated = !tryParseChildTag(jsDocTypeLiteral);
+                                        if (!parentTagTerminated) {
+                                            resumePos = scanner.getStartPos();
+                                        }
                                     }
                                     seenAsterisk = false;
                                     break;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

There is a bug where the children JSDoc tag nodes of `@typedef` tag are parsed and added to the tree twice, once as the children nodes of the `@typedef` tag, and again as the children nodes of the top level `JSDocComment` node. This PR fixes the issue.
