### PR TITLE
Fix type union of differing Salsa assignment-properties

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3166,17 +3166,17 @@ namespace ts {
                 }
 
                 let type: Type = undefined;
-                // Handle module.exports = expr or this.p = expr
-                if (declaration.kind === SyntaxKind.BinaryExpression) {
-                    type = getUnionType(map(symbol.declarations, (decl: BinaryExpression) => checkExpressionCached(decl.right)));
-                }
-                else if (declaration.kind === SyntaxKind.PropertyAccessExpression) {
-                    // Declarations only exist for property access expressions for certain
-                    // special assignment kinds
-                    if (declaration.parent.kind === SyntaxKind.BinaryExpression) {
-                        // Handle exports.p = expr  or className.prototype.method = expr
-                        type = checkExpressionCached((<BinaryExpression>declaration.parent).right);
-                    }
+                // Handle certain special assignment kinds, which happen to union across multiple declarations:
+                // * module.exports = expr
+                // * exports.p = expr
+                // * this.p = expr
+                // * className.prototype.method = expr
+                if (declaration.kind === SyntaxKind.BinaryExpression ||
+                    declaration.kind === SyntaxKind.PropertyAccessExpression && declaration.parent.kind === SyntaxKind.BinaryExpression) {
+                    type = getUnionType(map(symbol.declarations,
+                                            decl => decl.kind === SyntaxKind.BinaryExpression ?
+                                                        checkExpressionCached((<BinaryExpression>decl).right) :
+                                                        checkExpressionCached((<BinaryExpression>decl.parent).right)));
                 }
 
                 if (type === undefined) {

--- a/tests/baselines/reference/multipleDeclarations.js
+++ b/tests/baselines/reference/multipleDeclarations.js
@@ -1,0 +1,17 @@
+//// [input.js]
+
+function C() {
+    this.m = null;
+}
+C.prototype.m = function() {
+    this.nothing();
+};
+
+
+//// [output.js]
+function C() {
+    this.m = null;
+}
+C.prototype.m = function () {
+    this.nothing();
+};

--- a/tests/baselines/reference/multipleDeclarations.symbols
+++ b/tests/baselines/reference/multipleDeclarations.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/salsa/input.js ===
+
+function C() {
+>C : Symbol(C, Decl(input.js, 0, 0))
+
+    this.m = null;
+>m : Symbol(C.m, Decl(input.js, 1, 14), Decl(input.js, 3, 1))
+}
+C.prototype.m = function() {
+>C.prototype : Symbol(C.m, Decl(input.js, 1, 14), Decl(input.js, 3, 1))
+>C : Symbol(C, Decl(input.js, 0, 0))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>m : Symbol(C.m, Decl(input.js, 1, 14), Decl(input.js, 3, 1))
+
+    this.nothing();
+};
+

--- a/tests/baselines/reference/multipleDeclarations.types
+++ b/tests/baselines/reference/multipleDeclarations.types
@@ -1,0 +1,29 @@
+=== tests/cases/conformance/salsa/input.js ===
+
+function C() {
+>C : () => void
+
+    this.m = null;
+>this.m = null : null
+>this.m : any
+>this : any
+>m : any
+>null : null
+}
+C.prototype.m = function() {
+>C.prototype.m = function() {    this.nothing();} : () => void
+>C.prototype.m : any
+>C.prototype : any
+>C : () => void
+>prototype : any
+>m : any
+>function() {    this.nothing();} : () => void
+
+    this.nothing();
+>this.nothing() : any
+>this.nothing : any
+>this : { m: () => void; }
+>nothing : any
+
+};
+

--- a/tests/cases/conformance/salsa/multipleDeclarations.ts
+++ b/tests/cases/conformance/salsa/multipleDeclarations.ts
@@ -1,0 +1,10 @@
+// @filename: input.js
+// @out: output.js
+// @allowJs: true
+
+function C() {
+    this.m = null;
+}
+C.prototype.m = function() {
+    this.nothing();
+};


### PR DESCRIPTION
Partial fix for #9527 -- I haven't tested whether the out-of-memory crash still happens.

Salsa supports four kinds of assignment-properties:

```ts
// in constructor
this.p = null;
// outside constructor
Class.prototype.p = null;
exports.p = null;
module.exports = null;
```

Basically, the code used to assume that all salsa declarations would be of the same kind, so it treated `this.p = ...` assignments separately. But declarations of both types are allowed to merge, so the loop across declarations now handles both kinds and all assignments are handled in the same code path.
