### PR TITLE
Provide a symbol for salsa-inferred class types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11673,7 +11673,7 @@ namespace ts {
         function getInferredClassType(symbol: Symbol) {
             const links = getSymbolLinks(symbol);
             if (!links.inferredClassType) {
-                links.inferredClassType = createAnonymousType(undefined, symbol.members, emptyArray, emptyArray, /*stringIndexType*/ undefined, /*numberIndexType*/ undefined);
+                links.inferredClassType = createAnonymousType(symbol, symbol.members, emptyArray, emptyArray, /*stringIndexType*/ undefined, /*numberIndexType*/ undefined);
             }
             return links.inferredClassType;
         }

--- a/tests/baselines/reference/methodsReturningThis.js
+++ b/tests/baselines/reference/methodsReturningThis.js
@@ -1,0 +1,36 @@
+//// [input.js]
+function Class()
+{
+}
+
+// error: 'Class' doesn't have property 'notPresent'
+Class.prototype.containsError = function () { return this.notPresent; };
+
+// lots of methods that return this, which caused out-of-memory in #9527
+Class.prototype.m1 = function (a, b, c, d, tx, ty) { return this; };
+Class.prototype.m2 = function (x, y) { return this; };
+Class.prototype.m3 = function (x, y) { return this; };
+Class.prototype.m4 = function (angle) { return this; };
+Class.prototype.m5 = function (matrix) { return this; };
+Class.prototype.m6 = function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; };
+Class.prototype.m7 = function(matrix) { return this; };
+Class.prototype.m8 = function() { return this; };
+Class.prototype.m9 = function () { return this; };
+
+
+
+//// [output.js]
+function Class() {
+}
+// error: 'Class' doesn't have property 'notPresent'
+Class.prototype.containsError = function () { return this.notPresent; };
+// lots of methods that return this, which caused out-of-memory in #9527
+Class.prototype.m1 = function (a, b, c, d, tx, ty) { return this; };
+Class.prototype.m2 = function (x, y) { return this; };
+Class.prototype.m3 = function (x, y) { return this; };
+Class.prototype.m4 = function (angle) { return this; };
+Class.prototype.m5 = function (matrix) { return this; };
+Class.prototype.m6 = function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; };
+Class.prototype.m7 = function (matrix) { return this; };
+Class.prototype.m8 = function () { return this; };
+Class.prototype.m9 = function () { return this; };

--- a/tests/baselines/reference/methodsReturningThis.symbols
+++ b/tests/baselines/reference/methodsReturningThis.symbols
@@ -1,0 +1,101 @@
+=== tests/cases/conformance/salsa/input.js ===
+function Class()
+>Class : Symbol(Class, Decl(input.js, 0, 0))
+{
+}
+
+// error: 'Class' doesn't have property 'notPresent'
+Class.prototype.containsError = function () { return this.notPresent; };
+>Class.prototype : Symbol(Class.containsError, Decl(input.js, 2, 1))
+>Class : Symbol(Class, Decl(input.js, 0, 0))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>containsError : Symbol(Class.containsError, Decl(input.js, 2, 1))
+>this : Symbol(Class, Decl(input.js, 0, 0))
+
+// lots of methods that return this, which caused out-of-memory in #9527
+Class.prototype.m1 = function (a, b, c, d, tx, ty) { return this; };
+>Class.prototype : Symbol(Class.m1, Decl(input.js, 5, 72))
+>Class : Symbol(Class, Decl(input.js, 0, 0))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>m1 : Symbol(Class.m1, Decl(input.js, 5, 72))
+>a : Symbol(a, Decl(input.js, 8, 31))
+>b : Symbol(b, Decl(input.js, 8, 33))
+>c : Symbol(c, Decl(input.js, 8, 36))
+>d : Symbol(d, Decl(input.js, 8, 39))
+>tx : Symbol(tx, Decl(input.js, 8, 42))
+>ty : Symbol(ty, Decl(input.js, 8, 46))
+>this : Symbol(Class, Decl(input.js, 0, 0))
+
+Class.prototype.m2 = function (x, y) { return this; };
+>Class.prototype : Symbol(Class.m2, Decl(input.js, 8, 68))
+>Class : Symbol(Class, Decl(input.js, 0, 0))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>m2 : Symbol(Class.m2, Decl(input.js, 8, 68))
+>x : Symbol(x, Decl(input.js, 9, 31))
+>y : Symbol(y, Decl(input.js, 9, 33))
+>this : Symbol(Class, Decl(input.js, 0, 0))
+
+Class.prototype.m3 = function (x, y) { return this; };
+>Class.prototype : Symbol(Class.m3, Decl(input.js, 9, 54))
+>Class : Symbol(Class, Decl(input.js, 0, 0))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>m3 : Symbol(Class.m3, Decl(input.js, 9, 54))
+>x : Symbol(x, Decl(input.js, 10, 31))
+>y : Symbol(y, Decl(input.js, 10, 33))
+>this : Symbol(Class, Decl(input.js, 0, 0))
+
+Class.prototype.m4 = function (angle) { return this; };
+>Class.prototype : Symbol(Class.m4, Decl(input.js, 10, 54))
+>Class : Symbol(Class, Decl(input.js, 0, 0))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>m4 : Symbol(Class.m4, Decl(input.js, 10, 54))
+>angle : Symbol(angle, Decl(input.js, 11, 31))
+>this : Symbol(Class, Decl(input.js, 0, 0))
+
+Class.prototype.m5 = function (matrix) { return this; };
+>Class.prototype : Symbol(Class.m5, Decl(input.js, 11, 55))
+>Class : Symbol(Class, Decl(input.js, 0, 0))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>m5 : Symbol(Class.m5, Decl(input.js, 11, 55))
+>matrix : Symbol(matrix, Decl(input.js, 12, 31))
+>this : Symbol(Class, Decl(input.js, 0, 0))
+
+Class.prototype.m6 = function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; };
+>Class.prototype : Symbol(Class.m6, Decl(input.js, 12, 56))
+>Class : Symbol(Class, Decl(input.js, 0, 0))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>m6 : Symbol(Class.m6, Decl(input.js, 12, 56))
+>x : Symbol(x, Decl(input.js, 13, 31))
+>y : Symbol(y, Decl(input.js, 13, 33))
+>pivotX : Symbol(pivotX, Decl(input.js, 13, 36))
+>pivotY : Symbol(pivotY, Decl(input.js, 13, 44))
+>scaleX : Symbol(scaleX, Decl(input.js, 13, 52))
+>scaleY : Symbol(scaleY, Decl(input.js, 13, 60))
+>rotation : Symbol(rotation, Decl(input.js, 13, 68))
+>skewX : Symbol(skewX, Decl(input.js, 13, 78))
+>skewY : Symbol(skewY, Decl(input.js, 13, 85))
+>this : Symbol(Class, Decl(input.js, 0, 0))
+
+Class.prototype.m7 = function(matrix) { return this; };
+>Class.prototype : Symbol(Class.m7, Decl(input.js, 13, 110))
+>Class : Symbol(Class, Decl(input.js, 0, 0))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>m7 : Symbol(Class.m7, Decl(input.js, 13, 110))
+>matrix : Symbol(matrix, Decl(input.js, 14, 30))
+>this : Symbol(Class, Decl(input.js, 0, 0))
+
+Class.prototype.m8 = function() { return this; };
+>Class.prototype : Symbol(Class.m8, Decl(input.js, 14, 55))
+>Class : Symbol(Class, Decl(input.js, 0, 0))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>m8 : Symbol(Class.m8, Decl(input.js, 14, 55))
+>this : Symbol(Class, Decl(input.js, 0, 0))
+
+Class.prototype.m9 = function () { return this; };
+>Class.prototype : Symbol(Class.m9, Decl(input.js, 15, 49))
+>Class : Symbol(Class, Decl(input.js, 0, 0))
+>prototype : Symbol(Function.prototype, Decl(lib.d.ts, --, --))
+>m9 : Symbol(Class.m9, Decl(input.js, 15, 49))
+>this : Symbol(Class, Decl(input.js, 0, 0))
+
+

--- a/tests/baselines/reference/methodsReturningThis.types
+++ b/tests/baselines/reference/methodsReturningThis.types
@@ -1,0 +1,133 @@
+=== tests/cases/conformance/salsa/input.js ===
+function Class()
+>Class : () => void
+{
+}
+
+// error: 'Class' doesn't have property 'notPresent'
+Class.prototype.containsError = function () { return this.notPresent; };
+>Class.prototype.containsError = function () { return this.notPresent; } : () => any
+>Class.prototype.containsError : any
+>Class.prototype : any
+>Class : () => void
+>prototype : any
+>containsError : any
+>function () { return this.notPresent; } : () => any
+>this.notPresent : any
+>this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>notPresent : any
+
+// lots of methods that return this, which caused out-of-memory in #9527
+Class.prototype.m1 = function (a, b, c, d, tx, ty) { return this; };
+>Class.prototype.m1 = function (a, b, c, d, tx, ty) { return this; } : (a: any, b: any, c: any, d: any, tx: any, ty: any) => { containsError: () => any; m1: any; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>Class.prototype.m1 : any
+>Class.prototype : any
+>Class : () => void
+>prototype : any
+>m1 : any
+>function (a, b, c, d, tx, ty) { return this; } : (a: any, b: any, c: any, d: any, tx: any, ty: any) => { containsError: () => any; m1: any; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>a : any
+>b : any
+>c : any
+>d : any
+>tx : any
+>ty : any
+>this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+
+Class.prototype.m2 = function (x, y) { return this; };
+>Class.prototype.m2 = function (x, y) { return this; } : (x: any, y: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: any; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>Class.prototype.m2 : any
+>Class.prototype : any
+>Class : () => void
+>prototype : any
+>m2 : any
+>function (x, y) { return this; } : (x: any, y: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: any; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>x : any
+>y : any
+>this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+
+Class.prototype.m3 = function (x, y) { return this; };
+>Class.prototype.m3 = function (x, y) { return this; } : (x: any, y: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: any; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>Class.prototype.m3 : any
+>Class.prototype : any
+>Class : () => void
+>prototype : any
+>m3 : any
+>function (x, y) { return this; } : (x: any, y: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: any; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>x : any
+>y : any
+>this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+
+Class.prototype.m4 = function (angle) { return this; };
+>Class.prototype.m4 = function (angle) { return this; } : (angle: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: any; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>Class.prototype.m4 : any
+>Class.prototype : any
+>Class : () => void
+>prototype : any
+>m4 : any
+>function (angle) { return this; } : (angle: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: any; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>angle : any
+>this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+
+Class.prototype.m5 = function (matrix) { return this; };
+>Class.prototype.m5 = function (matrix) { return this; } : (matrix: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: any; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>Class.prototype.m5 : any
+>Class.prototype : any
+>Class : () => void
+>prototype : any
+>m5 : any
+>function (matrix) { return this; } : (matrix: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: any; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>matrix : any
+>this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+
+Class.prototype.m6 = function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; };
+>Class.prototype.m6 = function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; } : (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: any; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>Class.prototype.m6 : any
+>Class.prototype : any
+>Class : () => void
+>prototype : any
+>m6 : any
+>function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; } : (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: any; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+>x : any
+>y : any
+>pivotX : any
+>pivotY : any
+>scaleX : any
+>scaleY : any
+>rotation : any
+>skewX : any
+>skewY : any
+>this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+
+Class.prototype.m7 = function(matrix) { return this; };
+>Class.prototype.m7 = function(matrix) { return this; } : (matrix: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: any; m8: () => typeof Class; m9: () => typeof Class; }
+>Class.prototype.m7 : any
+>Class.prototype : any
+>Class : () => void
+>prototype : any
+>m7 : any
+>function(matrix) { return this; } : (matrix: any) => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: any; m8: () => typeof Class; m9: () => typeof Class; }
+>matrix : any
+>this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+
+Class.prototype.m8 = function() { return this; };
+>Class.prototype.m8 = function() { return this; } : () => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: any; m9: () => typeof Class; }
+>Class.prototype.m8 : any
+>Class.prototype : any
+>Class : () => void
+>prototype : any
+>m8 : any
+>function() { return this; } : () => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: any; m9: () => typeof Class; }
+>this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+
+Class.prototype.m9 = function () { return this; };
+>Class.prototype.m9 = function () { return this; } : () => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: any; }
+>Class.prototype.m9 : any
+>Class.prototype : any
+>Class : () => void
+>prototype : any
+>m9 : any
+>function () { return this; } : () => { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: any; }
+>this : { containsError: () => any; m1: (a: any, b: any, c: any, d: any, tx: any, ty: any) => typeof Class; m2: (x: any, y: any) => typeof Class; m3: (x: any, y: any) => typeof Class; m4: (angle: any) => typeof Class; m5: (matrix: any) => typeof Class; m6: (x: any, y: any, pivotX: any, pivotY: any, scaleX: any, scaleY: any, rotation: any, skewX: any, skewY: any) => typeof Class; m7: (matrix: any) => typeof Class; m8: () => typeof Class; m9: () => typeof Class; }
+
+

--- a/tests/baselines/reference/signaturesUseJSDocForOptionalParameters.symbols
+++ b/tests/baselines/reference/signaturesUseJSDocForOptionalParameters.symbols
@@ -19,6 +19,8 @@ MyClass.prototype.optionalParam = function(required, notRequired) {
 >notRequired : Symbol(notRequired, Decl(jsDocOptionality.js, 8, 52))
 
     return this;
+>this : Symbol(MyClass, Decl(jsDocOptionality.js, 0, 0))
+
 };
 let pInst = new MyClass();
 >pInst : Symbol(pInst, Decl(jsDocOptionality.js, 11, 3))

--- a/tests/baselines/reference/signaturesUseJSDocForOptionalParameters.types
+++ b/tests/baselines/reference/signaturesUseJSDocForOptionalParameters.types
@@ -26,27 +26,27 @@ MyClass.prototype.optionalParam = function(required, notRequired) {
 >notRequired : string
 
     return this;
->this : { prop: null; optionalParam: (required: string, notRequired?: string) => { prop: null; optionalParam: any; }; }
+>this : { prop: null; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
 
 };
 let pInst = new MyClass();
->pInst : { prop: null; optionalParam: (required: string, notRequired?: string) => { prop: null; optionalParam: any; }; }
->new MyClass() : { prop: null; optionalParam: (required: string, notRequired?: string) => { prop: null; optionalParam: any; }; }
+>pInst : { prop: null; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
+>new MyClass() : { prop: null; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
 >MyClass : () => void
 
 let c1 = pInst.optionalParam('hello')
->c1 : { prop: null; optionalParam: (required: string, notRequired?: string) => { prop: null; optionalParam: any; }; }
->pInst.optionalParam('hello') : { prop: null; optionalParam: (required: string, notRequired?: string) => { prop: null; optionalParam: any; }; }
+>c1 : { prop: null; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
+>pInst.optionalParam('hello') : { prop: null; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
 >pInst.optionalParam : (required: string, notRequired?: string) => { prop: null; optionalParam: any; }
->pInst : { prop: null; optionalParam: (required: string, notRequired?: string) => { prop: null; optionalParam: any; }; }
+>pInst : { prop: null; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
 >optionalParam : (required: string, notRequired?: string) => { prop: null; optionalParam: any; }
 >'hello' : string
 
 let c2 = pInst.optionalParam('hello', null)
->c2 : { prop: null; optionalParam: (required: string, notRequired?: string) => { prop: null; optionalParam: any; }; }
->pInst.optionalParam('hello', null) : { prop: null; optionalParam: (required: string, notRequired?: string) => { prop: null; optionalParam: any; }; }
+>c2 : { prop: null; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
+>pInst.optionalParam('hello', null) : { prop: null; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
 >pInst.optionalParam : (required: string, notRequired?: string) => { prop: null; optionalParam: any; }
->pInst : { prop: null; optionalParam: (required: string, notRequired?: string) => { prop: null; optionalParam: any; }; }
+>pInst : { prop: null; optionalParam: (required: string, notRequired?: string) => typeof MyClass; }
 >optionalParam : (required: string, notRequired?: string) => { prop: null; optionalParam: any; }
 >'hello' : string
 >null : null

--- a/tests/cases/conformance/salsa/methodsReturningThis.ts
+++ b/tests/cases/conformance/salsa/methodsReturningThis.ts
@@ -1,0 +1,21 @@
+// @filename: input.js
+// @out: output.js
+// @allowJs: true
+function Class()
+{
+}
+
+// error: 'Class' doesn't have property 'notPresent'
+Class.prototype.containsError = function () { return this.notPresent; };
+
+// lots of methods that return this, which caused out-of-memory in #9527
+Class.prototype.m1 = function (a, b, c, d, tx, ty) { return this; };
+Class.prototype.m2 = function (x, y) { return this; };
+Class.prototype.m3 = function (x, y) { return this; };
+Class.prototype.m4 = function (angle) { return this; };
+Class.prototype.m5 = function (matrix) { return this; };
+Class.prototype.m6 = function (x, y, pivotX, pivotY, scaleX, scaleY, rotation, skewX, skewY) { return this; };
+Class.prototype.m7 = function(matrix) { return this; };
+Class.prototype.m8 = function() { return this; };
+Class.prototype.m9 = function () { return this; };
+


### PR DESCRIPTION
Fixes #9527 

The out-of-memory error happens when a class has a property that's not initialised in the constructor and a method that returns `this`. Thanks to @vladima for debugging and finding the fix.

The property that's lazily initialised outside the constructor causes an error (that will ultimately be discarded instead of reported). In the course of constructing this error message, the compiler tries to stringify the ES3 'class'. Unfortunately, Salsa represents ES3 'classes' as anonymous types. The stringify code assumes that anonymous types aren't circular, but methods that return `this` actually cause a circularity.

The simplest fix is to change ES3 classes not to be anonymous types. However, we should consider not even producing checker errors in Salsa since they will be discarded, even though they may be quite expensive.