### PR TITLE
Compile with --noImplicitThis

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -11,8 +11,11 @@ import newer = require("gulp-newer");
 import tsc = require("gulp-typescript");
 declare module "gulp-typescript" {
     interface Settings {
-        stripInternal?: boolean;
+        pretty?: boolean;
         newLine?: string;
+        noImplicitThis?: boolean;
+        stripInternal?: boolean;
+        types?: string[];
     }
     interface CompileStream extends NodeJS.ReadWriteStream {} // Either gulp or gulp-typescript has some odd typings which don't reflect reality, making this required
 }
@@ -306,9 +309,11 @@ function needsUpdate(source: string | string[], dest: string | string[]): boolea
 
 function getCompilerSettings(base: tsc.Settings, useBuiltCompiler?: boolean): tsc.Settings {
     const copy: tsc.Settings = {};
-    // TODO: Add --noImplicitThis --types --pretty when gulp-typescript adds support for them
-    copy.noImplicitAny = true;
     copy.noEmitOnError = true;
+    copy.noImplicitAny = true;
+    copy.noImplicitThis = true;
+    copy.pretty = true;
+    copy.types = [];
     for (const key in base) {
         copy[key] = base[key];
     }

--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -306,6 +306,9 @@ function needsUpdate(source: string | string[], dest: string | string[]): boolea
 
 function getCompilerSettings(base: tsc.Settings, useBuiltCompiler?: boolean): tsc.Settings {
     const copy: tsc.Settings = {};
+    // TODO: Add --noImplicitThis --types --pretty when gulp-typescript adds support for them
+    copy.noImplicitAny = true;
+    copy.noEmitOnError = true;
     for (const key in base) {
         copy[key] = base[key];
     }

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -284,7 +284,7 @@ var builtLocalCompiler = path.join(builtLocalDirectory, compilerFilename);
 function compileFile(outFile, sources, prereqs, prefixes, useBuiltCompiler, opts, callback) {
     file(outFile, prereqs, function() {
         var compilerPath = useBuiltCompiler ? builtLocalCompiler : LKGCompiler;
-        var options = "--noImplicitAny --noEmitOnError --types --pretty";
+        var options = "--noImplicitAny --noImplicitThis --noEmitOnError --types --pretty";
         opts = opts || {};
         // Keep comments when specifically requested
         // or when in debug mode.

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1237,20 +1237,20 @@ namespace ts {
         getSignatureConstructor(): new (checker: TypeChecker) => Signature;
     }
 
-    function Symbol(flags: SymbolFlags, name: string) {
+    function Symbol(this: Symbol, flags: SymbolFlags, name: string) {
         this.flags = flags;
         this.name = name;
         this.declarations = undefined;
     }
 
-    function Type(checker: TypeChecker, flags: TypeFlags) {
+    function Type(this: Type, checker: TypeChecker, flags: TypeFlags) {
         this.flags = flags;
     }
 
     function Signature(checker: TypeChecker) {
     }
 
-    function Node(kind: SyntaxKind, pos: number, end: number) {
+    function Node(this: Node, kind: SyntaxKind, pos: number, end: number) {
         this.kind = kind;
         this.pos = pos;
         this.end = end;

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1398,7 +1398,7 @@ namespace ts {
             return noDiagnosticsTypeChecker || (noDiagnosticsTypeChecker = createTypeChecker(program, /*produceDiagnostics:*/ false));
         }
 
-        function emit(sourceFile?: SourceFile, writeFileCallback?: WriteFileCallback, cancellationToken?: CancellationToken): EmitResult {
+        function emit(this: Program, sourceFile?: SourceFile, writeFileCallback?: WriteFileCallback, cancellationToken?: CancellationToken): EmitResult {
             return runWithCancellationToken(() => emitWorker(this, sourceFile, writeFileCallback, cancellationToken));
         }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1398,8 +1398,8 @@ namespace ts {
             return noDiagnosticsTypeChecker || (noDiagnosticsTypeChecker = createTypeChecker(program, /*produceDiagnostics:*/ false));
         }
 
-        function emit(this: Program, sourceFile?: SourceFile, writeFileCallback?: WriteFileCallback, cancellationToken?: CancellationToken): EmitResult {
-            return runWithCancellationToken(() => emitWorker(this, sourceFile, writeFileCallback, cancellationToken));
+        function emit(sourceFile?: SourceFile, writeFileCallback?: WriteFileCallback, cancellationToken?: CancellationToken): EmitResult {
+            return runWithCancellationToken(() => emitWorker(program, sourceFile, writeFileCallback, cancellationToken));
         }
 
         function isEmitBlocked(emitFileName: string): boolean {

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -182,7 +182,7 @@ namespace ts {
                 return matchFiles(path, extensions, excludes, includes, /*useCaseSensitiveFileNames*/ false, shell.CurrentDirectory, getAccessibleFileSystemEntries);
             }
 
-            return {
+            const wscriptSystem: System = {
                 args,
                 newLine: "\r\n",
                 useCaseSensitiveFileNames: false,
@@ -200,8 +200,8 @@ namespace ts {
                 directoryExists(path: string) {
                     return fso.FolderExists(path);
                 },
-                createDirectory(this: System, directoryName: string) {
-                    if (!this.directoryExists(directoryName)) {
+                createDirectory(directoryName: string) {
+                    if (!wscriptSystem.directoryExists(directoryName)) {
                         fso.CreateFolder(directoryName);
                     }
                 },
@@ -221,6 +221,7 @@ namespace ts {
                     }
                 }
             };
+            return wscriptSystem;
         }
 
         function getNodeSystem(): System {
@@ -439,7 +440,7 @@ namespace ts {
                 return filter<string>(_fs.readdirSync(path), p => fileSystemEntryExists(combinePaths(path, p), FileSystemEntryKind.Directory));
             }
 
-            return {
+            const nodeSystem: System = {
                 args: process.argv.slice(2),
                 newLine: _os.EOL,
                 useCaseSensitiveFileNames: useCaseSensitiveFileNames,
@@ -500,8 +501,8 @@ namespace ts {
                 },
                 fileExists,
                 directoryExists,
-                createDirectory(this: System, directoryName: string) {
-                    if (!this.directoryExists(directoryName)) {
+                createDirectory(directoryName: string) {
+                    if (!nodeSystem.directoryExists(directoryName)) {
                         _fs.mkdirSync(directoryName);
                     }
                 },
@@ -549,6 +550,7 @@ namespace ts {
                     return _fs.realpathSync(path);
                 }
             };
+            return nodeSystem;
         }
 
         function getChakraSystem(): System {

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -200,7 +200,7 @@ namespace ts {
                 directoryExists(path: string) {
                     return fso.FolderExists(path);
                 },
-                createDirectory(directoryName: string) {
+                createDirectory(this: System, directoryName: string) {
                     if (!this.directoryExists(directoryName)) {
                         fso.CreateFolder(directoryName);
                     }
@@ -500,7 +500,7 @@ namespace ts {
                 },
                 fileExists,
                 directoryExists,
-                createDirectory(directoryName: string) {
+                createDirectory(this: System, directoryName: string) {
                     if (!this.directoryExists(directoryName)) {
                         _fs.mkdirSync(directoryName);
                     }

--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "noImplicitAny": true,
+        "noImplicitThis": true,
         "removeComments": true,
         "preserveConstEnums": true,
         "outFile": "../../built/local/tsc.js",

--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -4,6 +4,7 @@
         "noImplicitThis": true,
         "removeComments": true,
         "preserveConstEnums": true,
+        "pretty": true,
         "outFile": "../../built/local/tsc.js",
         "sourceMap": true,
         "declaration": true,

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -127,7 +127,7 @@ namespace Utils {
     export function memoize<T extends Function>(f: T): T {
         const cache: { [idx: string]: any } = {};
 
-        return <any>(function() {
+        return <any>(function(this: any) {
             const key = Array.prototype.join.call(arguments);
             const cachedResult = cache[key];
             if (cachedResult) {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2081,7 +2081,7 @@ namespace ts.server {
             const walkFns = {
                 goSubtree: true,
                 done: false,
-                leaf: function (relativeStart: number, relativeLength: number, ll: LineLeaf) {
+                leaf: function (this: ILineIndexWalker, relativeStart: number, relativeLength: number, ll: LineLeaf) {
                     if (!f(ll, relativeStart, relativeLength)) {
                         this.done = true;
                     }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -2081,9 +2081,9 @@ namespace ts.server {
             const walkFns = {
                 goSubtree: true,
                 done: false,
-                leaf: function (this: ILineIndexWalker, relativeStart: number, relativeLength: number, ll: LineLeaf) {
+                leaf: function (relativeStart: number, relativeLength: number, ll: LineLeaf) {
                     if (!f(ll, relativeStart, relativeLength)) {
-                        this.done = true;
+                        walkFns.done = true;
                     }
                 }
             };

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -4,6 +4,7 @@
         "noImplicitThis": true,
         "removeComments": true,
         "preserveConstEnums": true,
+        "pretty": true,
         "out": "../../built/local/tsserver.js",
         "sourceMap": true,
         "stripInternal": true

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "noImplicitAny": true,
+        "noImplicitThis": true,
         "removeComments": true,
         "preserveConstEnums": true,
         "out": "../../built/local/tsserver.js",

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -16,7 +16,7 @@
 /// <reference path='services.ts' />
 
 /* @internal */
-let debugObjectHost = (<any>this);
+let debugObjectHost = new Function("return this")();
 
 // We need to use 'null' to interface with the managed side.
 /* tslint:disable:no-null-keyword */

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -1,6 +1,7 @@
 {
     "compilerOptions": {
         "noImplicitAny": true,
+        "noImplicitThis": true,
         "removeComments": false,
         "preserveConstEnums": true,
         "outFile": "../../built/local/typescriptServices.js",

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -4,6 +4,7 @@
         "noImplicitThis": true,
         "removeComments": false,
         "preserveConstEnums": true,
+        "pretty": true,
         "outFile": "../../built/local/typescriptServices.js",
         "sourceMap": true,
         "stripInternal": true,


### PR DESCRIPTION
1. Add `--noImplicitThis` to various tsconfig.json (gulp uses tsconfig).
2. Add `--noImplicitThis` to Jakefile.
3. Add annotations where needed.
4. Add workaround to shims.ts, which uses toplevel `this`.

Also, fixes #9608