### PR TITLE
Update conflicting baseline.

### DIFF
--- a/tests/baselines/reference/multipleDeclarations.symbols
+++ b/tests/baselines/reference/multipleDeclarations.symbols
@@ -13,5 +13,7 @@ C.prototype.m = function() {
 >m : Symbol(C.m, Decl(input.js, 1, 14), Decl(input.js, 3, 1))
 
     this.nothing();
+>this : Symbol(C, Decl(input.js, 0, 0))
+
 };
 


### PR DESCRIPTION
Fix build break.

PR #9574 added a baseline that #9578 caused to be changed. The two PRs
went in so close to each other that the CI build didn't catch the change
to the new test's baseline.