### PR TITLE
Fix #9601: Clarify the unused property message

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14565,11 +14565,11 @@ namespace ts {
                                     !isParameterPropertyDeclaration(parameter) &&
                                     !parameterIsThisKeyword(parameter) &&
                                     !parameterNameStartsWithUnderscore(parameter)) {
-                                    error(local.valueDeclaration.name, Diagnostics._0_is_declared_but_never_used, local.name);
+                                    error(local.valueDeclaration.name, Diagnostics.Property_0_is_declared_but_never_used, local.name);
                                 }
                             }
                             else if (compilerOptions.noUnusedLocals) {
-                                forEach(local.declarations, d => error(d.name || d, Diagnostics._0_is_declared_but_never_used, local.name));
+                                forEach(local.declarations, d => error(d.name || d, Diagnostics.Property_0_is_declared_but_never_used, local.name));
                             }
                         }
                     }
@@ -14591,13 +14591,13 @@ namespace ts {
                     for (const member of node.members) {
                         if (member.kind === SyntaxKind.MethodDeclaration || member.kind === SyntaxKind.PropertyDeclaration) {
                             if (!member.symbol.isReferenced && member.flags & NodeFlags.Private) {
-                                error(member.name, Diagnostics._0_is_declared_but_never_used, member.symbol.name);
+                                error(member.name, Diagnostics.Property_0_is_declared_but_never_used, member.symbol.name);
                             }
                         }
                         else if (member.kind === SyntaxKind.Constructor) {
                             for (const parameter of (<ConstructorDeclaration>member).parameters) {
                                 if (!parameter.symbol.isReferenced && parameter.flags & NodeFlags.Private) {
-                                    error(parameter.name, Diagnostics._0_is_declared_but_never_used, parameter.symbol.name);
+                                    error(parameter.name, Diagnostics.Property_0_is_declared_but_never_used, parameter.symbol.name);
                                 }
                             }
                         }
@@ -14611,7 +14611,7 @@ namespace ts {
                 if (node.typeParameters) {
                     for (const typeParameter of node.typeParameters) {
                         if (!typeParameter.symbol.isReferenced) {
-                            error(typeParameter.name, Diagnostics._0_is_declared_but_never_used, typeParameter.symbol.name);
+                            error(typeParameter.name, Diagnostics.Property_0_is_declared_but_never_used, typeParameter.symbol.name);
                         }
                     }
                 }
@@ -14626,7 +14626,7 @@ namespace ts {
                         if (!local.isReferenced && !local.exportSymbol) {
                             for (const declaration of local.declarations) {
                                 if (!isAmbientModule(declaration)) {
-                                    error(declaration.name, Diagnostics._0_is_declared_but_never_used, local.name);
+                                    error(declaration.name, Diagnostics.Property_0_is_declared_but_never_used, local.name);
                                 }
                             }
                         }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2796,7 +2796,7 @@
         "category": "Message",
         "code": 6132
     },
-    "'{0}' is declared but never used.": {
+    "Property '{0}' is declared but never used.": {
         "category": "Error",
         "code": 6133
     },


### PR DESCRIPTION
Pull request to fix #9601 `'used' is declared but never used.` -> `Property 'used' is declared but never used.`
