### PR TITLE
Normalize slashes for getDirectoryPath arguments

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -16,6 +16,7 @@ namespace ts {
     const defaultTypeRoots = ["node_modules/@types"];
 
     export function findConfigFile(searchPath: string, fileExists: (fileName: string) => boolean): string {
+        searchPath = normalizeSlashes(searchPath);
         while (true) {
             const fileName = combinePaths(searchPath, "tsconfig.json");
             if (fileExists(fileName)) {
@@ -31,7 +32,7 @@ namespace ts {
     }
 
     export function resolveTripleslashReference(moduleName: string, containingFile: string): string {
-        const basePath = getDirectoryPath(containingFile);
+        const basePath = getDirectoryPath(normalizeSlashes(containingFile));
         const referencedFileName = isRootedDiskPath(moduleName) ? moduleName : combinePaths(basePath, moduleName);
         return normalizePath(referencedFileName);
     }


### PR DESCRIPTION
Fixes #9486.

In the absence of guidance or discussion regarding whether or not `normalizeSlashes` is expected to be called on paths passed to the TypeScript API - `findConfigFile`, in particular - it seems reasonable that `normalizeSlashes` should be called on paths passed to `getDirecoryPath` - as that is done [elsewhere in the codebase](https://github.com/Microsoft/TypeScript/blob/master/src/compiler/declarationEmitter.ts#L1731-L1736).

This PR will fix a problem that I have with [`tsify`](https://github.com/TypeStrong/tsify). I have submitted a PR to the `tsify` repo that includes a work around, but the maintainer feels that this [is definitely something that should be fixed in TypeScript](https://github.com/TypeStrong/tsify/pull/146#issuecomment-230064126).
