### PR TITLE
Most of Events dose have value property

### DIFF
--- a/lib/lib.es6.d.ts
+++ b/lib/lib.es6.d.ts
@@ -9454,6 +9454,7 @@ interface EventTarget {
 declare var EventTarget: {
     prototype: EventTarget;
     new(): EventTarget;
+    value?: any;
 }
 
 interface External {


### PR DESCRIPTION
Allow optional implicit target: any for interface EventTarget. This will allow us developers to define custom EventTypes and use them as argument type instead of using any and than casting it every time a value is needed.

Example using React:

```typescript
interface EventValue<T> {
    target: {
        value: T
    }
}

public onConfiguredChange: (event: EventValue<number>) => void;
```
This now throws the following compilation time error:

error TS2322: Type '(event: EventValue<number>) => void' is not assignable to type 'EventHandler<FormEvent>'.
  Types of parameters 'event' and 'event' are incompatible.
    Type 'FormEvent' is not assignable to type 'EventValue<number>'.
      Types of property 'target' are incompatible.
        Type 'EventTarget' is not assignable to type '{ value: number; }'.
          Property 'value' is missing in type 'EventTarget'.

Although is 100% guaranteed that event will have target value and it's going to be of type number.