### PR TITLE
Harden compilerRunner vs rooted path names in tests

### DIFF
--- a/src/harness/compilerRunner.ts
+++ b/src/harness/compilerRunner.ts
@@ -51,7 +51,8 @@ class CompilerBaselineRunner extends RunnerBase {
 
     private makeUnitName(name: string, root: string) {
         const path = ts.toPath(name, root, (fileName) => Harness.Compiler.getCanonicalFileName(fileName));
-        return path.replace(Harness.IO.getCurrentDirectory(), "/");
+        const pathStart = ts.toPath(Harness.IO.getCurrentDirectory(), "", (fileName) => Harness.Compiler.getCanonicalFileName(fileName));
+        return path.replace(pathStart, "/");
     };
 
     public checkTestCodeOutput(fileName: string) {

--- a/src/harness/compilerRunner.ts
+++ b/src/harness/compilerRunner.ts
@@ -50,7 +50,8 @@ class CompilerBaselineRunner extends RunnerBase {
     }
 
     private makeUnitName(name: string, root: string) {
-        return ts.isRootedDiskPath(name) ? name : ts.combinePaths(root, name);
+        const path = ts.toPath(name, root, (fileName) => Harness.Compiler.getCanonicalFileName(fileName));
+        return path.replace(Harness.IO.getCurrentDirectory(), "/");
     };
 
     public checkTestCodeOutput(fileName: string) {


### PR DESCRIPTION
Should fix the root cause of #9709, test file paths beginning with what looks like a rooted path.

@vladima How does this look to you?