### PR TITLE
Have travis build on OSX in addition to Linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,7 @@ node_js:
   - '0.10'
 
 sudo: false
+
+os:
+  - linux
+  - osx


### PR DESCRIPTION
This way we can have a CI environment with a case-insensitive filesystem. Travis added supprot for this around April.