### PR TITLE
Have travis fast_finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,6 @@ sudo: false
 os:
   - linux
   - osx
+
+matrix:
+  fast_finish: true


### PR DESCRIPTION
This causes a build to be marked as failed the instant any of its component builds fail (rather than waiting for them all to finish to mark a failure).