### PR TITLE
Fixes capitalization

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -135,12 +135,12 @@ namespace ts {
         {
             name: "noUnusedLocals",
             type: "boolean",
-            description: Diagnostics.Report_Errors_on_Unused_Locals,
+            description: Diagnostics.Report_errors_on_unused_locals,
         },
         {
             name: "noUnusedParameters",
             type: "boolean",
-            description: Diagnostics.Report_Errors_on_Unused_Parameters
+            description: Diagnostics.Report_errors_on_unused_parameters,
         },
         {
             name: "noLib",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2800,11 +2800,11 @@
         "category": "Error",
         "code": 6133
     },
-    "Report Errors on Unused Locals.": {
+    "Report errors on unused locals.": {
         "category": "Message",
         "code": 6134
     },
-    "Report Errors on Unused Parameters.": {
+    "Report errors on unused parameters.": {
         "category": "Message",
         "code": 6135
     },


### PR DESCRIPTION
The `--help` description seem to include some description text that was capitalized.
