### PR TITLE
Improve definition of trailing vs leading comments

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -851,7 +851,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 }
             }
 
-            function emitLinePreservingList(parent: Node, nodes: NodeArray<Node>, allowTrailingComma: boolean, spacesBetweenBraces: boolean) {
+            function emitLinePreservingList(parent: Node, nodes: NodeArray<Node>, allowTrailingComma: boolean, spacesBetweenBraces: boolean, commentsBeforePunctuation: boolean) {
                 Debug.assert(nodes.length > 0);
 
                 increaseIndent();
@@ -877,6 +877,9 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     }
 
                     emit(nodes[i]);
+                    if (commentsBeforePunctuation) {
+                        emitLeadingCommentsAtEnd(nodes[i]);
+                    }
                 }
 
                 if (nodes.hasTrailingComma && allowTrailingComma) {
@@ -895,7 +898,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 }
             }
 
-            function emitList<TNode extends Node>(nodes: TNode[], start: number, count: number, multiLine: boolean, trailingComma: boolean, leadingComma?: boolean, noTrailingNewLine?: boolean, emitNode?: (node: TNode) => void): number {
+            function emitList<TNode extends Node>(nodes: TNode[], start: number, count: number, multiLine: boolean, trailingComma: boolean, leadingComma?: boolean, noTrailingNewLine?: boolean, commentsBeforePunctuation?: boolean, emitNode?: (node: TNode) => void): number {
                 if (!emitNode) {
                     emitNode = emit;
                 }
@@ -913,13 +916,10 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                         }
                     }
                     const node = nodes[start + i];
-                    // This emitting is to make sure we emit following comment properly
-                    //   ...(x, /*comment1*/ y)...
-                    //         ^ => node.pos
-                    // "comment1" is not considered leading comment for "y" but rather
-                    // considered as trailing comment of the previous node.
-                    emitTrailingCommentsOfPosition(node.pos);
                     emitNode(node);
+                    if (commentsBeforePunctuation) {
+                        emitLeadingCommentsAtEnd(nodes[i]);
+                    }
                     leadingComma = true;
                 }
                 if (trailingComma) {
@@ -1893,7 +1893,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 }
                 else if (languageVersion >= ScriptTarget.ES6 || !forEach(elements, isSpreadElementExpression)) {
                     write("[");
-                    emitLinePreservingList(node, node.elements, elements.hasTrailingComma, /*spacesBetweenBraces*/ false);
+                    emitLinePreservingList(node, node.elements, elements.hasTrailingComma, /*spacesBetweenBraces*/ false, /*commentsBeforePunctuation*/ true);
                     write("]");
                 }
                 else {
@@ -1917,7 +1917,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     // then try to preserve the original shape of the object literal.
                     // Otherwise just try to preserve the formatting.
                     if (numElements === properties.length) {
-                        emitLinePreservingList(node, properties, /*allowTrailingComma*/ languageVersion >= ScriptTarget.ES5, /*spacesBetweenBraces*/ true);
+                        emitLinePreservingList(node, properties, /*allowTrailingComma*/ languageVersion >= ScriptTarget.ES5, /*spacesBetweenBraces*/ true, /*commentsBeforePunctuation*/ true);
                     }
                     else {
                         const multiLine = node.multiLine;
@@ -2162,14 +2162,6 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
             function emitPropertyAssignment(node: PropertyDeclaration) {
                 emit(node.name);
                 write(": ");
-                // This is to ensure that we emit comment in the following case:
-                //      For example:
-                //          obj = {
-                //              id: /*comment1*/ ()=>void
-                //          }
-                // "comment1" is not considered to be leading comment for node.initializer
-                // but rather a trailing comment on the previous node.
-                emitTrailingCommentsOfPosition(node.initializer.pos);
                 emit(node.initializer);
             }
 
@@ -2281,6 +2273,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 }
 
                 emit(node.expression);
+                emitLeadingCommentsAtEnd(node.expression);
                 const dotRangeStart = nodeIsSynthesized(node.expression) ? -1 : node.expression.end;
                 const dotRangeEnd = nodeIsSynthesized(node.expression) ? -1 : skipTrivia(currentText, node.expression.end) + 1;
                 const dotToken = <TextRange>{ pos: dotRangeStart, end: dotRangeEnd };
@@ -2497,13 +2490,17 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     emitThis(expression);
                     if (node.arguments.length) {
                         write(", ");
+                        emitTrailingCommentsOfPosition(node.arguments.pos);
                         emitCommaList(node.arguments);
+                        emitLeadingCommentsAtEnd(node.arguments);
                     }
                     write(")");
                 }
                 else {
                     write("(");
+                    emitTrailingCommentsOfPosition(node.arguments.pos);
                     emitCommaList(node.arguments);
+                    emitLeadingCommentsAtEnd(node.arguments);
                     write(")");
                 }
             }
@@ -2603,6 +2600,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 
                 write("(");
                 emit(node.expression);
+                emitLeadingCommentsAtEnd(node.expression);
                 write(")");
             }
 
@@ -2881,6 +2879,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     }
                     else {
                         emit(node.left);
+                        emitLeadingCommentsAtEnd(node.left);
                         // Add indentation before emit the operator if the operator is on different line
                         // For example:
                         //      3
@@ -3893,6 +3892,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 }
                 emitNodeWithCommentsAndWithoutSourcemap(node.name);
                 emitEnd(node.name);
+                emitLeadingCommentsAtEnd(node.name);
             }
 
             function createVoidZero(): Expression {
@@ -4035,6 +4035,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                         emit(name);
                     }
 
+                    emitLeadingCommentsAtEnd(name);
                     write(" = ");
                     emit(value);
                 });
@@ -4586,6 +4587,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     emitStart(restParam);
                     write("var ");
                     emitNodeWithCommentsAndWithoutSourcemap(restParam.name);
+                    emitLeadingCommentsAtEnd(restParam.name);
                     write(" = [];");
                     emitEnd(restParam);
                     emitTrailingComments(restParam);
@@ -4607,6 +4609,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     writeLine();
                     emitStart(restParam);
                     emitNodeWithCommentsAndWithoutSourcemap(restParam.name);
+                    emitLeadingCommentsAtEnd(restParam.name);
                     write("[" + tempName + " - " + restIndex + "] = arguments[" + tempName + "];");
                     emitEnd(restParam);
                     decreaseIndent();
@@ -4628,6 +4631,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
             function emitDeclarationName(node: Declaration) {
                 if (node.name) {
                     emitNodeWithCommentsAndWithoutSourcemap(node.name);
+                    emitLeadingCommentsAtEnd(node.name);
                 }
                 else {
                     write(getGeneratedNameForNode(node));
@@ -4655,6 +4659,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                 const { kind, parent } = node;
                 if (kind !== SyntaxKind.MethodDeclaration &&
                     kind !== SyntaxKind.MethodSignature &&
+                    kind !== SyntaxKind.ArrowFunction &&
                     parent &&
                     parent.kind !== SyntaxKind.PropertyAssignment &&
                     parent.kind !== SyntaxKind.CallExpression &&
@@ -4729,7 +4734,11 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
                     const parameters = node.parameters;
                     const skipCount = node.parameters.length && (<Identifier>node.parameters[0].name).originalKeywordKind === SyntaxKind.ThisKeyword ? 1 : 0;
                     const omitCount = languageVersion < ScriptTarget.ES6 && hasDeclaredRestParameter(node) ? 1 : 0;
-                    emitList(parameters, skipCount, parameters.length - omitCount - skipCount, /*multiLine*/ false, /*trailingComma*/ false);
+                    emitTrailingCommentsOfPosition(node.parameters.pos);
+                    emitList(parameters, skipCount, parameters.length - omitCount - skipCount, /*multiLine*/ false, /*trailingComma*/ false, /*leadingComma*/ false, /*noTrailingNewLine*/ false, /*commentsBeforePunctuation*/ true);
+                    if ((parameters.length - omitCount - skipCount) <= 0) {
+                        emitLeadingCommentsAtEnd(node.parameters);
+                    }
                 }
                 write(")");
                 decreaseIndent();
@@ -5777,7 +5786,7 @@ const _super = (function (geti, seti) {
                 writeLine();
 
                 const decoratorCount = decorators ? decorators.length : 0;
-                let argumentsWritten = emitList(decorators, 0, decoratorCount, /*multiLine*/ true, /*trailingComma*/ false, /*leadingComma*/ false, /*noTrailingNewLine*/ true,
+                let argumentsWritten = emitList(decorators, 0, decoratorCount, /*multiLine*/ true, /*trailingComma*/ false, /*leadingComma*/ false, /*noTrailingNewLine*/ true, /*commentsBeforePunctuation*/ false,
                     decorator => emit(decorator.expression));
                 if (firstParameterDecorator) {
                     argumentsWritten += emitDecoratorsOfParameters(constructor, /*leadingComma*/ argumentsWritten > 0);
@@ -5877,7 +5886,7 @@ const _super = (function (geti, seti) {
                     writeLine();
 
                     const decoratorCount = decorators ? decorators.length : 0;
-                    let argumentsWritten = emitList(decorators, 0, decoratorCount, /*multiLine*/ true, /*trailingComma*/ false, /*leadingComma*/ false, /*noTrailingNewLine*/ true,
+                    let argumentsWritten = emitList(decorators, 0, decoratorCount, /*multiLine*/ true, /*trailingComma*/ false, /*leadingComma*/ false, /*noTrailingNewLine*/ true, /*commentsBeforePunctuation*/ false,
                         decorator => emit(decorator.expression));
 
                     if (firstParameterDecorator) {
@@ -5919,7 +5928,7 @@ const _super = (function (geti, seti) {
                     for (const parameter of node.parameters) {
                         if (nodeIsDecorated(parameter)) {
                             const decorators = parameter.decorators;
-                            argumentsWritten += emitList(decorators, 0, decorators.length, /*multiLine*/ true, /*trailingComma*/ false, /*leadingComma*/ leadingComma, /*noTrailingNewLine*/ true, decorator => {
+                            argumentsWritten += emitList(decorators, 0, decorators.length, /*multiLine*/ true, /*trailingComma*/ false, /*leadingComma*/ leadingComma, /*noTrailingNewLine*/ true, /*commentsBeforePunctuation*/ false, decorator => {
                                 write(`__param(${parameterIndex}, `);
                                 emit(decorator.expression);
                                 write(")");
@@ -6333,6 +6342,7 @@ const _super = (function (geti, seti) {
                 emitExpressionForPropertyName(node.name);
                 emitEnd(node);
                 write(";");
+                emitLeadingCommentsAtEnd(node.name);
             }
 
             function writeEnumMemberDeclarationValue(member: EnumMember) {
@@ -8274,7 +8284,11 @@ const _super = (function (geti, seti) {
                 emitNewLineBeforeLeadingComments(currentLineMap, writer, node, leadingComments);
 
                 // Leading comments are emitted at /*leading comment1 */space/*leading comment*/space
-                emitComments(currentText, currentLineMap, writer, leadingComments, /*trailingSeparator*/ true, newLine, writeComment);
+                // However, a leading mid-line comment of the end of file token is emitted with spaces before,
+                // as if it were a trailing comment of the previous token
+                const commentStartsInMidLine = leadingComments && leadingComments.length && leadingComments[0].pos - 1 > 0 && currentText.charCodeAt(leadingComments[0].pos - 1) !== 10;
+                const isEndOfFile = node.kind === SyntaxKind.EndOfFileToken && commentStartsInMidLine;
+                emitComments(currentText, currentLineMap, writer, leadingComments, /*trailingSeparator*/ !isEndOfFile, newLine, writeComment);
             }
 
             function emitTrailingComments(node: Node) {
@@ -8291,8 +8305,11 @@ const _super = (function (geti, seti) {
 
             /**
              * Emit trailing comments at the position. The term trailing comment is used here to describe following comment:
-             *      x, /comment1/ y
-             *        ^ => pos; the function will emit "comment1" in the emitJS
+             *      x, /*comment1* / // comment2
+             *         ^ => pos; the function will emit "comment1" and "comment2" in the emitJS
+             * However,
+             *      x /*comment1* /, y
+             * 'comment1' is actually a leading comment of ',' and needs to be emitted using emitLeadingCommentsAtEnd
              */
             function emitTrailingCommentsOfPosition(pos: number) {
                 if (compilerOptions.removeComments) {
@@ -8305,7 +8322,18 @@ const _super = (function (geti, seti) {
                 emitComments(currentText, currentLineMap, writer, trailingComments, /*trailingSeparator*/ true, newLine, writeComment);
             }
 
-            function emitLeadingCommentsOfPositionWorker(pos: number) {
+            /**
+             * Emit leading comments for the token after the current token.
+             * This is only needed for punctuation tokens. For example, in
+             *      x /*comment1* /, y
+             * 'comment1' is a leading comment of ',' but needs to be emitted
+             * from x because there is no token for ','.
+             */
+            function emitLeadingCommentsAtEnd(node: Node | NodeArray<any>) {
+                emitLeadingCommentsOfPositionWorker(node.end, false);
+            }
+
+            function emitLeadingCommentsOfPositionWorker(pos: number, trailingSeparator = true) {
                 if (compilerOptions.removeComments) {
                     return;
                 }
@@ -8323,7 +8351,7 @@ const _super = (function (geti, seti) {
                 emitNewLineBeforeLeadingComments(currentLineMap, writer, { pos: pos, end: pos }, leadingComments);
 
                 // Leading comments are emitted at /*leading comment1 */space/*leading comment*/space
-                emitComments(currentText, currentLineMap, writer, leadingComments, /*trailingSeparator*/ true, newLine, writeComment);
+                emitComments(currentText, currentLineMap, writer, leadingComments, trailingSeparator, newLine, writeComment);
             }
 
             function emitDetachedCommentsAndUpdateCommentsInfo(node: TextRange) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -611,13 +611,7 @@ namespace ts {
     }
 
     export function getJsDocCommentsFromText(node: Node, text: string) {
-        const commentRanges = (node.kind === SyntaxKind.Parameter ||
-                               node.kind === SyntaxKind.TypeParameter ||
-                               node.kind === SyntaxKind.FunctionExpression ||
-                               node.kind === SyntaxKind.ArrowFunction) ?
-            concatenate(getTrailingCommentRanges(text, node.pos), getLeadingCommentRanges(text, node.pos)) :
-            getLeadingCommentRangesOfNodeFromText(node, text);
-        return filter(commentRanges, isJsDocComment);
+        return filter(getLeadingCommentRanges(text, node.pos), isJsDocComment);
 
         function isJsDocComment(comment: CommentRange) {
             // True if the comment starts with '/**' but not if it is '/**/'

--- a/tests/baselines/reference/arrowFunctionErrorSpan.js
+++ b/tests/baselines/reference/arrowFunctionErrorSpan.js
@@ -83,7 +83,9 @@ f(// comment 1
 // comment 2
 function () {
     // comment 4
-});
+}
+ // comment 5
+);
 // body is not a block
 f(function (_) { return 1 +
     2; });

--- a/tests/baselines/reference/augmentExportEquals1.js
+++ b/tests/baselines/reference/augmentExportEquals1.js
@@ -32,5 +32,5 @@ define(["require", "exports"], function (require, exports) {
 //// [file3.js]
 define(["require", "exports", "./file2"], function (require, exports) {
     "use strict";
-    var a; // should not work
-});
+    var a;
+}); // should not work

--- a/tests/baselines/reference/augmentExportEquals1_1.js
+++ b/tests/baselines/reference/augmentExportEquals1_1.js
@@ -29,5 +29,5 @@ define(["require", "exports"], function (require, exports) {
 //// [file3.js]
 define(["require", "exports", "file2"], function (require, exports) {
     "use strict";
-    var a; // should not work
-});
+    var a;
+}); // should not work

--- a/tests/baselines/reference/augmentExportEquals2.js
+++ b/tests/baselines/reference/augmentExportEquals2.js
@@ -31,5 +31,5 @@ define(["require", "exports"], function (require, exports) {
 //// [file3.js]
 define(["require", "exports", "./file2"], function (require, exports) {
     "use strict";
-    var a; // should not work
-});
+    var a;
+}); // should not work

--- a/tests/baselines/reference/augmentExportEquals2_1.js
+++ b/tests/baselines/reference/augmentExportEquals2_1.js
@@ -29,5 +29,5 @@ define(["require", "exports"], function (require, exports) {
 //// [file3.js]
 define(["require", "exports", "file2"], function (require, exports) {
     "use strict";
-    var a; // should not work
-});
+    var a;
+}); // should not work

--- a/tests/baselines/reference/augmentedTypesExternalModule1.js
+++ b/tests/baselines/reference/augmentedTypesExternalModule1.js
@@ -13,4 +13,4 @@ define(["require", "exports"], function (require, exports) {
         c5.prototype.foo = function () { };
         return c5;
     }());
-});
+}); // should be ok everywhere

--- a/tests/baselines/reference/blockScopedFunctionDeclarationInStrictModule.js
+++ b/tests/baselines/reference/blockScopedFunctionDeclarationInStrictModule.js
@@ -14,4 +14,4 @@ define(["require", "exports"], function (require, exports) {
         foo(); // ok
     }
     return foo;
-});
+}); // not ok

--- a/tests/baselines/reference/callOverloads1.js
+++ b/tests/baselines/reference/callOverloads1.js
@@ -22,7 +22,7 @@ var Foo = (function () {
     function Foo(x) {
         // WScript.Echo("Constructor function has executed");
     }
-    Foo.prototype.bar1 = function () { };
+    Foo.prototype.bar1 = function () { /*WScript.Echo("bar1");*/ };
     return Foo;
 }());
 function F1(a) { return a; }

--- a/tests/baselines/reference/callOverloads2.js
+++ b/tests/baselines/reference/callOverloads2.js
@@ -30,7 +30,7 @@ var Foo = (function () {
     function Foo(x) {
         // WScript.Echo("Constructor function has executed");
     }
-    Foo.prototype.bar1 = function () { };
+    Foo.prototype.bar1 = function () { /*WScript.Echo("bar1");*/ };
     return Foo;
 }());
 function F1(s) { return s; } // error

--- a/tests/baselines/reference/callOverloads3.js
+++ b/tests/baselines/reference/callOverloads3.js
@@ -23,7 +23,7 @@ var Foo = (function () {
     function Foo(x) {
         // WScript.Echo("Constructor function has executed");
     }
-    Foo.prototype.bar1 = function () { };
+    Foo.prototype.bar1 = function () { /*WScript.Echo("bar1");*/ };
     return Foo;
 }());
 //class Foo(s: String);

--- a/tests/baselines/reference/callOverloads4.js
+++ b/tests/baselines/reference/callOverloads4.js
@@ -23,7 +23,7 @@ var Foo = (function () {
     function Foo(x) {
         // WScript.Echo("Constructor function has executed");
     }
-    Foo.prototype.bar1 = function () { };
+    Foo.prototype.bar1 = function () { /*WScript.Echo("bar1");*/ };
     return Foo;
 }());
 var f1 = new Foo("hey");

--- a/tests/baselines/reference/callOverloads5.js
+++ b/tests/baselines/reference/callOverloads5.js
@@ -24,7 +24,7 @@ var Foo = (function () {
     function Foo(x) {
         // WScript.Echo("Constructor function has executed");
     }
-    Foo.prototype.bar1 = function (a) { };
+    Foo.prototype.bar1 = function (a) { /*WScript.Echo(a);*/ };
     return Foo;
 }());
 //class Foo(s: String);

--- a/tests/baselines/reference/collisionArgumentsFunction.js
+++ b/tests/baselines/reference/collisionArgumentsFunction.js
@@ -90,3 +90,4 @@ function f42(i) {
 function f4NoError(arguments) {
     var arguments; // No error
 }
+ // no codegen no error

--- a/tests/baselines/reference/collisionRestParameterFunction.js
+++ b/tests/baselines/reference/collisionRestParameterFunction.js
@@ -63,3 +63,4 @@ function f4(_i) {
 }
 function f4NoError(_i) {
 }
+ // no codegen no error

--- a/tests/baselines/reference/collisionThisExpressionAndParameter.js
+++ b/tests/baselines/reference/collisionThisExpressionAndParameter.js
@@ -167,3 +167,4 @@ function f3(_this) {
     var _this = this;
     (function (x) { console.log(_this.x); });
 }
+ // no code gen - no error

--- a/tests/baselines/reference/commentInEmptyParameterList1.js
+++ b/tests/baselines/reference/commentInEmptyParameterList1.js
@@ -3,5 +3,5 @@ function foo(/** nothing */) {
 }
 
 //// [commentInEmptyParameterList1.js]
-function foo() {
+function foo( /** nothing */) {
 }

--- a/tests/baselines/reference/commentOnParenthesizedExpressionOpenParen1.js
+++ b/tests/baselines/reference/commentOnParenthesizedExpressionOpenParen1.js
@@ -7,4 +7,4 @@ var f: () => any;
 //// [commentOnParenthesizedExpressionOpenParen1.js]
 var j;
 var f;
-(j = f());
+(/* Preserve */ j = f());

--- a/tests/baselines/reference/commentsArgumentsOfCallExpression2.js
+++ b/tests/baselines/reference/commentsArgumentsOfCallExpression2.js
@@ -14,7 +14,7 @@ foo(
 function foo(/*c1*/ x, /*d1*/ y, /*e1*/ w) { }
 var a, b;
 foo(/*c2*/ 1, /*d2*/ 1 + 2, /*e1*/ a + b);
-foo(/*c3*/ function () { }, /*d2*/ function () { }, /*e2*/ a + b);
+foo(/*c3*/ function () { }, /*d2*/ function () { }, /*e2*/ a + /*e3*/ b);
 foo(/*c3*/ function () { }, /*d3*/ function () { }, /*e3*/ (a + b));
 foo(
 /*c4*/ function () { }, 

--- a/tests/baselines/reference/commentsFunction.js
+++ b/tests/baselines/reference/commentsFunction.js
@@ -74,8 +74,8 @@ var fooFunc = function FooFunctionValue(/** fooFunctionValue param */ b) {
     return b;
 };
 /// lamdaFoo var comment
-var lambdaFoo = function (/**param a*/ a, /**param b*/ b) { return a + b; };
-var lambddaNoVarComment = function (/**param a*/ a, /**param b*/ b) { return a * b; };
+var lambdaFoo = /** this is lambda comment*/ function (/**param a*/ a, /**param b*/ b) { return a + b; };
+var lambddaNoVarComment = /** this is lambda multiplication*/ function (/**param a*/ a, /**param b*/ b) { return a * b; };
 lambdaFoo(10, 20);
 lambddaNoVarComment(10, 20);
 function blah(a /* multiline trailing comment

--- a/tests/baselines/reference/commentsVarDecl.js
+++ b/tests/baselines/reference/commentsVarDecl.js
@@ -64,13 +64,13 @@ x = myVariable;
 /** jsdocstyle comment - only this comment should be in .d.ts file*/
 var n = 30;
 /** var deckaration with comment on type as well*/
-var y = 20;
+var y = /** value comment */ 20;
 /// var deckaration with comment on type as well
 var yy = 
 /// value comment
 20;
 /** comment2 */
-var z = function (x, y) { return x + y; };
+var z = /** lambda comment */ function (x, y) { return x + y; };
 var z2;
 var x2 = z2;
 var n4;
@@ -98,6 +98,6 @@ declare var y: number;
 declare var yy: number;
 /** comment2 */
 declare var z: (x: number, y: number) => number;
-declare var z2: (x: number) => string;
+declare var z2: /** type comment*/ (x: number) => string;
 declare var x2: (x: number) => string;
 declare var n4: (x: number) => string;

--- a/tests/baselines/reference/computedPropertyNames48_ES5.js
+++ b/tests/baselines/reference/computedPropertyNames48_ES5.js
@@ -34,5 +34,5 @@ extractIndexer((_b = {},
 extractIndexer((_c = {},
     _c["" || 0] = "",
     _c
-)); // Should return any (widened form of undefined)
-var _a, _b, _c;
+));
+var _a, _b, _c; // Should return any (widened form of undefined)

--- a/tests/baselines/reference/constructorOverloads1.js
+++ b/tests/baselines/reference/constructorOverloads1.js
@@ -25,8 +25,8 @@ f1.bar2();
 var Foo = (function () {
     function Foo(x) {
     }
-    Foo.prototype.bar1 = function () { };
-    Foo.prototype.bar2 = function () { };
+    Foo.prototype.bar1 = function () { /*WScript.Echo("bar1");*/ };
+    Foo.prototype.bar2 = function () { /*WScript.Echo("bar1");*/ };
     return Foo;
 }());
 var f1 = new Foo("hey");

--- a/tests/baselines/reference/constructorOverloads2.js
+++ b/tests/baselines/reference/constructorOverloads2.js
@@ -34,7 +34,7 @@ var __extends = (this && this.__extends) || function (d, b) {
 var FooBase = (function () {
     function FooBase(x) {
     }
-    FooBase.prototype.bar1 = function () { };
+    FooBase.prototype.bar1 = function () { /*WScript.Echo("base bar1");*/ };
     return FooBase;
 }());
 var Foo = (function (_super) {
@@ -42,7 +42,7 @@ var Foo = (function (_super) {
     function Foo(x, y) {
         _super.call(this, x);
     }
-    Foo.prototype.bar1 = function () { };
+    Foo.prototype.bar1 = function () { /*WScript.Echo("bar1");*/ };
     return Foo;
 }(FooBase));
 var f1 = new Foo("hey");

--- a/tests/baselines/reference/constructorOverloads3.js
+++ b/tests/baselines/reference/constructorOverloads3.js
@@ -32,7 +32,7 @@ var Foo = (function (_super) {
     __extends(Foo, _super);
     function Foo(x, y) {
     }
-    Foo.prototype.bar1 = function () { };
+    Foo.prototype.bar1 = function () { /*WScript.Echo("Yo");*/ };
     return Foo;
 }(FooBase));
 var f1 = new Foo("hey");

--- a/tests/baselines/reference/contextuallyTypingRestParameters.js
+++ b/tests/baselines/reference/contextuallyTypingRestParameters.js
@@ -9,9 +9,9 @@ var x: (...y: string[]) => void = function (.../*3*/y) {
 
 //// [contextuallyTypingRestParameters.js]
 var x = function () {
-    var y = [];
+    var /*3*/ y = [];
     for (var _i = 0; _i < arguments.length; _i++) {
-        y[_i - 0] = arguments[_i];
+        /*3*/ y[_i - 0] = arguments[_i];
     }
     var t = y;
     var x2 = t; // This should be error

--- a/tests/baselines/reference/declFileObjectLiteralWithAccessors.js
+++ b/tests/baselines/reference/declFileObjectLiteralWithAccessors.js
@@ -12,7 +12,7 @@ var /*2*/x = point.x;
 point./*3*/x = 30;
 
 //// [declFileObjectLiteralWithAccessors.js]
-function makePoint(x) {
+function /*1*/ makePoint(x) {
     return {
         b: 10,
         get x() { return x; },
@@ -22,7 +22,7 @@ function makePoint(x) {
 ;
 var /*4*/ point = makePoint(2);
 var /*2*/ x = point.x;
-point.x = 30;
+point./*3*/ x = 30;
 
 
 //// [declFileObjectLiteralWithAccessors.d.ts]

--- a/tests/baselines/reference/declFileObjectLiteralWithOnlyGetter.js
+++ b/tests/baselines/reference/declFileObjectLiteralWithOnlyGetter.js
@@ -10,14 +10,14 @@ var /*2*/x = point./*3*/x;
 
 
 //// [declFileObjectLiteralWithOnlyGetter.js]
-function makePoint(x) {
+function /*1*/ makePoint(x) {
     return {
         get x() { return x; },
     };
 }
 ;
 var /*4*/ point = makePoint(2);
-var /*2*/ x = point.x;
+var /*2*/ x = point./*3*/ x;
 
 
 //// [declFileObjectLiteralWithOnlyGetter.d.ts]

--- a/tests/baselines/reference/declFileObjectLiteralWithOnlySetter.js
+++ b/tests/baselines/reference/declFileObjectLiteralWithOnlySetter.js
@@ -10,7 +10,7 @@ var /*3*/point = makePoint(2);
 point./*2*/x = 30;
 
 //// [declFileObjectLiteralWithOnlySetter.js]
-function makePoint(x) {
+function /*1*/ makePoint(x) {
     return {
         b: 10,
         set x(a) { this.b = a; }
@@ -18,7 +18,7 @@ function makePoint(x) {
 }
 ;
 var /*3*/ point = makePoint(2);
-point.x = 30;
+point./*2*/ x = 30;
 
 
 //// [declFileObjectLiteralWithOnlySetter.d.ts]

--- a/tests/baselines/reference/errorSupression1.js
+++ b/tests/baselines/reference/errorSupression1.js
@@ -18,4 +18,4 @@ var Foo = (function () {
 var baz = Foo.b;
 // Foo.b won't bind. 
 baz.concat("y");
-// So we don't want an error on 'concat'. 
+ // So we don't want an error on 'concat'.

--- a/tests/baselines/reference/es6ImportDefaultBindingWithExport.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingWithExport.js
@@ -21,7 +21,7 @@ define(["require", "exports"], function (require, exports) {
 define(["require", "exports", "server"], function (require, exports, server_1) {
     "use strict";
     exports.x = server_1.default;
-});
+}); // non referenced
 
 
 //// [server.d.ts]

--- a/tests/baselines/reference/es6ImportNameSpaceImportDts.js
+++ b/tests/baselines/reference/es6ImportNameSpaceImportDts.js
@@ -22,6 +22,7 @@ exports.c = c;
 "use strict";
 var nameSpaceBinding = require("./server");
 exports.x = new nameSpaceBinding.c();
+ // unreferenced
 
 
 //// [server.d.ts]

--- a/tests/baselines/reference/es6ImportNameSpaceImportNoNamedExports.js
+++ b/tests/baselines/reference/es6ImportNameSpaceImportNoNamedExports.js
@@ -14,3 +14,4 @@ var a = 10;
 module.exports = a;
 //// [es6ImportNameSpaceImportNoNamedExports_1.js]
 "use strict";
+ // error

--- a/tests/baselines/reference/es6ImportNamedImportIdentifiersParsing.js
+++ b/tests/baselines/reference/es6ImportNamedImportIdentifiersParsing.js
@@ -7,3 +7,4 @@ import { default as yield } from "somemodule"; // no error
 import { default as default } from "somemodule"; // default as is ok, error of default binding name
 
 //// [es6ImportNamedImportIdentifiersParsing.js]
+ // default as is ok, error of default binding name

--- a/tests/baselines/reference/es6modulekindWithES5Target10.js
+++ b/tests/baselines/reference/es6modulekindWithES5Target10.js
@@ -8,3 +8,4 @@ namespace N {
 export = N; // Error
 
 //// [es6modulekindWithES5Target10.js]
+ // Error

--- a/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration4.js
+++ b/tests/baselines/reference/exportSpecifierReferencingOuterDeclaration4.js
@@ -12,3 +12,4 @@ export declare function bar(): X.bar; // error
 //// [exportSpecifierReferencingOuterDeclaration2_A.js]
 //// [exportSpecifierReferencingOuterDeclaration2_B.js]
 "use strict";
+ // error

--- a/tests/baselines/reference/genericConstraint3.js
+++ b/tests/baselines/reference/genericConstraint3.js
@@ -4,3 +4,4 @@ interface A<T, U extends C<T>> { x: U; }
 interface B extends A<{}, { x: {} }> { } // Should not produce an error
 
 //// [genericConstraint3.js]
+ // Should not produce an error

--- a/tests/baselines/reference/inheritedMembersAndIndexSignaturesFromDifferentBases.js
+++ b/tests/baselines/reference/inheritedMembersAndIndexSignaturesFromDifferentBases.js
@@ -28,3 +28,4 @@ interface G extends A, B, C, E { } // should only report one error
 interface H extends A, F { } // Should report no error at all because error is internal to F
 
 //// [inheritedMembersAndIndexSignaturesFromDifferentBases.js]
+ // Should report no error at all because error is internal to F

--- a/tests/baselines/reference/inheritedMembersAndIndexSignaturesFromDifferentBases2.js
+++ b/tests/baselines/reference/inheritedMembersAndIndexSignaturesFromDifferentBases2.js
@@ -10,3 +10,4 @@ interface B {
 interface C extends B, A<string> { } // Should succeed
 
 //// [inheritedMembersAndIndexSignaturesFromDifferentBases2.js]
+ // Should succeed

--- a/tests/baselines/reference/inheritedStringIndexersFromDifferentBaseTypes.js
+++ b/tests/baselines/reference/inheritedStringIndexersFromDifferentBaseTypes.js
@@ -29,3 +29,4 @@ interface D2 {
 interface E2 extends A2, D2 { } // error
 
 //// [inheritedStringIndexersFromDifferentBaseTypes.js]
+ // error

--- a/tests/baselines/reference/inheritedStringIndexersFromDifferentBaseTypes2.js
+++ b/tests/baselines/reference/inheritedStringIndexersFromDifferentBaseTypes2.js
@@ -25,3 +25,4 @@ interface F extends A, D {
 } // ok because we overrode D's number index signature
 
 //// [inheritedStringIndexersFromDifferentBaseTypes2.js]
+ // ok because we overrode D's number index signature

--- a/tests/baselines/reference/jsxInvalidEsprimaTestSuite.js
+++ b/tests/baselines/reference/jsxInvalidEsprimaTestSuite.js
@@ -62,7 +62,7 @@ a['foo'] > ;
 <a><a />;
 <a b=>;
 var x = <div>one</div><div>two</div>;;
-var x = <div>one</div> /* intervening comment */ /* intervening comment */ <div>two</div>;;
+var x = <div>one</div>/* intervening comment */  /* intervening comment */ <div>two</div>;;
 <a>{"str"}}</a>;
 <span className="a"/> id="b" />;
 <div className/>>;
@@ -76,4 +76,4 @@ var x = <div>one</div> /* intervening comment */ /* intervening comment */ <div>
 <a b=>;
 <a b={ < }>;
 <a>}</a>;
-<a /> /*hai*//*hai*/asdf/>;</></></></>;
+<a />/*hai*/ /*hai*/asdf/>;</></></></>;

--- a/tests/baselines/reference/nonConflictingRecursiveBaseTypeMembers.js
+++ b/tests/baselines/reference/nonConflictingRecursiveBaseTypeMembers.js
@@ -10,3 +10,4 @@ interface B<T> {
 interface C<T> extends A<T>, B<T> { } // Should not be an error
 
 //// [nonConflictingRecursiveBaseTypeMembers.js]
+ // Should not be an error

--- a/tests/baselines/reference/objectTypesWithOptionalProperties2.js
+++ b/tests/baselines/reference/objectTypesWithOptionalProperties2.js
@@ -42,6 +42,5 @@ var C2 = (function () {
     return C2;
 }());
 var b = {
-    x: function () { }, 1: // error
-     // error
+    x: function () { }, 1:  // error
 };

--- a/tests/baselines/reference/parseRegularExpressionMixedWithComments.js
+++ b/tests/baselines/reference/parseRegularExpressionMixedWithComments.js
@@ -8,7 +8,7 @@ var regex5 = /**// asdf/**/ /;
 
 //// [parseRegularExpressionMixedWithComments.js]
 var regex1 = / asdf /;
-var regex2 = / asdf /;
+var regex2 = /**/ / asdf /;
 var regex3 = 1;
-var regex4 = Math.pow(/ /, /asdf /);
-var regex5 = Math.pow(/ asdf/, / /);
+var regex4 = /**/ Math.pow(/ /, /asdf /);
+var regex5 = /**/ Math.pow(/ asdf/, / /);

--- a/tests/baselines/reference/parserGreaterThanTokenAmbiguity10.js
+++ b/tests/baselines/reference/parserGreaterThanTokenAmbiguity10.js
@@ -6,5 +6,6 @@
 
 //// [parserGreaterThanTokenAmbiguity10.js]
 1
+ // before
     >>>
         2;

--- a/tests/baselines/reference/parserGreaterThanTokenAmbiguity13.js
+++ b/tests/baselines/reference/parserGreaterThanTokenAmbiguity13.js
@@ -2,5 +2,5 @@
 1 >>/**/= 2;
 
 //// [parserGreaterThanTokenAmbiguity13.js]
-1 >> ; /**/
+1 >> /**/ ;
 2;

--- a/tests/baselines/reference/parserGreaterThanTokenAmbiguity15.js
+++ b/tests/baselines/reference/parserGreaterThanTokenAmbiguity15.js
@@ -6,5 +6,6 @@
 
 //// [parserGreaterThanTokenAmbiguity15.js]
 1
+ // before
     >>=
         2;

--- a/tests/baselines/reference/parserGreaterThanTokenAmbiguity18.js
+++ b/tests/baselines/reference/parserGreaterThanTokenAmbiguity18.js
@@ -2,5 +2,5 @@
 1 >>>/**/= 2;
 
 //// [parserGreaterThanTokenAmbiguity18.js]
-1 >>> ; /**/
+1 >>> /**/ ;
 2;

--- a/tests/baselines/reference/parserGreaterThanTokenAmbiguity20.js
+++ b/tests/baselines/reference/parserGreaterThanTokenAmbiguity20.js
@@ -6,5 +6,6 @@
 
 //// [parserGreaterThanTokenAmbiguity20.js]
 1
+ // Before
     >>>=
         2;

--- a/tests/baselines/reference/parserGreaterThanTokenAmbiguity3.js
+++ b/tests/baselines/reference/parserGreaterThanTokenAmbiguity3.js
@@ -2,4 +2,4 @@
 1 >/**/> 2;
 
 //// [parserGreaterThanTokenAmbiguity3.js]
-1 >  /**/ > 2;
+1 > /**/  /**/ > 2;

--- a/tests/baselines/reference/parserGreaterThanTokenAmbiguity5.js
+++ b/tests/baselines/reference/parserGreaterThanTokenAmbiguity5.js
@@ -6,5 +6,6 @@
 
 //// [parserGreaterThanTokenAmbiguity5.js]
 1
+ // before
     >>
         2;

--- a/tests/baselines/reference/parserGreaterThanTokenAmbiguity8.js
+++ b/tests/baselines/reference/parserGreaterThanTokenAmbiguity8.js
@@ -2,4 +2,4 @@
 1 >>/**/> 2;
 
 //// [parserGreaterThanTokenAmbiguity8.js]
-1 >>  /**/ > 2;
+1 >> /**/  /**/ > 2;

--- a/tests/baselines/reference/parserSkippedTokens5.js
+++ b/tests/baselines/reference/parserSkippedTokens5.js
@@ -2,4 +2,4 @@
 \ /*foo*/ ;
 
 //// [parserSkippedTokens5.js]
-;
+/*foo*/ ;

--- a/tests/baselines/reference/parserSkippedTokens7.js
+++ b/tests/baselines/reference/parserSkippedTokens7.js
@@ -2,3 +2,4 @@
 /*foo*/ \ /*bar*/
 
 //// [parserSkippedTokens7.js]
+ /*bar*/

--- a/tests/baselines/reference/parserSkippedTokens8.js
+++ b/tests/baselines/reference/parserSkippedTokens8.js
@@ -3,4 +3,4 @@
 /*foo*/ \ /*bar*/
 
 //// [parserSkippedTokens8.js]
-;
+; /*bar*/

--- a/tests/baselines/reference/parserSkippedTokens9.js
+++ b/tests/baselines/reference/parserSkippedTokens9.js
@@ -4,3 +4,4 @@
 
 //// [parserSkippedTokens9.js]
 ; // existing trivia
+ /*bar*/

--- a/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType1.js
+++ b/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType1.js
@@ -29,4 +29,4 @@ define(["require", "exports"], function (require, exports) {
 //// [recursiveExportAssignmentAndFindAliasedType1_moduleA.js]
 define(["require", "exports"], function (require, exports) {
     "use strict";
-});
+}); // This should result in type ClassB

--- a/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType2.js
+++ b/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType2.js
@@ -33,4 +33,4 @@ define(["require", "exports"], function (require, exports) {
 //// [recursiveExportAssignmentAndFindAliasedType2_moduleA.js]
 define(["require", "exports"], function (require, exports) {
     "use strict";
-});
+}); // This should result in type ClassB

--- a/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType3.js
+++ b/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType3.js
@@ -37,4 +37,4 @@ define(["require", "exports"], function (require, exports) {
 //// [recursiveExportAssignmentAndFindAliasedType3_moduleA.js]
 define(["require", "exports"], function (require, exports) {
     "use strict";
-});
+}); // This should result in type ClassB

--- a/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType4.js
+++ b/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType4.js
@@ -31,4 +31,4 @@ define(["require", "exports"], function (require, exports) {
 //// [recursiveExportAssignmentAndFindAliasedType4_moduleA.js]
 define(["require", "exports"], function (require, exports) {
     "use strict";
-});
+}); // This should result in type ClassB

--- a/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType5.js
+++ b/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType5.js
@@ -40,4 +40,4 @@ define(["require", "exports"], function (require, exports) {
 //// [recursiveExportAssignmentAndFindAliasedType5_moduleA.js]
 define(["require", "exports"], function (require, exports) {
     "use strict";
-});
+}); // This should result in type ClassB

--- a/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType6.js
+++ b/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType6.js
@@ -49,4 +49,4 @@ define(["require", "exports"], function (require, exports) {
 //// [recursiveExportAssignmentAndFindAliasedType6_moduleA.js]
 define(["require", "exports"], function (require, exports) {
     "use strict";
-});
+}); // This should result in type ClassB

--- a/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType7.js
+++ b/tests/baselines/reference/recursiveExportAssignmentAndFindAliasedType7.js
@@ -51,4 +51,4 @@ define(["require", "exports"], function (require, exports) {
 //// [recursiveExportAssignmentAndFindAliasedType7_moduleA.js]
 define(["require", "exports"], function (require, exports) {
     "use strict";
-});
+}); // This should result in type ClassB

--- a/tests/baselines/reference/thisInInvalidContextsExternalModule.js
+++ b/tests/baselines/reference/thisInInvalidContextsExternalModule.js
@@ -107,4 +107,4 @@ var SomeEnum;
     SomeEnum[SomeEnum["A"] = this] = "A";
     SomeEnum[SomeEnum["B"] = this.spaaaace] = "B"; // Also should not be allowed
 })(SomeEnum || (SomeEnum = {}));
-module.exports = this;
+module.exports = this; // Should be an error

--- a/tests/baselines/reference/tsxParseTests2.js
+++ b/tests/baselines/reference/tsxParseTests2.js
@@ -8,4 +8,4 @@ var x = </**/div></div>;
 
 
 //// [file.jsx]
-var x = <div></div>;
+var x = </**/ div></div>;

--- a/tests/baselines/reference/typeAliasDoesntMakeModuleInstantiated.js
+++ b/tests/baselines/reference/typeAliasDoesntMakeModuleInstantiated.js
@@ -11,3 +11,4 @@ declare module m {
 declare var m: m.IStatic; // Should be ok to have var 'm' as module is non instantiated
 
 //// [typeAliasDoesntMakeModuleInstantiated.js]
+ // Should be ok to have var 'm' as module is non instantiated


### PR DESCRIPTION
This PR changes the definition of trailing comment to be a comment that occurs after a non-whitespace token and before a newline. All other comments are now leading comments.
Previously, a trailing comment was one that occurred after a non-whitespace token and before another token, or before a newline. All other comments were leading comments, but this set was very hard to characterize.

Some examples:

```ts
/*1*/ x /*2 */, /*3*/ y /*4*/ // 5
// 6
z
// 7
```

1. Leading comment of 'x'
2. Leading comment of ','
3. Leading comment of 'y'
4. Trailing comment of 'y'
5. Trailing comment of 'y'
6. Leading comment of 'z'
7. Leading comment of end-of-file

I needed this work for the new-improved JSDoc parser that I'm working on -- comments like `/*3*/` need to be leading comments, never trailing ones. Unfortunately, this led to a lot of noise in the old emitter. But the baselines are mostly improved &mdash; they pull in a lot of previously-missed comments. @rbuckton or @yuit maybe you have some suggestions about the emitter code?