### PR TITLE
Lock ts-node to 1.1.0 while perf issue is investigated

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "run-sequence": "latest",
         "sorcery": "latest",
         "through2": "latest",
-        "ts-node": "latest",
+        "ts-node": "~1.1.0",
         "tslint": "next",
         "typescript": "next"
     },


### PR DESCRIPTION
Fixes #9918

The underlying issue in `ts-node` is still unsolved, however.

@blakeembrey Do you know why your alterations to tsconfig parsing in `1.2` vs `1.1` would cause `ts` to try to scan the entire project folder?