### PR TITLE
Attempt to fix #9919 - Intersecting discriminated union breaks type narrowing

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7811,9 +7811,12 @@ namespace ts {
                 }
                 return getIntersectionType(filteredSubtypes);
             }
-            return type.flags & TypeFlags.Union ?
-                getUnionType(filter((<UnionType>type).types, f)) :
-                f(type) ? type : neverType;
+            if (type.flags & TypeFlags.Union) {
+                return getUnionType(
+                    map((<UnionType>type).types, t => filterType(t, f))
+                );
+            }
+            return  f(type) ? type : neverType;
         }
 
         function getFlowTypeOfReference(reference: Node, declaredType: Type, assumeInitialized: boolean, includeOuterFunctions: boolean) {

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -350,7 +350,8 @@ namespace ts.formatting {
 
             return Value.Unknown;
 
-            function getStartingExpression(node: PropertyAccessExpression | CallExpression | ElementAccessExpression) {
+            // inferred type is (correctly) `never` as all known node kinds are handled, thus resulting in an infinite loop
+            function getStartingExpression(node: PropertyAccessExpression | CallExpression | ElementAccessExpression): LeftHandSideExpression {
                 while (true) {
                     switch (node.kind) {
                         case SyntaxKind.CallExpression:

--- a/tests/baselines/reference/discriminatedUnionTypesWithIntersection.errors.txt
+++ b/tests/baselines/reference/discriminatedUnionTypesWithIntersection.errors.txt
@@ -116,3 +116,46 @@ tests/cases/conformance/types/union/discriminatedUnionTypesWithIntersection.ts(9
         }
     }
     
+    type Ext = { strVal: string } & { kind:    'int' }
+             | { intVal: string } & { kind: 'string' }
+    
+    type Boxed2 = { kind: 'null' }
+                | BoxIntersection & Ext;
+    
+    function arbitraryNesting_if(value: Boxed2): void {
+        if (value.kind === 'null') {
+            return;
+        }
+    
+        if (value.kind === 'int') {
+            value; // { kind: 'int', num: number } & { x: string; }
+            value.x;
+            value.num;
+            value.strVal;
+            return;
+        }
+    
+        value; // { kind: 'string', str: string } & { x: string } & { intVal: string } & { kind: 'string' }
+        value.x;
+        value.str;
+        value.intVal;
+    }
+    
+    function arbitraryNesting_switch(value: Boxed2): void {
+        switch (value.kind) {
+            case 'null':
+                return;
+    
+            case 'int':
+                value.x;
+                value.num;
+                value.strVal;
+                return;
+    
+            case 'string':
+                value.x;
+                value.str;
+                value.intVal;
+        }
+    }
+    

--- a/tests/baselines/reference/discriminatedUnionTypesWithIntersection.errors.txt
+++ b/tests/baselines/reference/discriminatedUnionTypesWithIntersection.errors.txt
@@ -1,0 +1,118 @@
+tests/cases/conformance/types/union/discriminatedUnionTypesWithIntersection.ts(64,18): error TS2339: Property 'str' does not exist on type 'never'.
+tests/cases/conformance/types/union/discriminatedUnionTypesWithIntersection.ts(75,26): error TS2339: Property 'str' does not exist on type 'never'.
+tests/cases/conformance/types/union/discriminatedUnionTypesWithIntersection.ts(82,27): error TS2339: Property 'num' does not exist on type 'never'.
+tests/cases/conformance/types/union/discriminatedUnionTypesWithIntersection.ts(93,31): error TS2339: Property 'num' does not exist on type 'never'.
+tests/cases/conformance/types/union/discriminatedUnionTypesWithIntersection.ts(97,26): error TS2339: Property 'str' does not exist on type 'never'.
+
+
+==== tests/cases/conformance/types/union/discriminatedUnionTypesWithIntersection.ts (5 errors) ====
+    type WithX = {
+        x: string;
+    }
+    
+    type BoxedValue = { kind: 'int',    num: number }
+                    | { kind: 'string', str: string }
+    
+    type BoxIntersection = BoxedValue & WithX
+    
+    type BoxInline = { kind: 'int',    num: number } & WithX
+                   | { kind: 'string', str: string } & WithX
+    
+    function getValueAsString_inline_if(value: BoxInline): string {
+        if (value.kind === 'int') {
+            value; // { kind: "int", num: number } & { x: string }
+            return '' + value.num;
+        }
+    
+        value; // { kind: "string", str: string } & { x: string }
+        return value.str;
+    }
+    
+    function getValueAsString_inline_switch(value: BoxInline): string {
+        switch (value.kind) {
+            case 'int':
+                value; // { kind: "int", num: number } & { x: string }
+                return '' + value.num;
+    
+            case 'string':
+                value; // { kind: "string", str: string } & { x: string }
+                return value.str;
+        }
+    }
+    
+    function getValueAsString_if(value: BoxIntersection): string {
+        if (value.kind === 'int') {
+            value; // { kind: "int", num: number } & { x: string }
+            return '' + value.num;
+        }
+    
+        value; // { kind: "string", str: string } & { x: string }
+        return value.str;
+    }
+    
+    function getValueAsString_switch(value: BoxIntersection): string {
+        switch (value.kind) {
+            case 'int':
+                value; // { kind: "int", num: number } & { x: string }
+                return '' + value.num;
+    
+            case 'string':
+                value; // { kind: "string", str: string } & { x: string }
+                return value.str;
+        }
+    }
+    
+    function getValueAsString_if_fixed(value: BoxIntersection & { kind: 'int' }): string {
+        if (value.kind === 'int') {
+            value; // { kind: "int", num: number } & { x: string } & { kind: "number" }
+            return '' + value.num;
+        }
+    
+        value; // never
+        return value.str;
+                     ~~~
+!!! error TS2339: Property 'str' does not exist on type 'never'.
+    }
+    
+    function getValueAsString_switch_fixed(value: BoxIntersection & { kind: 'int' }): string {
+        switch (value.kind) {
+            case 'int':
+                value; // { kind: "int", num: number } & { x: string } & { kind: "number" }
+                return '' + value.num;
+    
+            case 'string':
+                value; // never
+                return value.str;
+                             ~~~
+!!! error TS2339: Property 'str' does not exist on type 'never'.
+        }
+    }
+    
+    function getValueAsString_if_never(value: BoxIntersection & { kind: number }): string {
+        if (value.kind === 'int') {
+            value; // never
+            return '' + value.num;
+                              ~~~
+!!! error TS2339: Property 'num' does not exist on type 'never'.
+        }
+    
+        value; // { kind: "string", str: string } & { x: string } & { kind: "number" }
+        return value.str;
+    }
+    
+    function getValueAsString_switch_never(value: BoxIntersection & { kind: number }): string {
+        switch (value.kind) {
+            case 'int':
+                value; // never
+                return '' + value.num;
+                                  ~~~
+!!! error TS2339: Property 'num' does not exist on type 'never'.
+    
+            case 'string':
+                value; // never
+                return value.str;
+                             ~~~
+!!! error TS2339: Property 'str' does not exist on type 'never'.
+        }
+    }
+    

--- a/tests/baselines/reference/discriminatedUnionTypesWithIntersection.js
+++ b/tests/baselines/reference/discriminatedUnionTypesWithIntersection.js
@@ -99,6 +99,49 @@ function getValueAsString_switch_never(value: BoxIntersection & { kind: number }
     }
 }
 
+type Ext = { strVal: string } & { kind:    'int' }
+         | { intVal: string } & { kind: 'string' }
+
+type Boxed2 = { kind: 'null' }
+            | BoxIntersection & Ext;
+
+function arbitraryNesting_if(value: Boxed2): void {
+    if (value.kind === 'null') {
+        return;
+    }
+
+    if (value.kind === 'int') {
+        value; // { kind: 'int', num: number } & { x: string; }
+        value.x;
+        value.num;
+        value.strVal;
+        return;
+    }
+
+    value; // { kind: 'string', str: string } & { x: string } & { intVal: string } & { kind: 'string' }
+    value.x;
+    value.str;
+    value.intVal;
+}
+
+function arbitraryNesting_switch(value: Boxed2): void {
+    switch (value.kind) {
+        case 'null':
+            return;
+
+        case 'int':
+            value.x;
+            value.num;
+            value.strVal;
+            return;
+
+        case 'string':
+            value.x;
+            value.str;
+            value.intVal;
+    }
+}
+
 
 //// [discriminatedUnionTypesWithIntersection.js]
 function getValueAsString_inline_if(value) {
@@ -171,5 +214,36 @@ function getValueAsString_switch_never(value) {
         case 'string':
             value; // never
             return value.str;
+    }
+}
+function arbitraryNesting_if(value) {
+    if (value.kind === 'null') {
+        return;
+    }
+    if (value.kind === 'int') {
+        value; // { kind: 'int', num: number } & { x: string; }
+        value.x;
+        value.num;
+        value.strVal;
+        return;
+    }
+    value; // { kind: 'string', str: string } & { x: string } & { intVal: string } & { kind: 'string' }
+    value.x;
+    value.str;
+    value.intVal;
+}
+function arbitraryNesting_switch(value) {
+    switch (value.kind) {
+        case 'null':
+            return;
+        case 'int':
+            value.x;
+            value.num;
+            value.strVal;
+            return;
+        case 'string':
+            value.x;
+            value.str;
+            value.intVal;
     }
 }

--- a/tests/baselines/reference/discriminatedUnionTypesWithIntersection.js
+++ b/tests/baselines/reference/discriminatedUnionTypesWithIntersection.js
@@ -1,0 +1,175 @@
+//// [discriminatedUnionTypesWithIntersection.ts]
+type WithX = {
+    x: string;
+}
+
+type BoxedValue = { kind: 'int',    num: number }
+                | { kind: 'string', str: string }
+
+type BoxIntersection = BoxedValue & WithX
+
+type BoxInline = { kind: 'int',    num: number } & WithX
+               | { kind: 'string', str: string } & WithX
+
+function getValueAsString_inline_if(value: BoxInline): string {
+    if (value.kind === 'int') {
+        value; // { kind: "int", num: number } & { x: string }
+        return '' + value.num;
+    }
+
+    value; // { kind: "string", str: string } & { x: string }
+    return value.str;
+}
+
+function getValueAsString_inline_switch(value: BoxInline): string {
+    switch (value.kind) {
+        case 'int':
+            value; // { kind: "int", num: number } & { x: string }
+            return '' + value.num;
+
+        case 'string':
+            value; // { kind: "string", str: string } & { x: string }
+            return value.str;
+    }
+}
+
+function getValueAsString_if(value: BoxIntersection): string {
+    if (value.kind === 'int') {
+        value; // { kind: "int", num: number } & { x: string }
+        return '' + value.num;
+    }
+
+    value; // { kind: "string", str: string } & { x: string }
+    return value.str;
+}
+
+function getValueAsString_switch(value: BoxIntersection): string {
+    switch (value.kind) {
+        case 'int':
+            value; // { kind: "int", num: number } & { x: string }
+            return '' + value.num;
+
+        case 'string':
+            value; // { kind: "string", str: string } & { x: string }
+            return value.str;
+    }
+}
+
+function getValueAsString_if_fixed(value: BoxIntersection & { kind: 'int' }): string {
+    if (value.kind === 'int') {
+        value; // { kind: "int", num: number } & { x: string } & { kind: "number" }
+        return '' + value.num;
+    }
+
+    value; // never
+    return value.str;
+}
+
+function getValueAsString_switch_fixed(value: BoxIntersection & { kind: 'int' }): string {
+    switch (value.kind) {
+        case 'int':
+            value; // { kind: "int", num: number } & { x: string } & { kind: "number" }
+            return '' + value.num;
+
+        case 'string':
+            value; // never
+            return value.str;
+    }
+}
+
+function getValueAsString_if_never(value: BoxIntersection & { kind: number }): string {
+    if (value.kind === 'int') {
+        value; // never
+        return '' + value.num;
+    }
+
+    value; // { kind: "string", str: string } & { x: string } & { kind: "number" }
+    return value.str;
+}
+
+function getValueAsString_switch_never(value: BoxIntersection & { kind: number }): string {
+    switch (value.kind) {
+        case 'int':
+            value; // never
+            return '' + value.num;
+
+        case 'string':
+            value; // never
+            return value.str;
+    }
+}
+
+
+//// [discriminatedUnionTypesWithIntersection.js]
+function getValueAsString_inline_if(value) {
+    if (value.kind === 'int') {
+        value; // { kind: "int", num: number } & { x: string }
+        return '' + value.num;
+    }
+    value; // { kind: "string", str: string } & { x: string }
+    return value.str;
+}
+function getValueAsString_inline_switch(value) {
+    switch (value.kind) {
+        case 'int':
+            value; // { kind: "int", num: number } & { x: string }
+            return '' + value.num;
+        case 'string':
+            value; // { kind: "string", str: string } & { x: string }
+            return value.str;
+    }
+}
+function getValueAsString_if(value) {
+    if (value.kind === 'int') {
+        value; // { kind: "int", num: number } & { x: string }
+        return '' + value.num;
+    }
+    value; // { kind: "string", str: string } & { x: string }
+    return value.str;
+}
+function getValueAsString_switch(value) {
+    switch (value.kind) {
+        case 'int':
+            value; // { kind: "int", num: number } & { x: string }
+            return '' + value.num;
+        case 'string':
+            value; // { kind: "string", str: string } & { x: string }
+            return value.str;
+    }
+}
+function getValueAsString_if_fixed(value) {
+    if (value.kind === 'int') {
+        value; // { kind: "int", num: number } & { x: string } & { kind: "number" }
+        return '' + value.num;
+    }
+    value; // never
+    return value.str;
+}
+function getValueAsString_switch_fixed(value) {
+    switch (value.kind) {
+        case 'int':
+            value; // { kind: "int", num: number } & { x: string } & { kind: "number" }
+            return '' + value.num;
+        case 'string':
+            value; // never
+            return value.str;
+    }
+}
+function getValueAsString_if_never(value) {
+    if (value.kind === 'int') {
+        value; // never
+        return '' + value.num;
+    }
+    value; // { kind: "string", str: string } & { x: string } & { kind: "number" }
+    return value.str;
+}
+function getValueAsString_switch_never(value) {
+    switch (value.kind) {
+        case 'int':
+            value; // never
+            return '' + value.num;
+        case 'string':
+            value; // never
+            return value.str;
+    }
+}

--- a/tests/cases/conformance/types/union/discriminatedUnionTypesWithIntersection.ts
+++ b/tests/cases/conformance/types/union/discriminatedUnionTypesWithIntersection.ts
@@ -97,3 +97,46 @@ function getValueAsString_switch_never(value: BoxIntersection & { kind: number }
             return value.str;
     }
 }
+
+type Ext = { strVal: string } & { kind:    'int' }
+         | { intVal: string } & { kind: 'string' }
+
+type Boxed2 = { kind: 'null' }
+            | BoxIntersection & Ext;
+
+function arbitraryNesting_if(value: Boxed2): void {
+    if (value.kind === 'null') {
+        return;
+    }
+
+    if (value.kind === 'int') {
+        value; // { kind: 'int', num: number } & { x: string; }
+        value.x;
+        value.num;
+        value.strVal;
+        return;
+    }
+
+    value; // { kind: 'string', str: string } & { x: string } & { intVal: string } & { kind: 'string' }
+    value.x;
+    value.str;
+    value.intVal;
+}
+
+function arbitraryNesting_switch(value: Boxed2): void {
+    switch (value.kind) {
+        case 'null':
+            return;
+
+        case 'int':
+            value.x;
+            value.num;
+            value.strVal;
+            return;
+
+        case 'string':
+            value.x;
+            value.str;
+            value.intVal;
+    }
+}

--- a/tests/cases/conformance/types/union/discriminatedUnionTypesWithIntersection.ts
+++ b/tests/cases/conformance/types/union/discriminatedUnionTypesWithIntersection.ts
@@ -1,0 +1,99 @@
+type WithX = {
+    x: string;
+}
+
+type BoxedValue = { kind: 'int',    num: number }
+                | { kind: 'string', str: string }
+
+type BoxIntersection = BoxedValue & WithX
+
+type BoxInline = { kind: 'int',    num: number } & WithX
+               | { kind: 'string', str: string } & WithX
+
+function getValueAsString_inline_if(value: BoxInline): string {
+    if (value.kind === 'int') {
+        value; // { kind: "int", num: number } & { x: string }
+        return '' + value.num;
+    }
+
+    value; // { kind: "string", str: string } & { x: string }
+    return value.str;
+}
+
+function getValueAsString_inline_switch(value: BoxInline): string {
+    switch (value.kind) {
+        case 'int':
+            value; // { kind: "int", num: number } & { x: string }
+            return '' + value.num;
+
+        case 'string':
+            value; // { kind: "string", str: string } & { x: string }
+            return value.str;
+    }
+}
+
+function getValueAsString_if(value: BoxIntersection): string {
+    if (value.kind === 'int') {
+        value; // { kind: "int", num: number } & { x: string }
+        return '' + value.num;
+    }
+
+    value; // { kind: "string", str: string } & { x: string }
+    return value.str;
+}
+
+function getValueAsString_switch(value: BoxIntersection): string {
+    switch (value.kind) {
+        case 'int':
+            value; // { kind: "int", num: number } & { x: string }
+            return '' + value.num;
+
+        case 'string':
+            value; // { kind: "string", str: string } & { x: string }
+            return value.str;
+    }
+}
+
+function getValueAsString_if_fixed(value: BoxIntersection & { kind: 'int' }): string {
+    if (value.kind === 'int') {
+        value; // { kind: "int", num: number } & { x: string } & { kind: "number" }
+        return '' + value.num;
+    }
+
+    value; // never
+    return value.str;
+}
+
+function getValueAsString_switch_fixed(value: BoxIntersection & { kind: 'int' }): string {
+    switch (value.kind) {
+        case 'int':
+            value; // { kind: "int", num: number } & { x: string } & { kind: "number" }
+            return '' + value.num;
+
+        case 'string':
+            value; // never
+            return value.str;
+    }
+}
+
+function getValueAsString_if_never(value: BoxIntersection & { kind: number }): string {
+    if (value.kind === 'int') {
+        value; // never
+        return '' + value.num;
+    }
+
+    value; // { kind: "string", str: string } & { x: string } & { kind: "number" }
+    return value.str;
+}
+
+function getValueAsString_switch_never(value: BoxIntersection & { kind: number }): string {
+    switch (value.kind) {
+        case 'int':
+            value; // never
+            return '' + value.num;
+
+        case 'string':
+            value; // never
+            return value.str;
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #9919.

This PR adds support for correctly narrowing discriminated unions that are also intersected. As a side effect a type is now eligible for discrimination whenever it is a union or intersection, regardless whether the discrimination property is a union itself. This is to handle situations where the property type is narrowed by subsequent intersections.
