### PR TITLE
In ts.performance.now, bind window.performance.now

### DIFF
--- a/src/compiler/performance.ts
+++ b/src/compiler/performance.ts
@@ -2,7 +2,7 @@
 namespace ts {
     declare const performance: { now?(): number } | undefined;
     /** Gets a timestamp with (at least) ms resolution */
-    export const timestamp = typeof performance !== "undefined" && performance.now ? performance.now : Date.now ? Date.now : () => +(new Date());
+    export const timestamp = typeof performance !== "undefined" && performance.now ? () => performance.now() : Date.now ? Date.now : () => +(new Date());
 }
 
 /*@internal*/


### PR DESCRIPTION
Fixes #9954

Using an arrow function. Previously, it was set directly to window.performance.now, which fails when used in Chrome.