### PR TITLE
Unlock ts-node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
         "run-sequence": "latest",
         "sorcery": "latest",
         "through2": "latest",
-        "ts-node": "~1.1.0",
+        "ts-node": "latest",
         "tslint": "next",
         "typescript": "next"
     },


### PR DESCRIPTION
With [this commit](https://github.com/TypeStrong/tsconfig/commit/cbdaae6046ce35b201189d624b21c291003345d7) to `ts-node`'s dependency `tsconfig`, its default result now has an empty `files` object (causing it to no longer scan the entire directory for files to build), and it now back to old behavior.
