### PR TITLE
Limit travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,13 @@ os:
 
 matrix:
   fast_finish: true
+  exclude:
+  - os: osx
+    node_js: '4'
+  - os: osx
+    node_js: '0.10'
+
+branches:
+  only:
+  - master
+  - transforms


### PR DESCRIPTION
Only build `master` and `transforms` branches (PRs will still get run), and stop building on osx with node 4 and 0.10 (these seemed flaky in the last week of using them, and haven't added much value while greatly increasing required build time).
