### PR TITLE
Always use a hardcoded port

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -59,7 +59,6 @@ const cmdLineOptions = minimist(process.argv.slice(2), {
         browser: process.env.browser || process.env.b || "IE",
         tests: process.env.test || process.env.tests || process.env.t,
         light: process.env.light || false,
-        port: process.env.port || process.env.p || "8888",
         reporter: process.env.reporter || process.env.r,
         lint: process.env.lint || true,
         files: process.env.f || process.env.file || process.env.files || "",
@@ -766,7 +765,7 @@ function writeTestConfigFile(tests: string, light: boolean, taskConfigsFolder?: 
 }
 
 
-gulp.task("runtests-browser", "Runs the tests using the built run.js file like 'gulp runtests'. Syntax is gulp runtests-browser. Additional optional parameters --tests=[regex], --port=, --browser=[chrome|IE]", ["browserify", nodeServerOutFile], (done) => {
+gulp.task("runtests-browser", "Runs the tests using the built run.js file like 'gulp runtests'. Syntax is gulp runtests-browser. Additional optional parameters --tests=[regex], --browser=[chrome|IE]", ["browserify", nodeServerOutFile], (done) => {
     cleanTestDirs((err) => {
         if (err) { console.error(err); done(err); process.exit(1); }
         host = "node";
@@ -781,9 +780,6 @@ gulp.task("runtests-browser", "Runs the tests using the built run.js file like '
         }
 
         const args = [nodeServerOutFile];
-        if (cmdLineOptions["port"]) {
-            args.push(cmdLineOptions["port"]);
-        }
         if (cmdLineOptions["browser"]) {
             args.push(cmdLineOptions["browser"]);
         }

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -847,11 +847,10 @@ task("browserify", ["tests", builtLocalDirectory, nodeServerOutFile], function()
     exec(cmd);
 }, {async: true});
 
-desc("Runs the tests using the built run.js file like 'jake runtests'. Syntax is jake runtests-browser. Additional optional parameters tests=[regex], port=, browser=[chrome|IE]");
+desc("Runs the tests using the built run.js file like 'jake runtests'. Syntax is jake runtests-browser. Additional optional parameters tests=[regex], browser=[chrome|IE]");
 task("runtests-browser", ["tests", "browserify", builtLocalDirectory, servicesFileInBrowserTest], function() {
     cleanTestDirs();
     host = "node";
-    port = process.env.port || process.env.p || '8888';
     browser = process.env.browser || process.env.b || "IE";
     tests = process.env.test || process.env.tests || process.env.t;
     var light = process.env.light || false;
@@ -864,7 +863,7 @@ task("runtests-browser", ["tests", "browserify", builtLocalDirectory, servicesFi
     }
 
     tests = tests ? tests : '';
-    var cmd = host + " tests/webTestServer.js " + port + " " + browser + " " + JSON.stringify(tests);
+    var cmd = host + " tests/webTestServer.js " + browser + " " + JSON.stringify(tests);
     console.log(cmd);
     exec(cmd);
 }, {async: true});

--- a/tests/webTestServer.ts
+++ b/tests/webTestServer.ts
@@ -11,7 +11,7 @@ import os = require("os");
 
 if (process.argv[2] == '--help') {
     console.log('Runs a node server on port 8888, looking for tests folder in the current directory\n');
-    console.log('Syntax: node nodeServer.js [port] [typescriptEnlistmentDirectory] [tests] [--browser] [--verbose]\n');
+    console.log('Syntax: node nodeServer.js [typescriptEnlistmentDirectory] [tests] [--browser] [--verbose]\n');
     console.log('Examples: \n\tnode nodeServer.js .');
     console.log('\tnode nodeServer.js 3000 D:/src/typescript/public --verbose IE');
 }

--- a/tests/webTestServer.ts
+++ b/tests/webTestServer.ts
@@ -20,8 +20,10 @@ function switchToForwardSlashes(path: string) {
     return path.replace(/\\/g, "/").replace(/\/\//g, '/');
 }
 
-var defaultPort = 8888;
-var port = process.argv[2] || defaultPort;
+var port = parseInt(process.argv[2], 10) || 8888;
+if (port !== 8888) {
+    throw new Error(`Port must be 8888. Got ${port}. See GH#9987`);
+}
 var rootDir = switchToForwardSlashes(__dirname + '/../');
 
 var browser: string;
@@ -267,7 +269,7 @@ http.createServer(function (req: http.ServerRequest, res: http.ServerResponse) {
     var reqPath = path.join(process.cwd(), uri);
     var operation = getRequestOperation(req, reqPath);
     handleRequestOperation(req, res, operation, reqPath);
-}).listen(8888);
+}).listen(port);
 
 var browserPath: string;
 if ((browser && browser === 'chrome')) {

--- a/tests/webTestServer.ts
+++ b/tests/webTestServer.ts
@@ -10,9 +10,9 @@ import os = require("os");
 /// Command line processing ///
 
 if (process.argv[2] == '--help') {
-    console.log('Runs a node server on port 8888 by default, looking for tests folder in the current directory\n');
+    console.log('Runs a node server on port 8888, looking for tests folder in the current directory\n');
     console.log('Syntax: node nodeServer.js [port] [typescriptEnlistmentDirectory] [tests] [--browser] [--verbose]\n');
-    console.log('Examples: \n\tnode nodeServer.js 8888 .');
+    console.log('Examples: \n\tnode nodeServer.js .');
     console.log('\tnode nodeServer.js 3000 D:/src/typescript/public --verbose IE');
 }
 
@@ -20,27 +20,24 @@ function switchToForwardSlashes(path: string) {
     return path.replace(/\\/g, "/").replace(/\/\//g, '/');
 }
 
-var port = parseInt(process.argv[2], 10) || 8888;
-if (port !== 8888) {
-    throw new Error(`Port must be 8888. Got ${port}. See GH#9987`);
-}
+var port = 8888; // harness.ts and webTestResults.html depend on this exact port number.
 var rootDir = switchToForwardSlashes(__dirname + '/../');
 
 var browser: string;
-if (process.argv[3]) {
-    browser = process.argv[3];
+if (process.argv[2]) {
+    browser = process.argv[2];
     if (browser !== 'chrome' && browser !== 'IE') {
         console.log('Invalid command line arguments. Got ' + browser + ' but expected chrome, IE or nothing.');
     }
 }
 
-var grep = process.argv[4];
+var grep = process.argv[3];
 
 var verbose = false;
-if (process.argv[5] == '--verbose') {
+if (process.argv[4] == '--verbose') {
     verbose = true;
-} else if (process.argv[5] && process.argv[5] !== '--verbose') {
-    console.log('Invalid command line arguments. Got ' + process.argv[5] + ' but expected --verbose or nothing.');
+} else if (process.argv[4] && process.argv[4] !== '--verbose') {
+    console.log('Invalid command line arguments. Got ' + process.argv[4] + ' but expected --verbose or nothing.');
 }
 
 /// Utils ///


### PR DESCRIPTION
I had a PORT environment variable set to 80, and runtests-browser used that in some cases but not in others. Turns out it currently only works with a port of 8888, see #9987.