### PR TITLE
Jsdoc string literal types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5326,6 +5326,8 @@ namespace ts {
                     return getTypeFromThisTypeNode(node);
                 case SyntaxKind.StringLiteralType:
                     return getTypeFromStringLiteralTypeNode(<StringLiteralTypeNode>node);
+                case SyntaxKind.JSDocStringLiteralType:
+                    return getTypeFromStringLiteralTypeNode((<JSDocStringLiteralType>node).stringLiteral);
                 case SyntaxKind.TypeReference:
                 case SyntaxKind.JSDocTypeReference:
                     return getTypeFromTypeReference(<TypeReferenceNode>node);

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5860,9 +5860,10 @@ namespace ts {
                     case SyntaxKind.SymbolKeyword:
                     case SyntaxKind.VoidKeyword:
                         return parseTokenNode<JSDocType>();
+                    case SyntaxKind.StringLiteral:
+                        return parseJSDocStringLiteralType();
                 }
 
-                // TODO (drosen): Parse string literal types in JSDoc as well.
                 return parseJSDocTypeReference();
             }
 
@@ -6038,6 +6039,12 @@ namespace ts {
             function parseJSDocAllType(): JSDocAllType {
                 const result = <JSDocAllType>createNode(SyntaxKind.JSDocAllType);
                 nextToken();
+                return finishNode(result);
+            }
+
+            function parseJSDocStringLiteralType(): JSDocStringLiteralType {
+                const result = <JSDocStringLiteralType>createNode(SyntaxKind.JSDocStringLiteralType);
+                result.stringLiteral = parseStringLiteralTypeNode();
                 return finishNode(result);
             }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -346,6 +346,7 @@ namespace ts {
         JSDocTypedefTag,
         JSDocPropertyTag,
         JSDocTypeLiteral,
+        JSDocStringLiteralType,
 
         // Synthesized list
         SyntaxList,
@@ -1489,6 +1490,10 @@ namespace ts {
     // @kind(SyntaxKind.JSDocThisType)
     export interface JSDocThisType extends JSDocType {
         type: JSDocType;
+    }
+
+    export interface JSDocStringLiteralType extends JSDocType {
+        stringLiteral: StringLiteralTypeNode;
     }
 
     export type JSDocTypeReferencingNode = JSDocThisType | JSDocConstructorType | JSDocVariadicType | JSDocOptionalType | JSDocNullableType | JSDocNonNullableType;

--- a/tests/baselines/reference/jsdocStringLiteral.js
+++ b/tests/baselines/reference/jsdocStringLiteral.js
@@ -1,16 +1,22 @@
 //// [in.js]
 /**
- * @param {'literal'} input
+ * @param {'literal'} p1
+ * @param {"literal"} p2
+ * @param {'literal' | 'other'} p3
+ * @param {'literal' | number} p4
  */
-function f(input) {
-    return input + '.';
+function f(p1, p2, p3, p4) {
+    return p1 + p2 + p3 + p4 + '.';
 }
 
 
 //// [out.js]
 /**
- * @param {'literal'} input
+ * @param {'literal'} p1
+ * @param {"literal"} p2
+ * @param {'literal' | 'other'} p3
+ * @param {'literal' | number} p4
  */
-function f(input) {
-    return input + '.';
+function f(p1, p2, p3, p4) {
+    return p1 + p2 + p3 + p4 + '.';
 }

--- a/tests/baselines/reference/jsdocStringLiteral.js
+++ b/tests/baselines/reference/jsdocStringLiteral.js
@@ -1,0 +1,16 @@
+//// [in.js]
+/**
+ * @param {'literal'} input
+ */
+function f(input) {
+    return input + '.';
+}
+
+
+//// [out.js]
+/**
+ * @param {'literal'} input
+ */
+function f(input) {
+    return input + '.';
+}

--- a/tests/baselines/reference/jsdocStringLiteral.symbols
+++ b/tests/baselines/reference/jsdocStringLiteral.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/in.js ===
+/**
+ * @param {'literal'} input
+ */
+function f(input) {
+>f : Symbol(f, Decl(in.js, 0, 0))
+>input : Symbol(input, Decl(in.js, 3, 11))
+
+    return input + '.';
+>input : Symbol(input, Decl(in.js, 3, 11))
+}
+

--- a/tests/baselines/reference/jsdocStringLiteral.symbols
+++ b/tests/baselines/reference/jsdocStringLiteral.symbols
@@ -1,12 +1,21 @@
 === tests/cases/compiler/in.js ===
 /**
- * @param {'literal'} input
+ * @param {'literal'} p1
+ * @param {"literal"} p2
+ * @param {'literal' | 'other'} p3
+ * @param {'literal' | number} p4
  */
-function f(input) {
+function f(p1, p2, p3, p4) {
 >f : Symbol(f, Decl(in.js, 0, 0))
->input : Symbol(input, Decl(in.js, 3, 11))
+>p1 : Symbol(p1, Decl(in.js, 6, 11))
+>p2 : Symbol(p2, Decl(in.js, 6, 14))
+>p3 : Symbol(p3, Decl(in.js, 6, 18))
+>p4 : Symbol(p4, Decl(in.js, 6, 22))
 
-    return input + '.';
->input : Symbol(input, Decl(in.js, 3, 11))
+    return p1 + p2 + p3 + p4 + '.';
+>p1 : Symbol(p1, Decl(in.js, 6, 11))
+>p2 : Symbol(p2, Decl(in.js, 6, 14))
+>p3 : Symbol(p3, Decl(in.js, 6, 18))
+>p4 : Symbol(p4, Decl(in.js, 6, 22))
 }
 

--- a/tests/baselines/reference/jsdocStringLiteral.types
+++ b/tests/baselines/reference/jsdocStringLiteral.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/in.js ===
+/**
+ * @param {'literal'} input
+ */
+function f(input) {
+>f : (input: "literal") => string
+>input : "literal"
+
+    return input + '.';
+>input + '.' : string
+>input : "literal"
+>'.' : string
+}
+

--- a/tests/baselines/reference/jsdocStringLiteral.types
+++ b/tests/baselines/reference/jsdocStringLiteral.types
@@ -1,14 +1,26 @@
 === tests/cases/compiler/in.js ===
 /**
- * @param {'literal'} input
+ * @param {'literal'} p1
+ * @param {"literal"} p2
+ * @param {'literal' | 'other'} p3
+ * @param {'literal' | number} p4
  */
-function f(input) {
->f : (input: "literal") => string
->input : "literal"
+function f(p1, p2, p3, p4) {
+>f : (p1: "literal", p2: "literal", p3: "literal" | "other", p4: "literal" | number) => string
+>p1 : "literal"
+>p2 : "literal"
+>p3 : "literal" | "other"
+>p4 : "literal" | number
 
-    return input + '.';
->input + '.' : string
->input : "literal"
+    return p1 + p2 + p3 + p4 + '.';
+>p1 + p2 + p3 + p4 + '.' : string
+>p1 + p2 + p3 + p4 : string
+>p1 + p2 + p3 : string
+>p1 + p2 : string
+>p1 : "literal"
+>p2 : "literal"
+>p3 : "literal" | "other"
+>p4 : "literal" | number
 >'.' : string
 }
 

--- a/tests/cases/conformance/jsdoc/jsdocStringLiteral.ts
+++ b/tests/cases/conformance/jsdoc/jsdocStringLiteral.ts
@@ -1,0 +1,12 @@
+// @allowJs: true
+// @filename: in.js
+// @out: out.js
+/**
+ * @param {'literal'} p1
+ * @param {"literal"} p2
+ * @param {'literal' | 'other'} p3
+ * @param {'literal' | number} p4
+ */
+function f(p1, p2, p3, p4) {
+    return p1 + p2 + p3 + p4 + '.';
+}


### PR DESCRIPTION
Fixes #9902 

Unfortunately, I didn't find a way to reuse the normal string literal type, so I had to extend the existing JSDoc type hierarchy. Otherwise, this feature is very simple.
