### PR TITLE
Re-add strict concat signature

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1112,6 +1112,11 @@ interface Array<T> {
       * Combines two or more arrays.
       * @param items Additional items to add to the end of array1.
       */
+    concat(...items: T[][]): T[];
+    /**
+      * Combines two or more arrays.
+      * @param items Additional items to add to the end of array1.
+      */
     concat(...items: (T | T[])[]): T[];
     /**
       * Adds all the elements of an array separated by the specified separator string.

--- a/tests/baselines/reference/arrayConcat2.symbols
+++ b/tests/baselines/reference/arrayConcat2.symbols
@@ -3,21 +3,21 @@ var a: string[] = [];
 >a : Symbol(a, Decl(arrayConcat2.ts, 0, 3))
 
 a.concat("hello", 'world');
->a.concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>a.concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >a : Symbol(a, Decl(arrayConcat2.ts, 0, 3))
->concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
 a.concat('Hello');
->a.concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>a.concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >a : Symbol(a, Decl(arrayConcat2.ts, 0, 3))
->concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
 var b = new Array<string>();
 >b : Symbol(b, Decl(arrayConcat2.ts, 5, 3))
 >Array : Symbol(Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
 b.concat('hello');
->b.concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>b.concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >b : Symbol(b, Decl(arrayConcat2.ts, 5, 3))
->concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 

--- a/tests/baselines/reference/arrayConcat2.types
+++ b/tests/baselines/reference/arrayConcat2.types
@@ -5,17 +5,17 @@ var a: string[] = [];
 
 a.concat("hello", 'world');
 >a.concat("hello", 'world') : string[]
->a.concat : (...items: (string | string[])[]) => string[]
+>a.concat : { (...items: string[][]): string[]; (...items: (string | string[])[]): string[]; }
 >a : string[]
->concat : (...items: (string | string[])[]) => string[]
+>concat : { (...items: string[][]): string[]; (...items: (string | string[])[]): string[]; }
 >"hello" : string
 >'world' : string
 
 a.concat('Hello');
 >a.concat('Hello') : string[]
->a.concat : (...items: (string | string[])[]) => string[]
+>a.concat : { (...items: string[][]): string[]; (...items: (string | string[])[]): string[]; }
 >a : string[]
->concat : (...items: (string | string[])[]) => string[]
+>concat : { (...items: string[][]): string[]; (...items: (string | string[])[]): string[]; }
 >'Hello' : string
 
 var b = new Array<string>();
@@ -25,8 +25,8 @@ var b = new Array<string>();
 
 b.concat('hello');
 >b.concat('hello') : string[]
->b.concat : (...items: (string | string[])[]) => string[]
+>b.concat : { (...items: string[][]): string[]; (...items: (string | string[])[]): string[]; }
 >b : string[]
->concat : (...items: (string | string[])[]) => string[]
+>concat : { (...items: string[][]): string[]; (...items: (string | string[])[]): string[]; }
 >'hello' : string
 

--- a/tests/baselines/reference/arrayConcatMap.symbols
+++ b/tests/baselines/reference/arrayConcatMap.symbols
@@ -2,8 +2,8 @@
 var x = [].concat([{ a: 1 }], [{ a: 2 }])
 >x : Symbol(x, Decl(arrayConcatMap.ts, 0, 3))
 >[].concat([{ a: 1 }], [{ a: 2 }])          .map : Symbol(Array.map, Decl(lib.d.ts, --, --))
->[].concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
->concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>[].concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >a : Symbol(a, Decl(arrayConcatMap.ts, 0, 20))
 >a : Symbol(a, Decl(arrayConcatMap.ts, 0, 32))
 

--- a/tests/baselines/reference/arrayConcatMap.types
+++ b/tests/baselines/reference/arrayConcatMap.types
@@ -4,9 +4,9 @@ var x = [].concat([{ a: 1 }], [{ a: 2 }])
 >[].concat([{ a: 1 }], [{ a: 2 }])          .map(b => b.a) : any[]
 >[].concat([{ a: 1 }], [{ a: 2 }])          .map : <U>(callbackfn: (value: any, index: number, array: any[]) => U, thisArg?: any) => U[]
 >[].concat([{ a: 1 }], [{ a: 2 }]) : any[]
->[].concat : (...items: any[]) => any[]
+>[].concat : { (...items: any[][]): any[]; (...items: any[]): any[]; }
 >[] : undefined[]
->concat : (...items: any[]) => any[]
+>concat : { (...items: any[][]): any[]; (...items: any[]): any[]; }
 >[{ a: 1 }] : { a: number; }[]
 >{ a: 1 } : { a: number; }
 >a : number

--- a/tests/baselines/reference/concatError.symbols
+++ b/tests/baselines/reference/concatError.symbols
@@ -14,15 +14,15 @@ var fa: number[];
 
 fa = fa.concat([0]);
 >fa : Symbol(fa, Decl(concatError.ts, 8, 3))
->fa.concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>fa.concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >fa : Symbol(fa, Decl(concatError.ts, 8, 3))
->concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
 fa = fa.concat(0);
 >fa : Symbol(fa, Decl(concatError.ts, 8, 3))
->fa.concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>fa.concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >fa : Symbol(fa, Decl(concatError.ts, 8, 3))
->concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
 
 

--- a/tests/baselines/reference/concatError.types
+++ b/tests/baselines/reference/concatError.types
@@ -16,9 +16,9 @@ fa = fa.concat([0]);
 >fa = fa.concat([0]) : number[]
 >fa : number[]
 >fa.concat([0]) : number[]
->fa.concat : (...items: (number | number[])[]) => number[]
+>fa.concat : { (...items: number[][]): number[]; (...items: (number | number[])[]): number[]; }
 >fa : number[]
->concat : (...items: (number | number[])[]) => number[]
+>concat : { (...items: number[][]): number[]; (...items: (number | number[])[]): number[]; }
 >[0] : number[]
 >0 : number
 
@@ -26,9 +26,9 @@ fa = fa.concat(0);
 >fa = fa.concat(0) : number[]
 >fa : number[]
 >fa.concat(0) : number[]
->fa.concat : (...items: (number | number[])[]) => number[]
+>fa.concat : { (...items: number[][]): number[]; (...items: (number | number[])[]): number[]; }
 >fa : number[]
->concat : (...items: (number | number[])[]) => number[]
+>concat : { (...items: number[][]): number[]; (...items: (number | number[])[]): number[]; }
 >0 : number
 
 

--- a/tests/baselines/reference/concatTuples.js
+++ b/tests/baselines/reference/concatTuples.js
@@ -1,0 +1,8 @@
+//// [concatTuples.ts]
+let ijs: [number, number][] = [[1, 2]];
+ijs = ijs.concat([[3, 4], [5, 6]]);
+
+
+//// [concatTuples.js]
+var ijs = [[1, 2]];
+ijs = ijs.concat([[3, 4], [5, 6]]);

--- a/tests/baselines/reference/concatTuples.symbols
+++ b/tests/baselines/reference/concatTuples.symbols
@@ -1,0 +1,10 @@
+=== tests/cases/compiler/concatTuples.ts ===
+let ijs: [number, number][] = [[1, 2]];
+>ijs : Symbol(ijs, Decl(concatTuples.ts, 0, 3))
+
+ijs = ijs.concat([[3, 4], [5, 6]]);
+>ijs : Symbol(ijs, Decl(concatTuples.ts, 0, 3))
+>ijs.concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>ijs : Symbol(ijs, Decl(concatTuples.ts, 0, 3))
+>concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+

--- a/tests/baselines/reference/concatTuples.types
+++ b/tests/baselines/reference/concatTuples.types
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/concatTuples.ts ===
+let ijs: [number, number][] = [[1, 2]];
+>ijs : [number, number][]
+>[[1, 2]] : [number, number][]
+>[1, 2] : [number, number]
+>1 : number
+>2 : number
+
+ijs = ijs.concat([[3, 4], [5, 6]]);
+>ijs = ijs.concat([[3, 4], [5, 6]]) : [number, number][]
+>ijs : [number, number][]
+>ijs.concat([[3, 4], [5, 6]]) : [number, number][]
+>ijs.concat : { (...items: [number, number][][]): [number, number][]; (...items: ([number, number] | [number, number][])[]): [number, number][]; }
+>ijs : [number, number][]
+>concat : { (...items: [number, number][][]): [number, number][]; (...items: ([number, number] | [number, number][])[]): [number, number][]; }
+>[[3, 4], [5, 6]] : [number, number][]
+>[3, 4] : [number, number]
+>3 : number
+>4 : number
+>[5, 6] : [number, number]
+>5 : number
+>6 : number
+

--- a/tests/baselines/reference/emitSkipsThisWithRestParameter.symbols
+++ b/tests/baselines/reference/emitSkipsThisWithRestParameter.symbols
@@ -15,9 +15,9 @@ function rebase(fn: (base: any, ...args: any[]) => any): (...args: any[]) => any
 >fn : Symbol(fn, Decl(emitSkipsThisWithRestParameter.ts, 0, 16))
 >apply : Symbol(Function.apply, Decl(lib.d.ts, --, --))
 >this : Symbol(this, Decl(emitSkipsThisWithRestParameter.ts, 1, 20))
->[ this ].concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>[ this ].concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >this : Symbol(this, Decl(emitSkipsThisWithRestParameter.ts, 1, 20))
->concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >args : Symbol(args, Decl(emitSkipsThisWithRestParameter.ts, 1, 30))
 
     };

--- a/tests/baselines/reference/emitSkipsThisWithRestParameter.types
+++ b/tests/baselines/reference/emitSkipsThisWithRestParameter.types
@@ -18,10 +18,10 @@ function rebase(fn: (base: any, ...args: any[]) => any): (...args: any[]) => any
 >apply : (this: Function, thisArg: any, argArray?: any) => any
 >this : any
 >[ this ].concat(args) : any[]
->[ this ].concat : (...items: any[]) => any[]
+>[ this ].concat : { (...items: any[][]): any[]; (...items: any[]): any[]; }
 >[ this ] : any[]
 >this : any
->concat : (...items: any[]) => any[]
+>concat : { (...items: any[][]): any[]; (...items: any[]): any[]; }
 >args : any[]
 
     };

--- a/tests/baselines/reference/iteratorSpreadInArray7.symbols
+++ b/tests/baselines/reference/iteratorSpreadInArray7.symbols
@@ -3,9 +3,9 @@ var array: symbol[];
 >array : Symbol(array, Decl(iteratorSpreadInArray7.ts, 0, 3))
 
 array.concat([...new SymbolIterator]);
->array.concat : Symbol(Array.concat, Decl(lib.es5.d.ts, --, --))
+>array.concat : Symbol(Array.concat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >array : Symbol(array, Decl(iteratorSpreadInArray7.ts, 0, 3))
->concat : Symbol(Array.concat, Decl(lib.es5.d.ts, --, --))
+>concat : Symbol(Array.concat, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >SymbolIterator : Symbol(SymbolIterator, Decl(iteratorSpreadInArray7.ts, 1, 38))
 
 class SymbolIterator {

--- a/tests/baselines/reference/iteratorSpreadInArray7.types
+++ b/tests/baselines/reference/iteratorSpreadInArray7.types
@@ -4,9 +4,9 @@ var array: symbol[];
 
 array.concat([...new SymbolIterator]);
 >array.concat([...new SymbolIterator]) : symbol[]
->array.concat : (...items: (symbol | symbol[])[]) => symbol[]
+>array.concat : { (...items: symbol[][]): symbol[]; (...items: (symbol | symbol[])[]): symbol[]; }
 >array : symbol[]
->concat : (...items: (symbol | symbol[])[]) => symbol[]
+>concat : { (...items: symbol[][]): symbol[]; (...items: (symbol | symbol[])[]): symbol[]; }
 >[...new SymbolIterator] : symbol[]
 >...new SymbolIterator : symbol
 >new SymbolIterator : SymbolIterator

--- a/tests/baselines/reference/staticAnonymousTypeNotReferencingTypeParameter.symbols
+++ b/tests/baselines/reference/staticAnonymousTypeNotReferencingTypeParameter.symbols
@@ -300,9 +300,9 @@ class ListWrapper {
 >ListWrapper : Symbol(ListWrapper, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 38, 1))
 >a : Symbol(a, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 68, 40))
 >b : Symbol(b, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 68, 50))
->a.concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>a.concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >a : Symbol(a, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 68, 40))
->concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >b : Symbol(b, Decl(staticAnonymousTypeNotReferencingTypeParameter.ts, 68, 50))
 
   static insert<T>(dit: typeof ListWrapper, list: T[], index: number, value: T) { list.splice(index, 0, value); }

--- a/tests/baselines/reference/staticAnonymousTypeNotReferencingTypeParameter.types
+++ b/tests/baselines/reference/staticAnonymousTypeNotReferencingTypeParameter.types
@@ -348,9 +348,9 @@ class ListWrapper {
 >a : any[]
 >b : any[]
 >a.concat(b) : any[]
->a.concat : (...items: any[]) => any[]
+>a.concat : { (...items: any[][]): any[]; (...items: any[]): any[]; }
 >a : any[]
->concat : (...items: any[]) => any[]
+>concat : { (...items: any[][]): any[]; (...items: any[]): any[]; }
 >b : any[]
 
   static insert<T>(dit: typeof ListWrapper, list: T[], index: number, value: T) { list.splice(index, 0, value); }

--- a/tests/baselines/reference/underscoreTest1.symbols
+++ b/tests/baselines/reference/underscoreTest1.symbols
@@ -71,9 +71,9 @@ var flat = _.reduceRight(list, (a, b) => a.concat(b), []);
 >list : Symbol(list, Decl(underscoreTest1_underscoreTests.ts, 13, 3))
 >a : Symbol(a, Decl(underscoreTest1_underscoreTests.ts, 14, 32))
 >b : Symbol(b, Decl(underscoreTest1_underscoreTests.ts, 14, 34))
->a.concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>a.concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >a : Symbol(a, Decl(underscoreTest1_underscoreTests.ts, 14, 32))
->concat : Symbol(Array.concat, Decl(lib.d.ts, --, --))
+>concat : Symbol(Array.concat, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >b : Symbol(b, Decl(underscoreTest1_underscoreTests.ts, 14, 34))
 
 var even = _.find([1, 2, 3, 4, 5, 6], (num) => num % 2 == 0);

--- a/tests/baselines/reference/underscoreTest1.types
+++ b/tests/baselines/reference/underscoreTest1.types
@@ -124,9 +124,9 @@ var flat = _.reduceRight(list, (a, b) => a.concat(b), []);
 >a : number[]
 >b : number[]
 >a.concat(b) : number[]
->a.concat : (...items: (number | number[])[]) => number[]
+>a.concat : { (...items: number[][]): number[]; (...items: (number | number[])[]): number[]; }
 >a : number[]
->concat : (...items: (number | number[])[]) => number[]
+>concat : { (...items: number[][]): number[]; (...items: (number | number[])[]): number[]; }
 >b : number[]
 >[] : undefined[]
 

--- a/tests/cases/compiler/concatTuples.ts
+++ b/tests/cases/compiler/concatTuples.ts
@@ -1,0 +1,2 @@
+let ijs: [number, number][] = [[1, 2]];
+ijs = ijs.concat([[3, 4], [5, 6]]);


### PR DESCRIPTION
Fixes #9901. Broken by #6629 after we missed the bug during the discussion in #6594.

#6629 introduces a new type for concat: `(...items: (T | T[])[]): T[]`. This means that `concat` accepts either list-wrapped arguments (`T[]`) or top-level arguments (`T`):

```ts
numbers.concat(1, [2, 3], 4)
```

Here, (1) and (4) are top-level arguments (`T`) whereas (2) and (3) are wrapped-arguments. Unfortunately, when you have a tuple or list type parameter, it's ambiguous whether an argument is list-wrapped or top-level:

```ts
pairs.concat([[1, 2], [3, 4]]);
```

If `[[1,2], [3, 4]]` is a top-level argument, then its type is `number[][]` (or `[number, number][]` or [[number, number], [number, number]]). If it's a list-wrapped argument, then its type is `number[]` (or `[number, number]`). But TypeScript can't tell, so it has to guess. Unfortunately, it guesses "top-level argument" (`T`) with type `number[][]`/`[number, number][]`. In the #9901 repro, `number[][]` is not compatible with the type argument `T=[number, number]`.

Adding a stricter overload first guides the inference process to prefer the list-wrapped-only case (`T[]` only) before falling back to the mixed top-level/list-wrapped overload.