### PR TITLE
`Null` and `undefined` are allowed as index expressions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10394,11 +10394,11 @@ namespace ts {
             }
 
             // Check for compatible indexer types.
-            const allowedOptionalFlags = strictNullChecks ? 0 : TypeFlags.Null | TypeFlags.Undefined;
-            if (isTypeAnyOrAllConstituentTypesHaveKind(indexType, TypeFlags.StringLike | TypeFlags.NumberLike | TypeFlags.ESSymbol | allowedOptionalFlags)) {
+            const allowedNullableFlags = strictNullChecks ? 0 : TypeFlags.Nullable;
+            if (isTypeAnyOrAllConstituentTypesHaveKind(indexType, TypeFlags.StringLike | TypeFlags.NumberLike | TypeFlags.ESSymbol | allowedNullableFlags)) {
 
                 // Try to use a number indexer.
-                if (isTypeAnyOrAllConstituentTypesHaveKind(indexType, TypeFlags.NumberLike | allowedOptionalFlags) || isForInVariableForNumericPropertyNames(node.argumentExpression)) {
+                if (isTypeAnyOrAllConstituentTypesHaveKind(indexType, TypeFlags.NumberLike | allowedNullableFlags) || isForInVariableForNumericPropertyNames(node.argumentExpression)) {
                     const numberIndexInfo = getIndexInfoOfType(objectType, IndexKind.Number);
                     if (numberIndexInfo) {
                         getNodeLinks(node).resolvedIndexInfo = numberIndexInfo;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10394,10 +10394,11 @@ namespace ts {
             }
 
             // Check for compatible indexer types.
-            if (isTypeAnyOrAllConstituentTypesHaveKind(indexType, TypeFlags.StringLike | TypeFlags.NumberLike | TypeFlags.ESSymbol)) {
+            const allowedOptionalFlags = strictNullChecks ? 0 : TypeFlags.Null | TypeFlags.Undefined;
+            if (isTypeAnyOrAllConstituentTypesHaveKind(indexType, TypeFlags.StringLike | TypeFlags.NumberLike | TypeFlags.ESSymbol | allowedOptionalFlags)) {
 
                 // Try to use a number indexer.
-                if (isTypeAnyOrAllConstituentTypesHaveKind(indexType, TypeFlags.NumberLike) || isForInVariableForNumericPropertyNames(node.argumentExpression)) {
+                if (isTypeAnyOrAllConstituentTypesHaveKind(indexType, TypeFlags.NumberLike | allowedOptionalFlags) || isForInVariableForNumericPropertyNames(node.argumentExpression)) {
                     const numberIndexInfo = getIndexInfoOfType(objectType, IndexKind.Number);
                     if (numberIndexInfo) {
                         getNodeLinks(node).resolvedIndexInfo = numberIndexInfo;

--- a/tests/baselines/reference/indexWithUndefinedAndNull.js
+++ b/tests/baselines/reference/indexWithUndefinedAndNull.js
@@ -1,0 +1,22 @@
+//// [indexWithUndefinedAndNull.ts]
+interface N {
+    [n: number]: string;
+}
+interface S {
+    [s: string]: number;
+}
+let n: N;
+let s: S;
+let str: string = n[undefined];
+str = n[null];
+let num: number = s[undefined];
+num = s[null];
+
+
+//// [indexWithUndefinedAndNull.js]
+var n;
+var s;
+var str = n[undefined];
+str = n[null];
+var num = s[undefined];
+num = s[null];

--- a/tests/baselines/reference/indexWithUndefinedAndNull.symbols
+++ b/tests/baselines/reference/indexWithUndefinedAndNull.symbols
@@ -1,0 +1,39 @@
+=== tests/cases/compiler/indexWithUndefinedAndNull.ts ===
+interface N {
+>N : Symbol(N, Decl(indexWithUndefinedAndNull.ts, 0, 0))
+
+    [n: number]: string;
+>n : Symbol(n, Decl(indexWithUndefinedAndNull.ts, 1, 5))
+}
+interface S {
+>S : Symbol(S, Decl(indexWithUndefinedAndNull.ts, 2, 1))
+
+    [s: string]: number;
+>s : Symbol(s, Decl(indexWithUndefinedAndNull.ts, 4, 5))
+}
+let n: N;
+>n : Symbol(n, Decl(indexWithUndefinedAndNull.ts, 6, 3))
+>N : Symbol(N, Decl(indexWithUndefinedAndNull.ts, 0, 0))
+
+let s: S;
+>s : Symbol(s, Decl(indexWithUndefinedAndNull.ts, 7, 3))
+>S : Symbol(S, Decl(indexWithUndefinedAndNull.ts, 2, 1))
+
+let str: string = n[undefined];
+>str : Symbol(str, Decl(indexWithUndefinedAndNull.ts, 8, 3))
+>n : Symbol(n, Decl(indexWithUndefinedAndNull.ts, 6, 3))
+>undefined : Symbol(undefined)
+
+str = n[null];
+>str : Symbol(str, Decl(indexWithUndefinedAndNull.ts, 8, 3))
+>n : Symbol(n, Decl(indexWithUndefinedAndNull.ts, 6, 3))
+
+let num: number = s[undefined];
+>num : Symbol(num, Decl(indexWithUndefinedAndNull.ts, 10, 3))
+>s : Symbol(s, Decl(indexWithUndefinedAndNull.ts, 7, 3))
+>undefined : Symbol(undefined)
+
+num = s[null];
+>num : Symbol(num, Decl(indexWithUndefinedAndNull.ts, 10, 3))
+>s : Symbol(s, Decl(indexWithUndefinedAndNull.ts, 7, 3))
+

--- a/tests/baselines/reference/indexWithUndefinedAndNull.types
+++ b/tests/baselines/reference/indexWithUndefinedAndNull.types
@@ -1,0 +1,47 @@
+=== tests/cases/compiler/indexWithUndefinedAndNull.ts ===
+interface N {
+>N : N
+
+    [n: number]: string;
+>n : number
+}
+interface S {
+>S : S
+
+    [s: string]: number;
+>s : string
+}
+let n: N;
+>n : N
+>N : N
+
+let s: S;
+>s : S
+>S : S
+
+let str: string = n[undefined];
+>str : string
+>n[undefined] : string
+>n : N
+>undefined : undefined
+
+str = n[null];
+>str = n[null] : string
+>str : string
+>n[null] : string
+>n : N
+>null : null
+
+let num: number = s[undefined];
+>num : number
+>s[undefined] : number
+>s : S
+>undefined : undefined
+
+num = s[null];
+>num = s[null] : number
+>num : number
+>s[null] : number
+>s : S
+>null : null
+

--- a/tests/baselines/reference/indexWithUndefinedAndNullStrictNullChecks.errors.txt
+++ b/tests/baselines/reference/indexWithUndefinedAndNullStrictNullChecks.errors.txt
@@ -1,0 +1,40 @@
+tests/cases/compiler/indexWithUndefinedAndNullStrictNullChecks.ts(9,19): error TS2454: Variable 'n' is used before being assigned.
+tests/cases/compiler/indexWithUndefinedAndNullStrictNullChecks.ts(9,19): error TS2342: An index expression argument must be of type 'string', 'number', 'symbol', or 'any'.
+tests/cases/compiler/indexWithUndefinedAndNullStrictNullChecks.ts(10,7): error TS2454: Variable 'n' is used before being assigned.
+tests/cases/compiler/indexWithUndefinedAndNullStrictNullChecks.ts(10,7): error TS2342: An index expression argument must be of type 'string', 'number', 'symbol', or 'any'.
+tests/cases/compiler/indexWithUndefinedAndNullStrictNullChecks.ts(11,19): error TS2454: Variable 's' is used before being assigned.
+tests/cases/compiler/indexWithUndefinedAndNullStrictNullChecks.ts(11,19): error TS2342: An index expression argument must be of type 'string', 'number', 'symbol', or 'any'.
+tests/cases/compiler/indexWithUndefinedAndNullStrictNullChecks.ts(12,7): error TS2454: Variable 's' is used before being assigned.
+tests/cases/compiler/indexWithUndefinedAndNullStrictNullChecks.ts(12,7): error TS2342: An index expression argument must be of type 'string', 'number', 'symbol', or 'any'.
+
+
+==== tests/cases/compiler/indexWithUndefinedAndNullStrictNullChecks.ts (8 errors) ====
+    interface N {
+        [n: number]: string;
+    }
+    interface S {
+        [s: string]: number;
+    }
+    let n: N;
+    let s: S;
+    let str: string = n[undefined];
+                      ~
+!!! error TS2454: Variable 'n' is used before being assigned.
+                      ~~~~~~~~~~~~
+!!! error TS2342: An index expression argument must be of type 'string', 'number', 'symbol', or 'any'.
+    str = n[null];
+          ~
+!!! error TS2454: Variable 'n' is used before being assigned.
+          ~~~~~~~
+!!! error TS2342: An index expression argument must be of type 'string', 'number', 'symbol', or 'any'.
+    let num: number = s[undefined];
+                      ~
+!!! error TS2454: Variable 's' is used before being assigned.
+                      ~~~~~~~~~~~~
+!!! error TS2342: An index expression argument must be of type 'string', 'number', 'symbol', or 'any'.
+    num = s[null];
+          ~
+!!! error TS2454: Variable 's' is used before being assigned.
+          ~~~~~~~
+!!! error TS2342: An index expression argument must be of type 'string', 'number', 'symbol', or 'any'.
+    

--- a/tests/baselines/reference/indexWithUndefinedAndNullStrictNullChecks.js
+++ b/tests/baselines/reference/indexWithUndefinedAndNullStrictNullChecks.js
@@ -1,0 +1,22 @@
+//// [indexWithUndefinedAndNullStrictNullChecks.ts]
+interface N {
+    [n: number]: string;
+}
+interface S {
+    [s: string]: number;
+}
+let n: N;
+let s: S;
+let str: string = n[undefined];
+str = n[null];
+let num: number = s[undefined];
+num = s[null];
+
+
+//// [indexWithUndefinedAndNullStrictNullChecks.js]
+var n;
+var s;
+var str = n[undefined];
+str = n[null];
+var num = s[undefined];
+num = s[null];

--- a/tests/cases/compiler/indexWithUndefinedAndNull.ts
+++ b/tests/cases/compiler/indexWithUndefinedAndNull.ts
@@ -1,0 +1,13 @@
+// @strictNullChecks: false
+interface N {
+    [n: number]: string;
+}
+interface S {
+    [s: string]: number;
+}
+let n: N;
+let s: S;
+let str: string = n[undefined];
+str = n[null];
+let num: number = s[undefined];
+num = s[null];

--- a/tests/cases/compiler/indexWithUndefinedAndNullStrictNullChecks.ts
+++ b/tests/cases/compiler/indexWithUndefinedAndNullStrictNullChecks.ts
@@ -1,0 +1,13 @@
+// @strictNullChecks: true
+interface N {
+    [n: number]: string;
+}
+interface S {
+    [s: string]: number;
+}
+let n: N;
+let s: S;
+let str: string = n[undefined];
+str = n[null];
+let num: number = s[undefined];
+num = s[null];


### PR DESCRIPTION
`null` and `undefined` are not allowed with `--strictNullChecks` turned on. Previously, they were disallowed whether or not it was on.

eg `window[null]` is allowed with `strictNullChecks: false`, even though it's a bad idea, because `Window` has a numeric index signature.

Fixes #9684.
