### PR TITLE
Have travis use a newer image for the OSX build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,12 @@ node_js:
 
 sudo: false
 
-os:
-  - linux
-  - osx
-
 matrix:
   fast_finish: true
-  exclude:
+  include:
   - os: osx
-    node_js: '4'
-  - os: osx
-    node_js: '0.10'
+    node_js: stable
+    osx_image: xcode7.3
 
 branches:
   only:


### PR DESCRIPTION
Suggested by travis support for stopping the randomly-halting-builds issue.

If anyone notices any halted/errored OSX builds after this change is merged, let me know and we'll keep debugging the issue.