### PR TITLE
Provide `realpath` for module resolvution in LSHost

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -115,6 +115,9 @@ namespace ts.server {
                 readFile: fileName => this.host.readFile(fileName),
                 directoryExists: directoryName => this.host.directoryExists(directoryName)
             };
+            if (this.host.realpath) {
+                this.moduleResolutionHost.realpath = path => this.host.realpath(path);
+            }
         }
 
         private resolveNamesWithLocalCache<T extends Timestamped & { failedLookupLocations: string[] }, R>(


### PR DESCRIPTION
Fixes #9585

Tested in VSCode and Visual Studio.

