### PR TITLE
Fix #10083 - allowSyntheticDefaultImports alters getExternalModuleMember

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1135,6 +1135,10 @@ namespace ts {
                     else {
                         symbolFromVariable = getPropertyOfVariable(targetSymbol, name.text);
                     }
+                    // If the export member we're looking for is default, and there is no real default but allowSyntheticDefaultImports is on, return the entire module as the default
+                    if (!symbolFromVariable && allowSyntheticDefaultImports && name.text === "default") {
+                        symbolFromVariable = resolveExternalModuleSymbol(moduleSymbol) || resolveSymbol(moduleSymbol);
+                    }
                     // if symbolFromVariable is export - get its final target
                     symbolFromVariable = resolveSymbol(symbolFromVariable);
                     const symbolFromModule = getExportOfModule(targetSymbol, name.text);

--- a/tests/baselines/reference/allowSyntheticDefaultImports10.errors.txt
+++ b/tests/baselines/reference/allowSyntheticDefaultImports10.errors.txt
@@ -1,0 +1,17 @@
+tests/cases/compiler/a.ts(2,5): error TS2339: Property 'default' does not exist on type 'typeof "tests/cases/compiler/b"'.
+tests/cases/compiler/a.ts(3,5): error TS2339: Property 'default' does not exist on type 'typeof "tests/cases/compiler/b"'.
+
+
+==== tests/cases/compiler/a.ts (2 errors) ====
+    import Foo = require("./b");
+    Foo.default.bar();
+        ~~~~~~~
+!!! error TS2339: Property 'default' does not exist on type 'typeof "tests/cases/compiler/b"'.
+    Foo.default.default.foo();
+        ~~~~~~~
+!!! error TS2339: Property 'default' does not exist on type 'typeof "tests/cases/compiler/b"'.
+==== tests/cases/compiler/b.d.ts (0 errors) ====
+    export function foo();
+    
+    export function bar();
+    

--- a/tests/baselines/reference/allowSyntheticDefaultImports10.js
+++ b/tests/baselines/reference/allowSyntheticDefaultImports10.js
@@ -1,0 +1,17 @@
+//// [tests/cases/compiler/allowSyntheticDefaultImports10.ts] ////
+
+//// [b.d.ts]
+export function foo();
+
+export function bar();
+
+//// [a.ts]
+import Foo = require("./b");
+Foo.default.bar();
+Foo.default.default.foo();
+
+//// [a.js]
+"use strict";
+var Foo = require("./b");
+Foo.default.bar();
+Foo.default.default.foo();

--- a/tests/baselines/reference/allowSyntheticDefaultImports7.js
+++ b/tests/baselines/reference/allowSyntheticDefaultImports7.js
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/allowSyntheticDefaultImports7.ts] ////
+
+//// [b.d.ts]
+export function foo();
+
+export function bar();
+
+//// [a.ts]
+import { default as Foo } from "./b";
+Foo.bar();
+Foo.foo();
+
+//// [a.js]
+System.register(["./b"], function(exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    var b_1;
+    return {
+        setters:[
+            function (b_1_1) {
+                b_1 = b_1_1;
+            }],
+        execute: function() {
+            b_1["default"].bar();
+            b_1["default"].foo();
+        }
+    }
+});

--- a/tests/baselines/reference/allowSyntheticDefaultImports7.symbols
+++ b/tests/baselines/reference/allowSyntheticDefaultImports7.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/b.d.ts ===
+export function foo();
+>foo : Symbol(foo, Decl(b.d.ts, 0, 0))
+
+export function bar();
+>bar : Symbol(bar, Decl(b.d.ts, 0, 22))
+
+=== tests/cases/compiler/a.ts ===
+import { default as Foo } from "./b";
+>default : Symbol(Foo, Decl(a.ts, 0, 8))
+>Foo : Symbol(Foo, Decl(a.ts, 0, 8))
+
+Foo.bar();
+>Foo.bar : Symbol(Foo.bar, Decl(b.d.ts, 0, 22))
+>Foo : Symbol(Foo, Decl(a.ts, 0, 8))
+>bar : Symbol(Foo.bar, Decl(b.d.ts, 0, 22))
+
+Foo.foo();
+>Foo.foo : Symbol(Foo.foo, Decl(b.d.ts, 0, 0))
+>Foo : Symbol(Foo, Decl(a.ts, 0, 8))
+>foo : Symbol(Foo.foo, Decl(b.d.ts, 0, 0))
+

--- a/tests/baselines/reference/allowSyntheticDefaultImports7.types
+++ b/tests/baselines/reference/allowSyntheticDefaultImports7.types
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/b.d.ts ===
+export function foo();
+>foo : () => any
+
+export function bar();
+>bar : () => any
+
+=== tests/cases/compiler/a.ts ===
+import { default as Foo } from "./b";
+>default : typeof Foo
+>Foo : typeof Foo
+
+Foo.bar();
+>Foo.bar() : any
+>Foo.bar : () => any
+>Foo : typeof Foo
+>bar : () => any
+
+Foo.foo();
+>Foo.foo() : any
+>Foo.foo : () => any
+>Foo : typeof Foo
+>foo : () => any
+

--- a/tests/baselines/reference/allowSyntheticDefaultImports8.errors.txt
+++ b/tests/baselines/reference/allowSyntheticDefaultImports8.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/a.ts(1,10): error TS2305: Module '"tests/cases/compiler/b"' has no exported member 'default'.
+
+
+==== tests/cases/compiler/b.d.ts (0 errors) ====
+    export function foo();
+    
+    export function bar();
+    
+==== tests/cases/compiler/a.ts (1 errors) ====
+    import { default as Foo } from "./b";
+             ~~~~~~~
+!!! error TS2305: Module '"tests/cases/compiler/b"' has no exported member 'default'.
+    Foo.bar();
+    Foo.foo();

--- a/tests/baselines/reference/allowSyntheticDefaultImports8.js
+++ b/tests/baselines/reference/allowSyntheticDefaultImports8.js
@@ -1,0 +1,28 @@
+//// [tests/cases/compiler/allowSyntheticDefaultImports8.ts] ////
+
+//// [b.d.ts]
+export function foo();
+
+export function bar();
+
+//// [a.ts]
+import { default as Foo } from "./b";
+Foo.bar();
+Foo.foo();
+
+//// [a.js]
+System.register(["./b"], function(exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    var b_1;
+    return {
+        setters:[
+            function (b_1_1) {
+                b_1 = b_1_1;
+            }],
+        execute: function() {
+            b_1["default"].bar();
+            b_1["default"].foo();
+        }
+    }
+});

--- a/tests/baselines/reference/allowSyntheticDefaultImports9.js
+++ b/tests/baselines/reference/allowSyntheticDefaultImports9.js
@@ -1,0 +1,17 @@
+//// [tests/cases/compiler/allowSyntheticDefaultImports9.ts] ////
+
+//// [b.d.ts]
+export function foo();
+
+export function bar();
+
+//// [a.ts]
+import { default as Foo } from "./b";
+Foo.bar();
+Foo.foo();
+
+//// [a.js]
+"use strict";
+var b_1 = require("./b");
+b_1["default"].bar();
+b_1["default"].foo();

--- a/tests/baselines/reference/allowSyntheticDefaultImports9.symbols
+++ b/tests/baselines/reference/allowSyntheticDefaultImports9.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/b.d.ts ===
+export function foo();
+>foo : Symbol(foo, Decl(b.d.ts, 0, 0))
+
+export function bar();
+>bar : Symbol(bar, Decl(b.d.ts, 0, 22))
+
+=== tests/cases/compiler/a.ts ===
+import { default as Foo } from "./b";
+>default : Symbol(Foo, Decl(a.ts, 0, 8))
+>Foo : Symbol(Foo, Decl(a.ts, 0, 8))
+
+Foo.bar();
+>Foo.bar : Symbol(Foo.bar, Decl(b.d.ts, 0, 22))
+>Foo : Symbol(Foo, Decl(a.ts, 0, 8))
+>bar : Symbol(Foo.bar, Decl(b.d.ts, 0, 22))
+
+Foo.foo();
+>Foo.foo : Symbol(Foo.foo, Decl(b.d.ts, 0, 0))
+>Foo : Symbol(Foo, Decl(a.ts, 0, 8))
+>foo : Symbol(Foo.foo, Decl(b.d.ts, 0, 0))
+

--- a/tests/baselines/reference/allowSyntheticDefaultImports9.types
+++ b/tests/baselines/reference/allowSyntheticDefaultImports9.types
@@ -1,0 +1,24 @@
+=== tests/cases/compiler/b.d.ts ===
+export function foo();
+>foo : () => any
+
+export function bar();
+>bar : () => any
+
+=== tests/cases/compiler/a.ts ===
+import { default as Foo } from "./b";
+>default : typeof Foo
+>Foo : typeof Foo
+
+Foo.bar();
+>Foo.bar() : any
+>Foo.bar : () => any
+>Foo : typeof Foo
+>bar : () => any
+
+Foo.foo();
+>Foo.foo() : any
+>Foo.foo : () => any
+>Foo : typeof Foo
+>foo : () => any
+

--- a/tests/cases/compiler/allowSyntheticDefaultImports10.ts
+++ b/tests/cases/compiler/allowSyntheticDefaultImports10.ts
@@ -1,0 +1,11 @@
+// @allowSyntheticDefaultImports: true
+// @module: commonjs
+// @Filename: b.d.ts
+export function foo();
+
+export function bar();
+
+// @Filename: a.ts
+import Foo = require("./b");
+Foo.default.bar();
+Foo.default.default.foo();

--- a/tests/cases/compiler/allowSyntheticDefaultImports7.ts
+++ b/tests/cases/compiler/allowSyntheticDefaultImports7.ts
@@ -1,0 +1,10 @@
+// @module: system
+// @Filename: b.d.ts
+export function foo();
+
+export function bar();
+
+// @Filename: a.ts
+import { default as Foo } from "./b";
+Foo.bar();
+Foo.foo();

--- a/tests/cases/compiler/allowSyntheticDefaultImports8.ts
+++ b/tests/cases/compiler/allowSyntheticDefaultImports8.ts
@@ -1,0 +1,11 @@
+// @allowSyntheticDefaultImports: false
+// @module: system
+// @Filename: b.d.ts
+export function foo();
+
+export function bar();
+
+// @Filename: a.ts
+import { default as Foo } from "./b";
+Foo.bar();
+Foo.foo();

--- a/tests/cases/compiler/allowSyntheticDefaultImports9.ts
+++ b/tests/cases/compiler/allowSyntheticDefaultImports9.ts
@@ -1,0 +1,11 @@
+// @allowSyntheticDefaultImports: true
+// @module: commonjs
+// @Filename: b.d.ts
+export function foo();
+
+export function bar();
+
+// @Filename: a.ts
+import { default as Foo } from "./b";
+Foo.bar();
+Foo.foo();


### PR DESCRIPTION
Fixes #10083. Adds tests for the scenario in each available configuration, also adds a test checking that there's no default member when using `import = require()`.