### PR TITLE
Check return code paths on getters

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13916,14 +13916,10 @@ namespace ts {
 
                 checkDecorators(node);
                 checkSignatureDeclaration(node);
+                // TODO (weswig): Consolidate the below into checkAllCodePathsInNonVoidFunctionReturnOrThrow
                 if (node.kind === SyntaxKind.GetAccessor) {
                     if (!isInAmbientContext(node) && nodeIsPresent(node.body) && (node.flags & NodeFlags.HasImplicitReturn)) {
-                        if (node.flags & NodeFlags.HasExplicitReturn) {
-                            if (compilerOptions.noImplicitReturns) {
-                                error(node.name, Diagnostics.Not_all_code_paths_return_a_value);
-                            }
-                        }
-                        else {
+                        if (!(node.flags & NodeFlags.HasExplicitReturn)) {
                             error(node.name, Diagnostics.A_get_accessor_must_return_a_value);
                         }
                     }
@@ -13953,7 +13949,10 @@ namespace ts {
                         checkAccessorDeclarationTypesIdentical(node, otherAccessor, getThisTypeOfDeclaration, Diagnostics.get_and_set_accessor_must_have_the_same_this_type);
                     }
                 }
-                getTypeOfAccessors(getSymbolOfNode(node));
+                const returnType = getTypeOfAccessors(getSymbolOfNode(node));
+                if (node.kind === SyntaxKind.GetAccessor) {
+                    checkAllCodePathsInNonVoidFunctionReturnOrThrow(node, returnType);
+                }
             }
             if (node.parent.kind !== SyntaxKind.ObjectLiteralExpression) {
                 checkSourceElement(node.body);

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13916,7 +13916,6 @@ namespace ts {
 
                 checkDecorators(node);
                 checkSignatureDeclaration(node);
-                // TODO (weswig): Consolidate the below into checkAllCodePathsInNonVoidFunctionReturnOrThrow
                 if (node.kind === SyntaxKind.GetAccessor) {
                     if (!isInAmbientContext(node) && nodeIsPresent(node.body) && (node.flags & NodeFlags.HasImplicitReturn)) {
                         if (!(node.flags & NodeFlags.HasExplicitReturn)) {

--- a/tests/baselines/reference/getterControlFlowStrictNull.errors.txt
+++ b/tests/baselines/reference/getterControlFlowStrictNull.errors.txt
@@ -1,0 +1,27 @@
+tests/cases/compiler/getterControlFlowStrictNull.ts(2,9): error TS2366: Function lacks ending return statement and return type does not include 'undefined'.
+tests/cases/compiler/getterControlFlowStrictNull.ts(11,14): error TS2366: Function lacks ending return statement and return type does not include 'undefined'.
+
+
+==== tests/cases/compiler/getterControlFlowStrictNull.ts (2 errors) ====
+    class A {
+       a(): string | null {
+            ~~~~~~~~~~~~~
+!!! error TS2366: Function lacks ending return statement and return type does not include 'undefined'.
+            if (Math.random() > 0.5) {
+                return '';
+            }
+    
+            // it does error here as expected
+        }
+    }
+    class B {
+        get a(): string | null {
+                 ~~~~~~~~~~~~~
+!!! error TS2366: Function lacks ending return statement and return type does not include 'undefined'.
+            if (Math.random() > 0.5) {
+                return '';
+            }
+    
+            // it should error here because it returns undefined
+        }
+    }

--- a/tests/baselines/reference/getterControlFlowStrictNull.js
+++ b/tests/baselines/reference/getterControlFlowStrictNull.js
@@ -1,0 +1,47 @@
+//// [getterControlFlowStrictNull.ts]
+class A {
+   a(): string | null {
+        if (Math.random() > 0.5) {
+            return '';
+        }
+
+        // it does error here as expected
+    }
+}
+class B {
+    get a(): string | null {
+        if (Math.random() > 0.5) {
+            return '';
+        }
+
+        // it should error here because it returns undefined
+    }
+}
+
+//// [getterControlFlowStrictNull.js]
+var A = (function () {
+    function A() {
+    }
+    A.prototype.a = function () {
+        if (Math.random() > 0.5) {
+            return '';
+        }
+        // it does error here as expected
+    };
+    return A;
+}());
+var B = (function () {
+    function B() {
+    }
+    Object.defineProperty(B.prototype, "a", {
+        get: function () {
+            if (Math.random() > 0.5) {
+                return '';
+            }
+            // it should error here because it returns undefined
+        },
+        enumerable: true,
+        configurable: true
+    });
+    return B;
+}());

--- a/tests/cases/compiler/getterControlFlowStrictNull.ts
+++ b/tests/cases/compiler/getterControlFlowStrictNull.ts
@@ -1,0 +1,20 @@
+//@strictNullChecks: true
+//@target: ES5
+class A {
+   a(): string | null {
+        if (Math.random() > 0.5) {
+            return '';
+        }
+
+        // it does error here as expected
+    }
+}
+class B {
+    get a(): string | null {
+        if (Math.random() > 0.5) {
+            return '';
+        }
+
+        // it should error here because it returns undefined
+    }
+}


### PR DESCRIPTION
Fixes #9671. I reuse `checkAllCodePathsInNonVoidFunctionReturnOrThrow` and remove a redundant check from `checkAccessorDeclaration`, however I can't quite seem to easily merge this block:
```ts
                // TODO (weswig): Consolidate the below into checkAllCodePathsInNonVoidFunctionReturnOrThrow
                if (node.kind === SyntaxKind.GetAccessor) {
                    if (!isInAmbientContext(node) && nodeIsPresent(node.body) && (node.flags & NodeFlags.HasImplicitReturn)) {
                        if (!(node.flags & NodeFlags.HasExplicitReturn)) {
                            error(node.name, Diagnostics.A_get_accessor_must_return_a_value);
                        }
                    }
                }
```
into `checkAllCodePathsInNonVoidFunctionReturnOrThrow` (likely because this error is getter-specific - it's perfectly valid to have a function which never returns, while a getter must always return in at least one branch, apparently.)

cc: @RyanCavanaugh 
