### PR TITLE
Don't allow properties inherited from Object to be automatically included in TSX attributes

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10060,7 +10060,7 @@ namespace ts {
             for (const prop of props) {
                 // Is there a corresponding property in the element attributes type? Skip checking of properties
                 // that have already been assigned to, as these are not actually pushed into the resulting type
-                if (!nameTable[prop.name]) {
+                if (!hasProperty(nameTable, prop.name)) {
                     const targetPropSym = getPropertyOfType(elementAttributesType, prop.name);
                     if (targetPropSym) {
                         const msg = chainDiagnosticMessages(undefined, Diagnostics.Property_0_of_JSX_spread_attribute_is_not_assignable_to_target_property, prop.name);
@@ -10406,7 +10406,7 @@ namespace ts {
                 const targetProperties = getPropertiesOfType(targetAttributesType);
                 for (let i = 0; i < targetProperties.length; i++) {
                     if (!(targetProperties[i].flags & SymbolFlags.Optional) &&
-                        nameTable[targetProperties[i].name] === undefined) {
+                        !hasProperty(nameTable, targetProperties[i].name)) {
 
                         error(node, Diagnostics.Property_0_is_missing_in_type_1, targetProperties[i].name, typeToString(targetAttributesType));
                     }

--- a/tests/baselines/reference/tsxAttributeResolution5.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution5.errors.txt
@@ -2,9 +2,10 @@ tests/cases/conformance/jsx/file.tsx(21,16): error TS2606: Property 'x' of JSX s
   Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/jsx/file.tsx(25,9): error TS2324: Property 'x' is missing in type 'Attribs1'.
 tests/cases/conformance/jsx/file.tsx(29,1): error TS2324: Property 'x' is missing in type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(30,1): error TS2324: Property 'toString' is missing in type 'Attribs2'.
 
 
-==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
+==== tests/cases/conformance/jsx/file.tsx (4 errors) ====
     declare module JSX {
     	interface Element { }
     	interface IntrinsicElements {
@@ -41,5 +42,7 @@ tests/cases/conformance/jsx/file.tsx(29,1): error TS2324: Property 'x' is missin
     <test1 {...{}} />; // Error, missing x
     ~~~~~~~~~~~~~~~~~
 !!! error TS2324: Property 'x' is missing in type 'Attribs1'.
-    <test2 {...{}} />; // OK
+    <test2 {...{}} />; // Error, missing toString
+    ~~~~~~~~~~~~~~~~~
+!!! error TS2324: Property 'toString' is missing in type 'Attribs2'.
     

--- a/tests/baselines/reference/tsxAttributeResolution5.js
+++ b/tests/baselines/reference/tsxAttributeResolution5.js
@@ -28,7 +28,7 @@ function make3<T extends {y: string}> (obj: T) {
 
 
 <test1 {...{}} />; // Error, missing x
-<test2 {...{}} />; // OK
+<test2 {...{}} />; // Error, missing toString
 
 
 //// [file.jsx]
@@ -42,4 +42,4 @@ function make3(obj) {
     return <test1 {...obj}/>; // Error, missing x
 }
 <test1 {...{}}/>; // Error, missing x
-<test2 {...{}}/>; // OK
+<test2 {...{}}/>; // Error, missing toString

--- a/tests/cases/conformance/jsx/tsxAttributeResolution5.tsx
+++ b/tests/cases/conformance/jsx/tsxAttributeResolution5.tsx
@@ -29,4 +29,4 @@ function make3<T extends {y: string}> (obj: T) {
 
 
 <test1 {...{}} />; // Error, missing x
-<test2 {...{}} />; // OK
+<test2 {...{}} />; // Error, missing toString


### PR DESCRIPTION
We were using unprotected accesses to a table of property names, which I assume was mistaken. We now generate an error if a TSX element requires e.g. a `toString` property and it is not explicitly provided.