### PR TITLE
Surface noErrorTruncation option

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -127,6 +127,11 @@ namespace ts {
             description: Diagnostics.Do_not_emit_outputs_if_any_errors_were_reported,
         },
         {
+            name: "noErrorTruncation",
+            type: "boolean",
+            description: Diagnostics.Do_not_truncate_verbose_types,
+        },
+        {
             name: "noImplicitAny",
             type: "boolean",
             description: Diagnostics.Raise_error_on_expressions_and_declarations_with_an_implied_any_type,

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2828,6 +2828,10 @@
         "category": "Message",
         "code": 6137
     },
+    "Do not truncate verbose types.": {
+        "category": "Message",
+        "code": 6138
+    },
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",
         "code": 7005

--- a/tests/baselines/reference/noErrorTruncation.errors.txt
+++ b/tests/baselines/reference/noErrorTruncation.errors.txt
@@ -1,0 +1,22 @@
+tests/cases/compiler/noErrorTruncation.ts(10,7): error TS2322: Type 'number' is not assignable to type '{ someLongOptionA: string; } | { someLongOptionB: string; } | { someLongOptionC: string; } | { someLongOptionD: string; } | { someLongOptionE: string; } | { someLongOptionF: string; }'.
+
+
+==== tests/cases/compiler/noErrorTruncation.ts (1 errors) ====
+    // @noErrorTruncation
+    
+    type SomeLongOptionA = { someLongOptionA: string }
+    type SomeLongOptionB = { someLongOptionB: string }
+    type SomeLongOptionC = { someLongOptionC: string }
+    type SomeLongOptionD = { someLongOptionD: string }
+    type SomeLongOptionE = { someLongOptionE: string }
+    type SomeLongOptionF = { someLongOptionF: string }
+    
+    const x: SomeLongOptionA
+          ~
+!!! error TS2322: Type 'number' is not assignable to type '{ someLongOptionA: string; } | { someLongOptionB: string; } | { someLongOptionC: string; } | { someLongOptionD: string; } | { someLongOptionE: string; } | { someLongOptionF: string; }'.
+           | SomeLongOptionB
+           | SomeLongOptionC
+           | SomeLongOptionD
+           | SomeLongOptionE
+           | SomeLongOptionF = 42;
+    

--- a/tests/baselines/reference/noErrorTruncation.js
+++ b/tests/baselines/reference/noErrorTruncation.js
@@ -1,0 +1,21 @@
+//// [noErrorTruncation.ts]
+// @noErrorTruncation
+
+type SomeLongOptionA = { someLongOptionA: string }
+type SomeLongOptionB = { someLongOptionB: string }
+type SomeLongOptionC = { someLongOptionC: string }
+type SomeLongOptionD = { someLongOptionD: string }
+type SomeLongOptionE = { someLongOptionE: string }
+type SomeLongOptionF = { someLongOptionF: string }
+
+const x: SomeLongOptionA
+       | SomeLongOptionB
+       | SomeLongOptionC
+       | SomeLongOptionD
+       | SomeLongOptionE
+       | SomeLongOptionF = 42;
+
+
+//// [noErrorTruncation.js]
+// @noErrorTruncation
+var x = 42;

--- a/tests/cases/compiler/noErrorTruncation.ts
+++ b/tests/cases/compiler/noErrorTruncation.ts
@@ -1,0 +1,15 @@
+// @noErrorTruncation
+
+type SomeLongOptionA = { someLongOptionA: string }
+type SomeLongOptionB = { someLongOptionB: string }
+type SomeLongOptionC = { someLongOptionC: string }
+type SomeLongOptionD = { someLongOptionD: string }
+type SomeLongOptionE = { someLongOptionE: string }
+type SomeLongOptionF = { someLongOptionF: string }
+
+const x: SomeLongOptionA
+       | SomeLongOptionB
+       | SomeLongOptionC
+       | SomeLongOptionD
+       | SomeLongOptionE
+       | SomeLongOptionF = 42;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

This PR surfaces the existing (though not publicly available) `noErrorTruncation` compiler option. It's much more rarely needed now, considering the compiler outputs aliases instead of inlined types, but still useful in certain situations. In such situation its absence equates in loss of vital diagnostic tools.
