### PR TITLE
[Release 2.0] fix10179: 2.0 emits optional class properties defined in constructors, which breaks compatibility 

### DIFF
--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -1134,8 +1134,10 @@ namespace ts {
                     // it if it's not a well known symbol. In that case, the text of the name will be exactly
                     // what we want, namely the name expression enclosed in brackets.
                     writeTextOfNode(currentText, node.name);
-                    // If optional property emit ?
-                    if ((node.kind === SyntaxKind.PropertyDeclaration || node.kind === SyntaxKind.PropertySignature || node.kind === SyntaxKind.Parameter) && hasQuestionToken(node)) {
+                    // If optional property emit ? but in the case of parameterProperty declaration with "?" indicating optional parameter for the constructor
+                    // we don't want to emit property declaration with "?"
+                    if ((node.kind === SyntaxKind.PropertyDeclaration || node.kind === SyntaxKind.PropertySignature ||
+                        (node.kind === SyntaxKind.Parameter && !isParameterPropertyDeclaration(node))) && hasQuestionToken(node)) {
                         write("?");
                     }
                     if ((node.kind === SyntaxKind.PropertyDeclaration || node.kind === SyntaxKind.PropertySignature) && node.parent.kind === SyntaxKind.TypeLiteral) {

--- a/tests/baselines/reference/declFileConstructors.js
+++ b/tests/baselines/reference/declFileConstructors.js
@@ -247,7 +247,7 @@ export declare class ConstructorWithPrivateParameterProperty {
     constructor(x: string);
 }
 export declare class ConstructorWithOptionalParameterProperty {
-    x?: string;
+    x: string;
     constructor(x?: string);
 }
 export declare class ConstructorWithParameterInitializer {
@@ -281,7 +281,7 @@ declare class GlobalConstructorWithPrivateParameterProperty {
     constructor(x: string);
 }
 declare class GlobalConstructorWithOptionalParameterProperty {
-    x?: string;
+    x: string;
     constructor(x?: string);
 }
 declare class GlobalConstructorWithParameterInitializer {

--- a/tests/baselines/reference/optionalMethods.js
+++ b/tests/baselines/reference/optionalMethods.js
@@ -126,7 +126,7 @@ interface Foo {
 }
 declare function test1(x: Foo): void;
 declare class Bar {
-    d?: number;
+    d: number;
     e: number;
     a: number;
     b?: number;


### PR DESCRIPTION
Fix #10179 