### PR TITLE
Fix loop over array to use for-of instead of for-in

### DIFF
--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -750,7 +750,7 @@ namespace Harness {
 
             export function readDirectory(path: string, extension?: string[], exclude?: string[], include?: string[]) {
                 const fs = new Utils.VirtualFileSystem(path, useCaseSensitiveFileNames());
-                for (const file in listFiles(path)) {
+                for (const file of listFiles(path)) {
                     fs.addFile(file);
                 }
                 return ts.matchFiles(path, extension, exclude, include, useCaseSensitiveFileNames(), getCurrentDirectory(), path => {


### PR DESCRIPTION
I can't find any tests that this changes, but `listFiles` returns an array and `fs.addFile` expects a path, not an array index. Why is this not getting caught by our tests?

Also, @weswigham: I've been thinking we could add a lint rule where the object of a for-in loop would have to be of the `Map` type. What do you think?

