### PR TITLE
Don't always emit two periods for const enum members in property accesses

### DIFF
--- a/tests/baselines/reference/constEnumMemberMemberAccess01.js
+++ b/tests/baselines/reference/constEnumMemberMemberAccess01.js
@@ -1,0 +1,9 @@
+//// [constEnumMemberMemberAccess01.ts]
+const enum Foo {
+    A
+}
+
+Foo.A["toString"]();
+
+//// [constEnumMemberMemberAccess01.js]
+0 /* A */["toString"]();

--- a/tests/baselines/reference/constEnumMemberMemberAccess01.symbols
+++ b/tests/baselines/reference/constEnumMemberMemberAccess01.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/constEnums/constEnumMemberMemberAccess01.ts ===
+const enum Foo {
+>Foo : Symbol(Foo, Decl(constEnumMemberMemberAccess01.ts, 0, 0))
+
+    A
+>A : Symbol(Foo.A, Decl(constEnumMemberMemberAccess01.ts, 0, 16))
+}
+
+Foo.A["toString"]();
+>Foo.A : Symbol(Foo.A, Decl(constEnumMemberMemberAccess01.ts, 0, 16))
+>Foo : Symbol(Foo, Decl(constEnumMemberMemberAccess01.ts, 0, 0))
+>A : Symbol(Foo.A, Decl(constEnumMemberMemberAccess01.ts, 0, 16))
+>"toString" : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+

--- a/tests/baselines/reference/constEnumMemberMemberAccess01.types
+++ b/tests/baselines/reference/constEnumMemberMemberAccess01.types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/constEnums/constEnumMemberMemberAccess01.ts ===
+const enum Foo {
+>Foo : Foo
+
+    A
+>A : Foo
+}
+
+Foo.A["toString"]();
+>Foo.A["toString"]() : string
+>Foo.A["toString"] : (radix?: number) => string
+>Foo.A : Foo
+>Foo : typeof Foo
+>A : Foo
+>"toString" : string
+

--- a/tests/baselines/reference/constEnumMemberMemberAccess02.js
+++ b/tests/baselines/reference/constEnumMemberMemberAccess02.js
@@ -1,0 +1,10 @@
+//// [constEnumMemberMemberAccess02.ts]
+
+const enum Foo {
+    A
+}
+
+Foo.A["toString"]();
+
+//// [constEnumMemberMemberAccess02.js]
+0["toString"]();

--- a/tests/baselines/reference/constEnumMemberMemberAccess02.symbols
+++ b/tests/baselines/reference/constEnumMemberMemberAccess02.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/constEnums/constEnumMemberMemberAccess02.ts ===
+
+const enum Foo {
+>Foo : Symbol(Foo, Decl(constEnumMemberMemberAccess02.ts, 0, 0))
+
+    A
+>A : Symbol(Foo.A, Decl(constEnumMemberMemberAccess02.ts, 1, 16))
+}
+
+Foo.A["toString"]();
+>Foo.A : Symbol(Foo.A, Decl(constEnumMemberMemberAccess02.ts, 1, 16))
+>Foo : Symbol(Foo, Decl(constEnumMemberMemberAccess02.ts, 0, 0))
+>A : Symbol(Foo.A, Decl(constEnumMemberMemberAccess02.ts, 1, 16))
+>"toString" : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+

--- a/tests/baselines/reference/constEnumMemberMemberAccess02.types
+++ b/tests/baselines/reference/constEnumMemberMemberAccess02.types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/constEnums/constEnumMemberMemberAccess02.ts ===
+
+const enum Foo {
+>Foo : Foo
+
+    A
+>A : Foo
+}
+
+Foo.A["toString"]();
+>Foo.A["toString"]() : string
+>Foo.A["toString"] : (radix?: number) => string
+>Foo.A : Foo
+>Foo : typeof Foo
+>A : Foo
+>"toString" : string
+

--- a/tests/baselines/reference/constEnumMemberPropertyAccess01.js
+++ b/tests/baselines/reference/constEnumMemberPropertyAccess01.js
@@ -6,4 +6,4 @@ const enum Foo {
 Foo.A.toString();
 
 //// [constEnumMemberPropertyAccess01.js]
-0 /* A */..toString();
+0 /* A */.toString();

--- a/tests/baselines/reference/constEnumMemberPropertyAccess01.js
+++ b/tests/baselines/reference/constEnumMemberPropertyAccess01.js
@@ -1,0 +1,9 @@
+//// [constEnumMemberPropertyAccess01.ts]
+const enum Foo {
+    A
+}
+
+Foo.A.toString();
+
+//// [constEnumMemberPropertyAccess01.js]
+0 /* A */..toString();

--- a/tests/baselines/reference/constEnumMemberPropertyAccess01.symbols
+++ b/tests/baselines/reference/constEnumMemberPropertyAccess01.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/constEnums/constEnumMemberPropertyAccess01.ts ===
+const enum Foo {
+>Foo : Symbol(Foo, Decl(constEnumMemberPropertyAccess01.ts, 0, 0))
+
+    A
+>A : Symbol(Foo.A, Decl(constEnumMemberPropertyAccess01.ts, 0, 16))
+}
+
+Foo.A.toString();
+>Foo.A.toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+>Foo.A : Symbol(Foo.A, Decl(constEnumMemberPropertyAccess01.ts, 0, 16))
+>Foo : Symbol(Foo, Decl(constEnumMemberPropertyAccess01.ts, 0, 0))
+>A : Symbol(Foo.A, Decl(constEnumMemberPropertyAccess01.ts, 0, 16))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+

--- a/tests/baselines/reference/constEnumMemberPropertyAccess01.types
+++ b/tests/baselines/reference/constEnumMemberPropertyAccess01.types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/constEnums/constEnumMemberPropertyAccess01.ts ===
+const enum Foo {
+>Foo : Foo
+
+    A
+>A : Foo
+}
+
+Foo.A.toString();
+>Foo.A.toString() : string
+>Foo.A.toString : (radix?: number) => string
+>Foo.A : Foo
+>Foo : typeof Foo
+>A : Foo
+>toString : (radix?: number) => string
+

--- a/tests/baselines/reference/constEnumMemberPropertyAccess02.js
+++ b/tests/baselines/reference/constEnumMemberPropertyAccess02.js
@@ -1,0 +1,10 @@
+//// [constEnumMemberPropertyAccess02.ts]
+
+const enum Foo {
+    A
+}
+
+Foo.A.toString();
+
+//// [constEnumMemberPropertyAccess02.js]
+0..toString();

--- a/tests/baselines/reference/constEnumMemberPropertyAccess02.symbols
+++ b/tests/baselines/reference/constEnumMemberPropertyAccess02.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/constEnums/constEnumMemberPropertyAccess02.ts ===
+
+const enum Foo {
+>Foo : Symbol(Foo, Decl(constEnumMemberPropertyAccess02.ts, 0, 0))
+
+    A
+>A : Symbol(Foo.A, Decl(constEnumMemberPropertyAccess02.ts, 1, 16))
+}
+
+Foo.A.toString();
+>Foo.A.toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+>Foo.A : Symbol(Foo.A, Decl(constEnumMemberPropertyAccess02.ts, 1, 16))
+>Foo : Symbol(Foo, Decl(constEnumMemberPropertyAccess02.ts, 0, 0))
+>A : Symbol(Foo.A, Decl(constEnumMemberPropertyAccess02.ts, 1, 16))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+

--- a/tests/baselines/reference/constEnumMemberPropertyAccess02.types
+++ b/tests/baselines/reference/constEnumMemberPropertyAccess02.types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/constEnums/constEnumMemberPropertyAccess02.ts ===
+
+const enum Foo {
+>Foo : Foo
+
+    A
+>A : Foo
+}
+
+Foo.A.toString();
+>Foo.A.toString() : string
+>Foo.A.toString : (radix?: number) => string
+>Foo.A : Foo
+>Foo : typeof Foo
+>A : Foo
+>toString : (radix?: number) => string
+

--- a/tests/baselines/reference/constEnumToStringWithComments.js
+++ b/tests/baselines/reference/constEnumToStringWithComments.js
@@ -23,15 +23,15 @@ let c1 = Foo["C"].toString();
 
 
 //// [constEnumToStringWithComments.js]
-var x0 = 100 /* X */..toString();
-var x1 = 100 /* "X" */..toString();
+var x0 = 100 /* X */.toString();
+var x1 = 100 /* "X" */.toString();
 var y0 = 0.5 /* Y */.toString();
 var y1 = 0.5 /* "Y" */.toString();
-var z0 = 2 /* Z */..toString();
-var z1 = 2 /* "Z" */..toString();
-var a0 = -1 /* A */..toString();
-var a1 = -1 /* "A" */..toString();
+var z0 = 2 /* Z */.toString();
+var z1 = 2 /* "Z" */.toString();
+var a0 = -1 /* A */.toString();
+var a1 = -1 /* "A" */.toString();
 var b0 = -1.5 /* B */.toString();
 var b1 = -1.5 /* "B" */.toString();
-var c0 = -1 /* C */..toString();
-var c1 = -1 /* "C" */..toString();
+var c0 = -1 /* C */.toString();
+var c1 = -1 /* "C" */.toString();

--- a/tests/cases/conformance/constEnums/constEnumMemberMemberAccess01.ts
+++ b/tests/cases/conformance/constEnums/constEnumMemberMemberAccess01.ts
@@ -1,0 +1,5 @@
+const enum Foo {
+    A
+}
+
+Foo.A["toString"]();

--- a/tests/cases/conformance/constEnums/constEnumMemberMemberAccess02.ts
+++ b/tests/cases/conformance/constEnums/constEnumMemberMemberAccess02.ts
@@ -1,0 +1,7 @@
+// @removeComments: true
+
+const enum Foo {
+    A
+}
+
+Foo.A["toString"]();

--- a/tests/cases/conformance/constEnums/constEnumMemberPropertyAccess01.ts
+++ b/tests/cases/conformance/constEnums/constEnumMemberPropertyAccess01.ts
@@ -1,0 +1,5 @@
+const enum Foo {
+    A
+}
+
+Foo.A.toString();

--- a/tests/cases/conformance/constEnums/constEnumMemberPropertyAccess02.ts
+++ b/tests/cases/conformance/constEnums/constEnumMemberPropertyAccess02.ts
@@ -1,0 +1,7 @@
+// @removeComments: true
+
+const enum Foo {
+    A
+}
+
+Foo.A.toString();


### PR DESCRIPTION
Fixes #10232.