### PR TITLE
Optimize format of type list id strings used in maps

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4941,24 +4941,27 @@ namespace ts {
         }
 
         function getTypeListId(types: Type[]) {
+            let result = "";
             if (types) {
-                switch (types.length) {
-                    case 1:
-                        return "" + types[0].id;
-                    case 2:
-                        return types[0].id + "," + types[1].id;
-                    default:
-                        let result = "";
-                        for (let i = 0; i < types.length; i++) {
-                            if (i > 0) {
-                                result += ",";
-                            }
-                            result += types[i].id;
-                        }
-                        return result;
+                const length = types.length;
+                let i = 0;
+                while (i < length) {
+                    const startId = types[i].id;
+                    let count = 1;
+                    while (i + count < length && types[i + count].id === startId + count) {
+                        count++;
+                    }
+                    if (result.length) {
+                        result += ",";
+                    }
+                    result += startId;
+                    if (count > 1) {
+                        result += ":" + count;
+                    }
+                    i += count;
                 }
             }
-            return "";
+            return result;
         }
 
         // This function is used to propagate certain flags when creating new object type references and union types.


### PR DESCRIPTION
The compiler extensively uses caches to share instantiations of generic types as well as union, intersection, and tuple types. These caches are simply objects where the entries are keyed by property names synthesized from the unique IDs assigned to type objects. Previously we'd construct type cache keys as comma separated lists of type IDs. For example, the union type A | B | C | D would have a key like "1000,1001,1002,1003", where each numeric string is the unique ID of the type. This PR optimizes the key format by encoding two or more consecutive IDs as "xxxx:nnnn", where xxxx is the starting ID and nnnn is the number of IDs. So, the key for A | B | C | D simply becomes "1000:4" if the types have consecutive IDs. Since union types often have constituents with consecutive IDs (particularly union enum types), this can dramatically reduce the length of keys, which helps performance and memory consumption. Informal tests show a 2-3% speedup of the type check phase when compiling the compiler itself.