### PR TITLE
Make ReadonlyArray iterable.

### DIFF
--- a/src/lib/es2015.iterable.d.ts
+++ b/src/lib/es2015.iterable.d.ts
@@ -63,6 +63,26 @@ interface ArrayConstructor {
     from<T>(iterable: Iterable<T>): Array<T>;
 }
 
+interface ReadonlyArray<T> {
+    /** Iterator */
+    [Symbol.iterator](): IterableIterator<T>;
+
+    /** 
+      * Returns an array of key, value pairs for every entry in the array
+      */
+    entries(): IterableIterator<[number, T]>;
+
+    /** 
+      * Returns an list of keys in the array
+      */
+    keys(): IterableIterator<number>;
+
+    /** 
+      * Returns an list of values in the array
+      */
+    values(): IterableIterator<T>;
+}
+
 interface IArguments {
     /** Iterator */
     [Symbol.iterator](): IterableIterator<any>;


### PR DESCRIPTION
In the same vein as #9996.

`ReadonlyArray<T>` should be considered iterable too.