### PR TITLE
Allow OSX to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
     node_js: stable
     osx_image: xcode7.3
     env: workerCount=2
+  allow_failures:
+  - os: osx
 
 branches:
   only:


### PR DESCRIPTION
The random test timeouts are an issue, and this lets us investigate the issue while not holding up any other PRs/builds.