### PR TITLE
Add folds to travis log

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -35,6 +35,7 @@ import merge2 = require("merge2");
 import intoStream = require("into-stream");
 import * as os from "os";
 import Linter = require("tslint");
+import fold = require("travis-fold");
 const gulp = helpMaker(originalGulp);
 const mochaParallel = require("./scripts/mocha-parallel.js");
 const {runTestsInParallel} = mochaParallel;
@@ -964,6 +965,7 @@ gulp.task("lint", "Runs tslint on the compiler sources. Optional arguments are: 
     const fileMatcher = RegExp(cmdLineOptions["files"]);
     const lintOptions = getLinterOptions();
     let failed = 0;
+    if (fold.isTravis()) console.log(fold.start("lint"));
     return gulp.src(lintTargets)
         .pipe(insert.transform((contents, file) => {
             if (!fileMatcher.test(file.path)) return contents;
@@ -975,6 +977,7 @@ gulp.task("lint", "Runs tslint on the compiler sources. Optional arguments are: 
             return contents; // TODO (weswig): Automatically apply fixes? :3
         }))
         .on("end", () => {
+            if (fold.isTravis()) console.log(fold.end("lint"));
             if (failed > 0) {
                 console.error("Linter errors.");
                 process.exit(1);

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
     },
     "devDependencies": {
         "@types/browserify": "latest",
-        "@types/convert-source-map": "latest",
         "@types/chai": "latest",
+        "@types/convert-source-map": "latest",
         "@types/del": "latest",
         "@types/glob": "latest",
         "@types/gulp": "latest",
@@ -72,6 +72,7 @@
         "run-sequence": "latest",
         "sorcery": "latest",
         "through2": "latest",
+        "travis-fold": "latest",
         "ts-node": "latest",
         "tslint": "next",
         "typescript": "next"


### PR DESCRIPTION
Places folds around builds and the lint output (keeps the failure string outside of the fold if either fails, however). These folds should only be present under CI. The gulpfile doesn't place folds around builds because 1. They happen simultaneously (making the output unfoldable), and 2. It already skips printing compiler output (except on error) by using a gulp plugin to build.

