### PR TITLE
Have travis take shallow clones of the repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,3 +34,6 @@ install:
 cache:
   directories:
     - node_modules
+
+git:
+  depth: 1


### PR DESCRIPTION
Just cloning TS on travis takes 23 seconds on linux (68 seconds on mac), hopefully having it do a shallow clone will help.

We don't rely on any tagging/artifacts from the travis servers which clone depth could impact, so this shouldn't impact anything other than build speed.