### PR TITLE
Reduce OSX to 1 worker, make 1 worker = not parallel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ matrix:
   include:
   - os: osx
     node_js: stable
-    osx_image: xcode7.3
-    env: workerCount=2
+    osx_image: xcode8
+    env: workerCount=1
   allow_failures:
   - os: osx
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
   include:
   - os: osx
     node_js: stable
-    osx_image: xcode8
+    osx_image: xcode7.3
     env: workerCount=1
   allow_failures:
   - os: osx

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -728,6 +728,10 @@ function runConsoleTests(defaultReporter, runInParallel) {
         fs.unlinkSync(testConfigFile);
     }
     var workerCount, taskConfigsFolder;
+    var notReallyParallel = process.env.workerCount && (+process.env.workerCount === 1);
+    if (notReallyParallel) {
+        runInParallel = false;
+    }
     if (runInParallel) {
         // generate name to store task configuration files
         var prefix = os.tmpdir() + "/ts-tests";


### PR DESCRIPTION
This should make the OSX travis logs more clear (and since the parallelism doesn't seem to really help on OSX (possibly even hurts), generally seems better).