### PR TITLE
Simplifies performance API

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -89,9 +89,10 @@ namespace ts {
     const binder = createBinder();
 
     export function bindSourceFile(file: SourceFile, options: CompilerOptions) {
-        const start = performance.mark();
+        performance.mark("bindStart");
         binder(file, options);
-        performance.measure("Bind", start);
+        performance.mark("bindEnd");
+        performance.measure("Bind", "bindStart", "bindEnd");
     }
 
     function createBinder(): (file: SourceFile, options: CompilerOptions) => void {

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -89,10 +89,10 @@ namespace ts {
     const binder = createBinder();
 
     export function bindSourceFile(file: SourceFile, options: CompilerOptions) {
-        performance.mark("bindStart");
+        performance.mark("beforeBind");
         binder(file, options);
-        performance.mark("bindEnd");
-        performance.measure("Bind", "bindStart", "bindEnd");
+        performance.mark("afterBind");
+        performance.measure("Bind", "beforeBind", "afterBind");
     }
 
     function createBinder(): (file: SourceFile, options: CompilerOptions) => void {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17535,11 +17535,10 @@ namespace ts {
         }
 
         function checkSourceFile(node: SourceFile) {
-            const start = performance.mark();
-
+            performance.mark("checkStart");
             checkSourceFileWorker(node);
-
-            performance.measure("Check", start);
+            performance.mark("checkEnd");
+            performance.measure("Check", "checkStart", "checkEnd");
         }
 
         // Fully type check a source file and collect the relevant diagnostics.

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17535,10 +17535,10 @@ namespace ts {
         }
 
         function checkSourceFile(node: SourceFile) {
-            performance.mark("checkStart");
+            performance.mark("beforeCheck");
             checkSourceFileWorker(node);
-            performance.mark("checkEnd");
-            performance.measure("Check", "checkStart", "checkEnd");
+            performance.mark("afterCheck");
+            performance.measure("Check", "beforeCheck", "afterCheck");
         }
 
         // Fully type check a source file and collect the relevant diagnostics.

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -421,10 +421,10 @@ namespace ts {
     }
 
     export function createSourceFile(fileName: string, sourceText: string, languageVersion: ScriptTarget, setParentNodes = false, scriptKind?: ScriptKind): SourceFile {
-        performance.mark("parseStart");
+        performance.mark("beforeParse");
         const result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, scriptKind);
-        performance.mark("parseEnd");
-        performance.measure("Parse", "parseStart", "parseEnd");
+        performance.mark("afterParse");
+        performance.measure("Parse", "beforeParse", "afterParse");
         return result;
     }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -421,10 +421,10 @@ namespace ts {
     }
 
     export function createSourceFile(fileName: string, sourceText: string, languageVersion: ScriptTarget, setParentNodes = false, scriptKind?: ScriptKind): SourceFile {
-        const start = performance.mark();
+        performance.mark("parseStart");
         const result = Parser.parseSourceFile(fileName, sourceText, languageVersion, /*syntaxCursor*/ undefined, setParentNodes, scriptKind);
-
-        performance.measure("Parse", start);
+        performance.mark("parseEnd");
+        performance.measure("Parse", "parseStart", "parseEnd");
         return result;
     }
 

--- a/src/compiler/performance.ts
+++ b/src/compiler/performance.ts
@@ -6,71 +6,57 @@ namespace ts {
 }
 
 /*@internal*/
+/** Performance measurements for the compiler. */
 namespace ts.performance {
-    /** Performance measurements for the compiler. */
     declare const onProfilerEvent: { (markName: string): void; profiler: boolean; };
-    let profilerEvent: (markName: string) => void;
-    let counters: MapLike<number>;
-    let measures: MapLike<number>;
+
+    const profilerEvent = typeof onProfilerEvent === "function" && onProfilerEvent.profiler === true
+            ? onProfilerEvent
+            : (markName: string) => { };
+
+    let enabled = false;
+    let profilerStart = 0;
+    let counts: Map<number>;
+    let marks: Map<number>;
+    let measures: Map<number>;
 
     /**
-     * Emit a performance event if ts-profiler is connected. This is primarily used
-     * to generate heap snapshots.
+     * Marks a performance event.
      *
-     * @param eventName A name for the event.
+     * @param markName The name of the mark.
      */
-    export function emit(eventName: string) {
-        if (profilerEvent) {
-            profilerEvent(eventName);
+    export function mark(markName: string) {
+        if (enabled) {
+            marks[markName] = timestamp();
+            counts[markName] = (counts[markName] || 0) + 1;
+            profilerEvent(markName);
         }
-    }
-
-    /**
-     * Increments a counter with the specified name.
-     *
-     * @param counterName The name of the counter.
-     */
-    export function increment(counterName: string) {
-        if (counters) {
-            counters[counterName] = (getProperty(counters, counterName) || 0) + 1;
-        }
-    }
-
-    /**
-     * Gets the value of the counter with the specified name.
-     *
-     * @param counterName The name of the counter.
-     */
-    export function getCount(counterName: string) {
-        return counters && getProperty(counters, counterName) || 0;
-    }
-
-    /**
-     * Marks the start of a performance measurement.
-     */
-    export function mark() {
-        return measures ? timestamp() : 0;
     }
 
     /**
      * Adds a performance measurement with the specified name.
      *
      * @param measureName The name of the performance measurement.
-     * @param marker The timestamp of the starting mark.
+     * @param startMarkName The name of the starting mark. If not supplied, the point at which the
+     *      profiler was enabled is used.
+     * @param endMarkName The name of the ending mark. If not supplied, the current timestamp is
+     *      used.
      */
-    export function measure(measureName: string, marker: number) {
-        if (measures) {
-            measures[measureName] = (getProperty(measures, measureName) || 0) + (timestamp() - marker);
+    export function measure(measureName: string, startMarkName?: string, endMarkName?: string) {
+        if (enabled) {
+            const end = endMarkName && marks[endMarkName] || timestamp();
+            const start = startMarkName && marks[startMarkName] || profilerStart;
+            measures[measureName] = (measures[measureName] || 0) + (end - start);
         }
     }
 
     /**
-     * Iterate over each measure, performing some action
-     * 
-     * @param cb The action to perform for each measure
+     * Gets the number of times a marker was encountered.
+     *
+     * @param markName The name of the mark.
      */
-    export function forEachMeasure(cb: (measureName: string, duration: number) => void) {
-        return forEachKey(measures, key => cb(key, measures[key]));
+    export function getCount(markName: string) {
+        return counts && counts[markName] || 0;
     }
 
     /**
@@ -79,31 +65,31 @@ namespace ts.performance {
      * @param measureName The name of the measure whose durations should be accumulated.
      */
     export function getDuration(measureName: string) {
-        return measures && getProperty(measures, measureName) || 0;
+        return measures && measures[measureName] || 0;
+    }
+
+    /**
+     * Iterate over each measure, performing some action
+     *
+     * @param cb The action to perform for each measure
+     */
+    export function forEachMeasure(cb: (measureName: string, duration: number) => void) {
+        for (const key in measures) {
+            cb(key, measures[key]);
+        }
     }
 
     /** Enables (and resets) performance measurements for the compiler. */
     export function enable() {
-        counters = { };
-        measures = {
-            "I/O Read": 0,
-            "I/O Write": 0,
-            "Program": 0,
-            "Parse": 0,
-            "Bind": 0,
-            "Check": 0,
-            "Emit": 0,
-        };
-
-        profilerEvent = typeof onProfilerEvent === "function" && onProfilerEvent.profiler === true
-            ? onProfilerEvent
-            : undefined;
+        counts = createMap<number>();
+        marks = createMap<number>();
+        measures = createMap<number>();
+        enabled = true;
+        profilerStart = timestamp();
     }
 
-    /** Disables (and clears) performance measurements for the compiler. */
+    /** Disables performance measurements for the compiler. */
     export function disable() {
-        counters = undefined;
-        measures = undefined;
-        profilerEvent = undefined;
+        enabled = false;
     }
 }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -857,9 +857,10 @@ namespace ts {
         function getSourceFile(fileName: string, languageVersion: ScriptTarget, onError?: (message: string) => void): SourceFile {
             let text: string;
             try {
-                const start = performance.mark();
+                performance.mark("ioReadStart");
                 text = sys.readFile(fileName, options.charset);
-                performance.measure("I/O Read", start);
+                performance.mark("ioReadEnd");
+                performance.measure("I/O Read", "ioReadStart", "ioReadEnd");
             }
             catch (e) {
                 if (onError) {
@@ -926,7 +927,7 @@ namespace ts {
 
         function writeFile(fileName: string, data: string, writeByteOrderMark: boolean, onError?: (message: string) => void) {
             try {
-                const start = performance.mark();
+                performance.mark("ioWriteStart");
                 ensureDirectoriesExist(getDirectoryPath(normalizePath(fileName)));
 
                 if (isWatchSet(options) && sys.createHash && sys.getModifiedTime) {
@@ -936,7 +937,8 @@ namespace ts {
                     sys.writeFile(fileName, data, writeByteOrderMark);
                 }
 
-                performance.measure("I/O Write", start);
+                performance.mark("ioWriteEnd");
+                performance.measure("I/O Write", "ioWriteStart", "ioWriteEnd");
             }
             catch (e) {
                 if (onError) {
@@ -1118,7 +1120,7 @@ namespace ts {
         // Track source files that are source files found by searching under node_modules, as these shouldn't be compiled.
         const sourceFilesFoundSearchingNodeModules = createMap<boolean>();
 
-        const start = performance.mark();
+        performance.mark("programStart");
 
         host = host || createCompilerHost(options);
 
@@ -1216,8 +1218,8 @@ namespace ts {
         };
 
         verifyCompilerOptions();
-
-        performance.measure("Program", start);
+        performance.mark("programEnd");
+        performance.measure("Program", "programStart", "programEnd");
 
         return program;
 
@@ -1460,14 +1462,15 @@ namespace ts {
             // checked is to not pass the file to getEmitResolver.
             const emitResolver = getDiagnosticsProducingTypeChecker().getEmitResolver((options.outFile || options.out) ? undefined : sourceFile);
 
-            const start = performance.mark();
+            performance.mark("emitStart");
 
             const emitResult = emitFiles(
                 emitResolver,
                 getEmitHost(writeFileCallback),
                 sourceFile);
 
-            performance.measure("Emit", start);
+            performance.mark("emitEnd");
+            performance.measure("Emit", "emitStart", "emitEnd");
             return emitResult;
         }
 

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -857,10 +857,10 @@ namespace ts {
         function getSourceFile(fileName: string, languageVersion: ScriptTarget, onError?: (message: string) => void): SourceFile {
             let text: string;
             try {
-                performance.mark("ioReadStart");
+                performance.mark("beforeIORead");
                 text = sys.readFile(fileName, options.charset);
-                performance.mark("ioReadEnd");
-                performance.measure("I/O Read", "ioReadStart", "ioReadEnd");
+                performance.mark("afterIORead");
+                performance.measure("I/O Read", "beforeIORead", "afterIORead");
             }
             catch (e) {
                 if (onError) {
@@ -927,7 +927,7 @@ namespace ts {
 
         function writeFile(fileName: string, data: string, writeByteOrderMark: boolean, onError?: (message: string) => void) {
             try {
-                performance.mark("ioWriteStart");
+                performance.mark("beforeIOWrite");
                 ensureDirectoriesExist(getDirectoryPath(normalizePath(fileName)));
 
                 if (isWatchSet(options) && sys.createHash && sys.getModifiedTime) {
@@ -937,8 +937,8 @@ namespace ts {
                     sys.writeFile(fileName, data, writeByteOrderMark);
                 }
 
-                performance.mark("ioWriteEnd");
-                performance.measure("I/O Write", "ioWriteStart", "ioWriteEnd");
+                performance.mark("afterIOWrite");
+                performance.measure("I/O Write", "beforeIOWrite", "afterIOWrite");
             }
             catch (e) {
                 if (onError) {
@@ -1120,7 +1120,7 @@ namespace ts {
         // Track source files that are source files found by searching under node_modules, as these shouldn't be compiled.
         const sourceFilesFoundSearchingNodeModules = createMap<boolean>();
 
-        performance.mark("programStart");
+        performance.mark("beforeProgram");
 
         host = host || createCompilerHost(options);
 
@@ -1218,8 +1218,8 @@ namespace ts {
         };
 
         verifyCompilerOptions();
-        performance.mark("programEnd");
-        performance.measure("Program", "programStart", "programEnd");
+        performance.mark("afterProgram");
+        performance.measure("Program", "beforeProgram", "afterProgram");
 
         return program;
 
@@ -1462,15 +1462,15 @@ namespace ts {
             // checked is to not pass the file to getEmitResolver.
             const emitResolver = getDiagnosticsProducingTypeChecker().getEmitResolver((options.outFile || options.out) ? undefined : sourceFile);
 
-            performance.mark("emitStart");
+            performance.mark("beforeEmit");
 
             const emitResult = emitFiles(
                 emitResolver,
                 getEmitHost(writeFileCallback),
                 sourceFile);
 
-            performance.mark("emitEnd");
-            performance.measure("Emit", "emitStart", "emitEnd");
+            performance.mark("afterEmit");
+            performance.measure("Emit", "beforeEmit", "afterEmit");
             return emitResult;
         }
 

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -46,6 +46,7 @@ namespace ts {
 
     export function createSourceMapWriter(host: EmitHost, writer: EmitTextWriter): SourceMapWriter {
         const compilerOptions = host.getCompilerOptions();
+        const extendedDiagnostics = compilerOptions.extendedDiagnostics;
         let currentSourceFile: SourceFile;
         let sourceMapDir: string; // The directory in which sourcemap will be
         let stopOverridingSpan = false;
@@ -240,7 +241,9 @@ namespace ts {
                 return;
             }
 
-            const start = performance.mark();
+            if (extendedDiagnostics) {
+                performance.mark("sourcemapStart");
+            }
 
             const sourceLinePos = getLineAndCharacterOfPosition(currentSourceFile, pos);
 
@@ -282,7 +285,10 @@ namespace ts {
 
             updateLastEncodedAndRecordedSpans();
 
-            performance.measure("Source Map", start);
+            if (extendedDiagnostics) {
+                performance.mark("sourcemapEnd");
+                performance.measure("Source Map", "sourcemapStart", "sourcemapEnd");
+            }
         }
 
         function getStartPos(range: TextRange) {

--- a/src/compiler/sourcemap.ts
+++ b/src/compiler/sourcemap.ts
@@ -242,7 +242,7 @@ namespace ts {
             }
 
             if (extendedDiagnostics) {
-                performance.mark("sourcemapStart");
+                performance.mark("beforeSourcemap");
             }
 
             const sourceLinePos = getLineAndCharacterOfPosition(currentSourceFile, pos);
@@ -286,8 +286,8 @@ namespace ts {
             updateLastEncodedAndRecordedSpans();
 
             if (extendedDiagnostics) {
-                performance.mark("sourcemapEnd");
-                performance.measure("Source Map", "sourcemapStart", "sourcemapEnd");
+                performance.mark("afterSourcemap");
+                performance.measure("Source Map", "beforeSourcemap", "afterSourcemap");
             }
         }
 


### PR DESCRIPTION
This change streamlines the performance API and moves the various markers and measurements to `Map` over `MapLike`. As a result, some scenarios such as Angular are improved by another 3% (350ms). This change also improves integration with the ts-perf profiler, making it easier to analyze performance events. 