### PR TITLE
Use lowercase names for type reference directives

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -2012,15 +2012,16 @@ namespace ts {
         }
 
         function processTypeReferenceDirectives(file: SourceFile) {
-            const typeDirectives = map(file.typeReferenceDirectives, l => l.fileName);
+            const typeDirectives = map(file.typeReferenceDirectives, ref => ref.fileName.toLocaleLowerCase());
             const resolutions = resolveTypeReferenceDirectiveNamesWorker(typeDirectives, file.fileName);
 
             for (let i = 0; i < typeDirectives.length; i++) {
                 const ref = file.typeReferenceDirectives[i];
                 const resolvedTypeReferenceDirective = resolutions[i];
                 // store resolved type directive on the file
-                setResolvedTypeReferenceDirective(file, ref.fileName, resolvedTypeReferenceDirective);
-                processTypeReferenceDirective(ref.fileName, resolvedTypeReferenceDirective, file, ref.pos, ref.end);
+                const fileName = ref.fileName.toLocaleLowerCase();
+                setResolvedTypeReferenceDirective(file, fileName, resolvedTypeReferenceDirective);
+                processTypeReferenceDirective(fileName, resolvedTypeReferenceDirective, file, ref.pos, ref.end);
             }
         }
 

--- a/tests/baselines/reference/typingsLookup3.js
+++ b/tests/baselines/reference/typingsLookup3.js
@@ -1,0 +1,13 @@
+//// [tests/cases/conformance/typings/typingsLookup3.ts] ////
+
+//// [index.d.ts]
+declare var $: { x: any };
+
+//// [a.ts]
+/// <reference types="JqUeRy" />
+$.x;
+
+
+//// [a.js]
+/// <reference types="JqUeRy" />
+$.x;

--- a/tests/baselines/reference/typingsLookup3.symbols
+++ b/tests/baselines/reference/typingsLookup3.symbols
@@ -1,0 +1,12 @@
+=== /a.ts ===
+/// <reference types="JqUeRy" />
+$.x;
+>$.x : Symbol(x, Decl(index.d.ts, 0, 16))
+>$ : Symbol($, Decl(index.d.ts, 0, 11))
+>x : Symbol(x, Decl(index.d.ts, 0, 16))
+
+=== /node_modules/@types/jquery/index.d.ts ===
+declare var $: { x: any };
+>$ : Symbol($, Decl(index.d.ts, 0, 11))
+>x : Symbol(x, Decl(index.d.ts, 0, 16))
+

--- a/tests/baselines/reference/typingsLookup3.trace.json
+++ b/tests/baselines/reference/typingsLookup3.trace.json
@@ -1,0 +1,12 @@
+[
+    "======== Resolving type reference directive 'jquery', containing file '/a.ts', root directory '/node_modules/@types'. ========",
+    "Resolving with primary search path '/node_modules/@types'",
+    "File '/node_modules/@types/jquery/package.json' does not exist.",
+    "File '/node_modules/@types/jquery/index.d.ts' exist - use it as a name resolution result.",
+    "======== Type reference directive 'jquery' was successfully resolved to '/node_modules/@types/jquery/index.d.ts', primary: true. ========",
+    "======== Resolving type reference directive 'jquery', containing file '/__inferred type names__.ts', root directory '/node_modules/@types'. ========",
+    "Resolving with primary search path '/node_modules/@types'",
+    "File '/node_modules/@types/jquery/package.json' does not exist.",
+    "File '/node_modules/@types/jquery/index.d.ts' exist - use it as a name resolution result.",
+    "======== Type reference directive 'jquery' was successfully resolved to '/node_modules/@types/jquery/index.d.ts', primary: true. ========"
+]

--- a/tests/baselines/reference/typingsLookup3.types
+++ b/tests/baselines/reference/typingsLookup3.types
@@ -1,0 +1,12 @@
+=== /a.ts ===
+/// <reference types="JqUeRy" />
+$.x;
+>$.x : any
+>$ : { x: any; }
+>x : any
+
+=== /node_modules/@types/jquery/index.d.ts ===
+declare var $: { x: any };
+>$ : { x: any; }
+>x : any
+

--- a/tests/cases/conformance/typings/typingsLookup3.ts
+++ b/tests/cases/conformance/typings/typingsLookup3.ts
@@ -1,0 +1,14 @@
+// @traceResolution: true
+// @noImplicitReferences: true
+// @currentDirectory: /
+// This tests that `types` references are automatically lowercased.
+
+// @filename: /tsconfig.json
+{ "files": "a.ts" }
+
+// @filename: /node_modules/@types/jquery/index.d.ts
+declare var $: { x: any };
+
+// @filename: /a.ts
+/// <reference types="JqUeRy" />
+$.x;


### PR DESCRIPTION
Fixes #9824

Note: since we don't try un-lowercasing names on failure, this would break any code that intentionally used an uppercased name for a type reference, although that's not too likely since `@types` is the default and anything installed by npm will be lowercase.
