### PR TITLE
Treat ambient shorthand declarations as explicit uses of the `any` type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17034,11 +17034,6 @@ namespace ts {
                 }
             }
 
-            if (compilerOptions.noImplicitAny && !node.body) {
-                // Ambient shorthand module is an implicit any
-                reportImplicitAnyError(node, anyType);
-            }
-
             if (node.body) {
                 checkSourceElement(node.body);
                 if (!isGlobalScopeAugmentation(node)) {

--- a/tests/baselines/reference/ambientShorthand_isImplicitAny.errors.txt
+++ b/tests/baselines/reference/ambientShorthand_isImplicitAny.errors.txt
@@ -1,8 +1,0 @@
-tests/cases/conformance/ambient/ambientShorthand_isImplicitAny.ts(1,16): error TS7005: Variable '"jquery"' implicitly has an 'any' type.
-
-
-==== tests/cases/conformance/ambient/ambientShorthand_isImplicitAny.ts (1 errors) ====
-    declare module "jquery";
-                   ~~~~~~~~
-!!! error TS7005: Variable '"jquery"' implicitly has an 'any' type.
-    

--- a/tests/baselines/reference/ambientShorthand_isImplicitAny.js
+++ b/tests/baselines/reference/ambientShorthand_isImplicitAny.js
@@ -1,5 +1,0 @@
-//// [ambientShorthand_isImplicitAny.ts]
-declare module "jquery";
-
-
-//// [ambientShorthand_isImplicitAny.js]

--- a/tests/cases/conformance/ambient/ambientShorthand_isImplicitAny.ts
+++ b/tests/cases/conformance/ambient/ambientShorthand_isImplicitAny.ts
@@ -1,2 +1,0 @@
-// @noImplicitAny: true
-declare module "jquery";


### PR DESCRIPTION
Fixes #10191.
Pending discussion with @DanielRosenwasser, @RyanCavanaugh, and @mhegazy.

