### PR TITLE
Fix 10266: Add ES2015 Date constructor signature that accepts another Date

### DIFF
--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -68,6 +68,10 @@ interface ArrayConstructor {
     of<T>(...items: T[]): Array<T>;
 }
 
+interface DateConstructor {
+    new (value: Date): Date;
+}
+
 interface Function {
     /**
       * Returns the name of the function. Function names are read-only and can not be changed.


### PR DESCRIPTION
Fix #10266 