### PR TITLE
Implicit const parameters

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2157,7 +2157,7 @@ namespace ts {
         /* @internal */ exportSymbol?: Symbol;  // Exported symbol associated with this symbol
         /* @internal */ constEnumOnlyModule?: boolean; // True if module contains only const enums or other modules with only const enums
         /* @internal */ isReferenced?: boolean; // True if the symbol is referenced elsewhere
-        /* @internal */ isAssigned?: boolean;   // True if the symbol has assignments
+        /* @internal */ isAssigned?: boolean;   // True if the symbol is a parameter with assignments
     }
 
     /* @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2157,6 +2157,7 @@ namespace ts {
         /* @internal */ exportSymbol?: Symbol;  // Exported symbol associated with this symbol
         /* @internal */ constEnumOnlyModule?: boolean; // True if module contains only const enums or other modules with only const enums
         /* @internal */ isReferenced?: boolean; // True if the symbol is referenced elsewhere
+        /* @internal */ isAssigned?: boolean;   // True if the symbol has assignments
     }
 
     /* @internal */
@@ -2209,23 +2210,24 @@ namespace ts {
         AsyncMethodWithSuper                = 0x00000800,  // An async method that reads a value from a member of 'super'.
         AsyncMethodWithSuperBinding         = 0x00001000,  // An async method that assigns a value to a member of 'super'.
         CaptureArguments                    = 0x00002000,  // Lexical 'arguments' used in body (for async functions)
-        EnumValuesComputed                  = 0x00004000, // Values for enum members have been computed, and any errors have been reported for them.
-        LexicalModuleMergesWithClass        = 0x00008000, // Instantiated lexical module declaration is merged with a previous class declaration.
-        LoopWithCapturedBlockScopedBinding  = 0x00010000, // Loop that contains block scoped variable captured in closure
-        CapturedBlockScopedBinding          = 0x00020000, // Block-scoped binding that is captured in some function
-        BlockScopedBindingInLoop            = 0x00040000, // Block-scoped binding with declaration nested inside iteration statement
-        ClassWithBodyScopedClassBinding     = 0x00080000, // Decorated class that contains a binding to itself inside of the class body.
-        BodyScopedClassBinding              = 0x00100000, // Binding to a decorated class inside of the class's body.
-        NeedsLoopOutParameter               = 0x00200000, // Block scoped binding whose value should be explicitly copied outside of the converted loop
+        EnumValuesComputed                  = 0x00004000,  // Values for enum members have been computed, and any errors have been reported for them.
+        LexicalModuleMergesWithClass        = 0x00008000,  // Instantiated lexical module declaration is merged with a previous class declaration.
+        LoopWithCapturedBlockScopedBinding  = 0x00010000,  // Loop that contains block scoped variable captured in closure
+        CapturedBlockScopedBinding          = 0x00020000,  // Block-scoped binding that is captured in some function
+        BlockScopedBindingInLoop            = 0x00040000,  // Block-scoped binding with declaration nested inside iteration statement
+        ClassWithBodyScopedClassBinding     = 0x00080000,  // Decorated class that contains a binding to itself inside of the class body.
+        BodyScopedClassBinding              = 0x00100000,  // Binding to a decorated class inside of the class's body.
+        NeedsLoopOutParameter               = 0x00200000,  // Block scoped binding whose value should be explicitly copied outside of the converted loop
+        AssignmentsMarked                   = 0x00400000,  // Parameter assignments have been marked
     }
 
     /* @internal */
     export interface NodeLinks {
+        flags?: NodeCheckFlags;           // Set of flags specific to Node
         resolvedType?: Type;              // Cached type of type node
         resolvedSignature?: Signature;    // Cached signature of signature node or call expression
         resolvedSymbol?: Symbol;          // Cached name resolution result
         resolvedIndexInfo?: IndexInfo;    // Cached indexing info resolution result
-        flags?: NodeCheckFlags;           // Set of flags specific to Node
         enumMemberValue?: number;         // Constant value of enum member
         isVisible?: boolean;              // Is this node visible
         hasReportedStatementInAmbientContext?: boolean;  // Cache boolean if we report statements in ambient context

--- a/tests/baselines/reference/implicitConstParameters.errors.txt
+++ b/tests/baselines/reference/implicitConstParameters.errors.txt
@@ -1,0 +1,65 @@
+tests/cases/compiler/implicitConstParameters.ts(39,27): error TS2532: Object is possibly 'undefined'.
+tests/cases/compiler/implicitConstParameters.ts(45,27): error TS2532: Object is possibly 'undefined'.
+
+
+==== tests/cases/compiler/implicitConstParameters.ts (2 errors) ====
+    
+    function doSomething(cb: () => void) {
+        cb();
+    }
+    
+    function fn(x: number | string) {
+      if (typeof x === 'number') {
+          doSomething(() => x.toFixed());
+      }
+    }
+    
+    function f1(x: string | undefined) {
+        if (!x) {
+            return;
+        }
+        doSomething(() => x.length);
+    }
+    
+    function f2(x: string | undefined) {
+        if (x) {
+            doSomething(() => {
+                doSomething(() => x.length);
+            });
+        }
+    }
+    
+    function f3(x: string | undefined) {
+        inner();
+        function inner() {
+            if (x) {
+                doSomething(() => x.length);
+            }
+        }
+    }
+    
+    function f4(x: string | undefined) {
+        x = "abc";  // causes x to be considered non-const
+        if (x) {
+            doSomething(() => x.length);
+                              ~
+!!! error TS2532: Object is possibly 'undefined'.
+        }
+    }
+    
+    function f5(x: string | undefined) {
+        if (x) {
+            doSomething(() => x.length);
+                              ~
+!!! error TS2532: Object is possibly 'undefined'.
+        }
+        x = "abc";  // causes x to be considered non-const
+    }
+    
+    
+    function f6(x: string | undefined) {
+        const y = x || "";
+        if (x) {
+            doSomething(() => y.length);
+        }
+    }

--- a/tests/baselines/reference/implicitConstParameters.js
+++ b/tests/baselines/reference/implicitConstParameters.js
@@ -1,0 +1,106 @@
+//// [implicitConstParameters.ts]
+
+function doSomething(cb: () => void) {
+    cb();
+}
+
+function fn(x: number | string) {
+  if (typeof x === 'number') {
+      doSomething(() => x.toFixed());
+  }
+}
+
+function f1(x: string | undefined) {
+    if (!x) {
+        return;
+    }
+    doSomething(() => x.length);
+}
+
+function f2(x: string | undefined) {
+    if (x) {
+        doSomething(() => {
+            doSomething(() => x.length);
+        });
+    }
+}
+
+function f3(x: string | undefined) {
+    inner();
+    function inner() {
+        if (x) {
+            doSomething(() => x.length);
+        }
+    }
+}
+
+function f4(x: string | undefined) {
+    x = "abc";  // causes x to be considered non-const
+    if (x) {
+        doSomething(() => x.length);
+    }
+}
+
+function f5(x: string | undefined) {
+    if (x) {
+        doSomething(() => x.length);
+    }
+    x = "abc";  // causes x to be considered non-const
+}
+
+
+function f6(x: string | undefined) {
+    const y = x || "";
+    if (x) {
+        doSomething(() => y.length);
+    }
+}
+
+//// [implicitConstParameters.js]
+function doSomething(cb) {
+    cb();
+}
+function fn(x) {
+    if (typeof x === 'number') {
+        doSomething(function () { return x.toFixed(); });
+    }
+}
+function f1(x) {
+    if (!x) {
+        return;
+    }
+    doSomething(function () { return x.length; });
+}
+function f2(x) {
+    if (x) {
+        doSomething(function () {
+            doSomething(function () { return x.length; });
+        });
+    }
+}
+function f3(x) {
+    inner();
+    function inner() {
+        if (x) {
+            doSomething(function () { return x.length; });
+        }
+    }
+}
+function f4(x) {
+    x = "abc"; // causes x to be considered non-const
+    if (x) {
+        doSomething(function () { return x.length; });
+    }
+}
+function f5(x) {
+    if (x) {
+        doSomething(function () { return x.length; });
+    }
+    x = "abc"; // causes x to be considered non-const
+}
+function f6(x) {
+    var y = x || "";
+    if (x) {
+        doSomething(function () { return y.length; });
+    }
+}

--- a/tests/cases/compiler/implicitConstParameters.ts
+++ b/tests/cases/compiler/implicitConstParameters.ts
@@ -1,0 +1,57 @@
+// @strictNullChecks: true
+
+function doSomething(cb: () => void) {
+    cb();
+}
+
+function fn(x: number | string) {
+  if (typeof x === 'number') {
+      doSomething(() => x.toFixed());
+  }
+}
+
+function f1(x: string | undefined) {
+    if (!x) {
+        return;
+    }
+    doSomething(() => x.length);
+}
+
+function f2(x: string | undefined) {
+    if (x) {
+        doSomething(() => {
+            doSomething(() => x.length);
+        });
+    }
+}
+
+function f3(x: string | undefined) {
+    inner();
+    function inner() {
+        if (x) {
+            doSomething(() => x.length);
+        }
+    }
+}
+
+function f4(x: string | undefined) {
+    x = "abc";  // causes x to be considered non-const
+    if (x) {
+        doSomething(() => x.length);
+    }
+}
+
+function f5(x: string | undefined) {
+    if (x) {
+        doSomething(() => x.length);
+    }
+    x = "abc";  // causes x to be considered non-const
+}
+
+
+function f6(x: string | undefined) {
+    const y = x || "";
+    if (x) {
+        doSomething(() => y.length);
+    }
+}


### PR DESCRIPTION
With this PR a parameter is implicitly considered `const` when there are no assignments to the parameter anywhere in the declaring function (or functions nested within it). Similar to `const` variables, when a parameter is considered `const`, type guards for the parameter remain in effect in nested function expressions and arrow functions:

```ts
function f1(x: Object) {
    if (typeof x === "string") {
        setTimeout(() => console.log(x.charAt(0)), 0);
    }
}

function f2(info?: { name: string }) {
    if (!info) {
        return;
    }
    setTimeout(() => console.log(info.name), 0);
}
```

Above, `x` and `info` are implicitly `const` because there are no assignments to them anywhere in their containing functions, and therefore the type guards remain in effect in the callback functions.

Fixes #10180. Also see #7719 and a number of similar issues.