### PR TITLE
Improve ReadonlyArray<T>.concat to match Array<T>

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1006,7 +1006,12 @@ interface ReadonlyArray<T> {
       * Combines two or more arrays.
       * @param items Additional items to add to the end of array1.
       */
-    concat(...items: T[]): T[];
+    concat(...items: T[][]): T[];
+    /**
+      * Combines two or more arrays.
+      * @param items Additional items to add to the end of array1.
+      */
+    concat(...items: (T | T[])[]): T[];
     /**
       * Adds all the elements of an array separated by the specified separator string.
       * @param separator A string used to separate one element of an array from the next in the resulting String. If omitted, the array elements are separated with a comma.

--- a/tests/baselines/reference/arrayOfSubtypeIsAssignableToReadonlyArray.errors.txt
+++ b/tests/baselines/reference/arrayOfSubtypeIsAssignableToReadonlyArray.errors.txt
@@ -1,0 +1,46 @@
+tests/cases/compiler/arrayOfSubtypeIsAssignableToReadonlyArray.ts(13,1): error TS2322: Type 'A[]' is not assignable to type 'ReadonlyArray<B>'.
+  Types of property 'concat' are incompatible.
+    Type '{ (...items: A[][]): A[]; (...items: (A | A[])[]): A[]; }' is not assignable to type '{ <U extends ReadonlyArray<B>>(...items: U[]): B[]; (...items: B[][]): B[]; (...items: (B | B[])[]): B[]; }'.
+      Type 'A[]' is not assignable to type 'B[]'.
+        Type 'A' is not assignable to type 'B'.
+          Property 'b' is missing in type 'A'.
+tests/cases/compiler/arrayOfSubtypeIsAssignableToReadonlyArray.ts(18,1): error TS2322: Type 'C<A>' is not assignable to type 'ReadonlyArray<B>'.
+  Types of property 'concat' are incompatible.
+    Type '{ (...items: A[][]): A[]; (...items: (A | A[])[]): A[]; }' is not assignable to type '{ <U extends ReadonlyArray<B>>(...items: U[]): B[]; (...items: B[][]): B[]; (...items: (B | B[])[]): B[]; }'.
+      Type 'A[]' is not assignable to type 'B[]'.
+        Type 'A' is not assignable to type 'B'.
+
+
+==== tests/cases/compiler/arrayOfSubtypeIsAssignableToReadonlyArray.ts (2 errors) ====
+    class A { a }
+    class B extends A { b }
+    class C<T> extends Array<T> { c }
+    declare var ara: A[];
+    declare var arb: B[];
+    declare var cra: C<A>;
+    declare var crb: C<B>;
+    declare var rra: ReadonlyArray<A>;
+    declare var rrb: ReadonlyArray<B>;
+    rra = ara;
+    rrb = arb; // OK, Array<B> is assignable to ReadonlyArray<A>
+    rra = arb;
+    rrb = ara; // error: 'A' is not assignable to 'B'
+    ~~~
+!!! error TS2322: Type 'A[]' is not assignable to type 'ReadonlyArray<B>'.
+!!! error TS2322:   Types of property 'concat' are incompatible.
+!!! error TS2322:     Type '{ (...items: A[][]): A[]; (...items: (A | A[])[]): A[]; }' is not assignable to type '{ <U extends ReadonlyArray<B>>(...items: U[]): B[]; (...items: B[][]): B[]; (...items: (B | B[])[]): B[]; }'.
+!!! error TS2322:       Type 'A[]' is not assignable to type 'B[]'.
+!!! error TS2322:         Type 'A' is not assignable to type 'B'.
+!!! error TS2322:           Property 'b' is missing in type 'A'.
+    
+    rra = cra;
+    rra = crb; // OK, C<B> is assignable to ReadonlyArray<A>
+    rrb = crb;
+    rrb = cra; // error: 'A' is not assignable to 'B'
+    ~~~
+!!! error TS2322: Type 'C<A>' is not assignable to type 'ReadonlyArray<B>'.
+!!! error TS2322:   Types of property 'concat' are incompatible.
+!!! error TS2322:     Type '{ (...items: A[][]): A[]; (...items: (A | A[])[]): A[]; }' is not assignable to type '{ <U extends ReadonlyArray<B>>(...items: U[]): B[]; (...items: B[][]): B[]; (...items: (B | B[])[]): B[]; }'.
+!!! error TS2322:       Type 'A[]' is not assignable to type 'B[]'.
+!!! error TS2322:         Type 'A' is not assignable to type 'B'.
+    

--- a/tests/baselines/reference/arrayOfSubtypeIsAssignableToReadonlyArray.js
+++ b/tests/baselines/reference/arrayOfSubtypeIsAssignableToReadonlyArray.js
@@ -1,0 +1,54 @@
+//// [arrayOfSubtypeIsAssignableToReadonlyArray.ts]
+class A { a }
+class B extends A { b }
+class C<T> extends Array<T> { c }
+declare var ara: A[];
+declare var arb: B[];
+declare var cra: C<A>;
+declare var crb: C<B>;
+declare var rra: ReadonlyArray<A>;
+declare var rrb: ReadonlyArray<B>;
+rra = ara;
+rrb = arb; // OK, Array<B> is assignable to ReadonlyArray<A>
+rra = arb;
+rrb = ara; // error: 'A' is not assignable to 'B'
+
+rra = cra;
+rra = crb; // OK, C<B> is assignable to ReadonlyArray<A>
+rrb = crb;
+rrb = cra; // error: 'A' is not assignable to 'B'
+
+
+//// [arrayOfSubtypeIsAssignableToReadonlyArray.js]
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var A = (function () {
+    function A() {
+    }
+    return A;
+}());
+var B = (function (_super) {
+    __extends(B, _super);
+    function B() {
+        _super.apply(this, arguments);
+    }
+    return B;
+}(A));
+var C = (function (_super) {
+    __extends(C, _super);
+    function C() {
+        _super.apply(this, arguments);
+    }
+    return C;
+}(Array));
+rra = ara;
+rrb = arb; // OK, Array<B> is assignable to ReadonlyArray<A>
+rra = arb;
+rrb = ara; // error: 'A' is not assignable to 'B'
+rra = cra;
+rra = crb; // OK, C<B> is assignable to ReadonlyArray<A>
+rrb = crb;
+rrb = cra; // error: 'A' is not assignable to 'B'

--- a/tests/cases/compiler/arrayOfSubtypeIsAssignableToReadonlyArray.ts
+++ b/tests/cases/compiler/arrayOfSubtypeIsAssignableToReadonlyArray.ts
@@ -1,0 +1,18 @@
+class A { a }
+class B extends A { b }
+class C<T> extends Array<T> { c }
+declare var ara: A[];
+declare var arb: B[];
+declare var cra: C<A>;
+declare var crb: C<B>;
+declare var rra: ReadonlyArray<A>;
+declare var rrb: ReadonlyArray<B>;
+rra = ara;
+rrb = arb; // OK, Array<B> is assignable to ReadonlyArray<A>
+rra = arb;
+rrb = ara; // error: 'A' is not assignable to 'B'
+
+rra = cra;
+rra = crb; // OK, C<B> is assignable to ReadonlyArray<A>
+rrb = crb;
+rrb = cra; // error: 'A' is not assignable to 'B'


### PR DESCRIPTION
Fixes #10368

The Array-based signature was incorrect and also out-of-date.