### PR TITLE
Set isNewIdentifierLocation to true for JavaScript files

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -4247,7 +4247,7 @@ namespace ts {
                 addRange(entries, keywordCompletions);
             }
 
-            return { isMemberCompletion, isNewIdentifierLocation: isSourceFileJavaScript(sourceFile) ? true : isNewIdentifierLocation, entries };
+            return { isMemberCompletion, isNewIdentifierLocation: isNewIdentifierLocation || isSourceFileJavaScript(sourceFile), entries };
 
             function getJavaScriptCompletionEntries(sourceFile: SourceFile, position: number, uniqueNames: Map<string>): CompletionEntry[] {
                 const entries: CompletionEntry[] = [];

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -4247,7 +4247,7 @@ namespace ts {
                 addRange(entries, keywordCompletions);
             }
 
-            return { isMemberCompletion, isNewIdentifierLocation, entries };
+            return { isMemberCompletion, isNewIdentifierLocation: isSourceFileJavaScript(sourceFile) ? true : isNewIdentifierLocation, entries };
 
             function getJavaScriptCompletionEntries(sourceFile: SourceFile, position: number, uniqueNames: Map<string>): CompletionEntry[] {
                 const entries: CompletionEntry[] = [];


### PR DESCRIPTION
Issue: Completion list auto-select is leading to a poor editing experience in JS files for Salsa
ex:  var test = "test";
test.at<space> auto-selects test.charAt

This is fine for TS where all completion items are high confidence.  For JS, the completion lists will often contain low confidence items (identifiers in file) so auto-selecting is undesirable.

Fix: Always set isNewIdentifierLocation to true for JavaScript files. This ensures that for JS completions IsBuilder is true and auto-select is disabled.
