### PR TITLE
Return non-JsDocComment children for syntactic classification

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -301,6 +301,10 @@ namespace ts {
         return node.kind >= SyntaxKind.FirstJSDocNode && node.kind <= SyntaxKind.LastJSDocNode;
     }
 
+    export function isJSDocTag(node: Node) {
+        return node.kind >= SyntaxKind.FirstJSDocTagNode && node.kind <= SyntaxKind.LastJSDocTagNode;
+    }
+
     export function getNonDecoratorTokenPosOfNode(node: Node, sourceFile?: SourceFile): number {
         if (nodeIsMissing(node) || !node.decorators) {
             return getTokenPosOfNode(node, sourceFile);

--- a/tests/cases/fourslash/syntacticClassificationsDocComment4.ts
+++ b/tests/cases/fourslash/syntacticClassificationsDocComment4.ts
@@ -1,0 +1,24 @@
+/// <reference path="fourslash.ts"/>
+
+//// /** @param {number} p1 */
+//// function foo(p1) {}
+
+var c = classification;
+verify.syntacticClassificationsAre(
+    c.comment("/** "),
+    c.punctuation("@"),
+    c.docCommentTagName("param"),
+    c.comment(" "),
+    c.punctuation("{"),
+    c.keyword("number"),
+    c.punctuation("}"),
+    c.comment(" "),
+    c.parameterName("p1"),
+    c.comment(" */"),
+    c.keyword("function"),
+    c.identifier("foo"),
+    c.punctuation("("),
+    c.parameterName("p1"),
+    c.punctuation(")"),
+    c.punctuation("{"),
+    c.punctuation("}"));


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #9650