### PR TITLE
Output test baselines to tests/baselines/local instead of root

### DIFF
--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1667,16 +1667,17 @@ namespace Harness {
             const encoded_actual = Utils.encodeString(actual);
             if (expected !== encoded_actual) {
                 if (actual === NoContent) {
-                    IO.writeFile(relativeFileName + ".delete", "");
+                    IO.writeFile(localPath(relativeFileName + ".delete"), "");
                 }
                 else {
-                    IO.writeFile(relativeFileName, actual);
+                    IO.writeFile(localPath(relativeFileName), actual);
                 }
                 // Overwrite & issue error
                 const errMsg = "The baseline file " + relativeFileName + " has changed.";
                 throw new Error(errMsg);
             }
         }
+
 
         export function runBaseline(
             descriptionForDescribe: string,


### PR DESCRIPTION
This behavior changed in #10213.

To verify these changes:

* Add `xyz` to the beginning of `tests/cases/compiler/2dArrays.ts`
* `gulp runtests --t 2dArrays`
* Get test errors, see that files are placed in root directory
* Switch to this branch, repeat, see that files are placed in `tests/baselines/local`