### PR TITLE
Remove extraneous arguments from harness's runBaseline

### DIFF
--- a/src/harness/compilerRunner.ts
+++ b/src/harness/compilerRunner.ts
@@ -147,7 +147,7 @@ class CompilerBaselineRunner extends RunnerBase {
             // check errors
             it("Correct errors for " + fileName, () => {
                 if (this.errors) {
-                    Harness.Baseline.runBaseline("Correct errors for " + fileName, justName.replace(/\.tsx?$/, ".errors.txt"), (): string => {
+                    Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, ".errors.txt"), (): string => {
                         if (result.errors.length === 0) return null;
                         return getErrorBaseline(toBeCompiled, otherFiles, result);
                     });
@@ -156,7 +156,7 @@ class CompilerBaselineRunner extends RunnerBase {
 
             it (`Correct module resolution tracing for ${fileName}`, () => {
                 if (options.traceResolution) {
-                    Harness.Baseline.runBaseline("Correct module resolution tracing for " + fileName, justName.replace(/\.tsx?$/, ".trace.json"), () => {
+                    Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, ".trace.json"), () => {
                         return JSON.stringify(result.traceResults || [], undefined, 4);
                     });
                 }
@@ -165,7 +165,7 @@ class CompilerBaselineRunner extends RunnerBase {
             // Source maps?
             it("Correct sourcemap content for " + fileName, () => {
                 if (options.sourceMap || options.inlineSourceMap) {
-                    Harness.Baseline.runBaseline("Correct sourcemap content for " + fileName, justName.replace(/\.tsx?$/, ".sourcemap.txt"), () => {
+                    Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, ".sourcemap.txt"), () => {
                         const record = result.getSourceMapRecord();
                         if (options.noEmitOnError && result.errors.length !== 0 && record === undefined) {
                             // Because of the noEmitOnError option no files are created. We need to return null because baselining isn"t required.
@@ -183,7 +183,7 @@ class CompilerBaselineRunner extends RunnerBase {
                     }
 
                     // check js output
-                    Harness.Baseline.runBaseline("Correct JS output for " + fileName, justName.replace(/\.tsx?/, ".js"), () => {
+                    Harness.Baseline.runBaseline(justName.replace(/\.tsx?/, ".js"), () => {
                         let tsCode = "";
                         const tsSources = otherFiles.concat(toBeCompiled);
                         if (tsSources.length > 1) {
@@ -242,7 +242,7 @@ class CompilerBaselineRunner extends RunnerBase {
                         throw new Error("Number of sourcemap files should be same as js files.");
                     }
 
-                    Harness.Baseline.runBaseline("Correct Sourcemap output for " + fileName, justName.replace(/\.tsx?/, ".js.map"), () => {
+                    Harness.Baseline.runBaseline(justName.replace(/\.tsx?/, ".js.map"), () => {
                         if (options.noEmitOnError && result.errors.length !== 0 && result.sourceMaps.length === 0) {
                             // We need to return null here or the runBaseLine will actually create a empty file.
                             // Baselining isn't required here because there is no output.
@@ -330,11 +330,11 @@ class CompilerBaselineRunner extends RunnerBase {
                     const pullExtension = isSymbolBaseLine ? ".symbols.pull" : ".types.pull";
 
                     if (fullBaseLine !== pullBaseLine) {
-                        Harness.Baseline.runBaseline("Correct full information for " + fileName, justName.replace(/\.tsx?/, fullExtension), () => fullBaseLine);
-                        Harness.Baseline.runBaseline("Correct pull information for " + fileName, justName.replace(/\.tsx?/, pullExtension), () => pullBaseLine);
+                        Harness.Baseline.runBaseline(justName.replace(/\.tsx?/, fullExtension), () => fullBaseLine);
+                        Harness.Baseline.runBaseline(justName.replace(/\.tsx?/, pullExtension), () => pullBaseLine);
                     }
                     else {
-                        Harness.Baseline.runBaseline("Correct information for " + fileName, justName.replace(/\.tsx?/, fullExtension), () => fullBaseLine);
+                        Harness.Baseline.runBaseline(justName.replace(/\.tsx?/, fullExtension), () => fullBaseLine);
                     }
                 }
 

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1132,12 +1132,10 @@ namespace FourSlash {
 
             }
             Harness.Baseline.runBaseline(
-                "Breakpoint Locations for " + this.activeFile.fileName,
                 baselineFile,
                 () => {
                     return this.baselineCurrentFileLocations(pos => this.getBreakpointStatementLocation(pos));
-                },
-                true /* run immediately */);
+                });
         }
 
         public baselineGetEmitOutput() {
@@ -1159,7 +1157,6 @@ namespace FourSlash {
             }
 
             Harness.Baseline.runBaseline(
-                "Generate getEmitOutput baseline : " + emitFiles.join(" "),
                 this.testData.globalOptions[metadataOptionNames.baselineFile],
                 () => {
                     let resultString = "";
@@ -1185,8 +1182,7 @@ namespace FourSlash {
                     });
 
                     return resultString;
-                },
-                true /* run immediately */);
+                });
         }
 
         public printBreakpointLocation(pos: number) {
@@ -1730,13 +1726,11 @@ namespace FourSlash {
 
         public baselineCurrentFileNameOrDottedNameSpans() {
             Harness.Baseline.runBaseline(
-                "Name OrDottedNameSpans for " + this.activeFile.fileName,
                 this.testData.globalOptions[metadataOptionNames.baselineFile],
                 () => {
                     return this.baselineCurrentFileLocations(pos =>
                         this.getNameOrDottedNameSpan(pos));
-                },
-                true /* run immediately */);
+                });
         }
 
         public printNameOrDottedNameSpans(pos: number) {

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1663,43 +1663,26 @@ namespace Harness {
             return { expected, actual };
         }
 
-        function writeComparison(expected: string, actual: string, relativeFileName: string, actualFileName: string, descriptionForDescribe: string) {
+        function writeComparison(expected: string, actual: string, relativeFileName: string, actualFileName: string) {
             const encoded_actual = Utils.encodeString(actual);
             if (expected !== encoded_actual) {
                 if (actual === NoContent) {
-                    IO.writeFile(localPath(relativeFileName + ".delete"), "");
+                    IO.writeFile(actualFileName + ".delete", "");
                 }
                 else {
-                    IO.writeFile(localPath(relativeFileName), actual);
+                    IO.writeFile(actualFileName, actual);
                 }
-                // Overwrite & issue error
-                const errMsg = "The baseline file " + relativeFileName + " has changed.";
-                throw new Error(errMsg);
+                throw new Error(`The baseline file ${relativeFileName} has changed.`);
             }
         }
 
+        export function runBaseline(relativeFileName: string, generateContent: () => string, opts?: BaselineOptions): void {
 
-        export function runBaseline(
-            descriptionForDescribe: string,
-            relativeFileName: string,
-            generateContent: () => string,
-            runImmediately = false,
-            opts?: BaselineOptions): void {
-
-            let actual = <string>undefined;
             const actualFileName = localPath(relativeFileName, opts && opts.Baselinefolder, opts && opts.Subfolder);
 
-            if (runImmediately) {
-                actual = generateActual(actualFileName, generateContent);
-                const comparison = compareToBaseline(actual, relativeFileName, opts);
-                writeComparison(comparison.expected, comparison.actual, relativeFileName, actualFileName, descriptionForDescribe);
-            }
-            else {
-                actual = generateActual(actualFileName, generateContent);
-
-                const comparison = compareToBaseline(actual, relativeFileName, opts);
-                writeComparison(comparison.expected, comparison.actual, relativeFileName, actualFileName, descriptionForDescribe);
-            }
+            const actual = generateActual(actualFileName, generateContent);
+            const comparison = compareToBaseline(actual, relativeFileName, opts);
+            writeComparison(comparison.expected, comparison.actual, relativeFileName, actualFileName);
         }
     }
 

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -1604,31 +1604,7 @@ namespace Harness {
         }
 
         const fileCache: { [idx: string]: boolean } = {};
-        function generateActual(actualFileName: string, generateContent: () => string): string {
-            // For now this is written using TypeScript, because sys is not available when running old test cases.
-            // But we need to move to sys once we have
-            // Creates the directory including its parent if not already present
-            function createDirectoryStructure(dirName: string) {
-                if (fileCache[dirName] || IO.directoryExists(dirName)) {
-                    fileCache[dirName] = true;
-                    return;
-                }
-
-                const parentDirectory = IO.directoryName(dirName);
-                if (parentDirectory != "") {
-                    createDirectoryStructure(parentDirectory);
-                }
-                IO.createDirectory(dirName);
-                fileCache[dirName] = true;
-            }
-
-            // Create folders if needed
-            createDirectoryStructure(Harness.IO.directoryName(actualFileName));
-
-            // Delete the actual file in case it fails
-            if (IO.fileExists(actualFileName)) {
-                IO.deleteFile(actualFileName);
-            }
+        function generateActual(generateContent: () => string): string {
 
             const actual = generateContent();
 
@@ -1664,6 +1640,31 @@ namespace Harness {
         }
 
         function writeComparison(expected: string, actual: string, relativeFileName: string, actualFileName: string) {
+            // For now this is written using TypeScript, because sys is not available when running old test cases.
+            // But we need to move to sys once we have
+            // Creates the directory including its parent if not already present
+            function createDirectoryStructure(dirName: string) {
+                if (fileCache[dirName] || IO.directoryExists(dirName)) {
+                    fileCache[dirName] = true;
+                    return;
+                }
+
+                const parentDirectory = IO.directoryName(dirName);
+                if (parentDirectory != "") {
+                    createDirectoryStructure(parentDirectory);
+                }
+                IO.createDirectory(dirName);
+                fileCache[dirName] = true;
+            }
+
+            // Create folders if needed
+            createDirectoryStructure(Harness.IO.directoryName(actualFileName));
+
+            // Delete the actual file in case it fails
+            if (IO.fileExists(actualFileName)) {
+                IO.deleteFile(actualFileName);
+            }
+
             const encoded_actual = Utils.encodeString(actual);
             if (expected !== encoded_actual) {
                 if (actual === NoContent) {
@@ -1680,7 +1681,7 @@ namespace Harness {
 
             const actualFileName = localPath(relativeFileName, opts && opts.Baselinefolder, opts && opts.Subfolder);
 
-            const actual = generateActual(actualFileName, generateContent);
+            const actual = generateActual(generateContent);
             const comparison = compareToBaseline(actual, relativeFileName, opts);
             writeComparison(comparison.expected, comparison.actual, relativeFileName, actualFileName);
         }

--- a/src/harness/projectsRunner.ts
+++ b/src/harness/projectsRunner.ts
@@ -459,7 +459,7 @@ class ProjectRunner extends RunnerBase {
                     });
 
                     it("Resolution information of (" + moduleNameToString(moduleKind) + "): " + testCaseFileName, () => {
-                        Harness.Baseline.runBaseline("Resolution information of (" + moduleNameToString(compilerResult.moduleKind) + "): " + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + ".json", () => {
+                        Harness.Baseline.runBaseline(getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + ".json", () => {
                             return JSON.stringify(getCompilerResolutionInfo(), undefined, "    ");
                         });
                     });
@@ -467,7 +467,7 @@ class ProjectRunner extends RunnerBase {
 
                     it("Errors for (" + moduleNameToString(moduleKind) + "): " + testCaseFileName, () => {
                         if (compilerResult.errors.length) {
-                            Harness.Baseline.runBaseline("Errors for (" + moduleNameToString(compilerResult.moduleKind) + "): " + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + ".errors.txt", () => {
+                            Harness.Baseline.runBaseline(getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + ".errors.txt", () => {
                                 return getErrorsBaseline(compilerResult);
                             });
                         }
@@ -481,7 +481,7 @@ class ProjectRunner extends RunnerBase {
                                 // There may be multiple files with different baselines. Run all and report at the end, else
                                 // it stops copying the remaining emitted files from 'local/projectOutput' to 'local/project'.
                                 try {
-                                    Harness.Baseline.runBaseline("Baseline of emitted result (" + moduleNameToString(compilerResult.moduleKind) + "): " + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + outputFile.fileName, () => {
+                                    Harness.Baseline.runBaseline(getBaselineFolder(compilerResult.moduleKind) + outputFile.fileName, () => {
                                         try {
                                             return Harness.IO.readFile(getProjectOutputFolder(outputFile.fileName, compilerResult.moduleKind));
                                         }
@@ -503,7 +503,7 @@ class ProjectRunner extends RunnerBase {
 
                     it("SourceMapRecord for (" + moduleNameToString(moduleKind) + "): " + testCaseFileName, () => {
                         if (compilerResult.sourceMapData) {
-                            Harness.Baseline.runBaseline("SourceMapRecord for (" + moduleNameToString(compilerResult.moduleKind) + "): " + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + ".sourcemap.txt", () => {
+                            Harness.Baseline.runBaseline(getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + ".sourcemap.txt", () => {
                                 return Harness.SourceMapRecorder.getSourceMapRecord(compilerResult.sourceMapData, compilerResult.program,
                                     ts.filter(compilerResult.outputFiles, outputFile => Harness.Compiler.isJS(outputFile.emittedFileName)));
                             });
@@ -516,7 +516,7 @@ class ProjectRunner extends RunnerBase {
                         if (!compilerResult.errors.length && testCase.declaration) {
                             const dTsCompileResult = compileCompileDTsFiles(compilerResult);
                             if (dTsCompileResult && dTsCompileResult.errors.length) {
-                                Harness.Baseline.runBaseline("Errors in generated Dts files for (" + moduleNameToString(compilerResult.moduleKind) + "): " + testCaseFileName, getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + ".dts.errors.txt", () => {
+                                Harness.Baseline.runBaseline(getBaselineFolder(compilerResult.moduleKind) + testCaseJustName + ".dts.errors.txt", () => {
                                     return getErrorsBaseline(dTsCompileResult);
                                 });
                             }

--- a/src/harness/rwcRunner.ts
+++ b/src/harness/rwcRunner.ts
@@ -158,41 +158,41 @@ namespace RWC {
 
 
             it("has the expected emitted code", () => {
-                Harness.Baseline.runBaseline("has the expected emitted code", baseName + ".output.js", () => {
+                Harness.Baseline.runBaseline(baseName + ".output.js", () => {
                     return Harness.Compiler.collateOutputs(compilerResult.files);
-                }, false, baselineOpts);
+                }, baselineOpts);
             });
 
             it("has the expected declaration file content", () => {
-                Harness.Baseline.runBaseline("has the expected declaration file content", baseName + ".d.ts", () => {
+                Harness.Baseline.runBaseline(baseName + ".d.ts", () => {
                     if (!compilerResult.declFilesCode.length) {
                         return null;
                     }
 
                     return Harness.Compiler.collateOutputs(compilerResult.declFilesCode);
-                }, false, baselineOpts);
+                }, baselineOpts);
             });
 
             it("has the expected source maps", () => {
-                Harness.Baseline.runBaseline("has the expected source maps", baseName + ".map", () => {
+                Harness.Baseline.runBaseline(baseName + ".map", () => {
                     if (!compilerResult.sourceMaps.length) {
                         return null;
                     }
 
                     return Harness.Compiler.collateOutputs(compilerResult.sourceMaps);
-                }, false, baselineOpts);
+                }, baselineOpts);
             });
 
             /*it("has correct source map record", () => {
                 if (compilerOptions.sourceMap) {
-                    Harness.Baseline.runBaseline("has correct source map record", baseName + ".sourcemap.txt", () => {
+                    Harness.Baseline.runBaseline(baseName + ".sourcemap.txt", () => {
                         return compilerResult.getSourceMapRecord();
-                    }, false, baselineOpts);
+                    }, baselineOpts);
                 }
             });*/
 
             it("has the expected errors", () => {
-                Harness.Baseline.runBaseline("has the expected errors", baseName + ".errors.txt", () => {
+                Harness.Baseline.runBaseline(baseName + ".errors.txt", () => {
                     if (compilerResult.errors.length === 0) {
                         return null;
                     }
@@ -200,14 +200,14 @@ namespace RWC {
                     const baselineFiles = inputFiles.concat(otherFiles).filter(f => !Harness.isDefaultLibraryFile(f.unitName));
                     const errors = compilerResult.errors.filter(e => !Harness.isDefaultLibraryFile(e.file.fileName));
                     return Harness.Compiler.getErrorBaseline(baselineFiles, errors);
-                }, false, baselineOpts);
+                }, baselineOpts);
             });
 
             // Ideally, a generated declaration file will have no errors. But we allow generated
             // declaration file errors as part of the baseline.
             it("has the expected errors in generated declaration files", () => {
                 if (compilerOptions.declaration && !compilerResult.errors.length) {
-                    Harness.Baseline.runBaseline("has the expected errors in generated declaration files", baseName + ".dts.errors.txt", () => {
+                    Harness.Baseline.runBaseline(baseName + ".dts.errors.txt", () => {
                         const declFileCompilationResult = Harness.Compiler.compileDeclarationFiles(
                             inputFiles, otherFiles, compilerResult, /*harnessSettings*/ undefined, compilerOptions, currentDirectory);
 
@@ -218,7 +218,7 @@ namespace RWC {
                         return Harness.Compiler.minimalDiagnosticsToString(declFileCompilationResult.declResult.errors) +
                             Harness.IO.newLine() + Harness.IO.newLine() +
                             Harness.Compiler.getErrorBaseline(declFileCompilationResult.declInputFiles.concat(declFileCompilationResult.declOtherFiles), declFileCompilationResult.declResult.errors);
-                    }, false, baselineOpts);
+                    }, baselineOpts);
                 }
             });
 

--- a/src/harness/test262Runner.ts
+++ b/src/harness/test262Runner.ts
@@ -67,21 +67,21 @@ class Test262BaselineRunner extends RunnerBase {
             });
 
             it("has the expected emitted code", () => {
-                Harness.Baseline.runBaseline("has the expected emitted code", testState.filename + ".output.js", () => {
+                Harness.Baseline.runBaseline(testState.filename + ".output.js", () => {
                     const files = testState.compilerResult.files.filter(f => f.fileName !== Test262BaselineRunner.helpersFilePath);
                     return Harness.Compiler.collateOutputs(files);
-                }, false, Test262BaselineRunner.baselineOptions);
+                }, Test262BaselineRunner.baselineOptions);
             });
 
             it("has the expected errors", () => {
-                Harness.Baseline.runBaseline("has the expected errors", testState.filename + ".errors.txt", () => {
+                Harness.Baseline.runBaseline(testState.filename + ".errors.txt", () => {
                     const errors = testState.compilerResult.errors;
                     if (errors.length === 0) {
                         return null;
                     }
 
                     return Harness.Compiler.getErrorBaseline(testState.inputFiles, errors);
-                }, false, Test262BaselineRunner.baselineOptions);
+                }, Test262BaselineRunner.baselineOptions);
             });
 
             it("satisfies invariants", () => {
@@ -90,10 +90,10 @@ class Test262BaselineRunner extends RunnerBase {
             });
 
             it("has the expected AST", () => {
-                Harness.Baseline.runBaseline("has the expected AST", testState.filename + ".AST.txt", () => {
+                Harness.Baseline.runBaseline(testState.filename + ".AST.txt", () => {
                     const sourceFile = testState.compilerResult.program.getSourceFile(Test262BaselineRunner.getTestFilePath(testState.filename));
                     return Utils.sourceFileToJSON(sourceFile);
-                }, false, Test262BaselineRunner.baselineOptions);
+                }, Test262BaselineRunner.baselineOptions);
             });
         });
     }

--- a/src/harness/unittests/initializeTSConfig.ts
+++ b/src/harness/unittests/initializeTSConfig.ts
@@ -10,7 +10,7 @@ namespace ts {
                 const outputFileName = `tsConfig/${name.replace(/[^a-z0-9\-. ]/ig, "")}/tsconfig.json`;
 
                 it(`Correct output for ${outputFileName}`, () => {
-                    Harness.Baseline.runBaseline("Correct output", outputFileName, () => {
+                    Harness.Baseline.runBaseline(outputFileName, () => {
                         if (initResult) {
                             return JSON.stringify(initResult, undefined, 4);
                         }

--- a/src/harness/unittests/transpile.ts
+++ b/src/harness/unittests/transpile.ts
@@ -62,7 +62,7 @@ namespace ts {
                 });
 
                 it("Correct errors for " + justName, () => {
-                    Harness.Baseline.runBaseline("Correct errors", justName.replace(/\.tsx?$/, ".errors.txt"), () => {
+                    Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, ".errors.txt"), () => {
                         if (transpileResult.diagnostics.length === 0) {
                             /* tslint:disable:no-null-keyword */
                             return null;
@@ -75,7 +75,7 @@ namespace ts {
 
                 if (canUseOldTranspile) {
                     it("Correct errors (old transpile) for " + justName, () => {
-                        Harness.Baseline.runBaseline("Correct errors", justName.replace(/\.tsx?$/, ".oldTranspile.errors.txt"), () => {
+                        Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, ".oldTranspile.errors.txt"), () => {
                             if (oldTranspileDiagnostics.length === 0) {
                                 /* tslint:disable:no-null-keyword */
                                 return null;
@@ -88,7 +88,7 @@ namespace ts {
                 }
 
                 it("Correct output for " + justName, () => {
-                    Harness.Baseline.runBaseline("Correct output", justName.replace(/\.tsx?$/, ".js"), () => {
+                    Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, ".js"), () => {
                         if (transpileResult.outputText) {
                             return transpileResult.outputText;
                         }
@@ -104,7 +104,7 @@ namespace ts {
 
                 if (canUseOldTranspile) {
                     it("Correct output (old transpile) for " + justName, () => {
-                        Harness.Baseline.runBaseline("Correct output", justName.replace(/\.tsx?$/, ".oldTranspile.js"), () => {
+                        Harness.Baseline.runBaseline(justName.replace(/\.tsx?$/, ".oldTranspile.js"), () => {
                             return oldTranspileResult;
                         });
                     });


### PR DESCRIPTION
I noticed the issue #10415 fixed, but also went through and removed all of the arguments/code paths in `runBaseline` which were unused/pointless. The test code looks much more DRY now.