### PR TITLE
Treat special property access symbol differently when retriving documentation

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -4913,6 +4913,24 @@ namespace ts {
 
             if (!documentation) {
                 documentation = symbol.getDocumentationComment();
+                if ((!documentation || documentation.length === 0) && symbol.flags & SymbolFlags.Property) {
+                    // For some special property access expressions like `experts.foo = foo` or `module.exports.foo = foo`
+                    // there documentation comments might be attached to the right hand side symbol of their declarations.
+                    // The pattern of such special property access is that the parent symbol is the symbol of the file.
+                    if (symbol.parent && forEach(symbol.parent.declarations, declaration => declaration.kind === SyntaxKind.SourceFile)) {
+                        forEach(symbol.declarations, declaration => {
+                            if (declaration.parent && declaration.parent.kind === SyntaxKind.BinaryExpression) {
+                                const rhsSymbol = program.getTypeChecker().getSymbolAtLocation((<BinaryExpression>declaration.parent).right);
+                                if (rhsSymbol) {
+                                    documentation = rhsSymbol.getDocumentationComment();
+                                    if (documentation && documentation.length > 0) {
+                                        return true;
+                                    }
+                                }
+                            }
+                        });
+                    }
+                }
             }
 
             return { displayParts, documentation, symbolKind };

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -4913,22 +4913,24 @@ namespace ts {
 
             if (!documentation) {
                 documentation = symbol.getDocumentationComment();
-                if ((!documentation || documentation.length === 0) && symbol.flags & SymbolFlags.Property) {
+                if (documentation.length === 0 && symbol.flags & SymbolFlags.Property) {
                     // For some special property access expressions like `experts.foo = foo` or `module.exports.foo = foo`
                     // there documentation comments might be attached to the right hand side symbol of their declarations.
                     // The pattern of such special property access is that the parent symbol is the symbol of the file.
                     if (symbol.parent && forEach(symbol.parent.declarations, declaration => declaration.kind === SyntaxKind.SourceFile)) {
-                        forEach(symbol.declarations, declaration => {
-                            if (declaration.parent && declaration.parent.kind === SyntaxKind.BinaryExpression) {
-                                const rhsSymbol = program.getTypeChecker().getSymbolAtLocation((<BinaryExpression>declaration.parent).right);
-                                if (rhsSymbol) {
-                                    documentation = rhsSymbol.getDocumentationComment();
-                                    if (documentation && documentation.length > 0) {
-                                        return true;
-                                    }
+                        for(const declaration of symbol.declarations) {
+                            if (!declaration.parent || declaration.parent.kind !== SyntaxKind.BinaryExpression) {
+                                continue;
+                            }
+
+                            const rhsSymbol = program.getTypeChecker().getSymbolAtLocation((<BinaryExpression>declaration.parent).right);
+                            if (rhsSymbol) {
+                                documentation = rhsSymbol.getDocumentationComment();
+                                if (documentation.length > 0) {
+                                    return;
                                 }
                             }
-                        });
+                        }
                     }
                 }
             }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -4918,17 +4918,19 @@ namespace ts {
                     // there documentation comments might be attached to the right hand side symbol of their declarations.
                     // The pattern of such special property access is that the parent symbol is the symbol of the file.
                     if (symbol.parent && forEach(symbol.parent.declarations, declaration => declaration.kind === SyntaxKind.SourceFile)) {
-                        for(const declaration of symbol.declarations) {
+                        for (const declaration of symbol.declarations) {
                             if (!declaration.parent || declaration.parent.kind !== SyntaxKind.BinaryExpression) {
                                 continue;
                             }
 
                             const rhsSymbol = program.getTypeChecker().getSymbolAtLocation((<BinaryExpression>declaration.parent).right);
-                            if (rhsSymbol) {
-                                documentation = rhsSymbol.getDocumentationComment();
-                                if (documentation.length > 0) {
-                                    return;
-                                }
+                            if (!rhsSymbol) {
+                                continue;
+                            }
+
+                            documentation = rhsSymbol.getDocumentationComment();
+                            if (documentation.length > 0) {
+                                break;
                             }
                         }
                     }

--- a/tests/cases/fourslash/server/completionEntryDetailAcrossFiles01.ts
+++ b/tests/cases/fourslash/server/completionEntryDetailAcrossFiles01.ts
@@ -1,0 +1,20 @@
+/// <reference path="../fourslash.ts"/>
+
+// @allowNonTsExtensions: true
+// @Filename: a.js
+//// /**
+////  * Modify the parameter
+////  * @param {string} p1
+////  */
+//// var foo = function (p1) { }
+//// exports.foo = foo;
+//// fo/*1*/
+
+// @Filename: b.ts
+//// import a = require("./a");
+//// a.fo/*2*/
+
+goTo.marker('1');
+verify.completionEntryDetailIs("foo", "var foo: (p1: string) => void", "Modify the parameter");
+goTo.marker('2');
+verify.completionEntryDetailIs("foo", "(property) a.foo: (p1: string) => void", "Modify the parameter");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #9518

We used to not be able to get documentation for the following case:
```js
// @Filename: a.js
/**
* Modify the parameter
* @param {string} p1
*/
var foo = function (p1) { }
exports.foo = foo;

// @Filename: b.js
import a = require("./a");
a.fo/*Cursor Here*/
```
The completion entry detail at cursor position is supposed to show `Modify the parameter` comment but it wasn't. This PR fixes the issue.