### PR TITLE
Unify representation of tuples and other generic types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4979,7 +4979,7 @@ namespace ts {
         }
 
         function getTypeReferenceArity(type: TypeReference): number {
-            return type.target.typeParameters.length;
+            return type.target.typeParameters ? type.target.typeParameters.length : 0;
         }
 
         // Get type from reference to class or interface

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3564,11 +3564,13 @@ namespace ts {
                 if (type.flags & TypeFlags.Tuple) {
                     type.resolvedBaseTypes = [createArrayType(getUnionType(type.typeParameters))];
                 }
-                else if (type.symbol.flags & SymbolFlags.Class) {
-                    resolveBaseTypesOfClass(type);
-                }
-                else if (type.symbol.flags & SymbolFlags.Interface) {
-                    resolveBaseTypesOfInterface(type);
+                else if (type.symbol.flags & (SymbolFlags.Class | SymbolFlags.Interface)) {
+                    if (type.symbol.flags & SymbolFlags.Class) {
+                        resolveBaseTypesOfClass(type);
+                    }
+                    if (type.symbol.flags & SymbolFlags.Interface) {
+                        resolveBaseTypesOfInterface(type);
+                    }
                 }
                 else {
                     Debug.fail("type must be class or interface");
@@ -4972,7 +4974,7 @@ namespace ts {
         }
 
         function cloneTypeReference(source: TypeReference): TypeReference {
-            let type = <TypeReference>createObjectType(source.flags, source.symbol);
+            const type = <TypeReference>createObjectType(source.flags, source.symbol);
             type.target = source.target;
             type.typeArguments = source.typeArguments;
             return type;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2385,10 +2385,7 @@ namespace ts {
         instantiations: Map<TypeReference>;   // Generic instantiation cache
     }
 
-    export interface TupleType extends ObjectType {
-        elementTypes: Type[];  // Element types
-        thisType?: Type;       // This-type of tuple (only needed for tuples that are constraints of type parameters)
-    }
+    export interface TupleType extends GenericType { }
 
     export interface UnionOrIntersectionType extends Type {
         types: Type[];                    // Constituent types

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2263,7 +2263,7 @@ namespace ts {
         Class                   = 1 << 15,  // Class
         Interface               = 1 << 16,  // Interface
         Reference               = 1 << 17,  // Generic type reference
-        Tuple                   = 1 << 18,  // Tuple
+        Tuple                   = 1 << 18,  // Synthesized generic tuple type
         Union                   = 1 << 19,  // Union (T | U)
         Intersection            = 1 << 20,  // Intersection (T & U)
         Anonymous               = 1 << 21,  // Anonymous
@@ -2384,8 +2384,6 @@ namespace ts {
         /* @internal */
         instantiations: Map<TypeReference>;   // Generic instantiation cache
     }
-
-    export interface TupleType extends GenericType { }
 
     export interface UnionOrIntersectionType extends Type {
         types: Type[];                    // Constituent types

--- a/tests/baselines/reference/arityAndOrderCompatibility01.errors.txt
+++ b/tests/baselines/reference/arityAndOrderCompatibility01.errors.txt
@@ -39,8 +39,7 @@ tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(26,5): error
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(27,5): error TS2322: Type '{ 0: string; 1: number; }' is not assignable to type '[string]'.
   Property 'length' is missing in type '{ 0: string; 1: number; }'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(28,5): error TS2322: Type '[string, number]' is not assignable to type '[number, string]'.
-  Types of property '0' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+  Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(29,5): error TS2322: Type 'StrNum' is not assignable to type '[number, string]'.
   Types of property '0' are incompatible.
     Type 'string' is not assignable to type 'number'.
@@ -136,8 +135,7 @@ tests/cases/conformance/types/tuple/arityAndOrderCompatibility01.ts(30,5): error
     var n1: [number, string] = x;
         ~~
 !!! error TS2322: Type '[string, number]' is not assignable to type '[number, string]'.
-!!! error TS2322:   Types of property '0' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:   Type 'string' is not assignable to type 'number'.
     var n2: [number, string] = y;
         ~~
 !!! error TS2322: Type 'StrNum' is not assignable to type '[number, string]'.

--- a/tests/baselines/reference/arrayLiterals3.errors.txt
+++ b/tests/baselines/reference/arrayLiterals3.errors.txt
@@ -1,8 +1,7 @@
 tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts(10,5): error TS2322: Type 'undefined[]' is not assignable to type '[any, any, any]'.
   Property '0' is missing in type 'undefined[]'.
 tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts(11,5): error TS2322: Type '[string, number, boolean]' is not assignable to type '[boolean, string, number]'.
-  Types of property '0' are incompatible.
-    Type 'string' is not assignable to type 'boolean'.
+  Type 'string' is not assignable to type 'boolean'.
 tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts(17,5): error TS2322: Type '[number, number, string, boolean]' is not assignable to type '[number, number]'.
   Types of property 'pop' are incompatible.
     Type '() => string | number | boolean' is not assignable to type '() => number'.
@@ -37,8 +36,7 @@ tests/cases/conformance/expressions/arrayLiterals/arrayLiterals3.ts(34,5): error
     var a1: [boolean, string, number] = ["string", 1, true];  // Error
         ~~
 !!! error TS2322: Type '[string, number, boolean]' is not assignable to type '[boolean, string, number]'.
-!!! error TS2322:   Types of property '0' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'boolean'.
+!!! error TS2322:   Type 'string' is not assignable to type 'boolean'.
     
     // The resulting type an array literal expression is determined as follows:
     //     - If the array literal contains no spread elements and is an array assignment pattern in a destructuring assignment (section 4.17.1),

--- a/tests/baselines/reference/castingTuple.errors.txt
+++ b/tests/baselines/reference/castingTuple.errors.txt
@@ -1,10 +1,8 @@
 tests/cases/conformance/types/tuple/castingTuple.ts(28,10): error TS2352: Type '[number, string]' cannot be converted to type '[number, number]'.
-  Types of property '1' are incompatible.
-    Type 'string' is not comparable to type 'number'.
+  Type 'string' is not comparable to type 'number'.
 tests/cases/conformance/types/tuple/castingTuple.ts(29,10): error TS2352: Type '[C, D]' cannot be converted to type '[A, I]'.
-  Types of property '0' are incompatible.
-    Type 'C' is not comparable to type 'A'.
-      Property 'a' is missing in type 'C'.
+  Type 'C' is not comparable to type 'A'.
+    Property 'a' is missing in type 'C'.
 tests/cases/conformance/types/tuple/castingTuple.ts(30,5): error TS2403: Subsequent variable declarations must have the same type.  Variable 'array1' must be of type '{}[]', but here has type 'number[]'.
 tests/cases/conformance/types/tuple/castingTuple.ts(31,1): error TS2304: Cannot find name 't4'.
 
@@ -40,14 +38,12 @@ tests/cases/conformance/types/tuple/castingTuple.ts(31,1): error TS2304: Cannot 
     var t3 = <[number, number]>numStrTuple;
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2352: Type '[number, string]' cannot be converted to type '[number, number]'.
-!!! error TS2352:   Types of property '1' are incompatible.
-!!! error TS2352:     Type 'string' is not comparable to type 'number'.
+!!! error TS2352:   Type 'string' is not comparable to type 'number'.
     var t9 = <[A, I]>classCDTuple;
              ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2352: Type '[C, D]' cannot be converted to type '[A, I]'.
-!!! error TS2352:   Types of property '0' are incompatible.
-!!! error TS2352:     Type 'C' is not comparable to type 'A'.
-!!! error TS2352:       Property 'a' is missing in type 'C'.
+!!! error TS2352:   Type 'C' is not comparable to type 'A'.
+!!! error TS2352:     Property 'a' is missing in type 'C'.
     var array1 = <number[]>numStrTuple;
         ~~~~~~
 !!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'array1' must be of type '{}[]', but here has type 'number[]'.

--- a/tests/baselines/reference/contextualTypeWithTuple.errors.txt
+++ b/tests/baselines/reference/contextualTypeWithTuple.errors.txt
@@ -5,9 +5,8 @@ tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(3,5): error TS232
         Type 'true' is not assignable to type 'string | number'.
 tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(15,1): error TS2322: Type '[number, string, boolean]' is not assignable to type '[number, string]'.
 tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(18,1): error TS2322: Type '[{}, number]' is not assignable to type '[{ a: string; }, number]'.
-  Types of property '0' are incompatible.
-    Type '{}' is not assignable to type '{ a: string; }'.
-      Property 'a' is missing in type '{}'.
+  Type '{}' is not assignable to type '{ a: string; }'.
+    Property 'a' is missing in type '{}'.
 tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(19,1): error TS2322: Type '[number, string]' is not assignable to type '[number, string, boolean]'.
   Property '2' is missing in type '[number, string]'.
 tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(20,5): error TS2322: Type '[string, string, number]' is not assignable to type '[string, string]'.
@@ -18,9 +17,8 @@ tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(20,5): error TS23
 tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(24,1): error TS2322: Type '[C, string | number]' is not assignable to type '[C, string | number, D]'.
   Property '2' is missing in type '[C, string | number]'.
 tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(25,1): error TS2322: Type '[number, string | number]' is not assignable to type '[number, string]'.
-  Types of property '1' are incompatible.
-    Type 'string | number' is not assignable to type 'string'.
-      Type 'number' is not assignable to type 'string'.
+  Type 'string | number' is not assignable to type 'string'.
+    Type 'number' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts (7 errors) ====
@@ -52,9 +50,8 @@ tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(25,1): error TS23
     objNumTuple = [ {}, 5];
     ~~~~~~~~~~~
 !!! error TS2322: Type '[{}, number]' is not assignable to type '[{ a: string; }, number]'.
-!!! error TS2322:   Types of property '0' are incompatible.
-!!! error TS2322:     Type '{}' is not assignable to type '{ a: string; }'.
-!!! error TS2322:       Property 'a' is missing in type '{}'.
+!!! error TS2322:   Type '{}' is not assignable to type '{ a: string; }'.
+!!! error TS2322:     Property 'a' is missing in type '{}'.
     numStrBoolTuple = numStrTuple;
     ~~~~~~~~~~~~~~~
 !!! error TS2322: Type '[number, string]' is not assignable to type '[number, string, boolean]'.
@@ -76,6 +73,5 @@ tests/cases/conformance/types/tuple/contextualTypeWithTuple.ts(25,1): error TS23
     numStrTuple = unionTuple3;
     ~~~~~~~~~~~
 !!! error TS2322: Type '[number, string | number]' is not assignable to type '[number, string]'.
-!!! error TS2322:   Types of property '1' are incompatible.
-!!! error TS2322:     Type 'string | number' is not assignable to type 'string'.
-!!! error TS2322:       Type 'number' is not assignable to type 'string'.
+!!! error TS2322:   Type 'string | number' is not assignable to type 'string'.
+!!! error TS2322:     Type 'number' is not assignable to type 'string'.

--- a/tests/baselines/reference/contextuallyTypedBindingInitializerNegative.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedBindingInitializerNegative.errors.txt
@@ -11,8 +11,7 @@ tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTyp
 tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializerNegative.ts(16,23): error TS2322: Type '(arg: string) => number' is not assignable to type '(s: string) => string'.
   Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializerNegative.ts(21,14): error TS2322: Type '[number, number]' is not assignable to type '[string, number]'.
-  Types of property '0' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+  Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTypedBindingInitializerNegative.ts(26,14): error TS2322: Type '"baz"' is not assignable to type '"foo" | "bar"'.
 
 
@@ -57,8 +56,7 @@ tests/cases/conformance/types/contextualTypes/methodDeclarations/contextuallyTyp
     function g({ prop = [101, 1234] }: Tuples) {}
                  ~~~~
 !!! error TS2322: Type '[number, number]' is not assignable to type '[string, number]'.
-!!! error TS2322:   Types of property '0' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2322:   Type 'number' is not assignable to type 'string'.
     
     interface StringUnion {
         prop: "foo" | "bar";

--- a/tests/baselines/reference/declarationsAndAssignments.errors.txt
+++ b/tests/baselines/reference/declarationsAndAssignments.errors.txt
@@ -18,11 +18,9 @@ tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(73,14): 
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(74,11): error TS2459: Type 'undefined[]' has no property 'a' and no string index signature.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(74,14): error TS2459: Type 'undefined[]' has no property 'b' and no string index signature.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(106,5): error TS2345: Argument of type '[number, [string, { y: boolean; }]]' is not assignable to parameter of type '[number, [string, { x: any; y?: boolean; }]]'.
-  Types of property '1' are incompatible.
-    Type '[string, { y: boolean; }]' is not assignable to type '[string, { x: any; y?: boolean; }]'.
-      Types of property '1' are incompatible.
-        Type '{ y: boolean; }' is not assignable to type '{ x: any; y?: boolean; }'.
-          Property 'x' is missing in type '{ y: boolean; }'.
+  Type '[string, { y: boolean; }]' is not assignable to type '[string, { x: any; y?: boolean; }]'.
+    Type '{ y: boolean; }' is not assignable to type '{ x: any; y?: boolean; }'.
+      Property 'x' is missing in type '{ y: boolean; }'.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(138,6): error TS2322: Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(138,9): error TS2322: Type 'number' is not assignable to type 'string'.
 
@@ -174,11 +172,9 @@ tests/cases/conformance/es6/destructuring/declarationsAndAssignments.ts(138,9): 
     f14([2, ["abc", { y: false }]]);  // Error, no x
         ~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '[number, [string, { y: boolean; }]]' is not assignable to parameter of type '[number, [string, { x: any; y?: boolean; }]]'.
-!!! error TS2345:   Types of property '1' are incompatible.
-!!! error TS2345:     Type '[string, { y: boolean; }]' is not assignable to type '[string, { x: any; y?: boolean; }]'.
-!!! error TS2345:       Types of property '1' are incompatible.
-!!! error TS2345:         Type '{ y: boolean; }' is not assignable to type '{ x: any; y?: boolean; }'.
-!!! error TS2345:           Property 'x' is missing in type '{ y: boolean; }'.
+!!! error TS2345:   Type '[string, { y: boolean; }]' is not assignable to type '[string, { x: any; y?: boolean; }]'.
+!!! error TS2345:     Type '{ y: boolean; }' is not assignable to type '{ x: any; y?: boolean; }'.
+!!! error TS2345:       Property 'x' is missing in type '{ y: boolean; }'.
     
     module M {
         export var [a, b] = [1, 2];

--- a/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.errors.txt
+++ b/tests/baselines/reference/destructuringArrayBindingPatternAndAssignment2.errors.txt
@@ -2,8 +2,7 @@ tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAss
 tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(3,12): error TS2525: Initializer provides no value for this binding element and the binding element has no default value.
 tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(4,5): error TS2461: Type 'undefined' is not an array type.
 tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(9,5): error TS2322: Type '[number, number, string]' is not assignable to type '[number, boolean, string]'.
-  Types of property '1' are incompatible.
-    Type 'number' is not assignable to type 'boolean'.
+  Type 'number' is not assignable to type 'boolean'.
 tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(17,6): error TS2322: Type 'string' is not assignable to type 'Number'.
 tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAssignment2.ts(22,5): error TS2322: Type 'number[]' is not assignable to type '[number, number]'.
   Property '0' is missing in type 'number[]'.
@@ -30,8 +29,7 @@ tests/cases/conformance/es6/destructuring/destructuringArrayBindingPatternAndAss
     var [b0, b1, b2]: [number, boolean, string] = [1, 2, "string"];  // Error
         ~~~~~~~~~~~~
 !!! error TS2322: Type '[number, number, string]' is not assignable to type '[number, boolean, string]'.
-!!! error TS2322:   Types of property '1' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'boolean'.
+!!! error TS2322:   Type 'number' is not assignable to type 'boolean'.
     interface J extends Array<Number> {
         2: number;
     }

--- a/tests/baselines/reference/destructuringParameterDeclaration2.errors.txt
+++ b/tests/baselines/reference/destructuringParameterDeclaration2.errors.txt
@@ -1,6 +1,5 @@
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(7,4): error TS2345: Argument of type '[number, string, string[][]]' is not assignable to parameter of type '[number, number, string[][]]'.
-  Types of property '1' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+  Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(7,29): error TS1005: ',' expected.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(8,4): error TS2345: Argument of type '[number, number, string[][], string]' is not assignable to parameter of type '[number, number, string[][]]'.
   Types of property 'pop' are incompatible.
@@ -32,12 +31,9 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(
   Types of property '2' are incompatible.
     Type 'boolean' is not assignable to type '[[any]]'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(40,4): error TS2345: Argument of type '[number, number, [[string]]]' is not assignable to parameter of type '[any, any, [[number]]]'.
-  Types of property '2' are incompatible.
-    Type '[[string]]' is not assignable to type '[[number]]'.
-      Types of property '0' are incompatible.
-        Type '[string]' is not assignable to type '[number]'.
-          Types of property '0' are incompatible.
-            Type 'string' is not assignable to type 'number'.
+  Type '[[string]]' is not assignable to type '[[number]]'.
+    Type '[string]' is not assignable to type '[number]'.
+      Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(46,13): error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(47,13): error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
 tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(55,7): error TS2420: Class 'C4' incorrectly implements interface 'F2'.
@@ -62,8 +58,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(
     a0([1, "string", [["world"]]);      // Error
        ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '[number, string, string[][]]' is not assignable to parameter of type '[number, number, string[][]]'.
-!!! error TS2345:   Types of property '1' are incompatible.
-!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+!!! error TS2345:   Type 'string' is not assignable to type 'number'.
                                 ~
 !!! error TS1005: ',' expected.
     a0([1, 2, [["world"]], "string"]);  // Error
@@ -142,12 +137,9 @@ tests/cases/conformance/es6/destructuring/destructuringParameterDeclaration2.ts(
     c6([1, 2, [["string"]]]);  // Error, implied type is [any, any, [[number]]]  // Use initializer
        ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '[number, number, [[string]]]' is not assignable to parameter of type '[any, any, [[number]]]'.
-!!! error TS2345:   Types of property '2' are incompatible.
-!!! error TS2345:     Type '[[string]]' is not assignable to type '[[number]]'.
-!!! error TS2345:       Types of property '0' are incompatible.
-!!! error TS2345:         Type '[string]' is not assignable to type '[number]'.
-!!! error TS2345:           Types of property '0' are incompatible.
-!!! error TS2345:             Type 'string' is not assignable to type 'number'.
+!!! error TS2345:   Type '[[string]]' is not assignable to type '[[number]]'.
+!!! error TS2345:     Type '[string]' is not assignable to type '[number]'.
+!!! error TS2345:       Type 'string' is not assignable to type 'number'.
     
     // A parameter can be marked optional by following its name or binding pattern with a question mark (?)
     // or by including an initializer.  Initializers (including binding property or element initializers) are

--- a/tests/baselines/reference/destructuringParameterProperties2.errors.txt
+++ b/tests/baselines/reference/destructuringParameterProperties2.errors.txt
@@ -6,8 +6,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(9
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(13,21): error TS2339: Property 'b' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(17,21): error TS2339: Property 'c' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(21,27): error TS2345: Argument of type '[number, undefined, string]' is not assignable to parameter of type '[number, string, boolean]'.
-  Types of property '2' are incompatible.
-    Type 'string' is not assignable to type 'boolean'.
+  Type 'string' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts (8 errors) ====
@@ -48,8 +47,7 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties2.ts(2
     var x = new C1(undefined, [0, undefined, ""]);
                               ~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '[number, undefined, string]' is not assignable to parameter of type '[number, string, boolean]'.
-!!! error TS2345:   Types of property '2' are incompatible.
-!!! error TS2345:     Type 'string' is not assignable to type 'boolean'.
+!!! error TS2345:   Type 'string' is not assignable to type 'boolean'.
     var [x_a, x_b, x_c] = [x.getA(), x.getB(), x.getC()];
     
     var y = new C1(10, [0, "", true]);

--- a/tests/baselines/reference/destructuringParameterProperties5.errors.txt
+++ b/tests/baselines/reference/destructuringParameterProperties5.errors.txt
@@ -8,9 +8,8 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7,62): error TS2339: Property 'y' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(7,72): error TS2339: Property 'z' does not exist on type 'C1'.
 tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(11,19): error TS2345: Argument of type '[{ x1: number; x2: string; x3: boolean; }, string, boolean]' is not assignable to parameter of type '[{ x: number; y: string; z: boolean; }, number, string]'.
-  Types of property '0' are incompatible.
-    Type '{ x1: number; x2: string; x3: boolean; }' is not assignable to type '{ x: number; y: string; z: boolean; }'.
-      Object literal may only specify known properties, and 'x1' does not exist in type '{ x: number; y: string; z: boolean; }'.
+  Type '{ x1: number; x2: string; x3: boolean; }' is not assignable to type '{ x: number; y: string; z: boolean; }'.
+    Object literal may only specify known properties, and 'x1' does not exist in type '{ x: number; y: string; z: boolean; }'.
 
 
 ==== tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts (10 errors) ====
@@ -45,7 +44,6 @@ tests/cases/conformance/es6/destructuring/destructuringParameterProperties5.ts(1
     var a = new C1([{ x1: 10, x2: "", x3: true }, "", false]);
                       ~~~~~~
 !!! error TS2345: Argument of type '[{ x1: number; x2: string; x3: boolean; }, string, boolean]' is not assignable to parameter of type '[{ x: number; y: string; z: boolean; }, number, string]'.
-!!! error TS2345:   Types of property '0' are incompatible.
-!!! error TS2345:     Type '{ x1: number; x2: string; x3: boolean; }' is not assignable to type '{ x: number; y: string; z: boolean; }'.
-!!! error TS2345:       Object literal may only specify known properties, and 'x1' does not exist in type '{ x: number; y: string; z: boolean; }'.
+!!! error TS2345:   Type '{ x1: number; x2: string; x3: boolean; }' is not assignable to type '{ x: number; y: string; z: boolean; }'.
+!!! error TS2345:     Object literal may only specify known properties, and 'x1' does not exist in type '{ x: number; y: string; z: boolean; }'.
     var [a_x1, a_x2, a_x3, a_y, a_z] = [a.x1, a.x2, a.x3, a.y, a.z];

--- a/tests/baselines/reference/destructuringVariableDeclaration2.errors.txt
+++ b/tests/baselines/reference/destructuringVariableDeclaration2.errors.txt
@@ -2,12 +2,9 @@ tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts(3
   Types of property 'a1' are incompatible.
     Type 'boolean' is not assignable to type 'number'.
 tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts(4,5): error TS2322: Type '[number, [[boolean]], boolean]' is not assignable to type '[number, [[string]], boolean]'.
-  Types of property '1' are incompatible.
-    Type '[[boolean]]' is not assignable to type '[[string]]'.
-      Types of property '0' are incompatible.
-        Type '[boolean]' is not assignable to type '[string]'.
-          Types of property '0' are incompatible.
-            Type 'boolean' is not assignable to type 'string'.
+  Type '[[boolean]]' is not assignable to type '[[string]]'.
+    Type '[boolean]' is not assignable to type '[string]'.
+      Type 'boolean' is not assignable to type 'string'.
 tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts(9,25): error TS2322: Type '{ t1: boolean; t2: string; }' is not assignable to type '{ t1: boolean; t2: number; }'.
   Types of property 't2' are incompatible.
     Type 'string' is not assignable to type 'number'.
@@ -28,12 +25,9 @@ tests/cases/conformance/es6/destructuring/destructuringVariableDeclaration2.ts(1
     var [a3, [[a4]], a5]: [number, [[string]], boolean] = [1, [[false]], true];  // Error
         ~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '[number, [[boolean]], boolean]' is not assignable to type '[number, [[string]], boolean]'.
-!!! error TS2322:   Types of property '1' are incompatible.
-!!! error TS2322:     Type '[[boolean]]' is not assignable to type '[[string]]'.
-!!! error TS2322:       Types of property '0' are incompatible.
-!!! error TS2322:         Type '[boolean]' is not assignable to type '[string]'.
-!!! error TS2322:           Types of property '0' are incompatible.
-!!! error TS2322:             Type 'boolean' is not assignable to type 'string'.
+!!! error TS2322:   Type '[[boolean]]' is not assignable to type '[[string]]'.
+!!! error TS2322:     Type '[boolean]' is not assignable to type '[string]'.
+!!! error TS2322:       Type 'boolean' is not assignable to type 'string'.
     
     // The type T associated with a destructuring variable declaration is determined as follows:
     //      Otherwise, if the declaration includes an initializer expression, T is the type of that initializer expression.

--- a/tests/baselines/reference/genericCallWithTupleType.errors.txt
+++ b/tests/baselines/reference/genericCallWithTupleType.errors.txt
@@ -6,11 +6,9 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithTup
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithTupleType.ts(14,1): error TS2322: Type '{ a: string; }' is not assignable to type 'string | number'.
   Type '{ a: string; }' is not assignable to type 'number'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithTupleType.ts(22,1): error TS2322: Type '[number, string]' is not assignable to type '[string, number]'.
-  Types of property '0' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+  Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithTupleType.ts(23,1): error TS2322: Type '[{}, {}]' is not assignable to type '[string, number]'.
-  Types of property '0' are incompatible.
-    Type '{}' is not assignable to type 'string'.
+  Type '{}' is not assignable to type 'string'.
 tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithTupleType.ts(24,1): error TS2322: Type '[{}]' is not assignable to type '[{}, {}]'.
   Property '1' is missing in type '[{}]'.
 
@@ -49,13 +47,11 @@ tests/cases/conformance/types/typeRelationships/typeInference/genericCallWithTup
     i1.tuple1 = [5, "foo"];
     ~~~~~~~~~
 !!! error TS2322: Type '[number, string]' is not assignable to type '[string, number]'.
-!!! error TS2322:   Types of property '0' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2322:   Type 'number' is not assignable to type 'string'.
     i1.tuple1 = [{}, {}];
     ~~~~~~~~~
 !!! error TS2322: Type '[{}, {}]' is not assignable to type '[string, number]'.
-!!! error TS2322:   Types of property '0' are incompatible.
-!!! error TS2322:     Type '{}' is not assignable to type 'string'.
+!!! error TS2322:   Type '{}' is not assignable to type 'string'.
     i2.tuple1 = [{}];
     ~~~~~~~~~
 !!! error TS2322: Type '[{}]' is not assignable to type '[{}, {}]'.

--- a/tests/baselines/reference/iterableArrayPattern29.errors.txt
+++ b/tests/baselines/reference/iterableArrayPattern29.errors.txt
@@ -1,7 +1,6 @@
 tests/cases/conformance/es6/destructuring/iterableArrayPattern29.ts(1,33): error TS2501: A rest element cannot contain a binding pattern.
 tests/cases/conformance/es6/destructuring/iterableArrayPattern29.ts(2,21): error TS2345: Argument of type '[string, boolean]' is not assignable to parameter of type '[string, number]'.
-  Types of property '1' are incompatible.
-    Type 'boolean' is not assignable to type 'number'.
+  Type 'boolean' is not assignable to type 'number'.
 
 
 ==== tests/cases/conformance/es6/destructuring/iterableArrayPattern29.ts (2 errors) ====
@@ -11,5 +10,4 @@ tests/cases/conformance/es6/destructuring/iterableArrayPattern29.ts(2,21): error
     takeFirstTwoEntries(...new Map([["", true], ["hello", true]]));
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '[string, boolean]' is not assignable to parameter of type '[string, number]'.
-!!! error TS2345:   Types of property '1' are incompatible.
-!!! error TS2345:     Type 'boolean' is not assignable to type 'number'.
+!!! error TS2345:   Type 'boolean' is not assignable to type 'number'.

--- a/tests/baselines/reference/optionalBindingParameters1.errors.txt
+++ b/tests/baselines/reference/optionalBindingParameters1.errors.txt
@@ -1,7 +1,6 @@
 tests/cases/conformance/es6/destructuring/optionalBindingParameters1.ts(2,14): error TS2463: A binding pattern parameter cannot be optional in an implementation signature.
 tests/cases/conformance/es6/destructuring/optionalBindingParameters1.ts(8,5): error TS2345: Argument of type '[boolean, number, string]' is not assignable to parameter of type '[string, number, boolean]'.
-  Types of property '0' are incompatible.
-    Type 'boolean' is not assignable to type 'string'.
+  Type 'boolean' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/es6/destructuring/optionalBindingParameters1.ts (2 errors) ====
@@ -17,5 +16,4 @@ tests/cases/conformance/es6/destructuring/optionalBindingParameters1.ts(8,5): er
     foo([false, 0, ""]);
         ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '[boolean, number, string]' is not assignable to parameter of type '[string, number, boolean]'.
-!!! error TS2345:   Types of property '0' are incompatible.
-!!! error TS2345:     Type 'boolean' is not assignable to type 'string'.
+!!! error TS2345:   Type 'boolean' is not assignable to type 'string'.

--- a/tests/baselines/reference/optionalBindingParametersInOverloads1.errors.txt
+++ b/tests/baselines/reference/optionalBindingParametersInOverloads1.errors.txt
@@ -1,6 +1,5 @@
 tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads1.ts(9,5): error TS2345: Argument of type '[boolean, number, string]' is not assignable to parameter of type '[string, number, boolean]'.
-  Types of property '0' are incompatible.
-    Type 'boolean' is not assignable to type 'string'.
+  Type 'boolean' is not assignable to type 'string'.
 
 
 ==== tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads1.ts (1 errors) ====
@@ -15,5 +14,4 @@ tests/cases/conformance/es6/destructuring/optionalBindingParametersInOverloads1.
     foo([false, 0, ""]);
         ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '[boolean, number, string]' is not assignable to parameter of type '[string, number, boolean]'.
-!!! error TS2345:   Types of property '0' are incompatible.
-!!! error TS2345:     Type 'boolean' is not assignable to type 'string'.
+!!! error TS2345:   Type 'boolean' is not assignable to type 'string'.

--- a/tests/baselines/reference/tupleTypes.errors.txt
+++ b/tests/baselines/reference/tupleTypes.errors.txt
@@ -4,8 +4,7 @@ tests/cases/compiler/tupleTypes.ts(14,1): error TS2322: Type 'undefined[]' is no
 tests/cases/compiler/tupleTypes.ts(15,1): error TS2322: Type '[number]' is not assignable to type '[number, string]'.
   Property '1' is missing in type '[number]'.
 tests/cases/compiler/tupleTypes.ts(17,1): error TS2322: Type '[string, number]' is not assignable to type '[number, string]'.
-  Types of property '0' are incompatible.
-    Type 'string' is not assignable to type 'number'.
+  Type 'string' is not assignable to type 'number'.
 tests/cases/compiler/tupleTypes.ts(41,1): error TS2322: Type 'undefined[]' is not assignable to type '[number, string]'.
 tests/cases/compiler/tupleTypes.ts(47,1): error TS2322: Type '[number, string]' is not assignable to type 'number[]'.
   Types of property 'pop' are incompatible.
@@ -18,11 +17,9 @@ tests/cases/compiler/tupleTypes.ts(49,1): error TS2322: Type '[number, {}]' is n
       Type 'number | {}' is not assignable to type 'number'.
         Type '{}' is not assignable to type 'number'.
 tests/cases/compiler/tupleTypes.ts(50,1): error TS2322: Type '[number, number]' is not assignable to type '[number, string]'.
-  Types of property '1' are incompatible.
-    Type 'number' is not assignable to type 'string'.
+  Type 'number' is not assignable to type 'string'.
 tests/cases/compiler/tupleTypes.ts(51,1): error TS2322: Type '[number, {}]' is not assignable to type '[number, string]'.
-  Types of property '1' are incompatible.
-    Type '{}' is not assignable to type 'string'.
+  Type '{}' is not assignable to type 'string'.
 
 
 ==== tests/cases/compiler/tupleTypes.ts (9 errors) ====
@@ -53,8 +50,7 @@ tests/cases/compiler/tupleTypes.ts(51,1): error TS2322: Type '[number, {}]' is n
     t = ["hello", 1];     // Error
     ~
 !!! error TS2322: Type '[string, number]' is not assignable to type '[number, string]'.
-!!! error TS2322:   Types of property '0' are incompatible.
-!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+!!! error TS2322:   Type 'string' is not assignable to type 'number'.
     t = [1, "hello", 2];  // Ok
     
     var tf: [string, (x: string) => number] = ["hello", x => x.length];
@@ -104,13 +100,11 @@ tests/cases/compiler/tupleTypes.ts(51,1): error TS2322: Type '[number, {}]' is n
     a1 = a2;  // Error
     ~~
 !!! error TS2322: Type '[number, number]' is not assignable to type '[number, string]'.
-!!! error TS2322:   Types of property '1' are incompatible.
-!!! error TS2322:     Type 'number' is not assignable to type 'string'.
+!!! error TS2322:   Type 'number' is not assignable to type 'string'.
     a1 = a3;  // Error
     ~~
 !!! error TS2322: Type '[number, {}]' is not assignable to type '[number, string]'.
-!!! error TS2322:   Types of property '1' are incompatible.
-!!! error TS2322:     Type '{}' is not assignable to type 'string'.
+!!! error TS2322:   Type '{}' is not assignable to type 'string'.
     a3 = a1;
     a3 = a2;
     


### PR DESCRIPTION
With this PR we unify the internal representation of tuple types and other generic types. Tuple types are now represented as regular type references to synthesized generic types of the form:

```ts
interface Tuple<T0, T1, T2, ...> extends Array<T0 | T1 | T2 | ...> { 0: T0, 1: T1, 2: T2, ... }
```

With these changes it is no longer necessary to special case tuple types throughout the type checker. All of the optimizations we have in place for regular generic type references now also apply to tuple types.

Fixes #10431. The compile time for the example drops from 1.2s to 0.08s with `--lib es5` and from 30.5s to 0.11s with `--lib es6`.