### PR TITLE
allowSyntheticDefaultImports resolves to modules instead of variables

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1126,13 +1126,13 @@ namespace ts {
                     else {
                         symbolFromVariable = getPropertyOfVariable(targetSymbol, name.text);
                     }
-                    // If the export member we're looking for is default, and there is no real default but allowSyntheticDefaultImports is on, return the entire module as the default
-                    if (!symbolFromVariable && allowSyntheticDefaultImports && name.text === "default") {
-                        symbolFromVariable = resolveExternalModuleSymbol(moduleSymbol) || resolveSymbol(moduleSymbol);
-                    }
                     // if symbolFromVariable is export - get its final target
                     symbolFromVariable = resolveSymbol(symbolFromVariable);
-                    const symbolFromModule = getExportOfModule(targetSymbol, name.text);
+                    let symbolFromModule = getExportOfModule(targetSymbol, name.text);
+                    // If the export member we're looking for is default, and there is no real default but allowSyntheticDefaultImports is on, return the entire module as the default
+                    if (!symbolFromModule && allowSyntheticDefaultImports && name.text === "default") {
+                        symbolFromModule = resolveExternalModuleSymbol(moduleSymbol) || resolveSymbol(moduleSymbol);
+                    }
                     const symbol = symbolFromModule && symbolFromVariable ?
                         combineValueAndTypeSymbols(symbolFromVariable, symbolFromModule) :
                         symbolFromModule || symbolFromVariable;

--- a/tests/baselines/reference/tsxDefaultImports.js
+++ b/tests/baselines/reference/tsxDefaultImports.js
@@ -1,0 +1,34 @@
+//// [tests/cases/compiler/tsxDefaultImports.ts] ////
+
+//// [a.ts]
+
+enum SomeEnum {
+  one,
+}
+export default class SomeClass {
+  public static E = SomeEnum;
+}
+
+//// [b.ts]
+import {default as Def} from "./a"
+let a = Def.E.one;
+
+
+//// [a.js]
+"use strict";
+var SomeEnum;
+(function (SomeEnum) {
+    SomeEnum[SomeEnum["one"] = 0] = "one";
+})(SomeEnum || (SomeEnum = {}));
+var SomeClass = (function () {
+    function SomeClass() {
+    }
+    SomeClass.E = SomeEnum;
+    return SomeClass;
+}());
+exports.__esModule = true;
+exports["default"] = SomeClass;
+//// [b.js]
+"use strict";
+var a_1 = require("./a");
+var a = a_1["default"].E.one;

--- a/tests/baselines/reference/tsxDefaultImports.symbols
+++ b/tests/baselines/reference/tsxDefaultImports.symbols
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/a.ts ===
+
+enum SomeEnum {
+>SomeEnum : Symbol(SomeEnum, Decl(a.ts, 0, 0))
+
+  one,
+>one : Symbol(SomeEnum.one, Decl(a.ts, 1, 15))
+}
+export default class SomeClass {
+>SomeClass : Symbol(SomeClass, Decl(a.ts, 3, 1))
+
+  public static E = SomeEnum;
+>E : Symbol(SomeClass.E, Decl(a.ts, 4, 32))
+>SomeEnum : Symbol(SomeEnum, Decl(a.ts, 0, 0))
+}
+
+=== tests/cases/compiler/b.ts ===
+import {default as Def} from "./a"
+>default : Symbol(Def, Decl(b.ts, 0, 8))
+>Def : Symbol(Def, Decl(b.ts, 0, 8))
+
+let a = Def.E.one;
+>a : Symbol(a, Decl(b.ts, 1, 3))
+>Def.E.one : Symbol(SomeEnum.one, Decl(a.ts, 1, 15))
+>Def.E : Symbol(Def.E, Decl(a.ts, 4, 32))
+>Def : Symbol(Def, Decl(b.ts, 0, 8))
+>E : Symbol(Def.E, Decl(a.ts, 4, 32))
+>one : Symbol(SomeEnum.one, Decl(a.ts, 1, 15))
+

--- a/tests/baselines/reference/tsxDefaultImports.types
+++ b/tests/baselines/reference/tsxDefaultImports.types
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/a.ts ===
+
+enum SomeEnum {
+>SomeEnum : SomeEnum
+
+  one,
+>one : SomeEnum
+}
+export default class SomeClass {
+>SomeClass : SomeClass
+
+  public static E = SomeEnum;
+>E : typeof SomeEnum
+>SomeEnum : typeof SomeEnum
+}
+
+=== tests/cases/compiler/b.ts ===
+import {default as Def} from "./a"
+>default : typeof Def
+>Def : typeof Def
+
+let a = Def.E.one;
+>a : SomeEnum
+>Def.E.one : SomeEnum
+>Def.E : typeof SomeEnum
+>Def : typeof Def
+>E : typeof SomeEnum
+>one : SomeEnum
+

--- a/tests/cases/compiler/tsxDefaultImports.ts
+++ b/tests/cases/compiler/tsxDefaultImports.ts
@@ -1,0 +1,12 @@
+// @Filename: a.ts
+
+enum SomeEnum {
+  one,
+}
+export default class SomeClass {
+  public static E = SomeEnum;
+}
+
+// @Filename: b.ts
+import {default as Def} from "./a"
+let a = Def.E.one;


### PR DESCRIPTION
Fixes #10429 by improving the fix in #10096.

#10096 allowed aliasing of default imports, but did so by treating the module as a variable and resolving names on this 'variable'. This changes the check introduced in #10096 to resolve the name as a module if resolving the name on a module fails.