### PR TITLE
Correct default compileOnSave value for different projects

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -712,7 +712,7 @@ namespace ts.server {
                 this.documentRegistry,
                 options,
                 /*languageServiceEnabled*/ !this.exceededTotalSizeLimitForNonTsFiles(options, files, externalFilePropertyReader),
-                !!options.compileOnSave);
+                options.compileOnSave === undefined ? true : options.compileOnSave);
 
             const errors = this.addFilesToProjectAndUpdateGraph(project, files, externalFilePropertyReader, /*clientFileName*/ undefined, typingOptions);
 
@@ -730,7 +730,7 @@ namespace ts.server {
                 projectOptions.compilerOptions,
                 projectOptions.wildcardDirectories,
                 /*languageServiceEnabled*/ !sizeLimitExceeded,
-                /*compileOnSaveEnabled*/ !!projectOptions.compileOnSave);
+                projectOptions.compileOnSave === undefined ? false : projectOptions.compileOnSave);
 
             const errors = this.addFilesToProjectAndUpdateGraph(project, projectOptions.files, fileNamePropertyReader, clientFileName, projectOptions.typingOptions);
 
@@ -877,7 +877,7 @@ namespace ts.server {
             const useExistingProject = this.useSingleInferredProject && this.inferredProjects.length;
             const project = useExistingProject
                 ? this.inferredProjects[0]
-                : new InferredProject(this, this.documentRegistry, /*languageServiceEnabled*/ true, this.compilerOptionsForInferredProjects);
+                : new InferredProject(this, this.documentRegistry, /*languageServiceEnabled*/ true, this.compilerOptionsForInferredProjects, /*compileOnSaveEnabled*/ false);
 
             project.addRoot(root);
 

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -491,14 +491,14 @@ namespace ts.server {
         // Used to keep track of what directories are watched for this project
         directoriesWatchedForTsconfig: string[] = [];
 
-        constructor(projectService: ProjectService, documentRegistry: ts.DocumentRegistry, languageServiceEnabled: boolean, compilerOptions: CompilerOptions) {
+        constructor(projectService: ProjectService, documentRegistry: ts.DocumentRegistry, languageServiceEnabled: boolean, compilerOptions: CompilerOptions, public compileOnSaveEnabled: boolean) {
             super(ProjectKind.Inferred,
                 projectService,
                 documentRegistry,
                 /*files*/ undefined,
                 languageServiceEnabled,
                 compilerOptions,
-                /*compileOnSaveEnabled*/ false);
+                compileOnSaveEnabled);
 
             this.inferredProjectName = makeInferredProjectName(InferredProject.NextId);
             InferredProject.NextId++;
@@ -540,7 +540,7 @@ namespace ts.server {
             compilerOptions: CompilerOptions,
             private wildcardDirectories: Map<WatchDirectoryFlags>,
             languageServiceEnabled: boolean,
-            public compileOnSaveEnabled = false) {
+            public compileOnSaveEnabled: boolean) {
             super(ProjectKind.Configured, projectService, documentRegistry, hasExplicitListOfFiles, languageServiceEnabled, compilerOptions, compileOnSaveEnabled);
         }
 
@@ -628,7 +628,7 @@ namespace ts.server {
             documentRegistry: ts.DocumentRegistry,
             compilerOptions: CompilerOptions,
             languageServiceEnabled: boolean,
-            public compileOnSaveEnabled = true) {
+            public compileOnSaveEnabled: boolean) {
             super(ProjectKind.External, projectService, documentRegistry, /*hasExplicitListOfFiles*/ true, languageServiceEnabled, compilerOptions, compileOnSaveEnabled);
         }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Issue:
The default parameter value for `compileOnSaveEnabled` for External projects were set to `true`, but in calling the constructor, I used `!!options.compileOnSaveEnabled` which if not specified will be `false`, thus overrides the actual `true` default value. PR fixes the issue and make it more explicit.

