### PR TITLE
Narrow on element access of known property

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -617,8 +617,9 @@ namespace ts {
             }
             if (expr.kind === SyntaxKind.ElementAccessExpression) {
                 const access = expr as ElementAccessExpression;
-                const isArgumentLiteral = access.argumentExpression.kind === SyntaxKind.StringLiteral ||
-                    access.argumentExpression.kind === SyntaxKind.NumericLiteral;
+                const isArgumentLiteral = access.argumentExpression &&
+                    (access.argumentExpression.kind === SyntaxKind.StringLiteral ||
+                     access.argumentExpression.kind === SyntaxKind.NumericLiteral);
                 return isArgumentLiteral && isNarrowableReference(access.expression);
             }
             return false;

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -594,6 +594,7 @@ namespace ts {
                 case SyntaxKind.Identifier:
                 case SyntaxKind.ThisKeyword:
                 case SyntaxKind.PropertyAccessExpression:
+                case SyntaxKind.ElementAccessExpression:
                     return isNarrowableReference(expr);
                 case SyntaxKind.CallExpression:
                     return hasNarrowableArgument(<CallExpression>expr);
@@ -608,9 +609,21 @@ namespace ts {
         }
 
         function isNarrowableReference(expr: Expression): boolean {
-            return expr.kind === SyntaxKind.Identifier ||
-                expr.kind === SyntaxKind.ThisKeyword ||
-                expr.kind === SyntaxKind.PropertyAccessExpression && isNarrowableReference((<PropertyAccessExpression>expr).expression);
+            if (expr.kind === SyntaxKind.ElementAccessExpression) {
+                const argument = (expr as ElementAccessExpression).argumentExpression;
+                return argument.kind === SyntaxKind.StringLiteral || argument.kind === SyntaxKind.NumericLiteral || argument.kind === SyntaxKind.EnumMember;
+            }
+            while (true) {
+                if (expr.kind === SyntaxKind.Identifier || expr.kind === SyntaxKind.ThisKeyword) {
+                    return true;
+                }
+                else if (expr.kind === SyntaxKind.PropertyAccessExpression) {
+                    expr = (expr as PropertyAccessExpression).expression;
+                }
+                else {
+                    return false;
+                }
+            }
         }
 
         function hasNarrowableArgument(expr: CallExpression) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14014,7 +14014,8 @@ namespace ts {
                 for (const decl of indexSymbol.declarations) {
                     const declaration = <SignatureDeclaration>decl;
                     if (declaration.parameters.length === 1 && declaration.parameters[0].type) {
-                        switch (declaration.parameters[0].type.kind) {
+                        const workaround = 0;
+                        switch (declaration.parameters[workaround].type.kind) {
                             case SyntaxKind.StringKeyword:
                                 if (!seenStringIndexer) {
                                     seenStringIndexer = true;

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.js
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.js
@@ -1,0 +1,42 @@
+//// [typeGuardNarrowsIndexedAccessOfKnownProperty.ts]
+interface Square {
+    kind: "square";
+    size: number;
+}
+
+interface Rectangle {
+    kind: "rectangle";
+    width: number;
+    height: number;
+}
+
+interface Circle {
+    kind: "circle";
+    radius: number;
+}
+
+type Shape = Square | Rectangle | Circle;
+
+function area(s: Shape) {
+    // In the following switch statement, the type of s is narrowed in each case clause
+    // according to the value of the discriminant property, thus allowing the other properties
+    // of that variant to be accessed without a type assertion.
+    switch (s['kind']) {
+        case "square": return s.size * s.size;
+        case "rectangle": return s.width * s.height;
+        case "circle": return Math.PI * s.radius * s.radius;
+    }
+}
+
+
+//// [typeGuardNarrowsIndexedAccessOfKnownProperty.js]
+function area(s) {
+    // In the following switch statement, the type of s is narrowed in each case clause
+    // according to the value of the discriminant property, thus allowing the other properties
+    // of that variant to be accessed without a type assertion.
+    switch (s['kind']) {
+        case "square": return s.size * s.size;
+        case "rectangle": return s.width * s.height;
+        case "circle": return Math.PI * s.radius * s.radius;
+    }
+}

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.js
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.js
@@ -16,27 +16,44 @@ interface Circle {
 }
 
 type Shape = Square | Rectangle | Circle;
-
-function area(s: Shape) {
-    // In the following switch statement, the type of s is narrowed in each case clause
-    // according to the value of the discriminant property, thus allowing the other properties
-    // of that variant to be accessed without a type assertion.
-    switch (s['kind']) {
+interface Subshape {
+    "0": {
+        sub: {
+            under: {
+                shape: Shape;
+            }
+        }
+    }
+}
+function area(s: Shape): number {
+    switch(s['kind']) {
         case "square": return s.size * s.size;
         case "rectangle": return s.width * s.height;
         case "circle": return Math.PI * s.radius * s.radius;
     }
 }
 
+function subarea(s: Subshape): number {
+    switch(s[0]["sub"].under["shape"]["kind"]) {
+        case "square": return s[0].sub.under.shape.size * s[0].sub.under.shape.size;
+        case "rectangle": return s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height;
+        case "circle": return Math.PI * s[0].sub.under["shape"].radius * s[0]["sub"].under.shape["radius"];
+    }
+}
+
 
 //// [typeGuardNarrowsIndexedAccessOfKnownProperty.js]
 function area(s) {
-    // In the following switch statement, the type of s is narrowed in each case clause
-    // according to the value of the discriminant property, thus allowing the other properties
-    // of that variant to be accessed without a type assertion.
     switch (s['kind']) {
         case "square": return s.size * s.size;
         case "rectangle": return s.width * s.height;
         case "circle": return Math.PI * s.radius * s.radius;
+    }
+}
+function subarea(s) {
+    switch (s[0]["sub"].under["shape"]["kind"]) {
+        case "square": return s[0].sub.under.shape.size * s[0].sub.under.shape.size;
+        case "rectangle": return s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height;
+        case "circle": return Math.PI * s[0].sub.under["shape"].radius * s[0]["sub"].under.shape["radius"];
     }
 }

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.symbols
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.symbols
@@ -1,0 +1,81 @@
+=== tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty.ts ===
+interface Square {
+>Square : Symbol(Square, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 0))
+
+    kind: "square";
+>kind : Symbol(Square.kind, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 18))
+
+    size: number;
+>size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+}
+
+interface Rectangle {
+>Rectangle : Symbol(Rectangle, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 3, 1))
+
+    kind: "rectangle";
+>kind : Symbol(Rectangle.kind, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 5, 21))
+
+    width: number;
+>width : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 6, 22))
+
+    height: number;
+>height : Symbol(Rectangle.height, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 7, 18))
+}
+
+interface Circle {
+>Circle : Symbol(Circle, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 9, 1))
+
+    kind: "circle";
+>kind : Symbol(Circle.kind, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 11, 18))
+
+    radius: number;
+>radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 19))
+}
+
+type Shape = Square | Rectangle | Circle;
+>Shape : Symbol(Shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 14, 1))
+>Square : Symbol(Square, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 0))
+>Rectangle : Symbol(Rectangle, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 3, 1))
+>Circle : Symbol(Circle, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 9, 1))
+
+function area(s: Shape) {
+>area : Symbol(area, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 41))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 14))
+>Shape : Symbol(Shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 14, 1))
+
+    // In the following switch statement, the type of s is narrowed in each case clause
+    // according to the value of the discriminant property, thus allowing the other properties
+    // of that variant to be accessed without a type assertion.
+    switch (s['kind']) {
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 14))
+>'kind' : Symbol(kind, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 18), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 5, 21), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 11, 18))
+
+        case "square": return s.size * s.size;
+>s.size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 14))
+>size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+>s.size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 14))
+>size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+
+        case "rectangle": return s.width * s.height;
+>s.width : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 6, 22))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 14))
+>width : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 6, 22))
+>s.height : Symbol(Rectangle.height, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 7, 18))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 14))
+>height : Symbol(Rectangle.height, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 7, 18))
+
+        case "circle": return Math.PI * s.radius * s.radius;
+>Math.PI : Symbol(Math.PI, Decl(lib.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>PI : Symbol(Math.PI, Decl(lib.d.ts, --, --))
+>s.radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 19))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 14))
+>radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 19))
+>s.radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 19))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 14))
+>radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 19))
+    }
+}
+

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.symbols
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.symbols
@@ -38,32 +38,46 @@ type Shape = Square | Rectangle | Circle;
 >Rectangle : Symbol(Rectangle, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 3, 1))
 >Circle : Symbol(Circle, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 9, 1))
 
-function area(s: Shape) {
->area : Symbol(area, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 41))
->s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 14))
+interface Subshape {
+>Subshape : Symbol(Subshape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 41))
+
+    "0": {
+        sub: {
+>sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 10))
+
+            under: {
+>under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 19, 14))
+
+                shape: Shape;
+>shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 20, 20))
+>Shape : Symbol(Shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 14, 1))
+            }
+        }
+    }
+}
+function area(s: Shape): number {
+>area : Symbol(area, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 25, 1))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 26, 14))
 >Shape : Symbol(Shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 14, 1))
 
-    // In the following switch statement, the type of s is narrowed in each case clause
-    // according to the value of the discriminant property, thus allowing the other properties
-    // of that variant to be accessed without a type assertion.
-    switch (s['kind']) {
->s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 14))
+    switch(s['kind']) {
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 26, 14))
 >'kind' : Symbol(kind, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 18), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 5, 21), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 11, 18))
 
         case "square": return s.size * s.size;
 >s.size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
->s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 14))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 26, 14))
 >size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
 >s.size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
->s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 14))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 26, 14))
 >size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
 
         case "rectangle": return s.width * s.height;
 >s.width : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 6, 22))
->s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 14))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 26, 14))
 >width : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 6, 22))
 >s.height : Symbol(Rectangle.height, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 7, 18))
->s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 14))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 26, 14))
 >height : Symbol(Rectangle.height, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 7, 18))
 
         case "circle": return Math.PI * s.radius * s.radius;
@@ -71,11 +85,86 @@ function area(s: Shape) {
 >Math : Symbol(Math, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >PI : Symbol(Math.PI, Decl(lib.d.ts, --, --))
 >s.radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 19))
->s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 14))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 26, 14))
 >radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 19))
 >s.radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 19))
->s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 14))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 26, 14))
 >radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 19))
+    }
+}
+
+function subarea(s: Subshape): number {
+>subarea : Symbol(subarea, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 32, 1))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 34, 17))
+>Subshape : Symbol(Subshape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 16, 41))
+
+    switch(s[0]["sub"].under["shape"]["kind"]) {
+>s[0]["sub"].under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 19, 14))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 34, 17))
+>0 : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>"sub" : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 10))
+>under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 19, 14))
+>"shape" : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 20, 20))
+>"kind" : Symbol(kind, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 0, 18), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 5, 21), Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 11, 18))
+
+        case "square": return s[0].sub.under.shape.size * s[0].sub.under.shape.size;
+>s[0].sub.under.shape.size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+>s[0].sub.under.shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 20, 20))
+>s[0].sub.under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 19, 14))
+>s[0].sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 10))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 34, 17))
+>0 : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 10))
+>under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 19, 14))
+>shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 20, 20))
+>size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+>s[0].sub.under.shape.size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+>s[0].sub.under.shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 20, 20))
+>s[0].sub.under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 19, 14))
+>s[0].sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 10))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 34, 17))
+>0 : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 10))
+>under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 19, 14))
+>shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 20, 20))
+>size : Symbol(Square.size, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 1, 19))
+
+        case "rectangle": return s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height;
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 34, 17))
+>0 : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>"sub" : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 10))
+>"under" : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 19, 14))
+>"shape" : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 20, 20))
+>"width" : Symbol(Rectangle.width, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 6, 22))
+>s[0]["sub"]["under"]["shape"].height : Symbol(Rectangle.height, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 7, 18))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 34, 17))
+>0 : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>"sub" : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 10))
+>"under" : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 19, 14))
+>"shape" : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 20, 20))
+>height : Symbol(Rectangle.height, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 7, 18))
+
+        case "circle": return Math.PI * s[0].sub.under["shape"].radius * s[0]["sub"].under.shape["radius"];
+>Math.PI : Symbol(Math.PI, Decl(lib.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>PI : Symbol(Math.PI, Decl(lib.d.ts, --, --))
+>s[0].sub.under["shape"].radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 19))
+>s[0].sub.under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 19, 14))
+>s[0].sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 10))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 34, 17))
+>0 : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>sub : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 10))
+>under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 19, 14))
+>"shape" : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 20, 20))
+>radius : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 19))
+>s[0]["sub"].under.shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 20, 20))
+>s[0]["sub"].under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 19, 14))
+>s : Symbol(s, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 34, 17))
+>0 : Symbol(Subshape["0"], Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 17, 20))
+>"sub" : Symbol(sub, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 18, 10))
+>under : Symbol(under, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 19, 14))
+>shape : Symbol(shape, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 20, 20))
+>"radius" : Symbol(Circle.radius, Decl(typeGuardNarrowsIndexedAccessOfKnownProperty.ts, 12, 19))
     }
 }
 

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.types
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.types
@@ -38,15 +38,29 @@ type Shape = Square | Rectangle | Circle;
 >Rectangle : Rectangle
 >Circle : Circle
 
-function area(s: Shape) {
+interface Subshape {
+>Subshape : Subshape
+
+    "0": {
+        sub: {
+>sub : { under: { shape: Shape; }; }
+
+            under: {
+>under : { shape: Shape; }
+
+                shape: Shape;
+>shape : Shape
+>Shape : Shape
+            }
+        }
+    }
+}
+function area(s: Shape): number {
 >area : (s: Shape) => number
 >s : Shape
 >Shape : Shape
 
-    // In the following switch statement, the type of s is narrowed in each case clause
-    // according to the value of the discriminant property, thus allowing the other properties
-    // of that variant to be accessed without a type assertion.
-    switch (s['kind']) {
+    switch(s['kind']) {
 >s['kind'] : "square" | "rectangle" | "circle"
 >s : Shape
 >'kind' : string
@@ -84,6 +98,108 @@ function area(s: Shape) {
 >s.radius : number
 >s : Circle
 >radius : number
+    }
+}
+
+function subarea(s: Subshape): number {
+>subarea : (s: Subshape) => number
+>s : Subshape
+>Subshape : Subshape
+
+    switch(s[0]["sub"].under["shape"]["kind"]) {
+>s[0]["sub"].under["shape"]["kind"] : "square" | "rectangle" | "circle"
+>s[0]["sub"].under["shape"] : Shape
+>s[0]["sub"].under : { shape: Shape; }
+>s[0]["sub"] : { under: { shape: Shape; }; }
+>s[0] : { sub: { under: { shape: Shape; }; }; }
+>s : Subshape
+>0 : number
+>"sub" : string
+>under : { shape: Shape; }
+>"shape" : string
+>"kind" : string
+
+        case "square": return s[0].sub.under.shape.size * s[0].sub.under.shape.size;
+>"square" : "square"
+>s[0].sub.under.shape.size * s[0].sub.under.shape.size : number
+>s[0].sub.under.shape.size : number
+>s[0].sub.under.shape : Square
+>s[0].sub.under : { shape: Shape; }
+>s[0].sub : { under: { shape: Shape; }; }
+>s[0] : { sub: { under: { shape: Shape; }; }; }
+>s : Subshape
+>0 : number
+>sub : { under: { shape: Shape; }; }
+>under : { shape: Shape; }
+>shape : Square
+>size : number
+>s[0].sub.under.shape.size : number
+>s[0].sub.under.shape : Square
+>s[0].sub.under : { shape: Shape; }
+>s[0].sub : { under: { shape: Shape; }; }
+>s[0] : { sub: { under: { shape: Shape; }; }; }
+>s : Subshape
+>0 : number
+>sub : { under: { shape: Shape; }; }
+>under : { shape: Shape; }
+>shape : Square
+>size : number
+
+        case "rectangle": return s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height;
+>"rectangle" : "rectangle"
+>s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height : number
+>s[0]["sub"]["under"]["shape"]["width"] : number
+>s[0]["sub"]["under"]["shape"] : Rectangle
+>s[0]["sub"]["under"] : { shape: Shape; }
+>s[0]["sub"] : { under: { shape: Shape; }; }
+>s[0] : { sub: { under: { shape: Shape; }; }; }
+>s : Subshape
+>0 : number
+>"sub" : string
+>"under" : string
+>"shape" : string
+>"width" : string
+>s[0]["sub"]["under"]["shape"].height : number
+>s[0]["sub"]["under"]["shape"] : Rectangle
+>s[0]["sub"]["under"] : { shape: Shape; }
+>s[0]["sub"] : { under: { shape: Shape; }; }
+>s[0] : { sub: { under: { shape: Shape; }; }; }
+>s : Subshape
+>0 : number
+>"sub" : string
+>"under" : string
+>"shape" : string
+>height : number
+
+        case "circle": return Math.PI * s[0].sub.under["shape"].radius * s[0]["sub"].under.shape["radius"];
+>"circle" : "circle"
+>Math.PI * s[0].sub.under["shape"].radius * s[0]["sub"].under.shape["radius"] : number
+>Math.PI * s[0].sub.under["shape"].radius : number
+>Math.PI : number
+>Math : Math
+>PI : number
+>s[0].sub.under["shape"].radius : number
+>s[0].sub.under["shape"] : Circle
+>s[0].sub.under : { shape: Shape; }
+>s[0].sub : { under: { shape: Shape; }; }
+>s[0] : { sub: { under: { shape: Shape; }; }; }
+>s : Subshape
+>0 : number
+>sub : { under: { shape: Shape; }; }
+>under : { shape: Shape; }
+>"shape" : string
+>radius : number
+>s[0]["sub"].under.shape["radius"] : number
+>s[0]["sub"].under.shape : Circle
+>s[0]["sub"].under : { shape: Shape; }
+>s[0]["sub"] : { under: { shape: Shape; }; }
+>s[0] : { sub: { under: { shape: Shape; }; }; }
+>s : Subshape
+>0 : number
+>"sub" : string
+>under : { shape: Shape; }
+>shape : Circle
+>"radius" : string
     }
 }
 

--- a/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.types
+++ b/tests/baselines/reference/typeGuardNarrowsIndexedAccessOfKnownProperty.types
@@ -1,0 +1,89 @@
+=== tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty.ts ===
+interface Square {
+>Square : Square
+
+    kind: "square";
+>kind : "square"
+
+    size: number;
+>size : number
+}
+
+interface Rectangle {
+>Rectangle : Rectangle
+
+    kind: "rectangle";
+>kind : "rectangle"
+
+    width: number;
+>width : number
+
+    height: number;
+>height : number
+}
+
+interface Circle {
+>Circle : Circle
+
+    kind: "circle";
+>kind : "circle"
+
+    radius: number;
+>radius : number
+}
+
+type Shape = Square | Rectangle | Circle;
+>Shape : Shape
+>Square : Square
+>Rectangle : Rectangle
+>Circle : Circle
+
+function area(s: Shape) {
+>area : (s: Shape) => number
+>s : Shape
+>Shape : Shape
+
+    // In the following switch statement, the type of s is narrowed in each case clause
+    // according to the value of the discriminant property, thus allowing the other properties
+    // of that variant to be accessed without a type assertion.
+    switch (s['kind']) {
+>s['kind'] : "square" | "rectangle" | "circle"
+>s : Shape
+>'kind' : string
+
+        case "square": return s.size * s.size;
+>"square" : "square"
+>s.size * s.size : number
+>s.size : number
+>s : Square
+>size : number
+>s.size : number
+>s : Square
+>size : number
+
+        case "rectangle": return s.width * s.height;
+>"rectangle" : "rectangle"
+>s.width * s.height : number
+>s.width : number
+>s : Rectangle
+>width : number
+>s.height : number
+>s : Rectangle
+>height : number
+
+        case "circle": return Math.PI * s.radius * s.radius;
+>"circle" : "circle"
+>Math.PI * s.radius * s.radius : number
+>Math.PI * s.radius : number
+>Math.PI : number
+>Math : Math
+>PI : number
+>s.radius : number
+>s : Circle
+>radius : number
+>s.radius : number
+>s : Circle
+>radius : number
+    }
+}
+

--- a/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty.ts
+++ b/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty.ts
@@ -1,47 +1,41 @@
 interface Square {
-    sub: {kind: 'square'; };
-    /*'0': {
-        sub: {
-            under: {
-                kind: "square"
-            }
-        }
-    };*/
+    kind: "square";
     size: number;
 }
 
 interface Rectangle {
-    /*'0': {
-        sub: {
-            under: {
-                kind: "rectangle"
-            }
-        }
-    };*/
-    sub: { kind: 'rectangle'; };
+    kind: "rectangle";
     width: number;
     height: number;
 }
 
 interface Circle {
-    /*'0': {
-        sub: {
-            under : {
-                kind: "circle"
-            }
-        }
-    };*/
-    sub: { kind: 'circle'; };
+    kind: "circle";
     radius: number;
 }
 
 type Shape = Square | Rectangle | Circle;
-
-function area(s: Shape) {
-    switch(s.sub.kind) {
-    //switch (s[0].sub['under']['kind']) {
+interface Subshape {
+    "0": {
+        sub: {
+            under: {
+                shape: Shape;
+            }
+        }
+    }
+}
+function area(s: Shape): number {
+    switch(s['kind']) {
         case "square": return s.size * s.size;
         case "rectangle": return s.width * s.height;
         case "circle": return Math.PI * s.radius * s.radius;
+    }
+}
+
+function subarea(s: Subshape): number {
+    switch(s[0]["sub"].under["shape"]["kind"]) {
+        case "square": return s[0].sub.under.shape.size * s[0].sub.under.shape.size;
+        case "rectangle": return s[0]["sub"]["under"]["shape"]["width"] * s[0]["sub"]["under"]["shape"].height;
+        case "circle": return Math.PI * s[0].sub.under["shape"].radius * s[0]["sub"].under.shape["radius"];
     }
 }

--- a/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty.ts
+++ b/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty.ts
@@ -1,26 +1,45 @@
 interface Square {
-    kind: "square";
+    sub: {kind: 'square'; };
+    /*'0': {
+        sub: {
+            under: {
+                kind: "square"
+            }
+        }
+    };*/
     size: number;
 }
 
 interface Rectangle {
-    kind: "rectangle";
+    /*'0': {
+        sub: {
+            under: {
+                kind: "rectangle"
+            }
+        }
+    };*/
+    sub: { kind: 'rectangle'; };
     width: number;
     height: number;
 }
 
 interface Circle {
-    kind: "circle";
+    /*'0': {
+        sub: {
+            under : {
+                kind: "circle"
+            }
+        }
+    };*/
+    sub: { kind: 'circle'; };
     radius: number;
 }
 
 type Shape = Square | Rectangle | Circle;
 
 function area(s: Shape) {
-    // In the following switch statement, the type of s is narrowed in each case clause
-    // according to the value of the discriminant property, thus allowing the other properties
-    // of that variant to be accessed without a type assertion.
-    switch (s['kind']) {
+    switch(s.sub.kind) {
+    //switch (s[0].sub['under']['kind']) {
         case "square": return s.size * s.size;
         case "rectangle": return s.width * s.height;
         case "circle": return Math.PI * s.radius * s.radius;

--- a/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty.ts
+++ b/tests/cases/compiler/typeGuardNarrowsIndexedAccessOfKnownProperty.ts
@@ -1,0 +1,28 @@
+interface Square {
+    kind: "square";
+    size: number;
+}
+
+interface Rectangle {
+    kind: "rectangle";
+    width: number;
+    height: number;
+}
+
+interface Circle {
+    kind: "circle";
+    radius: number;
+}
+
+type Shape = Square | Rectangle | Circle;
+
+function area(s: Shape) {
+    // In the following switch statement, the type of s is narrowed in each case clause
+    // according to the value of the discriminant property, thus allowing the other properties
+    // of that variant to be accessed without a type assertion.
+    switch (s['kind']) {
+        case "square": return s.size * s.size;
+        case "rectangle": return s.width * s.height;
+        case "circle": return Math.PI * s.radius * s.radius;
+    }
+}


### PR DESCRIPTION
Fixes #10530 

Narrowing now happens for `x['knownProperty']` the same way that it does for `x.knownProperty`
