### PR TITLE
Parse untyped object type members comma separated

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2339,6 +2339,7 @@ namespace ts {
                     token() === SyntaxKind.LessThanToken ||
                     token() === SyntaxKind.QuestionToken ||
                     token() === SyntaxKind.ColonToken ||
+                    token() === SyntaxKind.CommaToken ||
                     canParseSemicolon();
             }
             return false;

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentError.errors.txt
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentError.errors.txt
@@ -1,8 +1,5 @@
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(4,43): error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ b: string; id: number; }'.
   Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
-tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(5,16): error TS1131: Property or signature expected.
-tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(5,22): error TS2403: Subsequent variable declarations must have the same type.  Variable 'id' must be of type 'number', but here has type 'any'.
-tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(5,25): error TS1128: Declaration or statement expected.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts(6,79): error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ id: string; name: number; }'.
   Types of property 'id' are incompatible.
     Type 'number' is not assignable to type 'string'.
@@ -11,7 +8,7 @@ tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPr
     Type 'number' is not assignable to type 'boolean'.
 
 
-==== tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts (6 errors) ====
+==== tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts (3 errors) ====
     var id: number = 10000;
     var name: string = "my name";
     
@@ -19,13 +16,7 @@ tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPr
                                               ~~~~
 !!! error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ b: string; id: number; }'.
 !!! error TS2322:   Object literal may only specify known properties, and 'name' does not exist in type '{ b: string; id: number; }'.
-    var person1: { name, id };  // error: can't use short-hand property assignment in type position
-                   ~~~~
-!!! error TS1131: Property or signature expected.
-                         ~~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'id' must be of type 'number', but here has type 'any'.
-                            ~
-!!! error TS1128: Declaration or statement expected.
+    var person1: { name, id };  // ok
     function foo(name: string, id: number): { id: string, name: number } { return { name, id }; }  // error
                                                                                   ~~~~~~~~~~~~
 !!! error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ id: string; name: number; }'.

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentError.js
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentError.js
@@ -3,7 +3,7 @@ var id: number = 10000;
 var name: string = "my name";
 
 var person: { b: string; id: number } = { name, id };  // error
-var person1: { name, id };  // error: can't use short-hand property assignment in type position
+var person1: { name, id };  // ok
 function foo(name: string, id: number): { id: string, name: number } { return { name, id }; }  // error
 function bar(obj: { name: string; id: boolean }) { }
 bar({ name, id });  // error
@@ -14,8 +14,7 @@ bar({ name, id });  // error
 var id = 10000;
 var name = "my name";
 var person = { name: name, id: id }; // error
-var person1 = name, id;
-; // error: can't use short-hand property assignment in type position
+var person1; // ok
 function foo(name, id) { return { name: name, id: id }; } // error
 function bar(obj) { }
 bar({ name: name, id: id }); // error

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.errors.txt
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.errors.txt
@@ -3,15 +3,12 @@ tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPr
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts(5,79): error TS2322: Type '{ name: string; id: number; }' is not assignable to type '{ name: number; id: string; }'.
   Types of property 'name' are incompatible.
     Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts(7,16): error TS1131: Property or signature expected.
-tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts(7,22): error TS2403: Subsequent variable declarations must have the same type.  Variable 'id' must be of type 'number', but here has type 'any'.
-tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts(7,25): error TS1128: Declaration or statement expected.
 tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts(8,5): error TS2322: Type '{ name: number; id: string; }' is not assignable to type '{ name: string; id: number; }'.
   Types of property 'name' are incompatible.
     Type 'number' is not assignable to type 'string'.
 
 
-==== tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts (6 errors) ====
+==== tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts (3 errors) ====
     var id: number = 10000;
     var name: string = "my name";
     
@@ -25,15 +22,10 @@ tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPr
 !!! error TS2322:   Types of property 'name' are incompatible.
 !!! error TS2322:     Type 'string' is not assignable to type 'number'.
     function foo(name: string, id: number): { name: string, id: number } { return { name, id }; }  // error
-    var person1: { name, id };  // error : Can't use shorthand in the type position
-                   ~~~~
-!!! error TS1131: Property or signature expected.
-                         ~~
-!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'id' must be of type 'number', but here has type 'any'.
-                            ~
-!!! error TS1128: Declaration or statement expected.
+    var person1: { name, id }; // ok
     var person2: { name: string, id: number } = bar("hello", 5);
         ~~~~~~~
 !!! error TS2322: Type '{ name: number; id: string; }' is not assignable to type '{ name: string; id: number; }'.
 !!! error TS2322:   Types of property 'name' are incompatible.
 !!! error TS2322:     Type 'number' is not assignable to type 'string'.
+    

--- a/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.js
+++ b/tests/baselines/reference/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.js
@@ -5,8 +5,9 @@ var name: string = "my name";
 var person: { b: string; id: number } = { name, id };  // error
 function bar(name: string, id: number): { name: number, id: string } { return { name, id }; }  // error
 function foo(name: string, id: number): { name: string, id: number } { return { name, id }; }  // error
-var person1: { name, id };  // error : Can't use shorthand in the type position
+var person1: { name, id }; // ok
 var person2: { name: string, id: number } = bar("hello", 5);
+
 
 //// [objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.js]
 var id = 10000;
@@ -14,6 +15,5 @@ var name = "my name";
 var person = { name: name, id: id }; // error
 function bar(name, id) { return { name: name, id: id }; } // error
 function foo(name, id) { return { name: name, id: id }; } // error
-var person1 = name, id;
-; // error : Can't use shorthand in the type position
+var person1; // ok
 var person2 = bar("hello", 5);

--- a/tests/baselines/reference/parseObjectLiteralsWithoutTypes.js
+++ b/tests/baselines/reference/parseObjectLiteralsWithoutTypes.js
@@ -1,0 +1,10 @@
+//// [parseObjectLiteralsWithoutTypes.ts]
+let x: { foo, bar }
+let y: { foo: number, bar }
+let z: { foo, bar: number }
+
+
+//// [parseObjectLiteralsWithoutTypes.js]
+var x;
+var y;
+var z;

--- a/tests/baselines/reference/parseObjectLiteralsWithoutTypes.symbols
+++ b/tests/baselines/reference/parseObjectLiteralsWithoutTypes.symbols
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/parseObjectLiteralsWithoutTypes.ts ===
+let x: { foo, bar }
+>x : Symbol(x, Decl(parseObjectLiteralsWithoutTypes.ts, 0, 3))
+>foo : Symbol(foo, Decl(parseObjectLiteralsWithoutTypes.ts, 0, 8))
+>bar : Symbol(bar, Decl(parseObjectLiteralsWithoutTypes.ts, 0, 13))
+
+let y: { foo: number, bar }
+>y : Symbol(y, Decl(parseObjectLiteralsWithoutTypes.ts, 1, 3))
+>foo : Symbol(foo, Decl(parseObjectLiteralsWithoutTypes.ts, 1, 8))
+>bar : Symbol(bar, Decl(parseObjectLiteralsWithoutTypes.ts, 1, 21))
+
+let z: { foo, bar: number }
+>z : Symbol(z, Decl(parseObjectLiteralsWithoutTypes.ts, 2, 3))
+>foo : Symbol(foo, Decl(parseObjectLiteralsWithoutTypes.ts, 2, 8))
+>bar : Symbol(bar, Decl(parseObjectLiteralsWithoutTypes.ts, 2, 13))
+

--- a/tests/baselines/reference/parseObjectLiteralsWithoutTypes.types
+++ b/tests/baselines/reference/parseObjectLiteralsWithoutTypes.types
@@ -1,0 +1,16 @@
+=== tests/cases/compiler/parseObjectLiteralsWithoutTypes.ts ===
+let x: { foo, bar }
+>x : { foo: any; bar: any; }
+>foo : any
+>bar : any
+
+let y: { foo: number, bar }
+>y : { foo: number; bar: any; }
+>foo : number
+>bar : any
+
+let z: { foo, bar: number }
+>z : { foo: any; bar: number; }
+>foo : any
+>bar : number
+

--- a/tests/cases/compiler/parseObjectLiteralsWithoutTypes.ts
+++ b/tests/cases/compiler/parseObjectLiteralsWithoutTypes.ts
@@ -1,0 +1,3 @@
+let x: { foo, bar }
+let y: { foo: number, bar }
+let z: { foo, bar: number }

--- a/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts
+++ b/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentError.ts
@@ -2,7 +2,7 @@
 var name: string = "my name";
 
 var person: { b: string; id: number } = { name, id };  // error
-var person1: { name, id };  // error: can't use short-hand property assignment in type position
+var person1: { name, id };  // ok
 function foo(name: string, id: number): { id: string, name: number } { return { name, id }; }  // error
 function bar(obj: { name: string; id: boolean }) { }
 bar({ name, id });  // error

--- a/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts
+++ b/tests/cases/conformance/es6/shorthandPropertyAssignment/objectLiteralShorthandPropertiesAssignmentErrorFromMissingIdentifier.ts
@@ -4,5 +4,5 @@ var name: string = "my name";
 var person: { b: string; id: number } = { name, id };  // error
 function bar(name: string, id: number): { name: number, id: string } { return { name, id }; }  // error
 function foo(name: string, id: number): { name: string, id: number } { return { name, id }; }  // error
-var person1: { name, id };  // error : Can't use shorthand in the type position
+var person1: { name, id }; // ok
 var person2: { name: string, id: number } = bar("hello", 5);


### PR DESCRIPTION
Fixes #10545 

Parse untyped object type members separated by ','. Previously if the first member was untyped and the separator was ',', then parsing would fail.