### PR TITLE
Treat variable declaration as top-level if it has an important child.

### DIFF
--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -466,6 +466,7 @@ namespace ts.NavigationBar {
                 case SyntaxKind.MethodDeclaration:
                 case SyntaxKind.GetAccessor:
                 case SyntaxKind.SetAccessor:
+                case SyntaxKind.VariableDeclaration:
                     return hasSomeImportantChild(item);
 
                 case SyntaxKind.ArrowFunction:

--- a/tests/cases/fourslash/navigationBarAnonymousClassAndFunctionExpressions.ts
+++ b/tests/cases/fourslash/navigationBarAnonymousClassAndFunctionExpressions.ts
@@ -91,6 +91,17 @@ verify.navigationBar([
         "indent": 2
     },
     {
+        "text": "y",
+        "kind": "const",
+        "childItems": [
+            {
+                "text": "foo",
+                "kind": "function"
+            }
+        ],
+        "indent": 2
+    },
+    {
         "text": "<function>",
         "kind": "function",
         "childItems": [

--- a/tests/cases/fourslash/navigationBarFunctionIndirectlyInVariableDeclaration.ts
+++ b/tests/cases/fourslash/navigationBarFunctionIndirectlyInVariableDeclaration.ts
@@ -1,0 +1,46 @@
+/// <reference path="fourslash.ts"/>
+
+////var a = {
+////    propA: function() {}
+////};
+////var b;
+////b = {
+////    propB: function() {}
+////};
+
+verify.navigationBar([
+  {
+    "text": "<global>",
+    "kind": "script",
+    "childItems": [
+      {
+        "text": "a",
+        "kind": "var"
+      },
+      {
+        "text": "b",
+        "kind": "var"
+      },
+      {
+        "text": "propB",
+        "kind": "function"
+      }
+    ]
+  },
+  {
+    "text": "a",
+    "kind": "var",
+    "childItems": [
+      {
+        "text": "propA",
+        "kind": "function"
+      }
+    ],
+    "indent": 1
+  },
+  {
+    "text": "propB",
+    "kind": "function",
+    "indent": 1
+  }
+]);


### PR DESCRIPTION
Fixes #10558

I think a better long-term solution to this would be to avoid calling `topLevelItems` for vscode.
Currently we do this:

    map(topLevelItems(rootNavigationBarNode(sourceFile)), convertToTopLevelItem);

If a node isn't a top-level item or a child of one, it simply disappears from navigation.
In addition, the notion of top-level items are only used by visual studio anyway, so they waste time in vscode.
This also results in vscode counting a node twice if it is both a top-level item and also a child of one.
I think it would be better to do something like this:

    function getNavigationBarItemsForVsCode(sourceFile): VsCodeNavigationBarItem[] {
        return map(rootNavigationBarNode(sourceFile), convertToVsCodeItem);
    }

`VsCodeNavigationBarItem` could be simple: just `{ text, kind, kindModifiers, spans, indent }`.
