### PR TITLE
Default type roots when host.directoryExists is not implemented shoul…

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -188,7 +188,7 @@ namespace ts {
      */
     function getDefaultTypeRoots(currentDirectory: string, host: ModuleResolutionHost): string[] | undefined {
         if (!host.directoryExists) {
-            return [combinePaths(currentDirectory, "node_modules")];
+            return [combinePaths(currentDirectory, nodeModulesAtTypes)];
             // And if it doesn't exist, tough.
         }
 


### PR DESCRIPTION
Should have been part of #10670.