### PR TITLE
Fix10731: Correctly emit comment for decorated class declaration

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -694,19 +694,21 @@ namespace ts {
 
             //  let ${name} = ${classExpression} where name is either declaredName if the class doesn't contain self-reference
             //                                         or decoratedClassAlias if the class contain self-reference.
+            const transformedClassExpression = createVariableStatement(
+                /*modifiers*/ undefined,
+                createLetDeclarationList([
+                    createVariableDeclaration(
+                        classAlias || declaredName,
+                        /*type*/ undefined,
+                        classExpression
+                    )
+                ]),
+                /*location*/ location
+            );
+            setCommentRange(transformedClassExpression, node);
             statements.push(
                 setOriginalNode(
-                    createVariableStatement(
-                        /*modifiers*/ undefined,
-                        createLetDeclarationList([
-                            createVariableDeclaration(
-                                classAlias || declaredName,
-                                /*type*/ undefined,
-                                classExpression
-                            )
-                        ]),
-                        /*location*/ location
-                    ),
+                    /*node*/ transformedClassExpression,
                     /*original*/ node
                 )
             );

--- a/tests/baselines/reference/commentOnDecoratedClassDeclaration.js
+++ b/tests/baselines/reference/commentOnDecoratedClassDeclaration.js
@@ -1,0 +1,47 @@
+//// [commentOnDecoratedClassDeclaration.ts]
+declare function decorator(x: string): any;
+
+/**
+ * Leading trivia
+ */
+@decorator("hello")
+class Remote { }
+
+/**
+ * Floating Comment
+ */
+
+@decorator("hi")
+class AnotherRomote {
+    constructor() {}
+}
+
+//// [commentOnDecoratedClassDeclaration.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+/**
+ * Leading trivia
+ */
+var Remote = (function () {
+    function Remote() {
+    }
+    return Remote;
+}());
+Remote = __decorate([
+    decorator("hello")
+], Remote);
+/**
+ * Floating Comment
+ */
+var AnotherRomote = (function () {
+    function AnotherRomote() {
+    }
+    return AnotherRomote;
+}());
+AnotherRomote = __decorate([
+    decorator("hi")
+], AnotherRomote);

--- a/tests/baselines/reference/commentOnDecoratedClassDeclaration.symbols
+++ b/tests/baselines/reference/commentOnDecoratedClassDeclaration.symbols
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/commentOnDecoratedClassDeclaration.ts ===
+declare function decorator(x: string): any;
+>decorator : Symbol(decorator, Decl(commentOnDecoratedClassDeclaration.ts, 0, 0))
+>x : Symbol(x, Decl(commentOnDecoratedClassDeclaration.ts, 0, 27))
+
+/**
+ * Leading trivia
+ */
+@decorator("hello")
+>decorator : Symbol(decorator, Decl(commentOnDecoratedClassDeclaration.ts, 0, 0))
+
+class Remote { }
+>Remote : Symbol(Remote, Decl(commentOnDecoratedClassDeclaration.ts, 0, 43))
+
+/**
+ * Floating Comment
+ */
+
+@decorator("hi")
+>decorator : Symbol(decorator, Decl(commentOnDecoratedClassDeclaration.ts, 0, 0))
+
+class AnotherRomote {
+>AnotherRomote : Symbol(AnotherRomote, Decl(commentOnDecoratedClassDeclaration.ts, 6, 16))
+
+    constructor() {}
+}

--- a/tests/baselines/reference/commentOnDecoratedClassDeclaration.types
+++ b/tests/baselines/reference/commentOnDecoratedClassDeclaration.types
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/commentOnDecoratedClassDeclaration.ts ===
+declare function decorator(x: string): any;
+>decorator : (x: string) => any
+>x : string
+
+/**
+ * Leading trivia
+ */
+@decorator("hello")
+>decorator("hello") : any
+>decorator : (x: string) => any
+>"hello" : string
+
+class Remote { }
+>Remote : Remote
+
+/**
+ * Floating Comment
+ */
+
+@decorator("hi")
+>decorator("hi") : any
+>decorator : (x: string) => any
+>"hi" : string
+
+class AnotherRomote {
+>AnotherRomote : AnotherRomote
+
+    constructor() {}
+}

--- a/tests/cases/compiler/commentOnDecoratedClassDeclaration.ts
+++ b/tests/cases/compiler/commentOnDecoratedClassDeclaration.ts
@@ -1,0 +1,17 @@
+// @experimentalDecorators: true
+declare function decorator(x: string): any;
+
+/**
+ * Leading trivia
+ */
+@decorator("hello")
+class Remote { }
+
+/**
+ * Floating Comment
+ */
+
+@decorator("hi")
+class AnotherRomote {
+    constructor() {}
+}


### PR DESCRIPTION
Fix #10731 