### PR TITLE
Force source-map-support to not have source maps

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -39,6 +39,8 @@ const gulp = helpMaker(originalGulp);
 const mochaParallel = require("./scripts/mocha-parallel.js");
 const {runTestsInParallel} = mochaParallel;
 
+Error.stackTraceLimit = 1000;
+
 const cmdLineOptions = minimist(process.argv.slice(2), {
     boolean: ["debug", "light", "colors", "lint", "soft"],
     string: ["browser", "tests", "host", "reporter"],
@@ -727,6 +729,7 @@ gulp.task("browserify", "Runs browserify on run.js to produce a file suitable fo
                         sourcemaps: {
                             "built/local/_stream_0.js": originalMap,
                             "built/local/bundle.js": maps,
+                            "node_modules/source-map-support/source-map-support.js": null,
                         }
                     });
                     const finalMap = chain.apply();

--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -729,7 +729,7 @@ gulp.task("browserify", "Runs browserify on run.js to produce a file suitable fo
                         sourcemaps: {
                             "built/local/_stream_0.js": originalMap,
                             "built/local/bundle.js": maps,
-                            "node_modules/source-map-support/source-map-support.js": null,
+                            "node_modules/source-map-support/source-map-support.js": undefined,
                         }
                     });
                     const finalMap = chain.apply();


### PR DESCRIPTION
Fixes `gulp runtests-browser` after the transforms merge.

source-map-support fooled sorcery's incorrect check for sourceMappingURL into thinking it had a source map because it used the string "sourceMappingURL" so much. Now our gulpfile manually specifies that source-map-support has no source mapping.

Also up the error stack trace limit to 1000 to help future error reporting.