### PR TITLE
Fix 10739: Only emit comment once for export enum declaration

### DIFF
--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -802,17 +802,17 @@ namespace ts {
          * Adds a trailing VariableStatement for an enum or module declaration.
          */
         function addVarForExportedEnumOrNamespaceDeclaration(statements: Statement[], node: EnumDeclaration | ModuleDeclaration) {
-            statements.push(
-                createVariableStatement(
-                    /*modifiers*/ undefined,
-                    [createVariableDeclaration(
-                        getDeclarationName(node),
+            const transformedStatement = createVariableStatement(
+                /*modifiers*/ undefined,
+                [createVariableDeclaration(
+                    getDeclarationName(node),
                         /*type*/ undefined,
-                        createPropertyAccess(createIdentifier("exports"), getDeclarationName(node))
-                    )],
+                    createPropertyAccess(createIdentifier("exports"), getDeclarationName(node))
+                )],
                     /*location*/ node
-                )
             );
+            setNodeEmitFlags(transformedStatement, NodeEmitFlags.NoComments);
+            statements.push(transformedStatement);
         }
 
         function getDeclarationName(node: DeclarationStatement) {

--- a/tests/baselines/reference/commentOnExportEnumDeclaration.js
+++ b/tests/baselines/reference/commentOnExportEnumDeclaration.js
@@ -1,0 +1,19 @@
+//// [commentOnExportEnumDeclaration.ts]
+/**
+ * comment
+ */
+export enum Color {
+    r, g, b
+}
+
+//// [commentOnExportEnumDeclaration.js]
+"use strict";
+/**
+ * comment
+ */
+(function (Color) {
+    Color[Color["r"] = 0] = "r";
+    Color[Color["g"] = 1] = "g";
+    Color[Color["b"] = 2] = "b";
+})(exports.Color || (exports.Color = {}));
+var Color = exports.Color;

--- a/tests/baselines/reference/commentOnExportEnumDeclaration.symbols
+++ b/tests/baselines/reference/commentOnExportEnumDeclaration.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/commentOnExportEnumDeclaration.ts ===
+/**
+ * comment
+ */
+export enum Color {
+>Color : Symbol(Color, Decl(commentOnExportEnumDeclaration.ts, 0, 0))
+
+    r, g, b
+>r : Symbol(Color.r, Decl(commentOnExportEnumDeclaration.ts, 3, 19))
+>g : Symbol(Color.g, Decl(commentOnExportEnumDeclaration.ts, 4, 6))
+>b : Symbol(Color.b, Decl(commentOnExportEnumDeclaration.ts, 4, 9))
+}

--- a/tests/baselines/reference/commentOnExportEnumDeclaration.types
+++ b/tests/baselines/reference/commentOnExportEnumDeclaration.types
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/commentOnExportEnumDeclaration.ts ===
+/**
+ * comment
+ */
+export enum Color {
+>Color : Color
+
+    r, g, b
+>r : Color
+>g : Color
+>b : Color
+}

--- a/tests/cases/compiler/commentOnExportEnumDeclaration.ts
+++ b/tests/cases/compiler/commentOnExportEnumDeclaration.ts
@@ -1,0 +1,6 @@
+﻿/**
+ * comment
+ */
+export enum Color {
+    r, g, b
+}


### PR DESCRIPTION
Fix #10739 