### PR TITLE
Update prefer const rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         "ts-node": "latest",
         "tsd": "latest",
         "tslint": "next",
-        "typescript": "2.1.0-dev.20160906"
+        "typescript": "next"
     },
     "scripts": {
         "pretest": "jake tests",

--- a/scripts/tslint/preferConstRule.ts
+++ b/scripts/tslint/preferConstRule.ts
@@ -21,32 +21,12 @@ function walkUpBindingElementsAndPatterns(node: ts.Node): ts.Node {
     return node;
 }
 
-function getCombinedNodeFlags(node: ts.Node): ts.NodeFlags {
-    node = walkUpBindingElementsAndPatterns(node);
-
-    let flags = node.flags;
-    if (node.kind === ts.SyntaxKind.VariableDeclaration) {
-        node = node.parent;
-    }
-
-    if (node && node.kind === ts.SyntaxKind.VariableDeclarationList) {
-        flags |= node.flags;
-        node = node.parent;
-    }
-
-    if (node && node.kind === ts.SyntaxKind.VariableStatement) {
-        flags |= node.flags;
-    }
-
-    return flags;
-}
-
 function isLet(node: ts.Node) {
-    return !!(getCombinedNodeFlags(node) & ts.NodeFlags.Let);
+    return !!(ts.getCombinedNodeFlags(node) & ts.NodeFlags.Let);
 }
 
 function isExported(node: ts.Node) {
-    return !!(getCombinedNodeFlags(node) & ts.NodeFlags.Export);
+    return !!(ts.getCombinedModifierFlags(node) & ts.ModifierFlags.Export);
 }
 
 function isAssignmentOperator(token: ts.SyntaxKind): boolean {

--- a/scripts/tslint/preferConstRule.ts
+++ b/scripts/tslint/preferConstRule.ts
@@ -9,10 +9,6 @@ export class Rule extends Lint.Rules.AbstractRule {
     }
 }
 
-function isBindingPattern(node: ts.Node): node is ts.BindingPattern {
-    return !!node && (node.kind === ts.SyntaxKind.ArrayBindingPattern || node.kind === ts.SyntaxKind.ObjectBindingPattern);
-}
-
 function isLet(node: ts.Node) {
     return !!(ts.getCombinedNodeFlags(node) & ts.NodeFlags.Let);
 }

--- a/scripts/tslint/preferConstRule.ts
+++ b/scripts/tslint/preferConstRule.ts
@@ -13,14 +13,6 @@ function isBindingPattern(node: ts.Node): node is ts.BindingPattern {
     return !!node && (node.kind === ts.SyntaxKind.ArrayBindingPattern || node.kind === ts.SyntaxKind.ObjectBindingPattern);
 }
 
-function walkUpBindingElementsAndPatterns(node: ts.Node): ts.Node {
-    while (node && (node.kind === ts.SyntaxKind.BindingElement || isBindingPattern(node))) {
-        node = node.parent;
-    }
-
-    return node;
-}
-
 function isLet(node: ts.Node) {
     return !!(ts.getCombinedNodeFlags(node) & ts.NodeFlags.Let);
 }


### PR DESCRIPTION
Fixes #10750

Update preferConstRule to use getCombined*X*Flags now that they are exported instead of :scissors: :spaghetti: copying them. Also, many pieces of NodeFlags moved to ModifierFlags in the interim.
