### PR TITLE
Make preProcessFile public again

### DIFF
--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -232,7 +232,7 @@ namespace Harness.LanguageService {
         }
         getHost() { return this.host; }
         getLanguageService(): ts.LanguageService { return ts.createLanguageService(this.host); }
-        getClassifier(): ts.Classifier { return ts.Classifier.createClassifier(); }
+        getClassifier(): ts.Classifier { return ts.createClassifier(); }
         getPreProcessedFileInfo(fileName: string, fileContents: string): ts.PreProcessedFileInfo { return ts.preProcessFile(fileContents, /* readImportFiles */ true, ts.hasJavaScriptFileExtension(fileName)); }
     }
 

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -233,7 +233,7 @@ namespace Harness.LanguageService {
         getHost() { return this.host; }
         getLanguageService(): ts.LanguageService { return ts.createLanguageService(this.host); }
         getClassifier(): ts.Classifier { return ts.Classifier.createClassifier(); }
-        getPreProcessedFileInfo(fileName: string, fileContents: string): ts.PreProcessedFileInfo { return ts.PreProcess.preProcessFile(fileContents, /* readImportFiles */ true, ts.hasJavaScriptFileExtension(fileName)); }
+        getPreProcessedFileInfo(fileName: string, fileContents: string): ts.PreProcessedFileInfo { return ts.preProcessFile(fileContents, /* readImportFiles */ true, ts.hasJavaScriptFileExtension(fileName)); }
     }
 
     /// Shim adapter
@@ -258,7 +258,7 @@ namespace Harness.LanguageService {
                 };
                 this.getModuleResolutionsForFile = (fileName) => {
                     const scriptInfo = this.getScriptInfo(fileName);
-                    const preprocessInfo = ts.PreProcess.preProcessFile(scriptInfo.content, /*readImportFiles*/ true);
+                    const preprocessInfo = ts.preProcessFile(scriptInfo.content, /*readImportFiles*/ true);
                     const imports = ts.createMap<string>();
                     for (const module of preprocessInfo.importedFiles) {
                         const resolutionInfo = ts.resolveModuleName(module.fileName, fileName, compilerOptions, moduleResolutionHost);
@@ -271,7 +271,7 @@ namespace Harness.LanguageService {
                 this.getTypeReferenceDirectiveResolutionsForFile = (fileName) => {
                     const scriptInfo = this.getScriptInfo(fileName);
                     if (scriptInfo) {
-                        const preprocessInfo = ts.PreProcess.preProcessFile(scriptInfo.content, /*readImportFiles*/ false);
+                        const preprocessInfo = ts.preProcessFile(scriptInfo.content, /*readImportFiles*/ false);
                         const resolutions = ts.createMap<ts.ResolvedTypeReferenceDirective>();
                         const settings = this.nativeHost.getCompilationSettings();
                         for (const typeReferenceDirective of preprocessInfo.typeReferenceDirectives) {

--- a/src/harness/unittests/services/preProcessFile.ts
+++ b/src/harness/unittests/services/preProcessFile.ts
@@ -2,7 +2,7 @@
 
 describe("PreProcessFile:", function () {
     function test(sourceText: string, readImportFile: boolean, detectJavaScriptImports: boolean, expectedPreProcess: ts.PreProcessedFileInfo): void {
-        const resultPreProcess = ts.PreProcess.preProcessFile(sourceText, readImportFile, detectJavaScriptImports);
+        const resultPreProcess = ts.preProcessFile(sourceText, readImportFile, detectJavaScriptImports);
 
         assert.equal(resultPreProcess.isLibFile, expectedPreProcess.isLibFile, "Pre-processed file has different value for isLibFile. Expected: " + expectedPreProcess.isLibFile + ". Actual: " + resultPreProcess.isLibFile);
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1566,7 +1566,7 @@ namespace ts.server {
                 this.setCompilerOptions(defaultOpts);
             }
             this.languageService = ts.createLanguageService(this.host, this.documentRegistry);
-            this.classifier = ts.Classifier.createClassifier();
+            this.classifier = ts.createClassifier();
         }
 
         setCompilerOptions(opt: ts.CompilerOptions) {

--- a/src/services/classifier.ts
+++ b/src/services/classifier.ts
@@ -1,5 +1,4 @@
-/* @internal */
-namespace ts.Classifier {
+namespace ts {
     /// Classifier
     export function createClassifier(): Classifier {
         const scanner = createScanner(ScriptTarget.Latest, /*skipTrivia*/ false);
@@ -462,6 +461,7 @@ namespace ts.Classifier {
         };
     }
 
+    /* @internal */
     export function getSemanticClassifications(typeChecker: TypeChecker, cancellationToken: CancellationToken, sourceFile: SourceFile, classifiableNames: Map<string>, span: TextSpan): ClassifiedSpan[] {
         return convertClassifications(getEncodedSemanticClassifications(typeChecker, cancellationToken, sourceFile, classifiableNames, span));
     }
@@ -486,6 +486,7 @@ namespace ts.Classifier {
         }
     }
 
+    /* @internal */
     export function getEncodedSemanticClassifications(typeChecker: TypeChecker, cancellationToken: CancellationToken, sourceFile: SourceFile, classifiableNames: Map<string>, span: TextSpan): Classifications {
         const result: number[] = [];
         processNode(sourceFile);
@@ -614,10 +615,12 @@ namespace ts.Classifier {
         return result;
     }
 
+    /* @internal */
     export function getSyntacticClassifications(cancellationToken: CancellationToken, sourceFile: SourceFile, span: TextSpan): ClassifiedSpan[] {
         return convertClassifications(getEncodedSyntacticClassifications(cancellationToken, sourceFile, span));
     }
 
+    /* @internal */
     export function getEncodedSyntacticClassifications(cancellationToken: CancellationToken, sourceFile: SourceFile, span: TextSpan): Classifications {
         const spanStart = span.start;
         const spanLength = span.length;

--- a/src/services/preProcess.ts
+++ b/src/services/preProcess.ts
@@ -1,5 +1,4 @@
-/* @internal */
-namespace ts.PreProcess {
+namespace ts {
     export function preProcessFile(sourceText: string, readImportFiles = true, detectJavaScriptImports = false): PreProcessedFileInfo {
         const referencedFiles: FileReference[] = [];
         const typeReferenceDirectives: FileReference[] = [];

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1601,22 +1601,22 @@ namespace ts {
 
         function getSemanticClassifications(fileName: string, span: TextSpan): ClassifiedSpan[] {
             synchronizeHostData();
-            return Classifier.getSemanticClassifications(program.getTypeChecker(), cancellationToken, getValidSourceFile(fileName), program.getClassifiableNames(), span);
+            return ts.getSemanticClassifications(program.getTypeChecker(), cancellationToken, getValidSourceFile(fileName), program.getClassifiableNames(), span);
         }
 
         function getEncodedSemanticClassifications(fileName: string, span: TextSpan): Classifications {
             synchronizeHostData();
-            return Classifier.getEncodedSemanticClassifications(program.getTypeChecker(), cancellationToken, getValidSourceFile(fileName), program.getClassifiableNames(), span);
+            return ts.getEncodedSemanticClassifications(program.getTypeChecker(), cancellationToken, getValidSourceFile(fileName), program.getClassifiableNames(), span);
         }
 
         function getSyntacticClassifications(fileName: string, span: TextSpan): ClassifiedSpan[] {
             // doesn't use compiler - no need to synchronize with host
-            return Classifier.getSyntacticClassifications(cancellationToken, syntaxTreeCache.getCurrentSourceFile(fileName), span);
+            return ts.getSyntacticClassifications(cancellationToken, syntaxTreeCache.getCurrentSourceFile(fileName), span);
         }
 
         function getEncodedSyntacticClassifications(fileName: string, span: TextSpan): Classifications {
             // doesn't use compiler - no need to synchronize with host
-            return Classifier.getEncodedSyntacticClassifications(cancellationToken, syntaxTreeCache.getCurrentSourceFile(fileName), span);
+            return ts.getEncodedSyntacticClassifications(cancellationToken, syntaxTreeCache.getCurrentSourceFile(fileName), span);
         }
 
         function getOutliningSpans(fileName: string): OutliningSpan[] {

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -986,7 +986,7 @@ namespace ts {
 
         constructor(factory: ShimFactory, private logger: Logger) {
             super(factory);
-            this.classifier = Classifier.createClassifier();
+            this.classifier = createClassifier();
         }
 
         public getEncodedLexicalClassifications(text: string, lexState: EndOfLineState, syntacticClassifierAbsent?: boolean): string {

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -1047,7 +1047,7 @@ namespace ts {
                 `getPreProcessedFileInfo('${fileName}')`,
                 () => {
                     // for now treat files as JavaScript
-                    const result = PreProcess.preProcessFile(sourceTextSnapshot.getText(0, sourceTextSnapshot.getLength()), /* readImportFiles */ true, /* detectJavaScriptImports */ true);
+                    const result = preProcessFile(sourceTextSnapshot.getText(0, sourceTextSnapshot.getLength()), /* readImportFiles */ true, /* detectJavaScriptImports */ true);
                     return {
                         referencedFiles: this.convertFileReferences(result.referencedFiles),
                         importedFiles: this.convertFileReferences(result.importedFiles),


### PR DESCRIPTION
The change in #10753 breaks `gulp-tsb` as it depends on the publicly exported `preProcessFile` function which was moved and marked internal. This change removes the `PreProcess` namespace and the `/* @internal */` marker from `src/services/preProcess.ts`.