### PR TITLE
Simplify parameters of `quickInfoIs`

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -954,26 +954,20 @@ namespace FourSlash {
             assert.equal(actual, expected);
         }
 
-        public verifyQuickInfoString(negative: boolean, expectedText?: string, expectedDocumentation?: string) {
+        public verifyQuickInfoString(negative: boolean, expectedText: string, expectedDocumentation?: string) {
             const actualQuickInfo = this.languageService.getQuickInfoAtPosition(this.activeFile.fileName, this.currentCaretPosition);
             const actualQuickInfoText = actualQuickInfo ? ts.displayPartsToString(actualQuickInfo.displayParts) : "";
             const actualQuickInfoDocumentation = actualQuickInfo ? ts.displayPartsToString(actualQuickInfo.documentation) : "";
 
             if (negative) {
-                if (expectedText !== undefined) {
-                    assert.notEqual(actualQuickInfoText, expectedText, this.messageAtLastKnownMarker("quick info text"));
-                }
-                // TODO: should be '==='?
-                if (expectedDocumentation != undefined) {
+                assert.notEqual(actualQuickInfoText, expectedText, this.messageAtLastKnownMarker("quick info text"));
+                if (expectedDocumentation !== undefined) {
                     assert.notEqual(actualQuickInfoDocumentation, expectedDocumentation, this.messageAtLastKnownMarker("quick info doc comment"));
                 }
             }
             else {
-                if (expectedText !== undefined) {
-                    assert.equal(actualQuickInfoText, expectedText, this.messageAtLastKnownMarker("quick info text"));
-                }
-                // TODO: should be '==='?
-                if (expectedDocumentation != undefined) {
+                assert.equal(actualQuickInfoText, expectedText, this.messageAtLastKnownMarker("quick info text"));
+                if (expectedDocumentation !== undefined) {
                     assert.equal(actualQuickInfoDocumentation, expectedDocumentation, this.assertionMessageAtLastKnownMarker("quick info doc"));
                 }
             }
@@ -2969,7 +2963,7 @@ namespace FourSlashInterface {
             this.state.verifyErrorExistsAfterMarker(markerName, !this.negative, /*after*/ false);
         }
 
-        public quickInfoIs(expectedText?: string, expectedDocumentation?: string) {
+        public quickInfoIs(expectedText: string, expectedDocumentation?: string) {
             this.state.verifyQuickInfoString(this.negative, expectedText, expectedDocumentation);
         }
 

--- a/tests/cases/fourslash/commentsLinePreservation.ts
+++ b/tests/cases/fourslash/commentsLinePreservation.ts
@@ -107,55 +107,55 @@
 ////function /*l*/l(param1: string) { /*9*/param1 = "hello"; }
 
 goTo.marker('a');
-verify.quickInfoIs(undefined, "This is firstLine\nThis is second Line\n\nThis is fourth Line");
+verify.quickInfoIs("var a: string", "This is firstLine\nThis is second Line\n\nThis is fourth Line");
 
 goTo.marker('b');
-verify.quickInfoIs(undefined, "This is firstLine\nThis is second Line\n\nThis is fourth Line");
+verify.quickInfoIs("var b: string", "This is firstLine\nThis is second Line\n\nThis is fourth Line");
 
 goTo.marker('c');
-verify.quickInfoIs(undefined, "This is firstLine\nThis is second Line\n\nThis is fourth Line");
+verify.quickInfoIs("var c: string", "This is firstLine\nThis is second Line\n\nThis is fourth Line");
 
 goTo.marker('d');
-verify.quickInfoIs(undefined, "This is firstLine\nThis is second Line\n@random tag This should be third line");
+verify.quickInfoIs("function d(param: string): void", "This is firstLine\nThis is second Line\n@random tag This should be third line");
 goTo.marker('1');
-verify.quickInfoIs(undefined, "");
+verify.quickInfoIs("(parameter) param: string", "");
 
 goTo.marker('e');
-verify.quickInfoIs(undefined, "This is firstLine\nThis is second Line");
+verify.quickInfoIs("function e(param: string): void", "This is firstLine\nThis is second Line");
 goTo.marker('2');
-verify.quickInfoIs(undefined, "");
+verify.quickInfoIs("(parameter) param: string", "");
 
 goTo.marker('f');
-verify.quickInfoIs(undefined, "This is firstLine\nThis is second Line\n@random tag This should be third line");
+verify.quickInfoIs("function f(param1: string): void", "This is firstLine\nThis is second Line\n@random tag This should be third line");
 goTo.marker('3');
-verify.quickInfoIs(undefined, "first line of param\n\nparam information third line");
+verify.quickInfoIs("(parameter) param1: string", "first line of param\n\nparam information third line");
 
 goTo.marker('g');
-verify.quickInfoIs(undefined, "This is firstLine\nThis is second Line\n@random tag This should be third line");
+verify.quickInfoIs("function g(param1: string): void", "This is firstLine\nThis is second Line\n@random tag This should be third line");
 goTo.marker('4');
-verify.quickInfoIs(undefined, "param information first line");
+verify.quickInfoIs("(parameter) param1: string", "param information first line");
 
 goTo.marker('h');
-verify.quickInfoIs(undefined, "This is firstLine\nThis is second Line\n@random tag This should be third line");
+verify.quickInfoIs("function h(param1: string): void", "This is firstLine\nThis is second Line\n@random tag This should be third line");
 goTo.marker('5');
-verify.quickInfoIs(undefined, "param information first line\n\nparam information third line");
+verify.quickInfoIs("(parameter) param1: string", "param information first line\n\nparam information third line");
 
 goTo.marker('i');
-verify.quickInfoIs(undefined, "This is firstLine\nThis is second Line");
+verify.quickInfoIs("function i(param1: string): void", "This is firstLine\nThis is second Line");
 goTo.marker('6');
-verify.quickInfoIs(undefined, "param information first line\n\nparam information third line");
+verify.quickInfoIs("(parameter) param1: string", "param information first line\n\nparam information third line");
 
 goTo.marker('j');
-verify.quickInfoIs(undefined, "This is firstLine\nThis is second Line");
+verify.quickInfoIs("function j(param1: string): void", "This is firstLine\nThis is second Line");
 goTo.marker('7');
-verify.quickInfoIs(undefined, "param information first line\n\nparam information third line");
+verify.quickInfoIs("(parameter) param1: string", "param information first line\n\nparam information third line");
 
 goTo.marker('k');
-verify.quickInfoIs(undefined, "This is firstLine\nThis is second Line\n@randomtag \n\n random information first line\n\n random information third line");
+verify.quickInfoIs("function k(param1: string): void", "This is firstLine\nThis is second Line\n@randomtag \n\n random information first line\n\n random information third line");
 goTo.marker('8');
-verify.quickInfoIs(undefined, "hello   ");
+verify.quickInfoIs("(parameter) param1: string", "hello   ");
 
 goTo.marker('l');
-verify.quickInfoIs(undefined, "This is firstLine\nThis is second Line");
+verify.quickInfoIs("function l(param1: string): void", "This is firstLine\nThis is second Line");
 goTo.marker('9');
-verify.quickInfoIs(undefined, "first Line text\nblank line that shouldnt be shown when starting this \nsecond time information about the param again");
+verify.quickInfoIs("(parameter) param1: string", "first Line text\nblank line that shouldnt be shown when starting this \nsecond time information about the param again");

--- a/tests/cases/fourslash/contextuallyTypedFunctionExpressionGeneric1.ts
+++ b/tests/cases/fourslash/contextuallyTypedFunctionExpressionGeneric1.ts
@@ -10,13 +10,13 @@
 ////var max2: Comparer = (x/*1*/x, y/*2*/y) => { return x/*3*/x.compareTo(y/*4*/y) };
 
 goTo.marker('1');
-verify.quickInfoIs('(parameter) xx: any', null);
+verify.quickInfoIs('(parameter) xx: any');
 
 goTo.marker('2');
-verify.quickInfoIs('(parameter) yy: any', null);
+verify.quickInfoIs('(parameter) yy: any');
 
 goTo.marker('3');
-verify.quickInfoIs('(parameter) xx: any', null);
+verify.quickInfoIs('(parameter) xx: any');
 
 goTo.marker('4');
-verify.quickInfoIs('(parameter) yy: any', null);
+verify.quickInfoIs('(parameter) yy: any');

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -130,7 +130,7 @@ declare namespace FourSlashInterface {
         errorExistsBetweenMarkers(startMarker: string, endMarker: string): void;
         errorExistsAfterMarker(markerName?: string): void;
         errorExistsBeforeMarker(markerName?: string): void;
-        quickInfoIs(expectedText?: string, expectedDocumentation?: string): void;
+        quickInfoIs(expectedText: string, expectedDocumentation?: string): void;
         quickInfoExists(): void;
         typeDefinitionCountIs(expectedCount: number): void;
         isValidBraceCompletionAtPosition(openingBrace?: string): void;

--- a/tests/cases/fourslash/genericFunctionWithGenericParams1.ts
+++ b/tests/cases/fourslash/genericFunctionWithGenericParams1.ts
@@ -6,4 +6,4 @@
 ////};
 
 goTo.marker();
-verify.quickInfoIs('(local var) xx: T', null);
+verify.quickInfoIs('(local var) xx: T');

--- a/tests/cases/fourslash/genericInterfacesWithConstraints1.ts
+++ b/tests/cases/fourslash/genericInterfacesWithConstraints1.ts
@@ -12,8 +12,8 @@
 ////var v/*3*/3: G<G<A, B>, C>;         // Ok
 
 goTo.marker('1');
-verify.quickInfoIs('var v1: G<A, C>', null);
+verify.quickInfoIs('var v1: G<A, C>');
 goTo.marker('2');
-verify.quickInfoIs('var v2: G<{\n    a: string;\n}, C>', null);
+verify.quickInfoIs('var v2: G<{\n    a: string;\n}, C>');
 goTo.marker('3');
-verify.quickInfoIs('var v3: G<G<A, B>, C>', null);
+verify.quickInfoIs('var v3: G<G<A, B>, C>');

--- a/tests/cases/fourslash/genericTypeParamUnrelatedToArguments1.ts
+++ b/tests/cases/fourslash/genericTypeParamUnrelatedToArguments1.ts
@@ -11,19 +11,19 @@
 ////var f/*6*/6: Foo<number> = new Foo<number>(3);
 
 goTo.marker('1');
-verify.quickInfoIs('var f1: Foo<number>', null);
+verify.quickInfoIs('var f1: Foo<number>');
 
 goTo.marker('2');
-verify.quickInfoIs('var f2: Foo<number>', null);
+verify.quickInfoIs('var f2: Foo<number>');
 
 goTo.marker('3');
-verify.quickInfoIs('var f3: any', null);
+verify.quickInfoIs('var f3: any');
 
 goTo.marker('4');
-verify.quickInfoIs('var f4: Foo<number>', null);
+verify.quickInfoIs('var f4: Foo<number>');
 
 goTo.marker('5');
-verify.quickInfoIs('var f5: any', null);
+verify.quickInfoIs('var f5: any');
 
 goTo.marker('6');
-verify.quickInfoIs('var f6: Foo<number>', null);
+verify.quickInfoIs('var f6: Foo<number>');

--- a/tests/cases/fourslash/quickInfoOnGenericClass.ts
+++ b/tests/cases/fourslash/quickInfoOnGenericClass.ts
@@ -5,4 +5,4 @@
 ////}
 
 goTo.marker();
-verify.quickInfoIs('class Container<T>', null);
+verify.quickInfoIs('class Container<T>');

--- a/tests/cases/fourslash/quickInfoOnGenericWithConstraints1.ts
+++ b/tests/cases/fourslash/quickInfoOnGenericWithConstraints1.ts
@@ -3,7 +3,7 @@
 ////interface Fo/*1*/o<T/*2*/T extends Date> {}
 
 goTo.marker('1');
-verify.quickInfoIs('interface Foo<TT extends Date>', null);
+verify.quickInfoIs('interface Foo<TT extends Date>');
 
 goTo.marker('2');
-verify.quickInfoIs('(type parameter) TT in Foo<TT extends Date>', null);
+verify.quickInfoIs('(type parameter) TT in Foo<TT extends Date>');

--- a/tests/cases/fourslash/recursiveObjectLiteral.ts
+++ b/tests/cases/fourslash/recursiveObjectLiteral.ts
@@ -3,4 +3,4 @@
 ////var a = { f: /**/a
 
 goTo.marker();
-verify.quickInfoIs("var a: any", null);
+verify.quickInfoIs("var a: any");


### PR DESCRIPTION
`expectedText` must be present and `expectedDocumentation` must be a string or ommitted, never null.