### PR TITLE
Fix ECMA-402 declarations (issue #10618)

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -3949,12 +3949,9 @@ declare module Intl {
         resolvedOptions(): ResolvedCollatorOptions;
     }
     var Collator: {
-        new (locales?: string[], options?: CollatorOptions): Collator;
-        new (locale?: string, options?: CollatorOptions): Collator;
-        (locales?: string[], options?: CollatorOptions): Collator;
-        (locale?: string, options?: CollatorOptions): Collator;
-        supportedLocalesOf(locales: string[], options?: CollatorOptions): string[];
-        supportedLocalesOf(locale: string, options?: CollatorOptions): string[];
+        new (locales?: string | string[], options?: CollatorOptions): Collator;
+        (locales?: string | string[], options?: CollatorOptions): Collator;
+        supportedLocalesOf(locales: string | string[], options?: CollatorOptions): string[];
     }
 
     interface NumberFormatOptions {
@@ -3989,12 +3986,9 @@ declare module Intl {
         resolvedOptions(): ResolvedNumberFormatOptions;
     }
     var NumberFormat: {
-        new (locales?: string[], options?: NumberFormatOptions): NumberFormat;
-        new (locale?: string, options?: NumberFormatOptions): NumberFormat;
-        (locales?: string[], options?: NumberFormatOptions): NumberFormat;
-        (locale?: string, options?: NumberFormatOptions): NumberFormat;
-        supportedLocalesOf(locales: string[], options?: NumberFormatOptions): string[];
-        supportedLocalesOf(locale: string, options?: NumberFormatOptions): string[];
+        new (locales?: string | string[], options?: NumberFormatOptions): NumberFormat;
+        (locales?: string | string[], options?: NumberFormatOptions): NumberFormat;
+        supportedLocalesOf(locales: string | string[], options?: NumberFormatOptions): string[];
     }
 
     interface DateTimeFormatOptions {
@@ -4035,88 +4029,49 @@ declare module Intl {
         resolvedOptions(): ResolvedDateTimeFormatOptions;
     }
     var DateTimeFormat: {
-        new (locales?: string[], options?: DateTimeFormatOptions): DateTimeFormat;
-        new (locale?: string, options?: DateTimeFormatOptions): DateTimeFormat;
-        (locales?: string[], options?: DateTimeFormatOptions): DateTimeFormat;
-        (locale?: string, options?: DateTimeFormatOptions): DateTimeFormat;
-        supportedLocalesOf(locales: string[], options?: DateTimeFormatOptions): string[];
-        supportedLocalesOf(locale: string, options?: DateTimeFormatOptions): string[];
+        new (locales?: string | string[], options?: DateTimeFormatOptions): DateTimeFormat;
+        (locales?: string | string[], options?: DateTimeFormatOptions): DateTimeFormat;
+        supportedLocalesOf(locales: string | string[], options?: DateTimeFormatOptions): string[];
     }
 }
 
 interface String {
     /**
-      * Determines whether two strings are equivalent in the current locale.
+      * Determines whether two strings are equivalent in the current or specified locale.
       * @param that String to compare to target string
-      * @param locales An array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used. This parameter must conform to BCP 47 standards; see the Intl.Collator object for details.
+      * @param locales A locale string or array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used. This parameter must conform to BCP 47 standards; see the Intl.Collator object for details.
       * @param options An object that contains one or more properties that specify comparison options. see the Intl.Collator object for details.
       */
-    localeCompare(that: string, locales: string[], options?: Intl.CollatorOptions): number;
-
-    /**
-      * Determines whether two strings are equivalent in the current locale.
-      * @param that String to compare to target string
-      * @param locale Locale tag. If you omit this parameter, the default locale of the JavaScript runtime is used. This parameter must conform to BCP 47 standards; see the Intl.Collator object for details.
-      * @param options An object that contains one or more properties that specify comparison options. see the Intl.Collator object for details.
-      */
-    localeCompare(that: string, locale: string, options?: Intl.CollatorOptions): number;
+    localeCompare(that: string, locales?: string | string[], options?: Intl.CollatorOptions): number;
 }
 
 interface Number {
     /**
       * Converts a number to a string by using the current or specified locale.
-      * @param locales An array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
+      * @param locales A locale string or array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
       * @param options An object that contains one or more properties that specify comparison options.
       */
-    toLocaleString(locales?: string[], options?: Intl.NumberFormatOptions): string;
-
-    /**
-      * Converts a number to a string by using the current or specified locale.
-      * @param locale Locale tag. If you omit this parameter, the default locale of the JavaScript runtime is used.
-      * @param options An object that contains one or more properties that specify comparison options.
-      */
-    toLocaleString(locale?: string, options?: Intl.NumberFormatOptions): string;
+    toLocaleString(locales?: string | string[], options?: Intl.NumberFormatOptions): string;
 }
 
 interface Date {
     /**
       * Converts a date and time to a string by using the current or specified locale.
-      * @param locales An array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
+      * @param locales A locale string or array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
       * @param options An object that contains one or more properties that specify comparison options.
       */
-    toLocaleString(locales?: string[], options?: Intl.DateTimeFormatOptions): string;
+    toLocaleString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
     /**
       * Converts a date to a string by using the current or specified locale.
-      * @param locales An array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
+      * @param locales A locale string or array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
       * @param options An object that contains one or more properties that specify comparison options.
       */
-    toLocaleDateString(locales?: string[], options?: Intl.DateTimeFormatOptions): string;
+    toLocaleDateString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
 
     /**
       * Converts a time to a string by using the current or specified locale.
-      * @param locale Locale tag. If you omit this parameter, the default locale of the JavaScript runtime is used.
+      * @param locales A locale string or array of locale strings that contain one or more language or locale tags. If you include more than one locale string, list them in descending order of priority so that the first entry is the preferred locale. If you omit this parameter, the default locale of the JavaScript runtime is used.
       * @param options An object that contains one or more properties that specify comparison options.
       */
-    toLocaleTimeString(locale?: string[], options?: Intl.DateTimeFormatOptions): string;
-
-    /**
-      * Converts a date and time to a string by using the current or specified locale.
-      * @param locale Locale tag. If you omit this parameter, the default locale of the JavaScript runtime is used.
-      * @param options An object that contains one or more properties that specify comparison options.
-      */
-    toLocaleString(locale?: string, options?: Intl.DateTimeFormatOptions): string;
-
-    /**
-      * Converts a date to a string by using the current or specified locale.
-      * @param locale Locale tag. If you omit this parameter, the default locale of the JavaScript runtime is used.
-      * @param options An object that contains one or more properties that specify comparison options.
-      */
-    toLocaleDateString(locale?: string, options?: Intl.DateTimeFormatOptions): string;
-
-    /**
-      * Converts a time to a string by using the current or specified locale.
-      * @param locale Locale tag. If you omit this parameter, the default locale of the JavaScript runtime is used.
-      * @param options An object that contains one or more properties that specify comparison options.
-      */
-    toLocaleTimeString(locale?: string, options?: Intl.DateTimeFormatOptions): string;
+    toLocaleTimeString(locales?: string | string[], options?: Intl.DateTimeFormatOptions): string;
 }

--- a/tests/baselines/reference/library_DatePrototypeProperties.symbols
+++ b/tests/baselines/reference/library_DatePrototypeProperties.symbols
@@ -30,25 +30,25 @@ Date.prototype.toTimeString();
 >toTimeString : Symbol(Date.toTimeString, Decl(lib.d.ts, --, --))
 
 Date.prototype.toLocaleString();
->Date.prototype.toLocaleString : Symbol(Date.toLocaleString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>Date.prototype.toLocaleString : Symbol(Date.toLocaleString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Date.prototype : Symbol(DateConstructor.prototype, Decl(lib.d.ts, --, --))
 >Date : Symbol(Date, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >prototype : Symbol(DateConstructor.prototype, Decl(lib.d.ts, --, --))
->toLocaleString : Symbol(Date.toLocaleString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>toLocaleString : Symbol(Date.toLocaleString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
 Date.prototype.toLocaleDateString();
->Date.prototype.toLocaleDateString : Symbol(Date.toLocaleDateString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>Date.prototype.toLocaleDateString : Symbol(Date.toLocaleDateString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Date.prototype : Symbol(DateConstructor.prototype, Decl(lib.d.ts, --, --))
 >Date : Symbol(Date, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >prototype : Symbol(DateConstructor.prototype, Decl(lib.d.ts, --, --))
->toLocaleDateString : Symbol(Date.toLocaleDateString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>toLocaleDateString : Symbol(Date.toLocaleDateString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
 Date.prototype.toLocaleTimeString();
->Date.prototype.toLocaleTimeString : Symbol(Date.toLocaleTimeString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>Date.prototype.toLocaleTimeString : Symbol(Date.toLocaleTimeString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >Date.prototype : Symbol(DateConstructor.prototype, Decl(lib.d.ts, --, --))
 >Date : Symbol(Date, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >prototype : Symbol(DateConstructor.prototype, Decl(lib.d.ts, --, --))
->toLocaleTimeString : Symbol(Date.toLocaleTimeString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>toLocaleTimeString : Symbol(Date.toLocaleTimeString, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
 Date.prototype.valueOf();
 >Date.prototype.valueOf : Symbol(Date.valueOf, Decl(lib.d.ts, --, --))

--- a/tests/baselines/reference/library_DatePrototypeProperties.types
+++ b/tests/baselines/reference/library_DatePrototypeProperties.types
@@ -34,27 +34,27 @@ Date.prototype.toTimeString();
 
 Date.prototype.toLocaleString();
 >Date.prototype.toLocaleString() : string
->Date.prototype.toLocaleString : { (): string; (locales?: string[], options?: Intl.DateTimeFormatOptions): string; (locale?: string, options?: Intl.DateTimeFormatOptions): string; }
+>Date.prototype.toLocaleString : { (): string; (locales?: string | string[], options?: Intl.DateTimeFormatOptions): string; }
 >Date.prototype : Date
 >Date : DateConstructor
 >prototype : Date
->toLocaleString : { (): string; (locales?: string[], options?: Intl.DateTimeFormatOptions): string; (locale?: string, options?: Intl.DateTimeFormatOptions): string; }
+>toLocaleString : { (): string; (locales?: string | string[], options?: Intl.DateTimeFormatOptions): string; }
 
 Date.prototype.toLocaleDateString();
 >Date.prototype.toLocaleDateString() : string
->Date.prototype.toLocaleDateString : { (): string; (locales?: string[], options?: Intl.DateTimeFormatOptions): string; (locale?: string, options?: Intl.DateTimeFormatOptions): string; }
+>Date.prototype.toLocaleDateString : { (): string; (locales?: string | string[], options?: Intl.DateTimeFormatOptions): string; }
 >Date.prototype : Date
 >Date : DateConstructor
 >prototype : Date
->toLocaleDateString : { (): string; (locales?: string[], options?: Intl.DateTimeFormatOptions): string; (locale?: string, options?: Intl.DateTimeFormatOptions): string; }
+>toLocaleDateString : { (): string; (locales?: string | string[], options?: Intl.DateTimeFormatOptions): string; }
 
 Date.prototype.toLocaleTimeString();
 >Date.prototype.toLocaleTimeString() : string
->Date.prototype.toLocaleTimeString : { (): string; (locale?: string[], options?: Intl.DateTimeFormatOptions): string; (locale?: string, options?: Intl.DateTimeFormatOptions): string; }
+>Date.prototype.toLocaleTimeString : { (): string; (locales?: string | string[], options?: Intl.DateTimeFormatOptions): string; }
 >Date.prototype : Date
 >Date : DateConstructor
 >prototype : Date
->toLocaleTimeString : { (): string; (locale?: string[], options?: Intl.DateTimeFormatOptions): string; (locale?: string, options?: Intl.DateTimeFormatOptions): string; }
+>toLocaleTimeString : { (): string; (locales?: string | string[], options?: Intl.DateTimeFormatOptions): string; }
 
 Date.prototype.valueOf();
 >Date.prototype.valueOf() : number


### PR DESCRIPTION
Fixes #10618

1. Make String.prototype.localeCompare's `locales` parameter optional, so `undefined` is allowed.
2. Declare the `locales` parameter as a `string | string[]` union instead of using overloads. Having separate overloads for `string` and `string[]` unnecessarily prevents passing a `string | string[]`. (These overloads predate the introduction of union types.)