### PR TITLE
Fix issue with helper emit.

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -252,7 +252,9 @@ const _super = (function (geti, seti) {
 
             // Emit helpers from all the files
             if (isBundledEmit && moduleKind) {
-                forEach(sourceFiles, emitEmitHelpers);
+                for (const sourceFile of sourceFiles) {
+                    emitEmitHelpers(sourceFile);
+                }
             }
 
             // Print each transformed source file.


### PR DESCRIPTION
Helpers are not emit correctly for bundles due to `forEach` exiting early. This change switches to using `for..of` to avoid the early exit.

Fixes #10800