### PR TITLE
Support export default for target=ES5/module=ES6.

### DIFF
--- a/tests/baselines/reference/es5andes6module.js
+++ b/tests/baselines/reference/es5andes6module.js
@@ -23,3 +23,4 @@ var A = (function () {
     };
     return A;
 }());
+export default A;

--- a/tests/baselines/reference/es6modulekindWithES5Target.js
+++ b/tests/baselines/reference/es6modulekindWithES5Target.js
@@ -27,7 +27,7 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-var C = (function () {
+export var C = (function () {
     function C() {
         this.p = 1;
     }

--- a/tests/baselines/reference/es6modulekindWithES5Target2.js
+++ b/tests/baselines/reference/es6modulekindWithES5Target2.js
@@ -15,4 +15,5 @@ var C = (function () {
     C.prototype.method = function () { };
     return C;
 }());
+export default C;
 C.s = 0;

--- a/tests/baselines/reference/externModule.js
+++ b/tests/baselines/reference/externModule.js
@@ -43,7 +43,7 @@ n=XDate.UTC(1964,2,1);
 declare;
 module;
 {
-    var XDate = (function () {
+    export var XDate = (function () {
         function XDate() {
         }
         return XDate;

--- a/tests/baselines/reference/moduleElementsInWrongContext.js
+++ b/tests/baselines/reference/moduleElementsInWrongContext.js
@@ -44,6 +44,7 @@
         }
         return C;
     }());
+    export default C;
     function bee() { }
     import I2 = require("foo");
     import * as Foo from "ambient";

--- a/tests/baselines/reference/moduleElementsInWrongContext2.js
+++ b/tests/baselines/reference/moduleElementsInWrongContext2.js
@@ -44,6 +44,7 @@ function blah() {
         }
         return C;
     }());
+    export default C;
     function bee() { }
     import I2 = require("foo");
     import * as Foo from "ambient";


### PR DESCRIPTION
Fixes the emit for exported down-level classes when the options `--target es5 --module es6` are used.

Fixes #10855