### PR TITLE
Fix missing final label

### DIFF
--- a/tests/baselines/reference/generatorTransformFinalLabel.js
+++ b/tests/baselines/reference/generatorTransformFinalLabel.js
@@ -1,0 +1,28 @@
+//// [generatorTransformFinalLabel.ts]
+async function test(skip: boolean) {
+    if (!skip) {
+        await 1
+    }
+    else {
+        throw Error('test')
+    }
+}
+
+//// [generatorTransformFinalLabel.js]
+function test(skip) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    if (!!skip)
+                        return [3 /*break*/, 2];
+                    return [4 /*yield*/, 1];
+                case 1:
+                    _a.sent();
+                    return [3 /*break*/, 3];
+                case 2: throw Error('test');
+                case 3: return [2 /*return*/];
+            }
+        });
+    });
+}

--- a/tests/baselines/reference/generatorTransformFinalLabel.symbols
+++ b/tests/baselines/reference/generatorTransformFinalLabel.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/generatorTransformFinalLabel.ts ===
+async function test(skip: boolean) {
+>test : Symbol(test, Decl(generatorTransformFinalLabel.ts, 0, 0))
+>skip : Symbol(skip, Decl(generatorTransformFinalLabel.ts, 0, 20))
+
+    if (!skip) {
+>skip : Symbol(skip, Decl(generatorTransformFinalLabel.ts, 0, 20))
+
+        await 1
+    }
+    else {
+        throw Error('test')
+>Error : Symbol(Error, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+    }
+}

--- a/tests/baselines/reference/generatorTransformFinalLabel.types
+++ b/tests/baselines/reference/generatorTransformFinalLabel.types
@@ -1,0 +1,20 @@
+=== tests/cases/compiler/generatorTransformFinalLabel.ts ===
+async function test(skip: boolean) {
+>test : (skip: boolean) => Promise<void>
+>skip : boolean
+
+    if (!skip) {
+>!skip : boolean
+>skip : boolean
+
+        await 1
+>await 1 : 1
+>1 : 1
+    }
+    else {
+        throw Error('test')
+>Error('test') : Error
+>Error : ErrorConstructor
+>'test' : "test"
+    }
+}

--- a/tests/cases/compiler/generatorTransformFinalLabel.ts
+++ b/tests/cases/compiler/generatorTransformFinalLabel.ts
@@ -1,0 +1,11 @@
+// @target: es5
+// @lib: es5,es6
+// @noEmitHelpers: true
+async function test(skip: boolean) {
+    if (!skip) {
+        await 1
+    }
+    else {
+        throw Error('test')
+    }
+}


### PR DESCRIPTION
The generator transformer tries to avoid emitting an unnecessary final `return` statement if it would be otherwise unreachable. However, the detection logic for this case did not account for the possibility of a preceding break instruction pointing to the final label. This expands on the detection logic for this case.

Fixes #10876