### PR TITLE
Simplify quick-info tests

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -954,23 +954,35 @@ namespace FourSlash {
             assert.equal(actual, expected);
         }
 
-        public verifyQuickInfoString(negative: boolean, expectedText: string, expectedDocumentation?: string) {
+        public verifyQuickInfoAt(markerName: string, expectedText: string, expectedDocumentation?: string) {
+            this.goToMarker(markerName);
+            this.verifyQuickInfoString(expectedText, expectedDocumentation);
+        }
+
+        public verifyQuickInfos(namesAndTexts: { [name: string]: string | [string, string] }) {
+            ts.forEachProperty(ts.createMap(namesAndTexts), (text, name) => {
+                if (text instanceof Array) {
+                    assert(text.length === 2);
+                    const [expectedText, expectedDocumentation] = text;
+                    this.verifyQuickInfoAt(name, expectedText, expectedDocumentation);
+                }
+                else {
+                    this.verifyQuickInfoAt(name, text);
+                }
+            });
+        }
+
+        public verifyQuickInfoString(expectedText: string, expectedDocumentation?: string) {
+            if (expectedDocumentation === "") {
+                throw new Error("Use 'undefined' instead");
+            }
+
             const actualQuickInfo = this.languageService.getQuickInfoAtPosition(this.activeFile.fileName, this.currentCaretPosition);
             const actualQuickInfoText = actualQuickInfo ? ts.displayPartsToString(actualQuickInfo.displayParts) : "";
             const actualQuickInfoDocumentation = actualQuickInfo ? ts.displayPartsToString(actualQuickInfo.documentation) : "";
 
-            if (negative) {
-                assert.notEqual(actualQuickInfoText, expectedText, this.messageAtLastKnownMarker("quick info text"));
-                if (expectedDocumentation !== undefined) {
-                    assert.notEqual(actualQuickInfoDocumentation, expectedDocumentation, this.messageAtLastKnownMarker("quick info doc comment"));
-                }
-            }
-            else {
-                assert.equal(actualQuickInfoText, expectedText, this.messageAtLastKnownMarker("quick info text"));
-                if (expectedDocumentation !== undefined) {
-                    assert.equal(actualQuickInfoDocumentation, expectedDocumentation, this.assertionMessageAtLastKnownMarker("quick info doc"));
-                }
-            }
+            assert.equal(actualQuickInfoText, expectedText, this.messageAtLastKnownMarker("quick info text"));
+            assert.equal(actualQuickInfoDocumentation, expectedDocumentation || "", this.assertionMessageAtLastKnownMarker("quick info doc"));
         }
 
         public verifyQuickInfoDisplayParts(kind: string, kindModifiers: string, textSpan: { start: number; length: number; },
@@ -2963,10 +2975,6 @@ namespace FourSlashInterface {
             this.state.verifyErrorExistsAfterMarker(markerName, !this.negative, /*after*/ false);
         }
 
-        public quickInfoIs(expectedText: string, expectedDocumentation?: string) {
-            this.state.verifyQuickInfoString(this.negative, expectedText, expectedDocumentation);
-        }
-
         public quickInfoExists() {
             this.state.verifyQuickInfoExists(this.negative);
         }
@@ -2983,6 +2991,18 @@ namespace FourSlashInterface {
     export class Verify extends VerifyNegatable {
         constructor(state: FourSlash.TestState) {
             super(state);
+        }
+
+        public quickInfoIs(expectedText: string, expectedDocumentation?: string) {
+            this.state.verifyQuickInfoString(expectedText, expectedDocumentation);
+        }
+
+        public quickInfoAt(markerName: string, expectedText?: string, expectedDocumentation?: string) {
+            this.state.verifyQuickInfoAt(markerName, expectedText, expectedDocumentation);
+        }
+
+        public quickInfos(namesAndTexts: { [name: string]: string }) {
+            this.state.verifyQuickInfos(namesAndTexts);
         }
 
         public caretAtMarker(markerName?: string) {

--- a/tests/cases/fourslash/addInterfaceMemberAboveClass.ts
+++ b/tests/cases/fourslash/addInterfaceMemberAboveClass.ts
@@ -10,12 +10,9 @@
 ////     }
 //// }
 
-goTo.marker('className');
-verify.quickInfoIs('class Sphere');
+verify.quickInfoAt("className", "class Sphere");
 
 goTo.marker('insertHere');
 edit.insert("ray: Ray;");
 
-goTo.marker('className');
-
-verify.quickInfoIs('class Sphere');
+verify.quickInfoAt("className", "class Sphere");

--- a/tests/cases/fourslash/addMemberToInterface.ts
+++ b/tests/cases/fourslash/addMemberToInterface.ts
@@ -10,11 +10,9 @@
 
 edit.disableFormatting();
 
-goTo.marker('check');
-verify.quickInfoIs('namespace Mod');
+verify.quickInfoAt("check", "namespace Mod");
 
 goTo.marker('insert');
 edit.insert("x: number;\n");
 
-goTo.marker('check');
-verify.quickInfoIs('namespace Mod');
+verify.quickInfoAt("check", "namespace Mod");

--- a/tests/cases/fourslash/aliasMergingWithNamespace.ts
+++ b/tests/cases/fourslash/aliasMergingWithNamespace.ts
@@ -3,7 +3,6 @@
 ////namespace bar { }
 ////import bar = bar/**/;
 
-goTo.marker();
-verify.quickInfoIs(
+verify.quickInfoAt("",
 `namespace bar
 import bar = bar`);

--- a/tests/cases/fourslash/ambientShorthandGotoDefinition.ts
+++ b/tests/cases/fourslash/ambientShorthandGotoDefinition.ts
@@ -10,26 +10,22 @@
 /////*importBang*/import /*idBang*/bang = require("jquery");
 ////foo/*useFoo*/(bar/*useBar*/, baz/*useBaz*/, bang/*useBang*/);
 
-goTo.marker("useFoo");
-verify.quickInfoIs("import foo");
+verify.quickInfoAt("useFoo", "import foo");
 verify.goToDefinition({
     useFoo: "importFoo",
     importFoo: "module"
 });
 
-goTo.marker("useBar");
-verify.quickInfoIs("import bar");
+verify.quickInfoAt("useBar", "import bar");
 verify.goToDefinition("useBar", "module");
 
-goTo.marker("useBaz");
-verify.quickInfoIs("import baz");
+verify.quickInfoAt("useBaz", "import baz");
 verify.goToDefinition({
     useBaz: "importBaz",
     idBaz: "module"
 });
 
-goTo.marker("useBang");
-verify.quickInfoIs("import bang = require(\"jquery\")");
+verify.quickInfoAt("useBang", "import bang = require(\"jquery\")");
 verify.goToDefinition({
     useBang: "importBang",
     idBang: "module"

--- a/tests/cases/fourslash/arrayCallAndConstructTypings.ts
+++ b/tests/cases/fourslash/arrayCallAndConstructTypings.ts
@@ -11,33 +11,15 @@
 ////var a/*9*/9 = Array<boolean>(1);
 ////var a/*10*/10 = Array("s");
 
-
-goTo.marker('1');
-verify.quickInfoIs('var a1: any[]');
-
-goTo.marker('2');
-verify.quickInfoIs('var a2: any[]');
-
-goTo.marker('3');
-verify.quickInfoIs('var a3: boolean[]');
-
-goTo.marker('4');
-verify.quickInfoIs('var a4: boolean[]');
-
-goTo.marker('5');
-verify.quickInfoIs('var a5: string[]');
-
-goTo.marker('6');
-verify.quickInfoIs('var a6: any[]');
-
-goTo.marker('7');
-verify.quickInfoIs('var a7: any[]');
-
-goTo.marker('8');
-verify.quickInfoIs('var a8: boolean[]');
-
-goTo.marker('9');
-verify.quickInfoIs('var a9: boolean[]');
-
-goTo.marker('10');
-verify.quickInfoIs('var a10: string[]');
+verify.quickInfos({
+    1: "var a1: any[]",
+    2: "var a2: any[]",
+    3: "var a3: boolean[]",
+    4: "var a4: boolean[]",
+    5: "var a5: string[]",
+    6: "var a6: any[]",
+    7: "var a7: any[]",
+    8: "var a8: boolean[]",
+    9: "var a9: boolean[]",
+    10: "var a10: string[]"
+});

--- a/tests/cases/fourslash/assertContextualType.ts
+++ b/tests/cases/fourslash/assertContextualType.ts
@@ -2,5 +2,4 @@
 
 ////<(aa: number) =>void >(function myFn(b/**/b) { });
 
-goTo.marker();
-verify.quickInfoIs('(parameter) bb: number');
+verify.quickInfoAt("", "(parameter) bb: number");

--- a/tests/cases/fourslash/augmentedTypesClass3.ts
+++ b/tests/cases/fourslash/augmentedTypesClass3.ts
@@ -4,11 +4,10 @@
 ////namespace c/*2*/5b { export var y = 2; } // should be ok
 /////*3*/
 
-goTo.marker('1');
-verify.quickInfoIs("class c5b\nnamespace c5b");
-
-goTo.marker('2');
-verify.quickInfoIs("class c5b\nnamespace c5b");
+verify.quickInfos({
+    1: "class c5b\nnamespace c5b",
+    2: "class c5b\nnamespace c5b"
+});
 
 goTo.marker('3');
 verify.completionListContains("c5b", "class c5b\nnamespace c5b");

--- a/tests/cases/fourslash/augmentedTypesModule1.ts
+++ b/tests/cases/fourslash/augmentedTypesModule1.ts
@@ -11,5 +11,4 @@ goTo.marker('1');
 verify.completionListContains('I');
 verify.not.completionListContains('foo');
 
-goTo.marker('2');
-verify.quickInfoIs('var r: number');
+verify.quickInfoAt("2", "var r: number");

--- a/tests/cases/fourslash/augmentedTypesModule2.ts
+++ b/tests/cases/fourslash/augmentedTypesModule2.ts
@@ -5,8 +5,7 @@
 ////var x: m2f./*1*/
 ////var /*2*/r = m2f/*3*/;
 
-goTo.marker('11');
-verify.quickInfoIs('function m2f(x: number): void\nnamespace m2f');
+verify.quickInfoAt("11", "function m2f(x: number): void\nnamespace m2f");
 
 goTo.marker('1');
 verify.completionListContains('I');
@@ -15,8 +14,7 @@ edit.insert('I.');
 verify.not.completionListContains('foo');
 edit.backspace(1);
 
-goTo.marker('2');
-verify.quickInfoIs('var r: (x: number) => void');
+verify.quickInfoAt("2", "var r: (x: number) => void");
 
 goTo.marker('3');
 edit.insert('(');

--- a/tests/cases/fourslash/augmentedTypesModule3.ts
+++ b/tests/cases/fourslash/augmentedTypesModule3.ts
@@ -12,8 +12,7 @@ edit.insert('C.');
 verify.not.completionListContains('foo');
 edit.backspace(1);
 
-goTo.marker('2');
-verify.quickInfoIs("var r: typeof m2g");
+verify.quickInfoAt("2", "var r: typeof m2g");
 
 goTo.marker('3');
 edit.insert('(');

--- a/tests/cases/fourslash/augmentedTypesModule4.ts
+++ b/tests/cases/fourslash/augmentedTypesModule4.ts
@@ -6,8 +6,7 @@
 ////r./*2*/
 ////var /*4*/r2 = m3d./*3*/
 
-goTo.marker('1');
-verify.quickInfoIs('var r: m3d');
+verify.quickInfoAt("1", "var r: m3d");
 
 goTo.marker('2');
 verify.completionListContains('foo');
@@ -17,5 +16,4 @@ goTo.marker('3');
 verify.completionListContains('y');
 edit.insert('y;');
 
-goTo.marker('4');
-verify.quickInfoIs('var r2: number');
+verify.quickInfoAt("4", "var r2: number");

--- a/tests/cases/fourslash/augmentedTypesModule5.ts
+++ b/tests/cases/fourslash/augmentedTypesModule5.ts
@@ -6,8 +6,7 @@
 ////r./*2*/
 ////var /*4*/r2 = m3e./*3*/
 
-goTo.marker('1');
-verify.quickInfoIs('var r: m3e');
+verify.quickInfoAt("1", "var r: m3e");
 
 goTo.marker('2');
 verify.completionListContains('foo');
@@ -18,5 +17,4 @@ goTo.marker('3');
 verify.completionListContains('y');
 edit.insert('y;');
 
-goTo.marker('4');
-verify.quickInfoIs('var r2: number');
+verify.quickInfoAt("4", "var r2: number");

--- a/tests/cases/fourslash/augmentedTypesModule6.ts
+++ b/tests/cases/fourslash/augmentedTypesModule6.ts
@@ -19,8 +19,7 @@ verify.completionListContains('m3f');
 goTo.marker('3');
 verify.currentSignatureHelpIs('m3f(): m3f');
 
-goTo.marker('4');
-verify.quickInfoIs('var r: m3f');
+verify.quickInfoAt("4", "var r: m3f");
 
 goTo.marker('5');
 verify.completionListContains('foo');

--- a/tests/cases/fourslash/automaticConstructorToggling.ts
+++ b/tests/cases/fourslash/automaticConstructorToggling.ts
@@ -16,42 +16,27 @@ var C = 'C';
 var D = 'D'
 goTo.marker(B);
 edit.insert('constructor(val: T) { }');
-goTo.marker('Asig');
-verify.quickInfoIs("constructor A<string>(): A<string>");
-
-goTo.marker('Bsig');
-verify.quickInfoIs("constructor B<string>(val: string): B<string>");
-
-goTo.marker('Csig'); 
-verify.quickInfoIs("constructor C<string>(val: string): C<string>");
-
-goTo.marker('Dsig');
-verify.quickInfoIs("constructor D<T>(val: T): D<T>"); // Cannot resolve signature
+verify.quickInfos({
+    Asig: "constructor A<string>(): A<string>",
+    Bsig: "constructor B<string>(val: string): B<string>",
+    Csig: "constructor C<string>(val: string): C<string>",
+    Dsig: "constructor D<T>(val: T): D<T>" // Cannot resolve signature
+});
 
 goTo.marker(C);
 edit.deleteAtCaret('constructor(val: T) { }'.length);
-goTo.marker('Asig');
-verify.quickInfoIs("constructor A<string>(): A<string>");
-
-goTo.marker('Bsig');
-verify.quickInfoIs("constructor B<string>(val: string): B<string>");
-
-goTo.marker('Csig');
-verify.quickInfoIs("constructor C<T>(): C<T>"); // Cannot resolve signature
-
-goTo.marker('Dsig');
-verify.quickInfoIs("constructor D<T>(val: T): D<T>"); // Cannot resolve signature
+verify.quickInfos({
+    Asig: "constructor A<string>(): A<string>",
+    Bsig: "constructor B<string>(val: string): B<string>",
+    Csig: "constructor C<T>(): C<T>", // Cannot resolve signature
+    Dsig: "constructor D<T>(val: T): D<T>" // Cannot resolve signature
+});
 
 goTo.marker(D);
 edit.deleteAtCaret("val: T".length);
-goTo.marker('Asig');
-verify.quickInfoIs("constructor A<string>(): A<string>");
-
-goTo.marker('Bsig');
-verify.quickInfoIs("constructor B<string>(val: string): B<string>");
-
-goTo.marker('Csig');
-verify.quickInfoIs("constructor C<T>(): C<T>"); // Cannot resolve signature
-
-goTo.marker('Dsig');
-verify.quickInfoIs("constructor D<string>(): D<string>");
+verify.quickInfos({
+    Asig: "constructor A<string>(): A<string>",
+    Bsig: "constructor B<string>(val: string): B<string>",
+    Csig: "constructor C<T>(): C<T>", // Cannot resolve signature
+    Dsig: "constructor D<string>(): D<string>"
+});

--- a/tests/cases/fourslash/bestCommonTypeObjectLiterals1.ts
+++ b/tests/cases/fourslash/bestCommonTypeObjectLiterals1.ts
@@ -20,23 +20,18 @@
 ////var i: I;
 ////var /*4*/c3 = [i, a];
 
-goTo.marker('1');
-verify.quickInfoIs('var c: {\n    name: string;\n    age: number;\n}[]');
-
-goTo.marker('2');
-verify.quickInfoIs('var c1: {\n    name: string;\n    age: number;\n}[]');
-
-goTo.marker('3');
-verify.quickInfoIs('var c2: ({\n\
-    name: string;\n\
-    age: number;\n\
-    address: string;\n\
-} | {\n\
-    name: string;\n\
-    age: number;\n\
-    dob: Date;\n\
-})[]');
-
-goTo.marker('4');
-verify.quickInfoIs('var c3: I[]');
-
+verify.quickInfos({
+    1: "var c: {\n    name: string;\n    age: number;\n}[]",
+    2: "var c1: {\n    name: string;\n    age: number;\n}[]",
+    3:
+`var c2: ({
+    name: string;
+    age: number;
+    address: string;
+} | {
+    name: string;
+    age: number;
+    dob: Date;
+})[]`,
+    4: "var c3: I[]"
+});

--- a/tests/cases/fourslash/classInterfaceInsert.ts
+++ b/tests/cases/fourslash/classInterfaceInsert.ts
@@ -9,11 +9,9 @@
 ////     }
 //// }
 
-goTo.marker('className');
-verify.quickInfoIs('class Sphere');
+verify.quickInfoAt("className", "class Sphere");
 
 goTo.marker('interfaceGoesHere');
 edit.insert("\r\ninterface Surface {\r\n    reflect: () => number;\r\n}\r\n");
 
-goTo.marker('className');
-verify.quickInfoIs('class Sphere');
+verify.quickInfoAt("className", "class Sphere");

--- a/tests/cases/fourslash/cloduleTypeOf1.ts
+++ b/tests/cases/fourslash/cloduleTypeOf1.ts
@@ -22,14 +22,12 @@ edit.insert('foo(1);');
 goTo.marker('2');
 verify.completionListContains('x');
 
-goTo.marker('3');
-verify.quickInfoIs('(local var) r: C<number>');
+verify.quickInfoAt("3", "(local var) r: C<number>");
 
 goTo.marker('4');
 verify.completionListContains('x');
 edit.insert('x;');
 
-goTo.marker('5');
-verify.quickInfoIs('(local var) r2: number');
+verify.quickInfoAt("5", "(local var) r2: number");
 
 verify.numberOfErrorsInCurrentFile(0);

--- a/tests/cases/fourslash/cloduleWithRecursiveReference.ts
+++ b/tests/cases/fourslash/cloduleWithRecursiveReference.ts
@@ -9,6 +9,5 @@
 ////  }
 ////}
 
-goTo.marker();
-verify.quickInfoIs('var M.C.C: typeof M.C');
+verify.quickInfoAt("", "var M.C.C: typeof M.C");
 verify.numberOfErrorsInCurrentFile(0);

--- a/tests/cases/fourslash/commentsClass.ts
+++ b/tests/cases/fourslash/commentsClass.ts
@@ -58,80 +58,58 @@
 ////}
 ////var myVar = new m.m2.c/*33*/1();
 
-goTo.marker('1');
-verify.quickInfoIs("class c2", "This is class c2 without constuctor");
-
-goTo.marker('2');
-verify.quickInfoIs("var i2: c2", "");
+verify.quickInfos({
+    1: ["class c2", "This is class c2 without constuctor"],
+    2: "var i2: c2"
+});
 
 goTo.marker('3');
 verify.currentSignatureHelpDocCommentIs("");
 
-goTo.marker('4');
-verify.quickInfoIs("var i2_c: typeof c2", "");
-
-goTo.marker('5');
-verify.quickInfoIs("class c2", "This is class c2 without constuctor");
-
-goTo.marker('6');
-verify.quickInfoIs("class c3", "");
-
-goTo.marker('7');
-verify.quickInfoIs("var i3: c3", "");
+verify.quickInfos({
+    4: "var i2_c: typeof c2",
+    5: ["class c2", "This is class c2 without constuctor"],
+    6: "class c3",
+    7: "var i3: c3"
+});
 
 goTo.marker('8');
 verify.currentSignatureHelpDocCommentIs("Constructor comment");
 
-goTo.marker('9');
-verify.quickInfoIs("var i3_c: typeof c3", "");
-
-goTo.marker('10');
-verify.quickInfoIs("class c3", "");
-
-goTo.marker('11');
-verify.quickInfoIs("class c4", "Class comment");
-
-goTo.marker('12');
-verify.quickInfoIs("var i4: c4", "");
+verify.quickInfos({
+    9: "var i3_c: typeof c3",
+    10: "class c3",
+    11: ["class c4", "Class comment"],
+    12: "var i4: c4"
+});
 
 goTo.marker('13');
 verify.currentSignatureHelpDocCommentIs("Constructor comment");
 
-goTo.marker('14');
-verify.quickInfoIs("var i4_c: typeof c4", "");
-
-goTo.marker('15');
-verify.quickInfoIs("class c4", "Class comment");
-
-goTo.marker('16');
-verify.quickInfoIs("class c5", "Class with statics");
-
-goTo.marker('17');
-verify.quickInfoIs("var i5: c5", "");
+verify.quickInfos({
+    14: "var i4_c: typeof c4",
+    15: ["class c4", "Class comment"],
+    16: ["class c5", "Class with statics"],
+    17: "var i5: c5"
+});
 
 goTo.marker('18');
 verify.currentSignatureHelpDocCommentIs("");
 
-goTo.marker('19');
-verify.quickInfoIs("var i5_c: typeof c5", "");
-
-goTo.marker('20');
-verify.quickInfoIs("class c5", "Class with statics");
-
-goTo.marker('21');
-verify.quickInfoIs("class c6", "class with statics and constructor");
-
-goTo.marker('22');
-verify.quickInfoIs("var i6: c6", "");
+verify.quickInfos({
+    19: "var i5_c: typeof c5",
+    20: ["class c5", "Class with statics"],
+    21: ["class c6", "class with statics and constructor"],
+    22: "var i6: c6"
+});
 
 goTo.marker('23');
 verify.currentSignatureHelpDocCommentIs("constructor comment");
 
-goTo.marker('24');
-verify.quickInfoIs("var i6_c: typeof c6", "");
-
-goTo.marker('25');
-verify.quickInfoIs("class c6", "class with statics and constructor");
+verify.quickInfos({
+    24: "var i6_c: typeof c6",
+    25: ["class c6", "class with statics and constructor"]
+});
 
 goTo.marker('26');
 verify.completionListContains("c2", "class c2", "This is class c2 without constuctor");
@@ -154,20 +132,11 @@ goTo.marker('27');
 verify.currentSignatureHelpDocCommentIs("constructor for a");
 verify.currentParameterHelpArgumentDocCommentIs("this is my a");
 
-goTo.marker('28');
-verify.quickInfoIs("constructor c2(): c2", "");
-
-goTo.marker('29');
-verify.quickInfoIs("constructor c3(): c3", "Constructor comment");
-
-goTo.marker('30');
-verify.quickInfoIs("constructor c4(): c4", "Constructor comment");
-
-goTo.marker('31');
-verify.quickInfoIs("constructor c5(): c5", "");
-
-goTo.marker('32');
-verify.quickInfoIs("constructor c6(): c6", "constructor comment");
-
-goTo.marker('33');
-verify.quickInfoIs("constructor m.m2.c1(): m.m2.c1", "constructor comment");
+verify.quickInfos({
+    28: "constructor c2(): c2",
+    29: ["constructor c3(): c3", "Constructor comment"],
+    30: ["constructor c4(): c4", "Constructor comment"],
+    31: "constructor c5(): c5",
+    32: ["constructor c6(): c6", "constructor comment"],
+    33: ["constructor m.m2.c1(): m.m2.c1", "constructor comment"]
+});

--- a/tests/cases/fourslash/commentsClassMembers.ts
+++ b/tests/cases/fourslash/commentsClassMembers.ts
@@ -132,14 +132,11 @@
 ////    }
 ////}
 
-goTo.marker('1');
-verify.quickInfoIs("class c1", "This is comment for c1");
-
-goTo.marker('2');
-verify.quickInfoIs("(property) c1.p1: number", "p1 is property of c1");
-
-goTo.marker('3');
-verify.quickInfoIs("(method) c1.p2(b: number): number", "sum with property");
+verify.quickInfos({
+    1: ["class c1", "This is comment for c1"],
+    2: ["(property) c1.p1: number", "p1 is property of c1"],
+    3: ["(method) c1.p2(b: number): number", "sum with property"]
+});
 
 goTo.marker('4');
 verify.memberListContains("p1", "(property) c1.p1: number", "p1 is property of c1");
@@ -158,8 +155,7 @@ verify.memberListContains("nc_pp3", "(property) c1.nc_pp3: number", "");
 goTo.marker('5');
 verify.completionListContains("b", "(parameter) b: number", "number to add");
 
-goTo.marker('6');
-verify.quickInfoIs("(property) c1.p3: number", "getter property\nsetter property");
+verify.quickInfoAt("6", "(property) c1.p3: number", "getter property\nsetter property");
 
 goTo.marker('7');
 verify.memberListContains("p1", "(property) c1.p1: number", "p1 is property of c1");
@@ -178,8 +174,7 @@ verify.memberListContains("nc_pp3", "(property) c1.nc_pp3: number", "");
 goTo.marker('8');
 verify.currentSignatureHelpDocCommentIs("sum with property");
 verify.currentParameterHelpArgumentDocCommentIs("number to add");
-goTo.marker('8q');
-verify.quickInfoIs("(method) c1.p2(b: number): number", "sum with property");
+verify.quickInfoAt("8q", "(method) c1.p2(b: number): number", "sum with property");
 
 goTo.marker('9');
 verify.memberListContains("p1", "(property) c1.p1: number", "p1 is property of c1");
@@ -195,8 +190,7 @@ verify.memberListContains("nc_pp1", "(property) c1.nc_pp1: number", "");
 verify.memberListContains("nc_pp2", "(method) c1.nc_pp2(b: number): number", "");
 verify.memberListContains("nc_pp3", "(property) c1.nc_pp3: number", "");
 
-goTo.marker('10');
-verify.quickInfoIs("(property) c1.p3: number", "getter property\nsetter property");
+verify.quickInfoAt("10", "(property) c1.p3: number", "getter property\nsetter property");
 
 goTo.marker('11');
 verify.memberListContains("p1", "(property) c1.p1: number", "p1 is property of c1");
@@ -230,14 +224,12 @@ goTo.marker('13');
 verify.currentSignatureHelpDocCommentIs("sum with property");
 verify.currentParameterHelpArgumentDocCommentIs("number to add");
 verify.completionListContains("value", "(parameter) value: number", "this is value");
-goTo.marker('13q');
-verify.quickInfoIs("(method) c1.p2(b: number): number", "sum with property");
 
-goTo.marker('14');
-verify.quickInfoIs("(property) c1.pp1: number", "pp1 is property of c1");
-
-goTo.marker('15');
-verify.quickInfoIs("(method) c1.pp2(b: number): number", "sum with property");
+verify.quickInfos({
+    "13q": ["(method) c1.p2(b: number): number", "sum with property"],
+    14: ["(property) c1.pp1: number", "pp1 is property of c1"],
+    15: ["(method) c1.pp2(b: number): number", "sum with property"]
+});
 
 goTo.marker('16');
 verify.memberListContains("p1", "(property) c1.p1: number", "p1 is property of c1");
@@ -256,8 +248,7 @@ verify.memberListContains("nc_pp3", "(property) c1.nc_pp3: number", "");
 goTo.marker('17');
 verify.completionListContains("b", "(parameter) b: number", "number to add");
 
-goTo.marker('18');
-verify.quickInfoIs("(property) c1.pp3: number", "getter property\nsetter property");
+verify.quickInfoAt("18", "(property) c1.pp3: number", "getter property\nsetter property");
 
 goTo.marker('19');
 verify.memberListContains("p1", "(property) c1.p1: number", "p1 is property of c1");
@@ -276,8 +267,7 @@ verify.memberListContains("nc_pp3", "(property) c1.nc_pp3: number", "");
 goTo.marker('20');
 verify.currentSignatureHelpDocCommentIs("sum with property");
 verify.currentParameterHelpArgumentDocCommentIs("number to add");
-goTo.marker('20q');
-verify.quickInfoIs("(method) c1.pp2(b: number): number", "sum with property");
+verify.quickInfoAt("20q", "(method) c1.pp2(b: number): number", "sum with property");
 
 goTo.marker('21');
 verify.memberListContains("p1", "(property) c1.p1: number", "p1 is property of c1");
@@ -293,8 +283,7 @@ verify.memberListContains("nc_pp1", "(property) c1.nc_pp1: number", "");
 verify.memberListContains("nc_pp2", "(method) c1.nc_pp2(b: number): number", "");
 verify.memberListContains("nc_pp3", "(property) c1.nc_pp3: number", "");
 
-goTo.marker('22');
-verify.quickInfoIs("(property) c1.pp3: number", "getter property\nsetter property");
+verify.quickInfoAt("22", "(property) c1.pp3: number", "getter property\nsetter property");
 
 goTo.marker('23');
 verify.memberListContains("p1", "(property) c1.p1: number", "p1 is property of c1");
@@ -328,17 +317,13 @@ goTo.marker('25');
 verify.currentSignatureHelpDocCommentIs("sum with property");
 verify.currentParameterHelpArgumentDocCommentIs("number to add");
 verify.completionListContains("value", "(parameter) value: number", "this is value");
-goTo.marker('25q');
-verify.quickInfoIs("(method) c1.pp2(b: number): number", "sum with property");
 
-goTo.marker('26');
-verify.quickInfoIs("constructor c1(): c1", "Constructor method");
-
-goTo.marker('27');
-verify.quickInfoIs("(property) c1.s1: number", "s1 is static property of c1");
-
-goTo.marker('28');
-verify.quickInfoIs("(method) c1.s2(b: number): number", "static sum with property");
+verify.quickInfos({
+    "25q": ["(method) c1.pp2(b: number): number", "sum with property"],
+    26: ["constructor c1(): c1", "Constructor method"],
+    27: ["(property) c1.s1: number", "s1 is static property of c1"],
+    28: ["(method) c1.s2(b: number): number", "static sum with property"]
+});
 
 goTo.marker('29');
 verify.completionListContains("c1", "class c1", "This is comment for c1");
@@ -354,8 +339,7 @@ verify.memberListContains("nc_s3", "(property) c1.nc_s3: number", "");
 goTo.marker('31');
 verify.completionListContains("b", "(parameter) b: number", "number to add");
 
-goTo.marker('32');
-verify.quickInfoIs("(property) c1.s3: number", "static getter property\nsetter property");
+verify.quickInfoAt("32", "(property) c1.s3: number", "static getter property\nsetter property");
 
 goTo.marker('33');
 verify.completionListContains("c1", "class c1", "This is comment for c1");
@@ -372,8 +356,7 @@ goTo.marker('35');
 verify.currentSignatureHelpDocCommentIs("static sum with property");
 verify.currentParameterHelpArgumentDocCommentIs("number to add");
 verify.completionListContains("c1", "class c1", "This is comment for c1");
-goTo.marker('35q');
-verify.quickInfoIs("(method) c1.s2(b: number): number", "static sum with property");
+verify.quickInfoAt("35q", "(method) c1.s2(b: number): number", "static sum with property");
 
 goTo.marker('36');
 verify.memberListContains("s1", "(property) c1.s1: number", "s1 is static property of c1");
@@ -383,8 +366,7 @@ verify.memberListContains("nc_s1", "(property) c1.nc_s1: number", "");
 verify.memberListContains("nc_s2", "(method) c1.nc_s2(b: number): number", "");
 verify.memberListContains("nc_s3", "(property) c1.nc_s3: number", "");
 
-goTo.marker('37');
-verify.quickInfoIs("(property) c1.s3: number", "static getter property\nsetter property");
+verify.quickInfoAt("37", "(property) c1.s3: number", "static getter property\nsetter property");
 
 goTo.marker('38');
 verify.completionListContains("c1", "class c1", "This is comment for c1");
@@ -412,105 +394,88 @@ goTo.marker('42');
 verify.currentSignatureHelpDocCommentIs("static sum with property");
 verify.currentParameterHelpArgumentDocCommentIs("number to add");
 verify.completionListContains("value", "(parameter) value: number", "this is value");
-goTo.marker('42q');
-verify.quickInfoIs("(method) c1.s2(b: number): number", "static sum with property");
-
-goTo.marker('43');
-verify.quickInfoIs("(property) c1.nc_p1: number", "");
-
-goTo.marker('44');
-verify.quickInfoIs("(method) c1.nc_p2(b: number): number", "");
+verify.quickInfos({
+    "42q": ["(method) c1.s2(b: number): number", "static sum with property"],
+    43: "(property) c1.nc_p1: number",
+    44: "(method) c1.nc_p2(b: number): number"
+});
 
 goTo.marker('45');
 verify.completionListContains("b", "(parameter) b: number", "");
 
-goTo.marker('46');
-verify.quickInfoIs("(property) c1.nc_p3: number", "");
+verify.quickInfoAt("46", "(property) c1.nc_p3: number");
 
 goTo.marker('47');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('47q');
-verify.quickInfoIs("(method) c1.nc_p2(b: number): number", "");
-
-goTo.marker('48');
-verify.quickInfoIs("(property) c1.nc_p3: number", "");
+verify.quickInfos({
+    "47q": "(method) c1.nc_p2(b: number): number",
+    48: "(property) c1.nc_p3: number"
+});
 
 goTo.marker('49');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
 verify.completionListContains("value", "(parameter) value: number", "");
-goTo.marker('49q');
-verify.quickInfoIs("(method) c1.nc_p2(b: number): number", "");
-
-goTo.marker('50');
-verify.quickInfoIs("(property) c1.nc_pp1: number", "");
-
-goTo.marker('51');
-verify.quickInfoIs("(method) c1.nc_pp2(b: number): number", "");
+verify.quickInfos({
+    "49q": "(method) c1.nc_p2(b: number): number",
+    50: "(property) c1.nc_pp1: number",
+    51: "(method) c1.nc_pp2(b: number): number"
+});
 
 goTo.marker('52');
 verify.completionListContains("b", "(parameter) b: number", "");
 
-goTo.marker('53');
-verify.quickInfoIs("(property) c1.nc_pp3: number", "");
+verify.quickInfoAt("53", "(property) c1.nc_pp3: number");
 
 goTo.marker('54');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('54q');
-verify.quickInfoIs("(method) c1.nc_pp2(b: number): number", "");
-
-goTo.marker('55');
-verify.quickInfoIs("(property) c1.nc_pp3: number", "");
+verify.quickInfos({
+    "54q": "(method) c1.nc_pp2(b: number): number",
+    55: "(property) c1.nc_pp3: number"
+});
 
 goTo.marker('56');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
 verify.completionListContains("value", "(parameter) value: number", "");
-goTo.marker('56q');
-verify.quickInfoIs("(method) c1.nc_pp2(b: number): number", "");
-
-goTo.marker('57');
-verify.quickInfoIs("(property) c1.nc_s1: number", "");
-
-goTo.marker('58');
-verify.quickInfoIs("(method) c1.nc_s2(b: number): number", "");
+verify.quickInfos({
+    "56q": "(method) c1.nc_pp2(b: number): number",
+    57: "(property) c1.nc_s1: number",
+    58: "(method) c1.nc_s2(b: number): number"
+});
 
 goTo.marker('59');
 verify.completionListContains("b", "(parameter) b: number", "");
 
-goTo.marker('60');
-verify.quickInfoIs("(property) c1.nc_s3: number", "");
+verify.quickInfoAt("60", "(property) c1.nc_s3: number");
 
 goTo.marker('61');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('61q');
-verify.quickInfoIs("(method) c1.nc_s2(b: number): number", "");
-
-goTo.marker('62');
-verify.quickInfoIs("(property) c1.nc_s3: number", "");
+verify.quickInfos({
+    "61q": "(method) c1.nc_s2(b: number): number",
+    62: "(property) c1.nc_s3: number"
+});
 
 goTo.marker('63');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
 verify.completionListContains("value", "(parameter) value: number", "");
-goTo.marker('63q');
-verify.quickInfoIs("(method) c1.nc_s2(b: number): number", "");
-
-goTo.marker('64');
-verify.quickInfoIs("var i1: c1", "");
+verify.quickInfos({
+    "63q": "(method) c1.nc_s2(b: number): number",
+    64: "var i1: c1"
+});
 
 goTo.marker('65');
 verify.currentSignatureHelpDocCommentIs("Constructor method");
-goTo.marker('65q');
-verify.quickInfoIs("constructor c1(): c1", "Constructor method");
+verify.quickInfos({
+    "65q": ["constructor c1(): c1", "Constructor method"],
+    66: "var i1_p: number"
+});
 
-goTo.marker('66');
-verify.quickInfoIs("var i1_p: number", "");
-
-goTo.marker('67');
+goTo.marker("67");
 verify.quickInfoIs("(property) c1.p1: number", "p1 is property of c1");
 verify.memberListContains("p1", "(property) c1.p1: number", "p1 is property of c1");
 verify.memberListContains("p2", "(method) c1.p2(b: number): number", "sum with property");
@@ -519,62 +484,41 @@ verify.memberListContains("nc_p1", "(property) c1.nc_p1: number", "");
 verify.memberListContains("nc_p2", "(method) c1.nc_p2(b: number): number", "");
 verify.memberListContains("nc_p3", "(property) c1.nc_p3: number", "");
 
-goTo.marker('68');
-verify.quickInfoIs("var i1_f: (b: number) => number", "");
-
-goTo.marker('69');
-verify.quickInfoIs("(method) c1.p2(b: number): number", "sum with property");
-
-goTo.marker('70');
-verify.quickInfoIs("var i1_r: number", "");
+verify.quickInfos({
+    68: "var i1_f: (b: number) => number",
+    69: ["(method) c1.p2(b: number): number", "sum with property"],
+    70: "var i1_r: number"
+});
 
 goTo.marker('71');
 verify.currentSignatureHelpDocCommentIs("sum with property");
 verify.currentParameterHelpArgumentDocCommentIs("number to add");
-goTo.marker('71q');
-verify.quickInfoIs("(method) c1.p2(b: number): number", "sum with property");
 
-goTo.marker('72');
-verify.quickInfoIs("var i1_prop: number", "");
-goTo.marker('73');
-verify.quickInfoIs("(property) c1.p3: number", "getter property\nsetter property");
-goTo.marker('74');
-verify.quickInfoIs("(property) c1.p3: number", "getter property\nsetter property");
-goTo.marker('75');
-verify.quickInfoIs("var i1_prop: number", "");
-
-goTo.marker('76');
-verify.quickInfoIs("var i1_nc_p: number", "");
-
-goTo.marker('77');
-verify.quickInfoIs("(property) c1.nc_p1: number", "");
-
-goTo.marker('78');
-verify.quickInfoIs("var i1_ncf: (b: number) => number", "");
-
-goTo.marker('79');
-verify.quickInfoIs("(method) c1.nc_p2(b: number): number", "");
-
-goTo.marker('80');
-verify.quickInfoIs("var i1_ncr: number", "");
+verify.quickInfos({
+    "71q": ["(method) c1.p2(b: number): number", "sum with property"],
+    72: "var i1_prop: number",
+    73: ["(property) c1.p3: number", "getter property\nsetter property"],
+    74: ["(property) c1.p3: number", "getter property\nsetter property"],
+    75: "var i1_prop: number",
+    76: "var i1_nc_p: number",
+    77: "(property) c1.nc_p1: number",
+    78: "var i1_ncf: (b: number) => number",
+    79: "(method) c1.nc_p2(b: number): number",
+    80: "var i1_ncr: number"
+});
 
 goTo.marker('81');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('81q');
-verify.quickInfoIs("(method) c1.nc_p2(b: number): number", "");
 
-goTo.marker('82');
-verify.quickInfoIs("var i1_ncprop: number", "");
-goTo.marker('83');
-verify.quickInfoIs("(property) c1.nc_p3: number", "");
-goTo.marker('84');
-verify.quickInfoIs("(property) c1.nc_p3: number", "");
-goTo.marker('85');
-verify.quickInfoIs("var i1_ncprop: number", "");
-
-goTo.marker('86');
-verify.quickInfoIs("var i1_s_p: number", "");
+verify.quickInfos({
+    "81q": "(method) c1.nc_p2(b: number): number",
+    82: "var i1_ncprop: number",
+    83: "(property) c1.nc_p3: number",
+    84: "(property) c1.nc_p3: number",
+    85: "var i1_ncprop: number",
+    86: "var i1_s_p: number"
+});
 
 goTo.marker('87');
 verify.quickInfoIs("class c1", "This is comment for c1");
@@ -589,65 +533,41 @@ verify.memberListContains("nc_s1", "(property) c1.nc_s1: number", "");
 verify.memberListContains("nc_s2", "(method) c1.nc_s2(b: number): number", "");
 verify.memberListContains("nc_s3", "(property) c1.nc_s3: number", "");
 
-goTo.marker('89');
-verify.quickInfoIs("var i1_s_f: (b: number) => number", "");
-
-goTo.marker('90');
-verify.quickInfoIs("(method) c1.s2(b: number): number", "static sum with property");
-
-goTo.marker('91');
-verify.quickInfoIs("var i1_s_r: number", "");
+verify.quickInfos({
+    89: "var i1_s_f: (b: number) => number",
+    90: ["(method) c1.s2(b: number): number", "static sum with property"],
+    91: "var i1_s_r: number"
+});
 
 goTo.marker('92');
 verify.currentSignatureHelpDocCommentIs("static sum with property");
 verify.currentParameterHelpArgumentDocCommentIs("number to add");
-goTo.marker('92q');
-verify.quickInfoIs("(method) c1.s2(b: number): number", "static sum with property");
 
-goTo.marker('93');
-verify.quickInfoIs("var i1_s_prop: number", "");
-goTo.marker('94');
-verify.quickInfoIs("(property) c1.s3: number", "static getter property\nsetter property");
-goTo.marker('95');
-verify.quickInfoIs("(property) c1.s3: number", "static getter property\nsetter property");
-goTo.marker('96');
-verify.quickInfoIs("var i1_s_prop: number", "");
-
-goTo.marker('97');
-verify.quickInfoIs("var i1_s_nc_p: number", "");
-
-goTo.marker('98');
-verify.quickInfoIs("(property) c1.nc_s1: number", "");
-
-goTo.marker('99');
-verify.quickInfoIs("var i1_s_ncf: (b: number) => number", "");
-
-goTo.marker('100');
-verify.quickInfoIs("(method) c1.nc_s2(b: number): number", "");
-
-goTo.marker('101');
-verify.quickInfoIs("var i1_s_ncr: number", "");
+verify.quickInfos({
+    "92q": ["(method) c1.s2(b: number): number", "static sum with property"],
+    93: "var i1_s_prop: number",
+    94: ["(property) c1.s3: number", "static getter property\nsetter property"],
+    95: ["(property) c1.s3: number", "static getter property\nsetter property"],
+    96: "var i1_s_prop: number",
+    97: "var i1_s_nc_p: number",
+    98: "(property) c1.nc_s1: number",
+    99: "var i1_s_ncf: (b: number) => number",
+    100: "(method) c1.nc_s2(b: number): number",
+    101: "var i1_s_ncr: number"
+});
 
 goTo.marker('102');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('102q');
-verify.quickInfoIs("(method) c1.nc_s2(b: number): number", "");
-
-goTo.marker('103');
-verify.quickInfoIs("var i1_s_ncprop: number", "");
-goTo.marker('104');
-verify.quickInfoIs("(property) c1.nc_s3: number", "");
-goTo.marker('105');
-verify.quickInfoIs("(property) c1.nc_s3: number", "");
-goTo.marker('106');
-verify.quickInfoIs("var i1_s_ncprop: number", "");
-
-goTo.marker('107');
-verify.quickInfoIs("var i1_c: typeof c1", "");
-
-goTo.marker('108');
-verify.quickInfoIs("class c1", "This is comment for c1");
+verify.quickInfos({
+    "102q": "(method) c1.nc_s2(b: number): number",
+    103: "var i1_s_ncprop: number",
+    104: "(property) c1.nc_s3: number",
+    105: "(property) c1.nc_s3: number",
+    106: "var i1_s_ncprop: number",
+    107: "var i1_c: typeof c1",
+    108: ["class c1", "This is comment for c1"]
+});
 
 goTo.marker('109');
 verify.completionListContains("c1", "class c1", "This is comment for c1");
@@ -678,12 +598,11 @@ verify.memberListContains("p2", "(property) cProperties.p2: number", "setter onl
 verify.memberListContains("nc_p1", "(property) cProperties.nc_p1: number", "");
 verify.memberListContains("nc_p2", "(property) cProperties.nc_p2: number", "");
 
-goTo.marker('111');
-verify.quickInfoIs("(property) cProperties.p1: number", "getter only property");
-goTo.marker('112');
-verify.quickInfoIs("(property) cProperties.nc_p2: number", "");
-goTo.marker('113');
-verify.quickInfoIs("(property) cProperties.nc_p1: number", "");
+verify.quickInfos({
+    111: ["(property) cProperties.p1: number", "getter only property"],
+    112: "(property) cProperties.nc_p2: number",
+    113: "(property) cProperties.nc_p1: number"
+});
 
 goTo.marker('114');
 verify.memberListContains("a", "(property) cWithConstructorProperty.a: number", "more info about a");
@@ -693,14 +612,12 @@ goTo.marker('115');
 verify.completionListContains("a", "(parameter) a: number", "this is first parameter a\nmore info about a");
 verify.quickInfoIs("(parameter) a: number", "this is first parameter a\nmore info about a");
 
-goTo.marker('116');
-verify.quickInfoIs("this: this", "");
-
-goTo.marker('117');
-verify.quickInfoIs("(local var) bbbb: number", "");
-
-goTo.marker('118');
-verify.quickInfoIs("(local var) bbbb: number", "");
-
-goTo.marker('119');
-verify.quickInfoIs("constructor cWithConstructorProperty(a: number): cWithConstructorProperty", "this is class cWithConstructorProperty's constructor");
+verify.quickInfos({
+    116: "this: this",
+    117: "(local var) bbbb: number",
+    118: "(local var) bbbb: number",
+    119: [
+        "constructor cWithConstructorProperty(a: number): cWithConstructorProperty",
+        "this is class cWithConstructorProperty's constructor"
+    ]
+});

--- a/tests/cases/fourslash/commentsCommentParsing.ts
+++ b/tests/cases/fourslash/commentsCommentParsing.ts
@@ -204,73 +204,59 @@
 
 goTo.marker('1');
 verify.currentSignatureHelpDocCommentIs("");
-goTo.marker('1q');
-verify.quickInfoIs("function simple(): void", "");
+verify.quickInfoAt("1q", "function simple(): void");
 
 goTo.marker('2');
 verify.currentSignatureHelpDocCommentIs("");
-goTo.marker('2q');
-verify.quickInfoIs("function multiLine(): void", "");
+verify.quickInfoAt("2q", "function multiLine(): void");
 
 goTo.marker('3');
 verify.currentSignatureHelpDocCommentIs("this is eg of single line jsdoc style comment ");
-goTo.marker('3q');
-verify.quickInfoIs("function jsDocSingleLine(): void", "this is eg of single line jsdoc style comment ");
+verify.quickInfoAt("3q", "function jsDocSingleLine(): void", "this is eg of single line jsdoc style comment ");
 
 goTo.marker('4');
 verify.currentSignatureHelpDocCommentIs("this is multiple line jsdoc stule comment\nNew line1\nNew Line2");
-goTo.marker('4q');
-verify.quickInfoIs("function jsDocMultiLine(): void", "this is multiple line jsdoc stule comment\nNew line1\nNew Line2");
+verify.quickInfoAt("4q", "function jsDocMultiLine(): void", "this is multiple line jsdoc stule comment\nNew line1\nNew Line2");
 
 goTo.marker('5');
 verify.currentSignatureHelpDocCommentIs("this is multiple line jsdoc stule comment\nNew line1\nNew Line2\nShoul mege this line as well\nand this too\nAnother this one too");
-goTo.marker('5q');
-verify.quickInfoIs("function jsDocMultiLineMerge(): void", "this is multiple line jsdoc stule comment\nNew line1\nNew Line2\nShoul mege this line as well\nand this too\nAnother this one too");
+verify.quickInfoAt("5q", "function jsDocMultiLineMerge(): void", "this is multiple line jsdoc stule comment\nNew line1\nNew Line2\nShoul mege this line as well\nand this too\nAnother this one too");
 
 goTo.marker('6');
 verify.currentSignatureHelpDocCommentIs("jsdoc comment ");
-goTo.marker('6q');
-verify.quickInfoIs("function jsDocMixedComments1(): void", "jsdoc comment ");
+verify.quickInfoAt("6q", "function jsDocMixedComments1(): void", "jsdoc comment ");
 
 goTo.marker('7');
 verify.currentSignatureHelpDocCommentIs("jsdoc comment \nanother jsDocComment");
-goTo.marker('7q');
-verify.quickInfoIs("function jsDocMixedComments2(): void", "jsdoc comment \nanother jsDocComment");
+verify.quickInfoAt("7q", "function jsDocMixedComments2(): void", "jsdoc comment \nanother jsDocComment");
 
 goTo.marker('8');
 verify.currentSignatureHelpDocCommentIs("jsdoc comment \n* another jsDocComment");
-goTo.marker('8q');
-verify.quickInfoIs("function jsDocMixedComments3(): void", "jsdoc comment \n* another jsDocComment");
+verify.quickInfoAt("8q", "function jsDocMixedComments3(): void", "jsdoc comment \n* another jsDocComment");
 
 goTo.marker('9');
 verify.currentSignatureHelpDocCommentIs("jsdoc comment \nanother jsDocComment");
-goTo.marker('9q');
-verify.quickInfoIs("function jsDocMixedComments4(): void", "jsdoc comment \nanother jsDocComment");
+verify.quickInfoAt("9q", "function jsDocMixedComments4(): void", "jsdoc comment \nanother jsDocComment");
 
 goTo.marker('10');
 verify.currentSignatureHelpDocCommentIs("jsdoc comment \nanother jsDocComment");
-goTo.marker('10q');
-verify.quickInfoIs("function jsDocMixedComments5(): void", "jsdoc comment \nanother jsDocComment");
+verify.quickInfoAt("10q", "function jsDocMixedComments5(): void", "jsdoc comment \nanother jsDocComment");
 
 goTo.marker('11');
 verify.currentSignatureHelpDocCommentIs("another jsDocComment\njsdoc comment ");
-goTo.marker('11q');
-verify.quickInfoIs("function jsDocMixedComments6(): void", "another jsDocComment\njsdoc comment ");
+verify.quickInfoAt("11q", "function jsDocMixedComments6(): void", "another jsDocComment\njsdoc comment ");
 
 goTo.marker('12');
 verify.currentSignatureHelpDocCommentIs("");
-goTo.marker('12q');
-verify.quickInfoIs("function noHelpComment1(): void", "");
+verify.quickInfoAt("12q", "function noHelpComment1(): void");
 
 goTo.marker('13');
 verify.currentSignatureHelpDocCommentIs("");
-goTo.marker('13q');
-verify.quickInfoIs("function noHelpComment2(): void", "");
+verify.quickInfoAt("13q", "function noHelpComment2(): void");
 
 goTo.marker('14');
 verify.currentSignatureHelpDocCommentIs("");
-goTo.marker('14q');
-verify.quickInfoIs("function noHelpComment3(): void", "");
+verify.quickInfoAt("14q", "function noHelpComment3(): void");
 
 goTo.marker('15');
 verify.completionListContains("sum", "function sum(a: number, b: number): number", "Adds two integers and returns the result");
@@ -278,16 +264,15 @@ verify.completionListContains("sum", "function sum(a: number, b: number): number
 goTo.marker('16');
 verify.currentSignatureHelpDocCommentIs("Adds two integers and returns the result");
 verify.currentParameterHelpArgumentDocCommentIs("first number");
-goTo.marker('16q');
-verify.quickInfoIs("function sum(a: number, b: number): number", "Adds two integers and returns the result");
-goTo.marker('16aq');
-verify.quickInfoIs("(parameter) a: number", "first number");
+verify.quickInfos({
+    "16q": ["function sum(a: number, b: number): number", "Adds two integers and returns the result"],
+    "16aq": ["(parameter) a: number", "first number"]
+});
 
 goTo.marker('17');
 verify.currentSignatureHelpDocCommentIs("Adds two integers and returns the result");
 verify.currentParameterHelpArgumentDocCommentIs("second number");
-goTo.marker('17aq');
-verify.quickInfoIs("(parameter) b: number", "second number");
+verify.quickInfoAt("17aq", "(parameter) b: number", "second number");
 
 goTo.marker('18');
 verify.quickInfoIs("(parameter) a: number", "first number");
@@ -297,34 +282,33 @@ verify.completionListContains("b", "(parameter) b: number", "second number");
 goTo.marker('19');
 verify.currentSignatureHelpDocCommentIs("This is multiplication function\n@anotherTag\n@anotherTag");
 verify.currentParameterHelpArgumentDocCommentIs("first number");
-goTo.marker('19q');
-verify.quickInfoIs("function multiply(a: number, b: number, c?: number, d?: any, e?: any): void", "This is multiplication function\n@anotherTag\n@anotherTag");
-goTo.marker('19aq');
-verify.quickInfoIs("(parameter) a: number", "first number");
+verify.quickInfos({
+    "19q": [
+        "function multiply(a: number, b: number, c?: number, d?: any, e?: any): void",
+        "This is multiplication function\n@anotherTag\n@anotherTag"
+    ],
+    "19aq": ["(parameter) a: number", "first number"]
+});
 
 goTo.marker('20');
 verify.currentSignatureHelpDocCommentIs("This is multiplication function\n@anotherTag\n@anotherTag");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('20aq');
-verify.quickInfoIs("(parameter) b: number", "");
+verify.quickInfoAt("20aq", "(parameter) b: number");
 
 goTo.marker('21');
 verify.currentSignatureHelpDocCommentIs("This is multiplication function\n@anotherTag\n@anotherTag");
 verify.currentParameterHelpArgumentDocCommentIs("{");
-goTo.marker('21aq');
-verify.quickInfoIs("(parameter) c: number", "{");
+verify.quickInfoAt("21aq", "(parameter) c: number", "{");
 
 goTo.marker('22');
 verify.currentSignatureHelpDocCommentIs("This is multiplication function\n@anotherTag\n@anotherTag");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('22aq');
-verify.quickInfoIs("(parameter) d: any", "");
+verify.quickInfoAt("22aq", "(parameter) d: any");
 
 goTo.marker('23');
 verify.currentSignatureHelpDocCommentIs("This is multiplication function\n@anotherTag\n@anotherTag");
 verify.currentParameterHelpArgumentDocCommentIs("LastParam ");
-goTo.marker('23aq');
-verify.quickInfoIs("(parameter) e: any", "LastParam ");
+verify.quickInfoAt("23aq", "(parameter) e: any", "LastParam ");
 
 goTo.marker('24');
 verify.completionListContains("aOrb", "(parameter) aOrb: any", "");
@@ -333,18 +317,18 @@ verify.completionListContains("opt", "(parameter) opt: any", "optional parameter
 goTo.marker('25');
 verify.currentSignatureHelpDocCommentIs("fn f1 with number");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('25q');
-verify.quickInfoIs("function f1(a: number): any (+1 overload)", "fn f1 with number");
-goTo.marker('25aq');
-verify.quickInfoIs("(parameter) a: number", "");
+verify.quickInfos({
+    "25q": ["function f1(a: number): any (+1 overload)", "fn f1 with number"],
+    "25aq": "(parameter) a: number"
+});
 
 goTo.marker('26');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('26q');
-verify.quickInfoIs("function f1(b: string): any (+1 overload)", "");
-goTo.marker('26aq');
-verify.quickInfoIs("(parameter) b: string", "");
+verify.quickInfos({
+    "26q": "function f1(b: string): any (+1 overload)",
+    "26aq": "(parameter) b: string"
+});
 
 goTo.marker('27');
 verify.completionListContains("multiply", "function multiply(a: number, b: number, c?: number, d?: any, e?: any): void", "This is multiplication function\n@anotherTag\n@anotherTag");
@@ -353,76 +337,84 @@ verify.completionListContains("f1", "function f1(a: number): any (+1 overload)",
 goTo.marker('28');
 verify.currentSignatureHelpDocCommentIs("This is subtract function");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('28q');
-verify.quickInfoIs("function subtract(a: number, b: number, c?: () => string, d?: () => string, e?: () => string, f?: () => string): void", "This is subtract function");
-goTo.marker('28aq');
-verify.quickInfoIs("(parameter) a: number", "");
+verify.quickInfos({
+    "28q": [
+        "function subtract(a: number, b: number, c?: () => string, d?: () => string, e?: () => string, f?: () => string): void",
+        "This is subtract function"
+    ],
+    "28aq": "(parameter) a: number"
+});
 
 goTo.marker('29');
 verify.currentSignatureHelpDocCommentIs("This is subtract function");
 verify.currentParameterHelpArgumentDocCommentIs("this is about b");
-goTo.marker('29aq');
-verify.quickInfoIs("(parameter) b: number", "this is about b");
+verify.quickInfoAt("29aq", "(parameter) b: number", "this is about b");
 
 goTo.marker('30');
 verify.currentSignatureHelpDocCommentIs("This is subtract function");
 verify.currentParameterHelpArgumentDocCommentIs("this is optional param c");
-goTo.marker('30aq');
-verify.quickInfoIs("(parameter) c: () => string", "this is optional param c");
+verify.quickInfoAt("30aq", "(parameter) c: () => string", "this is optional param c");
 
 goTo.marker('31');
 verify.currentSignatureHelpDocCommentIs("This is subtract function");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('31aq');
-verify.quickInfoIs("(parameter) d: () => string", "");
+verify.quickInfoAt("31aq", "(parameter) d: () => string");
 
 goTo.marker('32');
 verify.currentSignatureHelpDocCommentIs("This is subtract function");
 verify.currentParameterHelpArgumentDocCommentIs("this is optional param e");
-goTo.marker('32aq');
-verify.quickInfoIs("(parameter) e: () => string", "this is optional param e");
+verify.quickInfoAt("32aq", "(parameter) e: () => string", "this is optional param e");
 
 goTo.marker('33');
 verify.currentSignatureHelpDocCommentIs("This is subtract function");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('33aq');
-verify.quickInfoIs("(parameter) f: () => string", "");
+verify.quickInfoAt("33aq", "(parameter) f: () => string");
 
 goTo.marker('34');
 verify.currentSignatureHelpDocCommentIs("this is square function\n@paramTag { number } a this is input number of paramTag\n@returnType { number } it is return type");
 verify.currentParameterHelpArgumentDocCommentIs("this is input number");
-goTo.marker('34q');
-verify.quickInfoIs("function square(a: number): number", "this is square function\n@paramTag { number } a this is input number of paramTag\n@returnType { number } it is return type");
-goTo.marker('34aq');
-verify.quickInfoIs("(parameter) a: number", "this is input number");
+verify.quickInfos({
+    "34q": [
+        "function square(a: number): number",
+        "this is square function\n@paramTag { number } a this is input number of paramTag\n@returnType { number } it is return type"
+    ],
+    "34aq": [
+        "(parameter) a: number",
+        "this is input number"
+    ]
+});
 
 goTo.marker('35');
 verify.currentSignatureHelpDocCommentIs("this is divide function\n@paramTag { number } g this is optional param g");
 verify.currentParameterHelpArgumentDocCommentIs("this is a");
-goTo.marker('35q');
-verify.quickInfoIs("function divide(a: number, b: number): void", "this is divide function\n@paramTag { number } g this is optional param g");
-goTo.marker('35aq');
-verify.quickInfoIs("(parameter) a: number", "this is a");
+verify.quickInfos({
+    "35q": [
+        "function divide(a: number, b: number): void",
+        "this is divide function\n@paramTag { number } g this is optional param g"
+    ],
+    "35aq": [
+        "(parameter) a: number",
+        "this is a"
+    ]
+});
 
 goTo.marker('36');
 verify.currentSignatureHelpDocCommentIs("this is divide function\n@paramTag { number } g this is optional param g");
 verify.currentParameterHelpArgumentDocCommentIs("this is b");
-goTo.marker('36aq');
-verify.quickInfoIs("(parameter) b: number", "this is b");
+verify.quickInfoAt("36aq", "(parameter) b: number", "this is b");
 
 goTo.marker('37');
 verify.currentSignatureHelpDocCommentIs("Function returns string concat of foo and bar");
 verify.currentParameterHelpArgumentDocCommentIs("is string");
-goTo.marker('37q');
-verify.quickInfoIs("function fooBar(foo: string, bar: string): string", "Function returns string concat of foo and bar");
-goTo.marker('37aq');
-verify.quickInfoIs("(parameter) foo: string", "is string");
+verify.quickInfos({
+    "37q": ["function fooBar(foo: string, bar: string): string", "Function returns string concat of foo and bar"],
+    "37aq": ["(parameter) foo: string", "is string"]
+});
 
 goTo.marker('38');
 verify.currentSignatureHelpDocCommentIs("Function returns string concat of foo and bar");
 verify.currentParameterHelpArgumentDocCommentIs("is second string");
-goTo.marker('38aq');
-verify.quickInfoIs("(parameter) bar: string", "is second string");
+verify.quickInfoAt("38aq", "(parameter) bar: string", "is second string");
 
 goTo.marker('39');
 verify.completionListContains("a", "(parameter) a: number", "it is first parameter\nthis is inline comment for a ");
@@ -433,28 +425,31 @@ verify.completionListContains("d", "(parameter) d: number", "");
 goTo.marker('40');
 verify.currentSignatureHelpDocCommentIs("this is jsdoc style function with param tag as well as inline parameter help");
 verify.currentParameterHelpArgumentDocCommentIs("it is first parameter\nthis is inline comment for a ");
-goTo.marker('40q');
-verify.quickInfoIs("function jsDocParamTest(a: number, b: number, c: number, d: number): number", "this is jsdoc style function with param tag as well as inline parameter help");
-goTo.marker('40aq');
-verify.quickInfoIs("(parameter) a: number", "it is first parameter\nthis is inline comment for a ");
+verify.quickInfos({
+    "40q": [
+        "function jsDocParamTest(a: number, b: number, c: number, d: number): number",
+        "this is jsdoc style function with param tag as well as inline parameter help"
+    ],
+    "40aq": [
+        "(parameter) a: number",
+        "it is first parameter\nthis is inline comment for a "
+    ]
+});
 
 goTo.marker('41');
 verify.currentSignatureHelpDocCommentIs("this is jsdoc style function with param tag as well as inline parameter help");
 verify.currentParameterHelpArgumentDocCommentIs("this is inline comment for b");
-goTo.marker('41aq');
-verify.quickInfoIs("(parameter) b: number", "this is inline comment for b");
+verify.quickInfoAt("41aq", "(parameter) b: number", "this is inline comment for b");
 
 goTo.marker('42');
 verify.currentSignatureHelpDocCommentIs("this is jsdoc style function with param tag as well as inline parameter help");
 verify.currentParameterHelpArgumentDocCommentIs("it is third parameter");
-goTo.marker('42aq');
-verify.quickInfoIs("(parameter) c: number", "it is third parameter");
+verify.quickInfoAt("42aq", "(parameter) c: number", "it is third parameter");
 
 goTo.marker('43');
 verify.currentSignatureHelpDocCommentIs("this is jsdoc style function with param tag as well as inline parameter help");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('43aq');
-verify.quickInfoIs("(parameter) d: number", "");
+verify.quickInfoAt("43aq", "(parameter) d: number");
 
 goTo.marker('44');
 verify.completionListContains("jsDocParamTest", "function jsDocParamTest(a: number, b: number, c: number, d: number): number", "this is jsdoc style function with param tag as well as inline parameter help");
@@ -463,33 +458,38 @@ verify.completionListContains("y", "var y: any", "This is a comment ");
 
 goTo.marker('45');
 verify.currentSignatureHelpDocCommentIs("This is function comment\nAnd properly aligned comment ");
-goTo.marker('45q');
-verify.quickInfoIs("function jsDocCommentAlignmentTest1(): void", "This is function comment\nAnd properly aligned comment ");
+verify.quickInfoAt("45q", "function jsDocCommentAlignmentTest1(): void", "This is function comment\nAnd properly aligned comment ");
 
 goTo.marker('46');
 verify.currentSignatureHelpDocCommentIs("This is function comment\n    And aligned with 4 space char margin");
-goTo.marker('46q');
-verify.quickInfoIs("function jsDocCommentAlignmentTest2(): void", "This is function comment\n    And aligned with 4 space char margin");
+verify.quickInfoAt("46q", "function jsDocCommentAlignmentTest2(): void", "This is function comment\n    And aligned with 4 space char margin");
 
 goTo.marker('47');
 verify.currentSignatureHelpDocCommentIs("This is function comment\n    And aligned with 4 space char margin");
 verify.currentParameterHelpArgumentDocCommentIs("this is info about a\nspanning on two lines and aligned perfectly");
-goTo.marker('47q');
-verify.quickInfoIs("function jsDocCommentAlignmentTest3(a: string, b: any, c: any): void", "This is function comment\n    And aligned with 4 space char margin");
-goTo.marker('47aq');
-verify.quickInfoIs("(parameter) a: string", "this is info about a\nspanning on two lines and aligned perfectly");
+verify.quickInfos({
+    "47q": [
+        "function jsDocCommentAlignmentTest3(a: string, b: any, c: any): void",
+        "This is function comment\n    And aligned with 4 space char margin"
+    ],
+    "47aq": [
+        "(parameter) a: string",
+        "this is info about a\nspanning on two lines and aligned perfectly"
+    ]
+});
 
 goTo.marker('48');
 verify.currentSignatureHelpDocCommentIs("This is function comment\n    And aligned with 4 space char margin");
 verify.currentParameterHelpArgumentDocCommentIs("this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin");
-goTo.marker('48aq');
-verify.quickInfoIs("(parameter) b: any", "this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin");
+verify.quickInfoAt("48aq", "(parameter) b: any", "this is info about b\nspanning on two lines and aligned perfectly\nspanning one more line alined perfectly\n    spanning another line with more margin");
 
 goTo.marker('49');
 verify.currentSignatureHelpDocCommentIs("This is function comment\n    And aligned with 4 space char margin");
 verify.currentParameterHelpArgumentDocCommentIs("this is info about b\nnot aligned text about parameter will eat only one space");
-goTo.marker('49aq');
-verify.quickInfoIs("(parameter) c: any", "this is info about b\nnot aligned text about parameter will eat only one space");
-
-goTo.marker('50');
-verify.quickInfoIs("class NoQuickInfoClass", "");
+verify.quickInfos({
+    "49aq": [
+        "(parameter) c: any",
+        "this is info about b\nnot aligned text about parameter will eat only one space"
+    ],
+    50: "class NoQuickInfoClass"
+});

--- a/tests/cases/fourslash/commentsEnums.ts
+++ b/tests/cases/fourslash/commentsEnums.ts
@@ -10,17 +10,12 @@
 ////var /*4*/x = /*5*/Colors./*6*/Cornflower;
 ////x = Colors./*7*/FancyPink;
 
-goTo.marker('1');
-verify.quickInfoIs("enum Colors", "Enum of colors");
-
-goTo.marker('2');
-verify.quickInfoIs("(enum member) Colors.Cornflower = 0", "Fancy name for 'blue'");
-
-goTo.marker('3');
-verify.quickInfoIs("(enum member) Colors.FancyPink = 1", "Fancy name for 'pink'");
-
-goTo.marker('4');
-verify.quickInfoIs("var x: Colors", "");
+verify.quickInfos({
+    1: ["enum Colors", "Enum of colors"],
+    2: ["(enum member) Colors.Cornflower = 0", "Fancy name for 'blue'"],
+    3: ["(enum member) Colors.FancyPink = 1", "Fancy name for 'pink'"],
+    4: "var x: Colors"
+});
 
 goTo.marker('5');
 verify.completionListContains("Colors", "enum Colors", "Enum of colors");

--- a/tests/cases/fourslash/commentsExternalModules.ts
+++ b/tests/cases/fourslash/commentsExternalModules.ts
@@ -32,8 +32,7 @@
 ////var new/*14*/Var = new extMod.m1.m2./*15*/c();
 
 goTo.file("commentsExternalModules_file0.ts");
-goTo.marker('1');
-verify.quickInfoIs("namespace m1", "Namespace comment");
+verify.quickInfoAt("1", "namespace m1", "Namespace comment");
 
 goTo.marker('2');
 verify.completionListContains("b", "var m1.b: number", "b's comment");
@@ -41,8 +40,7 @@ verify.completionListContains("foo", "function foo(): number", "foo's comment");
 
 goTo.marker('3');
 verify.currentSignatureHelpDocCommentIs("foo's comment");
-goTo.marker('3q');
-verify.quickInfoIs("function foo(): number", "foo's comment");
+verify.quickInfoAt("3q", "function foo(): number", "foo's comment");
 
 goTo.marker('4');
 verify.completionListContains("m1", "namespace m1", "Namespace comment");
@@ -54,19 +52,16 @@ verify.memberListContains("m2", "namespace m1.m2");
 
 goTo.marker('6');
 verify.currentSignatureHelpDocCommentIs("exported function");
-goTo.marker('6q');
-verify.quickInfoIs("function m1.fooExport(): number", "exported function");
+verify.quickInfoAt("6q", "function m1.fooExport(): number", "exported function");
 
-goTo.marker('7');
-verify.quickInfoIs("var myvar: m1.m2.c", "");
+verify.quickInfoAt("7", "var myvar: m1.m2.c");
 
 goTo.marker('8');
 verify.memberListContains("c", "constructor m1.m2.c(): m1.m2.c", "");
 verify.memberListContains("i", "var m1.m2.i: m1.m2.c", "i");
 
 goTo.file("commentsExternalModules_file1.ts");
-goTo.marker('9');
-verify.quickInfoIs('import extMod = require("./commentsExternalModules_file0")', "This is on import declaration");
+verify.quickInfoAt("9", 'import extMod = require("./commentsExternalModules_file0")', "This is on import declaration");
 
 goTo.marker('10');
 verify.completionListContains("extMod", 'import extMod = require("./commentsExternalModules_file0")', "This is on import declaration");
@@ -81,11 +76,9 @@ verify.memberListContains("m2", "namespace extMod.m1.m2");
 
 goTo.marker('13');
 verify.currentSignatureHelpDocCommentIs("exported function");
-goTo.marker('13q');
-verify.quickInfoIs("function extMod.m1.fooExport(): number", "exported function");
+verify.quickInfoAt("13q", "function extMod.m1.fooExport(): number", "exported function");
 
-goTo.marker('14');
-verify.quickInfoIs("var newVar: extMod.m1.m2.c", "");
+verify.quickInfoAt("14", "var newVar: extMod.m1.m2.c");
 
 goTo.marker('15');
 verify.memberListContains("c", "constructor extMod.m1.m2.c(): extMod.m1.m2.c", "");

--- a/tests/cases/fourslash/commentsFunctionDeclaration.ts
+++ b/tests/cases/fourslash/commentsFunctionDeclaration.ts
@@ -20,11 +20,9 @@
 ////declare function fn(a: string);
 ////fn(/*12*/"hello");
 
-goTo.marker('1');
-verify.quickInfoIs("function foo(): void", "This comment should appear for foo");
+verify.quickInfoAt("1", "function foo(): void", "This comment should appear for foo");
 
-goTo.marker('2');
-verify.quickInfoIs("function foo(): void", "This comment should appear for foo");
+verify.quickInfoAt("2", "function foo(): void", "This comment should appear for foo");
 
 goTo.marker('3');
 verify.completionListContains('foo', 'function foo(): void', 'This comment should appear for foo');
@@ -32,18 +30,15 @@ verify.completionListContains('foo', 'function foo(): void', 'This comment shoul
 goTo.marker('4');
 verify.currentSignatureHelpDocCommentIs("This comment should appear for foo");
 
-goTo.marker('5');
-verify.quickInfoIs("function fooWithParameters(a: string, b: number): void", "This is comment for function signature");
+verify.quickInfoAt("5", "function fooWithParameters(a: string, b: number): void", "This is comment for function signature");
 
-goTo.marker('6');
-verify.quickInfoIs('(local var) d: string', '');
+verify.quickInfoAt("6", "(local var) d: string");
 
 goTo.marker('7');
 verify.completionListContains('a', '(parameter) a: string', 'this is comment about a');
 verify.completionListContains('b', '(parameter) b: number', 'this is comment for b');
 
-goTo.marker('8');
-verify.quickInfoIs("function fooWithParameters(a: string, b: number): void", "This is comment for function signature");
+verify.quickInfoAt("8", "function fooWithParameters(a: string, b: number): void", "This is comment for function signature");
 
 goTo.marker('9');
 verify.completionListContains('fooWithParameters', 'function fooWithParameters(a: string, b: number): void', 'This is comment for function signature');

--- a/tests/cases/fourslash/commentsFunctionExpression.ts
+++ b/tests/cases/fourslash/commentsFunctionExpression.ts
@@ -34,16 +34,14 @@
 
 
 
-goTo.marker('1');
-verify.quickInfoIs("var lambdaFoo: (a: number, b: number) => number", "lamdaFoo var comment\nthis is lambda comment");
+verify.quickInfoAt("1", "var lambdaFoo: (a: number, b: number) => number", "lamdaFoo var comment\nthis is lambda comment");
 
 goTo.marker('2');
 verify.completionListContains('a', '(parameter) a: number', 'param a');
 verify.completionListContains('b', '(parameter) b: number', 'param b');
 
-goTo.marker('3');
 // pick up doccomments from the lambda itself
-verify.quickInfoIs("var lambddaNoVarComment: (a: number, b: number) => number", "this is lambda multiplication");
+verify.quickInfoAt("3", "var lambddaNoVarComment: (a: number, b: number) => number", "this is lambda multiplication");
 
 goTo.marker('4');
 verify.completionListContains('lambdaFoo', 'var lambdaFoo: (a: number, b: number) => number', 'lamdaFoo var comment\nthis is lambda comment');
@@ -58,28 +56,24 @@ verify.currentParameterHelpArgumentDocCommentIs("param b");
 
 
 
-goTo.marker('7');
 // no documentation from nested lambda
-verify.quickInfoIs('function anotherFunc(a: number): string', '');
-goTo.marker('8');
-verify.quickInfoIs('(local var) lambdaVar: (b: string) => string', 'documentation\ninner docs ');
-goTo.marker('9');
-verify.quickInfoIs('(parameter) b: string', '{string} inner parameter ');
-goTo.marker('10');
-verify.quickInfoIs('(local var) localVar: string', '');
-goTo.marker('11');
-verify.quickInfoIs('(local var) localVar: string', '');
-goTo.marker('12');
-verify.quickInfoIs('(parameter) b: string', '{string} inner parameter ');
-goTo.marker('13');
-verify.quickInfoIs('(local var) lambdaVar: (b: string) => string', 'documentation\ninner docs ');
+verify.quickInfos({
+    7: "function anotherFunc(a: number): string",
+    8: ["(local var) lambdaVar: (b: string) => string", "documentation\ninner docs "],
+    9: ["(parameter) b: string", "{string} inner parameter "],
+    10: "(local var) localVar: string",
+    11: "(local var) localVar: string",
+    12: ["(parameter) b: string", "{string} inner parameter "],
+    13: ["(local var) lambdaVar: (b: string) => string", "documentation\ninner docs "],
+    14: [
+        "var assigned: (s: string) => number",
+        "On variable\n@returns the parameter's length\nSummary on expression\n@returns return on expression"
+    ]
+});
 
-goTo.marker('14');
-verify.quickInfoIs("var assigned: (s: string) => number", "On variable\n@returns the parameter's length\nSummary on expression\n@returns return on expression");
 goTo.marker('15');
 verify.completionListContains('s', '(parameter) s: string', "the first parameter!\nparam on expression\nOn parameter ");
-goTo.marker('16');
-verify.quickInfoIs("var assigned: (s: string) => number", "On variable\n@returns the parameter's length\nSummary on expression\n@returns return on expression");
+verify.quickInfoAt("16", "var assigned: (s: string) => number", "On variable\n@returns the parameter's length\nSummary on expression\n@returns return on expression");
 goTo.marker('17');
 verify.completionListContains("assigned", "var assigned: (s: string) => number", "On variable\n@returns the parameter's length\nSummary on expression\n@returns return on expression");
 goTo.marker('18');

--- a/tests/cases/fourslash/commentsImportDeclaration.ts
+++ b/tests/cases/fourslash/commentsImportDeclaration.ts
@@ -24,11 +24,10 @@
 ////extMod./*6*/m1./*7*/fooEx/*8q*/port(/*8*/);
 ////var new/*9*/Var = new extMod.m1.m2./*10*/c();
 
-goTo.marker('2');
-verify.quickInfoIs("namespace m1", "NamespaceComment");
-
-goTo.marker('3');
-verify.quickInfoIs('import extMod = require("./commentsImportDeclaration_file0")', "Import declaration");
+verify.quickInfos({
+    2: ["namespace m1", "NamespaceComment"],
+    3: ['import extMod = require("./commentsImportDeclaration_file0")', "Import declaration"]
+});
 
 goTo.marker('6');
 verify.memberListContains("m1", "namespace extMod.m1");
@@ -40,11 +39,10 @@ verify.memberListContains("m2", "namespace extMod.m1.m2");
 
 goTo.marker('8');
 verify.currentSignatureHelpDocCommentIs("exported function");
-goTo.marker('8q');
-verify.quickInfoIs("function extMod.m1.fooExport(): number", "exported function");
-
-goTo.marker('9');
-verify.quickInfoIs("var newVar: extMod.m1.m2.c", "");
+verify.quickInfos({
+    "8q": ["function extMod.m1.fooExport(): number", "exported function"],
+    9: "var newVar: extMod.m1.m2.c"
+});
 
 goTo.marker('10');
 verify.memberListContains("c", "constructor extMod.m1.m2.c(): extMod.m1.m2.c", "");

--- a/tests/cases/fourslash/commentsInheritance.ts
+++ b/tests/cases/fourslash/commentsInheritance.ts
@@ -250,24 +250,17 @@ verify.currentSignatureHelpDocCommentIs("");
 goTo.marker('l5');
 verify.currentSignatureHelpDocCommentIs("");
 
-goTo.marker('1iq');
-verify.quickInfoIs("var i1_i: i1", "");
-goTo.marker('2q');
-verify.quickInfoIs("(method) i1.i1_f1(): void", "i1_f1");
-goTo.marker('3q');
-verify.quickInfoIs("(method) i1.i1_nc_f1(): void", "");
-goTo.marker('4q');
-verify.quickInfoIs("(method) i1.f1(): void", "");
-goTo.marker('5q');
-verify.quickInfoIs("(method) i1.nc_f1(): void", "");
-goTo.marker('l2q');
-verify.quickInfoIs("(property) i1.i1_l1: () => void", "");
-goTo.marker('l3q');
-verify.quickInfoIs("(property) i1.i1_nc_l1: () => void", "");
-goTo.marker('l4q');
-verify.quickInfoIs("(property) i1.l1: () => void", "");
-goTo.marker('l5q');
-verify.quickInfoIs("(property) i1.nc_l1: () => void", "");
+verify.quickInfos({
+    "1iq": "var i1_i: i1",
+    "2q": ["(method) i1.i1_f1(): void", "i1_f1"],
+    "3q": "(method) i1.i1_nc_f1(): void",
+    "4q": "(method) i1.f1(): void",
+    "5q": "(method) i1.nc_f1(): void",
+    l2q: "(property) i1.i1_l1: () => void",
+    l3q: "(property) i1.i1_nc_l1: () => void",
+    l4q: "(property) i1.l1: () => void",
+    l5q: "(property) i1.nc_l1: () => void"
+});
 
 goTo.marker('6');
 verify.memberListContains("i1_p1", "(property) c1.i1_p1: number", "");
@@ -299,24 +292,17 @@ verify.currentSignatureHelpDocCommentIs("");
 goTo.marker('l10');
 verify.currentSignatureHelpDocCommentIs("");
 
-goTo.marker('6iq');
-verify.quickInfoIs("var c1_i: c1", "");
-goTo.marker('7q');
-verify.quickInfoIs("(method) c1.i1_f1(): void", "");
-goTo.marker('8q');
-verify.quickInfoIs("(method) c1.i1_nc_f1(): void", "");
-goTo.marker('9q');
-verify.quickInfoIs("(method) c1.f1(): void", "c1_f1");
-goTo.marker('10q');
-verify.quickInfoIs("(method) c1.nc_f1(): void", "c1_nc_f1");
-goTo.marker('l7q');
-verify.quickInfoIs("(property) c1.i1_l1: () => void", "");
-goTo.marker('l8q');
-verify.quickInfoIs("(property) c1.i1_nc_l1: () => void", "");
-goTo.marker('l9q');
-verify.quickInfoIs("(property) c1.l1: () => void", "");
-goTo.marker('l10q');
-verify.quickInfoIs("(property) c1.nc_l1: () => void", "");
+verify.quickInfos({
+    "6iq": "var c1_i: c1",
+    "7q": "(method) c1.i1_f1(): void",
+    "8q": "(method) c1.i1_nc_f1(): void",
+    "9q": ["(method) c1.f1(): void", "c1_f1"],
+    "10q": ["(method) c1.nc_f1(): void", "c1_nc_f1"],
+    l7q: "(property) c1.i1_l1: () => void",
+    l8q: "(property) c1.i1_nc_l1: () => void",
+    l9q: "(property) c1.l1: () => void",
+    l10q: "(property) c1.nc_l1: () => void"
+});
 
 goTo.marker('11');
 verify.memberListContains("i1_p1", "(property) i1.i1_p1: number", "i1_p1");
@@ -347,22 +333,17 @@ goTo.marker('l14');
 verify.currentSignatureHelpDocCommentIs("");
 goTo.marker('l15');
 verify.currentSignatureHelpDocCommentIs("");
-goTo.marker('12q');
-verify.quickInfoIs("(method) i1.i1_f1(): void", "i1_f1");
-goTo.marker('13q');
-verify.quickInfoIs("(method) i1.i1_nc_f1(): void", "");
-goTo.marker('14q');
-verify.quickInfoIs("(method) i1.f1(): void", "");
-goTo.marker('15q');
-verify.quickInfoIs("(method) i1.nc_f1(): void", "");
-goTo.marker('l12q');
-verify.quickInfoIs("(property) i1.i1_l1: () => void", "");
-goTo.marker('l13q');
-verify.quickInfoIs("(property) i1.i1_nc_l1: () => void", "");
-goTo.marker('l14q');
-verify.quickInfoIs("(property) i1.l1: () => void", "");
-goTo.marker('l15q');
-verify.quickInfoIs("(property) i1.nc_l1: () => void", "");
+
+verify.quickInfos({
+    "12q": ["(method) i1.i1_f1(): void", "i1_f1"],
+    "13q": "(method) i1.i1_nc_f1(): void",
+    "14q": "(method) i1.f1(): void",
+    "15q": "(method) i1.nc_f1(): void",
+    l12q: "(property) i1.i1_l1: () => void",
+    l13q: "(property) i1.i1_nc_l1: () => void",
+    l14q: "(property) i1.l1: () => void",
+    l15q: "(property) i1.nc_l1: () => void",
+});
 
 goTo.marker('16');
 verify.completionListContains("i1", "interface i1", "i1 is interface with properties");
@@ -373,10 +354,10 @@ verify.completionListContains("c1_i", "var c1_i: c1", "");
 goTo.marker('16i');
 verify.completionListContains("i1", "interface i1", "i1 is interface with properties");
 
-goTo.marker('17iq');
-verify.quickInfoIs("var c2_i: c2", "");
-goTo.marker('18iq');
-verify.quickInfoIs("var c3_i: c3", "");
+verify.quickInfos({
+    "17iq": "var c2_i: c2",
+    "18iq": "var c3_i: c3"
+});
 
 goTo.marker('17');
 verify.currentSignatureHelpDocCommentIs("c2 constructor");
@@ -384,18 +365,15 @@ verify.currentSignatureHelpDocCommentIs("c2 constructor");
 goTo.marker('18');
 verify.currentSignatureHelpDocCommentIs("");
 
-goTo.marker('18sq');
-verify.quickInfoIs("constructor c2(a: number): c2", "c2 constructor");
+verify.quickInfos({
+    "18sq": ["constructor c2(a: number): c2", "c2 constructor"],
 
-goTo.marker('18spropq');
-verify.quickInfoIs("class c2", "");
-goTo.marker('18spropProp');
-verify.quickInfoIs("(property) c2.c2_p1: number", "c2 c2_p1");
+    "18spropq": "class c2",
+    "18spropProp": ["(property) c2.c2_p1: number", "c2 c2_p1"],
 
-goTo.marker('17q');
-verify.quickInfoIs("constructor c2(a: number): c2", "c2 constructor");
-goTo.marker('18q');
-verify.quickInfoIs("constructor c3(): c3", "");
+    "17q": ["constructor c2(a: number): c2", "c2 constructor"],
+    "18q": "constructor c3(): c3"
+});
 
 goTo.marker('19');
 verify.memberListContains("c2_p1", "(property) c2.c2_p1: number", "c2 c2_p1");
@@ -419,14 +397,12 @@ verify.currentSignatureHelpDocCommentIs("c2 f1");
 goTo.marker('23');
 verify.currentSignatureHelpDocCommentIs("");
 
-goTo.marker('20q');
-verify.quickInfoIs("(method) c2.c2_f1(): void", "c2 c2_f1");
-goTo.marker('21q');
-verify.quickInfoIs("(method) c2.c2_nc_f1(): void", "");
-goTo.marker('22q');
-verify.quickInfoIs("(method) c2.f1(): void", "c2 f1");
-goTo.marker('23q');
-verify.quickInfoIs("(method) c2.nc_f1(): void", "");
+verify.quickInfos({
+    "20q": ["(method) c2.c2_f1(): void", "c2 c2_f1"],
+    "21q": "(method) c2.c2_nc_f1(): void",
+    "22q": ["(method) c2.f1(): void", "c2 f1"],
+    "23q": "(method) c2.nc_f1(): void"
+});
 
 goTo.marker('24');
 verify.memberListContains("c2_p1", "(property) c2.c2_p1: number", "c2 c2_p1");
@@ -450,14 +426,12 @@ verify.currentSignatureHelpDocCommentIs("c3 f1");
 goTo.marker('28');
 verify.currentSignatureHelpDocCommentIs("");
 
-goTo.marker('25q');
-verify.quickInfoIs("(method) c2.c2_f1(): void", "c2 c2_f1");
-goTo.marker('26q');
-verify.quickInfoIs("(method) c2.c2_nc_f1(): void", "");
-goTo.marker('27q');
-verify.quickInfoIs("(method) c3.f1(): void", "c3 f1");
-goTo.marker('28q');
-verify.quickInfoIs("(method) c3.nc_f1(): void", "");
+verify.quickInfos({
+    "25q": ["(method) c2.c2_f1(): void", "c2 c2_f1"],
+    "26q": "(method) c2.c2_nc_f1(): void",
+    "27q": ["(method) c3.f1(): void", "c3 f1"],
+    "28q": "(method) c3.nc_f1(): void"
+});
 
 goTo.marker('29');
 verify.memberListContains("c2_p1", "(property) c2.c2_p1: number", "c2 c2_p1");
@@ -481,21 +455,19 @@ verify.currentSignatureHelpDocCommentIs("c2 f1");
 goTo.marker('33');
 verify.currentSignatureHelpDocCommentIs("");
 
-goTo.marker('30q');
-verify.quickInfoIs("(method) c2.c2_f1(): void", "c2 c2_f1");
-goTo.marker('31q');
-verify.quickInfoIs("(method) c2.c2_nc_f1(): void", "");
-goTo.marker('32q');
-verify.quickInfoIs("(method) c2.f1(): void", "c2 f1");
-goTo.marker('33q');
-verify.quickInfoIs("(method) c2.nc_f1(): void", "");
+verify.quickInfos({
+    "30q": ["(method) c2.c2_f1(): void", "c2 c2_f1"],
+    "31q": "(method) c2.c2_nc_f1(): void",
+    "32q": ["(method) c2.f1(): void", "c2 f1"],
+    "33q": "(method) c2.nc_f1(): void"
+});
 
 goTo.marker('34');
 verify.currentSignatureHelpDocCommentIs("c2 constructor");
-goTo.marker('34iq');
-verify.quickInfoIs("var c4_i: c4", "");
-goTo.marker('34q');
-verify.quickInfoIs("constructor c4(a: number): c4", "c2 constructor");
+verify.quickInfos({
+    "34iq": "var c4_i: c4",
+    "34q": ["constructor c4(a: number): c4", "c2 constructor"]
+});
 
 goTo.marker('35');
 verify.completionListContains("c2", "class c2", "");
@@ -535,26 +507,18 @@ verify.currentSignatureHelpDocCommentIs("");
 goTo.marker('l40');
 verify.currentSignatureHelpDocCommentIs("");
 
-goTo.marker('36iq');
-verify.quickInfoIs("var i2_i: i2", "");
-goTo.marker('37iq');
-verify.quickInfoIs("var i3_i: i3", "");
-goTo.marker('37q');
-verify.quickInfoIs("(method) i2.i2_f1(): void", "i2_f1");
-goTo.marker('38q');
-verify.quickInfoIs("(method) i2.i2_nc_f1(): void", "");
-goTo.marker('39q');
-verify.quickInfoIs("(method) i2.f1(): void", "i2 f1");
-goTo.marker('40q');
-verify.quickInfoIs("(method) i2.nc_f1(): void", "");
-goTo.marker('l37q');
-verify.quickInfoIs("(property) i2.i2_l1: () => void", "");
-goTo.marker('l38q');
-verify.quickInfoIs("(property) i2.i2_nc_l1: () => void", "");
-goTo.marker('l39q');
-verify.quickInfoIs("(property) i2.l1: () => void", "");
-goTo.marker('l40q');
-verify.quickInfoIs("(property) i2.nc_l1: () => void", "");
+verify.quickInfos({
+    "36iq": "var i2_i: i2",
+    "37iq": "var i3_i: i3",
+    "37q": ["(method) i2.i2_f1(): void", "i2_f1"],
+    "38q": "(method) i2.i2_nc_f1(): void",
+    "39q": ["(method) i2.f1(): void", "i2 f1"],
+    "40q": "(method) i2.nc_f1(): void",
+    "l37q": "(property) i2.i2_l1: () => void",
+    "l38q": "(property) i2.i2_nc_l1: () => void", 
+    "l39q": "(property) i2.l1: () => void",
+    "l40q": "(property) i2.nc_l1: () => void",
+});
 
 goTo.marker('41');
 verify.memberListContains("i2_p1", "(property) i2.i2_p1: number", "i2_p1");
@@ -586,22 +550,16 @@ verify.currentSignatureHelpDocCommentIs("");
 goTo.marker('l45');
 verify.currentSignatureHelpDocCommentIs("");
 
-goTo.marker('42q');
-verify.quickInfoIs("(method) i2.i2_f1(): void", "i2_f1");
-goTo.marker('43q');
-verify.quickInfoIs("(method) i2.i2_nc_f1(): void", "");
-goTo.marker('44q');
-verify.quickInfoIs("(method) i3.f1(): void", "i3 f1");
-goTo.marker('45q');
-verify.quickInfoIs("(method) i3.nc_f1(): void", "");
-goTo.marker('l42q');
-verify.quickInfoIs("(property) i2.i2_l1: () => void", "");
-goTo.marker('l43q');
-verify.quickInfoIs("(property) i2.i2_nc_l1: () => void", "");
-goTo.marker('l44q');
-verify.quickInfoIs("(property) i3.l1: () => void", "");
-goTo.marker('l45q');
-verify.quickInfoIs("(property) i3.nc_l1: () => void", "");
+verify.quickInfos({
+    "42q": ["(method) i2.i2_f1(): void", "i2_f1"],
+    "43q": "(method) i2.i2_nc_f1(): void",
+    "44q": ["(method) i3.f1(): void", "i3 f1"],
+    "45q": "(method) i3.nc_f1(): void",
+    l42q: "(property) i2.i2_l1: () => void",
+    l43q: "(property) i2.i2_nc_l1: () => void",
+    l44q: "(property) i3.l1: () => void",
+    l45q: "(property) i3.nc_l1: () => void"
+});
 
 goTo.marker('46');
 verify.memberListContains("i2_p1", "(property) i2.i2_p1: number", "i2_p1");
@@ -633,22 +591,16 @@ verify.currentSignatureHelpDocCommentIs("");
 goTo.marker('l50');
 verify.currentSignatureHelpDocCommentIs("");
 
-goTo.marker('47q');
-verify.quickInfoIs("(method) i2.i2_f1(): void", "i2_f1");
-goTo.marker('48q');
-verify.quickInfoIs("(method) i2.i2_nc_f1(): void", "");
-goTo.marker('49q');
-verify.quickInfoIs("(method) i2.f1(): void", "i2 f1");
-goTo.marker('50q');
-verify.quickInfoIs("(method) i2.nc_f1(): void", "");
-goTo.marker('l47q');
-verify.quickInfoIs("(property) i2.i2_l1: () => void", "");
-goTo.marker('l48q');
-verify.quickInfoIs("(property) i2.i2_nc_l1: () => void", "");
-goTo.marker('l49q');
-verify.quickInfoIs("(property) i2.l1: () => void", "");
-goTo.marker('l50q');
-verify.quickInfoIs("(property) i2.nc_l1: () => void", "");
+verify.quickInfos({
+    "47q": ["(method) i2.i2_f1(): void", "i2_f1"],
+    "48q": "(method) i2.i2_nc_f1(): void",
+    "49q": ["(method) i2.f1(): void", "i2 f1"],
+    "50q": "(method) i2.nc_f1(): void",
+    l47q: "(property) i2.i2_l1: () => void",
+    l48q: "(property) i2.i2_nc_l1: () => void",
+    l49q: "(property) i2.l1: () => void",
+    l40q: "(property) i2.nc_l1: () => void"
+});
 
 goTo.marker('51');
 verify.completionListContains("i2", "interface i2", "");
@@ -660,20 +612,11 @@ goTo.marker('51i');
 verify.completionListContains("i2", "interface i2", "");
 verify.completionListContains("i3", "interface i3", "");
 
-goTo.marker('52');
-verify.quickInfoIs("constructor c5(): c5", "");
-
-goTo.marker('53');
-verify.quickInfoIs("class c5", "c5 class");
-
-goTo.marker('54');
-verify.quickInfoIs("(property) c5.b: number", "");
-
-goTo.marker('55');
-verify.quickInfoIs("constructor c2(a: number): c2", "c2 constructor");
-
-goTo.marker('56');
-verify.quickInfoIs("constructor c3(): c3", "");
-
-goTo.marker('57');
-verify.quickInfoIs("constructor c6(): c6", "");
+verify.quickInfos({
+    52: "constructor c5(): c5",
+    53: ["class c5", "c5 class"],
+    54: "(property) c5.b: number",
+    55: ["constructor c2(a: number): c2", "c2 constructor"],
+    56: "constructor c3(): c3",
+    57: "constructor c6(): c6"
+});

--- a/tests/cases/fourslash/commentsInterface.ts
+++ b/tests/cases/fourslash/commentsInterface.ts
@@ -68,26 +68,15 @@
 ////i3_i.nc_/*44q*/f(/*44*/10);
 ////i3_i.nc/*45q*/_l(/*45*/10);
 
-goTo.marker('1');
-verify.quickInfoIs("interface i1", "this is interface 1");
-
-goTo.marker('2');
-verify.quickInfoIs("var i1_i: i1", "");
-
-goTo.marker('3');
-verify.quickInfoIs("interface nc_i1", "");
-
-goTo.marker('4');
-verify.quickInfoIs("var nc_i1_i: nc_i1", "");
-
-goTo.marker('5');
-verify.quickInfoIs("interface i2", "this is interface 2 with memebers");
-
-goTo.marker('6');
-verify.quickInfoIs("var i2_i: i2", "");
-
-goTo.marker('7');
-verify.quickInfoIs("var i2_i_x: number", "");
+verify.quickInfos({
+    1: ["interface i1", "this is interface 1"],
+    2: "var i1_i: i1",
+    3: "interface nc_i1",
+    4: "var nc_i1_i: nc_i1",
+    5: ["interface i2", "this is interface 2 with memebers"],
+    6: "var i2_i: i2",
+    7: "var i2_i_x: number"
+});
 
 goTo.marker('8');
 verify.quickInfoIs("(property) i2.x: number", "this is x");
@@ -98,103 +87,80 @@ verify.memberListContains("nc_foo", "(property) i2.nc_foo: (b: number) => string
 verify.memberListContains("fnfoo", "(method) i2.fnfoo(b: number): string", "this is fnfoo");
 verify.memberListContains("nc_fnfoo", "(method) i2.nc_fnfoo(b: number): string", "");
 
-goTo.marker('9');
-verify.quickInfoIs("var i2_i_foo: (b: number) => string", "");
-
-goTo.marker('10');
-verify.quickInfoIs("(property) i2.foo: (b: number) => string", "this is foo");
-
-goTo.marker('11');
-verify.quickInfoIs("var i2_i_foo_r: string", "");
+verify.quickInfos({
+    9: "var i2_i_foo: (b: number) => string",
+    10: ["(property) i2.foo: (b: number) => string", "this is foo"],
+    11: "var i2_i_foo_r: string"
+});
 
 goTo.marker('12');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("param help");
-goTo.marker('12q');
-verify.quickInfoIs("(property) i2.foo: (b: number) => string", "");
 
-goTo.marker('13');
-verify.quickInfoIs("var i2_i_i2_si: number", "");
-goTo.marker('13q');
-verify.quickInfoIs("var i2_i: i2", "");
+verify.quickInfos({
+    "12q": "(property) i2.foo: (b: number) => string",
 
-goTo.marker('14');
-verify.quickInfoIs("var i2_i_i2_ii: number", "");
-goTo.marker('14q');
-verify.quickInfoIs("var i2_i: i2", "");
+    13: "var i2_i_i2_si: number",
+    "13q": "var i2_i: i2",
 
-goTo.marker('15');
-verify.quickInfoIs("var i2_i_n: any", "");
+    14: "var i2_i_i2_ii: number",
+    "14q": "var i2_i: i2",
+
+    15: "var i2_i_n: any"
+});
 
 goTo.marker('16');
 verify.currentSignatureHelpDocCommentIs("new method");
 verify.currentParameterHelpArgumentDocCommentIs("param");
-goTo.marker('16q');
-verify.quickInfoIs("var i2_i: new i2(i: i1) => any", "new method");
+verify.quickInfos({
+    "16q": ["var i2_i: new i2(i: i1) => any", "new method"],
 
-goTo.marker('17');
-verify.quickInfoIs("var i2_i_nc_x: number", "");
-
-goTo.marker('18');
-verify.quickInfoIs("(property) i2.nc_x: number", "");
-
-goTo.marker('19');
-verify.quickInfoIs("var i2_i_nc_foo: (b: number) => string", "");
-
-goTo.marker('20');
-verify.quickInfoIs("(property) i2.nc_foo: (b: number) => string", "");
-
-goTo.marker('21');
-verify.quickInfoIs("var i2_i_nc_foo_r: string", "");
+    17: "var i2_i_nc_x: number",
+    18: "(property) i2.nc_x: number",
+    19: "var i2_i_nc_foo: (b: number) => string",
+    20: "(property) i2.nc_foo: (b: number) => string",
+    21: "var i2_i_nc_foo_r: string"
+});
 
 goTo.marker('22');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('22q');
-verify.quickInfoIs("(property) i2.nc_foo: (b: number) => string", "");
-
-goTo.marker('23');
-verify.quickInfoIs("var i2_i_r: number", "");
+verify.quickInfos({
+    "22q": "(property) i2.nc_foo: (b: number) => string",
+    23: "var i2_i_r: number"
+});
 
 goTo.marker('24');
 verify.currentSignatureHelpDocCommentIs("this is call signature");
 verify.currentParameterHelpArgumentDocCommentIs("paramhelp a");
-goTo.marker('24q');
-verify.quickInfoIs("var i2_i: i2(a: number, b: number) => number", "this is call signature");
+verify.quickInfoAt("24q", "var i2_i: i2(a: number, b: number) => number", "this is call signature");
 
 goTo.marker('25');
 verify.currentSignatureHelpDocCommentIs("this is call signature");
 verify.currentParameterHelpArgumentDocCommentIs("paramhelp b");
 
-goTo.marker('26');
-verify.quickInfoIs("var i2_i_fnfoo: (b: number) => string", "");
-
-goTo.marker('27');
-verify.quickInfoIs("(method) i2.fnfoo(b: number): string", "this is fnfoo");
-
-goTo.marker('28');
-verify.quickInfoIs("var i2_i_fnfoo_r: string", "");
+verify.quickInfos({
+    26: "var i2_i_fnfoo: (b: number) => string",
+    27: ["(method) i2.fnfoo(b: number): string", "this is fnfoo"],
+    28: "var i2_i_fnfoo_r: string"
+});
 
 goTo.marker('29');
 verify.currentSignatureHelpDocCommentIs("this is fnfoo");
 verify.currentParameterHelpArgumentDocCommentIs("param help");
-goTo.marker('29q');
-verify.quickInfoIs("(method) i2.fnfoo(b: number): string", "this is fnfoo");
 
-goTo.marker('30');
-verify.quickInfoIs("var i2_i_nc_fnfoo: (b: number) => string", "");
+verify.quickInfos({
+    "29q": ["(method) i2.fnfoo(b: number): string", "this is fnfoo"],
 
-goTo.marker('31');
-verify.quickInfoIs("(method) i2.nc_fnfoo(b: number): string", "");
-
-goTo.marker('32');
-verify.quickInfoIs("var i2_i_nc_fnfoo_r: string", "");
+    30: "var i2_i_nc_fnfoo: (b: number) => string",
+    31: "(method) i2.nc_fnfoo(b: number): string",
+    32: "var i2_i_nc_fnfoo_r: string"
+});
 
 goTo.marker('33');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('33q');
-verify.quickInfoIs("(method) i2.nc_fnfoo(b: number): string", "");
+verify.quickInfoAt("33q", "(method) i2.nc_fnfoo(b: number): string");
 
 goTo.marker('34');
 verify.completionListContains("i1", "interface i1", "this is interface 1");
@@ -226,8 +192,7 @@ verify.completionListContains("i2", "interface i2", "this is interface 2 with me
 goTo.marker('36');
 verify.completionListContains("a", "(parameter) a: number", "i3_i a");
 
-goTo.marker('40q');
-verify.quickInfoIs("var i3_i: i3", "");
+verify.quickInfoAt("40q", "var i3_i: i3");
 goTo.marker('40');
 verify.completionListContains("i3", "interface i3", "");
 verify.completionListContains("i3_i", "var i3_i: i3", "");
@@ -248,17 +213,14 @@ verify.currentParameterHelpArgumentDocCommentIs("number parameter");
 goTo.marker('43');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("comment i3 l b");
-goTo.marker('43q');
-verify.quickInfoIs("(property) i3.l: (b: number) => string", "");
+verify.quickInfoAt("43q", "(property) i3.l: (b: number) => string");
 
 goTo.marker('44');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('44q');
-verify.quickInfoIs("(method) i3.nc_f(a: number): string", "");
+verify.quickInfoAt("44q", "(method) i3.nc_f(a: number): string");
 
 goTo.marker('45');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('45q');
-verify.quickInfoIs("(property) i3.nc_l: (b: number) => string", "");
+verify.quickInfoAt("45q", "(property) i3.nc_l: (b: number) => string");

--- a/tests/cases/fourslash/commentsLinePreservation.ts
+++ b/tests/cases/fourslash/commentsLinePreservation.ts
@@ -106,56 +106,35 @@
 ////  */
 ////function /*l*/l(param1: string) { /*9*/param1 = "hello"; }
 
-goTo.marker('a');
-verify.quickInfoIs("var a: string", "This is firstLine\nThis is second Line\n\nThis is fourth Line");
+verify.quickInfos({
+    a: ["var a: string", "This is firstLine\nThis is second Line\n\nThis is fourth Line"],
+    b: ["var b: string", "This is firstLine\nThis is second Line\n\nThis is fourth Line"],
+    c: ["var c: string", "This is firstLine\nThis is second Line\n\nThis is fourth Line"],
+ 
+    d: ["function d(param: string): void", "This is firstLine\nThis is second Line\n@random tag This should be third line"],
+    1: "(parameter) param: string",
 
-goTo.marker('b');
-verify.quickInfoIs("var b: string", "This is firstLine\nThis is second Line\n\nThis is fourth Line");
+    e: ["function e(param: string): void", "This is firstLine\nThis is second Line"],
+    2: "(parameter) param: string",
 
-goTo.marker('c');
-verify.quickInfoIs("var c: string", "This is firstLine\nThis is second Line\n\nThis is fourth Line");
+    f: ["function f(param1: string): void", "This is firstLine\nThis is second Line\n@random tag This should be third line"],
+    3: ["(parameter) param1: string", "first line of param\n\nparam information third line"],
 
-goTo.marker('d');
-verify.quickInfoIs("function d(param: string): void", "This is firstLine\nThis is second Line\n@random tag This should be third line");
-goTo.marker('1');
-verify.quickInfoIs("(parameter) param: string", "");
+    g: ["function g(param1: string): void", "This is firstLine\nThis is second Line\n@random tag This should be third line"],
+    4: ["(parameter) param1: string", "param information first line"],
 
-goTo.marker('e');
-verify.quickInfoIs("function e(param: string): void", "This is firstLine\nThis is second Line");
-goTo.marker('2');
-verify.quickInfoIs("(parameter) param: string", "");
+    h: ["function h(param1: string): void", "This is firstLine\nThis is second Line\n@random tag This should be third line"],
+    5: ["(parameter) param1: string", "param information first line\n\nparam information third line"],
 
-goTo.marker('f');
-verify.quickInfoIs("function f(param1: string): void", "This is firstLine\nThis is second Line\n@random tag This should be third line");
-goTo.marker('3');
-verify.quickInfoIs("(parameter) param1: string", "first line of param\n\nparam information third line");
+    i: ["function i(param1: string): void", "This is firstLine\nThis is second Line"],
+    6: ["(parameter) param1: string", "param information first line\n\nparam information third line"],
 
-goTo.marker('g');
-verify.quickInfoIs("function g(param1: string): void", "This is firstLine\nThis is second Line\n@random tag This should be third line");
-goTo.marker('4');
-verify.quickInfoIs("(parameter) param1: string", "param information first line");
+    j: ["function j(param1: string): void", "This is firstLine\nThis is second Line"],
+    7: ["(parameter) param1: string", "param information first line\n\nparam information third line"],
 
-goTo.marker('h');
-verify.quickInfoIs("function h(param1: string): void", "This is firstLine\nThis is second Line\n@random tag This should be third line");
-goTo.marker('5');
-verify.quickInfoIs("(parameter) param1: string", "param information first line\n\nparam information third line");
+    k: ["function k(param1: string): void", "This is firstLine\nThis is second Line\n@randomtag \n\n random information first line\n\n random information third line"],
+    8: ["(parameter) param1: string", "hello   "],
 
-goTo.marker('i');
-verify.quickInfoIs("function i(param1: string): void", "This is firstLine\nThis is second Line");
-goTo.marker('6');
-verify.quickInfoIs("(parameter) param1: string", "param information first line\n\nparam information third line");
-
-goTo.marker('j');
-verify.quickInfoIs("function j(param1: string): void", "This is firstLine\nThis is second Line");
-goTo.marker('7');
-verify.quickInfoIs("(parameter) param1: string", "param information first line\n\nparam information third line");
-
-goTo.marker('k');
-verify.quickInfoIs("function k(param1: string): void", "This is firstLine\nThis is second Line\n@randomtag \n\n random information first line\n\n random information third line");
-goTo.marker('8');
-verify.quickInfoIs("(parameter) param1: string", "hello   ");
-
-goTo.marker('l');
-verify.quickInfoIs("function l(param1: string): void", "This is firstLine\nThis is second Line");
-goTo.marker('9');
-verify.quickInfoIs("(parameter) param1: string", "first Line text\nblank line that shouldnt be shown when starting this \nsecond time information about the param again");
+    l: ["function l(param1: string): void", "This is firstLine\nThis is second Line"],
+    9: ["(parameter) param1: string", "first Line text\nblank line that shouldnt be shown when starting this \nsecond time information about the param again"]
+});

--- a/tests/cases/fourslash/commentsModules.ts
+++ b/tests/cases/fourslash/commentsModules.ts
@@ -96,8 +96,7 @@
 ////}
 ////var myComp/*35*/lexVal = new compl/*36*/exM.m/*37*/2./*38*/c().f/*39*/oo2().f/*40*/oo();
 
-goTo.marker('1');
-verify.quickInfoIs("namespace m1", "Namespace comment");
+verify.quickInfoAt("1", "namespace m1", "Namespace comment");
 
 goTo.marker('2');
 verify.completionListContains("b", "var m1.b: number", "b's comment");
@@ -105,8 +104,7 @@ verify.completionListContains("foo", "function foo(): number", "foo's comment");
 
 goTo.marker('3');
 verify.currentSignatureHelpDocCommentIs("foo's comment");
-goTo.marker('3q');
-verify.quickInfoIs("function foo(): number", "foo's comment");
+verify.quickInfoAt("3q", "function foo(): number", "foo's comment");
 
 goTo.marker('4');
 verify.completionListContains("m1", "namespace m1", "Namespace comment");
@@ -120,49 +118,48 @@ verify.quickInfoIs("function m1.fooExport(): number", "exported function");
 goTo.marker('6');
 verify.currentSignatureHelpDocCommentIs("exported function");
 
-goTo.marker('7');
-verify.quickInfoIs("var myvar: m1.m2.c", "");
+verify.quickInfoAt("7", "var myvar: m1.m2.c");
 
 goTo.marker('8');
-verify.quickInfoIs("constructor m1.m2.c(): m1.m2.c", "");
+verify.quickInfoIs("constructor m1.m2.c(): m1.m2.c");
 verify.memberListContains("c", "constructor m1.m2.c(): m1.m2.c", "");
 verify.memberListContains("i", "var m1.m2.i: m1.m2.c", "i");
 
 goTo.marker('9');
 verify.completionListContains("m2", "namespace m2", "");
-verify.quickInfoIs("namespace m2", "");
+verify.quickInfoIs("namespace m2");
 
 goTo.marker('10');
 verify.memberListContains("m3", "namespace m2.m3");
 verify.quickInfoIs("namespace m2.m3", "namespace comment of m2.m3");
 
 goTo.marker('11');
-verify.quickInfoIs("constructor m2.m3.c(): m2.m3.c", "");
+verify.quickInfoIs("constructor m2.m3.c(): m2.m3.c");
 verify.memberListContains("c", "constructor m2.m3.c(): m2.m3.c", "");
 
 goTo.marker('12');
 verify.completionListContains("m3", "namespace m3", "");
-verify.quickInfoIs("namespace m3", "");
+verify.quickInfoIs("namespace m3");
 
 goTo.marker('13');
 verify.memberListContains("m4", "namespace m3.m4", "");
-verify.quickInfoIs("namespace m3.m4", "");
+verify.quickInfoIs("namespace m3.m4");
 
 goTo.marker('14');
 verify.memberListContains("m5", "namespace m3.m4.m5");
 verify.quickInfoIs("namespace m3.m4.m5", "namespace comment of m3.m4.m5");
 
 goTo.marker('15');
-verify.quickInfoIs("constructor m3.m4.m5.c(): m3.m4.m5.c", "");
+verify.quickInfoIs("constructor m3.m4.m5.c(): m3.m4.m5.c");
 verify.memberListContains("c", "constructor m3.m4.m5.c(): m3.m4.m5.c", "");
 
 goTo.marker('16');
 verify.completionListContains("m4", "namespace m4", "");
-verify.quickInfoIs("namespace m4", "");
+verify.quickInfoIs("namespace m4");
 
 goTo.marker('17');
 verify.memberListContains("m5", "namespace m4.m5", "");
-verify.quickInfoIs("namespace m4.m5", "");
+verify.quickInfoIs("namespace m4.m5");
 
 goTo.marker('18');
 verify.memberListContains("m6", "namespace m4.m5.m6");
@@ -170,19 +167,19 @@ verify.quickInfoIs("namespace m4.m5.m6", "namespace comment of m4.m5.m6");
 
 goTo.marker('19');
 verify.memberListContains("m7", "namespace m4.m5.m6.m7");
-verify.quickInfoIs("namespace m4.m5.m6.m7", "");
+verify.quickInfoIs("namespace m4.m5.m6.m7");
 
 goTo.marker('20');
 verify.memberListContains("c", "constructor m4.m5.m6.m7.c(): m4.m5.m6.m7.c", "");
-verify.quickInfoIs("constructor m4.m5.m6.m7.c(): m4.m5.m6.m7.c", "");
+verify.quickInfoIs("constructor m4.m5.m6.m7.c(): m4.m5.m6.m7.c");
 
 goTo.marker('21');
 verify.completionListContains("m5", "namespace m5");
-verify.quickInfoIs("namespace m5", "");
+verify.quickInfoIs("namespace m5");
 
 goTo.marker('22');
 verify.memberListContains("m6", "namespace m5.m6");
-verify.quickInfoIs("namespace m5.m6", "");
+verify.quickInfoIs("namespace m5.m6");
 
 goTo.marker('23');
 verify.memberListContains("m7", "namespace m5.m6.m7");
@@ -194,31 +191,31 @@ verify.quickInfoIs("namespace m5.m6.m7.m8", "namespace m8 comment");
 
 goTo.marker('25');
 verify.memberListContains("c", "constructor m5.m6.m7.m8.c(): m5.m6.m7.m8.c", "");
-verify.quickInfoIs("constructor m5.m6.m7.m8.c(): m5.m6.m7.m8.c", "");
+verify.quickInfoIs("constructor m5.m6.m7.m8.c(): m5.m6.m7.m8.c");
 
 goTo.marker('26');
 verify.completionListContains("m6", "namespace m6");
-verify.quickInfoIs("namespace m6", "");
+verify.quickInfoIs("namespace m6");
 
 goTo.marker('27');
 verify.memberListContains("m7", "namespace m6.m7");
-verify.quickInfoIs("namespace m6.m7", "");
+verify.quickInfoIs("namespace m6.m7");
 
 goTo.marker('28');
 verify.memberListContains("m8", "namespace m6.m7.m8");
-verify.quickInfoIs("namespace m6.m7.m8", "");
+verify.quickInfoIs("namespace m6.m7.m8");
 
 goTo.marker('29');
 verify.memberListContains("c", "constructor m6.m7.m8.c(): m6.m7.m8.c", "");
-verify.quickInfoIs("constructor m6.m7.m8.c(): m6.m7.m8.c", "");
+verify.quickInfoIs("constructor m6.m7.m8.c(): m6.m7.m8.c");
 
 goTo.marker('30');
 verify.completionListContains("m7", "namespace m7");
-verify.quickInfoIs("namespace m7", "");
+verify.quickInfoIs("namespace m7");
 
 goTo.marker('31');
 verify.memberListContains("m8", "namespace m7.m8");
-verify.quickInfoIs("namespace m7.m8", "");
+verify.quickInfoIs("namespace m7.m8");
 
 goTo.marker('32');
 verify.memberListContains("m9", "namespace m7.m8.m9");
@@ -226,26 +223,17 @@ verify.quickInfoIs("namespace m7.m8.m9", "namespace m9 comment");
 
 goTo.marker('33');
 verify.memberListContains("c", "constructor m7.m8.m9.c(): m7.m8.m9.c", "");
-verify.quickInfoIs("constructor m7.m8.m9.c(): m7.m8.m9.c", "");
+verify.quickInfoIs("constructor m7.m8.m9.c(): m7.m8.m9.c");
 
 goTo.marker('34');
 verify.completionListContains("c", 'class c', "");
-verify.quickInfoIs('class c', "");
+verify.quickInfoIs('class c');
 
-goTo.marker('35');
-verify.quickInfoIs("var myComplexVal: number", "");
-
-goTo.marker('36');
-verify.quickInfoIs("namespace complexM", "");
-
-goTo.marker('37');
-verify.quickInfoIs("namespace complexM.m2", "");
-
-goTo.marker('38');
-verify.quickInfoIs("constructor complexM.m2.c(): complexM.m2.c", "");
-
-goTo.marker('39');
-verify.quickInfoIs("(method) complexM.m2.c.foo2(): complexM.m1.c", "");
-
-goTo.marker('40');
-verify.quickInfoIs("(method) complexM.m1.c.foo(): number", "");
+verify.quickInfos({
+    35: "var myComplexVal: number",
+    36: "namespace complexM",
+    37: "namespace complexM.m2",
+    38: "constructor complexM.m2.c(): complexM.m2.c",
+    39: "(method) complexM.m2.c.foo2(): complexM.m1.c",
+    40: "(method) complexM.m1.c.foo(): number",
+});

--- a/tests/cases/fourslash/commentsMultiModuleMultiFile.ts
+++ b/tests/cases/fourslash/commentsMultiModuleMultiFile.ts
@@ -26,26 +26,14 @@
 ////}
 ////new /*7*/mu/*8*/ltiM.d();
 
+const comment = "this is multi declare namespace\nthi is multi namespace 2\nthis is multi namespace 3 comment";
+
 goTo.marker('1');
-verify.completionListContains("multiM", "namespace multiM", "this is multi declare namespace\nthi is multi namespace 2\nthis is multi namespace 3 comment");
+verify.completionListContains("multiM", "namespace multiM", comment);
 
-goTo.marker('2');
-verify.quickInfoIs("namespace multiM", "this is multi declare namespace\nthi is multi namespace 2\nthis is multi namespace 3 comment");
-
-goTo.marker('3');
-verify.quickInfoIs("namespace multiM", "this is multi declare namespace\nthi is multi namespace 2\nthis is multi namespace 3 comment");
-
-goTo.marker('4');
-verify.quickInfoIs("namespace multiM", "this is multi declare namespace\nthi is multi namespace 2\nthis is multi namespace 3 comment");
-
-goTo.marker('5');
-verify.quickInfoIs("namespace multiM", "this is multi declare namespace\nthi is multi namespace 2\nthis is multi namespace 3 comment");
-
-goTo.marker('6');
-verify.quickInfoIs("namespace multiM", "this is multi declare namespace\nthi is multi namespace 2\nthis is multi namespace 3 comment");
+for (const marker of ["2", "3", "4", "5", "6", "8"]) {
+    verify.quickInfoAt(marker, "namespace multiM", comment);
+}
 
 goTo.marker('7');
-verify.completionListContains("multiM", "namespace multiM", "this is multi declare namespace\nthi is multi namespace 2\nthis is multi namespace 3 comment");
-
-goTo.marker('8');
-verify.quickInfoIs("namespace multiM", "this is multi declare namespace\nthi is multi namespace 2\nthis is multi namespace 3 comment");
+verify.completionListContains("multiM", "namespace multiM", comment);

--- a/tests/cases/fourslash/commentsMultiModuleSingleFile.ts
+++ b/tests/cases/fourslash/commentsMultiModuleSingleFile.ts
@@ -16,17 +16,11 @@
 ////new /*1*/mu/*4*/ltiM.b();
 ////new mu/*5*/ltiM.c();
 
+const comment = "this is multi declare namespace\nthi is multi namespace 2";
+
 goTo.marker('1');
-verify.completionListContains("multiM", "namespace multiM", "this is multi declare namespace\nthi is multi namespace 2");
+verify.completionListContains("multiM", "namespace multiM", comment);
 
-goTo.marker('2');
-verify.quickInfoIs("namespace multiM", "this is multi declare namespace\nthi is multi namespace 2");
-
-goTo.marker('3');
-verify.quickInfoIs("namespace multiM", "this is multi declare namespace\nthi is multi namespace 2");
-
-goTo.marker('4');
-verify.quickInfoIs("namespace multiM", "this is multi declare namespace\nthi is multi namespace 2");
-
-goTo.marker('5');
-verify.quickInfoIs("namespace multiM", "this is multi declare namespace\nthi is multi namespace 2");
+for (const marker of ["2", "3", "4", "5"]) {
+    verify.quickInfoAt(marker, "namespace multiM", comment);
+}

--- a/tests/cases/fourslash/commentsOverloads.ts
+++ b/tests/cases/fourslash/commentsOverloads.ts
@@ -225,16 +225,13 @@
 ////}
 ////foo(null);
 
-goTo.marker('1');
-verify.quickInfoIs("function f1(a: number): number (+1 overload)", "this is signature 1");
-goTo.marker('2');
-verify.quickInfoIs("function f1(b: string): number (+1 overload)", "");
-goTo.marker('3');
-verify.quickInfoIs("function f1(a: number): number (+1 overload)", "this is signature 1");
-goTo.marker('4q');
-verify.quickInfoIs("function f1(b: string): number (+1 overload)", "");
-goTo.marker('o4q');
-verify.quickInfoIs("function f1(a: number): number (+1 overload)", "this is signature 1");
+verify.quickInfos({
+    1: ["function f1(a: number): number (+1 overload)", "this is signature 1"],
+    2: "function f1(b: string): number (+1 overload)",
+    3: ["function f1(a: number): number (+1 overload)", "this is signature 1"],
+    "4q": "function f1(b: string): number (+1 overload)",
+    o4q: ["function f1(a: number): number (+1 overload)", "this is signature 1"]
+});
 
 goTo.marker('4');
 verify.currentSignatureHelpDocCommentIs("");
@@ -243,16 +240,13 @@ goTo.marker('o4');
 verify.currentSignatureHelpDocCommentIs("this is signature 1");
 verify.currentParameterHelpArgumentDocCommentIs("param a");
 
-goTo.marker('5');
-verify.quickInfoIs("function f2(a: number): number (+1 overload)", "");
-goTo.marker('6');
-verify.quickInfoIs("function f2(b: string): number (+1 overload)", "this is signature 2");
-goTo.marker('7');
-verify.quickInfoIs("function f2(a: number): number (+1 overload)", "");
-goTo.marker('8q');
-verify.quickInfoIs("function f2(b: string): number (+1 overload)", "this is signature 2");
-goTo.marker('o8q');
-verify.quickInfoIs("function f2(a: number): number (+1 overload)", "");
+verify.quickInfos({
+    5: "function f2(a: number): number (+1 overload)",
+    6: ["function f2(b: string): number (+1 overload)", "this is signature 2"],
+    7: "function f2(a: number): number (+1 overload)",
+    "8q": ["function f2(b: string): number (+1 overload)", "this is signature 2"],
+    o8q: "function f2(a: number): number (+1 overload)"
+});
 
 goTo.marker('8');
 verify.currentSignatureHelpDocCommentIs("this is signature 2");
@@ -262,16 +256,13 @@ goTo.marker('o8');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("param a");
 
-goTo.marker('9');
-verify.quickInfoIs("function f3(a: number): number (+1 overload)", "");
-goTo.marker('10');
-verify.quickInfoIs("function f3(b: string): number (+1 overload)", "");
-goTo.marker('11');
-verify.quickInfoIs("function f3(a: number): number (+1 overload)", "");
-goTo.marker('12q');
-verify.quickInfoIs("function f3(b: string): number (+1 overload)", "");
-goTo.marker('o12q');
-verify.quickInfoIs("function f3(a: number): number (+1 overload)", "");
+verify.quickInfos({
+    9: "function f3(a: number): number (+1 overload)",
+    10: "function f3(b: string): number (+1 overload)",
+    11: "function f3(a: number): number (+1 overload)",
+    "12q": "function f3(b: string): number (+1 overload)",
+    o12q: "function f3(a: number): number (+1 overload)"
+});
 
 goTo.marker('12');
 verify.currentSignatureHelpDocCommentIs("");
@@ -281,16 +272,13 @@ goTo.marker('o12');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
 
-goTo.marker('13');
-verify.quickInfoIs("function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter");
-goTo.marker('14');
-verify.quickInfoIs("function f4(b: string): number (+1 overload)", "this is signature 4 - with string parameter");
-goTo.marker('15');
-verify.quickInfoIs("function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter");
-goTo.marker('16q');
-verify.quickInfoIs("function f4(b: string): number (+1 overload)", "this is signature 4 - with string parameter");
-goTo.marker('o16q');
-verify.quickInfoIs("function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter");
+verify.quickInfos({
+    13: ["function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter"],
+    14: ["function f4(b: string): number (+1 overload)", "this is signature 4 - with string parameter"],
+    15: ["function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter"],
+    "16q": ["function f4(b: string): number (+1 overload)", "this is signature 4 - with string parameter"],
+    o16q: ["function f4(a: number): number (+1 overload)", "this is signature 4 - with number parameter"]
+});
 
 goTo.marker('16');
 verify.currentSignatureHelpDocCommentIs("this is signature 4 - with string parameter");
@@ -319,26 +307,23 @@ verify.completionListContains('i4_i', 'var i4_i: new i4(a: string) => any (+1 ov
 goTo.marker('19');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('19q');
-verify.quickInfoIs("var i1_i: new i1(b: number) => any (+1 overload)", "");
+verify.quickInfoAt("19q", "var i1_i: new i1(b: number) => any (+1 overload)");
 
 goTo.marker('20');
 verify.currentSignatureHelpDocCommentIs("new 1");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('20q');
-verify.quickInfoIs("var i1_i: new i1(a: string) => any (+1 overload)", "new 1");
+verify.quickInfoAt("20q", "var i1_i: new i1(a: string) => any (+1 overload)", "new 1");
 
 goTo.marker('21');
 verify.currentSignatureHelpDocCommentIs("this signature 1");
 verify.currentParameterHelpArgumentDocCommentIs("param a");
-goTo.marker('21q');
-verify.quickInfoIs("var i1_i: i1(a: number) => number (+1 overload)", "this signature 1");
+verify.quickInfoAt("21q", "var i1_i: i1(a: number) => number (+1 overload)", "this signature 1");
 
 goTo.marker('22');
 verify.currentSignatureHelpDocCommentIs("this is signature 2");
 verify.currentParameterHelpArgumentDocCommentIs("");
 goTo.marker('22q');
-verify.quickInfoIs("var i1_i: i1(b: string) => number (+1 overload)", "this is signature 2");
+verify.quickInfoAt("22q", "var i1_i: i1(b: string) => number (+1 overload)", "this is signature 2");
 
 goTo.marker('23');
 verify.memberListContains('foo', '(method) i1.foo(a: number): number (+1 overload)', 'foo 1');
@@ -349,122 +334,102 @@ verify.memberListContains('foo4', '(method) i1.foo4(a: number): number (+1 overl
 goTo.marker('24');
 verify.currentSignatureHelpDocCommentIs("foo 1");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('24q');
-verify.quickInfoIs("(method) i1.foo(a: number): number (+1 overload)", "foo 1");
+verify.quickInfoAt("24q", "(method) i1.foo(a: number): number (+1 overload)", "foo 1");
 
 goTo.marker('25');
 verify.currentSignatureHelpDocCommentIs("foo 2");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('25q');
-verify.quickInfoIs("(method) i1.foo(b: string): number (+1 overload)", "foo 2");
+verify.quickInfoAt("25q", "(method) i1.foo(b: string): number (+1 overload)", "foo 2");
 
 goTo.marker('26');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('26q');
-verify.quickInfoIs("(method) i1.foo2(a: number): number (+1 overload)", "");
+verify.quickInfoAt("26q", "(method) i1.foo2(a: number): number (+1 overload)");
 
 goTo.marker('27');
 verify.currentSignatureHelpDocCommentIs("foo2 2");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('27q');
-verify.quickInfoIs("(method) i1.foo2(b: string): number (+1 overload)", "foo2 2");
+verify.quickInfoAt("27q", "(method) i1.foo2(b: string): number (+1 overload)", "foo2 2");
 
 goTo.marker('28');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('28q');
-verify.quickInfoIs("(method) i1.foo3(a: number): number (+1 overload)", "");
+verify.quickInfoAt("28q", "(method) i1.foo3(a: number): number (+1 overload)");
 
 goTo.marker('29');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('29q');
-verify.quickInfoIs("(method) i1.foo3(b: string): number (+1 overload)", "");
+verify.quickInfoAt("29q", "(method) i1.foo3(b: string): number (+1 overload)");
 
 goTo.marker('30');
 verify.currentSignatureHelpDocCommentIs("foo4 1");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('30q');
-verify.quickInfoIs("(method) i1.foo4(a: number): number (+1 overload)", "foo4 1");
+verify.quickInfoAt("30q", "(method) i1.foo4(a: number): number (+1 overload)", "foo4 1");
 
 goTo.marker('31');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('31q');
-verify.quickInfoIs("(method) i1.foo4(b: string): number (+1 overload)", "");
+verify.quickInfoAt("31q", "(method) i1.foo4(b: string): number (+1 overload)");
 
 goTo.marker('32');
 verify.currentSignatureHelpDocCommentIs("new 2");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('32q');
-verify.quickInfoIs("var i2_i: new i2(b: number) => any (+1 overload)", "new 2");
+verify.quickInfoAt("32q", "var i2_i: new i2(b: number) => any (+1 overload)", "new 2");
 
 goTo.marker('33');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('33q');
-verify.quickInfoIs("var i2_i: new i2(a: string) => any (+1 overload)", "");
+verify.quickInfoAt("33q", "var i2_i: new i2(a: string) => any (+1 overload)");
 
 goTo.marker('34');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('34q');
-verify.quickInfoIs("var i2_i: i2(a: number) => number (+1 overload)", "");
+verify.quickInfoAt("34q", "var i2_i: i2(a: number) => number (+1 overload)");
 
 goTo.marker('35');
 verify.currentSignatureHelpDocCommentIs("this is signature 2");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('35q');
-verify.quickInfoIs("var i2_i: i2(b: string) => number (+1 overload)", "this is signature 2");
+verify.quickInfoAt("35q", "var i2_i: i2(b: string) => number (+1 overload)", "this is signature 2");
 
 goTo.marker('36');
 verify.currentSignatureHelpDocCommentIs("new 2");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('36q');
-verify.quickInfoIs("var i3_i: new i3(b: number) => any (+1 overload)", "new 2");
+verify.quickInfoAt("36q", "var i3_i: new i3(b: number) => any (+1 overload)", "new 2");
 
 goTo.marker('37');
 verify.currentSignatureHelpDocCommentIs("new 1");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('37q');
-verify.quickInfoIs("var i3_i: new i3(a: string) => any (+1 overload)", "new 1");
+verify.quickInfoAt("37q", "var i3_i: new i3(a: string) => any (+1 overload)", "new 1");
 
 goTo.marker('38');
 verify.currentSignatureHelpDocCommentIs("this is signature 1");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('38q');
-verify.quickInfoIs("var i3_i: i3(a: number) => number (+1 overload)", "this is signature 1");
+verify.quickInfoAt("38q", "var i3_i: i3(a: number) => number (+1 overload)", "this is signature 1");
 
 goTo.marker('39');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('39q');
-verify.quickInfoIs("var i3_i: i3(b: string) => number (+1 overload)", "");
+verify.quickInfoAt("39q", "var i3_i: i3(b: string) => number (+1 overload)");
 
 goTo.marker('40');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('40q');
-verify.quickInfoIs("var i4_i: new i4(b: number) => any (+1 overload)", "");
+verify.quickInfoAt("40q", "var i4_i: new i4(b: number) => any (+1 overload)");
 
 goTo.marker('41');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('41q');
-verify.quickInfoIs("var i4_i: new i4(a: string) => any (+1 overload)", "");
+verify.quickInfoAt("41q", "var i4_i: new i4(a: string) => any (+1 overload)");
 
 goTo.marker('42');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('42q');
-verify.quickInfoIs("var i4_i: i4(a: number) => number (+1 overload)", "");
+verify.quickInfoAt("42q", "var i4_i: i4(a: number) => number (+1 overload)");
 
 goTo.marker('43');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('43q');
-verify.quickInfoIs("var i4_i: i4(b: string) => number (+1 overload)", "");
+verify.quickInfoAt("43q", "var i4_i: i4(b: string) => number (+1 overload)");
 
 goTo.marker('44');
 verify.memberListContains('prop1', '(method) c.prop1(a: number): number (+1 overload)', '');
@@ -476,122 +441,102 @@ verify.memberListContains('prop5', '(method) c.prop5(a: number): number (+1 over
 goTo.marker('45');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('45q');
-verify.quickInfoIs("(method) c.prop1(a: number): number (+1 overload)", "");
+verify.quickInfoAt("45q", "(method) c.prop1(a: number): number (+1 overload)");
 
 goTo.marker('46');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('46q');
-verify.quickInfoIs("(method) c.prop1(b: string): number (+1 overload)", "");
+verify.quickInfoAt("46q", "(method) c.prop1(b: string): number (+1 overload)");
 
 goTo.marker('47');
 verify.currentSignatureHelpDocCommentIs("prop2 1");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('47q');
-verify.quickInfoIs("(method) c.prop2(a: number): number (+1 overload)", "prop2 1");
+verify.quickInfoAt("47q", "(method) c.prop2(a: number): number (+1 overload)", "prop2 1");
 
 goTo.marker('48');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('48q');
-verify.quickInfoIs("(method) c.prop2(b: string): number (+1 overload)", "");
+verify.quickInfoAt("48q", "(method) c.prop2(b: string): number (+1 overload)");
 
 goTo.marker('49');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('49q');
-verify.quickInfoIs("(method) c.prop3(a: number): number (+1 overload)", "");
+verify.quickInfoAt("49q", "(method) c.prop3(a: number): number (+1 overload)");
 
 goTo.marker('50');
 verify.currentSignatureHelpDocCommentIs("prop3 2");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('50q');
-verify.quickInfoIs("(method) c.prop3(b: string): number (+1 overload)", "prop3 2");
+verify.quickInfoAt("50q", "(method) c.prop3(b: string): number (+1 overload)", "prop3 2");
 
 goTo.marker('51');
 verify.currentSignatureHelpDocCommentIs("prop4 1");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('51q');
-verify.quickInfoIs("(method) c.prop4(a: number): number (+1 overload)", "prop4 1");
+verify.quickInfoAt("51q", "(method) c.prop4(a: number): number (+1 overload)", "prop4 1");
 
 goTo.marker('52');
 verify.currentSignatureHelpDocCommentIs("prop4 2");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('52q');
-verify.quickInfoIs("(method) c.prop4(b: string): number (+1 overload)", "prop4 2");
+verify.quickInfoAt("52q", "(method) c.prop4(b: string): number (+1 overload)", "prop4 2");
 
 goTo.marker('53');
 verify.currentSignatureHelpDocCommentIs("prop5 1");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('53q');
-verify.quickInfoIs("(method) c.prop5(a: number): number (+1 overload)", "prop5 1");
+verify.quickInfoAt("53q", "(method) c.prop5(a: number): number (+1 overload)", "prop5 1");
 
 goTo.marker('54');
 verify.currentSignatureHelpDocCommentIs("prop5 2");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('54q');
-verify.quickInfoIs("(method) c.prop5(b: string): number (+1 overload)", "prop5 2");
+verify.quickInfoAt("54q", "(method) c.prop5(b: string): number (+1 overload)", "prop5 2");
 
 goTo.marker('55');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('55q');
-verify.quickInfoIs("constructor c1(a: number): c1 (+1 overload)", "");
+verify.quickInfoAt("55q", "constructor c1(a: number): c1 (+1 overload)");
 
 goTo.marker('56');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('56q');
-verify.quickInfoIs("constructor c1(b: string): c1 (+1 overload)", "");
+verify.quickInfoAt("56q", "constructor c1(b: string): c1 (+1 overload)");
 
 goTo.marker('57');
 verify.currentSignatureHelpDocCommentIs("c2 1");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('57q');
-verify.quickInfoIs("constructor c2(a: number): c2 (+1 overload)", "c2 1");
+verify.quickInfoAt("57q", "constructor c2(a: number): c2 (+1 overload)", "c2 1");
 
 goTo.marker('58');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('58q');
-verify.quickInfoIs("constructor c2(b: string): c2 (+1 overload)", "");
+verify.quickInfoAt("58q", "constructor c2(b: string): c2 (+1 overload)");
 
 goTo.marker('59');
 verify.currentSignatureHelpDocCommentIs("");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('59q');
-verify.quickInfoIs("constructor c3(a: number): c3 (+1 overload)", "");
+verify.quickInfoAt("59q", "constructor c3(a: number): c3 (+1 overload)");
 
 goTo.marker('60');
 verify.currentSignatureHelpDocCommentIs("c3 2");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('60q');
-verify.quickInfoIs("constructor c3(b: string): c3 (+1 overload)", "c3 2");
+verify.quickInfoAt("60q", "constructor c3(b: string): c3 (+1 overload)", "c3 2");
 
 goTo.marker('61');
 verify.currentSignatureHelpDocCommentIs("c4 1");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('61q');
-verify.quickInfoIs("constructor c4(a: number): c4 (+1 overload)", "c4 1");
+verify.quickInfoAt("61q", "constructor c4(a: number): c4 (+1 overload)", "c4 1");
 
 goTo.marker('62');
 verify.currentSignatureHelpDocCommentIs("c4 2");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('62q');
-verify.quickInfoIs("constructor c4(b: string): c4 (+1 overload)", "c4 2");
+verify.quickInfoAt("62q", "constructor c4(b: string): c4 (+1 overload)", "c4 2");
 
 goTo.marker('63');
 verify.currentSignatureHelpDocCommentIs("c5 1");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('63q');
-verify.quickInfoIs("constructor c5(a: number): c5 (+1 overload)", "c5 1");
+verify.quickInfoAt("63q", "constructor c5(a: number): c5 (+1 overload)", "c5 1");
 
 goTo.marker('64');
 verify.currentSignatureHelpDocCommentIs("c5 2");
 verify.currentParameterHelpArgumentDocCommentIs("");
-goTo.marker('64q');
-verify.quickInfoIs("constructor c5(b: string): c5 (+1 overload)", "c5 2");
+verify.quickInfoAt("64q", "constructor c5(b: string): c5 (+1 overload)", "c5 2");
 
 goTo.marker('65');
 verify.completionListContains("c", "class c", "");
@@ -614,120 +559,47 @@ verify.completionListContains("c5_i_2", "var c5_i_2: c5", "");
 verify.completionListContains('multiOverload', 'function multiOverload(a: number): string (+2 overloads)', 'This is multiOverload F1 1');
 verify.completionListContains('ambientF1', 'function ambientF1(a: number): string (+2 overloads)', 'This is ambient F1 1');
 
-goTo.marker('66');
-verify.quickInfoIs("var c1_i_1: c1", "");
-goTo.marker('67');
-verify.quickInfoIs("var c2_i_2: c2", "");
-goTo.marker('68');
-verify.quickInfoIs("var c3_i_2: c3", "");
-goTo.marker('69');
-verify.quickInfoIs("var c4_i_1: c4", "");
-goTo.marker('70');
-verify.quickInfoIs("var c5_i_1: c5", "");
-
-goTo.marker('71');
-verify.quickInfoIs("function multiOverload(a: number): string (+2 overloads)", "This is multiOverload F1 1");
-goTo.marker('72');
-verify.quickInfoIs("function multiOverload(b: string): string (+2 overloads)", "This is multiOverload F1 2");
-goTo.marker('73');
-verify.quickInfoIs("function multiOverload(c: boolean): string (+2 overloads)", "This is multiOverload F1 3");
-
-goTo.marker('74');
-verify.quickInfoIs("function ambientF1(a: number): string (+2 overloads)", "This is ambient F1 1");
-goTo.marker('75');
-verify.quickInfoIs("function ambientF1(b: string): string (+2 overloads)", "This is ambient F1 2");
-goTo.marker('76');
-verify.quickInfoIs("function ambientF1(c: boolean): boolean (+2 overloads)", "This is ambient F1 3");
-
-goTo.marker('77');
-verify.quickInfoIs("(parameter) aa: i3", "");
-
-goTo.marker('78');
-verify.quickInfoIs("constructor c1(a: number): c1 (+1 overload)", "");
-
-goTo.marker('79');
-verify.quickInfoIs("constructor c1(b: string): c1 (+1 overload)", "");
-
-goTo.marker('80');
-verify.quickInfoIs("constructor c1(a: number): c1 (+1 overload)", "");
-
-goTo.marker('81');
-verify.quickInfoIs("constructor c2(a: number): c2 (+1 overload)", "c2 1");
-
-goTo.marker('82');
-verify.quickInfoIs("constructor c2(b: string): c2 (+1 overload)", "");
-
-goTo.marker('83');
-verify.quickInfoIs("constructor c2(a: number): c2 (+1 overload)", "c2 1");
-
-goTo.marker('84');
-verify.quickInfoIs("constructor c3(a: number): c3 (+1 overload)", "");
-
-goTo.marker('85');
-verify.quickInfoIs("constructor c3(b: string): c3 (+1 overload)", "c3 2");
-
-goTo.marker('86');
-verify.quickInfoIs("constructor c3(a: number): c3 (+1 overload)", "");
-
-goTo.marker('87');
-verify.quickInfoIs("constructor c4(a: number): c4 (+1 overload)", "c4 1");
-
-goTo.marker('88');
-verify.quickInfoIs("constructor c4(b: string): c4 (+1 overload)", "c4 2");
-
-goTo.marker('89');
-verify.quickInfoIs("constructor c4(a: number): c4 (+1 overload)", "c4 1");
-
-goTo.marker('90');
-verify.quickInfoIs("constructor c5(a: number): c5 (+1 overload)", "c5 1");
-
-goTo.marker('91');
-verify.quickInfoIs("constructor c5(b: string): c5 (+1 overload)", "c5 2");
-
-goTo.marker('92');
-verify.quickInfoIs("constructor c5(a: number): c5 (+1 overload)", "c5 1");
-
-goTo.marker('93');
-verify.quickInfoIs("(method) c.prop1(a: number): number (+1 overload)", "");
-
-goTo.marker('94');
-verify.quickInfoIs("(method) c.prop1(b: string): number (+1 overload)", "");
-
-goTo.marker('95');
-verify.quickInfoIs("(method) c.prop1(a: number): number (+1 overload)", "");
-
-goTo.marker('96');
-verify.quickInfoIs("(method) c.prop2(a: number): number (+1 overload)", "prop2 1");
-
-goTo.marker('97');
-verify.quickInfoIs("(method) c.prop2(b: string): number (+1 overload)", "");
-
-goTo.marker('98');
-verify.quickInfoIs("(method) c.prop2(a: number): number (+1 overload)", "prop2 1");
-
-goTo.marker('99');
-verify.quickInfoIs("(method) c.prop3(a: number): number (+1 overload)", "");
-
-goTo.marker('100');
-verify.quickInfoIs("(method) c.prop3(b: string): number (+1 overload)", "prop3 2");
-
-goTo.marker('101');
-verify.quickInfoIs("(method) c.prop3(a: number): number (+1 overload)", "");
-
-goTo.marker('102');
-verify.quickInfoIs("(method) c.prop4(a: number): number (+1 overload)", "prop4 1");
-
-goTo.marker('103');
-verify.quickInfoIs("(method) c.prop4(b: string): number (+1 overload)", "prop4 2");
-
-goTo.marker('104');
-verify.quickInfoIs("(method) c.prop4(a: number): number (+1 overload)", "prop4 1");
-
-goTo.marker('105');
-verify.quickInfoIs("(method) c.prop5(a: number): number (+1 overload)", "prop5 1");
-
-goTo.marker('106');
-verify.quickInfoIs("(method) c.prop5(b: string): number (+1 overload)", "prop5 2");
-
-goTo.marker('107');
-verify.quickInfoIs("(method) c.prop5(a: number): number (+1 overload)", "prop5 1");
+verify.quickInfos({
+    66: "var c1_i_1: c1",
+    67: "var c2_i_2: c2",
+    68: "var c3_i_2: c3",
+    69: "var c4_i_1: c4",
+    70: "var c5_i_1: c5",
+    71: ["function multiOverload(a: number): string (+2 overloads)", "This is multiOverload F1 1"],
+    72: ["function multiOverload(b: string): string (+2 overloads)", "This is multiOverload F1 2"],
+    73: ["function multiOverload(c: boolean): string (+2 overloads)", "This is multiOverload F1 3"],
+    74: ["function ambientF1(a: number): string (+2 overloads)", "This is ambient F1 1"],
+    75: ["function ambientF1(b: string): string (+2 overloads)", "This is ambient F1 2"],
+    76: ["function ambientF1(c: boolean): boolean (+2 overloads)", "This is ambient F1 3"],
+    77: "(parameter) aa: i3",
+    78: "constructor c1(a: number): c1 (+1 overload)",
+    79: "constructor c1(b: string): c1 (+1 overload)",
+    80: "constructor c1(a: number): c1 (+1 overload)",
+    81: ["constructor c2(a: number): c2 (+1 overload)", "c2 1"],
+    82: "constructor c2(b: string): c2 (+1 overload)",
+    83: ["constructor c2(a: number): c2 (+1 overload)", "c2 1"],
+    84: "constructor c3(a: number): c3 (+1 overload)",
+    85: ["constructor c3(b: string): c3 (+1 overload)", "c3 2"],
+    86: "constructor c3(a: number): c3 (+1 overload)",
+    87: ["constructor c4(a: number): c4 (+1 overload)", "c4 1"],
+    88: ["constructor c4(b: string): c4 (+1 overload)", "c4 2"],
+    89: ["constructor c4(a: number): c4 (+1 overload)", "c4 1"],
+    90: ["constructor c5(a: number): c5 (+1 overload)", "c5 1"],
+    91: ["constructor c5(b: string): c5 (+1 overload)", "c5 2"],
+    92: ["constructor c5(a: number): c5 (+1 overload)", "c5 1"],
+    93: "(method) c.prop1(a: number): number (+1 overload)",
+    94: "(method) c.prop1(b: string): number (+1 overload)",
+    95: "(method) c.prop1(a: number): number (+1 overload)",
+    96: ["(method) c.prop2(a: number): number (+1 overload)", "prop2 1"],
+    97: "(method) c.prop2(b: string): number (+1 overload)",
+    98: ["(method) c.prop2(a: number): number (+1 overload)", "prop2 1"],
+    99: "(method) c.prop3(a: number): number (+1 overload)",
+    100: ["(method) c.prop3(b: string): number (+1 overload)", "prop3 2"],
+    101: "(method) c.prop3(a: number): number (+1 overload)",
+    102: ["(method) c.prop4(a: number): number (+1 overload)", "prop4 1"],
+    103: ["(method) c.prop4(b: string): number (+1 overload)", "prop4 2"],
+    104: ["(method) c.prop4(a: number): number (+1 overload)", "prop4 1"],
+    105: ["(method) c.prop5(a: number): number (+1 overload)", "prop5 1"],
+    106: ["(method) c.prop5(b: string): number (+1 overload)", "prop5 2"],
+    107: ["(method) c.prop5(a: number): number (+1 overload)", "prop5 1"]
+});

--- a/tests/cases/fourslash/commentsUnion.ts
+++ b/tests/cases/fourslash/commentsUnion.ts
@@ -3,5 +3,4 @@
 ////var a: Array<string> | Array<number>;
 ////a./*1*/length
 
-goTo.marker('1');
-verify.quickInfoIs("(property) length: number", "Gets or sets the length of the array. This is a number one higher than the highest element defined in an array.");
+verify.quickInfoAt("1", "(property) length: number", "Gets or sets the length of the array. This is a number one higher than the highest element defined in an array.");

--- a/tests/cases/fourslash/commentsVariables.ts
+++ b/tests/cases/fourslash/commentsVariables.ts
@@ -41,8 +41,7 @@
 ////}
 ////var x = fo/*15*/o2;
 
-goTo.marker('1');
-verify.quickInfoIs("var myVariable: number", "This is my variable");
+verify.quickInfoAt("1", "var myVariable: number", "This is my variable");
 
 goTo.marker('2');
 verify.completionListContains("myVariable", "var myVariable: number", "This is my variable");
@@ -57,13 +56,11 @@ verify.completionListContains("fooVar", "var fooVar: () => void", "fooVar commen
 
 goTo.marker('5');
 verify.currentSignatureHelpDocCommentIs("foos comment");
-goTo.marker('5q');
-verify.quickInfoIs("function foo(): void", "foos comment");
+verify.quickInfoAt("5q", "function foo(): void", "foos comment");
 
 goTo.marker('6');
 verify.currentSignatureHelpDocCommentIs("");
-goTo.marker('6q');
-verify.quickInfoIs("var fooVar: () => void", "");
+verify.quickInfoAt("6q", "var fooVar: () => void");
 
 goTo.marker('7');
 verify.completionListContains("foo", "function foo(): void", "foos comment");
@@ -71,15 +68,14 @@ verify.completionListContains("fooVar", "var fooVar: () => void", "fooVar commen
 
 goTo.marker('8');
 verify.currentSignatureHelpDocCommentIs("foos comment");
-goTo.marker('8q');
-verify.quickInfoIs("function foo(): void", "foos comment");
+verify.quickInfoAt("8q", "function foo(): void", "foos comment");
 
 goTo.marker('9');
 verify.currentSignatureHelpDocCommentIs("");
-goTo.marker('9q');
-verify.quickInfoIs("var fooVar: () => void", "");
-goTo.marker('9aq');
-verify.quickInfoIs("var fooVar: () => void", "fooVar comment");
+verify.quickInfos({
+    "9q": "var fooVar: () => void",
+    "9aq": ["var fooVar: () => void", "fooVar comment"]
+});
 
 goTo.marker('10');
 verify.completionListContains("i", "var i: c", "instance comment");
@@ -87,14 +83,9 @@ verify.completionListContains("i", "var i: c", "instance comment");
 goTo.marker('11');
 verify.completionListContains("i1_i", "var i1_i: i1", "interface instance comments");
 
-goTo.marker('12');
-verify.quickInfoIs("var fooVar: () => void", "fooVar comment");
-
-goTo.marker('13');
-verify.quickInfoIs("var fooVar: () => void", "fooVar comment");
-
-goTo.marker('14');
-verify.quickInfoIs("function foo(): void", "foos comment");
-
-goTo.marker('15');
-verify.quickInfoIs("function foo2(a: number): void (+1 overload)", "");
+verify.quickInfos({
+    12: ["var fooVar: () => void", "fooVar comment"],
+    13: ["var fooVar: () => void", "fooVar comment"],
+    14: ["function foo(): void", "foos comment"],
+    15: "function foo2(a: number): void (+1 overload)"
+});

--- a/tests/cases/fourslash/completionEntryForUnionMethod.ts
+++ b/tests/cases/fourslash/completionEntryForUnionMethod.ts
@@ -4,5 +4,7 @@
 ////y.map/**/(
 
 goTo.marker();
-verify.quickInfoIs("(property) map: (<U>(callbackfn: (value: string, index: number, array: string[]) => U, thisArg?: any) => U[]) | (<U>(callbackfn: (value: number, index: number, array: number[]) => U, thisArg?: any) => U[])");
+verify.quickInfoIs(
+    "(property) map: (<U>(callbackfn: (value: string, index: number, array: string[]) => U, thisArg?: any) => U[]) | (<U>(callbackfn: (value: number, index: number, array: number[]) => U, thisArg?: any) => U[])",
+    "Calls a defined callback function on each element of an array, and returns an array that contains the results.");
 verify.completionListContains('map', "(property) map: (<U>(callbackfn: (value: string, index: number, array: string[]) => U, thisArg?: any) => U[]) | (<U>(callbackfn: (value: number, index: number, array: number[]) => U, thisArg?: any) => U[])");

--- a/tests/cases/fourslash/completionListInNamedFunctionExpression.ts
+++ b/tests/cases/fourslash/completionListInNamedFunctionExpression.ts
@@ -23,8 +23,7 @@ verify.memberListContains("foo");
 goTo.marker("insideFunctionExpression");
 verify.memberListContains("foo");
 
-goTo.marker("referenceInsideFunctionExpression");
-verify.quickInfoIs("(local function) foo(): number");
-
-goTo.marker("referenceInGlobalScope");
-verify.quickInfoIs("function foo(a: number): string");
+verify.quickInfos({
+    referenceInsideFunctionExpression: "(local function) foo(): number",
+    referenceInGlobalScope: "function foo(a: number): string"
+});

--- a/tests/cases/fourslash/constEnumQuickInfoAndCompletionList.ts
+++ b/tests/cases/fourslash/constEnumQuickInfoAndCompletionList.ts
@@ -7,8 +7,7 @@
 ////}
 /////*2*/e.a;
 
-goTo.marker('1');
-verify.quickInfoIs("const enum e");
+verify.quickInfoAt("1", "const enum e");
 
 goTo.marker('2');
 verify.completionListContains("e", "const enum e");

--- a/tests/cases/fourslash/constQuickInfoAndCompletionList.ts
+++ b/tests/cases/fourslash/constQuickInfoAndCompletionList.ts
@@ -9,8 +9,7 @@
 ////    var z = /*6*/a;
 ////    /*7*/
 ////}
-goTo.marker('1');
-verify.quickInfoIs("const a: 10");
+verify.quickInfoAt("1", "const a: 10");
 
 goTo.marker('2');
 verify.completionListContains("a", "const a: 10");
@@ -19,8 +18,7 @@ verify.quickInfoIs("const a: 10");
 goTo.marker('3');
 verify.completionListContains("a", "const a: 10");
 
-goTo.marker('4');
-verify.quickInfoIs("const b: 20");
+verify.quickInfoAt("4", "const b: 20");
 
 goTo.marker('5');
 verify.completionListContains("a", "const a: 10");

--- a/tests/cases/fourslash/constructorQuickInfo.ts
+++ b/tests/cases/fourslash/constructorQuickInfo.ts
@@ -6,11 +6,8 @@
 ////var x/*2*/2 = new SS();
 ////var x/*3*/3 = new SS;
 
-goTo.marker('1');
-verify.quickInfoIs('var x1: SS<number>');
-
-goTo.marker('2');
-verify.quickInfoIs('var x2: SS<{}>');
-
-goTo.marker('3');
-verify.quickInfoIs('var x3: SS<{}>');
+verify.quickInfos({
+    1: "var x1: SS<number>",
+    2: "var x2: SS<{}>",
+    3: "var x3: SS<{}>"
+});

--- a/tests/cases/fourslash/contextualTyping.ts
+++ b/tests/cases/fourslash/contextualTyping.ts
@@ -194,223 +194,115 @@
 ////    }
 ////};
 
-goTo.marker('1');
-verify.quickInfoIs("(property) C1T5.foo: (i: number, s: string) => number");
-goTo.marker('2');
-verify.quickInfoIs("(parameter) i: number");
-goTo.marker('3');
-verify.quickInfoIs("(parameter) i: number");
-goTo.marker('4');
-verify.quickInfoIs("var C2T5.foo: (i: number, s: string) => number");
-goTo.marker('5');
-verify.quickInfoIs("(parameter) i: number");
-goTo.marker('6');
-verify.quickInfoIs("(parameter) i: number");
-goTo.marker('7');
-verify.quickInfoIs("var c3t1: (s: string) => string");
-goTo.marker('8');
-verify.quickInfoIs("(parameter) s: string");
-goTo.marker('9');
-verify.quickInfoIs("(parameter) s: string");
-goTo.marker('10');
-verify.quickInfoIs("var c3t2: IFoo");
-goTo.marker('11');
-verify.quickInfoIs("var c3t3: number[]");
-goTo.marker('12');
-verify.quickInfoIs("var c3t4: () => IFoo");
-goTo.marker('13');
-verify.quickInfoIs("var c3t5: (n: number) => IFoo");
-goTo.marker('14');
-verify.quickInfoIs("(parameter) n: number");
-goTo.marker('15');
-verify.quickInfoIs("var c3t6: (n: number, s: string) => IFoo");
-goTo.marker('16');
-verify.quickInfoIs("(parameter) n: number");
-goTo.marker('17');
-verify.quickInfoIs("(parameter) s: string");
-goTo.marker('18');
-verify.quickInfoIs("var c3t7: {\n    (n: number): number;\n    (s1: string): number;\n}");
-goTo.marker('20');
-verify.quickInfoIs("var c3t8: (n: number, s: string) => number");
-goTo.marker('21');
-verify.quickInfoIs("(parameter) n: number");
-goTo.marker('22');
-verify.quickInfoIs("var c3t9: number[][]");
-goTo.marker('23');
-verify.quickInfoIs("var c3t10: IFoo[]");
-goTo.marker('24');
-verify.quickInfoIs("var c3t11: ((n: number, s: string) => string)[]");
-goTo.marker('25');
-verify.quickInfoIs("(parameter) n: number");
-goTo.marker('26');
-verify.quickInfoIs("(parameter) s: string");
-goTo.marker('27');
-verify.quickInfoIs("var c3t12: IBar");
-goTo.marker('28');
-verify.quickInfoIs("(property) foo: IFoo");
-goTo.marker('29');
-verify.quickInfoIs("var c3t13: IFoo");
-goTo.marker('30');
-verify.quickInfoIs("(property) f: (i: number, s: string) => string");
-goTo.marker('31');
-verify.quickInfoIs("(parameter) i: number");
-goTo.marker('32');
-verify.quickInfoIs("(parameter) s: string");
-goTo.marker('33');
-verify.quickInfoIs("var c3t14: IFoo");
-goTo.marker('34');
-verify.quickInfoIs("(property) a: undefined[]");
-goTo.marker('35');
-verify.quickInfoIs("(property) C4T5.foo: (i: number, s: string) => string");
-goTo.marker('36');
-verify.quickInfoIs("(parameter) i: number");
-goTo.marker('37');
-verify.quickInfoIs("(parameter) s: string");
-goTo.marker('38');
-verify.quickInfoIs("var C5T5.foo: (i: number, s: string) => string");
-goTo.marker('39');
-verify.quickInfoIs("(parameter) i: number");
-goTo.marker('40');
-verify.quickInfoIs("(parameter) s: string");
-goTo.marker('41');
-verify.quickInfoIs("var c6t5: (n: number) => IFoo");
-goTo.marker('42');
-verify.quickInfoIs("(parameter) n: number");
-goTo.marker('43');
-verify.quickInfoIs("var c7t2: IFoo[]");
-goTo.marker('44');
-verify.quickInfoIs("var c7t2: IFoo[]");
-goTo.marker('45');
-verify.quickInfoIs("(property) t1: (s: string) => string");
-goTo.marker('46');
-verify.quickInfoIs("(parameter) s: string");
-goTo.marker('47');
-verify.quickInfoIs("(property) t2: IFoo");
-goTo.marker('48');
-verify.quickInfoIs("(property) t3: number[]");
-goTo.marker('49');
-verify.quickInfoIs("(property) t4: () => IFoo");
-goTo.marker('50');
-verify.quickInfoIs("(property) t5: (n: number) => IFoo");
-goTo.marker('51');
-verify.quickInfoIs("(parameter) n: number");
-goTo.marker('52');
-verify.quickInfoIs("(property) t6: (n: number, s: string) => IFoo");
-goTo.marker('53');
-verify.quickInfoIs("(parameter) n: number");
-goTo.marker('54');
-verify.quickInfoIs("(parameter) s: string");
-goTo.marker('55');
-verify.quickInfoIs("(property) t7: (n: number, s: string) => number");
-goTo.marker('56');
-verify.quickInfoIs("(property) t8: (n: number, s: string) => number");
-goTo.marker('57');
-verify.quickInfoIs("(parameter) n: number");
-goTo.marker('58');
-verify.quickInfoIs("(property) t9: number[][]");
-goTo.marker('59');
-verify.quickInfoIs("(property) t10: IFoo[]");
-goTo.marker('60');
-verify.quickInfoIs("(property) t11: ((n: number, s: string) => string)[]");
-goTo.marker('61');
-verify.quickInfoIs("(parameter) n: number");
-goTo.marker('62');
-verify.quickInfoIs("(parameter) s: string");
-goTo.marker('63');
-verify.quickInfoIs("(property) t12: IBar");
-goTo.marker('64');
-verify.quickInfoIs("(property) foo: IFoo");
-goTo.marker('65');
-verify.quickInfoIs("(property) t13: IFoo");
-goTo.marker('66');
-verify.quickInfoIs("(property) f: (i: number, s: string) => string");
-goTo.marker('67');
-verify.quickInfoIs("(parameter) i: number");
-goTo.marker('68');
-verify.quickInfoIs("(parameter) s: string");
-goTo.marker('69');
-verify.quickInfoIs("(property) t14: IFoo");
-goTo.marker('70');
-verify.quickInfoIs("(property) a: undefined[]");
-goTo.marker('71');
-verify.quickInfoIs("(parameter) n: number");
-goTo.marker('72');
-verify.quickInfoIs("var c10t5: () => (n: number) => IFoo");
-goTo.marker('73');
-verify.quickInfoIs("(parameter) n: number");
-goTo.marker('74');
-verify.quickInfoIs("(parameter) n: number");
-goTo.marker('75');
-verify.quickInfoIs("var c12t1: (s: string) => string");
-goTo.marker('76');
-verify.quickInfoIs("(parameter) s: string");
-goTo.marker('77');
-verify.quickInfoIs("var c12t2: IFoo");
-goTo.marker('78');
-verify.quickInfoIs("var c12t3: number[]");
-goTo.marker('79');
-verify.quickInfoIs("var c12t4: () => IFoo");
-goTo.marker('80');
-verify.quickInfoIs("var c12t5: (n: number) => IFoo");
-goTo.marker('81');
-verify.quickInfoIs("(parameter) n: number");
-goTo.marker('82');
-verify.quickInfoIs("var c12t6: (n: number, s: string) => IFoo");
-goTo.marker('83');
-verify.quickInfoIs("(parameter) n: number");
-goTo.marker('84');
-verify.quickInfoIs("(parameter) s: string");
-goTo.marker('85');
-verify.quickInfoIs("var c12t7: (n: number, s: string) => number");
-goTo.marker('86');
-verify.quickInfoIs("var c12t8: (n: number, s: string) => number");
-goTo.marker('87');
-verify.quickInfoIs("(parameter) n: number");
-goTo.marker('88');
-verify.quickInfoIs("var c12t9: number[][]");
-goTo.marker('89');
-verify.quickInfoIs("var c12t10: IFoo[]");
-goTo.marker('90');
-verify.quickInfoIs("var c12t11: ((n: number, s: string) => string)[]");
-goTo.marker('91');
-verify.quickInfoIs("(parameter) n: number");
-goTo.marker('92');
-verify.quickInfoIs("(parameter) s: string");
-goTo.marker('93');
-verify.quickInfoIs("var c12t12: IBar");
-goTo.marker('94');
-verify.quickInfoIs("(property) foo: IFoo");
-goTo.marker('95');
-verify.quickInfoIs("var c12t13: IFoo");
-goTo.marker('96');
-verify.quickInfoIs("(property) f: (i: number, s: string) => string");
-goTo.marker('97');
-verify.quickInfoIs("(parameter) i: number");
-goTo.marker('98');
-verify.quickInfoIs("(parameter) s: string");
-goTo.marker('99');
-verify.quickInfoIs("var c12t14: IFoo");
-goTo.marker('100');
-verify.quickInfoIs("(property) a: undefined[]");
-goTo.marker('101');
-verify.quickInfoIs("function EF1(a: number, b: number): number");
-goTo.marker('102');
-verify.quickInfoIs("(parameter) a: any");
-goTo.marker('103');
-verify.quickInfoIs("(parameter) b: any");
-goTo.marker('110');
-verify.quickInfoIs("(property) Point.origin: Point");
-goTo.marker('111');
-verify.quickInfoIs("constructor Point(x: number, y: number): Point");
-goTo.marker('112');
-verify.quickInfoIs("(method) Point.add(dx: number, dy: number): Point");
-goTo.marker('113');
-verify.quickInfoIs("(parameter) dx: number");
-goTo.marker('114');
-verify.quickInfoIs("(parameter) dy: number");
-goTo.marker('115');
-verify.quickInfoIs("(property) add: (dx: number, dy: number) => Point");
-goTo.marker('116');
-verify.quickInfoIs("(parameter) dx: number");
-goTo.marker('117');
-verify.quickInfoIs("(parameter) dy: number");
+verify.quickInfos({
+    1: "(property) C1T5.foo: (i: number, s: string) => number",
+    2: "(parameter) i: number",
+    3: "(parameter) i: number",
+    4: "var C2T5.foo: (i: number, s: string) => number",
+    5: "(parameter) i: number",
+    6: "(parameter) i: number",
+    7: "var c3t1: (s: string) => string",
+    8: "(parameter) s: string",
+    9: "(parameter) s: string",
+    10: "var c3t2: IFoo",
+    11: "var c3t3: number[]",
+    12: "var c3t4: () => IFoo",
+    13: "var c3t5: (n: number) => IFoo",
+    14: "(parameter) n: number",
+    15: "var c3t6: (n: number, s: string) => IFoo",
+    16: "(parameter) n: number",
+    17: "(parameter) s: string",
+    18: "var c3t7: {\n    (n: number): number;\n    (s1: string): number;\n}",
+    20: "var c3t8: (n: number, s: string) => number",
+    21: "(parameter) n: number",
+    22: "var c3t9: number[][]",
+    23: "var c3t10: IFoo[]",
+    24: "var c3t11: ((n: number, s: string) => string)[]",
+    25: "(parameter) n: number",
+    26: "(parameter) s: string",
+    27: "var c3t12: IBar",
+    28: "(property) foo: IFoo",
+    29: "var c3t13: IFoo",
+    30: "(property) f: (i: number, s: string) => string",
+    31: "(parameter) i: number",
+    32: "(parameter) s: string",
+    33: "var c3t14: IFoo",
+    34: "(property) a: undefined[]",
+    35: "(property) C4T5.foo: (i: number, s: string) => string",
+    36: "(parameter) i: number",
+    37: "(parameter) s: string",
+    38: "var C5T5.foo: (i: number, s: string) => string",
+    39: "(parameter) i: number",
+    40: "(parameter) s: string",
+    41: "var c6t5: (n: number) => IFoo",
+    42: "(parameter) n: number",
+    43: "var c7t2: IFoo[]",
+    44: "var c7t2: IFoo[]",
+    45: "(property) t1: (s: string) => string",
+    46: "(parameter) s: string",
+    47: "(property) t2: IFoo",
+    48: "(property) t3: number[]",
+    49: "(property) t4: () => IFoo",
+    50: "(property) t5: (n: number) => IFoo",
+    51: "(parameter) n: number",
+    52: "(property) t6: (n: number, s: string) => IFoo",
+    53: "(parameter) n: number",
+    54: "(parameter) s: string",
+    55: "(property) t7: (n: number, s: string) => number",
+    56: "(property) t8: (n: number, s: string) => number",
+    57: "(parameter) n: number",
+    58: "(property) t9: number[][]",
+    59: "(property) t10: IFoo[]",
+    60: "(property) t11: ((n: number, s: string) => string)[]",
+    61: "(parameter) n: number",
+    62: "(parameter) s: string",
+    63: "(property) t12: IBar",
+    64: "(property) foo: IFoo",
+    65: "(property) t13: IFoo",
+    66: "(property) f: (i: number, s: string) => string",
+    67: "(parameter) i: number",
+    68: "(parameter) s: string",
+    69: "(property) t14: IFoo",
+    70: "(property) a: undefined[]",
+    71: "(parameter) n: number",
+    72: "var c10t5: () => (n: number) => IFoo",
+    73: "(parameter) n: number",
+    74: "(parameter) n: number",
+    75: "var c12t1: (s: string) => string",
+    76: "(parameter) s: string",
+    77: "var c12t2: IFoo",
+    78: "var c12t3: number[]",
+    79: "var c12t4: () => IFoo",
+    80: "var c12t5: (n: number) => IFoo",
+    81: "(parameter) n: number",
+    82: "var c12t6: (n: number, s: string) => IFoo",
+    83: "(parameter) n: number",
+    84: "(parameter) s: string",
+    85: "var c12t7: (n: number, s: string) => number",
+    86: "var c12t8: (n: number, s: string) => number",
+    87: "(parameter) n: number",
+    88: "var c12t9: number[][]",
+    89: "var c12t10: IFoo[]",
+    90: "var c12t11: ((n: number, s: string) => string)[]",
+    91: "(parameter) n: number",
+    92: "(parameter) s: string",
+    93: "var c12t12: IBar",
+    94: "(property) foo: IFoo",
+    95: "var c12t13: IFoo",
+    96: "(property) f: (i: number, s: string) => string",
+    97: "(parameter) i: number",
+    98: "(parameter) s: string",
+    99: "var c12t14: IFoo",
+    100: "(property) a: undefined[]",
+    101: "function EF1(a: number, b: number): number",
+    102: "(parameter) a: any",
+    103: "(parameter) b: any",
+    110: "(property) Point.origin: Point",
+    111: "constructor Point(x: number, y: number): Point",
+    112: "(method) Point.add(dx: number, dy: number): Point",
+    113: "(parameter) dx: number",
+    114: "(parameter) dy: number",
+    115: "(property) add: (dx: number, dy: number) => Point",
+    116: "(parameter) dx: number",
+    117: "(parameter) dy: number"
+});

--- a/tests/cases/fourslash/contextualTypingFromTypeAssertion1.ts
+++ b/tests/cases/fourslash/contextualTypingFromTypeAssertion1.ts
@@ -2,6 +2,4 @@
 
 ////var f3 = <(x: string) => string> function (/**/x) { return x.toLowerCase(); };
 
-goTo.marker();
-verify.quickInfoIs('(parameter) x: string');
- 
+verify.quickInfoAt("", "(parameter) x: string");

--- a/tests/cases/fourslash/contextualTypingGenericFunction1.ts
+++ b/tests/cases/fourslash/contextualTypingGenericFunction1.ts
@@ -10,11 +10,8 @@
 ////var c = new C();
 ////c.obj = <S>(/*3*/x) => x;
 
-goTo.marker('1');
-verify.quickInfoIs('(parameter) x: any');
-
-goTo.marker('2');
-verify.quickInfoIs('(parameter) x: any');
-
-goTo.marker('3');
-verify.quickInfoIs('(parameter) x: any');
+verify.quickInfos({
+    1: "(parameter) x: any",
+    2: "(parameter) x: any",
+    3: "(parameter) x: any"
+});

--- a/tests/cases/fourslash/contextualTypingOfArrayLiterals1.ts
+++ b/tests/cases/fourslash/contextualTypingOfArrayLiterals1.ts
@@ -30,26 +30,17 @@
 // the above code should have a couple errors that will need to be updated with appropriate new (non-error) code and quick info checks
 verify.not.errorExistsBetweenMarkers('1', '6');
 
-goTo.marker('1');
-verify.quickInfoIs('var x: any[]');
-
-goTo.marker('2');
-verify.quickInfoIs('var r: C');
-
-goTo.marker('3');
-verify.quickInfoIs('var r3: C');
-
-goTo.marker('4');
-verify.quickInfoIs('var r4: C');
-
-goTo.marker('5');
-verify.quickInfoIs('var x5: {\n\
+verify.quickInfos({
+    1: "var x: any[]",
+    2: "var r: C",
+    3: "var r3: C",
+    4: "var r4: C",
+    5: "var x5: {\n\
     name: string;\n\
     age: number;\n\
-}[]');
-
-goTo.marker('6');
-verify.quickInfoIs('var r5: {\n\
+}[]",
+    6: "var r5: {\n\
     name: string;\n\
     age: number;\n\
-}');
+}"
+});

--- a/tests/cases/fourslash/contextualTypingOfGenericCallSignatures1.ts
+++ b/tests/cases/fourslash/contextualTypingOfGenericCallSignatures1.ts
@@ -6,6 +6,5 @@
 ////// x should not be contextually typed 
 ////var f24 = (/**/x) => { return 1 };
 
-goTo.marker();
-verify.quickInfoIs('(parameter) x: any');
+verify.quickInfoAt("", "(parameter) x: any");
 

--- a/tests/cases/fourslash/contextualTypingOfGenericCallSignatures2.ts
+++ b/tests/cases/fourslash/contextualTypingOfGenericCallSignatures2.ts
@@ -7,6 +7,5 @@
 ////// x should not be contextually typed so this should be an error
 ////f6(/**/x => x<number>())
 
-goTo.marker();
-verify.quickInfoIs('(parameter) x: any');
+verify.quickInfoAt("", "(parameter) x: any");
 verify.numberOfErrorsInCurrentFile(1);

--- a/tests/cases/fourslash/contextualTypingReturnExpressions.ts
+++ b/tests/cases/fourslash/contextualTypingReturnExpressions.ts
@@ -3,11 +3,8 @@
 ////interface A { }
 ////var f44: (x: A) => (y: A) => A = /*1*/x => /*2*/y => /*3*/x;
 
-goTo.marker('1');
-verify.quickInfoIs('(parameter) x: A');
-
-goTo.marker('2');
-verify.quickInfoIs('(parameter) y: A');
-
-goTo.marker('3');
-verify.quickInfoIs('(parameter) x: A');
+verify.quickInfos({
+    1: "(parameter) x: A",
+    2: "(parameter) y: A",
+    3: "(parameter) x: A"
+});

--- a/tests/cases/fourslash/contextuallyTypedFunctionExpressionGeneric1.ts
+++ b/tests/cases/fourslash/contextuallyTypedFunctionExpressionGeneric1.ts
@@ -9,14 +9,9 @@
 
 ////var max2: Comparer = (x/*1*/x, y/*2*/y) => { return x/*3*/x.compareTo(y/*4*/y) };
 
-goTo.marker('1');
-verify.quickInfoIs('(parameter) xx: any');
-
-goTo.marker('2');
-verify.quickInfoIs('(parameter) yy: any');
-
-goTo.marker('3');
-verify.quickInfoIs('(parameter) xx: any');
-
-goTo.marker('4');
-verify.quickInfoIs('(parameter) yy: any');
+verify.quickInfos({
+    1: "(parameter) xx: any",
+    2: "(parameter) yy: any",
+    3: "(parameter) xx: any",
+    4: "(parameter) yy: any"
+});

--- a/tests/cases/fourslash/contextuallyTypedObjectLiteralMethodDeclarationParam01.ts
+++ b/tests/cases/fourslash/contextuallyTypedObjectLiteralMethodDeclarationParam01.ts
@@ -26,7 +26,7 @@
 ////    }
 ////}
 
-goTo.marker("param1");
-verify.quickInfoIs("(parameter) arg: A")
-goTo.marker("param2");
-verify.quickInfoIs("(parameter) arg: B")
+verify.quickInfos({
+    param1: "(parameter) arg: A",
+    param2: "(parameter) arg: B"
+});

--- a/tests/cases/fourslash/defaultParamsAndContextualTypes.ts
+++ b/tests/cases/fourslash/defaultParamsAndContextualTypes.ts
@@ -12,7 +12,7 @@
 ////    }
 ////}
 
-goTo.marker('1');
-verify.quickInfoIs('(parameter) xy: string');
-goTo.marker('2');
-verify.quickInfoIs('(parameter) options: FooOptions');
+verify.quickInfos({
+    1: "(parameter) xy: string",
+    2: "(parameter) options: FooOptions"
+});

--- a/tests/cases/fourslash/derivedTypeIndexerWithGenericConstraints.ts
+++ b/tests/cases/fourslash/derivedTypeIndexerWithGenericConstraints.ts
@@ -24,6 +24,5 @@
 ////var r2 = a._itemsByKey['x'];
 ////var result2 = r2.x;
 
-goTo.marker('');
-verify.quickInfoIs('var r: CollectionItem');
+verify.quickInfoAt("", "var r: CollectionItem");
 verify.numberOfErrorsInCurrentFile(0);

--- a/tests/cases/fourslash/duplicateIndexers.ts
+++ b/tests/cases/fourslash/duplicateIndexers.ts
@@ -8,5 +8,4 @@
 ////var i: I;
 ////var /**/r = i[1];
 
-goTo.marker();
-verify.quickInfoIs('var r: string');
+verify.quickInfoAt("", "var r: string");

--- a/tests/cases/fourslash/emptyArrayInference.ts
+++ b/tests/cases/fourslash/emptyArrayInference.ts
@@ -3,8 +3,7 @@
 ////var x/*1*/x = true ? [1] : [undefined]; 
 ////var y/*2*/y = true ? [1] : [];
 
-goTo.marker('1');
-verify.quickInfoIs('var xx: number[]');
-
-goTo.marker('2');
-verify.quickInfoIs('var yy: number[]');
+verify.quickInfos({
+    1: "var xx: number[]",
+    2: "var yy: number[]"
+});

--- a/tests/cases/fourslash/enumAddition.ts
+++ b/tests/cases/fourslash/enumAddition.ts
@@ -3,6 +3,4 @@
 //// module m { export enum Color { Red } }
 //// var /**/t = m.Color.Red + 1;
 
-goTo.marker();
-verify.quickInfoExists();
-verify.quickInfoIs('var t: number');
+verify.quickInfoAt("", "var t: number");

--- a/tests/cases/fourslash/exportEqualTypes.ts
+++ b/tests/cases/fourslash/exportEqualTypes.ts
@@ -14,12 +14,11 @@
 ////var /*2*/r1 = t(); // Should return a Date
 ////var /*3*/r2 = t./*4*/foo; // t should have 'foo' in dropdown list and be of type 'string'
 
-goTo.marker('1');
-verify.quickInfoIs("import test = require('./exportEqualTypes_file0')");
-goTo.marker('2');
-verify.quickInfoIs('var r1: Date');
-goTo.marker('3');
-verify.quickInfoIs('var r2: string');
+verify.quickInfos({
+    1: "import test = require('./exportEqualTypes_file0')",
+    2: "var r1: Date",
+    3: "var r2: string"
+});
 goTo.marker('4');
 verify.memberListContains('foo');
 verify.numberOfErrorsInCurrentFile(0);

--- a/tests/cases/fourslash/extendArray.ts
+++ b/tests/cases/fourslash/extendArray.ts
@@ -8,8 +8,7 @@
 ////var x2: Foo2;
 ////var /*2*/r2 = x2[0];
 
-goTo.marker('1');
-verify.quickInfoIs('var r: string');
-
-goTo.marker('2');
-verify.quickInfoIs('var r2: string');
+verify.quickInfos({
+    1: "var r: string",
+    2: "var r2: string"
+});

--- a/tests/cases/fourslash/extendArrayInterfaceMember.ts
+++ b/tests/cases/fourslash/extendArrayInterfaceMember.ts
@@ -10,13 +10,11 @@ verify.numberOfErrorsInCurrentFile(1);
 // - Supplied parameters do not match any signature of call target.
 // - Could not select overload for 'call' expression.
 
-goTo.marker("y");
-verify.quickInfoIs("var y: any");
+verify.quickInfoAt("y", "var y: any");
 
 goTo.eof();
 edit.insert("interface Array<T> { pop(def: T): T; }");
 
 verify.not.errorExistsBetweenMarkers("1", "2");
-goTo.marker("y");
-verify.quickInfoIs("var y: number");
+verify.quickInfoAt("y", "var y: number");
 verify.numberOfErrorsInCurrentFile(0);

--- a/tests/cases/fourslash/extendInterfaceOverloadedMethod.ts
+++ b/tests/cases/fourslash/extendInterfaceOverloadedMethod.ts
@@ -11,6 +11,5 @@
 ////var b: B<number>;
 ////var /**/x = b.foo2().foo(5).foo(); // 'x' is of type 'void'
 
-goTo.marker();
-verify.quickInfoIs('var x: void');
+verify.quickInfoAt("", "var x: void");
 verify.numberOfErrorsInCurrentFile(0);

--- a/tests/cases/fourslash/extendsTArray.ts
+++ b/tests/cases/fourslash/extendsTArray.ts
@@ -10,6 +10,5 @@
 ////var /**/y = x(undefined); // Typeof y should be Date[]
 ////y.length;
 
-goTo.marker();
-verify.quickInfoIs('var y: Date[]');
+verify.quickInfoAt("", "var y: Date[]");
 verify.numberOfErrorsInCurrentFile(0);

--- a/tests/cases/fourslash/externalModuleWithExportAssignment.ts
+++ b/tests/cases/fourslash/externalModuleWithExportAssignment.ts
@@ -29,11 +29,8 @@
 ////var v1: a1./*15*/connectExport;
 
 goTo.file("externalModuleWithExportAssignment_file1.ts");
-goTo.marker('1');
-verify.quickInfoIs('import a1 = require("./externalModuleWithExportAssignment_file0")');
-
-goTo.marker('2');
-verify.quickInfoIs("var a: {\n    (): a1.connectExport;\n    test1: a1.connectModule;\n    test2(): a1.connectModule;\n}", undefined);
+verify.quickInfoAt("1", 'import a1 = require("./externalModuleWithExportAssignment_file0")');
+verify.quickInfoAt("2", "var a: {\n    (): a1.connectExport;\n    test1: a1.connectModule;\n    test2(): a1.connectModule;\n}", undefined);
 
 goTo.marker('3');
 verify.quickInfoIs("(property) test1: a1.connectModule(res: any, req: any, next: any) => void", undefined);
@@ -48,14 +45,12 @@ verify.currentSignatureHelpIs("test1(res: any, req: any, next: any): void");
 goTo.marker('5');
 verify.currentSignatureHelpIs("test2(): a1.connectModule");
 
-goTo.marker('6');
-verify.quickInfoIs("var r1: a1.connectModule", undefined);
+verify.quickInfoAt("6", "var r1: a1.connectModule", undefined);
 
 goTo.marker('7');
 verify.currentSignatureHelpIs("a(): a1.connectExport");
 
-goTo.marker('8');
-verify.quickInfoIs("var r2: a1.connectExport", undefined);
+verify.quickInfoAt("8", "var r2: a1.connectExport", undefined);
 
 goTo.marker('9');
 verify.quickInfoIs("(property) test1: a1.connectModule(res: any, req: any, next: any) => void", undefined);
@@ -70,14 +65,12 @@ verify.currentSignatureHelpIs("test1(res: any, req: any, next: any): void");
 goTo.marker('11');
 verify.currentSignatureHelpIs("test2(): a1.connectModule");
 
-goTo.marker('12');
-verify.quickInfoIs("var r3: a1.connectModule", undefined);
+verify.quickInfoAt("12", "var r3: a1.connectModule", undefined);
 
 goTo.marker('13');
 verify.currentSignatureHelpIs("a1(): a1.connectExport");
 
-goTo.marker('14');
-verify.quickInfoIs("var r4: a1.connectExport", undefined);
+verify.quickInfoAt("14", "var r4: a1.connectExport", undefined);
 
 goTo.marker('15');
 verify.not.completionListContains("test1", "(property) test1: a1.connectModule", undefined);

--- a/tests/cases/fourslash/fixingTypeParametersQuickInfo.ts
+++ b/tests/cases/fourslash/fixingTypeParametersQuickInfo.ts
@@ -3,11 +3,9 @@
 ////declare function f<T>(x: T, y: (p: T) => T, z: (p: T) => T): T;
 ////var /*1*/result = /*2*/f(0, /*3*/x => null, /*4*/x => x.blahblah);
 
-goTo.marker('1');
-verify.quickInfoIs('var result: number');
-goTo.marker('2');
-verify.quickInfoIs('function f<number>(x: number, y: (p: number) => number, z: (p: number) => number): number');
-goTo.marker('3');
-verify.quickInfoIs('(parameter) x: number');
-goTo.marker('4');
-verify.quickInfoIs('(parameter) x: number');
+verify.quickInfos({
+    1: "var result: number",
+    2: "function f<number>(x: number, y: (p: number) => number, z: (p: number) => number): number",
+    3: "(parameter) x: number",
+    4: "(parameter) x: number"
+});

--- a/tests/cases/fourslash/forIn.ts
+++ b/tests/cases/fourslash/forIn.ts
@@ -3,6 +3,4 @@
 ////var obj;
 ////for (var /**/p in obj) { }
 
-goTo.marker();
-
-verify.quickInfoIs('var p: string', "");
+verify.quickInfoAt("", "var p: string");

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -130,7 +130,6 @@ declare namespace FourSlashInterface {
         errorExistsBetweenMarkers(startMarker: string, endMarker: string): void;
         errorExistsAfterMarker(markerName?: string): void;
         errorExistsBeforeMarker(markerName?: string): void;
-        quickInfoIs(expectedText: string, expectedDocumentation?: string): void;
         quickInfoExists(): void;
         typeDefinitionCountIs(expectedCount: number): void;
         isValidBraceCompletionAtPosition(openingBrace?: string): void;
@@ -233,6 +232,16 @@ declare namespace FourSlashInterface {
         renameInfoSucceeded(displayName?: string, fullDisplayName?: string, kind?: string, kindModifiers?: string): void;
         renameInfoFailed(message?: string): void;
         renameLocations(findInStrings: boolean, findInComments: boolean, ranges?: Range[]): void;
+
+        /** Verify the quick info available at the current marker. */
+        quickInfoIs(expectedText: string, expectedDocumentation?: string): void;
+        /** Goto a marker and call `quickInfoIs`. */
+        quickInfoAt(markerName: string, expectedText?: string, expectedDocumentation?: string): void;
+        /**
+         * Call `quickInfoAt` for each pair in the object.
+         * (If the value is an array, it is [expectedText, expectedDocumentation].)
+         */
+        quickInfos(namesAndTexts: { [name: string]: string | [string, string] }): void;
         verifyQuickInfoDisplayParts(kind: string, kindModifiers: string, textSpan: {
             start: number;
             length: number;

--- a/tests/cases/fourslash/functionProperty.ts
+++ b/tests/cases/fourslash/functionProperty.ts
@@ -39,11 +39,8 @@ verify.completionListContains("x", "(property) x: (a: number) => void");
 goTo.marker('completionC');
 verify.completionListContains("x", "(property) x: (a: number) => void");
 
-goTo.marker('quickInfoA');
-verify.quickInfoIs("(method) x(a: number): void", undefined);
-
-goTo.marker('quickInfoB');
-verify.quickInfoIs("(property) x: (a: number) => void", undefined);
-
-goTo.marker('quickInfoC');
-verify.quickInfoIs("(property) x: (a: number) => void", undefined);
+verify.quickInfos({
+    quickInfoA: "(method) x(a: number): void",
+    quickInfoB: "(property) x: (a: number) => void",
+    quickInfoC: "(property) x: (a: number) => void"
+});

--- a/tests/cases/fourslash/funduleWithRecursiveReference.ts
+++ b/tests/cases/fourslash/funduleWithRecursiveReference.ts
@@ -7,6 +7,5 @@
 ////  }
 ////}
 
-goTo.marker();
-verify.quickInfoIs('var M.C.C: typeof M.C');
+verify.quickInfoAt("", "var M.C.C: typeof M.C");
 verify.numberOfErrorsInCurrentFile(0);

--- a/tests/cases/fourslash/genericCallSignaturesInNonGenericTypes1.ts
+++ b/tests/cases/fourslash/genericCallSignaturesInNonGenericTypes1.ts
@@ -15,5 +15,4 @@
 
 ////var /**/b = _(a); 
 
-goTo.marker();
-verify.quickInfoIs('var b: WrappedArray<number>');
+verify.quickInfoAt("", "var b: WrappedArray<number>");

--- a/tests/cases/fourslash/genericCallSignaturesInNonGenericTypes2.ts
+++ b/tests/cases/fourslash/genericCallSignaturesInNonGenericTypes2.ts
@@ -12,5 +12,4 @@
 
 ////var /**/b = _(a);  // WrappedArray<any>, should be WrappedArray<number>
 
-goTo.marker();
-verify.quickInfoIs('var b: WrappedArray<number>');
+verify.quickInfoAt("", "var b: WrappedArray<number>");

--- a/tests/cases/fourslash/genericCallsWithOptionalParams1.ts
+++ b/tests/cases/fourslash/genericCallsWithOptionalParams1.ts
@@ -12,8 +12,7 @@
 ////var /*1*/r = utils.fold(c, (s, t) => t, "");
 ////var /*2*/r2 = utils.fold(c, (s, t) => t);
 
-goTo.marker('1');
-verify.quickInfoIs('var r: string');
-
-goTo.marker('2');
-verify.quickInfoIs('var r2: string');
+verify.quickInfos({
+    1: "var r: string",
+    2: "var r2: string"
+});

--- a/tests/cases/fourslash/genericCombinatorWithConstraints1.ts
+++ b/tests/cases/fourslash/genericCombinatorWithConstraints1.ts
@@ -5,9 +5,7 @@
 ////    var /*2*/xs2 = source.map((x: T, a, b): U => { return null }); // any[] 
 ////}
 
-goTo.marker('1');
-verify.quickInfoIs('(local var) xs: U[]');
-
-goTo.marker('2');
-verify.quickInfoIs('(local var) xs2: U[]');
-
+verify.quickInfos({
+    1: "(local var) xs: U[]",
+    2: "(local var) xs2: U[]"
+});

--- a/tests/cases/fourslash/genericCombinators1.ts
+++ b/tests/cases/fourslash/genericCombinators1.ts
@@ -50,49 +50,29 @@
 
 ////var /*23*/r8a = _.map</*error1*/B/*error2*/, string>(c5, (/*8*/x) => { return x.foo() });
 
-goTo.marker('1');
-verify.quickInfoIs('(parameter) x: number');
-goTo.marker('2');
-verify.quickInfoIs('(parameter) x: Collection<number>');
-goTo.marker('3');
-verify.quickInfoIs('(parameter) x: A');
-goTo.marker('4');
-verify.quickInfoIs('(parameter) x: B<any>');
-goTo.marker('5');
-verify.quickInfoIs('(parameter) x: number');
-goTo.marker('6');
-verify.quickInfoIs('var c3: Collection<Collection<number>>');
-goTo.marker('7');
-verify.quickInfoIs('(parameter) x: A');
-goTo.marker('8');
-verify.quickInfoIs('(parameter) x: any'); // Specialized to any because no type argument was specified
-goTo.marker('9');
-verify.quickInfoIs('var r1a: Collection<string>');
-goTo.marker('10');
-verify.quickInfoIs('var r1b: Collection<string>');
-goTo.marker('11');
-verify.quickInfoIs('var r2a: Collection<number>');
-goTo.marker('12');
-verify.quickInfoIs('var r2b: Collection<number>');
-goTo.marker('13');
-verify.quickInfoIs('var r3a: Collection<A>');
-goTo.marker('14');
-verify.quickInfoIs('var r3b: Collection<A>');
-goTo.marker('15');
-verify.quickInfoIs('var r4a: Collection<any>');
-goTo.marker('17');
-verify.quickInfoIs('var r5a: Collection<string>');
-goTo.marker('18');
-verify.quickInfoIs('var r5b: Collection<string>');
-goTo.marker('19');
-verify.quickInfoIs('var r6a: Collection<number>');
-goTo.marker('20');
-verify.quickInfoIs('var r6b: Collection<number>');
-goTo.marker('21');
-verify.quickInfoIs('var r7a: Collection<A>');
-goTo.marker('22');
-verify.quickInfoIs('var r7b: Collection<A>');
-goTo.marker('23');
-verify.quickInfoIs('var r8a: Collection<string>');
+verify.quickInfos({
+    1: "(parameter) x: number",
+    2: "(parameter) x: Collection<number>",
+    3: "(parameter) x: A",
+    4: "(parameter) x: B<any>",
+    5: "(parameter) x: number",
+    6: "var c3: Collection<Collection<number>>",
+    7: "(parameter) x: A",
+    8: "(parameter) x: any", // Specialized to any because no type argument was specified
+    9: "var r1a: Collection<string>",
+    10: "var r1b: Collection<string>",
+    11: "var r2a: Collection<number>",
+    12: "var r2b: Collection<number>",
+    13: "var r3a: Collection<A>",
+    14: "var r3b: Collection<A>",
+    15: "var r4a: Collection<any>",
+    17: "var r5a: Collection<string>",
+    18: "var r5b: Collection<string>",
+    19: "var r6a: Collection<number>",
+    20: "var r6b: Collection<number>",
+    21: "var r7a: Collection<A>",
+    22: "var r7b: Collection<A>",
+    23: "var r8a: Collection<string>"
+});
 
 verify.errorExistsBetweenMarkers('error1', 'error2');

--- a/tests/cases/fourslash/genericCombinators2.ts
+++ b/tests/cases/fourslash/genericCombinators2.ts
@@ -56,76 +56,36 @@
 ////
 ////var /*23*/r8a = _.map<number, /*error1*/B/*error2*/, string>(c5, (/*8a*/x,/*8b*/y) => { return y.foo() }); 
 
-goTo.marker('2a');
-verify.quickInfoIs('(parameter) x: Collection<number, number>');
-goTo.marker('2b');
-verify.quickInfoIs('(parameter) y: string');
-
-goTo.marker('3a');
-verify.quickInfoIs('(parameter) x: number');
-goTo.marker('3b');
-verify.quickInfoIs('(parameter) y: A');
-
-goTo.marker('4a');
-verify.quickInfoIs('(parameter) x: number');
-goTo.marker('4b');
-verify.quickInfoIs('(parameter) y: B<any>');
-
-goTo.marker('5a');
-verify.quickInfoIs('(parameter) x: number');
-goTo.marker('5b');
-verify.quickInfoIs('(parameter) y: string');
-
-goTo.marker('6a');
-verify.quickInfoIs('(parameter) x: Collection<number, number>');
-goTo.marker('6b');
-verify.quickInfoIs('(parameter) y: string');
-
-goTo.marker('7a');
-verify.quickInfoIs('(parameter) x: number');
-goTo.marker('7b');
-verify.quickInfoIs('(parameter) y: A');
-
-goTo.marker('8a');
-verify.quickInfoIs('(parameter) x: number');
-goTo.marker('8b');
-verify.quickInfoIs('(parameter) y: any'); // Specialized to any because no type argument was specified
-
-goTo.marker('9');
-verify.quickInfoIs('var r1a: Collection<number, string>');
-goTo.marker('10');
-verify.quickInfoIs('var r1b: Collection<number, string>');
-goTo.marker('11');
-verify.quickInfoIs('var r2a: Collection<Collection<number, number>, number>');
-goTo.marker('12');
-verify.quickInfoIs('var r2b: Collection<Collection<number, number>, number>');
-goTo.marker('13');
-verify.quickInfoIs('var r3a: Collection<number, {}>');
-goTo.marker('14');
-verify.quickInfoIs('var r3b: Collection<number, {}>');
-goTo.marker('15');
-verify.quickInfoIs('var r4a: Collection<number, any>');
-
-goTo.marker('17');
-verify.quickInfoIs('var r5a: Collection<number, Date>');
-
-goTo.marker('18');
-verify.quickInfoIs('var r5b: Collection<number, Date>');
-
-goTo.marker('19');
-verify.quickInfoIs('var r6a: Collection<Collection<number, number>, Date>');
-
-goTo.marker('20');
-verify.quickInfoIs('var r6b: Collection<Collection<number, number>, Date>');
-
-goTo.marker('21');
-verify.quickInfoIs('var r7a: Collection<number, string>');
-
-goTo.marker('22');
-verify.quickInfoIs('var r7b: Collection<number, string>');
-
-goTo.marker('23');
-verify.quickInfoIs('var r8a: Collection<number, string>');
+verify.quickInfos({
+    "2a": "(parameter) x: Collection<number, number>",
+    "2b": "(parameter) y: string",
+    "3a": "(parameter) x: number",
+    "3b": "(parameter) y: A",
+    "4a": "(parameter) x: number",
+    "4b": "(parameter) y: B<any>",
+    "5a": "(parameter) x: number",
+    "5b": "(parameter) y: string",
+    "6a": "(parameter) x: Collection<number, number>",
+    "6b": "(parameter) y: string",
+    "7a": "(parameter) x: number",
+    "7b": "(parameter) y: A",
+    "8a": "(parameter) x: number",
+    "8b": "(parameter) y: any", // Specialized to any because no type argument was specified
+    9: "var r1a: Collection<number, string>",
+    10: "var r1b: Collection<number, string>",
+    11: "var r2a: Collection<Collection<number, number>, number>",
+    12: "var r2b: Collection<Collection<number, number>, number>",
+    13: "var r3a: Collection<number, {}>",
+    14: "var r3b: Collection<number, {}>",
+    15: "var r4a: Collection<number, any>",
+    17: "var r5a: Collection<number, Date>",
+    18: "var r5b: Collection<number, Date>",
+    19: "var r6a: Collection<Collection<number, number>, Date>",
+    20: "var r6b: Collection<Collection<number, number>, Date>",
+    21: "var r7a: Collection<number, string>",
+    22: "var r7b: Collection<number, string>",
+    23: "var r8a: Collection<number, string>"
+});
 
 verify.errorExistsBetweenMarkers('error1', 'error2');
 verify.errorExistsBetweenMarkers('17error1', '17error2');

--- a/tests/cases/fourslash/genericCombinators3.ts
+++ b/tests/cases/fourslash/genericCombinators3.ts
@@ -14,14 +14,9 @@
 ////
 ////var /*9*/r1a  = _.ma/*1c*/p(c2, (/*1a*/x,/*1b*/y) => { return x + "" });  // check quick info of map here
 
-goTo.marker('1a');
-verify.quickInfoIs('(parameter) x: number');
-
-goTo.marker('1b');
-verify.quickInfoIs('(parameter) y: string');
-
-goTo.marker('1c');
-verify.quickInfoIs('(method) Combinators.map<number, string, string>(c: Collection<number, string>, f: (x: number, y: string) => string): Collection<number, string> (+1 overload)');
-
-goTo.marker('9');
-verify.quickInfoIs('var r1a: Collection<number, string>');
+verify.quickInfos({
+    "1a": "(parameter) x: number",
+    "1b": "(parameter) y: string",
+    "1c": "(method) Combinators.map<number, string, string>(c: Collection<number, string>, f: (x: number, y: string) => string): Collection<number, string> (+1 overload)",
+    9: "var r1a: Collection<number, string>"
+});

--- a/tests/cases/fourslash/genericDerivedTypeAcrossModuleBoundary1.ts
+++ b/tests/cases/fourslash/genericDerivedTypeAcrossModuleBoundary1.ts
@@ -16,8 +16,7 @@
 ////var /*1*/n2 = new N.D2<number>();
 ////var /*2*/n3 = new N.D2();
 
-goTo.marker('1');
-verify.quickInfoIs('var n2: N.D2<number>');
-
-goTo.marker('2')
-verify.quickInfoIs('var n3: N.D2<{}>');
+verify.quickInfos({
+    1: "var n2: N.D2<number>",
+    2: "var n3: N.D2<{}>"
+});

--- a/tests/cases/fourslash/genericFunctionReturnType.ts
+++ b/tests/cases/fourslash/genericFunctionReturnType.ts
@@ -11,11 +11,9 @@
 // goTo.marker('1');
 // verify.currentSignatureHelpIs('foo(x: number, y: string): (a: string) => number');
 
-goTo.marker('2');
-verify.quickInfoIs('var r: (a: string) => number');
+verify.quickInfoAt("2", "var r: (a: string) => number");
 
 goTo.marker('3');
 verify.currentSignatureHelpIs('r(a: string): number');
 
-goTo.marker('4');
-verify.quickInfoIs('var r2: number');
+verify.quickInfoAt("4", "var r2: number");

--- a/tests/cases/fourslash/genericFunctionReturnType2.ts
+++ b/tests/cases/fourslash/genericFunctionReturnType2.ts
@@ -14,11 +14,9 @@
 goTo.marker('1');
 verify.currentSignatureHelpIs('foo(x: number): (a: number) => number');
 
-goTo.marker('2');
-verify.quickInfoIs('var r: (a: number) => number');
+verify.quickInfoAt("2", "var r: (a: number) => number");
 
 goTo.marker('3');
 verify.currentSignatureHelpIs('r(a: number): number');
 
-goTo.marker('4');
-verify.quickInfoIs('var r2: number');
+verify.quickInfoAt("4", "var r2: number");

--- a/tests/cases/fourslash/genericFunctionWithGenericParams1.ts
+++ b/tests/cases/fourslash/genericFunctionWithGenericParams1.ts
@@ -5,5 +5,4 @@
 ////    return a;
 ////};
 
-goTo.marker();
-verify.quickInfoIs('(local var) xx: T');
+verify.quickInfoAt("", "(local var) xx: T");

--- a/tests/cases/fourslash/genericInterfacePropertyInference1.ts
+++ b/tests/cases/fourslash/genericInterfacePropertyInference1.ts
@@ -89,99 +89,54 @@
 
 verify.numberOfErrorsInCurrentFile(0);
 
-goTo.marker('a1');
-verify.quickInfoIs('var f_r1: number');
-goTo.marker('a2');
-verify.quickInfoIs('var f_r2: string');
-goTo.marker('a3');
-verify.quickInfoIs('var f_r3: any');
-goTo.marker('a4');
-verify.quickInfoIs('var f_r5: Foo<number>');
-goTo.marker('a5');
-verify.quickInfoIs('var f_r8: I');
-goTo.marker('a6');
-verify.quickInfoIs('var f_r12: {\n    x: number;\n}');
-goTo.marker('a7');
-verify.quickInfoIs('var f_r14: {\n    x: any;\n}');
-goTo.marker('a8');
-verify.quickInfoIs('var f_r18: C<number>');
-goTo.marker('a9');
-verify.quickInfoIs('var f_r20: C<{\n    x: any;\n}>');
+verify.quickInfos({
+    "a1": "var f_r1: number",
+    "a2": "var f_r2: string",
+    "a3": "var f_r3: any",
+    "a4": "var f_r5: Foo<number>",
+    "a5": "var f_r8: I",
+    "a6": "var f_r12: {\n    x: number;\n}",
+    "a7": "var f_r14: {\n    x: any;\n}",
+    "a8": "var f_r18: C<number>",
+    "a9": "var f_r20: C<{\n    x: any;\n}>",
 
-goTo.marker('b1');
-verify.quickInfoIs('var f2_r1: number');
-goTo.marker('b2');
-verify.quickInfoIs('var f2_r2: string');
-goTo.marker('b3');
-verify.quickInfoIs('var f2_r3: number');
-goTo.marker('b4');
-verify.quickInfoIs('var f2_r5: Foo<number>'); 
-goTo.marker('b5');
-verify.quickInfoIs('var f2_r8: I');
-goTo.marker('b6');
-verify.quickInfoIs('var f2_r12: {\n    x: number;\n}');
-goTo.marker('b7');
-verify.quickInfoIs('var f2_r14: {\n    x: number;\n}');
-goTo.marker('b8');
-verify.quickInfoIs('var f2_r18: C<number>');
-goTo.marker('b9');
-verify.quickInfoIs('var f2_r20: C<{\n    x: number;\n}>');
+    "b1": "var f2_r1: number",
+    "b2": "var f2_r2: string",
+    "b3": "var f2_r3: number",
+    "b4": "var f2_r5: Foo<number>",
+    "b5": "var f2_r8: I",
+    "b6": "var f2_r12: {\n    x: number;\n}",
+    "b7": "var f2_r14: {\n    x: number;\n}",
+    "b8": "var f2_r18: C<number>",
+    "b9": "var f2_r20: C<{\n    x: number;\n}>",
 
-goTo.marker('c1');
-verify.quickInfoIs('var f3_r1: number');
-goTo.marker('c2');
-verify.quickInfoIs('var f3_r2: string');
-goTo.marker('c3');
-verify.quickInfoIs('var f3_r3: I');
-goTo.marker('c4');
-verify.quickInfoIs('var f3_r5: Foo<number>');
-goTo.marker('c5');
-verify.quickInfoIs('var f3_r8: I');
-goTo.marker('c6');
-verify.quickInfoIs('var f3_r12: {\n    x: number;\n}');
-goTo.marker('c7');
-verify.quickInfoIs('var f3_r14: {\n    x: I;\n}');
-goTo.marker('c8');
-verify.quickInfoIs('var f3_r18: C<number>');
-goTo.marker('c9');
-verify.quickInfoIs('var f3_r20: C<{\n    x: I;\n}>');
+    "c1": "var f3_r1: number",
+    "c2": "var f3_r2: string",
+    "c3": "var f3_r3: I",
+    "c4": "var f3_r5: Foo<number>",
+    "c5": "var f3_r8: I",
+    "c6": "var f3_r12: {\n    x: number;\n}",
+    "c7": "var f3_r14: {\n    x: I;\n}",
+    "c8": "var f3_r18: C<number>",
+    "c9": "var f3_r20: C<{\n    x: I;\n}>",
 
-goTo.marker('d1');
-verify.quickInfoIs('var f4_r1: number');
-goTo.marker('d2');
-verify.quickInfoIs('var f4_r2: string');
-goTo.marker('d3');
-verify.quickInfoIs('var f4_r3: {\n    x: number;\n}');
-goTo.marker('d4');
-verify.quickInfoIs('var f4_r5: Foo<number>');
-goTo.marker('d5');
-verify.quickInfoIs('var f4_r8: I');
-goTo.marker('d6');
-verify.quickInfoIs('var f4_r12: {\n    x: number;\n}');
-goTo.marker('d7');
-verify.quickInfoIs('var f4_r14: {\n    x: {\n        x: number;\n    };\n}');
-goTo.marker('d8');
-verify.quickInfoIs('var f4_r18: C<number>');
-goTo.marker('d9');
-verify.quickInfoIs('var f4_r20: C<{\n    x: {\n        x: number;\n    };\n}>');
+    "d1": "var f4_r1: number",
+    "d2": "var f4_r2: string",
+    "d3": "var f4_r3: {\n    x: number;\n}",
+    "d4": "var f4_r5: Foo<number>",
+    "d5": "var f4_r8: I",
+    "d6": "var f4_r12: {\n    x: number;\n}",
+    "d7": "var f4_r14: {\n    x: {\n        x: number;\n    };\n}",
+    "d8": "var f4_r18: C<number>",
+    "d9": "var f4_r20: C<{\n    x: {\n        x: number;\n    };\n}>",
 
-goTo.marker('e1');
-verify.quickInfoIs('var f5_r1: number');
-goTo.marker('e2');
-verify.quickInfoIs('var f5_r2: string');
-goTo.marker('e3');
-verify.quickInfoIs('var f5_r3: Foo<number>');
-goTo.marker('e4');
-verify.quickInfoIs('var f5_r5: Foo<number>');
-goTo.marker('e5');
-verify.quickInfoIs('var f5_r8: I');
-goTo.marker('e6');
-verify.quickInfoIs('var f5_r12: {\n    x: number;\n}');
-goTo.marker('e7');
-verify.quickInfoIs('var f5_r14: {\n    x: Foo<number>;\n}');
-goTo.marker('e8');
-verify.quickInfoIs('var f5_r18: C<number>');
-goTo.marker('e9');
-verify.quickInfoIs('var f5_r20: C<{\n    x: Foo<number>;\n}>');
-
-
+    "e1": "var f5_r1: number",
+    "e2": "var f5_r2: string",
+    "e3": "var f5_r3: Foo<number>",
+    "e4": "var f5_r5: Foo<number>",
+    "e5": "var f5_r8: I",
+    "e6": "var f5_r12: {\n    x: number;\n}",
+    "e7": "var f5_r14: {\n    x: Foo<number>;\n}",
+    "e8": "var f5_r18: C<number>",
+    "e9": "var f5_r20: C<{\n    x: Foo<number>;\n}>"
+});

--- a/tests/cases/fourslash/genericInterfacePropertyInference2.ts
+++ b/tests/cases/fourslash/genericInterfacePropertyInference2.ts
@@ -65,57 +65,34 @@
 
 verify.numberOfErrorsInCurrentFile(0);
 
-goTo.marker('a1');
-verify.quickInfoIs('var f_r4: Foo<any>');
-goTo.marker('a2');
-verify.quickInfoIs('var f_r7: Foo<Foo<number>>');
-goTo.marker('a3');
-verify.quickInfoIs('var f_r9: IG<any>');
-goTo.marker('a5');
-verify.quickInfoIs('var f_r13: {\n    x: Foo<any>;\n}');
-goTo.marker('a7');
-verify.quickInfoIs('var f_r17: C<any>');
+verify.quickInfos({
+    a1: "var f_r4: Foo<any>",
+    a2: "var f_r7: Foo<Foo<number>>",
+    a3: "var f_r9: IG<any>",
+    a5: "var f_r13: {\n    x: Foo<any>;\n}",
+    a7: "var f_r17: C<any>",
 
-goTo.marker('b1');
-verify.quickInfoIs('var f2_r4: Foo<number>');
-goTo.marker('b2');
-verify.quickInfoIs('var f2_r7: Foo<Foo<number>>'); 
-goTo.marker('b3');
-verify.quickInfoIs('var f2_r9: IG<number>');
-goTo.marker('b5');
-verify.quickInfoIs('var f2_r13: {\n    x: Foo<number>;\n}');
-goTo.marker('b7');
-verify.quickInfoIs('var f2_r17: C<number>');
+    b1: "var f2_r4: Foo<number>",
+    b2: "var f2_r7: Foo<Foo<number>>",
+    b3: "var f2_r9: IG<number>",
+    b5: "var f2_r13: {\n    x: Foo<number>;\n}",
+    b7: "var f2_r17: C<number>",
 
-goTo.marker('c1');
-verify.quickInfoIs('var f3_r4: Foo<I>');
-goTo.marker('c2');
-verify.quickInfoIs('var f3_r7: Foo<Foo<number>>');
-goTo.marker('c3');
-verify.quickInfoIs('var f3_r9: IG<I>');
-goTo.marker('c5');
-verify.quickInfoIs('var f3_r13: {\n    x: Foo<I>;\n}');
-goTo.marker('c7');
-verify.quickInfoIs('var f3_r17: C<I>');
+    c1: "var f3_r4: Foo<I>",
+    c2: "var f3_r7: Foo<Foo<number>>",
+    c3: "var f3_r9: IG<I>",
+    c5: "var f3_r13: {\n    x: Foo<I>;\n}",
+    c7: "var f3_r17: C<I>",
 
-goTo.marker('d1');
-verify.quickInfoIs('var f4_r4: Foo<{\n    x: number;\n}>');
-goTo.marker('d2');
-verify.quickInfoIs('var f4_r7: Foo<Foo<number>>');
-goTo.marker('d3');
-verify.quickInfoIs('var f4_r9: IG<{\n    x: number;\n}>');
-goTo.marker('d5');
-verify.quickInfoIs('var f4_r13: {\n    x: Foo<{\n        x: number;\n    }>;\n}');
-goTo.marker('d7');
-verify.quickInfoIs('var f4_r17: C<{\n    x: number;\n}>');
+    d1: "var f4_r4: Foo<{\n    x: number;\n}>",
+    d2: "var f4_r7: Foo<Foo<number>>",
+    d3: "var f4_r9: IG<{\n    x: number;\n}>",
+    d5: "var f4_r13: {\n    x: Foo<{\n        x: number;\n    }>;\n}",
+    d7: "var f4_r17: C<{\n    x: number;\n}>",
 
-goTo.marker('e1');
-verify.quickInfoIs('var f5_r4: Foo<Foo<number>>');
-goTo.marker('e2');
-verify.quickInfoIs('var f5_r7: Foo<Foo<number>>');
-goTo.marker('e3');
-verify.quickInfoIs('var f5_r9: IG<Foo<number>>');
-goTo.marker('e5');
-verify.quickInfoIs('var f5_r13: {\n    x: Foo<Foo<number>>;\n}');
-goTo.marker('e7');
-verify.quickInfoIs('var f5_r17: C<Foo<number>>');
+    e1: "var f5_r4: Foo<Foo<number>>",
+    e2: "var f5_r7: Foo<Foo<number>>",
+    e3: "var f5_r9: IG<Foo<number>>",
+    e5: "var f5_r13: {\n    x: Foo<Foo<number>>;\n}",
+    e7: "var f5_r17: C<Foo<number>>",
+});

--- a/tests/cases/fourslash/genericInterfacesWithConstraints1.ts
+++ b/tests/cases/fourslash/genericInterfacesWithConstraints1.ts
@@ -11,9 +11,8 @@
 ////var v/*2*/2: G<{ a: string }, C>;   // Ok, equivalent to G<A, C>
 ////var v/*3*/3: G<G<A, B>, C>;         // Ok
 
-goTo.marker('1');
-verify.quickInfoIs('var v1: G<A, C>');
-goTo.marker('2');
-verify.quickInfoIs('var v2: G<{\n    a: string;\n}, C>');
-goTo.marker('3');
-verify.quickInfoIs('var v3: G<G<A, B>, C>');
+verify.quickInfos({
+    1: "var v1: G<A, C>",
+    2: "var v2: G<{\n    a: string;\n}, C>",
+    3: "var v3: G<G<A, B>, C>"
+});

--- a/tests/cases/fourslash/genericMapTyping1.ts
+++ b/tests/cases/fourslash/genericMapTyping1.ts
@@ -21,29 +21,14 @@
 ////var d/*6*/dd = aaa.map(xx => xx.length);     // should not error, should be any[]
 
 verify.numberOfErrorsInCurrentFile(0);
-goTo.marker('1');
-verify.quickInfoIs('var bb: number[]');
-
-goTo.marker('2');
-verify.quickInfoIs('var cc: number[]');
-
-goTo.marker('3');
-verify.quickInfoIs('var dd: number[]');
-
-goTo.marker('4');
-verify.quickInfoIs('var bbb: any[]');
-
-goTo.marker('5');
-verify.quickInfoIs('var ccc: any[]');
-
-goTo.marker('6');
-verify.quickInfoIs('var ddd: any[]');
-
-goTo.marker('7');
-verify.quickInfoIs('(parameter) xx: string');
-
-goTo.marker('8');
-verify.quickInfoIs('(parameter) xx: string');
-
-goTo.marker('9');
-verify.quickInfoIs('(parameter) xx: string');
+verify.quickInfos({
+    1: "var bb: number[]",
+    2: "var cc: number[]",
+    3: "var dd: number[]",
+    4: "var bbb: any[]",
+    5: "var ccc: any[]",
+    6: "var ddd: any[]",
+    7: "(parameter) xx: string",
+    8: "(parameter) xx: string",
+    9: "(parameter) xx: string"
+});

--- a/tests/cases/fourslash/genericTypeArgumentInference1.ts
+++ b/tests/cases/fourslash/genericTypeArgumentInference1.ts
@@ -17,24 +17,17 @@
 ////var /*3*/r3 = _./*31*/all([], _.identity);
 ////var /*4*/r4 = _./*41*/all([<any>true], _.identity);
 
-goTo.marker('1');
-verify.quickInfoIs('var r: string | number | boolean');
-goTo.marker('11');
-verify.quickInfoIs('(method) Underscore.Static.all<string | number | boolean>(list: (string | number | boolean)[], iterator?: Underscore.Iterator<string | number | boolean, boolean>, context?: any): string | number | boolean');
+verify.quickInfos({
+    1: "var r: string | number | boolean",
+    11: "(method) Underscore.Static.all<string | number | boolean>(list: (string | number | boolean)[], iterator?: Underscore.Iterator<string | number | boolean, boolean>, context?: any): string | number | boolean",
 
-goTo.marker('2');
-verify.quickInfoIs('var r2: boolean');
-goTo.marker('21');
-verify.quickInfoIs('(method) Underscore.Static.all<boolean>(list: boolean[], iterator?: Underscore.Iterator<boolean, boolean>, context?: any): boolean');
+    2: "var r2: boolean",
+    21: "(method) Underscore.Static.all<boolean>(list: boolean[], iterator?: Underscore.Iterator<boolean, boolean>, context?: any): boolean",
 
-goTo.marker('3');
-verify.quickInfoIs('var r3: any');
-goTo.marker('31');
-verify.quickInfoIs('(method) Underscore.Static.all<any>(list: any[], iterator?: Underscore.Iterator<any, boolean>, context?: any): any');
+    3: "var r3: any",
+    31: "(method) Underscore.Static.all<any>(list: any[], iterator?: Underscore.Iterator<any, boolean>, context?: any): any",
 
-goTo.marker('4');
-verify.quickInfoIs('var r4: any');
-goTo.marker('41');
-verify.quickInfoIs('(method) Underscore.Static.all<any>(list: any[], iterator?: Underscore.Iterator<any, boolean>, context?: any): any');
-
+    4: "var r4: any",
+    41: "(method) Underscore.Static.all<any>(list: any[], iterator?: Underscore.Iterator<any, boolean>, context?: any): any"
+});
 verify.numberOfErrorsInCurrentFile(0);

--- a/tests/cases/fourslash/genericTypeArgumentInference2.ts
+++ b/tests/cases/fourslash/genericTypeArgumentInference2.ts
@@ -17,24 +17,17 @@
 ////var /*3*/r3 = _./*31*/all([], _.identity);
 ////var /*4*/r4 = _./*41*/all([<any>true], _.identity);
 
-goTo.marker('1');
-verify.quickInfoIs('var r: string | number | boolean');
-goTo.marker('11');
-verify.quickInfoIs('(method) Underscore.Static.all<string | number | boolean>(list: (string | number | boolean)[], iterator?: Underscore.Iterator<string | number | boolean, boolean>, context?: any): string | number | boolean');
+verify.quickInfos({
+    1: "var r: string | number | boolean",
+    11: "(method) Underscore.Static.all<string | number | boolean>(list: (string | number | boolean)[], iterator?: Underscore.Iterator<string | number | boolean, boolean>, context?: any): string | number | boolean",
 
-goTo.marker('2');
-verify.quickInfoIs('var r2: boolean');
-goTo.marker('21');
-verify.quickInfoIs('(method) Underscore.Static.all<boolean>(list: boolean[], iterator?: Underscore.Iterator<boolean, boolean>, context?: any): boolean');
+    2: "var r2: boolean",
+    21: "(method) Underscore.Static.all<boolean>(list: boolean[], iterator?: Underscore.Iterator<boolean, boolean>, context?: any): boolean",
 
-goTo.marker('3');
-verify.quickInfoIs('var r3: any');
-goTo.marker('31');
-verify.quickInfoIs('(method) Underscore.Static.all<any>(list: any[], iterator?: Underscore.Iterator<any, boolean>, context?: any): any');
+    3: "var r3: any",
+    31: "(method) Underscore.Static.all<any>(list: any[], iterator?: Underscore.Iterator<any, boolean>, context?: any): any",
 
-goTo.marker('4');
-verify.quickInfoIs('var r4: any');
-goTo.marker('41');
-verify.quickInfoIs('(method) Underscore.Static.all<any>(list: any[], iterator?: Underscore.Iterator<any, boolean>, context?: any): any');
-
+    4: "var r4: any",
+    41: "(method) Underscore.Static.all<any>(list: any[], iterator?: Underscore.Iterator<any, boolean>, context?: any): any"
+});
 verify.numberOfErrorsInCurrentFile(0);

--- a/tests/cases/fourslash/genericTypeParamUnrelatedToArguments1.ts
+++ b/tests/cases/fourslash/genericTypeParamUnrelatedToArguments1.ts
@@ -10,20 +10,11 @@
 ////var f/*5*/5 = new Foo<number>(3);
 ////var f/*6*/6: Foo<number> = new Foo<number>(3);
 
-goTo.marker('1');
-verify.quickInfoIs('var f1: Foo<number>');
-
-goTo.marker('2');
-verify.quickInfoIs('var f2: Foo<number>');
-
-goTo.marker('3');
-verify.quickInfoIs('var f3: any');
-
-goTo.marker('4');
-verify.quickInfoIs('var f4: Foo<number>');
-
-goTo.marker('5');
-verify.quickInfoIs('var f5: any');
-
-goTo.marker('6');
-verify.quickInfoIs('var f6: Foo<number>');
+verify.quickInfos({
+    1: "var f1: Foo<number>",
+    2: "var f2: Foo<number>",
+    3: "var f3: any",
+    4: "var f4: Foo<number>",
+    5: "var f5: any",
+    6: "var f6: Foo<number>"
+});

--- a/tests/cases/fourslash/genericWithSpecializedProperties1.ts
+++ b/tests/cases/fourslash/genericWithSpecializedProperties1.ts
@@ -13,12 +13,9 @@
 ////var /*3*/x2 = f2.x;
 ////var /*4*/y2 = f2.y;
 
-goTo.marker('1');
-verify.quickInfoIs('var xx: Foo<string>');
-goTo.marker('2');
-verify.quickInfoIs('var yy: Foo<number>');
-
-goTo.marker('3');
-verify.quickInfoIs('var x2: Foo<string>');
-goTo.marker('4');
-verify.quickInfoIs('var y2: Foo<number>');
+verify.quickInfos({
+    1: "var xx: Foo<string>",
+    2: "var yy: Foo<number>",
+    3: "var x2: Foo<string>",
+    4: "var y2: Foo<number>"
+});

--- a/tests/cases/fourslash/genericWithSpecializedProperties2.ts
+++ b/tests/cases/fourslash/genericWithSpecializedProperties2.ts
@@ -12,12 +12,9 @@
 ////var /*3*/x2 = f2.x; 
 ////var /*4*/y2 = f2.y; 
 
-goTo.marker('1');
-verify.quickInfoIs('var x: Foo<string>');
-goTo.marker('2');
-verify.quickInfoIs('var y: Foo<number>');
-
-goTo.marker('3');
-verify.quickInfoIs('var x2: Foo<string>');
-goTo.marker('4');
-verify.quickInfoIs('var y2: Foo<number>');
+verify.quickInfos({
+    1: "var x: Foo<string>",
+    2: "var y: Foo<number>",
+    3: "var x2: Foo<string>",
+    4: "var y2: Foo<number>"
+});

--- a/tests/cases/fourslash/genericWithSpecializedProperties3.ts
+++ b/tests/cases/fourslash/genericWithSpecializedProperties3.ts
@@ -13,12 +13,9 @@
 ////var /*3*/x2 = f2.x;
 ////var /*4*/y2 = f2.y;
 
-goTo.marker('1');
-verify.quickInfoIs('var xx: Foo<number, string>');
-goTo.marker('2');
-verify.quickInfoIs('var yy: Foo<string, string>');
-
-goTo.marker('3');
-verify.quickInfoIs('var x2: Foo<string, number>');
-goTo.marker('4');
-verify.quickInfoIs('var y2: Foo<number, number>');
+verify.quickInfos({
+    1: "var xx: Foo<number, string>",
+    2: "var yy: Foo<string, string>",
+    3: "var x2: Foo<string, number>",
+    4: "var y2: Foo<number, number>"
+});

--- a/tests/cases/fourslash/getJavaScriptQuickInfo1.ts
+++ b/tests/cases/fourslash/getJavaScriptQuickInfo1.ts
@@ -5,5 +5,4 @@
 /////** @type {function(new:string,number)} */
 ////var /**/v;
 
-goTo.marker();
-verify.quickInfoIs('var v: new (p1: number) => string');
+verify.quickInfoAt("", "var v: new (p1: number) => string", "@type {function(new:string,number)} ");

--- a/tests/cases/fourslash/getJavaScriptQuickInfo2.ts
+++ b/tests/cases/fourslash/getJavaScriptQuickInfo2.ts
@@ -5,5 +5,4 @@
 /////** @param {number} [a] */
 ////function /**/f(a) { }
 
-goTo.marker();
-verify.quickInfoIs('function f(a?: number): void');
+verify.quickInfoAt("", "function f(a?: number): void");

--- a/tests/cases/fourslash/getJavaScriptQuickInfo3.ts
+++ b/tests/cases/fourslash/getJavaScriptQuickInfo3.ts
@@ -5,5 +5,4 @@
 /////** @param {number[]} [a] */
 ////function /**/f(a) { }
 
-goTo.marker();
-verify.quickInfoIs('function f(a?: number[]): void');
+verify.quickInfoAt("", "function f(a?: number[]): void");

--- a/tests/cases/fourslash/getJavaScriptQuickInfo4.ts
+++ b/tests/cases/fourslash/getJavaScriptQuickInfo4.ts
@@ -5,5 +5,4 @@
 /////** @param {[number,string]} [a] */
 ////function /**/f(a) { }
 
-goTo.marker();
-verify.quickInfoIs('function f(a?: [number, string]): void');
+verify.quickInfoAt("", "function f(a?: [number, string]): void");

--- a/tests/cases/fourslash/getJavaScriptQuickInfo5.ts
+++ b/tests/cases/fourslash/getJavaScriptQuickInfo5.ts
@@ -5,5 +5,4 @@
 /////** @param {{b:number}} [a] */
 ////function /**/f(a) { }
 
-goTo.marker();
-verify.quickInfoIs('function f(a?: {\n    b: number;\n}): void');
+verify.quickInfoAt("", "function f(a?: {\n    b: number;\n}): void");

--- a/tests/cases/fourslash/getJavaScriptQuickInfo6.ts
+++ b/tests/cases/fourslash/getJavaScriptQuickInfo6.ts
@@ -5,5 +5,4 @@
 /////** @type {function(this:number)} */
 ////function f() { /**/this }
 
-goTo.marker();
-verify.quickInfoIs('number');
+verify.quickInfoAt("", "number");

--- a/tests/cases/fourslash/getJavaScriptQuickInfo7.ts
+++ b/tests/cases/fourslash/getJavaScriptQuickInfo7.ts
@@ -16,7 +16,5 @@
 //// 
 //// x - /**/a1()
 
-goTo.marker();
-verify.quickInfoExists();
-verify.quickInfoIs('function a1(p: any): number',
-                   'This is a very cool function that is very nice.\n@returns something');
+verify.quickInfoAt("", "function a1(p: any): number",
+                   "This is a very cool function that is very nice.\n@returns something");

--- a/tests/cases/fourslash/getJavaScriptSemanticDiagnostics24.ts
+++ b/tests/cases/fourslash/getJavaScriptSemanticDiagnostics24.ts
@@ -12,5 +12,4 @@
 //// let x = new Person(100);
 //// x.canVote/**/;
 
-goTo.marker();
-verify.quickInfoIs('(property) Person.canVote: true | 23');
+verify.quickInfoAt("", "(property) Person.canVote: true | 23");

--- a/tests/cases/fourslash/getQuickInfoForIntersectionTypes.ts
+++ b/tests/cases/fourslash/getQuickInfoForIntersectionTypes.ts
@@ -4,5 +4,4 @@
 ////let x = f();
 ////x/**/();
 
-goTo.marker();
-verify.quickInfoIs("let x: () => any");
+verify.quickInfoAt("", "let x: () => any");

--- a/tests/cases/fourslash/incrementalResolveAccessor.ts
+++ b/tests/cases/fourslash/incrementalResolveAccessor.ts
@@ -13,8 +13,7 @@
 /////*1*/b;
 
 // Resolve without typeCheck
-goTo.marker('1');
-verify.quickInfoIs("var b: string");
+verify.quickInfoAt("1", "var b: string");
 
 // TypeCheck
 verify.numberOfErrorsInCurrentFile(3);

--- a/tests/cases/fourslash/incrementalResolveConstructorDeclaration.ts
+++ b/tests/cases/fourslash/incrementalResolveConstructorDeclaration.ts
@@ -10,8 +10,7 @@
 /////*1*/val;
 
 // Do resolve without typeCheck
-goTo.marker('1');
-verify.quickInfoIs("var val: c1");
+verify.quickInfoAt("1", "var val: c1");
 
 // TypeCheck
 verify.numberOfErrorsInCurrentFile(1);

--- a/tests/cases/fourslash/incrementalResolveFunctionPropertyAssignment.ts
+++ b/tests/cases/fourslash/incrementalResolveFunctionPropertyAssignment.ts
@@ -21,8 +21,7 @@
 ////var val = foo(["myString1", "myString2"]);
 /////*1*/val;
 
-goTo.marker('1');
-verify.quickInfoIs("var val: string");
+verify.quickInfoAt("1", "var val: string");
 
 // TypeCheck
 verify.numberOfErrorsInCurrentFile(1);

--- a/tests/cases/fourslash/indexerReturnTypes1.ts
+++ b/tests/cases/fourslash/indexerReturnTypes1.ts
@@ -61,51 +61,21 @@
 ////var /*15*/r15 = ty2[1];
 ////var /*16*/r16 = ty2['1'];
 
-
-goTo.marker('1');
-verify.quickInfoIs('var r1: Date');
-
-goTo.marker('2');
-verify.quickInfoIs('var r2: any');
-
-goTo.marker('3');
-verify.quickInfoIs('var r3: RegExp');
-
-goTo.marker('4');
-verify.quickInfoIs('var r4: RegExp');
-
-goTo.marker('5');
-verify.quickInfoIs('var r5: Date');
-
-goTo.marker('6');
-verify.quickInfoIs('var r6: any');
-
-goTo.marker('7');
-verify.quickInfoIs('var r7: RegExp');
-
-goTo.marker('8');
-verify.quickInfoIs('var r8: RegExp');
-
-goTo.marker('9');
-verify.quickInfoIs('var r9: Date');
-
-goTo.marker('10');
-verify.quickInfoIs('var r10: any');
-
-goTo.marker('11');
-verify.quickInfoIs('var r11: Date');
-
-goTo.marker('12');
-verify.quickInfoIs('var r12: Date');
-
-goTo.marker('13');
-verify.quickInfoIs('var r13: Ty<Date>');
-
-goTo.marker('14');
-verify.quickInfoIs('var r14: any');
-
-goTo.marker('15');
-verify.quickInfoIs('var r15: {\n    [x: number]: Date;\n}');
-
-goTo.marker('16');
-verify.quickInfoIs('var r16: any');
+verify.quickInfos({
+    1: "var r1: Date",
+    2: "var r2: any",
+    3: "var r3: RegExp",
+    4: "var r4: RegExp",
+    5: "var r5: Date",
+    6: "var r6: any",
+    7: "var r7: RegExp",
+    8: "var r8: RegExp",
+    9: "var r9: Date",
+    10: "var r10: any",
+    11: "var r11: Date",
+    12: "var r12: Date",
+    13: "var r13: Ty<Date>",
+    14: "var r14: any",
+    15: "var r15: {\n    [x: number]: Date;\n}",
+    16: "var r16: any"
+});

--- a/tests/cases/fourslash/instanceTypesForGenericType1.ts
+++ b/tests/cases/fourslash/instanceTypesForGenericType1.ts
@@ -7,8 +7,7 @@
 ////    }
 ////}
 
-goTo.marker('1');
-verify.quickInfoIs('(property) G<T>.self: G<T>');
-
-goTo.marker('2');
-verify.quickInfoIs('this: this');
+verify.quickInfos({
+    1: "(property) G<T>.self: G<T>",
+    2: "this: this"
+});

--- a/tests/cases/fourslash/intellisenseInObjectLiteral.ts
+++ b/tests/cases/fourslash/intellisenseInObjectLiteral.ts
@@ -8,5 +8,4 @@
 ////     }
 //// }
 
-goTo.marker();
-verify.quickInfoIs("var x: number", "");
+verify.quickInfoAt("", "var x: number");

--- a/tests/cases/fourslash/jsRequireQuickInfo.ts
+++ b/tests/cases/fourslash/jsRequireQuickInfo.ts
@@ -7,5 +7,4 @@
 // @Filename: b.js
 ////exports.x = 0;
 
-goTo.marker();
-verify.quickInfoIs('const x: typeof "/tests/cases/fourslash/b"');
+verify.quickInfoAt("",'const x: typeof "/tests/cases/fourslash/b"');

--- a/tests/cases/fourslash/letQuickInfoAndCompletionList.ts
+++ b/tests/cases/fourslash/letQuickInfoAndCompletionList.ts
@@ -7,15 +7,13 @@
 ////    /*4*/b = /*5*/a;
 ////}
 
-goTo.marker('1');
-verify.quickInfoIs("let a: number");
+verify.quickInfoAt("1", "let a: number");
 
 goTo.marker('2');
 verify.completionListContains("a", "let a: number");
 verify.quickInfoIs("let a: number");
 
-goTo.marker('3');
-verify.quickInfoIs("let b: number");
+verify.quickInfoAt("3", "let b: number");
 
 goTo.marker('4');
 verify.completionListContains("a", "let a: number");

--- a/tests/cases/fourslash/localFunction.ts
+++ b/tests/cases/fourslash/localFunction.ts
@@ -9,11 +9,9 @@
 ////var x = function /*4*/bar4() {
 ////}
 
-goTo.marker("1");
-verify.quickInfoIs('function foo(): void');
-goTo.marker("2");
-verify.quickInfoIs('(local function) bar2(): void');
-goTo.marker("3");
-verify.quickInfoIs('(local function) bar3(): void');
-goTo.marker("4");
-verify.quickInfoIs('(local function) bar4(): void');
+verify.quickInfos({
+    1: "function foo(): void",
+    2: "(local function) bar2(): void",
+    3: "(local function) bar3(): void",
+    4: "(local function) bar4(): void"
+});

--- a/tests/cases/fourslash/mergedDeclarationsWithExportAssignment1.ts
+++ b/tests/cases/fourslash/mergedDeclarationsWithExportAssignment1.ts
@@ -15,18 +15,15 @@
 ////var /*3*/z = new /*2*/Foo();
 ////var /*5*/r2 = Foo./*4*/x;
 
-goTo.marker('1');
-verify.quickInfoIs("import Foo = require('./mergedDeclarationsWithExportAssignment1_file0')");
+verify.quickInfoAt("1", "import Foo = require('./mergedDeclarationsWithExportAssignment1_file0')");
 
 goTo.marker('2');
 verify.completionListContains('Foo');
 
-goTo.marker('3');
-verify.quickInfoIs('var z: Foo');
+verify.quickInfoAt("3", "var z: Foo");
 
 goTo.marker('4');
 verify.completionListContains('x');
 
-goTo.marker('5');
-verify.quickInfoIs('var r2: number');
+verify.quickInfoAt("5", "var r2: number");
 

--- a/tests/cases/fourslash/missingMethodAfterEditAfterImport.ts
+++ b/tests/cases/fourslash/missingMethodAfterEditAfterImport.ts
@@ -8,14 +8,12 @@
 //// 
 //// /*delete*/var x;
 
-// Sanity check
-goTo.marker('foo');
-verify.quickInfoIs('namespace foo');
+// Sanity check\
+verify.quickInfoAt("foo", "namespace foo");
 
 // Delete some code
 goTo.marker('delete');
 edit.deleteAtCaret('var x;'.length);
 
 // Pull on the RHS of an import
-goTo.marker('foo');
-verify.quickInfoIs('namespace foo');
+verify.quickInfoAt("foo", "namespace foo");

--- a/tests/cases/fourslash/moduleVariables.ts
+++ b/tests/cases/fourslash/moduleVariables.ts
@@ -13,11 +13,8 @@
 ////    console.log(/*3*/x); // 3
 ////}
 
-goTo.marker('1');
-verify.quickInfoIs("var M.x: number", undefined);
-
-goTo.marker('2');
-verify.quickInfoIs("var M.x: number", undefined);
-
-goTo.marker('3');
-verify.quickInfoIs("var x: number", undefined);
+verify.quickInfos({
+    1: "var M.x: number",
+    2: "var M.x: number",
+    3: "var x: number"
+});

--- a/tests/cases/fourslash/multiModuleFundule1.ts
+++ b/tests/cases/fourslash/multiModuleFundule1.ts
@@ -17,15 +17,13 @@ goTo.marker('1');
 verify.completionListContains('C');
 edit.insert('C.x);');
 
-goTo.marker('2');
-verify.quickInfoIs('var r: void');
+verify.quickInfoAt("2", "var r: void");
 
 goTo.marker('3');
 verify.completionListContains('C');
 edit.insert('C.x);');
 
-goTo.marker('4');
-verify.quickInfoIs('var r2: any');
+verify.quickInfoAt("4", "var r2: any");
 
 goTo.marker('5');
 verify.completionListContains('x');

--- a/tests/cases/fourslash/nameOfRetypedClassInModule.ts
+++ b/tests/cases/fourslash/nameOfRetypedClassInModule.ts
@@ -13,11 +13,10 @@
 
 edit.disableFormatting();
 
-goTo.marker('check');
-verify.quickInfoIs('constructor Check(val: any): Check');
-
-goTo.marker('check2');
-verify.quickInfoIs('constructor M.Check2(val: any): Check2');
+verify.quickInfos({
+    check: "constructor Check(val: any): Check",
+    check2: "constructor M.Check2(val: any): Check2"
+});
 
 goTo.marker('A');
 edit.deleteAtCaret('class A {}'.length);

--- a/tests/cases/fourslash/noTypeParameterInLHS.ts
+++ b/tests/cases/fourslash/noTypeParameterInLHS.ts
@@ -5,7 +5,7 @@
 ////var /*1*/i: I<any>;
 ////var /*2*/c: C<I>;
 
-goTo.marker('1');
-verify.quickInfoIs('var i: I<any>');
-goTo.marker('2');
-verify.quickInfoIs('var c: C<any>');
+verify.quickInfos({
+    1: "var i: I<any>",
+    2: "var c: C<any>"
+});

--- a/tests/cases/fourslash/numericPropertyNames.ts
+++ b/tests/cases/fourslash/numericPropertyNames.ts
@@ -2,5 +2,4 @@
 
 ////var /**/t2 = { 0: 1, 1: "" };
 
-goTo.marker();
-verify.quickInfoIs('var t2: {\n    0: number;\n    1: string;\n}');
+verify.quickInfoAt("", "var t2: {\n    0: number;\n    1: string;\n}");

--- a/tests/cases/fourslash/objectLiteralCallSignatures.ts
+++ b/tests/cases/fourslash/objectLiteralCallSignatures.ts
@@ -21,9 +21,7 @@
 ////y.func5 = y.func4;
 
 verify.not.errorExistsAfterMarker('1');
-goTo.marker('1');
-verify.quickInfoIs('var x: {\n    func1(x: number): number;\n    func2: (x: number) => number;\n    func3: (x: number) => number;\n}');
-
-goTo.marker('2');
-verify.quickInfoIs('var y: {\n    func4(x: number): number;\n    func4(s: string): string;\n    func5: {\n        (x: number): number;\n        (s: string): string;\n    };\n}');
-
+verify.quickInfos({
+    1: "var x: {\n    func1(x: number): number;\n    func2: (x: number) => number;\n    func3: (x: number) => number;\n}",
+    2: "var y: {\n    func4(x: number): number;\n    func4(s: string): string;\n    func5: {\n        (x: number): number;\n        (s: string): string;\n    };\n}"
+});

--- a/tests/cases/fourslash/overloadQuickInfo.ts
+++ b/tests/cases/fourslash/overloadQuickInfo.ts
@@ -17,7 +17,4 @@
 ////}
 ////Fo/**/o();
 
-goTo.marker();
-verify.quickInfoIs("function Foo(): any (+12 overloads)");
-
-
+verify.quickInfoAt("", "function Foo(): any (+12 overloads)");

--- a/tests/cases/fourslash/parameterWithDestructuring.ts
+++ b/tests/cases/fourslash/parameterWithDestructuring.ts
@@ -12,11 +12,8 @@
 ////    /*3*/a.charAt(0); // Not okay: inferred as `any`
 ////});
 
-goTo.marker('1');
-verify.quickInfoIs('var foo: string');
-
-goTo.marker('2');
-verify.quickInfoIs('var foo: string');
-
-goTo.marker('3');
-verify.quickInfoIs('var a: string');
+verify.quickInfos({
+    1: "var foo: string",
+    2: "var foo: string",
+    3: "var a: string"
+});

--- a/tests/cases/fourslash/parameterWithNestedDestructuring.ts
+++ b/tests/cases/fourslash/parameterWithNestedDestructuring.ts
@@ -3,8 +3,7 @@
 ////[[{foo: 'hello', bar: [1]}]]
 ////  .map(([{foo, bar: [baz]}]) => /*1*/foo + /*2*/baz);
 
-goTo.marker('1');
-verify.quickInfoIs('var foo: string');
-
-goTo.marker('2');
-verify.quickInfoIs('var baz: number');
+verify.quickInfos({
+    1: "var foo: string",
+    2: "var baz: number"
+});

--- a/tests/cases/fourslash/promiseTyping1.ts
+++ b/tests/cases/fourslash/promiseTyping1.ts
@@ -14,11 +14,8 @@
 //// p2.then(function (x/*3*/x) {
 //// } );
 
-goTo.marker("1");
-verify.quickInfoIs('var p2: IPromise<string>');
-
-goTo.marker("2");
-verify.quickInfoIs('(parameter) xx: string');
-
-goTo.marker("3");
-verify.quickInfoIs('(parameter) xx: string');
+verify.quickInfos({
+    1: "var p2: IPromise<string>",
+    2: "(parameter) xx: string",
+    3: "(parameter) xx: string"
+});

--- a/tests/cases/fourslash/promiseTyping2.ts
+++ b/tests/cases/fourslash/promiseTyping2.ts
@@ -14,24 +14,12 @@
 ////     return x/*7*/x;
 //// });
 
-
-goTo.marker("1");
-verify.quickInfoIs('var p1: IPromise<number>');
-
-goTo.marker("2");
-verify.quickInfoIs('(parameter) xx: number');
-
-goTo.marker("3");
-verify.quickInfoIs('var p2: IPromise<string>');
-
-goTo.marker("4");
-verify.quickInfoIs('(parameter) xx: number');
-
-goTo.marker("5");
-verify.quickInfoIs('var p3: IPromise<string>');
-
-goTo.marker("6");
-verify.quickInfoIs('(parameter) xx: string');
-
-goTo.marker("7");
-verify.quickInfoIs('(parameter) xx: string');
+verify.quickInfos({
+    1: "var p1: IPromise<number>",
+    2: "(parameter) xx: number",
+    3: "var p2: IPromise<string>",
+    4: "(parameter) xx: number",
+    5: "var p3: IPromise<string>",
+    6: "(parameter) xx: string",
+    7: "(parameter) xx: string"
+});

--- a/tests/cases/fourslash/proto.ts
+++ b/tests/cases/fourslash/proto.ts
@@ -7,13 +7,14 @@
 /////*3*/
 ////var /*4*/fun: (__proto__: any) => boolean;
 
-goTo.marker('1');
-verify.quickInfoIs("interface M.__proto__", "");
-goTo.marker('2');
-verify.quickInfoIs("var __proto__: M.__proto__", "");
+verify.quickInfos({
+    1: "interface M.__proto__",
+    2: "var __proto__: M.__proto__"
+});
+
 goTo.marker('3');
 verify.completionListContains("__proto__", "var __proto__: M.__proto__", "");
 edit.insert("__proto__");
 verify.goToDefinitionIs("2");
-goTo.marker('4');
-verify.quickInfoIs("var fun: (__proto__: any) => boolean", "");
+
+verify.quickInfoAt("4", "var fun: (__proto__: any) => boolean");

--- a/tests/cases/fourslash/protoPropertyInObjectLiteral.ts
+++ b/tests/cases/fourslash/protoPropertyInObjectLiteral.ts
@@ -12,10 +12,11 @@
 goTo.marker('1');
 verify.completionListContains("__proto__", '(property) "__proto__": number');
 edit.insert("__proto__ = 10;");
-goTo.marker('1');
-verify.quickInfoIs('(property) "__proto__": number');
+
+verify.quickInfoAt("1", '(property) "__proto__": number');
+
 goTo.marker('2');
 verify.completionListContains("__proto__", '(property) __proto__: number');
 edit.insert("__proto__ = 10;");
-goTo.marker('2');
-verify.quickInfoIs('(property) __proto__: number');
+
+verify.quickInfoAt("2", "(property) __proto__: number");

--- a/tests/cases/fourslash/prototypeProperty.ts
+++ b/tests/cases/fourslash/prototypeProperty.ts
@@ -4,8 +4,7 @@
 ////A./*1*/prototype;
 ////A./*2*/
 
-goTo.marker('1');
-verify.quickInfoIs('(property) A.prototype: A');
+verify.quickInfoAt("1", "(property) A.prototype: A");
 
 goTo.marker('2');
 verify.completionListContains('prototype', '(property) A.prototype: A');

--- a/tests/cases/fourslash/quickInfoExportAssignmentOfGenericInterface.ts
+++ b/tests/cases/fourslash/quickInfoExportAssignmentOfGenericInterface.ts
@@ -11,6 +11,4 @@
 ////export var /*1*/x: a<a<string>>;
 ////x.a;
 
-goTo.file("quickInfoExportAssignmentOfGenericInterface_1.ts");
-goTo.marker('1');
-verify.quickInfoIs("var x: a<a<string>>", undefined);
+verify.quickInfoAt("1", "var x: a<a<string>>");

--- a/tests/cases/fourslash/quickInfoForAliasedGeneric.ts
+++ b/tests/cases/fourslash/quickInfoForAliasedGeneric.ts
@@ -10,8 +10,7 @@
 ////var /*1*/aa: d.C<number>;
 ////var /*2*/bb: d.D;
 
-goTo.marker('1');
-verify.quickInfoIs('var aa: d.C<number>');
-
-goTo.marker('2');
-verify.quickInfoIs('var bb: d.D');
+verify.quickInfos({
+    1: "var aa: d.C<number>",
+    2: "var bb: d.D"
+});

--- a/tests/cases/fourslash/quickInfoForConstDeclaration.ts
+++ b/tests/cases/fourslash/quickInfoForConstDeclaration.ts
@@ -2,5 +2,4 @@
 
 ////const /**/c = 0 ;
 
-goTo.marker();
-verify.quickInfoIs("const c: 0");
+verify.quickInfoAt("", "const c: 0");

--- a/tests/cases/fourslash/quickInfoForContextuallyTypedArrowFunctionInSuperCall.ts
+++ b/tests/cases/fourslash/quickInfoForContextuallyTypedArrowFunctionInSuperCall.ts
@@ -10,11 +10,11 @@
 ////    constructor() { super(va/*1*/lue => String(va/*2*/lue.toExpone/*3*/ntial())); }
 ////}
 
-goTo.marker('1');
-verify.quickInfoIs('(parameter) value: number');
-
-goTo.marker('2');
-verify.quickInfoIs('(parameter) value: number');
-
-goTo.marker('3');
-verify.quickInfoIs('(method) Number.toExponential(fractionDigits?: number): string');
+verify.quickInfos({
+    1: "(parameter) value: number",
+    2: "(parameter) value: number",
+    3: [
+        "(method) Number.toExponential(fractionDigits?: number): string",
+        "Returns a string containing a number represented in exponential notation."
+    ]
+});

--- a/tests/cases/fourslash/quickInfoForContextuallyTypedFunctionInReturnStatement.ts
+++ b/tests/cases/fourslash/quickInfoForContextuallyTypedFunctionInReturnStatement.ts
@@ -15,6 +15,4 @@
 ////    };
 ////}
 
-
-goTo.marker();
-verify.quickInfoIs("(parameter) value: number");
+verify.quickInfoAt("", "(parameter) value: number");

--- a/tests/cases/fourslash/quickInfoForContextuallyTypedFunctionInTaggedTemplateExpression1.ts
+++ b/tests/cases/fourslash/quickInfoForContextuallyTypedFunctionInTaggedTemplateExpression1.ts
@@ -11,9 +11,6 @@
 ////tempTag1 `${ x => /*3*/x }${ (x: number) => /*4*/x }${ undefined }`;
 ////tempTag1 `${ (x: number) => /*5*/x }${ x => /*6*/x }${ undefined }`;
 
-var markers = test.markers();
-
-markers.forEach(marker => {
-    goTo.position(marker.position);
-    verify.quickInfoIs("(parameter) x: number");
-});
+for (const marker of test.markerNames()) {
+    verify.quickInfoAt(marker, "(parameter) x: number");
+}

--- a/tests/cases/fourslash/quickInfoForContextuallyTypedFunctionInTaggedTemplateExpression2.ts
+++ b/tests/cases/fourslash/quickInfoForContextuallyTypedFunctionInTaggedTemplateExpression2.ts
@@ -21,11 +21,9 @@ if (numTypedVariableCount + strTypedVariableCount !== test.markers().length) {
 }
 
 for (var i = 0; i < numTypedVariableCount; i++) {
-    goTo.marker("" + i);
-    verify.quickInfoIs("(parameter) x: number");
+    verify.quickInfoAt("" + i, "(parameter) x: number");
 }
 
 for (var i = 0; i < strTypedVariableCount; i++) {
-    goTo.marker("" + (i + numTypedVariableCount));
-    verify.quickInfoIs("(parameter) x: string");
+    verify.quickInfoAt("" + (i + numTypedVariableCount), "(parameter) x: string");
 }

--- a/tests/cases/fourslash/quickInfoForContextuallyTypedIife.ts
+++ b/tests/cases/fourslash/quickInfoForContextuallyTypedIife.ts
@@ -8,31 +8,19 @@
 ////    return q; })({ q: 13, qq: 12 }, 1, { p: 14 });
 ////((a/*9*/, b/*10*/, c/*11*/) => [a/*12*/,b/*13*/,c/*14*/])("foo", 101, false);
 
-goTo.marker('1');
-verify.quickInfoIs("var q: number");
-goTo.marker('2');
-verify.quickInfoIs("var qq: number");
-goTo.marker('3');
-verify.quickInfoIs("(parameter) x: number");
-goTo.marker('4');
-verify.quickInfoIs("var p: number");
-goTo.marker('5');
-verify.quickInfoIs("var q: number");
-goTo.marker('6');
-verify.quickInfoIs("var qq: number");
-goTo.marker('7');
-verify.quickInfoIs("var p: number");
-goTo.marker('8');
-verify.quickInfoIs("(parameter) x: number");
-goTo.marker('9');
-verify.quickInfoIs("(parameter) a: string");
-goTo.marker('10');
-verify.quickInfoIs("(parameter) b: number");
-goTo.marker('11');
-verify.quickInfoIs("(parameter) c: boolean");
-goTo.marker('12');
-verify.quickInfoIs("(parameter) a: string");
-goTo.marker('13');
-verify.quickInfoIs("(parameter) b: number");
-goTo.marker('14');
-verify.quickInfoIs("(parameter) c: boolean");
+verify.quickInfos({
+    1: "var q: number",
+    2: "var qq: number",
+    3: "(parameter) x: number",
+    4: "var p: number",
+    5: "var q: number",
+    6: "var qq: number",
+    7: "var p: number",
+    8: "(parameter) x: number",
+    9: "(parameter) a: string",
+    10: "(parameter) b: number",
+    11: "(parameter) c: boolean",
+    12: "(parameter) a: string",
+    13: "(parameter) b: number",
+    14: "(parameter) c: boolean"
+});

--- a/tests/cases/fourslash/quickInfoForDecorators.ts
+++ b/tests/cases/fourslash/quickInfoForDecorators.ts
@@ -7,5 +7,4 @@
 /////** decorator documentation*/
 ////var decorator = t=> t;
 
-goTo.marker("1");
-verify.quickInfoIs("var decorator: (t: any) => any", "decorator documentation");
+verify.quickInfoAt("1", "var decorator: (t: any) => any", "decorator documentation");

--- a/tests/cases/fourslash/quickInfoForDerivedGenericTypeWithConstructor.ts
+++ b/tests/cases/fourslash/quickInfoForDerivedGenericTypeWithConstructor.ts
@@ -13,8 +13,7 @@
 ////var /*1*/b: B<number>;
 ////var /*2*/b2: B<number>;
 
-goTo.marker('1');
-verify.quickInfoIs('var b: B<number>');
-
-goTo.marker('2');
-verify.quickInfoIs('var b2: B<number>');
+verify.quickInfos({
+    1: "var b: B<number>",
+    2: "var b2: B<number>"
+});

--- a/tests/cases/fourslash/quickInfoForFunctionDeclaration.ts
+++ b/tests/cases/fourslash/quickInfoForFunctionDeclaration.ts
@@ -11,8 +11,7 @@
 ////var x = f(0);
 ////var y = makeA(0);
 
-goTo.marker("makeA");
-verify.quickInfoIs("function makeA<T>(t: T): A<T>", undefined);
-
-goTo.marker("f");
-verify.quickInfoIs("function f<T>(t: T): A<T>", undefined);
+verify.quickInfos({
+    makeA: "function makeA<T>(t: T): A<T>",
+    f: "function f<T>(t: T): A<T>"
+});

--- a/tests/cases/fourslash/quickInfoForGenericConstraints1.ts
+++ b/tests/cases/fourslash/quickInfoForGenericConstraints1.ts
@@ -3,5 +3,4 @@
 ////function foo4<T extends Date>(te/**/st: T): T;
 ////function foo4<T extends Date>(test: any): any { return null; }
 
-goTo.marker();
-verify.quickInfoIs('(parameter) test: T extends Date');
+verify.quickInfoAt("", "(parameter) test: T extends Date");

--- a/tests/cases/fourslash/quickInfoForGenericPrototypeMember.ts
+++ b/tests/cases/fourslash/quickInfoForGenericPrototypeMember.ts
@@ -6,8 +6,7 @@
 ////var x = new /*1*/C<any>();
 ////var y = C.proto/*2*/type;
 
-goTo.marker('1');
-verify.quickInfoIs('constructor C<any>(): C<any>');
-
-goTo.marker('2');
-verify.quickInfoIs('(property) C<T>.prototype: C<any>');
+verify.quickInfos({
+    1: "constructor C<any>(): C<any>",
+    2: "(property) C<T>.prototype: C<any>"
+});

--- a/tests/cases/fourslash/quickInfoForIndexerResultWithConstraint.ts
+++ b/tests/cases/fourslash/quickInfoForIndexerResultWithConstraint.ts
@@ -9,5 +9,4 @@
 ////    var /*1*/r2 = foo(b); // just shows T
 ////}
 
-goTo.marker('1');
-verify.quickInfoIs('(local var) r2: {\n    [x: string]: T;\n}');
+verify.quickInfoAt("1", "(local var) r2: {\n    [x: string]: T;\n}");

--- a/tests/cases/fourslash/quickInfoForObjectBindingElementName01.ts
+++ b/tests/cases/fourslash/quickInfoForObjectBindingElementName01.ts
@@ -9,4 +9,4 @@
 ////var { /**/property1 } = foo;
 
 goTo.marker();
-verify.quickInfoIs("var property1: number");
+verify.quickInfoAt("", "var property1: number");

--- a/tests/cases/fourslash/quickInfoForObjectBindingElementName02.ts
+++ b/tests/cases/fourslash/quickInfoForObjectBindingElementName02.ts
@@ -8,5 +8,4 @@
 ////var foo: I;
 ////var { property1: /**/prop1 } = foo;
 
-goTo.marker();
-verify.quickInfoIs("var prop1: number");
+verify.quickInfoAt("", "var prop1: number");

--- a/tests/cases/fourslash/quickInfoForObjectBindingElementPropertyName01.ts
+++ b/tests/cases/fourslash/quickInfoForObjectBindingElementPropertyName01.ts
@@ -8,5 +8,4 @@
 ////var foo: I;
 ////var { /**/property1: prop1 } = foo;
 
-goTo.marker();
-verify.quickInfoIs("(property) I.property1: number");
+verify.quickInfoAt("", "(property) I.property1: number");

--- a/tests/cases/fourslash/quickInfoForObjectBindingElementPropertyName02.ts
+++ b/tests/cases/fourslash/quickInfoForObjectBindingElementPropertyName02.ts
@@ -8,5 +8,4 @@
 ////var foo: I;
 ////var { /**/property1: {} } = foo;
 
-goTo.marker();
-verify.quickInfoIs("(property) I.property1: number");
+verify.quickInfoAt("", "(property) I.property1: number");

--- a/tests/cases/fourslash/quickInfoForObjectBindingElementPropertyName03.ts
+++ b/tests/cases/fourslash/quickInfoForObjectBindingElementPropertyName03.ts
@@ -8,7 +8,6 @@
 ////function f ({ /*1*/next: { /*2*/next: x} }: Recursive) {
 ////}
 
-for (let { position } of test.markers()) {
-    goTo.position(position)
-    verify.quickInfoIs("(property) Recursive.next: Recursive");
+for (const marker of test.markerNames()) {
+    verify.quickInfoAt(marker, "(property) Recursive.next: Recursive");
 }

--- a/tests/cases/fourslash/quickInfoForObjectBindingElementPropertyName04.ts
+++ b/tests/cases/fourslash/quickInfoForObjectBindingElementPropertyName04.ts
@@ -8,10 +8,9 @@
 ////function f ({ /*1*/next: { /*2*/next: x} }) {
 ////}
 
-goTo.marker("1");
-verify.quickInfoIs(`(property) next: {
+verify.quickInfos({
+    1: `(property) next: {
     next: any;
-}`);
-
-goTo.marker("2");
-verify.quickInfoIs("(property) next: any");
+}`,
+    2: "(property) next: any"
+});

--- a/tests/cases/fourslash/quickInfoForOverloadOnConst1.ts
+++ b/tests/cases/fourslash/quickInfoForOverloadOnConst1.ts
@@ -19,23 +19,15 @@
 ////c.x1(1, (x/*9*/x: 'bye') => { return 1; } );
 ////c.x1(1, (x/*10*/x) => { return 1; } );
 
-goTo.marker('1');
-verify.quickInfoIs("(method) I.x1(a: number, callback: (x: \"hi\") => number): any");
-goTo.marker('2');
-verify.quickInfoIs("(method) C.x1(a: number, callback: (x: \"hi\") => number): any");
-goTo.marker('3');
-verify.quickInfoIs("(parameter) callback: (x: \"hi\") => number");
-goTo.marker('4');
-verify.quickInfoIs("(method) C.x1(a: number, callback: (x: \"hi\") => number): any");
-goTo.marker('5');
-verify.quickInfoIs('(parameter) callback: (x: string) => number');
-goTo.marker('6');
-verify.quickInfoIs('(parameter) callback: (x: string) => number');
-goTo.marker('7');
-verify.quickInfoIs("(method) C.x1(a: number, callback: (x: \"hi\") => number): any");
-goTo.marker('8');
-verify.quickInfoIs("(parameter) xx: \"hi\"");
-goTo.marker('9');
-verify.quickInfoIs("(parameter) xx: \"bye\"");
-goTo.marker('10');
-verify.quickInfoIs("(parameter) xx: \"hi\"");
+verify.quickInfos({
+    1: "(method) I.x1(a: number, callback: (x: \"hi\") => number): any",
+    2: "(method) C.x1(a: number, callback: (x: \"hi\") => number): any",
+    3: "(parameter) callback: (x: \"hi\") => number",
+    4: "(method) C.x1(a: number, callback: (x: \"hi\") => number): any",
+    5: "(parameter) callback: (x: string) => number",
+    6: "(parameter) callback: (x: string) => number",
+    7: "(method) C.x1(a: number, callback: (x: \"hi\") => number): any",
+    8: "(parameter) xx: \"hi\"",
+    9: "(parameter) xx: \"bye\"",
+    10: "(parameter) xx: \"hi\""
+});

--- a/tests/cases/fourslash/quickInfoForRequire.ts
+++ b/tests/cases/fourslash/quickInfoForRequire.ts
@@ -6,6 +6,5 @@
 //@Filename: quickInfoForRequire_input.ts
 ////import a = require("./AA/B/*1*/B");
 
-goTo.marker('1');
-verify.quickInfoIs('module a');
+verify.quickInfoAt("1", "module a");
 verify.referencesAre([]);

--- a/tests/cases/fourslash/quickInfoForShorthandProperty.ts
+++ b/tests/cases/fourslash/quickInfoForShorthandProperty.ts
@@ -6,16 +6,12 @@
 //// var id2 = 10000;
 //// var /*obj2*/obj2 = {/*name2*/name2, /*id2*/id2};
 
-goTo.marker("obj1");
-verify.quickInfoIs("var obj1: {\n    name1: any;\n    id1: any;\n}");
-goTo.marker("name1");
-verify.quickInfoIs("(property) name1: any");
-goTo.marker("id1");
-verify.quickInfoIs("(property) id1: any");
+verify.quickInfos({
+    obj1: "var obj1: {\n    name1: any;\n    id1: any;\n}",
+    name1: "(property) name1: any",
+    id1: "(property) id1: any",
 
-goTo.marker("obj2");
-verify.quickInfoIs("var obj2: {\n    name2: string;\n    id2: number;\n}");
-goTo.marker("name2");
-verify.quickInfoIs("(property) name2: string");
-goTo.marker("id2");
-verify.quickInfoIs("(property) id2: number");
+    obj2: "var obj2: {\n    name2: string;\n    id2: number;\n}",
+    name2: "(property) name2: string",
+    id2: "(property) id2: number"
+});

--- a/tests/cases/fourslash/quickInfoForTypeParameterInTypeAlias1.ts
+++ b/tests/cases/fourslash/quickInfoForTypeParameterInTypeAlias1.ts
@@ -6,14 +6,10 @@
 //// type Method<AA> = { method(): A/*4*/A };
 //// type Construct<AA> = { new(): A/*5*/A };
 
-
-goTo.marker('1');
-verify.quickInfoIs('(type parameter) AA in type Ctor<AA>');
-goTo.marker('2');
-verify.quickInfoIs('(type parameter) AA in type MixinCtor<AA>');
-goTo.marker('3');
-verify.quickInfoIs('(type parameter) AA in type NestedCtor<AA>');
-goTo.marker('4');
-verify.quickInfoIs('(type parameter) AA in type Method<AA>');
-goTo.marker('5');
-verify.quickInfoIs('(type parameter) AA in type Construct<AA>');
+verify.quickInfos({
+    1: "(type parameter) AA in type Ctor<AA>",
+    2: "(type parameter) AA in type MixinCtor<AA>",
+    3: "(type parameter) AA in type NestedCtor<AA>",
+    4: "(type parameter) AA in type Method<AA>",
+    5: "(type parameter) AA in type Construct<AA>"
+});

--- a/tests/cases/fourslash/quickInfoForTypeParameterInTypeAlias2.ts
+++ b/tests/cases/fourslash/quickInfoForTypeParameterInTypeAlias2.ts
@@ -5,18 +5,12 @@
 //// type GenericMethod<AA> = { method<BB>(): A/*3*/A & B/*4*/B }
 //// type Nesting<TT> = { method<UU>(): new <WW>() => T/*5*/T & U/*6*/U & W/*7*/W };
 
-goTo.marker('1');
-verify.quickInfoIs('(type parameter) AA in type Call<AA>');
-goTo.marker('2');
-verify.quickInfoIs('(type parameter) AA in type Index<AA>');
-goTo.marker('3');
-verify.quickInfoIs('(type parameter) AA in type GenericMethod<AA>');
-goTo.marker('4');
-verify.quickInfoIs('(type parameter) BB in method<BB>(): AA & BB');
-goTo.marker('5');
-verify.quickInfoIs('(type parameter) TT in type Nesting<TT>');
-goTo.marker('6');
-verify.quickInfoIs('(type parameter) UU in method<UU>(): new <WW>() => TT & UU & WW');
-goTo.marker('7');
-verify.quickInfoIs('(type parameter) WW in <WW>(): TT & UU & WW');
-
+verify.quickInfos({
+    1: "(type parameter) AA in type Call<AA>",
+    2: "(type parameter) AA in type Index<AA>",
+    3: "(type parameter) AA in type GenericMethod<AA>",
+    4: "(type parameter) BB in method<BB>(): AA & BB",
+    5: "(type parameter) TT in type Nesting<TT>",
+    6: "(type parameter) UU in method<UU>(): new <WW>() => TT & UU & WW",
+    7: "(type parameter) WW in <WW>(): TT & UU & WW"
+});

--- a/tests/cases/fourslash/quickInfoForTypeofParameter.ts
+++ b/tests/cases/fourslash/quickInfoForTypeofParameter.ts
@@ -5,11 +5,8 @@
 ////    var x: typeof y/*ref2*/1;
 ////}
 
-goTo.marker('ref2');
-verify.quickInfoIs("(local var) y1: string", undefined);
-
-goTo.marker('ref1');
-verify.quickInfoIs("(local var) y1: string", undefined);
-
-goTo.marker('ref2');
-verify.quickInfoIs("(local var) y1: string", undefined);
+verify.quickInfos({
+    ref2: "(local var) y1: string",
+    ref1: "(local var) y1: string",
+    ref2: "(local var) y1: string"
+});

--- a/tests/cases/fourslash/quickInfoForTypeofParameter.ts
+++ b/tests/cases/fourslash/quickInfoForTypeofParameter.ts
@@ -6,7 +6,6 @@
 ////}
 
 verify.quickInfos({
-    ref2: "(local var) y1: string",
     ref1: "(local var) y1: string",
     ref2: "(local var) y1: string"
 });

--- a/tests/cases/fourslash/quickInfoForUMDModuleAlias.ts
+++ b/tests/cases/fourslash/quickInfoForUMDModuleAlias.ts
@@ -10,8 +10,7 @@
 //// /// <reference path="0.d.ts" />
 //// /*1*/myLib.doThing();
 
-goTo.marker("0");
-verify.quickInfoIs("export namespace myLib");
-
-goTo.marker("1");
-verify.quickInfoIs("export namespace myLib");
+verify.quickInfos({
+    0: "export namespace myLib",
+    1: "export namespace myLib"
+});

--- a/tests/cases/fourslash/quickInfoFromEmptyBlockComment.ts
+++ b/tests/cases/fourslash/quickInfoFromEmptyBlockComment.ts
@@ -6,5 +6,4 @@
 
 ////var f/*A*/ff = new Foo();
 
-goTo.marker('A');
-verify.quickInfoIs('var fff: Foo');
+verify.quickInfoAt("A", "var fff: Foo");

--- a/tests/cases/fourslash/quickInfoGenerics.ts
+++ b/tests/cases/fourslash/quickInfoGenerics.ts
@@ -25,33 +25,20 @@
 ////var x3: IList<number>;
 ////var y2 = x./*15*/method(x2, [x3, x3]);
 
-goTo.marker("1");
-verify.quickInfoIs("class Container<T>", undefined);
-goTo.marker("2");
-verify.quickInfoIs("(type parameter) T in IList<T>", undefined);
-goTo.marker("3");
-verify.quickInfoIs("(type parameter) T in IList<T>", undefined);
-goTo.marker("4");
-verify.quickInfoIs("(type parameter) T in List2<T extends IList<number>>", undefined);
-goTo.marker("5");
-verify.quickInfoIs("(type parameter) T in List2<T extends IList<number>>", undefined);
-goTo.marker("6");
-verify.quickInfoIs("(property) List2<T extends IList<number>>.__item: T[]", undefined);
-goTo.marker("7");
-verify.quickInfoIs("(method) List2<T extends IList<number>>.getItem(i: number): T", undefined);
-goTo.marker("8");
-verify.quickInfoIs("(method) List2<T extends IList<number>>.method<S extends IList<T>>(s: S, p: T[]): S", undefined);
-goTo.marker("9");
-verify.quickInfoIs("(type parameter) S in List2<T extends IList<number>>.method<S extends IList<T>>(s: S, p: T[]): S", undefined);
-goTo.marker("10");
-verify.quickInfoIs("(type parameter) T in List2<T extends IList<number>>", undefined);
-goTo.marker("11");
-verify.quickInfoIs("(type parameter) T in foo4<T extends Date>(test: T): T", undefined);
-goTo.marker("12");
-verify.quickInfoIs("(type parameter) S in foo4<S extends string>(test: S): S", undefined);
-goTo.marker("13");
-verify.quickInfoIs("(type parameter) T in foo4<T extends Date>(test: any): any", undefined);
-goTo.marker("14");
-verify.quickInfoIs("(method) List2<IList<number>>.getItem(i: number): IList<number>", undefined);
-goTo.marker("15");
-verify.quickInfoIs("(method) List2<IList<number>>.method<IList<IList<number>>>(s: IList<IList<number>>, p: IList<number>[]): IList<IList<number>>", undefined);
+verify.quickInfos({
+    1: "class Container<T>",
+    2: "(type parameter) T in IList<T>",
+    3: "(type parameter) T in IList<T>",
+    4: "(type parameter) T in List2<T extends IList<number>>",
+    5: "(type parameter) T in List2<T extends IList<number>>",
+    6: "(property) List2<T extends IList<number>>.__item: T[]",
+    7: "(method) List2<T extends IList<number>>.getItem(i: number): T",
+    8: "(method) List2<T extends IList<number>>.method<S extends IList<T>>(s: S, p: T[]): S",
+    9: "(type parameter) S in List2<T extends IList<number>>.method<S extends IList<T>>(s: S, p: T[]): S",
+    10: "(type parameter) T in List2<T extends IList<number>>",
+    11: "(type parameter) T in foo4<T extends Date>(test: T): T",
+    12: "(type parameter) S in foo4<S extends string>(test: S): S",
+    13: "(type parameter) T in foo4<T extends Date>(test: any): any",
+    14: "(method) List2<IList<number>>.getItem(i: number): IList<number>",
+    15: "(method) List2<IList<number>>.method<IList<IList<number>>>(s: IList<IList<number>>, p: IList<number>[]): IList<IList<number>>"
+});

--- a/tests/cases/fourslash/quickInfoInFunctionTypeReference.ts
+++ b/tests/cases/fourslash/quickInfoInFunctionTypeReference.ts
@@ -4,8 +4,7 @@
 ////}
 ////var x = <{ (fn: (va/*2*/riable2: string) => void, a: string): void; }> () => { };
 
-goTo.marker("1");
-verify.quickInfoIs("(parameter) variable1: string", undefined);
-
-goTo.marker("2");
-verify.quickInfoIs("(parameter) variable2: string", undefined);
+verify.quickInfos({
+    1: "(parameter) variable1: string",
+    2: "(parameter) variable2: string"
+});

--- a/tests/cases/fourslash/quickInfoInFunctionTypeReference2.ts
+++ b/tests/cases/fourslash/quickInfoInFunctionTypeReference2.ts
@@ -8,11 +8,10 @@
 ////var c: C<number>;
 ////c.map(/*3*/
 
-goTo.marker('1');
-verify.quickInfoIs('(parameter) k: string');
-
-goTo.marker('2');
-verify.quickInfoIs('(parameter) value: T');
+verify.quickInfos({
+    1: "(parameter) k: string",
+    2: "(parameter) value: T"
+});
 
 goTo.marker('3');
 verify.currentSignatureHelpIs('map(fn: (k: string, value: number, context: any) => void, context: any): void');

--- a/tests/cases/fourslash/quickInfoInInvalidIndexSignature.ts
+++ b/tests/cases/fourslash/quickInfoInInvalidIndexSignature.ts
@@ -2,5 +2,4 @@
 
 //// function method() { var /**/dictionary = <{ [index]: string; }>{}; }
 
-goTo.marker();
-verify.quickInfoIs('(local var) dictionary: {}');
+verify.quickInfoAt("", "(local var) dictionary: {}");

--- a/tests/cases/fourslash/quickInfoInObjectLiteral.ts
+++ b/tests/cases/fourslash/quickInfoInObjectLiteral.ts
@@ -18,8 +18,7 @@
 ////  }
 ////}
 
-goTo.marker("1");
-verify.quickInfoIs("(property) y1: () => string", undefined);
-
-goTo.marker("2");
-verify.quickInfoIs("var value: number");
+verify.quickInfos({
+    1: "(property) y1: () => string",
+    2: "var value: number"
+});

--- a/tests/cases/fourslash/quickInfoInWithBlock.ts
+++ b/tests/cases/fourslash/quickInfoInWithBlock.ts
@@ -5,12 +5,8 @@
 ////    var /*2*/b = /*3*/f;
 ////}
 
-
-goTo.marker('1');
-verify.quickInfoIs("any");
-
-goTo.marker('2');
-verify.quickInfoIs("any");
-
-goTo.marker('3');
-verify.quickInfoIs("any");
+verify.quickInfos({
+    1: "any",
+    2: "any",
+    3: "any"
+});

--- a/tests/cases/fourslash/quickInfoOfGenericTypeAssertions1.ts
+++ b/tests/cases/fourslash/quickInfoOfGenericTypeAssertions1.ts
@@ -7,11 +7,8 @@
 ////var a;
 ////var /*3*/r3 = < <T>(x: <A>(y: A) => A) => T>a;
 
-goTo.marker('1');
-verify.quickInfoIs('var r: <T>(x: T) => T');
-
-goTo.marker('2');
-verify.quickInfoIs('var r2: <T>(x: T) => T');
-
-goTo.marker('3');
-verify.quickInfoIs('var r3: <T>(x: <A>(y: A) => A) => T');
+verify.quickInfos({
+    1: "var r: <T>(x: T) => T",
+    2: "var r2: <T>(x: T) => T",
+    3: "var r3: <T>(x: <A>(y: A) => A) => T"
+});

--- a/tests/cases/fourslash/quickInfoOfStringPropertyNames1.ts
+++ b/tests/cases/fourslash/quickInfoOfStringPropertyNames1.ts
@@ -20,14 +20,9 @@
 ////var /*3*/r4 = b['1'];
 ////var /*4*/r5 = b[1];
 
-goTo.marker('1');
-verify.quickInfoIs('var r: string');
-
-goTo.marker('2');
-verify.quickInfoIs('var r2: number');
-
-goTo.marker('3');
-verify.quickInfoIs('var r4: string');
-
-goTo.marker('4');
-verify.quickInfoIs('var r5: string');
+verify.quickInfos({
+    1: "var r: string",
+    2: "var r2: number",
+    3: "var r4: string",
+    4: "var r5: string"
+});

--- a/tests/cases/fourslash/quickInfoOnArgumentsInsideFunction.ts
+++ b/tests/cases/fourslash/quickInfoOnArgumentsInsideFunction.ts
@@ -4,5 +4,4 @@
 ////    return /*1*/arguments;
 ////}
 
-goTo.marker('1');
-verify.quickInfoIs('(local var) arguments: IArguments');
+verify.quickInfoAt("1", "(local var) arguments: IArguments");

--- a/tests/cases/fourslash/quickInfoOnCatchVariable.ts
+++ b/tests/cases/fourslash/quickInfoOnCatchVariable.ts
@@ -4,6 +4,4 @@
 ////    try { } catch (/**/e) { }
 //// }
 
-goTo.marker();
-verify.quickInfoExists();
-verify.quickInfoIs("(local var) e: any");
+verify.quickInfoAt("", "(local var) e: any");

--- a/tests/cases/fourslash/quickInfoOnCircularTypes.ts
+++ b/tests/cases/fourslash/quickInfoOnCircularTypes.ts
@@ -14,8 +14,7 @@
 ////
 ////x/*B*/x = y/*C*/y;
 
-goTo.marker('B');
-verify.quickInfoIs('var xx: B');
-
-goTo.marker('C');
-verify.quickInfoIs('var yy: C');
+verify.quickInfos({
+    B: "var xx: B",
+    C: "var yy: C"
+});

--- a/tests/cases/fourslash/quickInfoOnClassMergedWithFunction.ts
+++ b/tests/cases/fourslash/quickInfoOnClassMergedWithFunction.ts
@@ -13,5 +13,4 @@
 //// }
 ////}
 
-goTo.marker();
-verify.quickInfoIs("(property) myProp: string", undefined);
+verify.quickInfoAt("", "(property) myProp: string");

--- a/tests/cases/fourslash/quickInfoOnConstructorWithGenericParameter.ts
+++ b/tests/cases/fourslash/quickInfoOnConstructorWithGenericParameter.ts
@@ -22,5 +22,4 @@ edit.insert("null,");
 verify.currentSignatureHelpIs("B(a: Foo<I>, b: number): B");
 edit.insert("10);");
 
-goTo.marker("2");
-verify.quickInfoIs("constructor B(a: Foo<I>, b: number): B", undefined);
+verify.quickInfoAt("2", "constructor B(a: Foo<I>, b: number): B");

--- a/tests/cases/fourslash/quickInfoOnErrorTypes1.ts
+++ b/tests/cases/fourslash/quickInfoOnErrorTypes1.ts
@@ -5,5 +5,4 @@
 ////    <
 ////};
 
-goTo.marker('A');
-verify.quickInfoIs('var f: {\n    (): any;\n    x: number;\n}', "");
+verify.quickInfoAt("A", "var f: {\n    (): any;\n    x: number;\n}");

--- a/tests/cases/fourslash/quickInfoOnGenericClass.ts
+++ b/tests/cases/fourslash/quickInfoOnGenericClass.ts
@@ -4,5 +4,4 @@
 ////    x: T;
 ////}
 
-goTo.marker();
-verify.quickInfoIs('class Container<T>');
+verify.quickInfoAt("", "class Container<T>");

--- a/tests/cases/fourslash/quickInfoOnGenericWithConstraints1.ts
+++ b/tests/cases/fourslash/quickInfoOnGenericWithConstraints1.ts
@@ -2,8 +2,7 @@
 
 ////interface Fo/*1*/o<T/*2*/T extends Date> {}
 
-goTo.marker('1');
-verify.quickInfoIs('interface Foo<TT extends Date>');
-
-goTo.marker('2');
-verify.quickInfoIs('(type parameter) TT in Foo<TT extends Date>');
+verify.quickInfos({
+    1: "interface Foo<TT extends Date>",
+    2: "(type parameter) TT in Foo<TT extends Date>"
+});

--- a/tests/cases/fourslash/quickInfoOnInternalAliases.ts
+++ b/tests/cases/fourslash/quickInfoOnInternalAliases.ts
@@ -19,41 +19,18 @@
 ////var /*10*/callVar = /*11*/internalFoo();
 ////var /*12*/anotherAliasFoo = /*13*/internalFoo;
 
-goTo.marker('1');
-verify.quickInfoIs("class m1.m2.c", "class comment;");
-
-goTo.marker('2');
-verify.quickInfoIs('import internalAlias = m1.m2.c', "This is on import declaration");
-
-goTo.marker('3');
-verify.quickInfoIs("class m1.m2.c", "class comment;");
-
-goTo.marker('4');
-verify.quickInfoIs("var newVar: internalAlias", "");
-
-goTo.marker('5');
-verify.quickInfoIs("(alias) new internalAlias(): internalAlias\nimport internalAlias = m1.m2.c", "");
-
-goTo.marker('6');
-verify.quickInfoIs("var anotherAliasVar: typeof internalAlias", "");
-
-goTo.marker('7');
-verify.quickInfoIs("import internalAlias = m1.m2.c", "This is on import declaration");
-
-goTo.marker('8');
-verify.quickInfoIs('import internalFoo = m1.foo', "");
-
-goTo.marker('9');
-verify.quickInfoIs("function m1.foo(): void", "");
-
-goTo.marker('10');
-verify.quickInfoIs("var callVar: void", "");
-
-goTo.marker('11');
-verify.quickInfoIs("(alias) internalFoo(): void\nimport internalFoo = m1.foo", "");
-
-goTo.marker('12');
-verify.quickInfoIs("var anotherAliasFoo: () => void", "");
-
-goTo.marker('13');
-verify.quickInfoIs("import internalFoo = m1.foo", "");
+verify.quickInfos({
+    1: ["class m1.m2.c", "class comment;"],
+    2: ["import internalAlias = m1.m2.c", "This is on import declaration"],
+    3: ["class m1.m2.c", "class comment;"],
+    4: "var newVar: internalAlias",
+    5: "(alias) new internalAlias(): internalAlias\nimport internalAlias = m1.m2.c",
+    6: "var anotherAliasVar: typeof internalAlias",
+    7: ["import internalAlias = m1.m2.c", "This is on import declaration"],
+    8: "import internalFoo = m1.foo",
+    9: "function m1.foo(): void",
+    10: "var callVar: void",
+    11: "(alias) internalFoo(): void\nimport internalFoo = m1.foo",
+    12: "var anotherAliasFoo: () => void",
+    13: "import internalFoo = m1.foo"
+});

--- a/tests/cases/fourslash/quickInfoOnMergedInterfaces.ts
+++ b/tests/cases/fourslash/quickInfoOnMergedInterfaces.ts
@@ -16,5 +16,4 @@
 ////    var /*1*/r4 = a(1, true);
 ////}
 
-goTo.marker('1');
-verify.quickInfoIs("var r4: number");
+verify.quickInfoAt("1", "var r4: number");

--- a/tests/cases/fourslash/quickInfoOnMergedInterfacesWithIncrementalEdits.ts
+++ b/tests/cases/fourslash/quickInfoOnMergedInterfacesWithIncrementalEdits.ts
@@ -13,14 +13,14 @@
 ////}
 
 goTo.marker('1');
-verify.quickInfoIs("(property) B<string>.bar: string", undefined);
+verify.quickInfoIs("(property) B<string>.bar: string");
 edit.deleteAtCaret(1);
 edit.insert('z');
 verify.quickInfoIs("any");
 verify.numberOfErrorsInCurrentFile(1);
 edit.backspace(1);
 edit.insert('a');
-verify.quickInfoIs("(property) B<string>.bar: string", undefined);
+verify.quickInfoIs("(property) B<string>.bar: string");
 goTo.marker('2');
-verify.quickInfoIs("var r4: string", undefined);
+verify.quickInfoIs("var r4: string");
 verify.numberOfErrorsInCurrentFile(0);

--- a/tests/cases/fourslash/quickInfoOnMergedModule.ts
+++ b/tests/cases/fourslash/quickInfoOnMergedModule.ts
@@ -15,6 +15,5 @@
 ////    var r = a.fo/*1*/o + a.bar;
 ////}
 
-goTo.marker('1');
-verify.quickInfoIs("(property) M2.A.foo: string", undefined);
+verify.quickInfoAt("1", "(property) M2.A.foo: string", undefined);
 verify.numberOfErrorsInCurrentFile(0);

--- a/tests/cases/fourslash/quickInfoOnObjectLiteralWithAccessors.ts
+++ b/tests/cases/fourslash/quickInfoOnObjectLiteralWithAccessors.ts
@@ -11,16 +11,14 @@
 ////var /*2*/x = point.x;
 ////point./*3*/x = 30;
 
-goTo.marker('1');
-verify.quickInfoIs("function makePoint(x: number): {\n    b: number;\n    x: number;\n}", undefined);
-
-goTo.marker('2');
-verify.quickInfoIs("var x: number", undefined);
+verify.quickInfos({
+    1: "function makePoint(x: number): {\n    b: number;\n    x: number;\n}",
+    2: "var x: number"
+});
 
 goTo.marker('3');
 verify.memberListContains("x", "(property) x: number", undefined);
 verify.memberListContains("b", "(property) b: number", undefined);
-verify.quickInfoIs("(property) x: number", undefined);
+verify.quickInfoIs("(property) x: number");
 
-goTo.marker('4');
-verify.quickInfoIs("var point: {\n    b: number;\n    x: number;\n}", undefined);
+verify.quickInfoAt("4", "var point: {\n    b: number;\n    x: number;\n}");

--- a/tests/cases/fourslash/quickInfoOnObjectLiteralWithOnlyGetter.ts
+++ b/tests/cases/fourslash/quickInfoOnObjectLiteralWithOnlyGetter.ts
@@ -8,14 +8,12 @@
 ////var /*4*/point = makePoint(2);
 ////var /*2*/x = point./*3*/x;
 
-goTo.marker('1');
-verify.quickInfoIs("function makePoint(x: number): {\n    readonly x: number;\n}", undefined);
-
-goTo.marker('2');
-verify.quickInfoIs("var x: number", undefined);
+verify.quickInfos({
+    1: "function makePoint(x: number): {\n    readonly x: number;\n}",
+    2: "var x: number"
+});
 
 goTo.marker('3');
 verify.memberListContains("x", "(property) x: number", undefined);
 
-goTo.marker('4');
-verify.quickInfoIs("var point: {\n    readonly x: number;\n}", undefined);
+verify.quickInfoAt("4", "var point: {\n    readonly x: number;\n}");

--- a/tests/cases/fourslash/quickInfoOnObjectLiteralWithOnlySetter.ts
+++ b/tests/cases/fourslash/quickInfoOnObjectLiteralWithOnlySetter.ts
@@ -9,13 +9,11 @@
 ////var /*3*/point = makePoint(2);
 ////point./*2*/x = 30;
 
-goTo.marker('1');
-verify.quickInfoIs("function makePoint(x: number): {\n    b: number;\n    x: number;\n}", undefined);
+verify.quickInfoAt("1", "function makePoint(x: number): {\n    b: number;\n    x: number;\n}");
 
 goTo.marker('2');
 verify.memberListContains("x", "(property) x: number", undefined);
 verify.memberListContains("b", "(property) b: number", undefined);
-verify.quickInfoIs("(property) x: number", undefined);
+verify.quickInfoIs("(property) x: number");
 
-goTo.marker('3');
-verify.quickInfoIs("var point: {\n    b: number;\n    x: number;\n}", undefined);
+verify.quickInfoAt("3", "var point: {\n    b: number;\n    x: number;\n}");

--- a/tests/cases/fourslash/quickInfoOnThis.ts
+++ b/tests/cases/fourslash/quickInfoOnThis.ts
@@ -22,17 +22,12 @@
 ////    }
 ////}
 
-goTo.marker('0');
-verify.quickInfoIs('this: this');
-goTo.marker('1');
-verify.quickInfoIs('this: void');
-goTo.marker('2');
-verify.quickInfoIs('this: this');
-goTo.marker('3');
-verify.quickInfoIs('(parameter) this: Restricted');
-goTo.marker('4');
-verify.quickInfoIs('this: Restricted');
-goTo.marker('5');
-verify.quickInfoIs('(parameter) this: Foo');
-goTo.marker('6');
-verify.quickInfoIs('this: Foo');
+verify.quickInfos({
+    0: "this: this",
+    1: "this: void",
+    2: "this: this",
+    3: "(parameter) this: Restricted",
+    4: "this: Restricted",
+    5: "(parameter) this: Foo",
+    6: "this: Foo"
+});

--- a/tests/cases/fourslash/quickInfoOnThis2.ts
+++ b/tests/cases/fourslash/quickInfoOnThis2.ts
@@ -8,7 +8,7 @@
 ////    }
 ////}
 
-goTo.marker('1');
-verify.quickInfoIs('this: this');
-goTo.marker('2');
-verify.quickInfoIs('this: Bar<T>');
+verify.quickInfos({
+    1: "this: this",
+    2: "this: Bar<T>"
+});

--- a/tests/cases/fourslash/quickInfoOnThis3.ts
+++ b/tests/cases/fourslash/quickInfoOnThis3.ts
@@ -15,18 +15,12 @@
 ////    console.log(th/*7*/is);
 ////}
 
-goTo.marker('1');
-verify.quickInfoIs('any');
-goTo.marker('2');
-verify.quickInfoIs('(parameter) this: void');
-goTo.marker('3');
-verify.quickInfoIs('this: void');
-goTo.marker('4');
-verify.quickInfoIs('(parameter) this: Restricted');
-goTo.marker('5');
-verify.quickInfoIs('this: Restricted');
-goTo.marker('6');
-
-verify.quickInfoIs('(parameter) this: {\n    n: number;\n}');
-goTo.marker('7');
-verify.quickInfoIs('this: {\n    n: number;\n}');
+verify.quickInfos({
+    1: "any",
+    2: "(parameter) this: void",
+    3: "this: void", 
+    4: "(parameter) this: Restricted", 
+    5: "this: Restricted",
+    6: "(parameter) this: {\n    n: number;\n}",
+    7: "this: {\n    n: number;\n}"
+});

--- a/tests/cases/fourslash/quickInfoOnThis4.ts
+++ b/tests/cases/fourslash/quickInfoOnThis4.ts
@@ -14,7 +14,7 @@
 ////}
 ////let contextualInterface2: ContextualInterface2 = function (th/*2*/is, n) { }
 
-goTo.marker('1');
-verify.quickInfoIs('this: ContextualInterface');
-goTo.marker('2');
-verify.quickInfoIs('(parameter) this: void');
+verify.quickInfos({
+    1: "this: ContextualInterface",
+    2: "(parameter) this: void"
+});

--- a/tests/cases/fourslash/quickInfoOnUndefined.ts
+++ b/tests/cases/fourslash/quickInfoOnUndefined.ts
@@ -8,8 +8,7 @@
 ////};
 ////x./*2*/undefined = 30;
 
-goTo.marker('1');
-verify.quickInfoIs('var undefined');
-
-goTo.marker('2');
-verify.quickInfoIs('(property) undefined: number');
+verify.quickInfos({
+    1: "var undefined",
+    2: "(property) undefined: number"
+});

--- a/tests/cases/fourslash/quickInfoOnVarInArrowExpression.ts
+++ b/tests/cases/fourslash/quickInfoOnVarInArrowExpression.ts
@@ -12,5 +12,4 @@
 ////});
 ////function each<T>(items: T[], handler: (item: T) => void) { }
 
-goTo.marker('1');
-verify.quickInfoIs("(local var) changes: string[]", undefined);
+verify.quickInfoAt("1", "(local var) changes: string[]", undefined);

--- a/tests/cases/fourslash/quickInfoShowsGenericSpecialization.ts
+++ b/tests/cases/fourslash/quickInfoShowsGenericSpecialization.ts
@@ -3,5 +3,4 @@
 ////class A<T> { }
 ////var /**/foo = new A<number>();
 
-goTo.marker();
-verify.quickInfoIs('var foo: A<number>');
+verify.quickInfoAt("", "var foo: A<number>");

--- a/tests/cases/fourslash/quickinfoForUnionProperty.ts
+++ b/tests/cases/fourslash/quickinfoForUnionProperty.ts
@@ -15,13 +15,8 @@
 ////x./*2*/commonProperty;
 ////x./*3*/commonFunction;
 
-
-goTo.marker("1");
-verify.quickInfoIs('var x: One | Two');
-
-
-goTo.marker("2");
-verify.quickInfoIs('(property) commonProperty: string | number');
-
-goTo.marker("3");
-verify.quickInfoIs('(method) commonFunction(): number');
+verify.quickInfos({
+    1: "var x: One | Two",
+    2: "(property) commonProperty: string | number",
+    3: "(method) commonFunction(): number"
+});

--- a/tests/cases/fourslash/quickinfoIsConsistent.ts
+++ b/tests/cases/fourslash/quickinfoIsConsistent.ts
@@ -6,7 +6,6 @@
 ////    /*3*/f(3);
 ////}
 
-[1, 2, 3].forEach((val) => {
-    goTo.marker("" + val);
-    verify.quickInfoIs("var f: (x: number) => number", "");
-} );
+for (const val of [1, 2, 3]) {
+    verify.quickInfoAt("" + val, "var f: (x: number) => number");
+}

--- a/tests/cases/fourslash/recursiveObjectLiteral.ts
+++ b/tests/cases/fourslash/recursiveObjectLiteral.ts
@@ -2,5 +2,5 @@
 
 ////var a = { f: /**/a
 
-goTo.marker();
-verify.quickInfoIs("var a: any");
+verify.quickInfoAt("", "var a: any");
+

--- a/tests/cases/fourslash/recursiveWrappedTypeParameters1.ts
+++ b/tests/cases/fourslash/recursiveWrappedTypeParameters1.ts
@@ -14,23 +14,12 @@
 ////var e/*6*/e = x.c.b;
 ////var f/*7*/f = x.c.c; 
 
-goTo.marker('1');
-verify.quickInfoIs('var yy: I<I<I<I<I<I<number>>>>>>');
-
-goTo.marker('2');
-verify.quickInfoIs('var aa: number');
-
-goTo.marker('3');
-verify.quickInfoIs('var bb: I<number>');
-
-goTo.marker('4');
-verify.quickInfoIs('var cc: I<I<number>>');
-
-goTo.marker('5');
-verify.quickInfoIs('var dd: I<number>');
-
-goTo.marker('6');
-verify.quickInfoIs('var ee: I<I<number>>');
-
-goTo.marker('7');
-verify.quickInfoIs('var ff: I<I<I<number>>>');
+verify.quickInfos({
+    1: "var yy: I<I<I<I<I<I<number>>>>>>",
+    2: "var aa: number",
+    3: "var bb: I<number>",
+    4: "var cc: I<I<number>>",
+    5: "var dd: I<number>",
+    6: "var ee: I<I<number>>",
+    7: "var ff: I<I<I<number>>>"
+});

--- a/tests/cases/fourslash/regexDetection.ts
+++ b/tests/cases/fourslash/regexDetection.ts
@@ -6,7 +6,8 @@ goTo.marker("1");
 verify.not.quickInfoExists();
 
 goTo.marker("2");
-verify.not.quickInfoIs('RegExp');
+verify.quickInfoIs("const Math: Math",
+    "An intrinsic object that provides basic mathematics functionality and constants. ");
 
 goTo.marker("3");
 verify.not.quickInfoExists();

--- a/tests/cases/fourslash/regexp.ts
+++ b/tests/cases/fourslash/regexp.ts
@@ -1,6 +1,5 @@
 /// <reference path="fourslash.ts" />
 
 ////var /**/x = /aa/;
- 
-goTo.marker();
-verify.quickInfoIs("var x: RegExp");
+
+verify.quickInfoAt("", "var x: RegExp");

--- a/tests/cases/fourslash/restArgType.ts
+++ b/tests/cases/fourslash/restArgType.ts
@@ -29,52 +29,34 @@
 ////// Explicit initialization value
 ////var t9: (a1: string[], a2: string[]) => void = (/*t91*/f1 = 4, /*t92*/f2 = [false, true]) => { };
 
-goTo.marker("1");
-verify.quickInfoIs("(parameter) restArgs: any[]", "");
-goTo.marker("2");
-verify.quickInfoIs("(parameter) restArgs: any[]", "");
+verify.quickInfos({
+    1: "(parameter) restArgs: any[]",
+    2: "(parameter) restArgs: any[]",
 
-goTo.marker("3");
-verify.quickInfoIs("(parameter) y: string[]", "");
+    3: "(parameter) y: string[]",
 
-goTo.marker("4");
-verify.quickInfoIs("(parameter) y1: string[]", "");
-goTo.marker("5");
-verify.quickInfoIs("(parameter) y2: string", "");
+    4: "(parameter) y1: string[]",
+    5: "(parameter) y2: string",
 
-goTo.marker("t1");
-verify.quickInfoIs("(parameter) f1: any[]", "");
+    t1: "(parameter) f1: any[]",
 
-goTo.marker("t2");
-verify.quickInfoIs("(parameter) f1: any[]", "");
+    t2: "(parameter) f1: any[]",
 
-goTo.marker("t31");
-verify.quickInfoIs("(parameter) f1: number", "");
-goTo.marker("t32");
-verify.quickInfoIs("(parameter) f2: any[]", "");
+    t31: "(parameter) f1: number",
+    t32: "(parameter) f2: any[]",
 
-goTo.marker("t4");
-verify.quickInfoIs("(parameter) f1: string[]", "");
+    t4: "(parameter) f1: string[]",
+    t5: "(parameter) f1: string",
 
-goTo.marker("t5");
-verify.quickInfoIs("(parameter) f1: string", "");
+    t61: "(parameter) f1: string",
+    t62: "(parameter) f2: string[]",
 
-goTo.marker("t61");
-verify.quickInfoIs("(parameter) f1: string", "");
-goTo.marker("t62");
-verify.quickInfoIs("(parameter) f2: string[]", "");
+    t71: "(parameter) f1: string",
+    t72: "(parameter) f2: string",
+    t73: "(parameter) f3: string",
 
-goTo.marker("t71");
-verify.quickInfoIs("(parameter) f1: string", "");
-goTo.marker("t72");
-verify.quickInfoIs("(parameter) f2: string", "");
-goTo.marker("t73");
-verify.quickInfoIs("(parameter) f3: string", "");
+    t8: "(parameter) f1: number[]",
 
-goTo.marker("t8");
-verify.quickInfoIs("(parameter) f1: number[]", "");
-
-goTo.marker("t91");
-verify.quickInfoIs("(parameter) f1: string[]", "");
-goTo.marker("t92");
-verify.quickInfoIs("(parameter) f2: string[]", "");
+    t91: "(parameter) f1: string[]",
+    t92: "(parameter) f2: string[]"
+});

--- a/tests/cases/fourslash/restParamsContextuallyTyped.ts
+++ b/tests/cases/fourslash/restParamsContextuallyTyped.ts
@@ -2,9 +2,8 @@
 
 ////var foo: Function = function (/*1*/a, /*2*/b, /*3*/c) { };
 
-goTo.marker('1');
-verify.quickInfoIs('(parameter) a: any', "");
-goTo.marker('2');
-verify.quickInfoIs('(parameter) b: any', "");
-goTo.marker('3');
-verify.quickInfoIs('(parameter) c: any', "");
+verify.quickInfos({
+    1: "(parameter) a: any",
+    2: "(parameter) b: any",
+    3: "(parameter) c: any"
+});

--- a/tests/cases/fourslash/returnRecursiveType.ts
+++ b/tests/cases/fourslash/returnRecursiveType.ts
@@ -7,5 +7,4 @@
 ////function MyFn() { return <MyInt>MyFn; }
 ////var My/**/Var = MyFn();
 
-goTo.marker();
-verify.quickInfoIs('var MyVar: MyInt');
+verify.quickInfoAt("", "var MyVar: MyInt");

--- a/tests/cases/fourslash/returnTypeOfGenericFunction1.ts
+++ b/tests/cases/fourslash/returnTypeOfGenericFunction1.ts
@@ -6,5 +6,4 @@
 ////var x: WrappedArray<string>;
 ////var /**/y = x.map(s => s.length);
 
-goTo.marker();
-verify.quickInfoIs('var y: number[]');
+verify.quickInfoAt("", "var y: number[]");

--- a/tests/cases/fourslash/salsaMethodsOnAssignedFunctionExpressions.ts
+++ b/tests/cases/fourslash/salsaMethodsOnAssignedFunctionExpressions.ts
@@ -11,7 +11,7 @@
 ////
 ////var x = new C();
 ////x/*1*/./*2*/m();
-goTo.marker('1');
-verify.quickInfoIs('var x: {\n    m: (a: string) => void;\n}');
+
+verify.quickInfoAt("1", "var x: {\n    m: (a: string) => void;\n}");
 goTo.marker('2');
 verify.completionListContains('m', '(property) C.m: (a: string) => void', 'The prototype method.');

--- a/tests/cases/fourslash/selfReferencedExternalModule2.ts
+++ b/tests/cases/fourslash/selfReferencedExternalModule2.ts
@@ -9,8 +9,7 @@
 ////export import B = require('./app');
 ////export var Y = 1;
 
-goTo.marker("1");
-verify.quickInfoIs("var A.Y: number");
-
-goTo.marker("2");
-verify.quickInfoIs("var I: number");
+verify.quickInfos({
+    1: "var A.Y: number",
+    2: "var I: number"
+});

--- a/tests/cases/fourslash/server/quickinfo01.ts
+++ b/tests/cases/fourslash/server/quickinfo01.ts
@@ -15,13 +15,8 @@
 ////x./*2*/commonProperty;
 ////x./*3*/commonFunction;
 
-
-goTo.marker("1");
-verify.quickInfoIs('var x: One | Two');
-
-
-goTo.marker("2");
-verify.quickInfoIs('(property) commonProperty: string | number');
-
-goTo.marker("3");
-verify.quickInfoIs('(method) commonFunction(): number');
+verify.quickInfos({
+    1: "var x: One | Two",
+    2: "(property) commonProperty: string | number",
+    3: "(method) commonFunction(): number"
+});

--- a/tests/cases/fourslash/shims-pp/getQuickInfoAtPosition.ts
+++ b/tests/cases/fourslash/shims-pp/getQuickInfoAtPosition.ts
@@ -6,11 +6,8 @@
 ////var x/*2*/2 = new SS();
 ////var x/*3*/3 = new SS;
 
-goTo.marker('1');
-verify.quickInfoIs('var x1: SS<number>');
-
-goTo.marker('2');
-verify.quickInfoIs('var x2: SS<{}>');
-
-goTo.marker('3');
-verify.quickInfoIs('var x3: SS<{}>');
+verify.quickInfos({
+    1: "var x1: SS<number>",
+    2: "var x2: SS<{}>",
+    3: "var x3: SS<{}>"
+});

--- a/tests/cases/fourslash/shims/getQuickInfoAtPosition.ts
+++ b/tests/cases/fourslash/shims/getQuickInfoAtPosition.ts
@@ -6,11 +6,8 @@
 ////var x/*2*/2 = new SS();
 ////var x/*3*/3 = new SS;
 
-goTo.marker('1');
-verify.quickInfoIs('var x1: SS<number>');
-
-goTo.marker('2');
-verify.quickInfoIs('var x2: SS<{}>');
-
-goTo.marker('3');
-verify.quickInfoIs('var x3: SS<{}>');
+verify.quickInfos({
+    1: "var x1: SS<number>",
+    2: "var x2: SS<{}>",
+    3: "var x3: SS<{}>"
+});

--- a/tests/cases/fourslash/staticPrototypePropertyOnClass.ts
+++ b/tests/cases/fourslash/staticPrototypePropertyOnClass.ts
@@ -19,11 +19,9 @@
 ////c3./*3*/prototype;
 ////c4./*4*/prototype;
 
-goTo.marker('1');
-verify.quickInfoIs("(property) c1.prototype: c1");
-goTo.marker('2');
-verify.quickInfoIs("(property) c2<T>.prototype: c2<any>");
-goTo.marker('3');
-verify.quickInfoIs("(property) c3.prototype: c3");
-goTo.marker('4');
-verify.quickInfoIs("(property) c4.prototype: c4");
+verify.quickInfos({
+    1: "(property) c1.prototype: c1",
+    2: "(property) c2<T>.prototype: c2<any>",
+    3: "(property) c3.prototype: c3",
+    4: "(property) c4.prototype: c4"
+});

--- a/tests/cases/fourslash/stringPropertyNames1.ts
+++ b/tests/cases/fourslash/stringPropertyNames1.ts
@@ -6,5 +6,4 @@
 ////var a: Album;
 ////var /**/x = a['artist'];
 
-goTo.marker();
-verify.quickInfoIs('var x: number');
+verify.quickInfoAt("", "var x: number");

--- a/tests/cases/fourslash/stringPropertyNames2.ts
+++ b/tests/cases/fourslash/stringPropertyNames2.ts
@@ -6,5 +6,4 @@
 ////var a: Album<number>;
 ////var /**/x = a['artist']; 
 
-goTo.marker();
-verify.quickInfoIs('var x: number');
+verify.quickInfoAt("", "var x: number");

--- a/tests/cases/fourslash/thisBindingInLambda.ts
+++ b/tests/cases/fourslash/thisBindingInLambda.ts
@@ -8,5 +8,4 @@
 ////	}
 ////}
 
-goTo.marker();
-verify.quickInfoIs('this: this');
+verify.quickInfoAt("", "this: this");

--- a/tests/cases/fourslash/thisPredicateFunctionQuickInfo.ts
+++ b/tests/cases/fourslash/thisPredicateFunctionQuickInfo.ts
@@ -58,20 +58,12 @@
 //// }
 //// let checked/*14*/LeaderStatus = isLeader/*15*/Guard(a);
 
-
-goTo.marker("1");
-verify.quickInfoIs("(method) RoyalGuard.isLeader(): this is LeadGuard");
-goTo.marker("3");
-verify.quickInfoIs("(method) RoyalGuard.isFollower(): this is FollowerGuard");
-
-goTo.marker("5");
-verify.quickInfoIs("(method) GuardInterface.isLeader(): this is LeadGuard");
-goTo.marker("7");
-verify.quickInfoIs("(method) GuardInterface.isFollower(): this is FollowerGuard");
-
-goTo.marker("13");
-verify.quickInfoIs("let leaderStatus: boolean");
-goTo.marker("14");
-verify.quickInfoIs("let checkedLeaderStatus: boolean");
-goTo.marker("15");
-verify.quickInfoIs("function isLeaderGuard(g: RoyalGuard): boolean");
+verify.quickInfos({
+    1: "(method) RoyalGuard.isLeader(): this is LeadGuard",
+    3: "(method) RoyalGuard.isFollower(): this is FollowerGuard",
+    5: "(method) GuardInterface.isLeader(): this is LeadGuard",
+    7: "(method) GuardInterface.isFollower(): this is FollowerGuard",
+    13: "let leaderStatus: boolean",
+    14: "let checkedLeaderStatus: boolean",
+    15: "function isLeaderGuard(g: RoyalGuard): boolean"
+});

--- a/tests/cases/fourslash/thisPredicateFunctionQuickInfo01.ts
+++ b/tests/cases/fourslash/thisPredicateFunctionQuickInfo01.ts
@@ -40,20 +40,14 @@
 ////     obj.;
 //// }
 
-goTo.marker("1");
-verify.quickInfoIs("(method) FileSystemObject.isFile(): this is Item");
-goTo.marker("2");
-verify.quickInfoIs("(method) FileSystemObject.isDirectory(): this is Directory");
-goTo.marker("3");
-verify.quickInfoIs("(method) FileSystemObject.isNetworked(): this is Networked & this");
+verify.quickInfos({
+    1: "(method) FileSystemObject.isFile(): this is Item",
+    2: "(method) FileSystemObject.isDirectory(): this is Directory",
+    3: "(method) FileSystemObject.isNetworked(): this is Networked & this",
 
-goTo.marker("4");
-verify.quickInfoIs("(method) FileSystemObject.isFile(): this is Item");
-goTo.marker("5");
-verify.quickInfoIs("(method) FileSystemObject.isNetworked(): this is Networked & Item");
-goTo.marker("6");
-verify.quickInfoIs("(method) FileSystemObject.isDirectory(): this is Directory");
-goTo.marker("7");
-verify.quickInfoIs("(method) FileSystemObject.isNetworked(): this is Networked & Directory");
-goTo.marker("8");
-verify.quickInfoIs("(method) FileSystemObject.isNetworked(): this is Networked & FileSystemObject");
+    4: "(method) FileSystemObject.isFile(): this is Item",
+    5: "(method) FileSystemObject.isNetworked(): this is Networked & Item",
+    6: "(method) FileSystemObject.isDirectory(): this is Directory",
+    7: "(method) FileSystemObject.isNetworked(): this is Networked & Directory",
+    8: "(method) FileSystemObject.isNetworked(): this is Networked & FileSystemObject"
+});

--- a/tests/cases/fourslash/thisPredicateFunctionQuickInfo02.ts
+++ b/tests/cases/fourslash/thisPredicateFunctionQuickInfo02.ts
@@ -31,27 +31,21 @@
 ////     }
 //// }
 
-goTo.marker("1");
-verify.quickInfoIs("(method) Crate<T>.isSundries(): this is Crate<Sundries>");
-goTo.marker("2");
-verify.quickInfoIs("(method) Crate<T>.isSupplies(): this is Crate<Supplies>");
-goTo.marker("3");
-verify.quickInfoIs(`(method) Crate<T>.isPackedTight(): this is this & {
+verify.quickInfos({
+    1: "(method) Crate<T>.isSundries(): this is Crate<Sundries>",
+    2: "(method) Crate<T>.isSupplies(): this is Crate<Supplies>",
+    3: `(method) Crate<T>.isPackedTight(): this is this & {
     extraContents: T;
-}`);
-goTo.marker("4");
-verify.quickInfoIs(`(method) Crate<any>.isPackedTight(): this is Crate<any> & {
+}`,
+    4: `(method) Crate<any>.isPackedTight(): this is Crate<any> & {
     extraContents: any;
-}`);
-goTo.marker("5");
-verify.quickInfoIs("(method) Crate<any>.isSundries(): this is Crate<Sundries>");
-goTo.marker("6");
-verify.quickInfoIs(`(method) Crate<Sundries>.isPackedTight(): this is Crate<Sundries> & {
+}`,
+    5: "(method) Crate<any>.isSundries(): this is Crate<Sundries>",
+    6: `(method) Crate<Sundries>.isPackedTight(): this is Crate<Sundries> & {
     extraContents: Sundries;
-}`);
-goTo.marker("7");
-verify.quickInfoIs("(method) Crate<any>.isSupplies(): this is Crate<Supplies>");
-goTo.marker("8");
-verify.quickInfoIs(`(method) Crate<Supplies>.isPackedTight(): this is Crate<Supplies> & {
+}`,
+    7: "(method) Crate<any>.isSupplies(): this is Crate<Supplies>",
+    8: `(method) Crate<Supplies>.isPackedTight(): this is Crate<Supplies> & {
     extraContents: Supplies;
-}`);
+}`
+});

--- a/tests/cases/fourslash/tsxQuickInfo1.ts
+++ b/tests/cases/fourslash/tsxQuickInfo1.ts
@@ -5,14 +5,9 @@
 //// class MyElement {}
 //// var z = <My/*3*/Element></My/*4*/Element>
 
-goTo.marker("1");
-verify.quickInfoIs("any", undefined);
-
-goTo.marker("2");
-verify.quickInfoIs("any", undefined);;
-
-goTo.marker("3");
-verify.quickInfoIs("class MyElement", undefined);;
-
-goTo.marker("4");
-verify.quickInfoIs("class MyElement", undefined);;
+verify.quickInfos({
+    1: "any",
+    2: "any",
+    3: "class MyElement",
+    4: "class MyElement"
+});

--- a/tests/cases/fourslash/tsxQuickInfo2.ts
+++ b/tests/cases/fourslash/tsxQuickInfo2.ts
@@ -11,14 +11,9 @@
 //// class MyElement {}
 //// var z = <My/*3*/Element></My/*4*/Element>
 
-goTo.marker("1");
-verify.quickInfoIs("(property) JSX.IntrinsicElements.div: any", undefined);
-
-goTo.marker("2");
-verify.quickInfoIs("(property) JSX.IntrinsicElements.div: any", undefined);;
-
-goTo.marker("3");
-verify.quickInfoIs("class MyElement", undefined);;
-
-goTo.marker("4");
-verify.quickInfoIs("class MyElement", undefined);;
+verify.quickInfos({
+    1: "(property) JSX.IntrinsicElements.div: any",
+    2: "(property) JSX.IntrinsicElements.div: any",
+    3: "class MyElement",
+    4: "class MyElement"
+});

--- a/tests/cases/fourslash/typeCheckAfterResolve.ts
+++ b/tests/cases/fourslash/typeCheckAfterResolve.ts
@@ -11,8 +11,7 @@ goTo.eof();
 edit.insertLine("");
 
 // Attempt to resolve a symbol
-goTo.marker("IPointRef");
-verify.quickInfoIs(""); // not found
+verify.quickInfoAt("IPointRef", ""); // not found
 
 // trigger typecheck after the partial resolve, we should see errors
 verify.errorExistsAfterMarker("IPointRef");

--- a/tests/cases/fourslash/typeOfAFundule.ts
+++ b/tests/cases/fourslash/typeOfAFundule.ts
@@ -7,5 +7,4 @@
 ////}
 ////var /**/r13 = foo13();
 
-goTo.marker();
-verify.quickInfoIs('var r13: typeof m1');
+verify.quickInfoAt("", "var r13: typeof m1");

--- a/tests/cases/fourslash/typeOfThisInStatics.ts
+++ b/tests/cases/fourslash/typeOfThisInStatics.ts
@@ -10,8 +10,7 @@
 ////    }
 ////}
 
-goTo.marker('1');
-verify.quickInfoIs('(local var) r: typeof C');
-
-goTo.marker('2');
-verify.quickInfoIs('(local var) r: typeof C');
+verify.quickInfos({
+    1: "(local var) r: typeof C",
+    2: "(local var) r: typeof C"
+});

--- a/tests/cases/fourslash/typeParameterListInQuickInfoAfterEdit.ts
+++ b/tests/cases/fourslash/typeParameterListInQuickInfoAfterEdit.ts
@@ -10,8 +10,7 @@
 //// 
 
 // Sanity check: type name here should include the type parameter
-goTo.marker('1');
-verify.quickInfoIs('class Dictionary<V>');
+verify.quickInfoAt("1", "class Dictionary<V>");
 
 // Add a similar class -- name does not match
 goTo.marker('2');

--- a/tests/cases/fourslash/typedGenericPrototypeMember.ts
+++ b/tests/cases/fourslash/typedGenericPrototypeMember.ts
@@ -6,8 +6,7 @@
 ////var /*1*/x = new C<any>(); // Quick Info for x is C<any>
 ////var /*2*/y = C.prototype; // Quick Info for y is C<{}>
 
-goTo.marker('1');
-verify.quickInfoIs('var x: C<any>');
-
-goTo.marker('2');
-verify.quickInfoIs('var y: C<any>');
+verify.quickInfos({
+    1: "var x: C<any>",
+    2: "var y: C<any>"
+});

--- a/tests/cases/fourslash/underscoreTypings01.ts
+++ b/tests/cases/fourslash/underscoreTypings01.ts
@@ -27,35 +27,25 @@
 ////
 ////var e = a.map(x => x./*13*/
 
-goTo.marker('1');
-verify.quickInfoIs('var b: number[]');
-goTo.marker('2');
-verify.quickInfoIs('(parameter) x: string');
+verify.quickInfos({
+    1: "var b: number[]",
+    2: "(parameter) x: string",
 
-goTo.marker('3');
-verify.quickInfoIs('var c: number[]');
-goTo.marker('4');
-verify.quickInfoIs('(parameter) x: string');
+    3: "var c: number[]",
+    4: "(parameter) x: string",
 
-goTo.marker('5');
-verify.quickInfoIs('var d: number[]');
-goTo.marker('6');
-verify.quickInfoIs('(parameter) x: string');
+    5: "var d: number[]",
+    6: "(parameter) x: string",
 
-goTo.marker('7');
-verify.quickInfoIs('var bb: any[]');
-goTo.marker('8');
-verify.quickInfoIs('(parameter) x: any');
+    7: "var bb: any[]",
+    8: "(parameter) x: any",
 
-goTo.marker('9');
-verify.quickInfoIs('var cc: any[]');
-goTo.marker('10');
-verify.quickInfoIs('(parameter) x: any');
+    9: "var cc: any[]",
+    10: "(parameter) x: any",
 
-goTo.marker('11');
-verify.quickInfoIs('var dd: any[]');
-goTo.marker('12');
-verify.quickInfoIs('(parameter) x: any');
+    11: "var dd: any[]",
+    12: "(parameter) x: any"
+});
 
 goTo.marker('13');
 verify.completionListContains('length');

--- a/tests/cases/fourslash/verifySingleFileEmitOutput1.ts
+++ b/tests/cases/fourslash/verifySingleFileEmitOutput1.ts
@@ -10,5 +10,4 @@
 ////import f = require("./verifySingleFileEmitOutput1_file0");
 ////var /**/b = new f.A();
 
-goTo.marker();
-verify.quickInfoIs('var b: f.A');
+verify.quickInfoAt("", "var b: f.A");

--- a/tests/cases/fourslash/widenedTypes.ts
+++ b/tests/cases/fourslash/widenedTypes.ts
@@ -5,14 +5,9 @@
 ////var /*3*/c = { x: 0, y: null };	// var c: { x: number, y: any }
 ////var /*4*/d = [null, undefined];      // var d: any[]
 
-goTo.marker('1');
-verify.quickInfoIs('var a: any');
-
-goTo.marker('2');
-verify.quickInfoIs('var b: any');
-
-goTo.marker('3');
-verify.quickInfoIs('var c: {\n    x: number;\n    y: any;\n}');
-
-goTo.marker('4');
-verify.quickInfoIs('var d: any[]');
+verify.quickInfos({
+    1: "var a: any",
+    2: "var b: any",
+    3: "var c: {\n    x: number;\n    y: any;\n}",
+    4: "var d: any[]"
+});


### PR DESCRIPTION
This adds `verify.quickInfoAt` to simplify `goTo.marker(...); verify.quickInfoIs(...)`, and`verify.quickInfos` to simplify sequences of `verify.quickInfoAt`.

It also makes `quickInfoIs` not negatable. The only test using that ability was `regexDetection.ts`.

It also defaults the second argument (verifyDocumentation) of `verify.quickInfoIs` to "";
so if it is not provided, we assert that there is no documentation.
Since a `expectedDocumentation` is now required, `getJavaScriptQuickInfo1.ts` and `completionEntryForUnionMethod.ts` now include that argument.
