### PR TITLE
Add readonly typings for Set and Map

### DIFF
--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -15,6 +15,21 @@ interface MapConstructor {
 }
 declare var Map: MapConstructor;
 
+interface ReadonlyMap<K, V> {
+  forEach(
+      callbackfn: (value: V, index: K, map: ReadonlyMap<K, V>) => void,
+      thisArg?: any): void;
+  get(key: K): V|undefined;
+  has(key: K): boolean;
+  readonly size: number;
+}
+
+interface ReadonlyMapConstructor {
+  new<K, V>(entries?: [K, V][]): ReadonlyMap<K, V>;
+  readonly prototype: ReadonlyMap<any, any>;
+}
+declare var ReadonlyMap: ReadonlyMapConstructor;
+
 interface WeakMap<K, V> {
     delete(key: K): boolean;
     get(key: K): V | undefined;
@@ -44,6 +59,19 @@ interface SetConstructor {
     readonly prototype: Set<any>;
 }
 declare var Set: SetConstructor;
+
+interface ReadonlySet<T> {
+  forEach(callbackfn: (value: T, index: T, set: ReadonlySet<T>) => void, thisArg?: any):
+      void;
+  has(value: T): boolean;
+  readonly size: number;
+}
+
+interface ReadonlySetConstructor {
+  new<T>(values?: T[]): ReadonlySet<T>;
+  readonly prototype: ReadonlySet<any>;
+}
+declare var ReadonlySet: ReadonlySetConstructor;
 
 interface WeakSet<T> {
     add(value: T): this;

--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -16,12 +16,10 @@ interface MapConstructor {
 declare var Map: MapConstructor;
 
 interface ReadonlyMap<K, V> {
-  forEach(
-      callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void,
-      thisArg?: any): void;
-  get(key: K): V|undefined;
-  has(key: K): boolean;
-  readonly size: number;
+    forEach(callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void, thisArg?: any): void;
+    get(key: K): V|undefined;
+    has(key: K): boolean;
+    readonly size: number;
 }
 
 interface WeakMap<K, V> {
@@ -55,10 +53,9 @@ interface SetConstructor {
 declare var Set: SetConstructor;
 
 interface ReadonlySet<T> {
-  forEach(callbackfn: (value: T, value2: T, set: ReadonlySet<T>) => void, thisArg?: any):
-      void;
-  has(value: T): boolean;
-  readonly size: number;
+    forEach(callbackfn: (value: T, value2: T, set: ReadonlySet<T>) => void, thisArg?: any): void;
+    has(value: T): boolean;
+    readonly size: number;
 }
 
 interface WeakSet<T> {

--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -1,7 +1,7 @@
 interface Map<K, V> {
     clear(): void;
     delete(key: K): boolean;
-    forEach(callbackfn: (value: V, index: K, map: Map<K, V>) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: V, key: K, map: Map<K, V>) => void, thisArg?: any): void;
     get(key: K): V | undefined;
     has(key: K): boolean;
     set(key: K, value?: V): this;
@@ -17,18 +17,12 @@ declare var Map: MapConstructor;
 
 interface ReadonlyMap<K, V> {
   forEach(
-      callbackfn: (value: V, index: K, map: ReadonlyMap<K, V>) => void,
+      callbackfn: (value: V, key: K, map: ReadonlyMap<K, V>) => void,
       thisArg?: any): void;
   get(key: K): V|undefined;
   has(key: K): boolean;
   readonly size: number;
 }
-
-interface ReadonlyMapConstructor {
-  new<K, V>(entries?: [K, V][]): ReadonlyMap<K, V>;
-  readonly prototype: ReadonlyMap<any, any>;
-}
-declare var ReadonlyMap: ReadonlyMapConstructor;
 
 interface WeakMap<K, V> {
     delete(key: K): boolean;
@@ -48,7 +42,7 @@ interface Set<T> {
     add(value: T): this;
     clear(): void;
     delete(value: T): boolean;
-    forEach(callbackfn: (value: T, index: T, set: Set<T>) => void, thisArg?: any): void;
+    forEach(callbackfn: (value: T, value2: T, set: Set<T>) => void, thisArg?: any): void;
     has(value: T): boolean;
     readonly size: number;
 }
@@ -61,17 +55,11 @@ interface SetConstructor {
 declare var Set: SetConstructor;
 
 interface ReadonlySet<T> {
-  forEach(callbackfn: (value: T, index: T, set: ReadonlySet<T>) => void, thisArg?: any):
+  forEach(callbackfn: (value: T, value2: T, set: ReadonlySet<T>) => void, thisArg?: any):
       void;
   has(value: T): boolean;
   readonly size: number;
 }
-
-interface ReadonlySetConstructor {
-  new<T>(values?: T[]): ReadonlySet<T>;
-  readonly prototype: ReadonlySet<any>;
-}
-declare var ReadonlySet: ReadonlySetConstructor;
 
 interface WeakSet<T> {
     add(value: T): this;


### PR DESCRIPTION
Fixes #10919

Similar to ReadonlyArray, these typings remove the mutation methods from Set and Map so that they can only be initialized by the constructor.

[Example](https://www.typescriptlang.org/play/#src=interface%20ReadonlyMap%3CK%2C%20V%3E%20%7B%0D%0A%20%20forEach(callbackfn%3A%20(value%3A%20V%2C%20index%3A%20K%2C%20map%3A%20ReadonlyMap%3CK%2C%20V%3E)%20%3D%3E%20void%2C%20thisArg%3F%3A%20any)%3A%20void%3B%0D%0A%20%20get(key%3A%20K)%3A%20V%7Cundefined%3B%0D%0A%20%20has(key%3A%20K)%3A%20boolean%3B%0D%0A%20%20readonly%20size%3A%20number%3B%0D%0A%7D%0D%0A%0D%0Ainterface%20ReadonlySet%3CT%3E%20%7B%0D%0A%20%20forEach(callbackfn%3A%20(value%3A%20T%2C%20index%3A%20T%2C%20set%3A%20ReadonlySet%3CT%3E)%20%3D%3E%20void%2C%20thisArg%3F%3A%20any)%3A%0D%0A%20%20%20%20%20%20void%3B%0D%0A%20%20has(value%3A%20T)%3A%20boolean%3B%0D%0A%20%20readonly%20size%3A%20number%3B%0D%0A%7D%0D%0A%0D%0Alet%20roMap%3A%20ReadonlyMap%3Cstring%2C%20string%3E%20%3D%20new%20Map(%0D%0A%09%5B%5B%22key1%22%2C%20%22value1%22%5D%2C%20%5B%22key2%22%2C%20%22value2%22%5D%5D)%3B%0D%0Alet%20roSet%3A%20ReadonlySet%3Cnumber%3E%20%3D%20new%20Set(%5B1%2C2%2C3%2C4%2C4%5D)%3B%0D%0A%0D%0A%0D%0Alet%20v1%20%3D%20roMap.get(%22key1%22)%3B%0D%0A%2F%2F%20not%20available%3A%0D%0A%2F%2FroMap.set(%22key1%22%2C%20%22foo%22)%3B%0D%0A%0D%0Alet%20b%20%3D%20roSet.has(5)%3B%0D%0A%2F%2F%20not%20available%3A%0D%0A%2F%2FroSet.delete(4)%3B%0D%0A)