### PR TITLE
Fix super in down-level async method

### DIFF
--- a/tests/baselines/reference/asyncMethodWithSuper_es5.js
+++ b/tests/baselines/reference/asyncMethodWithSuper_es5.js
@@ -69,11 +69,11 @@ var B = (function (_super) {
             var a, b;
             return __generator(this, function (_a) {
                 // call with property access
-                _super.x.call(this);
+                _super.prototype.x.call(this);
                 // call with element access
-                _super["x"].call(this);
-                a = _super.x;
-                b = _super["x"];
+                _super.prototype["x"].call(this);
+                a = _super.prototype.x;
+                b = _super.prototype["x"];
                 return [2 /*return*/];
             });
         });
@@ -85,15 +85,15 @@ var B = (function (_super) {
             return __generator(this, function (_c) {
                 f = function () { };
                 // call with property access
-                _super.x.call(this);
+                _super.prototype.x.call(this);
                 // call with element access
-                _super["x"].call(this);
-                a = _super.x;
-                b = _super["x"];
+                _super.prototype["x"].call(this);
+                a = _super.prototype.x;
+                b = _super.prototype["x"];
                 // property access (assign)
-                _super.x = f;
+                _super.prototype.x = f;
                 // element access (assign)
-                _super["x"] = f;
+                _super.prototype["x"] = f;
                 // destructuring assign with property access
                 (_a = { f: f }, super.x = _a.f, _a);
                 // destructuring assign with element access


### PR DESCRIPTION
Fixes an issue with the emit for super property calls in async methods for down-level (ES5/3) async functions.

Fixes #10862

// CC: @mhegazy, @vladima