### PR TITLE
Remove require name collision check for ES6 modules and later

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15554,6 +15554,11 @@ namespace ts {
         }
 
         function checkCollisionWithRequireExportsInGeneratedCode(node: Node, name: Identifier) {
+            // No need to check for require or exports for ES6 modules and later
+            if (modulekind >= ModuleKind.ES6) {
+                return;
+            }
+
             if (!needCollisionCheckForIdentifier(node, name, "require") && !needCollisionCheckForIdentifier(node, name, "exports")) {
                 return;
             }

--- a/tests/baselines/reference/es6UseOfTopLevelRequire.js
+++ b/tests/baselines/reference/es6UseOfTopLevelRequire.js
@@ -1,0 +1,30 @@
+//// [tests/cases/compiler/es6UseOfTopLevelRequire.ts] ////
+
+//// [b.ts]
+
+export default function require(s: string): void {
+}
+
+//// [c.ts]
+export const exports = 0;
+export default exports;
+
+//// [a.ts]
+import require from "./b"
+require("arg");
+
+import exports from "./c"
+var x = exports + 2;
+
+
+//// [b.js]
+export default function require(s) {
+}
+//// [c.js]
+export const exports = 0;
+export default exports;
+//// [a.js]
+import require from "./b";
+require("arg");
+import exports from "./c";
+var x = exports + 2;

--- a/tests/baselines/reference/es6UseOfTopLevelRequire.symbols
+++ b/tests/baselines/reference/es6UseOfTopLevelRequire.symbols
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/a.ts ===
+import require from "./b"
+>require : Symbol(require, Decl(a.ts, 0, 6))
+
+require("arg");
+>require : Symbol(require, Decl(a.ts, 0, 6))
+
+import exports from "./c"
+>exports : Symbol(exports, Decl(a.ts, 3, 6))
+
+var x = exports + 2;
+>x : Symbol(x, Decl(a.ts, 4, 3))
+>exports : Symbol(exports, Decl(a.ts, 3, 6))
+
+=== tests/cases/compiler/b.ts ===
+
+export default function require(s: string): void {
+>require : Symbol(require, Decl(b.ts, 0, 0))
+>s : Symbol(s, Decl(b.ts, 1, 32))
+}
+
+=== tests/cases/compiler/c.ts ===
+export const exports = 0;
+>exports : Symbol(exports, Decl(c.ts, 0, 12))
+
+export default exports;
+>exports : Symbol(exports, Decl(c.ts, 0, 12))
+

--- a/tests/baselines/reference/es6UseOfTopLevelRequire.types
+++ b/tests/baselines/reference/es6UseOfTopLevelRequire.types
@@ -1,0 +1,33 @@
+=== tests/cases/compiler/a.ts ===
+import require from "./b"
+>require : (s: string) => void
+
+require("arg");
+>require("arg") : void
+>require : (s: string) => void
+>"arg" : "arg"
+
+import exports from "./c"
+>exports : 0
+
+var x = exports + 2;
+>x : number
+>exports + 2 : number
+>exports : 0
+>2 : 2
+
+=== tests/cases/compiler/b.ts ===
+
+export default function require(s: string): void {
+>require : (s: string) => void
+>s : string
+}
+
+=== tests/cases/compiler/c.ts ===
+export const exports = 0;
+>exports : 0
+>0 : 0
+
+export default exports;
+>exports : 0
+

--- a/tests/cases/compiler/es6UseOfTopLevelRequire.ts
+++ b/tests/cases/compiler/es6UseOfTopLevelRequire.ts
@@ -1,0 +1,16 @@
+// @target: ES6
+
+// @filename: b.ts
+export default function require(s: string): void {
+}
+
+// @filename: c.ts
+export const exports = 0;
+export default exports;
+
+// @filename: a.ts
+import require from "./b"
+require("arg");
+
+import exports from "./c"
+var x = exports + 2;


### PR DESCRIPTION
Ran across this while looking into https://github.com/Microsoft/TypeScript/issues/10931. We issue an error if you use a top-level declaration with the name `require` or `exports` even if the emitter is not going to write them to the output. this change relaxes the restriction for `--module ES6` and later.