### PR TITLE
Fix Reflect has method signature(s) per issue #10949 initial report

### DIFF
--- a/src/lib/es2015.reflect.d.ts
+++ b/src/lib/es2015.reflect.d.ts
@@ -6,8 +6,7 @@ declare namespace Reflect {
     function get(target: any, propertyKey: PropertyKey, receiver?: any): any;
     function getOwnPropertyDescriptor(target: any, propertyKey: PropertyKey): PropertyDescriptor;
     function getPrototypeOf(target: any): any;
-    function has(target: any, propertyKey: string): boolean;
-    function has(target: any, propertyKey: symbol): boolean;
+    function has(target: any, propertyKey: PropertyKey): boolean;
     function isExtensible(target: any): boolean;
     function ownKeys(target: any): Array<PropertyKey>;
     function preventExtensions(target: any): boolean;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ YES] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ YES] Code is up-to-date with the `master` branch
[ YES] You've successfully run `jake runtests` locally
[ YES] You've signed the CLA
[ N/A] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #10949 As per fix initially proposed when issue was created. We just delete the two 'has' methods and replace with a single 'has' method with the signature fixed with 'PropertyKey' annotation.
This brings Reflect into sync with Proxy handler methods noting that all the other methods in Reflect which accept a 'propKey' argument are already annotated with 'PropertyKey' type.

Note that ECMA-262 7th Edition has removed the 'enumerate' method from Reflect altogether yet it remains in es2015.proxy.d.ts. Whether this should be removed or not to bring 'ProxyHandler' into line with the 7th Edition or not I do not know. I don't otherwise know of any means of marking a method as "deprecated" in TypeScript (but perhaps there is?).



