### PR TITLE
defer setting format options on file until it is explicitly requested

### DIFF
--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -290,13 +290,14 @@ namespace ts.server {
         }
 
         getFormatCodeOptions(file?: NormalizedPath) {
+            let formatCodeSettings: FormatCodeSettings;
             if (file) {
                 const info = this.getScriptInfoForNormalizedPath(file);
                 if (info) {
-                    return info.formatCodeSettings;
+                    formatCodeSettings = info.getFormatCodeSettings();
                 }
             }
-            return this.hostConfiguration.formatCodeOptions;
+            return formatCodeSettings || this.hostConfiguration.formatCodeOptions;
         }
 
         private updateProjectGraphs(projects: Project[]) {
@@ -969,7 +970,6 @@ namespace ts.server {
                 }
                 if (content !== undefined) {
                     info = new ScriptInfo(this.host, fileName, content, scriptKind, openedByClient, hasMixedContent);
-                    info.setFormatOptions(toEditorSettings(this.getFormatCodeOptions()));
                     // do not watch files with mixed content - server doesn't know how to interpret it
                     this.filenameToScriptInfo.set(info.path, info);
                     if (!info.isOpen && !hasMixedContent) {

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -7,7 +7,7 @@ namespace ts.server {
          * All projects that include this file 
          */
         readonly containingProjects: Project[] = [];
-        readonly formatCodeSettings: ts.FormatCodeSettings;
+        private formatCodeSettings: ts.FormatCodeSettings;
         readonly path: Path;
 
         private fileWatcher: FileWatcher;
@@ -24,10 +24,13 @@ namespace ts.server {
 
             this.path = toPath(fileName, host.getCurrentDirectory(), createGetCanonicalFileName(host.useCaseSensitiveFileNames));
             this.svc = ScriptVersionCache.fromString(host, content);
-            this.formatCodeSettings = getDefaultFormatCodeSettings(this.host);
             this.scriptKind = scriptKind
                 ? scriptKind
                 : getScriptKindFromFileName(fileName);
+        }
+
+        getFormatCodeSettings() {
+            return this.formatCodeSettings;
         }
 
         attachToProject(project: Project): boolean {
@@ -90,6 +93,9 @@ namespace ts.server {
 
         setFormatOptions(formatSettings: protocol.FormatOptions): void {
             if (formatSettings) {
+                if (!this.formatCodeSettings) {
+                    this.formatCodeSettings = getDefaultFormatCodeSettings(this.host);
+                }
                 mergeMaps(this.formatCodeSettings, formatSettings);
             }
         }


### PR DESCRIPTION
this way hosts that don't support per-file settings can use `configure` message to update global format options.

// cc @mhegazy 