### PR TITLE
Resolve a problem of 1024 bytes limited help message in some terminals.

### DIFF
--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -667,7 +667,7 @@ namespace ts {
     }
 
     function printHelp() {
-        const output = [];
+        const output: any = [];
 
         // We want to align our "syntax" and "examples" commands to a certain margin.
         const syntaxLength = getDiagnosticText(Diagnostics.Syntax_Colon_0, "").length;
@@ -765,9 +765,9 @@ namespace ts {
                 output.push(sys.newLine);
             }
         }
-        output.forEach(function (val) {
+        output.forEach(function (val: any) {
             sys.write(val);
-        })
+        });
         return;
 
         function getParamType(option: CommandLineOption) {

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -667,7 +667,7 @@ namespace ts {
     }
 
     function printHelp() {
-        const output: any = [];
+        const output: string[] = [];
 
         // We want to align our "syntax" and "examples" commands to a certain margin.
         const syntaxLength = getDiagnosticText(Diagnostics.Syntax_Colon_0, "").length;
@@ -765,9 +765,10 @@ namespace ts {
                 output.push(sys.newLine);
             }
         }
-        output.forEach(function (val: any) {
-            sys.write(val);
-        });
+
+        for (const line of output) {
+            sys.write(line);
+        }
         return;
 
         function getParamType(option: CommandLineOption) {

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -667,7 +667,7 @@ namespace ts {
     }
 
     function printHelp() {
-        let output = "";
+        const output = [];
 
         // We want to align our "syntax" and "examples" commands to a certain margin.
         const syntaxLength = getDiagnosticText(Diagnostics.Syntax_Colon_0, "").length;
@@ -678,17 +678,17 @@ namespace ts {
         let syntax = makePadding(marginLength - syntaxLength);
         syntax += "tsc [" + getDiagnosticText(Diagnostics.options) + "] [" + getDiagnosticText(Diagnostics.file) + " ...]";
 
-        output += getDiagnosticText(Diagnostics.Syntax_Colon_0, syntax);
-        output += sys.newLine + sys.newLine;
+        output.push(getDiagnosticText(Diagnostics.Syntax_Colon_0, syntax));
+        output.push(sys.newLine + sys.newLine);
 
         // Build up the list of examples.
         const padding = makePadding(marginLength);
-        output += getDiagnosticText(Diagnostics.Examples_Colon_0, makePadding(marginLength - examplesLength) + "tsc hello.ts") + sys.newLine;
-        output += padding + "tsc --outFile file.js file.ts" + sys.newLine;
-        output += padding + "tsc @args.txt" + sys.newLine;
-        output += sys.newLine;
+        output.push(getDiagnosticText(Diagnostics.Examples_Colon_0, makePadding(marginLength - examplesLength) + "tsc hello.ts") + sys.newLine);
+        output.push(padding + "tsc --outFile file.js file.ts" + sys.newLine);
+        output.push(padding + "tsc @args.txt" + sys.newLine);
+        output.push(sys.newLine);
 
-        output += getDiagnosticText(Diagnostics.Options_Colon) + sys.newLine;
+        output.push(getDiagnosticText(Diagnostics.Options_Colon) + sys.newLine);
 
         // Sort our options by their names, (e.g. "--noImplicitAny" comes before "--watch")
         const optsList = filter(optionDeclarations.slice(), v => !v.experimental);
@@ -755,18 +755,19 @@ namespace ts {
             const usage = usageColumn[i];
             const description = descriptionColumn[i];
             const kindsList = optionsDescriptionMap[description];
-            output += usage + makePadding(marginLength - usage.length + 2) + description + sys.newLine;
+            output.push(usage + makePadding(marginLength - usage.length + 2) + description + sys.newLine);
 
             if (kindsList) {
-                output += makePadding(marginLength + 4);
+                output.push(makePadding(marginLength + 4));
                 for (const kind of kindsList) {
-                    output += kind + " ";
+                    output.push(kind + " ");
                 }
-                output += sys.newLine;
+                output.push(sys.newLine);
             }
         }
-
-        sys.write(output);
+        output.forEach(function (val) {
+            sys.write(val);
+        })
         return;
 
         function getParamType(option: CommandLineOption) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

### Description

Some terminals cannot excute a single line out of 1024 bytes. When users want to check the help message by typing **tsc** or **tsc --help**, They may get a 1024 bytes length broken message.
I have no idea about if using **console.log** here is better or not, so I fixed the output rule to echo the help message line by line.

### Enviroment

**TypeScript Version:**  1.8.10
**Node.js Version:** 6.2.0
**System Version:** OS X El Capitan 10.11.6

### Reproduction

- Install the text editor ATOM from https://atom.io/
- Install the ATOM package "platformio-ide-terminal@2.1.0"

```shell
$ apm install platformio-ide-terminal
```

- Open ATOM

```shell
$ atom
```

- Press the hotkey **ctrl + `** or get in the main menu `Packages -> platformio-ide-terminal -> Toggle` to open the terminal in ATOM.
- Input **tsc** in terminal.

```
$ tsc
```

- The terminal will output a 1024 bytes length , which has been broken, help message.

### Input

```shell
$ tsc
```

### Expected output

```shell
Version 1.8.10
Syntax:   tsc [options] [file ...]

Examples: tsc hello.ts
          tsc --out file.js file.ts
          tsc @args.txt

Options:
 --allowJs                           Allow javascript files to be compiled.
 --allowSyntheticDefaultImports      Allow default imports from modules with no default export. This does not affect code emit, just
typechecking.
 --allowUnreachableCode              Do not report errors on unreachable code.

 --allowUnusedLabels                 Do not report errors on unused labels.
 --baseUrl                           Base directory to resolve non-absolute module names.
 -d, --declaration                   Generates corresponding '.d.ts' file.
 --experimentalDecorators            Enables experimental support for ES7 decorators.
 --forceConsistentCasingInFileNames  Disallow inconsistently-cased references to the same file.
 -h, --help                          Print this message.
 --init                              Initializes a TypeScript project and creates a tsconfig.json file.
 --jsx KIND                          Specify JSX code generation: 'preserve' or 'react'
 --lib                               Specify library files to be included in the compilation:
                                       'es5' 'es6' 'es2015' 'es7' 'es2016' 'es2017' 'dom' 'webworker' 'scripthost' 'es2015.core' 'es2
015.collection' 'es2015.generator' 'es2015.iterable' 'es2015.promise' 'es2015.proxy' 'es2015.reflect' 'es2015.symbol' 'es2015.symbol.
wellknown' 'es2016.array.include' 'es2017.object' 'es2017.sharedmemory'
 --mapRoot LOCATION                  Specify the location where debugger should locate map files instead of generated locations.
 --maxNodeModuleJsDepth              The maximum dependency depth to search under node_modules and load JavaScript files
 -m KIND, --module KIND              Specify module code generation: 'commonjs', 'amd', 'system', 'umd' or 'es2015'
 --moduleResolution                  Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6).
 --newLine NEWLINE                   Specify the end of line sequence to be used when emitting files: 'CRLF' (dos) or 'LF' (unix).
 --noEmit                            Do not emit outputs.
--noEmitOnError                     Do not emit outputs if any errors were reported.
 --noFallthroughCasesInSwitch        Report errors for fallthrough cases in switch statement.
 --noImplicitAny                     Raise error on expressions and declarations with an implied 'any' type.
 --noImplicitReturns                 Report error when not all code paths in function return a value.
 --noImplicitThis                    Raise error on 'this' expressions with an implied 'any' type.
 --noImplicitUseStrict               Do not emit 'use strict' directives in module output.
 --noUnusedLocals                    Report Errors on Unused Locals.
 --noUnusedParameters                Report Errors on Unused Parameters.
 --outDir DIRECTORY                  Redirect output structure to the directory.

 --outFile FILE                      Concatenate and emit output to single file.
 --preserveConstEnums                Do not erase const enum declarations in generated code.
 --pretty                            Stylize errors and messages using color and context. (experimental)
 -p DIRECTORY, --project DIRECTORY   Compile the project in the given directory.
 --reactNamespace                    Specify the object invoked for createElement and __spread when targeting 'react' JSX emit
 --removeComments                    Do not emit comments to output.
 --rootDir LOCATION                  Specify the root directory of input files. Use to control the output directory structure with --
outDir.
 --skipLibCheck                      Skip type checking of declaration files.
 --sourceMap                         Generates corresponding '.map' file.
 --sourceRoot LOCATION               Specify the location where debugger should locate TypeScript files instead of source locations.
 --strictNullChecks                  Enable strict null checks.
 --suppressImplicitAnyIndexErrors    Suppress noImplicitAny errors for indexing objects lacking index signatures.
 -t VERSION, --target VERSION        Specify ECMAScript target version: 'ES3' (default), 'ES5', or 'ES2015'
 --traceResolution                   Enable tracing of the name resolution process.
 --types                             Type declaration files to be included in compilation.
 -v, --version                       Print the compiler's version.
 -w, --watch                         Watch input files.
 @<file>                             Insert command line options and files from a file.
```
### Actual output

```shell
Version 1.8.10
Syntax:   tsc [options] [file ...]

Examples: tsc hello.ts
          tsc --out file.js file.ts
          tsc @args.txt

Options:
 --allowJs                           Allow javascript files to be compiled.
 --allowSyntheticDefaultImports      Allow default imports from modules with no default export. This does not affect code emit, just typechecking.

 --allowUnreachableCode              Do not report errors on unreachable code.
 --allowUnusedLabels                 Do not report errors on unused labels.
 -d, --declaration                   Generates corresponding '.d.ts' file.
 --experimentalDecorators            Enables experimental support for ES7 decorators.
 --forceConsistentCasingInFileNames  Disallow inconsistently-cased references to the same file.
 -h, --help                          Print this message.
 --init                              Initializes a TypeScript project and creates a tsconfig.json file.
 --jsx KIND                          Specify JSX code generation: 'preserve' or 're
```

### Remark

Not only my terminal, I googled the 1024 bytes limit is appeared in such a lot of cases.

> - http://emacs.stackexchange.com/questions/20364/1024-char-limit-on-command-line-in-emacs-shell-mode-on-osx
> - http://superuser.com/questions/219225/command-limits-when-pasting-into-tcsh-mac-os-x
> - http://serverfault.com/questions/163371/linux-command-line-character-limit
> - http://unix.stackexchange.com/questions/204815/terminal-does-not-accept-pasted-or-typed-lines-of-more-than-1024-characters
> - http://stackoverflow.com/questions/11321829/unable-to-provide-long-1024-character-inputs-to-the-ocaml-toplevel-and-coqtop
> - etc.