### PR TITLE
added unittest for watching @types

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -937,7 +937,7 @@ desc("Runs the tests using the built run.js file like 'jake runtests'. Syntax is
 task("runtests-browser", ["tests", "browserify", builtLocalDirectory, servicesFileInBrowserTest], function () {
     cleanTestDirs();
     host = "node";
-    browser = process.env.browser || process.env.b || "IE";
+    browser = process.env.browser || process.env.b ||  (os.platform() === "linux" ? "chrome" : "IE");
     tests = process.env.test || process.env.tests || process.env.t;
     var light = process.env.light || false;
     var testConfigFile = 'test.config';

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -1939,7 +1939,7 @@ namespace ts.projectSystem {
                 content: JSON.stringify({ compilerOptions: { allowJs: true }, exclude: ["node_modules"] })
             };
             const host = createServerHost([f1, barjs, barTypings, config]);
-            const projectService = createProjectService(host, { typingsInstaller: new TestTypingsInstaller(typingsCacheLocation, host) });
+            const projectService = createProjectService(host, { typingsInstaller: new TestTypingsInstaller(typingsCacheLocation, /*throttleLimit*/ 5, host) });
 
             projectService.openClientFile(f1.path);
             projectService.checkNumberOfProjects({ configuredProjects: 1 });
@@ -1987,4 +1987,53 @@ namespace ts.projectSystem {
             assert.deepEqual(s3, newPerFileSettings, "file settings should still be the same with per-file settings");
         });
     });
+
+    describe("watching @types", () => {
+        it("works correctly when typings are added or removed", () => {
+            const f1 = {
+                path: "/a/b/app.ts",
+                content: "let x = 1;"
+            };
+            const t1 = {
+                path: "/a/b/node_modules/@types/lib1/index.d.ts",
+                content: "export let a: number"
+            };
+            const t2 = {
+                path: "/a/b/node_modules/@types/lib2/index.d.ts",
+                content: "export let b: number"
+            };
+            const tsconfig = {
+                path: "/a/b/tsconfig.json",
+                content: JSON.stringify({
+                    compilerOptions: {},
+                    exclude: ["node_modules"]
+                })
+            };
+            debugger
+            const host = createServerHost([f1, t1, tsconfig]);
+            const projectService = createProjectService(host);
+
+            projectService.openClientFile(f1.path);
+            projectService.checkNumberOfProjects({ configuredProjects: 1 });
+            checkProjectActualFiles(projectService.configuredProjects[0], [f1.path, t1.path]);
+
+            // delete t1
+            host.reloadFS([f1, tsconfig]);
+            host.triggerDirectoryWatcherCallback("/a/b/node_modules/@types", "lib1");
+            // run throttled operation
+            host.runQueuedTimeoutCallbacks();
+
+            projectService.checkNumberOfProjects({ configuredProjects: 1 });
+            checkProjectActualFiles(projectService.configuredProjects[0], [f1.path]);
+
+            // create t2
+            host.reloadFS([f1, tsconfig, t2]);
+            host.triggerDirectoryWatcherCallback("/a/b/node_modules/@types", "lib2");
+            // run throttled operation
+            host.runQueuedTimeoutCallbacks();
+
+            projectService.checkNumberOfProjects({ configuredProjects: 1 });
+            checkProjectActualFiles(projectService.configuredProjects[0], [f1.path, t2.path]);
+        })
+    })
 }

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -2009,7 +2009,6 @@ namespace ts.projectSystem {
                     exclude: ["node_modules"]
                 })
             };
-            debugger
             const host = createServerHost([f1, t1, tsconfig]);
             const projectService = createProjectService(host);
 
@@ -2034,6 +2033,6 @@ namespace ts.projectSystem {
 
             projectService.checkNumberOfProjects({ configuredProjects: 1 });
             checkProjectActualFiles(projectService.configuredProjects[0], [f1.path, t2.path]);
-        })
-    })
+        });
+    });
 }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -3154,6 +3154,13 @@ namespace ts {
                 }
             }
 
+            const typeRootsVersion = host.getTypeRootsVersion ? host.getTypeRootsVersion() : 0;
+            if (lastTypesRootVersion !== typeRootsVersion) {
+                log("TypeRoots version has changed; provide new program");
+                program = undefined;
+                lastTypesRootVersion = typeRootsVersion;
+            }
+
             // Get a fresh cache of the host information
             let hostCache = new HostCache(host, getCanonicalFileName);
 
@@ -3219,13 +3226,6 @@ namespace ts {
                 compilerHost.resolveTypeReferenceDirectives = (typeReferenceDirectiveNames, containingFile) => {
                     return host.resolveTypeReferenceDirectives(typeReferenceDirectiveNames, containingFile);
                 };
-            }
-
-            const typeRootsVersion = host.getTypeRootsVersion ? host.getTypeRootsVersion() : 0;
-            if (lastTypesRootVersion !== typeRootsVersion) {
-                log("TypeRoots version has changed; provide new program");
-                program = undefined;
-                lastTypesRootVersion = typeRootsVersion;
             }
 
             const documentRegistryBucketKey = documentRegistry.getKeyForCompilationSettings(newSettings);


### PR DESCRIPTION
changes in this PR
- added unit test for watching @types
- runtests-browser: use `chrome` as default browser in linux
- move checking project types version before the 'is program up-to-date' check. Reason: when new types are installed - it does not affect the list of root files so 'program-up-do-date' will yield true and we will not rebuild the program. Currently everything kind of work but for a different reason (set of root files usually does not include lib.d.ts and program pretty much always contains this file so up-do-date check fails because set of files did not match - ideally we should also fix it).
