### PR TITLE
Fix 9610

### DIFF
--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -526,7 +526,7 @@ namespace ts.server {
             }
             if (this.root.charCount() === 0) {
                 // TODO: assert deleteLength === 0
-                if (newText) {
+                if (newText !== undefined) {
                     this.load(LineIndex.linesFromText(newText).lines);
                     return this;
                 }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #9610 
The issue is that when opening an empty file, the `nexText` is equal to `""`, which results in an `undefined` `LineIndex` object been returned.

