### PR TITLE
Fix npm location

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -700,7 +700,7 @@ task("generate-spec", [specMd]);
 // Makes a new LKG. This target does not build anything, but errors if not all the outputs are present in the built/local directory
 desc("Makes a new LKG out of the built js files");
 task("LKG", ["clean", "release", "local"].concat(libraryTargets), function () {
-    var expectedFiles = [tscFile, servicesFile, serverFile, nodePackageFile, nodeDefinitionsFile, standaloneDefinitionsFile, tsserverLibraryFile, tsserverLibraryDefinitionFile].concat(libraryTargets);
+    var expectedFiles = [tscFile, servicesFile, serverFile, nodePackageFile, nodeDefinitionsFile, standaloneDefinitionsFile, tsserverLibraryFile, tsserverLibraryDefinitionFile, cancellationTokenFile, typingsInstallerFile].concat(libraryTargets);
     var missingFiles = expectedFiles.filter(function (f) {
         return !fs.existsSync(f);
     });

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -1939,7 +1939,7 @@ namespace ts.projectSystem {
                 content: JSON.stringify({ compilerOptions: { allowJs: true }, exclude: ["node_modules"] })
             };
             const host = createServerHost([f1, barjs, barTypings, config]);
-            const projectService = createProjectService(host, { typingsInstaller: new TestTypingsInstaller(typingsCacheLocation, host) });
+            const projectService = createProjectService(host, { typingsInstaller: new TestTypingsInstaller(typingsCacheLocation, 5, host) });
 
             projectService.openClientFile(f1.path);
             projectService.checkNumberOfProjects({ configuredProjects: 1 });

--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -9,6 +9,7 @@ namespace ts.server.typingsInstaller {
     const path: {
         join(...parts: string[]): string;
         dirname(path: string): string;
+        basename(path: string, extension?: string): string;
     } = require("path");
 
     class FileLog implements Log {
@@ -23,6 +24,15 @@ namespace ts.server.typingsInstaller {
         }
     }
 
+    function getNPMLocation(processName: string) {
+        if (path.basename(processName).indexOf("node") == 0) {
+            return `"${path.join(path.dirname(process.argv[0]), "npm")}"`;
+        }
+        else {
+            return "npm";
+        }
+    }
+
     export class NodeTypingsInstaller extends TypingsInstaller {
         private readonly exec: { (command: string, options: { cwd: string }, callback?: (error: Error, stdout: string, stderr: string) => void): any };
 
@@ -31,7 +41,7 @@ namespace ts.server.typingsInstaller {
         constructor(globalTypingsCacheLocation: string, throttleLimit: number, log: Log) {
             super(
                 globalTypingsCacheLocation,
-                /*npmPath*/ `"${path.join(path.dirname(process.argv[0]), "npm")}"`,
+                /*npmPath*/ getNPMLocation(process.argv[0]),
                 toPath("typingSafeList.json", __dirname, createGetCanonicalFileName(sys.useCaseSensitiveFileNames)),
                 throttleLimit,
                 log);

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -150,7 +150,7 @@ namespace ts.server.typingsInstaller {
             if (this.installTypingHost.fileExists(packageJson)) {
                 const npmConfig = <NpmConfig>JSON.parse(this.installTypingHost.readFile(packageJson));
                 if (this.log.isEnabled()) {
-                    this.log.writeLine(`Loaded content of '${npmConfig}': ${JSON.stringify(npmConfig)}`);
+                    this.log.writeLine(`Loaded content of '${packageJson}': ${JSON.stringify(npmConfig)}`);
                 }
                 if (npmConfig.devDependencies) {
                     for (const key in npmConfig.devDependencies) {

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -35,7 +35,7 @@ namespace ts.server {
     function getProjectRootPath(project: Project): Path {
         switch (project.projectKind) {
             case ProjectKind.Configured:
-                return <Path>project.getProjectName();
+                return <Path>getDirectoryPath(project.getProjectName());
             case ProjectKind.Inferred:
                 // TODO: fixme
                 return <Path>"";

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -187,7 +187,7 @@ namespace ts.JsTyping {
             }
 
             const typingNames: string[] = [];
-            const fileNames = host.readDirectory(nodeModulesPath, ["*.json"], /*excludes*/ undefined, /*includes*/ undefined, /*depth*/ 2);
+            const fileNames = host.readDirectory(nodeModulesPath, [".json"], /*excludes*/ undefined, /*includes*/ undefined, /*depth*/ 2);
             for (const fileName of fileNames) {
                 const normalizedFileName = normalizePath(fileName);
                 if (getBaseFileName(normalizedFileName) !== "package.json") {


### PR DESCRIPTION
If we are not running using node.exe (e.g. in VSCode), do not look up `npm` next to the host. also some unit tests and a fix for discovery using `node_module` folders.