### PR TITLE
Restructure ast to parse react attributes as object literal

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5947,7 +5947,7 @@ namespace ts {
 
         // Returns true if the given expression contains (at any level of nesting) a function or arrow expression
         // that is subject to contextual typing.
-        function isContextSensitive(node: Expression | MethodDeclaration | ObjectLiteralElement): boolean {
+        function isContextSensitive(node: Expression | MethodDeclaration | ObjectLiteralElementLike): boolean {
             Debug.assert(node.kind !== SyntaxKind.MethodDeclaration || isObjectLiteralMethod(node));
             switch (node.kind) {
                 case SyntaxKind.FunctionExpression:
@@ -9792,7 +9792,7 @@ namespace ts {
             return getContextualTypeForObjectLiteralElement(node);
         }
 
-        function getContextualTypeForObjectLiteralElement(element: ObjectLiteralElement) {
+        function getContextualTypeForObjectLiteralElement(element: ObjectLiteralElementLike) {
             const objectLiteral = <ObjectLiteralExpression>element.parent;
             const type = getApparentTypeOfContextualType(objectLiteral);
             if (type) {
@@ -9909,7 +9909,7 @@ namespace ts {
                     return getContextualTypeForBinaryOperand(node);
                 case SyntaxKind.PropertyAssignment:
                 case SyntaxKind.ShorthandPropertyAssignment:
-                    return getContextualTypeForObjectLiteralElement(<ObjectLiteralElement>parent);
+                    return getContextualTypeForObjectLiteralElement(<ObjectLiteralElementLike>parent);
                 case SyntaxKind.ArrayLiteralExpression:
                     return getContextualTypeForElementExpression(node);
                 case SyntaxKind.ConditionalExpression:
@@ -13185,7 +13185,7 @@ namespace ts {
             return sourceType;
         }
 
-        function checkObjectLiteralDestructuringPropertyAssignment(objectLiteralType: Type, property: ObjectLiteralElement, contextualMapper?: TypeMapper) {
+        function checkObjectLiteralDestructuringPropertyAssignment(objectLiteralType: Type, property: ObjectLiteralElementLike, contextualMapper?: TypeMapper) {
             if (property.kind === SyntaxKind.PropertyAssignment || property.kind === SyntaxKind.ShorthandPropertyAssignment) {
                 const name = <PropertyName>(<PropertyAssignment>property).name;
                 if (name.kind === SyntaxKind.ComputedPropertyName) {
@@ -18445,7 +18445,7 @@ namespace ts {
             //     for ({ skills: { primary, secondary } } = multiRobot, i = 0; i < 1; i++) {
             if (expr.parent.kind === SyntaxKind.PropertyAssignment) {
                 const typeOfParentObjectLiteral = getTypeOfArrayLiteralOrObjectLiteralDestructuringAssignment(<Expression>expr.parent.parent);
-                return checkObjectLiteralDestructuringPropertyAssignment(typeOfParentObjectLiteral || unknownType, <ObjectLiteralElement>expr.parent);
+                return checkObjectLiteralDestructuringPropertyAssignment(typeOfParentObjectLiteral || unknownType, <ObjectLiteralElementLike>expr.parent);
             }
             // Array literal assignment - array destructuring pattern
             Debug.assert(expr.parent.kind === SyntaxKind.ArrayLiteralExpression);

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -416,7 +416,7 @@ namespace ts {
         return node;
     }
 
-    export function createObjectLiteral(properties?: ObjectLiteralElement[], location?: TextRange, multiLine?: boolean) {
+    export function createObjectLiteral(properties?: ObjectLiteralElementLike[], location?: TextRange, multiLine?: boolean) {
         const node = <ObjectLiteralExpression>createNode(SyntaxKind.ObjectLiteralExpression, location);
         node.properties = createNodeArray(properties);
         if (multiLine) {
@@ -425,7 +425,7 @@ namespace ts {
         return node;
     }
 
-    export function updateObjectLiteral(node: ObjectLiteralExpression, properties: ObjectLiteralElement[]) {
+    export function updateObjectLiteral(node: ObjectLiteralExpression, properties: ObjectLiteralElementLike[]) {
         if (node.properties !== properties) {
             return updateNode(createObjectLiteral(properties, node, node.multiLine), node);
         }
@@ -2069,7 +2069,7 @@ namespace ts {
         }
     }
 
-    export function createExpressionForObjectLiteralElement(node: ObjectLiteralExpression, property: ObjectLiteralElement, receiver: Expression): Expression {
+    export function createExpressionForObjectLiteralElementLike(node: ObjectLiteralExpression, property: ObjectLiteralElementLike, receiver: Expression): Expression {
         switch (property.kind) {
             case SyntaxKind.GetAccessor:
             case SyntaxKind.SetAccessor:
@@ -2086,7 +2086,7 @@ namespace ts {
     function createExpressionForAccessorDeclaration(properties: NodeArray<Declaration>, property: AccessorDeclaration, receiver: Expression, multiLine: boolean) {
         const { firstAccessor, getAccessor, setAccessor } = getAllAccessorDeclarations(properties, property);
         if (property === firstAccessor) {
-            const properties: ObjectLiteralElement[] = [];
+            const properties: ObjectLiteralElementLike[] = [];
             if (getAccessor) {
                 const getterFunction = createFunctionExpression(
                     /*asteriskToken*/ undefined,

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -4121,7 +4121,7 @@ namespace ts {
             return undefined;
         }
 
-        function parseObjectLiteralElement(): ObjectLiteralElement {
+        function parseObjectLiteralElement(): ObjectLiteralElementLike {
             const fullStart = scanner.getStartPos();
             const decorators = parseDecorators();
             const modifiers = parseModifiers();

--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -1940,7 +1940,7 @@ namespace ts {
                 temp,
                 setNodeEmitFlags(
                     createObjectLiteral(
-                        visitNodes(properties, visitor, isObjectLiteralElement, 0, numInitialProperties),
+                        visitNodes(properties, visitor, isObjectLiteralElementLike, 0, numInitialProperties),
                         /*location*/ undefined,
                         node.multiLine
                     ),

--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -1259,7 +1259,7 @@ namespace ts {
             setNodeEmitFlags(propertyName, NodeEmitFlags.NoComments | NodeEmitFlags.NoLeadingSourceMap);
             setSourceMapRange(propertyName, firstAccessor.name);
 
-            const properties: ObjectLiteralElement[] = [];
+            const properties: ObjectLiteralElementLike[] = [];
             if (getAccessor) {
                 const getterFunction = transformFunctionLikeToExpression(getAccessor, /*location*/ undefined, /*name*/ undefined);
                 setSourceMapRange(getterFunction, getSourceMapRange(getAccessor));
@@ -2474,7 +2474,7 @@ namespace ts {
          *
          * @param node A MethodDeclaration node.
          */
-        function visitMethodDeclaration(node: MethodDeclaration): ObjectLiteralElement {
+        function visitMethodDeclaration(node: MethodDeclaration): ObjectLiteralElementLike {
             // We should only get here for methods on an object literal with regular identifier names.
             // Methods on classes are handled in visitClassDeclaration/visitClassExpression.
             // Methods with computed property names are handled in visitObjectLiteralExpression.
@@ -2493,7 +2493,7 @@ namespace ts {
          *
          * @param node A ShorthandPropertyAssignment node.
          */
-        function visitShorthandPropertyAssignment(node: ShorthandPropertyAssignment): ObjectLiteralElement {
+        function visitShorthandPropertyAssignment(node: ShorthandPropertyAssignment): ObjectLiteralElementLike {
             return createPropertyAssignment(
                 node.name,
                 getSynthesizedClone(node.name),

--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -1020,7 +1020,7 @@ namespace ts {
             const temp = declareLocal();
             emitAssignment(temp,
                 createObjectLiteral(
-                    visitNodes(properties, visitor, isObjectLiteralElement, 0, numInitialProperties),
+                    visitNodes(properties, visitor, isObjectLiteralElementLike, 0, numInitialProperties),
                     /*location*/ undefined,
                     multiLine
                 )

--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -1030,13 +1030,13 @@ namespace ts {
             expressions.push(multiLine ? startOnNewLine(getMutableClone(temp)) : temp);
             return inlineExpressions(expressions);
 
-            function reduceProperty(expressions: Expression[], property: ObjectLiteralElement) {
+            function reduceProperty(expressions: Expression[], property: ObjectLiteralElementLike) {
                 if (containsYield(property) && expressions.length > 0) {
                     emitStatement(createStatement(inlineExpressions(expressions)));
                     expressions = [];
                 }
 
-                const expression = createExpressionForObjectLiteralElement(node, property, temp);
+                const expression = createExpressionForObjectLiteralElementLike(node, property, temp);
                 const visited = visitNode(expression, visitor, isExpression);
                 if (visited) {
                     if (multiLine) {

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -850,7 +850,7 @@ namespace ts {
             return node;
         }
 
-        function substituteShorthandPropertyAssignment(node: ShorthandPropertyAssignment): ObjectLiteralElement {
+        function substituteShorthandPropertyAssignment(node: ShorthandPropertyAssignment): ObjectLiteralElementLike {
             const name = node.name;
             const exportedOrImportedName = substituteExpressionIdentifier(name);
             if (exportedOrImportedName !== name) {

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -288,7 +288,7 @@ namespace ts {
                 }
             }
 
-            const exportedNames: ObjectLiteralElement[] = [];
+            const exportedNames: ObjectLiteralElementLike[] = [];
             if (exportedLocalNames) {
                 for (const exportedLocalName of exportedLocalNames) {
                     // write name of exported declaration, i.e 'export var x...'
@@ -1107,7 +1107,7 @@ namespace ts {
             return false;
         }
 
-        function hasExportedReferenceInObjectDestructuringElement(node: ObjectLiteralElement): boolean {
+        function hasExportedReferenceInObjectDestructuringElement(node: ObjectLiteralElementLike): boolean {
             if (isShorthandPropertyAssignment(node)) {
                 return isExportedBinding(node.name);
             }

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -1560,7 +1560,7 @@ namespace ts {
 
         function addNewTypeMetadata(node: Declaration, decoratorExpressions: Expression[]) {
             if (compilerOptions.emitDecoratorMetadata) {
-                let properties: ObjectLiteralElement[];
+                let properties: ObjectLiteralElementLike[];
                 if (shouldAddTypeMetadata(node)) {
                     (properties || (properties = [])).push(createPropertyAssignment("type", createArrowFunction(/*modifiers*/ undefined, /*typeParameters*/ undefined, [], /*type*/ undefined, /*equalsGreaterThanToken*/ undefined, serializeTypeOfNode(node))));
                 }
@@ -3273,7 +3273,7 @@ namespace ts {
             return node;
         }
 
-        function substituteShorthandPropertyAssignment(node: ShorthandPropertyAssignment): ObjectLiteralElement {
+        function substituteShorthandPropertyAssignment(node: ShorthandPropertyAssignment): ObjectLiteralElementLike {
             if (enabledSubstitutions & TypeScriptSubstitutionFlags.NamespaceExports) {
                 const name = node.name;
                 const exportedName = trySubstituteNamespaceExportedName(name);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -316,7 +316,6 @@ namespace ts {
         // Property assignments
         PropertyAssignment,
         ShorthandPropertyAssignment,
-        SpreadObjectLiteralAssignment,
 
         // Enum
         EnumMember,
@@ -644,15 +643,15 @@ namespace ts {
         initializer?: Expression;           // Optional initializer
     }
 
-    export interface ObjectLiteralElementLike extends Declaration {
+    export interface ObjectLiteralElement extends Declaration {
         _objectLiteralBrandBrand: any;
         name?: PropertyName;
    }
 
-    export type ObjectLiteralElement = PropertyAssignment | ShorthandPropertyAssignment | SpreadObjectLiteralAssignment | MethodDeclaration | AccessorDeclaration;
+    export type ObjectLiteralElementLike = PropertyAssignment | ShorthandPropertyAssignment | MethodDeclaration | AccessorDeclaration;
 
     // @kind(SyntaxKind.PropertyAssignment)
-    export interface PropertyAssignment extends ObjectLiteralElementLike {
+    export interface PropertyAssignment extends ObjectLiteralElement {
         _propertyAssignmentBrand: any;
         name: PropertyName;
         questionToken?: Node;
@@ -660,19 +659,13 @@ namespace ts {
     }
 
     // @kind(SyntaxKind.ShorthandPropertyAssignment)
-    export interface ShorthandPropertyAssignment extends ObjectLiteralElementLike {
+    export interface ShorthandPropertyAssignment extends ObjectLiteralElement {
         name: Identifier;
         questionToken?: Node;
         // used when ObjectLiteralExpression is used in ObjectAssignmentPattern
         // it is grammar error to appear in actual object initializer
         equalsToken?: Node;
         objectAssignmentInitializer?: Expression;
-    }
-
-    // @kind(SyntaxKind.SpreadObjectLiteralAssignment)
-    export interface SpreadObjectLiteralAssignment extends ObjectLiteralElementLike, SpreadElementExpression {
-        _spreadObjectLiteralAssignmentBrand: any;
-        dotDotDotToken?: Node;
     }
 
     // SyntaxKind.VariableDeclaration
@@ -749,7 +742,7 @@ namespace ts {
     // at later stages of the compiler pipeline.  In that case, you can either check the parent kind
     // of the method, or use helpers like isObjectLiteralMethodDeclaration
     // @kind(SyntaxKind.MethodDeclaration)
-    export interface MethodDeclaration extends FunctionLikeDeclaration, ClassElement, ObjectLiteralElementLike {
+    export interface MethodDeclaration extends FunctionLikeDeclaration, ClassElement, ObjectLiteralElement {
         name: PropertyName;
         body?: FunctionBody;
     }
@@ -767,7 +760,7 @@ namespace ts {
 
     // See the comment on MethodDeclaration for the intuition behind AccessorDeclaration being a
     // ClassElement and an ObjectLiteralElement.
-    export interface AccessorDeclaration extends FunctionLikeDeclaration, ClassElement, ObjectLiteralElementLike {
+    export interface AccessorDeclaration extends FunctionLikeDeclaration, ClassElement, ObjectLiteralElement {
         _accessorDeclarationBrand: any;
         name: PropertyName;
         body: FunctionBody;
@@ -1063,13 +1056,13 @@ namespace ts {
       * JSXAttribute or JSXSpreadAttribute. ObjectLiteralExpression, on the other hand, can only have properties of type
       * ObjectLiteralElement (e.g. PropertyAssignment, ShorthandPropertyAssignment etc.)
      **/
-    export interface ObjectLiteralExpressionBase<T extends ObjectLiteralElementLike> extends PrimaryExpression, Declaration {
+    export interface ObjectLiteralExpressionBase<T extends ObjectLiteralElement> extends PrimaryExpression, Declaration {
         properties: NodeArray<T>;
     }
 
     // An ObjectLiteralExpression is the declaration node for an anonymous symbol.
     // @kind(SyntaxKind.ObjectLiteralExpression)
-    export interface ObjectLiteralExpression extends ObjectLiteralExpressionBase<ObjectLiteralElement> {
+    export interface ObjectLiteralExpression extends ObjectLiteralExpressionBase<ObjectLiteralElementLike> {
         /* @internal */
         multiLine?: boolean;
     }
@@ -1213,7 +1206,7 @@ namespace ts {
     export interface DebuggerStatement extends Statement { }
 
     // @kind(SyntaxKind.MissingDeclaration)
-    export interface MissingDeclaration extends DeclarationStatement, ClassElement, ObjectLiteralElementLike, TypeElement {
+    export interface MissingDeclaration extends DeclarationStatement, ClassElement, ObjectLiteralElement, TypeElement {
         name?: Identifier;
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1057,16 +1057,19 @@ namespace ts {
         expression: Expression;
     }
 
-    // The reason we create this interface so that JSXAttributes and ObjectLiteralExpression interface can extend out of it.
-    // JSXAttributes differs from normal ObjectLiteralExpression in that JSXAttributes can only take JSXAttribute or JSXSpreadAttribute
-    // but not ShortHandPropertyAssignment, methodDeclaration or other ObjectLiteralElementLike acceptable by ObjectLiteralExpression.
+    /**
+      * This interface is a base interface for ObjectLiteralExpression and JSXAttributes to extend from. JSXAttributes is similar to
+      * ObjectLiteralExpression in that it contains array of properties; however, JSXAttributes' properties can only be
+      * JSXAttribute or JSXSpreadAttribute. ObjectLiteralExpression, on the other hand, can only have properties of type
+      * ObjectLiteralElement (e.g. PropertyAssignment, ShorthandPropertyAssignment etc.)
+     **/
     export interface ObjectLiteralExpressionBase<T extends ObjectLiteralElementLike> extends PrimaryExpression, Declaration {
         properties: NodeArray<T>;
     }
 
     // An ObjectLiteralExpression is the declaration node for an anonymous symbol.
     // @kind(SyntaxKind.ObjectLiteralExpression)
-    export interface ObjectLiteralExpression extends ObjectLiteralExpressionBase<ObjectLiteralElement>{
+    export interface ObjectLiteralExpression extends ObjectLiteralExpressionBase<ObjectLiteralElement> {
         /* @internal */
         multiLine?: boolean;
     }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -643,13 +643,15 @@ namespace ts {
         initializer?: Expression;           // Optional initializer
     }
 
-    export interface ObjectLiteralElement extends Declaration {
+    export interface ObjectLiteralElementLike extends Declaration {
         _objectLiteralBrandBrand: any;
         name?: PropertyName;
    }
 
+    export type ObjectLiteralElement = PropertyAssignment | ShorthandPropertyAssignment | SpreadObjectLiteralAssignment | MethodDeclaration | AccessorDeclaration;
+
     // @kind(SyntaxKind.PropertyAssignment)
-    export interface PropertyAssignment extends ObjectLiteralElement {
+    export interface PropertyAssignment extends ObjectLiteralElementLike {
         _propertyAssignmentBrand: any;
         name: PropertyName;
         questionToken?: Node;
@@ -657,7 +659,7 @@ namespace ts {
     }
 
     // @kind(SyntaxKind.ShorthandPropertyAssignment)
-    export interface ShorthandPropertyAssignment extends ObjectLiteralElement {
+    export interface ShorthandPropertyAssignment extends ObjectLiteralElementLike {
         name: Identifier;
         questionToken?: Node;
         // used when ObjectLiteralExpression is used in ObjectAssignmentPattern
@@ -740,7 +742,7 @@ namespace ts {
     // at later stages of the compiler pipeline.  In that case, you can either check the parent kind
     // of the method, or use helpers like isObjectLiteralMethodDeclaration
     // @kind(SyntaxKind.MethodDeclaration)
-    export interface MethodDeclaration extends FunctionLikeDeclaration, ClassElement, ObjectLiteralElement {
+    export interface MethodDeclaration extends FunctionLikeDeclaration, ClassElement, ObjectLiteralElementLike {
         name: PropertyName;
         body?: FunctionBody;
     }
@@ -758,7 +760,7 @@ namespace ts {
 
     // See the comment on MethodDeclaration for the intuition behind AccessorDeclaration being a
     // ClassElement and an ObjectLiteralElement.
-    export interface AccessorDeclaration extends FunctionLikeDeclaration, ClassElement, ObjectLiteralElement {
+    export interface AccessorDeclaration extends FunctionLikeDeclaration, ClassElement, ObjectLiteralElementLike {
         _accessorDeclarationBrand: any;
         name: PropertyName;
         body: FunctionBody;
@@ -1048,10 +1050,16 @@ namespace ts {
         expression: Expression;
     }
 
+    // The reason we create this interface so that JSXAttributes and ObjectLiteralExpression interface can extend out of it.
+    // JSXAttributes differs from normal ObjectLiteralExpression in that JSXAttributes can only take JSXAttribute or JSXSpreadAttribute
+    // but not ShortHandPropertyAssignment, methodDeclaration or other ObjectLiteralElementLike acceptable by ObjectLiteralExpression.
+    export interface ObjectLiteralExpressionBase<T extends ObjectLiteralElementLike> extends PrimaryExpression, Declaration {
+        properties: NodeArray<T>;
+    }
+
     // An ObjectLiteralExpression is the declaration node for an anonymous symbol.
     // @kind(SyntaxKind.ObjectLiteralExpression)
-    export interface ObjectLiteralExpression extends PrimaryExpression, Declaration {
-        properties: NodeArray<ObjectLiteralElement>;
+    export interface ObjectLiteralExpression extends ObjectLiteralExpressionBase<ObjectLiteralElement>{
         /* @internal */
         multiLine?: boolean;
     }
@@ -1195,7 +1203,7 @@ namespace ts {
     export interface DebuggerStatement extends Statement { }
 
     // @kind(SyntaxKind.MissingDeclaration)
-    export interface MissingDeclaration extends DeclarationStatement, ClassElement, ObjectLiteralElement, TypeElement {
+    export interface MissingDeclaration extends DeclarationStatement, ClassElement, ObjectLiteralElementLike, TypeElement {
         name?: Identifier;
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -316,6 +316,7 @@ namespace ts {
         // Property assignments
         PropertyAssignment,
         ShorthandPropertyAssignment,
+        SpreadObjectLiteralAssignment,
 
         // Enum
         EnumMember,
@@ -666,6 +667,12 @@ namespace ts {
         // it is grammar error to appear in actual object initializer
         equalsToken?: Node;
         objectAssignmentInitializer?: Expression;
+    }
+
+    // @kind(SyntaxKind.SpreadObjectLiteralAssignment)
+    export interface SpreadObjectLiteralAssignment extends ObjectLiteralElementLike, SpreadElementExpression {
+        _spreadObjectLiteralAssignmentBrand: any;
+        dotDotDotToken?: Node;
     }
 
     // SyntaxKind.VariableDeclaration

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3736,7 +3736,7 @@ namespace ts {
             || kind === SyntaxKind.SemicolonClassElement;
     }
 
-    export function isObjectLiteralElement(node: Node): node is ObjectLiteralElement {
+    export function isObjectLiteralElementLike(node: Node): node is ObjectLiteralElementLike {
         const kind = node.kind;
         return kind === SyntaxKind.PropertyAssignment
             || kind === SyntaxKind.ShorthandPropertyAssignment

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -772,7 +772,7 @@ namespace ts {
 
             case SyntaxKind.ObjectLiteralExpression:
                 return updateObjectLiteral(<ObjectLiteralExpression>node,
-                    visitNodes((<ObjectLiteralExpression>node).properties, visitor, isObjectLiteralElement));
+                    visitNodes((<ObjectLiteralExpression>node).properties, visitor, isObjectLiteralElementLike));
 
             case SyntaxKind.PropertyAccessExpression:
                 return updatePropertyAccess(<PropertyAccessExpression>node,


### PR DESCRIPTION
@sandersn this is my restructure of the AST hierarchy to support  spread in JSXAttributes essentially JsxAttributes will take the following form


```typescript
export interface JsxAttributes extends ObjectLiteralExpressionBase<JsxAttributeLike> {
        _jsxAttributesBrand: any;
}

```