### PR TITLE
Fix downlevel async hoisting

### DIFF
--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -573,10 +573,10 @@ namespace ts {
             operationLocations = undefined;
             state = createTempVariable(/*recordTempVariable*/ undefined);
 
-            const statementOffset = addPrologueDirectives(statements, body.statements, /*ensureUseStrict*/ false, visitor);
-
             // Build the generator
             startLexicalEnvironment();
+
+            const statementOffset = addPrologueDirectives(statements, body.statements, /*ensureUseStrict*/ false, visitor);
 
             transformAndEmitStatements(body.statements, statementOffset);
 
@@ -615,6 +615,11 @@ namespace ts {
                 return undefined;
             }
             else {
+                // Do not hoist custom prologues.
+                if (node.emitFlags & NodeEmitFlags.CustomPrologue) {
+                    return node;
+                }
+
                 for (const variable of node.declarationList.declarations) {
                     hoistVariableDeclaration(<Identifier>variable.name);
                 }

--- a/tests/baselines/reference/asyncArrowFunction7_es5.js
+++ b/tests/baselines/reference/asyncArrowFunction7_es5.js
@@ -9,7 +9,7 @@ var bar = async (): Promise<void> => {
 //// [asyncArrowFunction7_es5.js]
 var _this = this;
 var bar = function () { return __awaiter(_this, void 0, void 0, function () {
-    _this = this;
+    var _this = this;
     var foo;
     return __generator(this, function (_a) {
         foo = function (a) {
@@ -22,4 +22,4 @@ var bar = function () { return __awaiter(_this, void 0, void 0, function () {
         };
         return [2 /*return*/];
     });
-}); var _this; };
+}); };


### PR DESCRIPTION
Fixes an issue with hoisting for `this` capturing in down-level async functions.

Fixes #11031.

