### PR TITLE
Fix some issues with module ES6/target ES5

### DIFF
--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -163,6 +163,7 @@ namespace ts {
         let currentText: string;
         let currentParent: Node;
         let currentNode: Node;
+        let enclosingVariableStatement: VariableStatement;
         let enclosingBlockScopeContainer: Node;
         let enclosingBlockScopeContainerParent: Node;
         let containingNonArrowFunction: FunctionLikeDeclaration | ClassElement;
@@ -210,6 +211,7 @@ namespace ts {
             const savedSuperScopeContainer = superScopeContainer;
             const savedCurrentParent = currentParent;
             const savedCurrentNode = currentNode;
+            const savedEnclosingVariableStatement = enclosingVariableStatement;
             const savedEnclosingBlockScopeContainer = enclosingBlockScopeContainer;
             const savedEnclosingBlockScopeContainerParent = enclosingBlockScopeContainerParent;
 
@@ -227,6 +229,7 @@ namespace ts {
             superScopeContainer = savedSuperScopeContainer;
             currentParent = savedCurrentParent;
             currentNode = savedCurrentNode;
+            enclosingVariableStatement = savedEnclosingVariableStatement;
             enclosingBlockScopeContainer = savedEnclosingBlockScopeContainer;
             enclosingBlockScopeContainerParent = savedEnclosingBlockScopeContainerParent;
             return visited;
@@ -320,7 +323,7 @@ namespace ts {
                     return visitFunctionExpression(<FunctionExpression>node);
 
                 case SyntaxKind.VariableDeclaration:
-                    return visitVariableDeclaration(<VariableDeclaration>node, /*offset*/ undefined);
+                    return visitVariableDeclaration(<VariableDeclaration>node);
 
                 case SyntaxKind.Identifier:
                     return visitIdentifier(<Identifier>node);
@@ -431,6 +434,25 @@ namespace ts {
                             superScopeContainer = containingNonArrowFunction;
                         }
                         break;
+                }
+
+                // keep track of the enclosing variable statement when in the context of
+                // variable statements, variable declarations, binding elements, and binding
+                // patterns.
+                switch (currentParent.kind) {
+                    case SyntaxKind.VariableStatement:
+                        enclosingVariableStatement = <VariableStatement>currentParent;
+                        break;
+
+                    case SyntaxKind.VariableDeclarationList:
+                    case SyntaxKind.VariableDeclaration:
+                    case SyntaxKind.BindingElement:
+                    case SyntaxKind.ObjectBindingPattern:
+                    case SyntaxKind.ArrayBindingPattern:
+                        break;
+
+                    default:
+                        enclosingVariableStatement = undefined;
                 }
             }
         }
@@ -1334,7 +1356,7 @@ namespace ts {
             return setOriginalNode(
                 createFunctionDeclaration(
                     /*decorators*/ undefined,
-                    /*modifiers*/ undefined,
+                    node.modifiers,
                     node.asteriskToken,
                     node.name,
                     /*typeParameters*/ undefined,
@@ -1663,13 +1685,13 @@ namespace ts {
          *
          * @param node A VariableDeclaration node.
          */
-        function visitVariableDeclarationInLetDeclarationList(node: VariableDeclaration, offset: number) {
+        function visitVariableDeclarationInLetDeclarationList(node: VariableDeclaration) {
             // For binding pattern names that lack initializers there is no point to emit
             // explicit initializer since downlevel codegen for destructuring will fail
             // in the absence of initializer so all binding elements will say uninitialized
             const name = node.name;
             if (isBindingPattern(name)) {
-                return visitVariableDeclaration(node, offset);
+                return visitVariableDeclaration(node);
             }
 
             if (!node.initializer && shouldEmitExplicitInitializerForLetDeclaration(node)) {
@@ -1686,10 +1708,13 @@ namespace ts {
          *
          * @param node A VariableDeclaration node.
          */
-        function visitVariableDeclaration(node: VariableDeclaration, offset: number): VisitResult<VariableDeclaration> {
+        function visitVariableDeclaration(node: VariableDeclaration): VisitResult<VariableDeclaration> {
             // If we are here it is because the name contains a binding pattern.
             if (isBindingPattern(node.name)) {
-                return flattenVariableDestructuring(context, node, /*value*/ undefined, visitor);
+                const recordTempVariablesInLine = !enclosingVariableStatement
+                    || !hasModifier(enclosingVariableStatement, ModifierFlags.Export);
+                return flattenVariableDestructuring(context, node, /*value*/ undefined, visitor,
+                    recordTempVariablesInLine ? undefined : hoistVariableDeclaration);
             }
 
             return visitEachChild(node, visitor, context);

--- a/tests/baselines/reference/es6modulekindWithES5Target6.js
+++ b/tests/baselines/reference/es6modulekindWithES5Target6.js
@@ -11,15 +11,15 @@ export default function f3(d = 0) {
 
 
 //// [es6modulekindWithES5Target6.js]
-function f1(d) {
+export function f1(d) {
     if (d === void 0) { d = 0; }
 }
-function f2() {
+export function f2() {
     var arg = [];
     for (var _i = 0; _i < arguments.length; _i++) {
         arg[_i - 0] = arguments[_i];
     }
 }
-function f3(d) {
+export default function f3(d) {
     if (d === void 0) { d = 0; }
 }

--- a/tests/baselines/reference/functionsWithModifiersInBlocks1.js
+++ b/tests/baselines/reference/functionsWithModifiersInBlocks1.js
@@ -7,5 +7,5 @@
 
 //// [functionsWithModifiersInBlocks1.js]
 {
-    function f() { }
+    export function f() { }
 }

--- a/tests/baselines/reference/moduleElementsInWrongContext.js
+++ b/tests/baselines/reference/moduleElementsInWrongContext.js
@@ -45,7 +45,7 @@
         return C;
     }());
     export default C;
-    function bee() { }
+    export function bee() { }
     import I2 = require("foo");
     import * as Foo from "ambient";
     import bar from "ambient";

--- a/tests/baselines/reference/moduleElementsInWrongContext2.js
+++ b/tests/baselines/reference/moduleElementsInWrongContext2.js
@@ -45,7 +45,7 @@ function blah() {
         return C;
     }());
     export default C;
-    function bee() { }
+    export function bee() { }
     import I2 = require("foo");
     import * as Foo from "ambient";
     import bar from "ambient";

--- a/tests/baselines/reference/parserModifierOnStatementInBlock3.js
+++ b/tests/baselines/reference/parserModifierOnStatementInBlock3.js
@@ -8,7 +8,7 @@ export function foo() {
 //// [parserModifierOnStatementInBlock3.js]
 "use strict";
 function foo() {
-    function bar() {
+    export function bar() {
     }
 }
 exports.foo = foo;

--- a/tests/baselines/reference/parserModifierOnStatementInBlock4.js
+++ b/tests/baselines/reference/parserModifierOnStatementInBlock4.js
@@ -7,6 +7,6 @@
 
 //// [parserModifierOnStatementInBlock4.js]
 {
-    function bar() {
+    export function bar() {
     }
 }


### PR DESCRIPTION
Enables additional missing scenarios for `--module ES6 --target ES5`.

Fixes #11037

