### PR TITLE
Fix missing visit of expression in for..of

### DIFF
--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -1765,7 +1765,7 @@ namespace ts {
             // Note also that because an extra statement is needed to assign to the LHS,
             // for-of bodies are always emitted as blocks.
 
-            const expression = node.expression;
+            const expression = visitNode(node.expression, visitor, isExpression);
             const initializer = node.initializer;
             const statements: Statement[] = [];
 
@@ -2014,7 +2014,7 @@ namespace ts {
                 case SyntaxKind.ForOfStatement:
                     const initializer = (<ForStatement | ForInStatement | ForOfStatement>node).initializer;
                     if (initializer && initializer.kind === SyntaxKind.VariableDeclarationList) {
-                        loopInitializer = <VariableDeclarationList>(<ForStatement | ForInStatement | ForOfStatement>node).initializer;
+                        loopInitializer = <VariableDeclarationList>initializer;
                     }
                     break;
             }

--- a/tests/baselines/reference/forOfTransformsExpression.js
+++ b/tests/baselines/reference/forOfTransformsExpression.js
@@ -1,0 +1,13 @@
+//// [forOfTransformsExpression.ts]
+// https://github.com/Microsoft/TypeScript/issues/11024
+let items = [{ name: "A" }, { name: "C" }, { name: "B" }];
+for (var item of items.sort((a, b) => a.name.localeCompare(b.name))) {
+
+}
+
+//// [forOfTransformsExpression.js]
+// https://github.com/Microsoft/TypeScript/issues/11024
+var items = [{ name: "A" }, { name: "C" }, { name: "B" }];
+for (var _i = 0, _a = items.sort(function (a, b) { return a.name.localeCompare(b.name); }); _i < _a.length; _i++) {
+    var item = _a[_i];
+}

--- a/tests/baselines/reference/forOfTransformsExpression.symbols
+++ b/tests/baselines/reference/forOfTransformsExpression.symbols
@@ -1,0 +1,25 @@
+=== tests/cases/compiler/forOfTransformsExpression.ts ===
+// https://github.com/Microsoft/TypeScript/issues/11024
+let items = [{ name: "A" }, { name: "C" }, { name: "B" }];
+>items : Symbol(items, Decl(forOfTransformsExpression.ts, 1, 3))
+>name : Symbol(name, Decl(forOfTransformsExpression.ts, 1, 14))
+>name : Symbol(name, Decl(forOfTransformsExpression.ts, 1, 29))
+>name : Symbol(name, Decl(forOfTransformsExpression.ts, 1, 44))
+
+for (var item of items.sort((a, b) => a.name.localeCompare(b.name))) {
+>item : Symbol(item, Decl(forOfTransformsExpression.ts, 2, 8))
+>items.sort : Symbol(Array.sort, Decl(lib.d.ts, --, --))
+>items : Symbol(items, Decl(forOfTransformsExpression.ts, 1, 3))
+>sort : Symbol(Array.sort, Decl(lib.d.ts, --, --))
+>a : Symbol(a, Decl(forOfTransformsExpression.ts, 2, 29))
+>b : Symbol(b, Decl(forOfTransformsExpression.ts, 2, 31))
+>a.name.localeCompare : Symbol(String.localeCompare, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>a.name : Symbol(name, Decl(forOfTransformsExpression.ts, 1, 14))
+>a : Symbol(a, Decl(forOfTransformsExpression.ts, 2, 29))
+>name : Symbol(name, Decl(forOfTransformsExpression.ts, 1, 14))
+>localeCompare : Symbol(String.localeCompare, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>b.name : Symbol(name, Decl(forOfTransformsExpression.ts, 1, 14))
+>b : Symbol(b, Decl(forOfTransformsExpression.ts, 2, 31))
+>name : Symbol(name, Decl(forOfTransformsExpression.ts, 1, 14))
+
+}

--- a/tests/baselines/reference/forOfTransformsExpression.types
+++ b/tests/baselines/reference/forOfTransformsExpression.types
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/forOfTransformsExpression.ts ===
+// https://github.com/Microsoft/TypeScript/issues/11024
+let items = [{ name: "A" }, { name: "C" }, { name: "B" }];
+>items : { name: string; }[]
+>[{ name: "A" }, { name: "C" }, { name: "B" }] : { name: string; }[]
+>{ name: "A" } : { name: string; }
+>name : string
+>"A" : "A"
+>{ name: "C" } : { name: string; }
+>name : string
+>"C" : "C"
+>{ name: "B" } : { name: string; }
+>name : string
+>"B" : "B"
+
+for (var item of items.sort((a, b) => a.name.localeCompare(b.name))) {
+>item : { name: string; }
+>items.sort((a, b) => a.name.localeCompare(b.name)) : { name: string; }[]
+>items.sort : (compareFn?: (a: { name: string; }, b: { name: string; }) => number) => { name: string; }[]
+>items : { name: string; }[]
+>sort : (compareFn?: (a: { name: string; }, b: { name: string; }) => number) => { name: string; }[]
+>(a, b) => a.name.localeCompare(b.name) : (a: { name: string; }, b: { name: string; }) => number
+>a : { name: string; }
+>b : { name: string; }
+>a.name.localeCompare(b.name) : number
+>a.name.localeCompare : { (that: string): number; (that: string, locales?: string | string[], options?: Intl.CollatorOptions): number; }
+>a.name : string
+>a : { name: string; }
+>name : string
+>localeCompare : { (that: string): number; (that: string, locales?: string | string[], options?: Intl.CollatorOptions): number; }
+>b.name : string
+>b : { name: string; }
+>name : string
+
+}

--- a/tests/cases/compiler/forOfTransformsExpression.ts
+++ b/tests/cases/compiler/forOfTransformsExpression.ts
@@ -1,0 +1,5 @@
+// https://github.com/Microsoft/TypeScript/issues/11024
+let items = [{ name: "A" }, { name: "C" }, { name: "B" }];
+for (var item of items.sort((a, b) => a.name.localeCompare(b.name))) {
+
+}


### PR DESCRIPTION
Fixes an issue where the es6 transformer was not visiting the `expression` of a `ForOfStatement`.

Fixes #11024

