### PR TITLE
Fix misleading error TS2410 from issue #10601

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16499,7 +16499,13 @@ namespace ts {
             }
 
             checkExpression(node.expression);
-            error(node.expression, Diagnostics.All_symbols_within_a_with_block_will_be_resolved_to_any);
+
+            const sourceFile = getSourceFileOfNode(node);
+            if (!hasParseDiagnostics(sourceFile)) {
+                const start = getSpanOfTokenAtPosition(sourceFile, node.pos).start;
+                const end = node.statement.pos;
+                grammarErrorAtPos(sourceFile, start, end - start, Diagnostics.Unsupported_with_statement_all_symbols_within_a_with_block_will_be_resolved_to_any);
+            }
         }
 
         function checkSwitchStatement(node: SwitchStatement) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16504,7 +16504,7 @@ namespace ts {
             if (!hasParseDiagnostics(sourceFile)) {
                 const start = getSpanOfTokenAtPosition(sourceFile, node.pos).start;
                 const end = node.statement.pos;
-                grammarErrorAtPos(sourceFile, start, end - start, Diagnostics.Unsupported_with_statement_all_symbols_within_a_with_block_will_be_resolved_to_any);
+                grammarErrorAtPos(sourceFile, start, end - start, Diagnostics.The_with_statement_is_not_supported_All_symbols_in_a_with_block_will_have_type_any);
             }
         }
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1279,7 +1279,7 @@
         "category": "Error",
         "code": 2409
     },
-    "Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.": {
+    "The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.": {
         "category": "Error",
         "code": 2410
     },

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1279,7 +1279,7 @@
         "category": "Error",
         "code": 2409
     },
-    "All symbols within a 'with' block will be resolved to 'any'.": {
+    "Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.": {
         "category": "Error",
         "code": 2410
     },

--- a/tests/baselines/reference/ambientWithStatements.errors.txt
+++ b/tests/baselines/reference/ambientWithStatements.errors.txt
@@ -2,7 +2,7 @@ tests/cases/compiler/ambientWithStatements.ts(2,5): error TS1036: Statements are
 tests/cases/compiler/ambientWithStatements.ts(3,5): error TS1104: A 'continue' statement can only be used within an enclosing iteration statement.
 tests/cases/compiler/ambientWithStatements.ts(7,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 tests/cases/compiler/ambientWithStatements.ts(11,5): error TS1108: A 'return' statement can only be used within a function body.
-tests/cases/compiler/ambientWithStatements.ts(25,5): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/ambientWithStatements.ts(25,5): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
 
 ==== tests/cases/compiler/ambientWithStatements.ts (5 errors) ====
@@ -40,6 +40,6 @@ tests/cases/compiler/ambientWithStatements.ts(25,5): error TS2410: Unsupported '
         }
         with (x) {
         ~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
         }
     }

--- a/tests/baselines/reference/ambientWithStatements.errors.txt
+++ b/tests/baselines/reference/ambientWithStatements.errors.txt
@@ -2,7 +2,7 @@ tests/cases/compiler/ambientWithStatements.ts(2,5): error TS1036: Statements are
 tests/cases/compiler/ambientWithStatements.ts(3,5): error TS1104: A 'continue' statement can only be used within an enclosing iteration statement.
 tests/cases/compiler/ambientWithStatements.ts(7,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 tests/cases/compiler/ambientWithStatements.ts(11,5): error TS1108: A 'return' statement can only be used within a function body.
-tests/cases/compiler/ambientWithStatements.ts(25,11): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/ambientWithStatements.ts(25,5): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 
 
 ==== tests/cases/compiler/ambientWithStatements.ts (5 errors) ====
@@ -39,7 +39,7 @@ tests/cases/compiler/ambientWithStatements.ts(25,11): error TS2410: All symbols 
         finally {
         }
         with (x) {
-              ~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+        ~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
         }
     }

--- a/tests/baselines/reference/arrowFunctionContexts.errors.txt
+++ b/tests/baselines/reference/arrowFunctionContexts.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(3,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(3,1): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(3,7): error TS2304: Cannot find name 'window'.
 tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(19,1): error TS2304: Cannot find name 'window'.
 tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(31,9): error TS2322: Type '() => number' is not assignable to type 'E'.
 tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(32,16): error TS2332: 'this' cannot be referenced in current location.
-tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(44,5): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(44,5): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(44,11): error TS2304: Cannot find name 'window'.
 tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(60,5): error TS2304: Cannot find name 'window'.
 tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(72,13): error TS2322: Type '() => number' is not assignable to type 'E'.
@@ -15,7 +15,7 @@ tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(73,20): e
     // Arrow function used in with statement
     with (window) {
     ~~~~~~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
           ~~~~~~
 !!! error TS2304: Cannot find name 'window'.
         var p = () => this;
@@ -66,7 +66,7 @@ tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(73,20): e
         // Arrow function used in with statement
         with (window) {
         ~~~~~~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
               ~~~~~~
 !!! error TS2304: Cannot find name 'window'.
             var p = () => this;

--- a/tests/baselines/reference/arrowFunctionContexts.errors.txt
+++ b/tests/baselines/reference/arrowFunctionContexts.errors.txt
@@ -1,10 +1,10 @@
+tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(3,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(3,7): error TS2304: Cannot find name 'window'.
-tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(3,7): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
 tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(19,1): error TS2304: Cannot find name 'window'.
 tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(31,9): error TS2322: Type '() => number' is not assignable to type 'E'.
 tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(32,16): error TS2332: 'this' cannot be referenced in current location.
+tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(44,5): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(44,11): error TS2304: Cannot find name 'window'.
-tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(44,11): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
 tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(60,5): error TS2304: Cannot find name 'window'.
 tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(72,13): error TS2322: Type '() => number' is not assignable to type 'E'.
 tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(73,20): error TS2332: 'this' cannot be referenced in current location.
@@ -14,10 +14,10 @@ tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(73,20): e
     
     // Arrow function used in with statement
     with (window) {
+    ~~~~~~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
           ~~~~~~
 !!! error TS2304: Cannot find name 'window'.
-          ~~~~~~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
         var p = () => this;
     }
     
@@ -65,10 +65,10 @@ tests/cases/conformance/expressions/functions/arrowFunctionContexts.ts(73,20): e
     module M2 {
         // Arrow function used in with statement
         with (window) {
+        ~~~~~~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
               ~~~~~~
 !!! error TS2304: Cannot find name 'window'.
-              ~~~~~~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
             var p = () => this;
         }
     

--- a/tests/baselines/reference/constDeclarations-invalidContexts.errors.txt
+++ b/tests/baselines/reference/constDeclarations-invalidContexts.errors.txt
@@ -2,7 +2,7 @@ tests/cases/compiler/constDeclarations-invalidContexts.ts(4,5): error TS1156: 'c
 tests/cases/compiler/constDeclarations-invalidContexts.ts(6,5): error TS1156: 'const' declarations can only be declared inside a block.
 tests/cases/compiler/constDeclarations-invalidContexts.ts(9,5): error TS1156: 'const' declarations can only be declared inside a block.
 tests/cases/compiler/constDeclarations-invalidContexts.ts(12,5): error TS1156: 'const' declarations can only be declared inside a block.
-tests/cases/compiler/constDeclarations-invalidContexts.ts(16,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/constDeclarations-invalidContexts.ts(16,1): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 tests/cases/compiler/constDeclarations-invalidContexts.ts(20,5): error TS1156: 'const' declarations can only be declared inside a block.
 tests/cases/compiler/constDeclarations-invalidContexts.ts(23,5): error TS1156: 'const' declarations can only be declared inside a block.
 tests/cases/compiler/constDeclarations-invalidContexts.ts(26,12): error TS1156: 'const' declarations can only be declared inside a block.
@@ -35,7 +35,7 @@ tests/cases/compiler/constDeclarations-invalidContexts.ts(29,29): error TS1156: 
     var obj;
     with (obj) 
     ~~~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
         const c5 = 0;  // No  Error will be reported here since we turn off all type checking
     
     for (var i = 0; i < 10; i++)

--- a/tests/baselines/reference/constDeclarations-invalidContexts.errors.txt
+++ b/tests/baselines/reference/constDeclarations-invalidContexts.errors.txt
@@ -2,7 +2,7 @@ tests/cases/compiler/constDeclarations-invalidContexts.ts(4,5): error TS1156: 'c
 tests/cases/compiler/constDeclarations-invalidContexts.ts(6,5): error TS1156: 'const' declarations can only be declared inside a block.
 tests/cases/compiler/constDeclarations-invalidContexts.ts(9,5): error TS1156: 'const' declarations can only be declared inside a block.
 tests/cases/compiler/constDeclarations-invalidContexts.ts(12,5): error TS1156: 'const' declarations can only be declared inside a block.
-tests/cases/compiler/constDeclarations-invalidContexts.ts(16,7): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/constDeclarations-invalidContexts.ts(16,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 tests/cases/compiler/constDeclarations-invalidContexts.ts(20,5): error TS1156: 'const' declarations can only be declared inside a block.
 tests/cases/compiler/constDeclarations-invalidContexts.ts(23,5): error TS1156: 'const' declarations can only be declared inside a block.
 tests/cases/compiler/constDeclarations-invalidContexts.ts(26,12): error TS1156: 'const' declarations can only be declared inside a block.
@@ -34,8 +34,8 @@ tests/cases/compiler/constDeclarations-invalidContexts.ts(29,29): error TS1156: 
     
     var obj;
     with (obj) 
-          ~~~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+    ~~~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
         const c5 = 0;  // No  Error will be reported here since we turn off all type checking
     
     for (var i = 0; i < 10; i++)

--- a/tests/baselines/reference/constDeclarations-scopes.errors.txt
+++ b/tests/baselines/reference/constDeclarations-scopes.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/constDeclarations-scopes.ts(13,5): error TS7027: Unreachable code detected.
 tests/cases/compiler/constDeclarations-scopes.ts(22,1): error TS7027: Unreachable code detected.
-tests/cases/compiler/constDeclarations-scopes.ts(28,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/constDeclarations-scopes.ts(28,1): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
 
 ==== tests/cases/compiler/constDeclarations-scopes.ts (3 errors) ====
@@ -37,7 +37,7 @@ tests/cases/compiler/constDeclarations-scopes.ts(28,1): error TS2410: Unsupporte
     var obj;
     with (obj) {
     ~~~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
         const c = 0;
         n = c;
     }

--- a/tests/baselines/reference/constDeclarations-scopes.errors.txt
+++ b/tests/baselines/reference/constDeclarations-scopes.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/constDeclarations-scopes.ts(13,5): error TS7027: Unreachable code detected.
 tests/cases/compiler/constDeclarations-scopes.ts(22,1): error TS7027: Unreachable code detected.
-tests/cases/compiler/constDeclarations-scopes.ts(28,7): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/constDeclarations-scopes.ts(28,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 
 
 ==== tests/cases/compiler/constDeclarations-scopes.ts (3 errors) ====
@@ -36,8 +36,8 @@ tests/cases/compiler/constDeclarations-scopes.ts(28,7): error TS2410: All symbol
     
     var obj;
     with (obj) {
-          ~~~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+    ~~~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
         const c = 0;
         n = c;
     }

--- a/tests/baselines/reference/constDeclarations-validContexts.errors.txt
+++ b/tests/baselines/reference/constDeclarations-validContexts.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/constDeclarations-validContexts.ts(20,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/constDeclarations-validContexts.ts(20,1): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
 
 ==== tests/cases/compiler/constDeclarations-validContexts.ts (1 errors) ====
@@ -23,7 +23,7 @@ tests/cases/compiler/constDeclarations-validContexts.ts(20,1): error TS2410: Uns
     var obj;
     with (obj) {
     ~~~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
         const c5 = 0;
     }
     

--- a/tests/baselines/reference/constDeclarations-validContexts.errors.txt
+++ b/tests/baselines/reference/constDeclarations-validContexts.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/constDeclarations-validContexts.ts(20,7): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/constDeclarations-validContexts.ts(20,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 
 
 ==== tests/cases/compiler/constDeclarations-validContexts.ts (1 errors) ====
@@ -22,8 +22,8 @@ tests/cases/compiler/constDeclarations-validContexts.ts(20,7): error TS2410: All
     
     var obj;
     with (obj) {
-          ~~~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+    ~~~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
         const c5 = 0;
     }
     

--- a/tests/baselines/reference/es5-asyncFunctionWithStatements.errors.txt
+++ b/tests/baselines/reference/es5-asyncFunctionWithStatements.errors.txt
@@ -1,11 +1,11 @@
 tests/cases/compiler/es5-asyncFunctionWithStatements.ts(4,5): error TS1300: 'with' statements are not allowed in an async function block.
-tests/cases/compiler/es5-asyncFunctionWithStatements.ts(4,5): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/es5-asyncFunctionWithStatements.ts(4,5): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 tests/cases/compiler/es5-asyncFunctionWithStatements.ts(10,5): error TS1300: 'with' statements are not allowed in an async function block.
-tests/cases/compiler/es5-asyncFunctionWithStatements.ts(10,5): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/es5-asyncFunctionWithStatements.ts(10,5): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 tests/cases/compiler/es5-asyncFunctionWithStatements.ts(16,5): error TS1300: 'with' statements are not allowed in an async function block.
-tests/cases/compiler/es5-asyncFunctionWithStatements.ts(16,5): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/es5-asyncFunctionWithStatements.ts(16,5): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 tests/cases/compiler/es5-asyncFunctionWithStatements.ts(24,5): error TS1300: 'with' statements are not allowed in an async function block.
-tests/cases/compiler/es5-asyncFunctionWithStatements.ts(24,5): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/es5-asyncFunctionWithStatements.ts(24,5): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
 
 ==== tests/cases/compiler/es5-asyncFunctionWithStatements.ts (8 errors) ====
@@ -16,7 +16,7 @@ tests/cases/compiler/es5-asyncFunctionWithStatements.ts(24,5): error TS2410: Uns
         ~~~~
 !!! error TS1300: 'with' statements are not allowed in an async function block.
         ~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
             y;
         }
     }
@@ -26,7 +26,7 @@ tests/cases/compiler/es5-asyncFunctionWithStatements.ts(24,5): error TS2410: Uns
         ~~~~
 !!! error TS1300: 'with' statements are not allowed in an async function block.
         ~~~~~~~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
             y;
         }
     }
@@ -36,7 +36,7 @@ tests/cases/compiler/es5-asyncFunctionWithStatements.ts(24,5): error TS2410: Uns
         ~~~~
 !!! error TS1300: 'with' statements are not allowed in an async function block.
         ~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
             a;
             await y;
             b;
@@ -48,7 +48,7 @@ tests/cases/compiler/es5-asyncFunctionWithStatements.ts(24,5): error TS2410: Uns
         ~~~~
 !!! error TS1300: 'with' statements are not allowed in an async function block.
         ~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
             with (z) {
                 a;
                 await y;

--- a/tests/baselines/reference/es5-asyncFunctionWithStatements.errors.txt
+++ b/tests/baselines/reference/es5-asyncFunctionWithStatements.errors.txt
@@ -1,11 +1,11 @@
 tests/cases/compiler/es5-asyncFunctionWithStatements.ts(4,5): error TS1300: 'with' statements are not allowed in an async function block.
-tests/cases/compiler/es5-asyncFunctionWithStatements.ts(4,11): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/es5-asyncFunctionWithStatements.ts(4,5): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 tests/cases/compiler/es5-asyncFunctionWithStatements.ts(10,5): error TS1300: 'with' statements are not allowed in an async function block.
-tests/cases/compiler/es5-asyncFunctionWithStatements.ts(10,11): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/es5-asyncFunctionWithStatements.ts(10,5): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 tests/cases/compiler/es5-asyncFunctionWithStatements.ts(16,5): error TS1300: 'with' statements are not allowed in an async function block.
-tests/cases/compiler/es5-asyncFunctionWithStatements.ts(16,11): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/es5-asyncFunctionWithStatements.ts(16,5): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 tests/cases/compiler/es5-asyncFunctionWithStatements.ts(24,5): error TS1300: 'with' statements are not allowed in an async function block.
-tests/cases/compiler/es5-asyncFunctionWithStatements.ts(24,11): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/es5-asyncFunctionWithStatements.ts(24,5): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 
 
 ==== tests/cases/compiler/es5-asyncFunctionWithStatements.ts (8 errors) ====
@@ -15,8 +15,8 @@ tests/cases/compiler/es5-asyncFunctionWithStatements.ts(24,11): error TS2410: Al
         with (x) {
         ~~~~
 !!! error TS1300: 'with' statements are not allowed in an async function block.
-              ~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+        ~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
             y;
         }
     }
@@ -25,8 +25,8 @@ tests/cases/compiler/es5-asyncFunctionWithStatements.ts(24,11): error TS2410: Al
         with (await x) {
         ~~~~
 !!! error TS1300: 'with' statements are not allowed in an async function block.
-              ~~~~~~~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+        ~~~~~~~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
             y;
         }
     }
@@ -35,8 +35,8 @@ tests/cases/compiler/es5-asyncFunctionWithStatements.ts(24,11): error TS2410: Al
         with (x) {
         ~~~~
 !!! error TS1300: 'with' statements are not allowed in an async function block.
-              ~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+        ~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
             a;
             await y;
             b;
@@ -47,8 +47,8 @@ tests/cases/compiler/es5-asyncFunctionWithStatements.ts(24,11): error TS2410: Al
         with (x) {
         ~~~~
 !!! error TS1300: 'with' statements are not allowed in an async function block.
-              ~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+        ~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
             with (z) {
                 a;
                 await y;

--- a/tests/baselines/reference/functionExpressionInWithBlock.errors.txt
+++ b/tests/baselines/reference/functionExpressionInWithBlock.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/compiler/functionExpressionInWithBlock.ts(2,7): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/functionExpressionInWithBlock.ts(2,2): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 
 
 ==== tests/cases/compiler/functionExpressionInWithBlock.ts (1 errors) ====
     function x() {
      with({}) {
-          ~~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+     ~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
       function f() {
        () => this;
       }

--- a/tests/baselines/reference/functionExpressionInWithBlock.errors.txt
+++ b/tests/baselines/reference/functionExpressionInWithBlock.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/compiler/functionExpressionInWithBlock.ts(2,2): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/functionExpressionInWithBlock.ts(2,2): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
 
 ==== tests/cases/compiler/functionExpressionInWithBlock.ts (1 errors) ====
     function x() {
      with({}) {
      ~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
       function f() {
        () => this;
       }

--- a/tests/baselines/reference/letDeclarations-invalidContexts.errors.txt
+++ b/tests/baselines/reference/letDeclarations-invalidContexts.errors.txt
@@ -2,7 +2,7 @@ tests/cases/compiler/letDeclarations-invalidContexts.ts(5,5): error TS1157: 'let
 tests/cases/compiler/letDeclarations-invalidContexts.ts(7,5): error TS1157: 'let' declarations can only be declared inside a block.
 tests/cases/compiler/letDeclarations-invalidContexts.ts(10,5): error TS1157: 'let' declarations can only be declared inside a block.
 tests/cases/compiler/letDeclarations-invalidContexts.ts(13,5): error TS1157: 'let' declarations can only be declared inside a block.
-tests/cases/compiler/letDeclarations-invalidContexts.ts(17,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/letDeclarations-invalidContexts.ts(17,1): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 tests/cases/compiler/letDeclarations-invalidContexts.ts(21,5): error TS1157: 'let' declarations can only be declared inside a block.
 tests/cases/compiler/letDeclarations-invalidContexts.ts(24,5): error TS1157: 'let' declarations can only be declared inside a block.
 tests/cases/compiler/letDeclarations-invalidContexts.ts(27,12): error TS1157: 'let' declarations can only be declared inside a block.
@@ -36,7 +36,7 @@ tests/cases/compiler/letDeclarations-invalidContexts.ts(30,29): error TS1157: 'l
     var obj;
     with (obj) 
     ~~~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
         let l5 = 0;
     
     for (var i = 0; i < 10; i++)

--- a/tests/baselines/reference/letDeclarations-invalidContexts.errors.txt
+++ b/tests/baselines/reference/letDeclarations-invalidContexts.errors.txt
@@ -2,7 +2,7 @@ tests/cases/compiler/letDeclarations-invalidContexts.ts(5,5): error TS1157: 'let
 tests/cases/compiler/letDeclarations-invalidContexts.ts(7,5): error TS1157: 'let' declarations can only be declared inside a block.
 tests/cases/compiler/letDeclarations-invalidContexts.ts(10,5): error TS1157: 'let' declarations can only be declared inside a block.
 tests/cases/compiler/letDeclarations-invalidContexts.ts(13,5): error TS1157: 'let' declarations can only be declared inside a block.
-tests/cases/compiler/letDeclarations-invalidContexts.ts(17,7): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/letDeclarations-invalidContexts.ts(17,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 tests/cases/compiler/letDeclarations-invalidContexts.ts(21,5): error TS1157: 'let' declarations can only be declared inside a block.
 tests/cases/compiler/letDeclarations-invalidContexts.ts(24,5): error TS1157: 'let' declarations can only be declared inside a block.
 tests/cases/compiler/letDeclarations-invalidContexts.ts(27,12): error TS1157: 'let' declarations can only be declared inside a block.
@@ -35,8 +35,8 @@ tests/cases/compiler/letDeclarations-invalidContexts.ts(30,29): error TS1157: 'l
     
     var obj;
     with (obj) 
-          ~~~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+    ~~~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
         let l5 = 0;
     
     for (var i = 0; i < 10; i++)

--- a/tests/baselines/reference/letDeclarations-scopes.errors.txt
+++ b/tests/baselines/reference/letDeclarations-scopes.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/letDeclarations-scopes.ts(29,7): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/letDeclarations-scopes.ts(29,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 
 
 ==== tests/cases/compiler/letDeclarations-scopes.ts (1 errors) ====
@@ -31,8 +31,8 @@ tests/cases/compiler/letDeclarations-scopes.ts(29,7): error TS2410: All symbols 
     
     var obj;
     with (obj) {
-          ~~~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+    ~~~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
         let l = 0;
         n = l;
     }

--- a/tests/baselines/reference/letDeclarations-scopes.errors.txt
+++ b/tests/baselines/reference/letDeclarations-scopes.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/letDeclarations-scopes.ts(29,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/letDeclarations-scopes.ts(29,1): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
 
 ==== tests/cases/compiler/letDeclarations-scopes.ts (1 errors) ====
@@ -32,7 +32,7 @@ tests/cases/compiler/letDeclarations-scopes.ts(29,1): error TS2410: Unsupported 
     var obj;
     with (obj) {
     ~~~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
         let l = 0;
         n = l;
     }

--- a/tests/baselines/reference/letDeclarations-validContexts.errors.txt
+++ b/tests/baselines/reference/letDeclarations-validContexts.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/letDeclarations-validContexts.ts(21,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/letDeclarations-validContexts.ts(21,1): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
 
 ==== tests/cases/compiler/letDeclarations-validContexts.ts (1 errors) ====
@@ -24,7 +24,7 @@ tests/cases/compiler/letDeclarations-validContexts.ts(21,1): error TS2410: Unsup
     var obj;
     with (obj) {
     ~~~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
         let l5 = 0;
     }
     

--- a/tests/baselines/reference/letDeclarations-validContexts.errors.txt
+++ b/tests/baselines/reference/letDeclarations-validContexts.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/letDeclarations-validContexts.ts(21,7): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/letDeclarations-validContexts.ts(21,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 
 
 ==== tests/cases/compiler/letDeclarations-validContexts.ts (1 errors) ====
@@ -23,8 +23,8 @@ tests/cases/compiler/letDeclarations-validContexts.ts(21,7): error TS2410: All s
     
     var obj;
     with (obj) {
-          ~~~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+    ~~~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
         let l5 = 0;
     }
     

--- a/tests/baselines/reference/parserStrictMode14.errors.txt
+++ b/tests/baselines/reference/parserStrictMode14.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode14.ts(2,1): error TS1101: 'with' statements are not allowed in strict mode.
-tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode14.ts(2,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode14.ts(2,1): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode14.ts(2,7): error TS2304: Cannot find name 'a'.
 
 
@@ -9,7 +9,7 @@ tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode14.ts(2,7)
     ~~~~
 !!! error TS1101: 'with' statements are not allowed in strict mode.
     ~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
           ~
 !!! error TS2304: Cannot find name 'a'.
     }

--- a/tests/baselines/reference/parserStrictMode14.errors.txt
+++ b/tests/baselines/reference/parserStrictMode14.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode14.ts(2,1): error TS1101: 'with' statements are not allowed in strict mode.
+tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode14.ts(2,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode14.ts(2,7): error TS2304: Cannot find name 'a'.
-tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode14.ts(2,7): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode14.ts (3 errors) ====
@@ -8,8 +8,8 @@ tests/cases/conformance/parser/ecmascript5/StrictMode/parserStrictMode14.ts(2,7)
     with (a) {
     ~~~~
 !!! error TS1101: 'with' statements are not allowed in strict mode.
+    ~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
           ~
 !!! error TS2304: Cannot find name 'a'.
-          ~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
     }

--- a/tests/baselines/reference/parserWithStatement1.d.errors.txt
+++ b/tests/baselines/reference/parserWithStatement1.d.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement1.d.ts(1,1): error TS1036: Statements are not allowed in ambient contexts.
-tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement1.d.ts(1,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement1.d.ts(1,1): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement1.d.ts(1,7): error TS2304: Cannot find name 'foo'.
 
 
@@ -8,7 +8,7 @@ tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement1.d.ts(
     ~~~~
 !!! error TS1036: Statements are not allowed in ambient contexts.
     ~~~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
           ~~~
 !!! error TS2304: Cannot find name 'foo'.
     }

--- a/tests/baselines/reference/parserWithStatement1.d.errors.txt
+++ b/tests/baselines/reference/parserWithStatement1.d.errors.txt
@@ -1,14 +1,14 @@
 tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement1.d.ts(1,1): error TS1036: Statements are not allowed in ambient contexts.
+tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement1.d.ts(1,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement1.d.ts(1,7): error TS2304: Cannot find name 'foo'.
-tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement1.d.ts(1,7): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement1.d.ts (3 errors) ====
     with (foo) {
     ~~~~
 !!! error TS1036: Statements are not allowed in ambient contexts.
+    ~~~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
           ~~~
 !!! error TS2304: Cannot find name 'foo'.
-          ~~~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
     }

--- a/tests/baselines/reference/parserWithStatement2.errors.txt
+++ b/tests/baselines/reference/parserWithStatement2.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement2.ts(1,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement2.ts(1,1): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement2.ts (1 errors) ====
     with (1)
     ~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
       return;

--- a/tests/baselines/reference/parserWithStatement2.errors.txt
+++ b/tests/baselines/reference/parserWithStatement2.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement2.ts(1,7): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement2.ts(1,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/Statements/parserWithStatement2.ts (1 errors) ====
     with (1)
-          ~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+    ~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
       return;

--- a/tests/baselines/reference/sourceMapValidationStatements.errors.txt
+++ b/tests/baselines/reference/sourceMapValidationStatements.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/sourceMapValidationStatements.ts(43,5): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/sourceMapValidationStatements.ts(43,5): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
 
 ==== tests/cases/compiler/sourceMapValidationStatements.ts (1 errors) ====
@@ -46,7 +46,7 @@ tests/cases/compiler/sourceMapValidationStatements.ts(43,5): error TS2410: Unsup
         }
         with (obj) {
         ~~~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
             i = 2;
             z = 10;
         }

--- a/tests/baselines/reference/sourceMapValidationStatements.errors.txt
+++ b/tests/baselines/reference/sourceMapValidationStatements.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/sourceMapValidationStatements.ts(43,11): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/sourceMapValidationStatements.ts(43,5): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 
 
 ==== tests/cases/compiler/sourceMapValidationStatements.ts (1 errors) ====
@@ -45,8 +45,8 @@ tests/cases/compiler/sourceMapValidationStatements.ts(43,11): error TS2410: All 
             y = 70;
         }
         with (obj) {
-              ~~~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+        ~~~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
             i = 2;
             z = 10;
         }

--- a/tests/baselines/reference/superCallsInConstructor.errors.txt
+++ b/tests/baselines/reference/superCallsInConstructor.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/superCallsInConstructor.ts(12,9): error TS1101: 'with' statements are not allowed in strict mode.
-tests/cases/compiler/superCallsInConstructor.ts(12,9): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/superCallsInConstructor.ts(12,9): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
 
 ==== tests/cases/compiler/superCallsInConstructor.ts (2 errors) ====
@@ -18,7 +18,7 @@ tests/cases/compiler/superCallsInConstructor.ts(12,9): error TS2410: Unsupported
             ~~~~
 !!! error TS1101: 'with' statements are not allowed in strict mode.
             ~~~~~~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
                 foo();
                 super();
                 bar();

--- a/tests/baselines/reference/superCallsInConstructor.errors.txt
+++ b/tests/baselines/reference/superCallsInConstructor.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/compiler/superCallsInConstructor.ts(12,9): error TS1101: 'with' statements are not allowed in strict mode.
-tests/cases/compiler/superCallsInConstructor.ts(12,14): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/superCallsInConstructor.ts(12,9): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 
 
 ==== tests/cases/compiler/superCallsInConstructor.ts (2 errors) ====
@@ -17,8 +17,8 @@ tests/cases/compiler/superCallsInConstructor.ts(12,14): error TS2410: All symbol
             with(new C()) {
             ~~~~
 !!! error TS1101: 'with' statements are not allowed in strict mode.
-                 ~~~~~~~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+            ~~~~~~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
                 foo();
                 super();
                 bar();

--- a/tests/baselines/reference/withStatement.errors.txt
+++ b/tests/baselines/reference/withStatement.errors.txt
@@ -1,12 +1,12 @@
-tests/cases/compiler/withStatement.ts(3,7): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/withStatement.ts(3,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 
 
 ==== tests/cases/compiler/withStatement.ts (1 errors) ====
     declare var ooo:any;
     
     with (ooo.eee.oo.ah_ah.ting.tang.walla.walla) { // error
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
         bing = true; // no error
         bang = true; // no error
         

--- a/tests/baselines/reference/withStatement.errors.txt
+++ b/tests/baselines/reference/withStatement.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/withStatement.ts(3,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/withStatement.ts(3,1): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
 
 ==== tests/cases/compiler/withStatement.ts (1 errors) ====
@@ -6,7 +6,7 @@ tests/cases/compiler/withStatement.ts(3,1): error TS2410: Unsupported 'with' sta
     
     with (ooo.eee.oo.ah_ah.ting.tang.walla.walla) { // error
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
         bing = true; // no error
         bang = true; // no error
         

--- a/tests/baselines/reference/withStatementErrors.errors.txt
+++ b/tests/baselines/reference/withStatementErrors.errors.txt
@@ -1,12 +1,12 @@
-tests/cases/compiler/withStatementErrors.ts(3,7): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/withStatementErrors.ts(3,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 
 
 ==== tests/cases/compiler/withStatementErrors.ts (1 errors) ====
     declare var ooo:any;
     
     with (ooo.eee.oo.ah_ah.ting.tang.walla.walla) { // error
-          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
         bing = true; // no error
         bang = true; // no error
         

--- a/tests/baselines/reference/withStatementErrors.errors.txt
+++ b/tests/baselines/reference/withStatementErrors.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/withStatementErrors.ts(3,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/withStatementErrors.ts(3,1): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
 
 ==== tests/cases/compiler/withStatementErrors.ts (1 errors) ====
@@ -6,7 +6,7 @@ tests/cases/compiler/withStatementErrors.ts(3,1): error TS2410: Unsupported 'wit
     
     with (ooo.eee.oo.ah_ah.ting.tang.walla.walla) { // error
     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
         bing = true; // no error
         bang = true; // no error
         

--- a/tests/baselines/reference/withStatementNestedScope.errors.txt
+++ b/tests/baselines/reference/withStatementNestedScope.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/compiler/withStatementNestedScope.ts(2,7): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/withStatementNestedScope.ts(2,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 
 
 ==== tests/cases/compiler/withStatementNestedScope.ts (1 errors) ====
     var x = 1;
     with (x) {
-          ~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+    ~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
         function f(a: number) {
             return 1;
         }

--- a/tests/baselines/reference/withStatementNestedScope.errors.txt
+++ b/tests/baselines/reference/withStatementNestedScope.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/compiler/withStatementNestedScope.ts(2,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/compiler/withStatementNestedScope.ts(2,1): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
 
 ==== tests/cases/compiler/withStatementNestedScope.ts (1 errors) ====
     var x = 1;
     with (x) {
     ~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
         function f(a: number) {
             return 1;
         }

--- a/tests/baselines/reference/withStatements.errors.txt
+++ b/tests/baselines/reference/withStatements.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/conformance/statements/withStatements/withStatements.ts(2,7): error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+tests/cases/conformance/statements/withStatements/withStatements.ts(2,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
 
 
 ==== tests/cases/conformance/statements/withStatements/withStatements.ts (1 errors) ====
     var x = 12;
     with (x) {
-          ~
-!!! error TS2410: All symbols within a 'with' block will be resolved to 'any'.
+    ~~~~~~~~
+!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
         name = 'twelve'
         id = 12
     }

--- a/tests/baselines/reference/withStatements.errors.txt
+++ b/tests/baselines/reference/withStatements.errors.txt
@@ -1,11 +1,11 @@
-tests/cases/conformance/statements/withStatements/withStatements.ts(2,1): error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+tests/cases/conformance/statements/withStatements/withStatements.ts(2,1): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
 
 ==== tests/cases/conformance/statements/withStatements/withStatements.ts (1 errors) ====
     var x = 12;
     with (x) {
     ~~~~~~~~
-!!! error TS2410: Unsupported 'with' statement, all symbols within a 'with' block will be resolved to 'any'.
+!!! error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
         name = 'twelve'
         id = 12
     }


### PR DESCRIPTION
Fixes #10601

- [x] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone: see #10601
- [x] Code is up-to-date with the `master` branch
- [x] You've signed the CLA
- [x] There are new or updated unit tests validating the change
- [ ] You've successfully run `jake runtests` locally: No, tslint did not run when I checked out the project. The tests run though.