### PR TITLE
Properly handle partially discriminated unions

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2289,7 +2289,8 @@ namespace ts {
         mapper?: TypeMapper;                // Type mapper for instantiation alias
         referenced?: boolean;               // True if alias symbol has been referenced as a value
         containingType?: UnionOrIntersectionType; // Containing union or intersection type for synthetic property
-        hasCommonType?: boolean;            // True if constituents of synthetic property all have same type
+        hasNonUniformType?: boolean;        // True if constituents have non-uniform types
+        isPartial?: boolean;                // True if syntheric property of union type occurs in some but not all constituents
         isDiscriminantProperty?: boolean;   // True if discriminant synthetic property
         resolvedExports?: SymbolTable;      // Resolved exports of module
         exportsChecked?: boolean;           // True if exports of external module have been checked

--- a/tests/baselines/reference/partiallyDiscriminantedUnions.js
+++ b/tests/baselines/reference/partiallyDiscriminantedUnions.js
@@ -1,0 +1,77 @@
+//// [partiallyDiscriminantedUnions.ts]
+// Repro from #10586
+
+interface A1 {
+    type: 'a';
+    subtype: 1;
+}
+
+interface A2 {
+    type: 'a';
+    subtype: 2;
+    foo: number;
+}
+
+interface B {
+    type: 'b';
+}
+
+type AB = A1 | A2 | B;
+
+const ab: AB = <AB>{};
+
+if (ab.type === 'a') {
+    if (ab.subtype === 2) {
+        ab.foo;
+    }
+}
+
+// Repro from #11185
+
+class Square { kind: "square"; }
+class Circle { kind: "circle"; }
+
+type Shape = Circle | Square;
+type Shapes = Shape | Array<Shape>;
+
+function isShape(s : Shapes): s is Shape {
+    return !Array.isArray(s);
+}
+
+function fail(s: Shapes) {
+    if (isShape(s)) {
+        if (s.kind === "circle") {
+            let c: Circle = s;
+        }
+    }
+}
+
+//// [partiallyDiscriminantedUnions.js]
+// Repro from #10586
+var ab = {};
+if (ab.type === 'a') {
+    if (ab.subtype === 2) {
+        ab.foo;
+    }
+}
+// Repro from #11185
+var Square = (function () {
+    function Square() {
+    }
+    return Square;
+}());
+var Circle = (function () {
+    function Circle() {
+    }
+    return Circle;
+}());
+function isShape(s) {
+    return !Array.isArray(s);
+}
+function fail(s) {
+    if (isShape(s)) {
+        if (s.kind === "circle") {
+            var c = s;
+        }
+    }
+}

--- a/tests/baselines/reference/partiallyDiscriminantedUnions.symbols
+++ b/tests/baselines/reference/partiallyDiscriminantedUnions.symbols
@@ -1,0 +1,117 @@
+=== tests/cases/compiler/partiallyDiscriminantedUnions.ts ===
+// Repro from #10586
+
+interface A1 {
+>A1 : Symbol(A1, Decl(partiallyDiscriminantedUnions.ts, 0, 0))
+
+    type: 'a';
+>type : Symbol(A1.type, Decl(partiallyDiscriminantedUnions.ts, 2, 14))
+
+    subtype: 1;
+>subtype : Symbol(A1.subtype, Decl(partiallyDiscriminantedUnions.ts, 3, 14))
+}
+
+interface A2 {
+>A2 : Symbol(A2, Decl(partiallyDiscriminantedUnions.ts, 5, 1))
+
+    type: 'a';
+>type : Symbol(A2.type, Decl(partiallyDiscriminantedUnions.ts, 7, 14))
+
+    subtype: 2;
+>subtype : Symbol(A2.subtype, Decl(partiallyDiscriminantedUnions.ts, 8, 14))
+
+    foo: number;
+>foo : Symbol(A2.foo, Decl(partiallyDiscriminantedUnions.ts, 9, 15))
+}
+
+interface B {
+>B : Symbol(B, Decl(partiallyDiscriminantedUnions.ts, 11, 1))
+
+    type: 'b';
+>type : Symbol(B.type, Decl(partiallyDiscriminantedUnions.ts, 13, 13))
+}
+
+type AB = A1 | A2 | B;
+>AB : Symbol(AB, Decl(partiallyDiscriminantedUnions.ts, 15, 1))
+>A1 : Symbol(A1, Decl(partiallyDiscriminantedUnions.ts, 0, 0))
+>A2 : Symbol(A2, Decl(partiallyDiscriminantedUnions.ts, 5, 1))
+>B : Symbol(B, Decl(partiallyDiscriminantedUnions.ts, 11, 1))
+
+const ab: AB = <AB>{};
+>ab : Symbol(ab, Decl(partiallyDiscriminantedUnions.ts, 19, 5))
+>AB : Symbol(AB, Decl(partiallyDiscriminantedUnions.ts, 15, 1))
+>AB : Symbol(AB, Decl(partiallyDiscriminantedUnions.ts, 15, 1))
+
+if (ab.type === 'a') {
+>ab.type : Symbol(type, Decl(partiallyDiscriminantedUnions.ts, 2, 14), Decl(partiallyDiscriminantedUnions.ts, 7, 14), Decl(partiallyDiscriminantedUnions.ts, 13, 13))
+>ab : Symbol(ab, Decl(partiallyDiscriminantedUnions.ts, 19, 5))
+>type : Symbol(type, Decl(partiallyDiscriminantedUnions.ts, 2, 14), Decl(partiallyDiscriminantedUnions.ts, 7, 14), Decl(partiallyDiscriminantedUnions.ts, 13, 13))
+
+    if (ab.subtype === 2) {
+>ab.subtype : Symbol(subtype, Decl(partiallyDiscriminantedUnions.ts, 3, 14), Decl(partiallyDiscriminantedUnions.ts, 8, 14))
+>ab : Symbol(ab, Decl(partiallyDiscriminantedUnions.ts, 19, 5))
+>subtype : Symbol(subtype, Decl(partiallyDiscriminantedUnions.ts, 3, 14), Decl(partiallyDiscriminantedUnions.ts, 8, 14))
+
+        ab.foo;
+>ab.foo : Symbol(A2.foo, Decl(partiallyDiscriminantedUnions.ts, 9, 15))
+>ab : Symbol(ab, Decl(partiallyDiscriminantedUnions.ts, 19, 5))
+>foo : Symbol(A2.foo, Decl(partiallyDiscriminantedUnions.ts, 9, 15))
+    }
+}
+
+// Repro from #11185
+
+class Square { kind: "square"; }
+>Square : Symbol(Square, Decl(partiallyDiscriminantedUnions.ts, 25, 1))
+>kind : Symbol(Square.kind, Decl(partiallyDiscriminantedUnions.ts, 29, 14))
+
+class Circle { kind: "circle"; }
+>Circle : Symbol(Circle, Decl(partiallyDiscriminantedUnions.ts, 29, 32))
+>kind : Symbol(Circle.kind, Decl(partiallyDiscriminantedUnions.ts, 30, 14))
+
+type Shape = Circle | Square;
+>Shape : Symbol(Shape, Decl(partiallyDiscriminantedUnions.ts, 30, 32))
+>Circle : Symbol(Circle, Decl(partiallyDiscriminantedUnions.ts, 29, 32))
+>Square : Symbol(Square, Decl(partiallyDiscriminantedUnions.ts, 25, 1))
+
+type Shapes = Shape | Array<Shape>;
+>Shapes : Symbol(Shapes, Decl(partiallyDiscriminantedUnions.ts, 32, 29))
+>Shape : Symbol(Shape, Decl(partiallyDiscriminantedUnions.ts, 30, 32))
+>Array : Symbol(Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>Shape : Symbol(Shape, Decl(partiallyDiscriminantedUnions.ts, 30, 32))
+
+function isShape(s : Shapes): s is Shape {
+>isShape : Symbol(isShape, Decl(partiallyDiscriminantedUnions.ts, 33, 35))
+>s : Symbol(s, Decl(partiallyDiscriminantedUnions.ts, 35, 17))
+>Shapes : Symbol(Shapes, Decl(partiallyDiscriminantedUnions.ts, 32, 29))
+>s : Symbol(s, Decl(partiallyDiscriminantedUnions.ts, 35, 17))
+>Shape : Symbol(Shape, Decl(partiallyDiscriminantedUnions.ts, 30, 32))
+
+    return !Array.isArray(s);
+>Array.isArray : Symbol(ArrayConstructor.isArray, Decl(lib.d.ts, --, --))
+>Array : Symbol(Array, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>isArray : Symbol(ArrayConstructor.isArray, Decl(lib.d.ts, --, --))
+>s : Symbol(s, Decl(partiallyDiscriminantedUnions.ts, 35, 17))
+}
+
+function fail(s: Shapes) {
+>fail : Symbol(fail, Decl(partiallyDiscriminantedUnions.ts, 37, 1))
+>s : Symbol(s, Decl(partiallyDiscriminantedUnions.ts, 39, 14))
+>Shapes : Symbol(Shapes, Decl(partiallyDiscriminantedUnions.ts, 32, 29))
+
+    if (isShape(s)) {
+>isShape : Symbol(isShape, Decl(partiallyDiscriminantedUnions.ts, 33, 35))
+>s : Symbol(s, Decl(partiallyDiscriminantedUnions.ts, 39, 14))
+
+        if (s.kind === "circle") {
+>s.kind : Symbol(kind, Decl(partiallyDiscriminantedUnions.ts, 29, 14), Decl(partiallyDiscriminantedUnions.ts, 30, 14))
+>s : Symbol(s, Decl(partiallyDiscriminantedUnions.ts, 39, 14))
+>kind : Symbol(kind, Decl(partiallyDiscriminantedUnions.ts, 29, 14), Decl(partiallyDiscriminantedUnions.ts, 30, 14))
+
+            let c: Circle = s;
+>c : Symbol(c, Decl(partiallyDiscriminantedUnions.ts, 42, 15))
+>Circle : Symbol(Circle, Decl(partiallyDiscriminantedUnions.ts, 29, 32))
+>s : Symbol(s, Decl(partiallyDiscriminantedUnions.ts, 39, 14))
+        }
+    }
+}

--- a/tests/baselines/reference/partiallyDiscriminantedUnions.types
+++ b/tests/baselines/reference/partiallyDiscriminantedUnions.types
@@ -1,0 +1,128 @@
+=== tests/cases/compiler/partiallyDiscriminantedUnions.ts ===
+// Repro from #10586
+
+interface A1 {
+>A1 : A1
+
+    type: 'a';
+>type : "a"
+
+    subtype: 1;
+>subtype : 1
+}
+
+interface A2 {
+>A2 : A2
+
+    type: 'a';
+>type : "a"
+
+    subtype: 2;
+>subtype : 2
+
+    foo: number;
+>foo : number
+}
+
+interface B {
+>B : B
+
+    type: 'b';
+>type : "b"
+}
+
+type AB = A1 | A2 | B;
+>AB : AB
+>A1 : A1
+>A2 : A2
+>B : B
+
+const ab: AB = <AB>{};
+>ab : AB
+>AB : AB
+><AB>{} : AB
+>AB : AB
+>{} : {}
+
+if (ab.type === 'a') {
+>ab.type === 'a' : boolean
+>ab.type : "a" | "b"
+>ab : AB
+>type : "a" | "b"
+>'a' : "a"
+
+    if (ab.subtype === 2) {
+>ab.subtype === 2 : boolean
+>ab.subtype : 1 | 2
+>ab : A1 | A2
+>subtype : 1 | 2
+>2 : 2
+
+        ab.foo;
+>ab.foo : number
+>ab : A2
+>foo : number
+    }
+}
+
+// Repro from #11185
+
+class Square { kind: "square"; }
+>Square : Square
+>kind : "square"
+
+class Circle { kind: "circle"; }
+>Circle : Circle
+>kind : "circle"
+
+type Shape = Circle | Square;
+>Shape : Shape
+>Circle : Circle
+>Square : Square
+
+type Shapes = Shape | Array<Shape>;
+>Shapes : Shapes
+>Shape : Shape
+>Array : T[]
+>Shape : Shape
+
+function isShape(s : Shapes): s is Shape {
+>isShape : (s: Shapes) => s is Shape
+>s : Shapes
+>Shapes : Shapes
+>s : any
+>Shape : Shape
+
+    return !Array.isArray(s);
+>!Array.isArray(s) : boolean
+>Array.isArray(s) : boolean
+>Array.isArray : (arg: any) => arg is any[]
+>Array : ArrayConstructor
+>isArray : (arg: any) => arg is any[]
+>s : Shapes
+}
+
+function fail(s: Shapes) {
+>fail : (s: Shapes) => void
+>s : Shapes
+>Shapes : Shapes
+
+    if (isShape(s)) {
+>isShape(s) : boolean
+>isShape : (s: Shapes) => s is Shape
+>s : Shapes
+
+        if (s.kind === "circle") {
+>s.kind === "circle" : boolean
+>s.kind : "square" | "circle"
+>s : Shape
+>kind : "square" | "circle"
+>"circle" : "circle"
+
+            let c: Circle = s;
+>c : Circle
+>Circle : Circle
+>s : Circle
+        }
+    }
+}

--- a/tests/cases/compiler/partiallyDiscriminantedUnions.ts
+++ b/tests/cases/compiler/partiallyDiscriminantedUnions.ts
@@ -1,0 +1,46 @@
+// Repro from #10586
+
+interface A1 {
+    type: 'a';
+    subtype: 1;
+}
+
+interface A2 {
+    type: 'a';
+    subtype: 2;
+    foo: number;
+}
+
+interface B {
+    type: 'b';
+}
+
+type AB = A1 | A2 | B;
+
+const ab: AB = <AB>{};
+
+if (ab.type === 'a') {
+    if (ab.subtype === 2) {
+        ab.foo;
+    }
+}
+
+// Repro from #11185
+
+class Square { kind: "square"; }
+class Circle { kind: "circle"; }
+
+type Shape = Circle | Square;
+type Shapes = Shape | Array<Shape>;
+
+function isShape(s : Shapes): s is Shape {
+    return !Array.isArray(s);
+}
+
+function fail(s: Shapes) {
+    if (isShape(s)) {
+        if (s.kind === "circle") {
+            let c: Circle = s;
+        }
+    }
+}


### PR DESCRIPTION
With this PR we no longer require a discriminant property to the present in all constituents of the declared union type of an entity. Now, a property of a union type is considered a discriminant property if

* the property occurs in more than one constituent type,
* the property occurrences do not all have an identical type,
* the type of each property occurrence is a literal type or a union of literal types.

Fixes #10586.
Fixes #11185.
