### PR TITLE
Improve Array.prototype.splice typing

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1156,8 +1156,9 @@ interface Array<T> {
     /**
       * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
       * @param start The zero-based location in the array from which to start removing elements.
+      * @param deleteCount The number of elements to remove.
       */
-    splice(start: number): T[];
+    splice(start: number, deleteCount?: number): T[];
     /**
       * Removes elements from an array and, if necessary, inserts new elements in their place, returning the deleted elements.
       * @param start The zero-based location in the array from which to start removing elements.

--- a/tests/baselines/reference/arraySlice.js
+++ b/tests/baselines/reference/arraySlice.js
@@ -1,0 +1,8 @@
+//// [arraySlice.ts]
+var arr: string[] | number[];
+arr.splice(1, 1);
+
+
+//// [arraySlice.js]
+var arr;
+arr.splice(1, 1);

--- a/tests/baselines/reference/arraySlice.symbols
+++ b/tests/baselines/reference/arraySlice.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/arraySlice.ts ===
+var arr: string[] | number[];
+>arr : Symbol(arr, Decl(arraySlice.ts, 0, 3))
+
+arr.splice(1, 1);
+>arr.splice : Symbol(splice, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>arr : Symbol(arr, Decl(arraySlice.ts, 0, 3))
+>splice : Symbol(splice, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+

--- a/tests/baselines/reference/arraySlice.types
+++ b/tests/baselines/reference/arraySlice.types
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/arraySlice.ts ===
+var arr: string[] | number[];
+>arr : string[] | number[]
+
+arr.splice(1, 1);
+>arr.splice(1, 1) : string[] | number[]
+>arr.splice : { (start: number, deleteCount?: number): string[]; (start: number, deleteCount: number, ...items: string[]): string[]; } | { (start: number, deleteCount?: number): number[]; (start: number, deleteCount: number, ...items: number[]): number[]; }
+>arr : string[] | number[]
+>splice : { (start: number, deleteCount?: number): string[]; (start: number, deleteCount: number, ...items: string[]): string[]; } | { (start: number, deleteCount?: number): number[]; (start: number, deleteCount: number, ...items: number[]): number[]; }
+>1 : 1
+>1 : 1
+

--- a/tests/baselines/reference/invalidSplice.types
+++ b/tests/baselines/reference/invalidSplice.types
@@ -2,9 +2,9 @@
 var arr = [].splice(0,3,4,5);
 >arr : any[]
 >[].splice(0,3,4,5) : any[]
->[].splice : { (start: number): any[]; (start: number, deleteCount: number, ...items: any[]): any[]; }
+>[].splice : { (start: number, deleteCount?: number): any[]; (start: number, deleteCount: number, ...items: any[]): any[]; }
 >[] : undefined[]
->splice : { (start: number): any[]; (start: number, deleteCount: number, ...items: any[]): any[]; }
+>splice : { (start: number, deleteCount?: number): any[]; (start: number, deleteCount: number, ...items: any[]): any[]; }
 >0 : 0
 >3 : 3
 >4 : 4

--- a/tests/baselines/reference/staticAnonymousTypeNotReferencingTypeParameter.types
+++ b/tests/baselines/reference/staticAnonymousTypeNotReferencingTypeParameter.types
@@ -364,9 +364,9 @@ class ListWrapper {
 >value : T
 >T : T
 >list.splice(index, 0, value) : T[]
->list.splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>list.splice : { (start: number, deleteCount?: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
 >list : T[]
->splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>splice : { (start: number, deleteCount?: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
 >index : number
 >0 : 0
 >value : T
@@ -389,9 +389,9 @@ class ListWrapper {
 
     list.splice(index, 1);
 >list.splice(index, 1) : T[]
->list.splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>list.splice : { (start: number, deleteCount?: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
 >list : T[]
->splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>splice : { (start: number, deleteCount?: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
 >index : number
 >1 : 1
 
@@ -431,9 +431,9 @@ class ListWrapper {
 
       list.splice(index, 1);
 >list.splice(index, 1) : T[]
->list.splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>list.splice : { (start: number, deleteCount?: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
 >list : T[]
->splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>splice : { (start: number, deleteCount?: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
 >index : number
 >1 : 1
     }
@@ -464,9 +464,9 @@ class ListWrapper {
 
       list.splice(index, 1);
 >list.splice(index, 1) : T[]
->list.splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>list.splice : { (start: number, deleteCount?: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
 >list : T[]
->splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>splice : { (start: number, deleteCount?: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
 >index : number
 >1 : 1
 
@@ -603,9 +603,9 @@ class ListWrapper {
 >length : number
 >T : T
 >l.splice(from, length) : T[]
->l.splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>l.splice : { (start: number, deleteCount?: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
 >l : T[]
->splice : { (start: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
+>splice : { (start: number, deleteCount?: number): T[]; (start: number, deleteCount: number, ...items: T[]): T[]; }
 >from : number
 >length : number
 

--- a/tests/cases/compiler/arraySlice.ts
+++ b/tests/cases/compiler/arraySlice.ts
@@ -1,0 +1,2 @@
+var arr: string[] | number[];
+arr.splice(1, 1);


### PR DESCRIPTION
- [X] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
- [X] Code is up-to-date with the `master` branch
- [X] You've successfully run `jake runtests` locally
- [X] You've signed the CLA
- [X] There are new or updated unit tests validating the change

Improves the typing of `Array.prototype.splice` so that when only passing the first two arguments with an intersection type, you do not get a confusing and useless `Supplied parameters do not match any signature of call target.` error.

Fixes #11205
