### PR TITLE
Ensure that `checkGrammarModuleElementContext` reliably returns `true` when there is bad grammar

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17706,9 +17706,11 @@ namespace ts {
         }
 
         function checkGrammarModuleElementContext(node: Statement, errorMessage: DiagnosticMessage): boolean {
-            if (node.parent.kind !== SyntaxKind.SourceFile && node.parent.kind !== SyntaxKind.ModuleBlock && node.parent.kind !== SyntaxKind.ModuleDeclaration) {
-                return grammarErrorOnFirstToken(node, errorMessage);
+            const isInAppropriateContext = node.parent.kind === SyntaxKind.SourceFile || node.parent.kind === SyntaxKind.ModuleBlock || node.parent.kind === SyntaxKind.ModuleDeclaration;
+            if (!isInAppropriateContext) {
+                grammarErrorOnFirstToken(node, errorMessage);
             }
+            return !isInAppropriateContext;
         }
 
         function checkExportSpecifier(node: ExportSpecifier) {
@@ -17749,7 +17751,7 @@ namespace ts {
                 checkExpressionCached(node.expression);
             }
 
-            checkExternalModuleExports(<SourceFile | ModuleDeclaration>container);
+            checkExternalModuleExports(container);
 
             if (node.isExportEquals && !isInAmbientContext(node)) {
                 if (modulekind === ModuleKind.ES6) {

--- a/tests/baselines/reference/exportInFunction.errors.txt
+++ b/tests/baselines/reference/exportInFunction.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/compiler/exportInFunction.ts(3,1): error TS1005: '}' expected.
+
+
+==== tests/cases/compiler/exportInFunction.ts (1 errors) ====
+    function f() {
+        export = 0;
+    
+    
+!!! error TS1005: '}' expected.

--- a/tests/baselines/reference/exportInFunction.js
+++ b/tests/baselines/reference/exportInFunction.js
@@ -1,0 +1,9 @@
+//// [exportInFunction.ts]
+function f() {
+    export = 0;
+
+
+//// [exportInFunction.js]
+function f() {
+    export = 0;
+}

--- a/tests/cases/compiler/exportInFunction.ts
+++ b/tests/cases/compiler/exportInFunction.ts
@@ -1,0 +1,2 @@
+function f() {
+    export = 0;


### PR DESCRIPTION
Fixes #11211
