### PR TITLE
Use `new Function`-less access to `this` for debugObjectHost

### DIFF
--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -16,7 +16,7 @@
 /// <reference path='services.ts' />
 
 /* @internal */
-let debugObjectHost = new Function("return this")();
+let debugObjectHost = (function (this: any) { return this; })();
 
 // We need to use 'null' to interface with the managed side.
 /* tslint:disable:no-null-keyword */


### PR DESCRIPTION
Fixes a comment on the original PR #9580.

Originally it was just `debugObjectHost = this as any`, but this breaks --noImplicitThis. So #9580 changed it to `(new Function("return this"))()`. Now it's `(function () { return this })()`.