### PR TITLE
replace hardcodes 'useCaseSensitiveFileNames=false' in services with actual value, use specialized map lookup methods instead of generic 'getOrCreate*'

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -2045,4 +2045,22 @@ namespace ts.projectSystem {
             assert.equal(snap.getLength(), expectedLength, "Incorrect snapshot size");
         }
     });
+
+    describe("Language service", () => {
+        it("should work correctly on case-sensitive file systems", () => {
+            const lib = {
+                path: "/a/Lib/lib.d.ts",
+                content: "let x: number"
+            };
+            const f = {
+                path: "/a/b/app.ts",
+                content: "let x = 1;"
+            };
+            const host = createServerHost([lib, f], { executingFilePath: "/a/Lib/tsc.js", useCaseSensitiveFileNames: true });
+            const projectService = createProjectService(host);
+            projectService.openClientFile(f.path);
+            projectService.checkNumberOfProjects({ inferredProjects: 1 });
+            projectService.inferredProjects[0].getLanguageService().getProgram();
+        });
+    });
 }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1001,8 +1001,13 @@ namespace ts.server {
         }
 
         getScriptInfoForNormalizedPath(fileName: NormalizedPath) {
-            return this.filenameToScriptInfo.get(normalizedPathToPath(fileName, this.host.getCurrentDirectory(), this.toCanonicalFileName));
+            return this.getScriptInfoForPath(normalizedPathToPath(fileName, this.host.getCurrentDirectory(), this.toCanonicalFileName));
         }
+
+        getScriptInfoForPath(fileName: Path) {
+            return this.filenameToScriptInfo.get(fileName);
+        }
+
 
         setHostConfiguration(args: protocol.ConfigureRequestArguments) {
             if (args.file) {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -215,7 +215,13 @@ namespace ts.server {
         }
 
         getScriptInfos() {
-            return map(this.program.getSourceFiles(), sourceFile => this.getScriptInfoLSHost(sourceFile.path));
+            return map(this.program.getSourceFiles(), sourceFile => {
+                const scriptInfo = this.projectService.getScriptInfoForPath(sourceFile.path);
+                if (!scriptInfo) {
+                    Debug.assert(false, `scriptInfo for a file '${sourceFile.fileName}' is missing.`);
+                }
+                return scriptInfo;
+            });
         }
 
         getFileEmitOutput(info: ScriptInfo, emitOnlyDtsFiles: boolean) {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -947,7 +947,7 @@ namespace ts {
 
         let lastTypesRootVersion = 0;
 
-        const useCaseSensitivefileNames = false;
+        const useCaseSensitivefileNames = host.useCaseSensitiveFileNames && host.useCaseSensitiveFileNames();
         const cancellationToken = new CancellationTokenObject(host.getCancellationToken && host.getCancellationToken());
 
         const currentDirectory = host.getCurrentDirectory();


### PR DESCRIPTION
Fixes #11282
