### PR TITLE
Visit VariableDeclaration initializer in converted loop

### DIFF
--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -2201,7 +2201,6 @@ namespace ts {
                 }
             }
 
-            debugger;
             let loopBody = visitNode(node.statement, visitor, isStatement);
 
             const currentState = convertedLoopState;

--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -1689,7 +1689,7 @@ namespace ts {
                             assignment = flattenVariableDestructuringToExpression(context, decl, hoistVariableDeclaration, /*nameSubstitution*/ undefined, visitor);
                         }
                         else {
-                            assignment = createBinary(<Identifier>decl.name, SyntaxKind.EqualsToken, decl.initializer);
+                            assignment = createBinary(<Identifier>decl.name, SyntaxKind.EqualsToken, visitNode(decl.initializer, visitor, isExpression));
                         }
                         (assignments || (assignments = [])).push(assignment);
                     }
@@ -2201,6 +2201,7 @@ namespace ts {
                 }
             }
 
+            debugger;
             let loopBody = visitNode(node.statement, visitor, isStatement);
 
             const currentState = convertedLoopState;

--- a/tests/baselines/reference/transformArrowInBlockScopedLoopVarInitializer.js
+++ b/tests/baselines/reference/transformArrowInBlockScopedLoopVarInitializer.js
@@ -1,0 +1,19 @@
+//// [transformArrowInBlockScopedLoopVarInitializer.ts]
+
+// https://github.com/Microsoft/TypeScript/issues/11236
+while (true)
+{
+    let local = null;
+    var a = () => local; // <-- Lambda should be converted to function()
+}
+
+//// [transformArrowInBlockScopedLoopVarInitializer.js]
+var _loop_1 = function () {
+    var local = null;
+    a = function () { return local; }; // <-- Lambda should be converted to function()
+};
+var a;
+// https://github.com/Microsoft/TypeScript/issues/11236
+while (true) {
+    _loop_1();
+}

--- a/tests/baselines/reference/transformArrowInBlockScopedLoopVarInitializer.symbols
+++ b/tests/baselines/reference/transformArrowInBlockScopedLoopVarInitializer.symbols
@@ -1,0 +1,12 @@
+=== tests/cases/compiler/transformArrowInBlockScopedLoopVarInitializer.ts ===
+
+// https://github.com/Microsoft/TypeScript/issues/11236
+while (true)
+{
+    let local = null;
+>local : Symbol(local, Decl(transformArrowInBlockScopedLoopVarInitializer.ts, 4, 7))
+
+    var a = () => local; // <-- Lambda should be converted to function()
+>a : Symbol(a, Decl(transformArrowInBlockScopedLoopVarInitializer.ts, 5, 7))
+>local : Symbol(local, Decl(transformArrowInBlockScopedLoopVarInitializer.ts, 4, 7))
+}

--- a/tests/baselines/reference/transformArrowInBlockScopedLoopVarInitializer.types
+++ b/tests/baselines/reference/transformArrowInBlockScopedLoopVarInitializer.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/transformArrowInBlockScopedLoopVarInitializer.ts ===
+
+// https://github.com/Microsoft/TypeScript/issues/11236
+while (true)
+>true : true
+{
+    let local = null;
+>local : any
+>null : null
+
+    var a = () => local; // <-- Lambda should be converted to function()
+>a : () => any
+>() => local : () => any
+>local : any
+}

--- a/tests/cases/compiler/transformArrowInBlockScopedLoopVarInitializer.ts
+++ b/tests/cases/compiler/transformArrowInBlockScopedLoopVarInitializer.ts
@@ -1,0 +1,8 @@
+// @target: es5
+
+// https://github.com/Microsoft/TypeScript/issues/11236
+while (true)
+{
+    let local = null;
+    var a = () => local; // <-- Lambda should be converted to function()
+}


### PR DESCRIPTION
This addresses an issue where the initializer of a variable declaration in a converted loop was not visited, and therefore not transformed down-level.

Fixes #11236

