### PR TITLE
Fix crash with nested generators

### DIFF
--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -552,6 +552,7 @@ namespace ts {
             const savedBlocks = blocks;
             const savedBlockOffsets = blockOffsets;
             const savedBlockActions = blockActions;
+            const savedBlockStack = blockStack;
             const savedLabelOffsets = labelOffsets;
             const savedLabelExpressions = labelExpressions;
             const savedNextLabelId = nextLabelId;
@@ -566,6 +567,7 @@ namespace ts {
             blocks = undefined;
             blockOffsets = undefined;
             blockActions = undefined;
+            blockStack = undefined;
             labelOffsets = undefined;
             labelExpressions = undefined;
             nextLabelId = 1;
@@ -591,6 +593,7 @@ namespace ts {
             blocks = savedBlocks;
             blockOffsets = savedBlockOffsets;
             blockActions = savedBlockActions;
+            blockStack = savedBlockStack;
             labelOffsets = savedLabelOffsets;
             labelExpressions = savedLabelExpressions;
             nextLabelId = savedNextLabelId;

--- a/tests/baselines/reference/transformNestedGeneratorsWithTry.js
+++ b/tests/baselines/reference/transformNestedGeneratorsWithTry.js
@@ -1,6 +1,7 @@
 //// [tests/cases/compiler/transformNestedGeneratorsWithTry.ts] ////
 
 //// [main.ts]
+// https://github.com/Microsoft/TypeScript/issues/11177
 import * as Bluebird from 'bluebird';
 async function a(): Bluebird<void> {
   try {
@@ -58,6 +59,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
         if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
     }
 };
+// https://github.com/Microsoft/TypeScript/issues/11177
 var Bluebird = require("bluebird");
 function a() {
     return __awaiter(this, void 0, Bluebird, function () {

--- a/tests/baselines/reference/transformNestedGeneratorsWithTry.js
+++ b/tests/baselines/reference/transformNestedGeneratorsWithTry.js
@@ -1,0 +1,99 @@
+//// [tests/cases/compiler/transformNestedGeneratorsWithTry.ts] ////
+
+//// [main.ts]
+import * as Bluebird from 'bluebird';
+async function a(): Bluebird<void> {
+  try {
+    const b = async function b(): Bluebird<void> {
+      try {
+        await Bluebird.resolve(); // -- remove this and it compiles
+      } catch (error) { }
+    };
+
+    await b(); // -- or remove this and it compiles
+  } catch (error) { }
+}
+
+//// [bluebird.d.ts]
+declare module "bluebird" {
+    type Bluebird<T> = Promise<T>;
+    const Bluebird: typeof Promise;
+    export = Bluebird;
+}
+
+//// [main.js]
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator.throw(value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments)).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t;
+    return { next: verb(0), "throw": verb(1), "return": verb(2) };
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var Bluebird = require("bluebird");
+function a() {
+    return __awaiter(this, void 0, Bluebird, function () {
+        var b, error_1;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    _a.trys.push([0, 2, , 3]);
+                    b = function b() {
+                        return __awaiter(this, void 0, Bluebird, function () {
+                            var error_2;
+                            return __generator(this, function (_a) {
+                                switch (_a.label) {
+                                    case 0:
+                                        _a.trys.push([0, 2, , 3]);
+                                        return [4 /*yield*/, Bluebird.resolve()];
+                                    case 1:
+                                        _a.sent(); // -- remove this and it compiles
+                                        return [3 /*break*/, 3];
+                                    case 2:
+                                        error_2 = _a.sent();
+                                        return [3 /*break*/, 3];
+                                    case 3: return [2 /*return*/];
+                                }
+                            });
+                        });
+                    };
+                    return [4 /*yield*/, b()];
+                case 1:
+                    _a.sent(); // -- or remove this and it compiles
+                    return [3 /*break*/, 3];
+                case 2:
+                    error_1 = _a.sent();
+                    return [3 /*break*/, 3];
+                case 3: return [2 /*return*/];
+            }
+        });
+    });
+}

--- a/tests/baselines/reference/transformNestedGeneratorsWithTry.symbols
+++ b/tests/baselines/reference/transformNestedGeneratorsWithTry.symbols
@@ -1,0 +1,47 @@
+=== tests/cases/compiler/main.ts ===
+import * as Bluebird from 'bluebird';
+>Bluebird : Symbol(Bluebird, Decl(main.ts, 0, 6))
+
+async function a(): Bluebird<void> {
+>a : Symbol(a, Decl(main.ts, 0, 37))
+>Bluebird : Symbol(Bluebird, Decl(main.ts, 0, 6))
+
+  try {
+    const b = async function b(): Bluebird<void> {
+>b : Symbol(b, Decl(main.ts, 3, 9))
+>b : Symbol(b, Decl(main.ts, 3, 13))
+>Bluebird : Symbol(Bluebird, Decl(main.ts, 0, 6))
+
+      try {
+        await Bluebird.resolve(); // -- remove this and it compiles
+>Bluebird.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Bluebird : Symbol(Bluebird, Decl(main.ts, 0, 6))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+      } catch (error) { }
+>error : Symbol(error, Decl(main.ts, 6, 15))
+
+    };
+
+    await b(); // -- or remove this and it compiles
+>b : Symbol(b, Decl(main.ts, 3, 9))
+
+  } catch (error) { }
+>error : Symbol(error, Decl(main.ts, 10, 11))
+}
+
+=== tests/cases/compiler/bluebird.d.ts ===
+declare module "bluebird" {
+    type Bluebird<T> = Promise<T>;
+>Bluebird : Symbol(Bluebird, Decl(bluebird.d.ts, 0, 27), Decl(bluebird.d.ts, 2, 9))
+>T : Symbol(T, Decl(bluebird.d.ts, 1, 18))
+>Promise : Symbol(Promise, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>T : Symbol(T, Decl(bluebird.d.ts, 1, 18))
+
+    const Bluebird: typeof Promise;
+>Bluebird : Symbol(Bluebird, Decl(bluebird.d.ts, 0, 27), Decl(bluebird.d.ts, 2, 9))
+>Promise : Symbol(Promise, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+
+    export = Bluebird;
+>Bluebird : Symbol(Bluebird, Decl(bluebird.d.ts, 0, 27), Decl(bluebird.d.ts, 2, 9))
+}

--- a/tests/baselines/reference/transformNestedGeneratorsWithTry.symbols
+++ b/tests/baselines/reference/transformNestedGeneratorsWithTry.symbols
@@ -1,33 +1,34 @@
 === tests/cases/compiler/main.ts ===
+// https://github.com/Microsoft/TypeScript/issues/11177
 import * as Bluebird from 'bluebird';
->Bluebird : Symbol(Bluebird, Decl(main.ts, 0, 6))
+>Bluebird : Symbol(Bluebird, Decl(main.ts, 1, 6))
 
 async function a(): Bluebird<void> {
->a : Symbol(a, Decl(main.ts, 0, 37))
->Bluebird : Symbol(Bluebird, Decl(main.ts, 0, 6))
+>a : Symbol(a, Decl(main.ts, 1, 37))
+>Bluebird : Symbol(Bluebird, Decl(main.ts, 1, 6))
 
   try {
     const b = async function b(): Bluebird<void> {
->b : Symbol(b, Decl(main.ts, 3, 9))
->b : Symbol(b, Decl(main.ts, 3, 13))
->Bluebird : Symbol(Bluebird, Decl(main.ts, 0, 6))
+>b : Symbol(b, Decl(main.ts, 4, 9))
+>b : Symbol(b, Decl(main.ts, 4, 13))
+>Bluebird : Symbol(Bluebird, Decl(main.ts, 1, 6))
 
       try {
         await Bluebird.resolve(); // -- remove this and it compiles
 >Bluebird.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
->Bluebird : Symbol(Bluebird, Decl(main.ts, 0, 6))
+>Bluebird : Symbol(Bluebird, Decl(main.ts, 1, 6))
 >resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
 
       } catch (error) { }
->error : Symbol(error, Decl(main.ts, 6, 15))
+>error : Symbol(error, Decl(main.ts, 7, 15))
 
     };
 
     await b(); // -- or remove this and it compiles
->b : Symbol(b, Decl(main.ts, 3, 9))
+>b : Symbol(b, Decl(main.ts, 4, 9))
 
   } catch (error) { }
->error : Symbol(error, Decl(main.ts, 10, 11))
+>error : Symbol(error, Decl(main.ts, 11, 11))
 }
 
 === tests/cases/compiler/bluebird.d.ts ===

--- a/tests/baselines/reference/transformNestedGeneratorsWithTry.types
+++ b/tests/baselines/reference/transformNestedGeneratorsWithTry.types
@@ -1,0 +1,52 @@
+=== tests/cases/compiler/main.ts ===
+import * as Bluebird from 'bluebird';
+>Bluebird : PromiseConstructor
+
+async function a(): Bluebird<void> {
+>a : () => Promise<void>
+>Bluebird : Promise<T>
+
+  try {
+    const b = async function b(): Bluebird<void> {
+>b : () => Promise<void>
+>async function b(): Bluebird<void> {      try {        await Bluebird.resolve(); // -- remove this and it compiles      } catch (error) { }    } : () => Promise<void>
+>b : () => Promise<void>
+>Bluebird : Promise<T>
+
+      try {
+        await Bluebird.resolve(); // -- remove this and it compiles
+>await Bluebird.resolve() : void
+>Bluebird.resolve() : Promise<void>
+>Bluebird.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Bluebird : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+
+      } catch (error) { }
+>error : any
+
+    };
+
+    await b(); // -- or remove this and it compiles
+>await b() : void
+>b() : Promise<void>
+>b : () => Promise<void>
+
+  } catch (error) { }
+>error : any
+}
+
+=== tests/cases/compiler/bluebird.d.ts ===
+declare module "bluebird" {
+    type Bluebird<T> = Promise<T>;
+>Bluebird : Promise<T>
+>T : T
+>Promise : Promise<T>
+>T : T
+
+    const Bluebird: typeof Promise;
+>Bluebird : PromiseConstructor
+>Promise : PromiseConstructor
+
+    export = Bluebird;
+>Bluebird : Promise<T>
+}

--- a/tests/baselines/reference/transformNestedGeneratorsWithTry.types
+++ b/tests/baselines/reference/transformNestedGeneratorsWithTry.types
@@ -1,4 +1,5 @@
 === tests/cases/compiler/main.ts ===
+// https://github.com/Microsoft/TypeScript/issues/11177
 import * as Bluebird from 'bluebird';
 >Bluebird : PromiseConstructor
 

--- a/tests/cases/compiler/transformNestedGeneratorsWithTry.ts
+++ b/tests/cases/compiler/transformNestedGeneratorsWithTry.ts
@@ -1,0 +1,23 @@
+// @target: ES5
+// @lib: es5,es6
+// @filename: main.ts
+// https://github.com/Microsoft/TypeScript/issues/11177
+import * as Bluebird from 'bluebird';
+async function a(): Bluebird<void> {
+  try {
+    const b = async function b(): Bluebird<void> {
+      try {
+        await Bluebird.resolve(); // -- remove this and it compiles
+      } catch (error) { }
+    };
+
+    await b(); // -- or remove this and it compiles
+  } catch (error) { }
+}
+
+// @filename: bluebird.d.ts
+declare module "bluebird" {
+    type Bluebird<T> = Promise<T>;
+    const Bluebird: typeof Promise;
+    export = Bluebird;
+}


### PR DESCRIPTION
This fixes a crash due to the fact the generators transform was not properly saving and restoring the `blockStack` variable.

Fixes #11177

