### PR TITLE
fix #10698: infer primitive return type in generic position

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4870,7 +4870,8 @@ namespace ts {
                 else {
                     type = getReturnTypeFromBody(<FunctionLikeDeclaration>signature.declaration);
                 }
-                if (!popTypeResolution()) {
+                // skip warning if type can be inferred, e.g. literal type in contextual typing position
+                if (!popTypeResolution() && !(type.flags & TypeFlags.Primitive)) {
                     type = anyType;
                     if (compilerOptions.noImplicitAny) {
                         const declaration = <Declaration>signature.declaration;

--- a/tests/baselines/reference/genericCallWithFunctionReturnLiteral.js
+++ b/tests/baselines/reference/genericCallWithFunctionReturnLiteral.js
@@ -1,0 +1,9 @@
+//// [genericCallWithFunctionReturnLiteral.ts]
+function foo<T>(t: T) { return t; }
+
+foo(() => 123)
+
+
+//// [genericCallWithFunctionReturnLiteral.js]
+function foo(t) { return t; }
+foo(function () { return 123; });

--- a/tests/baselines/reference/genericCallWithFunctionReturnLiteral.symbols
+++ b/tests/baselines/reference/genericCallWithFunctionReturnLiteral.symbols
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/genericCallWithFunctionReturnLiteral.ts ===
+function foo<T>(t: T) { return t; }
+>foo : Symbol(foo, Decl(genericCallWithFunctionReturnLiteral.ts, 0, 0))
+>T : Symbol(T, Decl(genericCallWithFunctionReturnLiteral.ts, 0, 13))
+>t : Symbol(t, Decl(genericCallWithFunctionReturnLiteral.ts, 0, 16))
+>T : Symbol(T, Decl(genericCallWithFunctionReturnLiteral.ts, 0, 13))
+>t : Symbol(t, Decl(genericCallWithFunctionReturnLiteral.ts, 0, 16))
+
+foo(() => 123)
+>foo : Symbol(foo, Decl(genericCallWithFunctionReturnLiteral.ts, 0, 0))
+

--- a/tests/baselines/reference/genericCallWithFunctionReturnLiteral.types
+++ b/tests/baselines/reference/genericCallWithFunctionReturnLiteral.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/genericCallWithFunctionReturnLiteral.ts ===
+function foo<T>(t: T) { return t; }
+>foo : <T>(t: T) => T
+>T : T
+>t : T
+>T : T
+>t : T
+
+foo(() => 123)
+>foo(() => 123) : () => number
+>foo : <T>(t: T) => T
+>() => 123 : () => number
+>123 : 123
+

--- a/tests/baselines/reference/implicitAnyFromCircularInference.errors.txt
+++ b/tests/baselines/reference/implicitAnyFromCircularInference.errors.txt
@@ -5,10 +5,10 @@ tests/cases/compiler/implicitAnyFromCircularInference.ts(10,5): error TS2502: 'd
 tests/cases/compiler/implicitAnyFromCircularInference.ts(15,10): error TS7023: 'g' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
 tests/cases/compiler/implicitAnyFromCircularInference.ts(18,10): error TS7024: Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
 tests/cases/compiler/implicitAnyFromCircularInference.ts(23,10): error TS7024: Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
-tests/cases/compiler/implicitAnyFromCircularInference.ts(26,10): error TS7023: 'h' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
-tests/cases/compiler/implicitAnyFromCircularInference.ts(28,14): error TS7023: 'foo' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
-tests/cases/compiler/implicitAnyFromCircularInference.ts(41,5): error TS7022: 's' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
-tests/cases/compiler/implicitAnyFromCircularInference.ts(46,9): error TS7023: 'x' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+tests/cases/compiler/implicitAnyFromCircularInference.ts(28,10): error TS7023: 'h' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+tests/cases/compiler/implicitAnyFromCircularInference.ts(30,14): error TS7023: 'foo' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+tests/cases/compiler/implicitAnyFromCircularInference.ts(43,5): error TS7022: 's' implicitly has type 'any' because it does not have a type annotation and is referenced directly or indirectly in its own initializer.
+tests/cases/compiler/implicitAnyFromCircularInference.ts(48,9): error TS7023: 'x' implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
 
 
 ==== tests/cases/compiler/implicitAnyFromCircularInference.ts (11 errors) ====
@@ -49,6 +49,8 @@ tests/cases/compiler/implicitAnyFromCircularInference.ts(46,9): error TS7023: 'x
     var f2 = () => f2();
              ~~~~~~~~~~
 !!! error TS7024: Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+    
+    var f3 = () => f3;
     
     // Error expected
     function h() {

--- a/tests/baselines/reference/implicitAnyFromCircularInference.js
+++ b/tests/baselines/reference/implicitAnyFromCircularInference.js
@@ -23,6 +23,8 @@ var f1 = function () {
 // Error expected
 var f2 = () => f2();
 
+var f3 = () => f3;
+
 // Error expected
 function h() {
     return foo();
@@ -67,6 +69,7 @@ var f1 = function () {
 };
 // Error expected
 var f2 = function () { return f2(); };
+var f3 = function () { return f3; };
 // Error expected
 function h() {
     return foo();

--- a/tests/baselines/reference/recursiveComplicatedClasses.types
+++ b/tests/baselines/reference/recursiveComplicatedClasses.types
@@ -24,7 +24,7 @@ class Symbol {
 >bound : boolean
 
     public visible() {
->visible : () => any
+>visible : () => boolean
 
         var b: TypeSymbol;
 >b : TypeSymbol

--- a/tests/cases/compiler/genericCallWithFunctionReturnLiteral.ts
+++ b/tests/cases/compiler/genericCallWithFunctionReturnLiteral.ts
@@ -1,0 +1,3 @@
+function foo<T>(t: T) { return t; }
+
+foo(() => 123)

--- a/tests/cases/compiler/implicitAnyFromCircularInference.ts
+++ b/tests/cases/compiler/implicitAnyFromCircularInference.ts
@@ -24,6 +24,8 @@ var f1 = function () {
 // Error expected
 var f2 = () => f2();
 
+var f3 = () => f3;
+
 // Error expected
 function h() {
     return foo();


### PR DESCRIPTION
Fix #10698 This fix only applies to primitive return type, so it guarantees no implicit any will escape the warning. It's just a mitigation for cyclic type inference, but I think it is good enough for common usage.

Some cyclic cases like `let f = () => f` are not fixed, because it will need to generate more anonymous type for later merging. I don't know whether this is good.

@yuit @mhegazy How do you feel about this approach? 
