### PR TITLE
More robust check for Intl.Collator

### DIFF
--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -326,7 +326,7 @@ namespace ts.NavigationBar {
     }
 
     // More efficient to create a collator once and use its `compare` than to call `a.localeCompare(b)` many times.
-    const collator: { compare(a: string, b: string): number } = typeof Intl === "object" && typeof Intl.Collator === "function" ? new Intl.Collator() : undefined;
+    const collator: { compare(a: string, b: string): number } = typeof Intl !== "undefined" && Intl && typeof Intl.Collator === "function" ? new Intl.Collator() : undefined;
     // Intl is missing in Safari, and node 0.10 treats "a" as greater than "B".
     const localeCompareIsCorrect = collator && collator.compare("a", "B") < 0;
     const localeCompareFix: (a: string, b: string) => number = localeCompareIsCorrect ? collator.compare : function(a, b) {


### PR DESCRIPTION
Small augmentation to https://github.com/Microsoft/TypeScript/pull/11268 by @yuit **Address how Chakra load globalization dll**

In the original PR comparing to `object` is both too wide and too narrow.

Too wide because `typeof null==="object"` so the check would pass in cases where it shouldn't.
Too narrow because there is no need to forbid `Intl` to be a function. All we care about is to be able to call `Intl.Collator`. Whilst the standard Chakra host might have `Intl` as plain object, it's best to keep it open and only limit to what we really need, not some implementation details.

My suggestion is to check that `Intl` is good enough to 'dot' it and nothing more.