### PR TITLE
Use a `for-of` loop for a dense array instead of iterating over keys and then indexing

### DIFF
--- a/src/compiler/transformers/es6.ts
+++ b/src/compiler/transformers/es6.ts
@@ -2308,8 +2308,7 @@ namespace ts {
                         extraVariableDeclarations = [];
                     }
                     // hoist collected variable declarations
-                    for (const name in currentState.hoistedLocalVariables) {
-                        const identifier = currentState.hoistedLocalVariables[name];
+                    for (const identifier of currentState.hoistedLocalVariables) {
                         extraVariableDeclarations.push(createVariableDeclaration(identifier));
                     }
                 }


### PR DESCRIPTION
`hoistedLocalVariables` appears to be a dense array, since we `push` to it and don't set by index.