### PR TITLE
Update browserify task for gulp-typescript 3.0

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -729,12 +729,12 @@ gulp.task("browserify", "Runs browserify on run.js to produce a file suitable fo
     return testProject.src()
         .pipe(newer("built/local/bundle.js"))
         .pipe(sourcemaps.init())
-        .pipe(testProject)
+        .pipe(testProject())
         .pipe(through2.obj((file, enc, next) => {
             const originalMap = file.sourceMap;
             const prebundledContent = file.contents.toString();
             // Make paths absolute to help sorcery deal with all the terrible paths being thrown around
-            originalMap.sources = originalMap.sources.map(s => path.resolve("src", s));
+            originalMap.sources = originalMap.sources.map(s => path.resolve(s));
             // intoStream (below) makes browserify think the input file is named this, so this is what it puts in the sourcemap
             originalMap.file = "built/local/_stream_0.js";
 

--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -725,7 +725,7 @@ declare module "convert-source-map" {
 }
 
 gulp.task("browserify", "Runs browserify on run.js to produce a file suitable for running tests in the browser", [servicesFile], (done) => {
-    const testProject = tsc.createProject("src/harness/tsconfig.json", getCompilerSettings({ outFile: "built/local/bundle.js" }, /*useBuiltCompiler*/ true));
+    const testProject = tsc.createProject("src/harness/tsconfig.json", getCompilerSettings({ outFile: "../../built/local/bundle.js" }, /*useBuiltCompiler*/ true));
     return testProject.src()
         .pipe(newer("built/local/bundle.js"))
         .pipe(sourcemaps.init())


### PR DESCRIPTION
Fixes runtests-browser

1. Doesn't need extra src/ prefix
2. testProject is now a function that needs to be called first.

2a. `path.resolve` apparently relies on this because you can't pass it straight to `map`. :(