### PR TITLE
Handle the require call in javascript file for getSymbolAtLocation

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18436,6 +18436,9 @@ namespace ts {
                             (<ImportDeclaration>node.parent).moduleSpecifier === node)) {
                         return resolveExternalModuleName(node, <LiteralExpression>node);
                     }
+                    if (isInJavaScriptFile(node) && isRequireCall(node.parent, /*checkArgumentIsStringLiteral*/ false)) {
+                        return resolveExternalModuleName(node, <LiteralExpression>node);
+                    }
                 // Fall through
 
                 case SyntaxKind.NumericLiteral:

--- a/tests/cases/fourslash/goToDefinitionJsModuleName.ts
+++ b/tests/cases/fourslash/goToDefinitionJsModuleName.ts
@@ -7,5 +7,4 @@
 // @Filename: bar.js
 ////var x = require(/*1*/"./foo");
 
-debugger;
 verify.goToDefinition("1", "2");

--- a/tests/cases/fourslash/goToDefinitionJsModuleName.ts
+++ b/tests/cases/fourslash/goToDefinitionJsModuleName.ts
@@ -1,0 +1,11 @@
+/// <reference path='fourslash.ts'/>
+
+// @allowJs: true
+// @Filename: foo.js
+/////*2*/module.exports = {};
+
+// @Filename: bar.js
+////var x = require(/*1*/"./foo");
+
+debugger;
+verify.goToDefinition("1", "2");


### PR DESCRIPTION
This helps in getting the alias symbol so that it can go to the definition of external module
Fixes #9251