### PR TITLE
Don't show globals (e.g. snippets) in JSX positions

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -904,6 +904,7 @@ namespace ts.Completions {
             }
             isMemberCompletion = true;
             isNewIdentifierLocation = false;
+            isGlobalCompletion = false;
         }
         else if (isStartingCloseTag) {
             const tagName = (<JsxElement>contextToken.parent.parent).openingElement.tagName;
@@ -914,6 +915,7 @@ namespace ts.Completions {
             }
             isMemberCompletion = true;
             isNewIdentifierLocation = false;
+            isGlobalCompletion = false;
         }
         else {
             // For JavaScript or TypeScript, if we're not after a dot, then just try to get the
@@ -1001,6 +1003,7 @@ namespace ts.Completions {
                 if ((jsxContainer.kind === SyntaxKind.JsxSelfClosingElement) || (jsxContainer.kind === SyntaxKind.JsxOpeningElement)) {
                     // Cursor is inside a JSX self-closing element or opening element
                     attrsType = typeChecker.getJsxElementAttributesType(<JsxOpeningLikeElement>jsxContainer);
+                    isGlobalCompletion = false;
 
                     if (attrsType) {
                         symbols = filterJsxAttributes(typeChecker.getPropertiesOfType(attrsType), (<JsxOpeningLikeElement>jsxContainer).attributes);

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -904,7 +904,6 @@ namespace ts.Completions {
             }
             isMemberCompletion = true;
             isNewIdentifierLocation = false;
-            isGlobalCompletion = false;
         }
         else if (isStartingCloseTag) {
             const tagName = (<JsxElement>contextToken.parent.parent).openingElement.tagName;
@@ -915,7 +914,6 @@ namespace ts.Completions {
             }
             isMemberCompletion = true;
             isNewIdentifierLocation = false;
-            isGlobalCompletion = false;
         }
         else {
             // For JavaScript or TypeScript, if we're not after a dot, then just try to get the

--- a/tests/cases/fourslash/completionListIsGlobalCompletion.ts
+++ b/tests/cases/fourslash/completionListIsGlobalCompletion.ts
@@ -1,5 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
+//@Filename: file.tsx
 /////// <reference path="/*1*/..\services\services.ts" /> // no globals in reference paths
 ////import { /*2*/ } from "./file.ts";  // no globals in imports
 ////var test = "/*3*/"; // no globals in strings
@@ -20,6 +21,7 @@
 ////   /*9*/ // insert globals
 ////}
 /////*10*/ // insert globals
+////const y = <div /*11*/ />;
 goTo.marker("1");
 verify.completionListIsGlobal(false);
 goTo.marker("2");
@@ -40,3 +42,5 @@ goTo.marker("9");
 verify.completionListIsGlobal(true);
 goTo.marker("10");
 verify.completionListIsGlobal(true);
+goTo.marker("11");
+verify.completionListIsGlobal(false);


### PR DESCRIPTION
Fixes part of internal bug 269788