### PR TITLE
do not run semantic classification on non-ts-or-tsx files

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1109,7 +1109,7 @@ namespace ts.server {
 
         private getNavigationBarItems(args: protocol.FileRequestArgs, simplifiedResult: boolean): protocol.NavigationBarItem[] | NavigationBarItem[] {
             const { file, project } = this.getFileAndProject(args);
-            const items = project.getLanguageService().getNavigationBarItems(file);
+            const items = project.getLanguageService(/*ensureSynchronized*/ false).getNavigationBarItems(file);
             if (!items) {
                 return undefined;
             }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1512,12 +1512,25 @@ namespace ts {
             return NavigationBar.getNavigationBarItems(sourceFile);
         }
 
+        function isTsOrTsxFile(fileName: string): boolean {
+            const kind = getScriptKind(fileName, host);
+            return kind === ScriptKind.TS || kind === ScriptKind.TSX;
+        }
+
         function getSemanticClassifications(fileName: string, span: TextSpan): ClassifiedSpan[] {
+            if (!isTsOrTsxFile(fileName)) {
+                // do not run semantic classification on non-ts-or-tsx files
+                return [];
+            }
             synchronizeHostData();
             return ts.getSemanticClassifications(program.getTypeChecker(), cancellationToken, getValidSourceFile(fileName), program.getClassifiableNames(), span);
         }
 
         function getEncodedSemanticClassifications(fileName: string, span: TextSpan): Classifications {
+            if (!isTsOrTsxFile(fileName)) {
+                // do not run semantic classification on non-ts-or-tsx files
+                return { spans: [], endOfLineState: EndOfLineState.None };
+            }
             synchronizeHostData();
             return ts.getEncodedSemanticClassifications(program.getTypeChecker(), cancellationToken, getValidSourceFile(fileName), program.getClassifiableNames(), span);
         }

--- a/tests/cases/fourslash/semanticClassificationJs.ts
+++ b/tests/cases/fourslash/semanticClassificationJs.ts
@@ -1,0 +1,9 @@
+/// <reference path="fourslash.ts"/>
+
+// @Filename: app.js
+//// function foo() {
+//// }
+//// let x = 1;
+
+// no semantic classification in js file
+verify.semanticClassificationsAre();


### PR DESCRIPTION
also don't re-create program for navbar request - we can get answer using only syntactic information