### PR TITLE
Fix #11314: Expose `insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces` and `insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces` on protocol definiton

### DIFF
--- a/src/server/protocol.d.ts
+++ b/src/server/protocol.d.ts
@@ -591,6 +591,12 @@ declare namespace ts.server.protocol {
         /** Defines space handling after opening and before closing non empty brackets. Default value is false. */
         insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets?: boolean;
 
+        /** Defines space handling before and after template string braces. Default value is false. */
+        insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: boolean;
+
+        /** Defines space handling before and after JSX expression braces. Default value is false. */
+        insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: boolean;
+
         /** Defines whether an open brace is put onto a new line for functions or not. Default value is false. */
         placeOpenBraceOnNewLineForFunctions?: boolean;
 

--- a/src/server/protocol.d.ts
+++ b/src/server/protocol.d.ts
@@ -592,10 +592,10 @@ declare namespace ts.server.protocol {
         insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets?: boolean;
 
         /** Defines space handling before and after template string braces. Default value is false. */
-        insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: boolean;
+        insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces?: boolean;
 
         /** Defines space handling before and after JSX expression braces. Default value is false. */
-        insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: boolean;
+        insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces?: boolean;
 
         /** Defines whether an open brace is put onto a new line for functions or not. Default value is false. */
         placeOpenBraceOnNewLineForFunctions?: boolean;


### PR DESCRIPTION
Fixes #11314
