### PR TITLE
[Release 2.0.5] Porting completion and goto def fixes

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -18167,6 +18167,9 @@ namespace ts {
                             (<ImportDeclaration>node.parent).moduleSpecifier === node)) {
                         return resolveExternalModuleName(node, <LiteralExpression>node);
                     }
+                    if (isInJavaScriptFile(node) && isRequireCall(node.parent, /*checkArgumentIsStringLiteral*/ false)) {
+                        return resolveExternalModuleName(node, <LiteralExpression>node);
+                    }
                 // Fall through
 
                 case SyntaxKind.NumericLiteral:

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -4497,7 +4497,9 @@ namespace ts {
                     return undefined;
                 }
 
-                if (node.parent.kind === SyntaxKind.PropertyAssignment && node.parent.parent.kind === SyntaxKind.ObjectLiteralExpression) {
+                if (node.parent.kind === SyntaxKind.PropertyAssignment &&
+                    node.parent.parent.kind === SyntaxKind.ObjectLiteralExpression &&
+                    (<PropertyAssignment>node.parent).name === node) {
                     // Get quoted name of properties of the object literal expression
                     // i.e. interface ConfigFiles {
                     //          'jspm:dev': string

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -4371,7 +4371,7 @@ namespace ts {
             const entries: CompletionEntry[] = [];
 
             if (isSourceFileJavaScript(sourceFile)) {
-                const uniqueNames = getCompletionEntriesFromSymbols(symbols, entries, location, /*performCharacterChecks*/ false);
+                const uniqueNames = getCompletionEntriesFromSymbols(symbols, entries, location, /*performCharacterChecks*/ true);
                 addRange(entries, getJavaScriptCompletionEntries(sourceFile, location.pos, uniqueNames));
             }
             else {

--- a/tests/cases/fourslash/completionListInObjectLiteralPropertyAssignment.ts
+++ b/tests/cases/fourslash/completionListInObjectLiteralPropertyAssignment.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+////var foo;
+////interface I {
+////    metadata: string;
+////    wat: string;
+////}
+////var x: I = {
+////    metadata: "/*1*/
+////}
+
+goTo.marker('1');
+
+verify.not.completionListContains("metadata");
+verify.not.completionListContains("wat");

--- a/tests/cases/fourslash/completionListInvalidMemberNames3.ts
+++ b/tests/cases/fourslash/completionListInvalidMemberNames3.ts
@@ -1,0 +1,71 @@
+/// <reference path='fourslash.ts' />
+
+// @allowjs: true
+
+// @Filename: test.js
+////interface Symbol {
+////    /** Returns a string representation of an object. */
+////    toString(): string;
+
+////    /** Returns the primitive value of the specified object. */
+////    valueOf(): Object;
+////}
+
+////interface SymbolConstructor {
+////    /** 
+////      * A reference to the prototype. 
+////      */
+////    readonly prototype: Symbol;
+
+////    /**
+////      * Returns a new unique Symbol value.
+////      * @param  description Description of the new Symbol object.
+////      */
+////    (description?: string | number): symbol;
+
+////    /**
+////      * Returns a Symbol object from the global symbol registry matching the given key if found. 
+////      * Otherwise, returns a new symbol with this key.
+////      * @param key key to search for.
+////      */
+////    for(key: string): symbol;
+
+////    /**
+////      * Returns a key from the global symbol registry matching the given Symbol if found. 
+////      * Otherwise, returns a undefined.
+////      * @param sym Symbol to find the key for.
+////      */
+////    keyFor(sym: symbol): string | undefined;
+////}
+
+////declare var Symbol: SymbolConstructor;/// <reference path="lib.es2015.symbol.d.ts" />
+
+////interface SymbolConstructor {
+////    /** 
+////      * A method that determines if a constructor object recognizes an object as one of the 
+////      * constructor’s instances. Called by the semantics of the instanceof operator. 
+////      */
+////    readonly hasInstance: symbol;
+////}
+
+////interface Function {
+////    /**
+////     * Determines whether the given value inherits from this function if this function was used
+////     * as a constructor function.
+////     *
+////     * A constructor function can control which objects are recognized as its instances by
+////     * 'instanceof' by overriding this method.
+////     */
+////    [Symbol.hasInstance](value: any): boolean;
+////}
+
+////interface SomeInterface {
+////    (value: number): any;
+////}
+
+////var _ : SomeInterface;
+////_./**/
+
+goTo.marker();
+
+verify.not.completionListContains("[Symbol.hasInstance]");

--- a/tests/cases/fourslash/goToDefinitionJsModuleName.ts
+++ b/tests/cases/fourslash/goToDefinitionJsModuleName.ts
@@ -1,0 +1,12 @@
+/// <reference path='fourslash.ts'/>
+
+// @allowJs: true
+// @Filename: foo.js
+/////*2*/module.exports = {};
+
+// @Filename: bar.js
+////var x = require(/*1*/"./foo");
+
+goTo.marker("1");
+goTo.definition();
+verify.caretAtMarker("2");


### PR DESCRIPTION
- Fix incorrect returning of completion entries when in string literal of property assignment expression  #11401 Fixes #11232
- Add missing check in javascript file for valid identifier when creating completion entry from symbol  #11395  Fixes #11217 
- Handle the require call in javascript file for getSymbolAtLocation  #11373 This helps in getting the alias symbol so that it can go to the definition of external module Fixes #9251
