### PR TITLE
 Do not get return type from contextual signature if we are already in process of getting return type of it 

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12771,7 +12771,10 @@ namespace ts {
             if (!contextualSignature) {
                 reportErrorsFromWidening(func, type);
             }
-            if (isUnitType(type) && !(contextualSignature && isLiteralContextualType(getReturnTypeOfSignature(contextualSignature)))) {
+            if (isUnitType(type) &&
+                !(contextualSignature &&
+                    isLiteralContextualType(
+                        contextualSignature === getSignatureFromDeclaration(func) ? type : getReturnTypeOfSignature(contextualSignature)))) {
                 type = getWidenedLiteralType(type);
             }
 

--- a/tests/baselines/reference/selfReference.errors.txt
+++ b/tests/baselines/reference/selfReference.errors.txt
@@ -1,8 +1,0 @@
-tests/cases/compiler/selfReference.ts(2,12): error TS7024: Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
-
-
-==== tests/cases/compiler/selfReference.ts (1 errors) ====
-    declare function asFunction<T>(value: T): () => T;
-    asFunction(() => { return 1; });
-               ~~~~~~~~~~~~~~~~~~~
-!!! error TS7024: Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.

--- a/tests/baselines/reference/selfReference.errors.txt
+++ b/tests/baselines/reference/selfReference.errors.txt
@@ -1,0 +1,8 @@
+tests/cases/compiler/selfReference.ts(2,12): error TS7024: Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.
+
+
+==== tests/cases/compiler/selfReference.ts (1 errors) ====
+    declare function asFunction<T>(value: T): () => T;
+    asFunction(() => { return 1; });
+               ~~~~~~~~~~~~~~~~~~~
+!!! error TS7024: Function implicitly has return type 'any' because it does not have a return type annotation and is referenced directly or indirectly in one of its return expressions.

--- a/tests/baselines/reference/selfReference.js
+++ b/tests/baselines/reference/selfReference.js
@@ -1,0 +1,6 @@
+//// [selfReference.ts]
+declare function asFunction<T>(value: T): () => T;
+asFunction(() => { return 1; });
+
+//// [selfReference.js]
+asFunction(function () { return 1; });

--- a/tests/baselines/reference/selfReference.symbols
+++ b/tests/baselines/reference/selfReference.symbols
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/selfReference.ts ===
+declare function asFunction<T>(value: T): () => T;
+>asFunction : Symbol(asFunction, Decl(selfReference.ts, 0, 0))
+>T : Symbol(T, Decl(selfReference.ts, 0, 28))
+>value : Symbol(value, Decl(selfReference.ts, 0, 31))
+>T : Symbol(T, Decl(selfReference.ts, 0, 28))
+>T : Symbol(T, Decl(selfReference.ts, 0, 28))
+
+asFunction(() => { return 1; });
+>asFunction : Symbol(asFunction, Decl(selfReference.ts, 0, 0))
+

--- a/tests/baselines/reference/selfReference.types
+++ b/tests/baselines/reference/selfReference.types
@@ -1,0 +1,14 @@
+=== tests/cases/compiler/selfReference.ts ===
+declare function asFunction<T>(value: T): () => T;
+>asFunction : <T>(value: T) => () => T
+>T : T
+>value : T
+>T : T
+>T : T
+
+asFunction(() => { return 1; });
+>asFunction(() => { return 1; }) : () => () => 1
+>asFunction : <T>(value: T) => () => T
+>() => { return 1; } : () => 1
+>1 : 1
+

--- a/tests/cases/compiler/selfReference.ts
+++ b/tests/cases/compiler/selfReference.ts
@@ -1,0 +1,3 @@
+// @noImplicitAny: true
+declare function asFunction<T>(value: T): () => T;
+asFunction(() => { return 1; });


### PR DESCRIPTION
Fixes #10073
