### PR TITLE
Fix #10758 Add compiler option to parse in strict mode

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -121,7 +121,8 @@ namespace ts {
 
         // If this file is an external module, then it is automatically in strict-mode according to
         // ES6.  If it is not an external module, then we'll determine if it is in strict mode or
-        // not depending on if we see "use strict" in certain places (or if we hit a class/namespace).
+        // not depending on if we see "use strict" in certain places or if we hit a class/namespace
+        // or if compiler options contain alwaysStrict.
         let inStrictMode: boolean;
 
         let symbolCount = 0;
@@ -139,7 +140,7 @@ namespace ts {
             file = f;
             options = opts;
             languageVersion = getEmitScriptTarget(options);
-            inStrictMode = !!file.externalModuleIndicator;
+            inStrictMode = bindInStrictMode(file, opts);
             classifiableNames = createMap<string>();
             symbolCount = 0;
             skipTransformFlagAggregation = isDeclarationFile(file);
@@ -173,6 +174,16 @@ namespace ts {
         }
 
         return bindSourceFile;
+
+        function bindInStrictMode(file: SourceFile, opts: CompilerOptions): boolean {
+            if (opts.alwaysStrict && !isDeclarationFile(file)) {
+                // bind in strict mode source files with alwaysStrict option
+                return true;
+            }
+            else {
+                return !!file.externalModuleIndicator;
+            }
+        }
 
         function createSymbol(flags: SymbolFlags, name: string): Symbol {
             symbolCount++;

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -444,6 +444,11 @@ namespace ts {
             name: "importHelpers",
             type: "boolean",
             description: Diagnostics.Import_emit_helpers_from_tslib
+        },
+        {
+            name: "alwaysStrict",
+            type: "boolean",
+            description: Diagnostics.Parse_in_strict_mode_and_emit_use_strict_for_each_source_file
         }
     ];
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2861,6 +2861,10 @@
         "category": "Error",
         "code": 6140
     },
+    "Parse in strict mode and emit \"use strict\" for each source file": {
+        "category": "Message",
+        "code": 6141
+    },
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",
         "code": 7005

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -2236,6 +2236,36 @@ namespace ts {
     }
 
     /**
+     * Ensures "use strict" directive is added
+     * 
+     * @param node source file
+     */
+    export function ensureUseStrict(node: SourceFile): SourceFile {
+        let foundUseStrict = false;
+        let statementOffset = 0;
+        const numStatements = node.statements.length;
+        while (statementOffset < numStatements) {
+            const statement = node.statements[statementOffset];
+            if (isPrologueDirective(statement)) {
+                if (isUseStrictPrologue(statement as ExpressionStatement)) {
+                    foundUseStrict = true;
+                }
+            }
+            else {
+                break;
+            }
+            statementOffset++;
+        }
+        if (!foundUseStrict) {
+            const statements: Statement[] = [];
+            statements.push(startOnNewLine(createStatement(createLiteral("use strict"))));
+            // add "use strict" as the first statement
+            return updateSourceFileNode(node, statements.concat(node.statements));
+        }
+        return node;
+    }
+
+    /**
      * Wraps the operand to a BinaryExpression in parentheses if they are needed to preserve the intended
      * order of operations.
      *

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -2242,19 +2242,16 @@ namespace ts {
      */
     export function ensureUseStrict(node: SourceFile): SourceFile {
         let foundUseStrict = false;
-        let statementOffset = 0;
-        const numStatements = node.statements.length;
-        while (statementOffset < numStatements) {
-            const statement = node.statements[statementOffset];
+        for (const statement of node.statements) {
             if (isPrologueDirective(statement)) {
                 if (isUseStrictPrologue(statement as ExpressionStatement)) {
                     foundUseStrict = true;
+                    break;
                 }
             }
             else {
                 break;
             }
-            statementOffset++;
         }
         if (!foundUseStrict) {
             const statements: Statement[] = [];

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -438,7 +438,7 @@ namespace ts {
 
             // ensure "use strict"" is emitted in all scenarios in alwaysStrict mode
             if (compilerOptions.alwaysStrict) {
-                node = emitUseStrict(node);
+                node = ensureUseStrict(node);
             }
 
             // If the source file requires any helpers and is an external module, and
@@ -475,13 +475,6 @@ namespace ts {
 
             setEmitFlags(node, EmitFlags.EmitEmitHelpers | getEmitFlags(node));
             return node;
-        }
-
-        function emitUseStrict(node: SourceFile): SourceFile {
-            const statements: Statement[] = [];
-            statements.push(startOnNewLine(createStatement(createLiteral("use strict"))));
-            // add "use strict" as the first statement
-            return updateSourceFileNode(node, statements.concat(node.statements));
         }
 
         /**

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -436,7 +436,7 @@ namespace ts {
         function visitSourceFile(node: SourceFile) {
             currentSourceFile = node;
 
-            // ensure "use strict"" is emitted in all scenarios in alwaysStrict mode
+            // ensure "use strict" is emitted in all scenarios in alwaysStrict mode
             if (compilerOptions.alwaysStrict) {
                 node = ensureUseStrict(node);
             }

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -436,6 +436,11 @@ namespace ts {
         function visitSourceFile(node: SourceFile) {
             currentSourceFile = node;
 
+            // ensure "use strict"" is emitted in all scenarios in alwaysStrict mode
+            if (compilerOptions.alwaysStrict) {
+                node = emitUseStrict(node);
+            }
+
             // If the source file requires any helpers and is an external module, and
             // the importHelpers compiler option is enabled, emit a synthesized import
             // statement for the helpers library.
@@ -470,6 +475,13 @@ namespace ts {
 
             setEmitFlags(node, EmitFlags.EmitEmitHelpers | getEmitFlags(node));
             return node;
+        }
+
+        function emitUseStrict(node: SourceFile): SourceFile {
+            const statements: Statement[] = [];
+            statements.push(startOnNewLine(createStatement(createLiteral("use strict"))));
+            // add "use strict" as the first statement
+            return updateSourceFileNode(node, statements.concat(node.statements));
         }
 
         /**

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2929,6 +2929,7 @@ namespace ts {
         allowSyntheticDefaultImports?: boolean;
         allowUnreachableCode?: boolean;
         allowUnusedLabels?: boolean;
+        alwaysStrict?: boolean;
         baseUrl?: string;
         charset?: string;
         /* @internal */ configFilePath?: string;

--- a/src/harness/unittests/transpile.ts
+++ b/src/harness/unittests/transpile.ts
@@ -253,6 +253,10 @@ var x = 0;`, {
             options: { compilerOptions: { allowUnusedLabels: true }, fileName: "input.js", reportDiagnostics: true }
         });
 
+        transpilesCorrectly("Supports setting 'alwaysStrict'", "x;", {
+            options: { compilerOptions: { alwaysStrict: true }, fileName: "input.js", reportDiagnostics: true }
+        });
+
         transpilesCorrectly("Supports setting 'baseUrl'", "x;", {
             options: { compilerOptions: { baseUrl: "./folder/baseUrl" }, fileName: "input.js", reportDiagnostics: true }
         });

--- a/tests/baselines/reference/alwaysStrict.errors.txt
+++ b/tests/baselines/reference/alwaysStrict.errors.txt
@@ -1,0 +1,10 @@
+tests/cases/compiler/alwaysStrict.ts(3,9): error TS1100: Invalid use of 'arguments' in strict mode.
+
+
+==== tests/cases/compiler/alwaysStrict.ts (1 errors) ====
+    
+    function f() {
+        var arguments = [];
+            ~~~~~~~~~
+!!! error TS1100: Invalid use of 'arguments' in strict mode.
+    }

--- a/tests/baselines/reference/alwaysStrict.js
+++ b/tests/baselines/reference/alwaysStrict.js
@@ -1,0 +1,11 @@
+//// [alwaysStrict.ts]
+
+function f() {
+    var arguments = [];
+}
+
+//// [alwaysStrict.js]
+"use strict";
+function f() {
+    var arguments = [];
+}

--- a/tests/baselines/reference/alwaysStrictAlreadyUseStrict.js
+++ b/tests/baselines/reference/alwaysStrictAlreadyUseStrict.js
@@ -1,0 +1,11 @@
+//// [alwaysStrictAlreadyUseStrict.ts]
+"use strict"
+function f() {
+    var a = [];
+}
+
+//// [alwaysStrictAlreadyUseStrict.js]
+"use strict";
+function f() {
+    var a = [];
+}

--- a/tests/baselines/reference/alwaysStrictAlreadyUseStrict.symbols
+++ b/tests/baselines/reference/alwaysStrictAlreadyUseStrict.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/alwaysStrictAlreadyUseStrict.ts ===
+"use strict"
+function f() {
+>f : Symbol(f, Decl(alwaysStrictAlreadyUseStrict.ts, 0, 12))
+
+    var a = [];
+>a : Symbol(a, Decl(alwaysStrictAlreadyUseStrict.ts, 2, 7))
+}

--- a/tests/baselines/reference/alwaysStrictAlreadyUseStrict.types
+++ b/tests/baselines/reference/alwaysStrictAlreadyUseStrict.types
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/alwaysStrictAlreadyUseStrict.ts ===
+"use strict"
+>"use strict" : "use strict"
+
+function f() {
+>f : () => void
+
+    var a = [];
+>a : any[]
+>[] : undefined[]
+}

--- a/tests/baselines/reference/alwaysStrictES6.errors.txt
+++ b/tests/baselines/reference/alwaysStrictES6.errors.txt
@@ -1,0 +1,10 @@
+tests/cases/compiler/alwaysStrictES6.ts(3,9): error TS1100: Invalid use of 'arguments' in strict mode.
+
+
+==== tests/cases/compiler/alwaysStrictES6.ts (1 errors) ====
+    
+    function f() {
+        var arguments = [];
+            ~~~~~~~~~
+!!! error TS1100: Invalid use of 'arguments' in strict mode.
+    }

--- a/tests/baselines/reference/alwaysStrictES6.js
+++ b/tests/baselines/reference/alwaysStrictES6.js
@@ -1,0 +1,11 @@
+//// [alwaysStrictES6.ts]
+
+function f() {
+    var arguments = [];
+}
+
+//// [alwaysStrictES6.js]
+"use strict";
+function f() {
+    var arguments = [];
+}

--- a/tests/baselines/reference/alwaysStrictModule.errors.txt
+++ b/tests/baselines/reference/alwaysStrictModule.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/alwaysStrictModule.ts(4,13): error TS1100: Invalid use of 'arguments' in strict mode.
+
+
+==== tests/cases/compiler/alwaysStrictModule.ts (1 errors) ====
+    
+    module M {
+        export function f() {
+            var arguments = [];
+                ~~~~~~~~~
+!!! error TS1100: Invalid use of 'arguments' in strict mode.
+        }
+    }

--- a/tests/baselines/reference/alwaysStrictModule.js
+++ b/tests/baselines/reference/alwaysStrictModule.js
@@ -1,0 +1,17 @@
+//// [alwaysStrictModule.ts]
+
+module M {
+    export function f() {
+        var arguments = [];
+    }
+}
+
+//// [alwaysStrictModule.js]
+"use strict";
+var M;
+(function (M) {
+    function f() {
+        var arguments = [];
+    }
+    M.f = f;
+})(M || (M = {}));

--- a/tests/baselines/reference/alwaysStrictNoImplicitUseStrict.errors.txt
+++ b/tests/baselines/reference/alwaysStrictNoImplicitUseStrict.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/alwaysStrictNoImplicitUseStrict.ts(4,13): error TS1100: Invalid use of 'arguments' in strict mode.
+
+
+==== tests/cases/compiler/alwaysStrictNoImplicitUseStrict.ts (1 errors) ====
+    
+    module M {
+        export function f() {
+            var arguments = [];
+                ~~~~~~~~~
+!!! error TS1100: Invalid use of 'arguments' in strict mode.
+        }
+    }

--- a/tests/baselines/reference/alwaysStrictNoImplicitUseStrict.js
+++ b/tests/baselines/reference/alwaysStrictNoImplicitUseStrict.js
@@ -1,0 +1,17 @@
+//// [alwaysStrictNoImplicitUseStrict.ts]
+
+module M {
+    export function f() {
+        var arguments = [];
+    }
+}
+
+//// [alwaysStrictNoImplicitUseStrict.js]
+"use strict";
+var M;
+(function (M) {
+    function f() {
+        var arguments = [];
+    }
+    M.f = f;
+})(M || (M = {}));

--- a/tests/baselines/reference/transpile/Supports setting alwaysStrict.js
+++ b/tests/baselines/reference/transpile/Supports setting alwaysStrict.js
@@ -1,0 +1,3 @@
+"use strict";
+x;
+//# sourceMappingURL=input.js.map

--- a/tests/cases/compiler/alwaysStrict.ts
+++ b/tests/cases/compiler/alwaysStrict.ts
@@ -1,0 +1,5 @@
+// @alwaysStrict: true
+
+function f() {
+    var arguments = [];
+}

--- a/tests/cases/compiler/alwaysStrictAlreadyUseStrict.ts
+++ b/tests/cases/compiler/alwaysStrictAlreadyUseStrict.ts
@@ -1,0 +1,5 @@
+// @alwaysStrict: true
+"use strict"
+function f() {
+    var a = [];
+}

--- a/tests/cases/compiler/alwaysStrictES6.ts
+++ b/tests/cases/compiler/alwaysStrictES6.ts
@@ -1,0 +1,6 @@
+// @target: ES6
+// @alwaysStrict: true
+
+function f() {
+    var arguments = [];
+}

--- a/tests/cases/compiler/alwaysStrictModule.ts
+++ b/tests/cases/compiler/alwaysStrictModule.ts
@@ -1,0 +1,8 @@
+// @module: commonjs
+// @alwaysStrict: true
+
+module M {
+    export function f() {
+        var arguments = [];
+    }
+}

--- a/tests/cases/compiler/alwaysStrictNoImplicitUseStrict.ts
+++ b/tests/cases/compiler/alwaysStrictNoImplicitUseStrict.ts
@@ -1,0 +1,9 @@
+// @module: commonjs
+// @alwaysStrict: true
+// @noImplicitUseStrict: true
+
+module M {
+    export function f() {
+        var arguments = [];
+    }
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #10758

 * add compiler option alwaysStrict
 * compile in strict mode when option is set
 * emit "use strict"