### PR TITLE
Resolve export= module members

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17893,7 +17893,8 @@ namespace ts {
             }
 
             function isNotOverload(declaration: Declaration): boolean {
-                return declaration.kind !== SyntaxKind.FunctionDeclaration || !!(declaration as FunctionDeclaration).body;
+                return (declaration.kind !== SyntaxKind.FunctionDeclaration && declaration.kind !== SyntaxKind.MethodDeclaration) || 
+                        !!(declaration as FunctionDeclaration).body;
             }
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17893,7 +17893,7 @@ namespace ts {
             }
 
             function isNotOverload(declaration: Declaration): boolean {
-                return (declaration.kind !== SyntaxKind.FunctionDeclaration && declaration.kind !== SyntaxKind.MethodDeclaration) || 
+                return (declaration.kind !== SyntaxKind.FunctionDeclaration && declaration.kind !== SyntaxKind.MethodDeclaration) ||
                         !!(declaration as FunctionDeclaration).body;
             }
         }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1465,6 +1465,10 @@ namespace ts {
 
         function getExportsForModule(moduleSymbol: Symbol): SymbolTable {
             const visitedSymbols: Symbol[] = [];
+
+            // A module defined by an 'export=' consists on one export that needs to be resolved
+            moduleSymbol = resolveExternalModuleSymbol(moduleSymbol);
+
             return visit(moduleSymbol) || moduleSymbol.exports;
 
             // The ES6 spec permits export * declarations in a module to circularly reference the module itself. For example,

--- a/tests/baselines/reference/bluebirdStaticThis.errors.txt
+++ b/tests/baselines/reference/bluebirdStaticThis.errors.txt
@@ -1,75 +1,13 @@
 tests/cases/compiler/bluebirdStaticThis.ts(5,15): error TS2420: Class 'Promise<R>' incorrectly implements interface 'Thenable<R>'.
   Property 'then' is missing in type 'Promise<R>'.
-tests/cases/compiler/bluebirdStaticThis.ts(7,12): error TS2323: Cannot redeclare exported variable 'try'.
-tests/cases/compiler/bluebirdStaticThis.ts(8,12): error TS2323: Cannot redeclare exported variable 'try'.
-tests/cases/compiler/bluebirdStaticThis.ts(10,12): error TS2323: Cannot redeclare exported variable 'attempt'.
-tests/cases/compiler/bluebirdStaticThis.ts(11,12): error TS2323: Cannot redeclare exported variable 'attempt'.
-tests/cases/compiler/bluebirdStaticThis.ts(15,12): error TS2323: Cannot redeclare exported variable 'resolve'.
-tests/cases/compiler/bluebirdStaticThis.ts(16,12): error TS2323: Cannot redeclare exported variable 'resolve'.
-tests/cases/compiler/bluebirdStaticThis.ts(17,12): error TS2323: Cannot redeclare exported variable 'resolve'.
-tests/cases/compiler/bluebirdStaticThis.ts(19,12): error TS2323: Cannot redeclare exported variable 'reject'.
-tests/cases/compiler/bluebirdStaticThis.ts(20,12): error TS2323: Cannot redeclare exported variable 'reject'.
 tests/cases/compiler/bluebirdStaticThis.ts(22,51): error TS2694: Namespace 'Promise' has no exported member 'Resolver'.
-tests/cases/compiler/bluebirdStaticThis.ts(24,12): error TS2323: Cannot redeclare exported variable 'cast'.
-tests/cases/compiler/bluebirdStaticThis.ts(25,12): error TS2323: Cannot redeclare exported variable 'cast'.
-tests/cases/compiler/bluebirdStaticThis.ts(33,12): error TS2323: Cannot redeclare exported variable 'delay'.
-tests/cases/compiler/bluebirdStaticThis.ts(34,12): error TS2323: Cannot redeclare exported variable 'delay'.
-tests/cases/compiler/bluebirdStaticThis.ts(35,12): error TS2323: Cannot redeclare exported variable 'delay'.
-tests/cases/compiler/bluebirdStaticThis.ts(49,12): error TS2323: Cannot redeclare exported variable 'all'.
-tests/cases/compiler/bluebirdStaticThis.ts(50,12): error TS2323: Cannot redeclare exported variable 'all'.
-tests/cases/compiler/bluebirdStaticThis.ts(51,12): error TS2323: Cannot redeclare exported variable 'all'.
-tests/cases/compiler/bluebirdStaticThis.ts(52,12): error TS2323: Cannot redeclare exported variable 'all'.
-tests/cases/compiler/bluebirdStaticThis.ts(54,12): error TS2323: Cannot redeclare exported variable 'props'.
-tests/cases/compiler/bluebirdStaticThis.ts(55,12): error TS2323: Cannot redeclare exported variable 'props'.
-tests/cases/compiler/bluebirdStaticThis.ts(57,12): error TS2323: Cannot redeclare exported variable 'settle'.
 tests/cases/compiler/bluebirdStaticThis.ts(57,109): error TS2694: Namespace 'Promise' has no exported member 'Inspection'.
-tests/cases/compiler/bluebirdStaticThis.ts(58,12): error TS2323: Cannot redeclare exported variable 'settle'.
 tests/cases/compiler/bluebirdStaticThis.ts(58,91): error TS2694: Namespace 'Promise' has no exported member 'Inspection'.
-tests/cases/compiler/bluebirdStaticThis.ts(59,12): error TS2323: Cannot redeclare exported variable 'settle'.
 tests/cases/compiler/bluebirdStaticThis.ts(59,91): error TS2694: Namespace 'Promise' has no exported member 'Inspection'.
-tests/cases/compiler/bluebirdStaticThis.ts(60,12): error TS2323: Cannot redeclare exported variable 'settle'.
 tests/cases/compiler/bluebirdStaticThis.ts(60,73): error TS2694: Namespace 'Promise' has no exported member 'Inspection'.
-tests/cases/compiler/bluebirdStaticThis.ts(62,12): error TS2323: Cannot redeclare exported variable 'any'.
-tests/cases/compiler/bluebirdStaticThis.ts(63,12): error TS2323: Cannot redeclare exported variable 'any'.
-tests/cases/compiler/bluebirdStaticThis.ts(64,12): error TS2323: Cannot redeclare exported variable 'any'.
-tests/cases/compiler/bluebirdStaticThis.ts(65,12): error TS2323: Cannot redeclare exported variable 'any'.
-tests/cases/compiler/bluebirdStaticThis.ts(67,12): error TS2323: Cannot redeclare exported variable 'race'.
-tests/cases/compiler/bluebirdStaticThis.ts(68,12): error TS2323: Cannot redeclare exported variable 'race'.
-tests/cases/compiler/bluebirdStaticThis.ts(69,12): error TS2323: Cannot redeclare exported variable 'race'.
-tests/cases/compiler/bluebirdStaticThis.ts(70,12): error TS2323: Cannot redeclare exported variable 'race'.
-tests/cases/compiler/bluebirdStaticThis.ts(72,12): error TS2323: Cannot redeclare exported variable 'some'.
-tests/cases/compiler/bluebirdStaticThis.ts(73,12): error TS2323: Cannot redeclare exported variable 'some'.
-tests/cases/compiler/bluebirdStaticThis.ts(74,12): error TS2323: Cannot redeclare exported variable 'some'.
-tests/cases/compiler/bluebirdStaticThis.ts(75,12): error TS2323: Cannot redeclare exported variable 'some'.
-tests/cases/compiler/bluebirdStaticThis.ts(77,12): error TS2323: Cannot redeclare exported variable 'join'.
-tests/cases/compiler/bluebirdStaticThis.ts(78,12): error TS2323: Cannot redeclare exported variable 'join'.
-tests/cases/compiler/bluebirdStaticThis.ts(80,12): error TS2323: Cannot redeclare exported variable 'map'.
-tests/cases/compiler/bluebirdStaticThis.ts(81,12): error TS2323: Cannot redeclare exported variable 'map'.
-tests/cases/compiler/bluebirdStaticThis.ts(82,12): error TS2323: Cannot redeclare exported variable 'map'.
-tests/cases/compiler/bluebirdStaticThis.ts(83,12): error TS2323: Cannot redeclare exported variable 'map'.
-tests/cases/compiler/bluebirdStaticThis.ts(84,12): error TS2323: Cannot redeclare exported variable 'map'.
-tests/cases/compiler/bluebirdStaticThis.ts(85,12): error TS2323: Cannot redeclare exported variable 'map'.
-tests/cases/compiler/bluebirdStaticThis.ts(86,12): error TS2323: Cannot redeclare exported variable 'map'.
-tests/cases/compiler/bluebirdStaticThis.ts(87,12): error TS2323: Cannot redeclare exported variable 'map'.
-tests/cases/compiler/bluebirdStaticThis.ts(89,12): error TS2323: Cannot redeclare exported variable 'reduce'.
-tests/cases/compiler/bluebirdStaticThis.ts(90,12): error TS2323: Cannot redeclare exported variable 'reduce'.
-tests/cases/compiler/bluebirdStaticThis.ts(92,12): error TS2323: Cannot redeclare exported variable 'reduce'.
-tests/cases/compiler/bluebirdStaticThis.ts(93,12): error TS2323: Cannot redeclare exported variable 'reduce'.
-tests/cases/compiler/bluebirdStaticThis.ts(95,12): error TS2323: Cannot redeclare exported variable 'reduce'.
-tests/cases/compiler/bluebirdStaticThis.ts(96,12): error TS2323: Cannot redeclare exported variable 'reduce'.
-tests/cases/compiler/bluebirdStaticThis.ts(98,12): error TS2323: Cannot redeclare exported variable 'reduce'.
-tests/cases/compiler/bluebirdStaticThis.ts(99,12): error TS2323: Cannot redeclare exported variable 'reduce'.
-tests/cases/compiler/bluebirdStaticThis.ts(101,12): error TS2323: Cannot redeclare exported variable 'filter'.
-tests/cases/compiler/bluebirdStaticThis.ts(102,12): error TS2323: Cannot redeclare exported variable 'filter'.
-tests/cases/compiler/bluebirdStaticThis.ts(103,12): error TS2323: Cannot redeclare exported variable 'filter'.
-tests/cases/compiler/bluebirdStaticThis.ts(104,12): error TS2323: Cannot redeclare exported variable 'filter'.
-tests/cases/compiler/bluebirdStaticThis.ts(105,12): error TS2323: Cannot redeclare exported variable 'filter'.
-tests/cases/compiler/bluebirdStaticThis.ts(106,12): error TS2323: Cannot redeclare exported variable 'filter'.
-tests/cases/compiler/bluebirdStaticThis.ts(107,12): error TS2323: Cannot redeclare exported variable 'filter'.
-tests/cases/compiler/bluebirdStaticThis.ts(108,12): error TS2323: Cannot redeclare exported variable 'filter'.
 
 
-==== tests/cases/compiler/bluebirdStaticThis.ts (68 errors) ====
+==== tests/cases/compiler/bluebirdStaticThis.ts (6 errors) ====
     // This version is reduced from the full d.ts by removing almost all the tests
     // and all the comments.
     // Then it adds explicit `this` arguments to the static members.
@@ -80,48 +18,26 @@ tests/cases/compiler/bluebirdStaticThis.ts(108,12): error TS2323: Cannot redecla
 !!! error TS2420:   Property 'then' is missing in type 'Promise<R>'.
     	constructor(callback: (resolve: (thenableOrResult: R | Promise.Thenable<R>) => void, reject: (error: any) => void) => void);
         static try<R>(dit: typeof Promise, fn: () => Promise.Thenable<R>, args?: any[], ctx?: any): Promise<R>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'try'.
         static try<R>(dit: typeof Promise, fn: () => R, args?: any[], ctx?: any): Promise<R>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'try'.
     
         static attempt<R>(dit: typeof Promise, fn: () => Promise.Thenable<R>, args?: any[], ctx?: any): Promise<R>;
-               ~~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'attempt'.
         static attempt<R>(dit: typeof Promise, fn: () => R, args?: any[], ctx?: any): Promise<R>;
-               ~~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'attempt'.
     
         static method(dit: typeof Promise, fn: Function): Function;
     
         static resolve(dit: typeof Promise): Promise<void>;
-               ~~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'resolve'.
         static resolve<R>(dit: typeof Promise, value: Promise.Thenable<R>): Promise<R>;
-               ~~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'resolve'.
         static resolve<R>(dit: typeof Promise, value: R): Promise<R>;
-               ~~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'resolve'.
     
         static reject(dit: typeof Promise, reason: any): Promise<any>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'reject'.
         static reject<R>(dit: typeof Promise, reason: any): Promise<R>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'reject'.
     
         static defer<R>(dit: typeof Promise): Promise.Resolver<R>;
                                                       ~~~~~~~~
 !!! error TS2694: Namespace 'Promise' has no exported member 'Resolver'.
     
         static cast<R>(dit: typeof Promise, value: Promise.Thenable<R>): Promise<R>;
-               ~~~~
-!!! error TS2323: Cannot redeclare exported variable 'cast'.
         static cast<R>(dit: typeof Promise, value: R): Promise<R>;
-               ~~~~
-!!! error TS2323: Cannot redeclare exported variable 'cast'.
     
         static bind(dit: typeof Promise, thisArg: any): Promise<void>;
     
@@ -130,14 +46,8 @@ tests/cases/compiler/bluebirdStaticThis.ts(108,12): error TS2323: Cannot redecla
         static longStackTraces(dit: typeof Promise): void;
     
         static delay<R>(dit: typeof Promise, value: Promise.Thenable<R>, ms: number): Promise<R>;
-               ~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'delay'.
         static delay<R>(dit: typeof Promise, value: R, ms: number): Promise<R>;
-               ~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'delay'.
         static delay(dit: typeof Promise, ms: number): Promise<void>;
-               ~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'delay'.
     
         static promisify(dit: typeof Promise, nodeFunction: Function, receiver?: any): Function;
     
@@ -152,169 +62,73 @@ tests/cases/compiler/bluebirdStaticThis.ts(108,12): error TS2323: Cannot redecla
         static onPossiblyUnhandledRejection(dit: typeof Promise, handler: (reason: any) => any): void;
     
         static all<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<R[]>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'all'.
         static all<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<R[]>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'all'.
         static all<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<R[]>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'all'.
         static all<R>(dit: typeof Promise, values: R[]): Promise<R[]>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'all'.
     
         static props(dit: typeof Promise, object: Promise<Object>): Promise<Object>;
-               ~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'props'.
         static props(dit: typeof Promise, object: Object): Promise<Object>;
-               ~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'props'.
     
         static settle<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<Promise.Inspection<R>[]>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'settle'.
                                                                                                                 ~~~~~~~~~~
 !!! error TS2694: Namespace 'Promise' has no exported member 'Inspection'.
         static settle<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<Promise.Inspection<R>[]>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'settle'.
                                                                                               ~~~~~~~~~~
 !!! error TS2694: Namespace 'Promise' has no exported member 'Inspection'.
         static settle<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<Promise.Inspection<R>[]>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'settle'.
                                                                                               ~~~~~~~~~~
 !!! error TS2694: Namespace 'Promise' has no exported member 'Inspection'.
         static settle<R>(dit: typeof Promise, values: R[]): Promise<Promise.Inspection<R>[]>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'settle'.
                                                                             ~~~~~~~~~~
 !!! error TS2694: Namespace 'Promise' has no exported member 'Inspection'.
     
         static any<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<R>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'any'.
         static any<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<R>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'any'.
         static any<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<R>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'any'.
         static any<R>(dit: typeof Promise, values: R[]): Promise<R>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'any'.
     
         static race<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<R>;
-               ~~~~
-!!! error TS2323: Cannot redeclare exported variable 'race'.
         static race<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<R>;
-               ~~~~
-!!! error TS2323: Cannot redeclare exported variable 'race'.
         static race<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<R>;
-               ~~~~
-!!! error TS2323: Cannot redeclare exported variable 'race'.
         static race<R>(dit: typeof Promise, values: R[]): Promise<R>;
-               ~~~~
-!!! error TS2323: Cannot redeclare exported variable 'race'.
     
         static some<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, count: number): Promise<R[]>;
-               ~~~~
-!!! error TS2323: Cannot redeclare exported variable 'some'.
         static some<R>(dit: typeof Promise, values: Promise.Thenable<R[]>, count: number): Promise<R[]>;
-               ~~~~
-!!! error TS2323: Cannot redeclare exported variable 'some'.
         static some<R>(dit: typeof Promise, values: Promise.Thenable<R>[], count: number): Promise<R[]>;
-               ~~~~
-!!! error TS2323: Cannot redeclare exported variable 'some'.
         static some<R>(dit: typeof Promise, values: R[], count: number): Promise<R[]>;
-               ~~~~
-!!! error TS2323: Cannot redeclare exported variable 'some'.
     
         static join<R>(dit: typeof Promise, ...values: Promise.Thenable<R>[]): Promise<R[]>;
-               ~~~~
-!!! error TS2323: Cannot redeclare exported variable 'join'.
         static join<R>(dit: typeof Promise, ...values: R[]): Promise<R[]>;
-               ~~~~
-!!! error TS2323: Cannot redeclare exported variable 'join'.
     
         static map<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'map'.
         static map<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'map'.
         static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'map'.
         static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'map'.
         static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'map'.
         static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'map'.
         static map<R, U>(dit: typeof Promise, values: R[], mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'map'.
         static map<R, U>(dit: typeof Promise, values: R[], mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
-               ~~~
-!!! error TS2323: Cannot redeclare exported variable 'map'.
     
         static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'reduce'.
         static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'reduce'.
     
         static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'reduce'.
         static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'reduce'.
     
         static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'reduce'.
         static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'reduce'.
     
         static reduce<R, U>(dit: typeof Promise, values: R[], reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'reduce'.
         static reduce<R, U>(dit: typeof Promise, values: R[], reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'reduce'.
     
         static filter<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'filter'.
         static filter<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'filter'.
         static filter<R>(dit: typeof Promise, values: Promise.Thenable<R[]>, filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'filter'.
         static filter<R>(dit: typeof Promise, values: Promise.Thenable<R[]>, filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'filter'.
         static filter<R>(dit: typeof Promise, values: Promise.Thenable<R>[], filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'filter'.
         static filter<R>(dit: typeof Promise, values: Promise.Thenable<R>[], filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'filter'.
         static filter<R>(dit: typeof Promise, values: R[], filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'filter'.
         static filter<R>(dit: typeof Promise, values: R[], filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
-               ~~~~~~
-!!! error TS2323: Cannot redeclare exported variable 'filter'.
     }
     
     declare module Promise {

--- a/tests/baselines/reference/bluebirdStaticThis.errors.txt
+++ b/tests/baselines/reference/bluebirdStaticThis.errors.txt
@@ -1,13 +1,75 @@
 tests/cases/compiler/bluebirdStaticThis.ts(5,15): error TS2420: Class 'Promise<R>' incorrectly implements interface 'Thenable<R>'.
   Property 'then' is missing in type 'Promise<R>'.
+tests/cases/compiler/bluebirdStaticThis.ts(7,12): error TS2323: Cannot redeclare exported variable 'try'.
+tests/cases/compiler/bluebirdStaticThis.ts(8,12): error TS2323: Cannot redeclare exported variable 'try'.
+tests/cases/compiler/bluebirdStaticThis.ts(10,12): error TS2323: Cannot redeclare exported variable 'attempt'.
+tests/cases/compiler/bluebirdStaticThis.ts(11,12): error TS2323: Cannot redeclare exported variable 'attempt'.
+tests/cases/compiler/bluebirdStaticThis.ts(15,12): error TS2323: Cannot redeclare exported variable 'resolve'.
+tests/cases/compiler/bluebirdStaticThis.ts(16,12): error TS2323: Cannot redeclare exported variable 'resolve'.
+tests/cases/compiler/bluebirdStaticThis.ts(17,12): error TS2323: Cannot redeclare exported variable 'resolve'.
+tests/cases/compiler/bluebirdStaticThis.ts(19,12): error TS2323: Cannot redeclare exported variable 'reject'.
+tests/cases/compiler/bluebirdStaticThis.ts(20,12): error TS2323: Cannot redeclare exported variable 'reject'.
 tests/cases/compiler/bluebirdStaticThis.ts(22,51): error TS2694: Namespace 'Promise' has no exported member 'Resolver'.
+tests/cases/compiler/bluebirdStaticThis.ts(24,12): error TS2323: Cannot redeclare exported variable 'cast'.
+tests/cases/compiler/bluebirdStaticThis.ts(25,12): error TS2323: Cannot redeclare exported variable 'cast'.
+tests/cases/compiler/bluebirdStaticThis.ts(33,12): error TS2323: Cannot redeclare exported variable 'delay'.
+tests/cases/compiler/bluebirdStaticThis.ts(34,12): error TS2323: Cannot redeclare exported variable 'delay'.
+tests/cases/compiler/bluebirdStaticThis.ts(35,12): error TS2323: Cannot redeclare exported variable 'delay'.
+tests/cases/compiler/bluebirdStaticThis.ts(49,12): error TS2323: Cannot redeclare exported variable 'all'.
+tests/cases/compiler/bluebirdStaticThis.ts(50,12): error TS2323: Cannot redeclare exported variable 'all'.
+tests/cases/compiler/bluebirdStaticThis.ts(51,12): error TS2323: Cannot redeclare exported variable 'all'.
+tests/cases/compiler/bluebirdStaticThis.ts(52,12): error TS2323: Cannot redeclare exported variable 'all'.
+tests/cases/compiler/bluebirdStaticThis.ts(54,12): error TS2323: Cannot redeclare exported variable 'props'.
+tests/cases/compiler/bluebirdStaticThis.ts(55,12): error TS2323: Cannot redeclare exported variable 'props'.
+tests/cases/compiler/bluebirdStaticThis.ts(57,12): error TS2323: Cannot redeclare exported variable 'settle'.
 tests/cases/compiler/bluebirdStaticThis.ts(57,109): error TS2694: Namespace 'Promise' has no exported member 'Inspection'.
+tests/cases/compiler/bluebirdStaticThis.ts(58,12): error TS2323: Cannot redeclare exported variable 'settle'.
 tests/cases/compiler/bluebirdStaticThis.ts(58,91): error TS2694: Namespace 'Promise' has no exported member 'Inspection'.
+tests/cases/compiler/bluebirdStaticThis.ts(59,12): error TS2323: Cannot redeclare exported variable 'settle'.
 tests/cases/compiler/bluebirdStaticThis.ts(59,91): error TS2694: Namespace 'Promise' has no exported member 'Inspection'.
+tests/cases/compiler/bluebirdStaticThis.ts(60,12): error TS2323: Cannot redeclare exported variable 'settle'.
 tests/cases/compiler/bluebirdStaticThis.ts(60,73): error TS2694: Namespace 'Promise' has no exported member 'Inspection'.
+tests/cases/compiler/bluebirdStaticThis.ts(62,12): error TS2323: Cannot redeclare exported variable 'any'.
+tests/cases/compiler/bluebirdStaticThis.ts(63,12): error TS2323: Cannot redeclare exported variable 'any'.
+tests/cases/compiler/bluebirdStaticThis.ts(64,12): error TS2323: Cannot redeclare exported variable 'any'.
+tests/cases/compiler/bluebirdStaticThis.ts(65,12): error TS2323: Cannot redeclare exported variable 'any'.
+tests/cases/compiler/bluebirdStaticThis.ts(67,12): error TS2323: Cannot redeclare exported variable 'race'.
+tests/cases/compiler/bluebirdStaticThis.ts(68,12): error TS2323: Cannot redeclare exported variable 'race'.
+tests/cases/compiler/bluebirdStaticThis.ts(69,12): error TS2323: Cannot redeclare exported variable 'race'.
+tests/cases/compiler/bluebirdStaticThis.ts(70,12): error TS2323: Cannot redeclare exported variable 'race'.
+tests/cases/compiler/bluebirdStaticThis.ts(72,12): error TS2323: Cannot redeclare exported variable 'some'.
+tests/cases/compiler/bluebirdStaticThis.ts(73,12): error TS2323: Cannot redeclare exported variable 'some'.
+tests/cases/compiler/bluebirdStaticThis.ts(74,12): error TS2323: Cannot redeclare exported variable 'some'.
+tests/cases/compiler/bluebirdStaticThis.ts(75,12): error TS2323: Cannot redeclare exported variable 'some'.
+tests/cases/compiler/bluebirdStaticThis.ts(77,12): error TS2323: Cannot redeclare exported variable 'join'.
+tests/cases/compiler/bluebirdStaticThis.ts(78,12): error TS2323: Cannot redeclare exported variable 'join'.
+tests/cases/compiler/bluebirdStaticThis.ts(80,12): error TS2323: Cannot redeclare exported variable 'map'.
+tests/cases/compiler/bluebirdStaticThis.ts(81,12): error TS2323: Cannot redeclare exported variable 'map'.
+tests/cases/compiler/bluebirdStaticThis.ts(82,12): error TS2323: Cannot redeclare exported variable 'map'.
+tests/cases/compiler/bluebirdStaticThis.ts(83,12): error TS2323: Cannot redeclare exported variable 'map'.
+tests/cases/compiler/bluebirdStaticThis.ts(84,12): error TS2323: Cannot redeclare exported variable 'map'.
+tests/cases/compiler/bluebirdStaticThis.ts(85,12): error TS2323: Cannot redeclare exported variable 'map'.
+tests/cases/compiler/bluebirdStaticThis.ts(86,12): error TS2323: Cannot redeclare exported variable 'map'.
+tests/cases/compiler/bluebirdStaticThis.ts(87,12): error TS2323: Cannot redeclare exported variable 'map'.
+tests/cases/compiler/bluebirdStaticThis.ts(89,12): error TS2323: Cannot redeclare exported variable 'reduce'.
+tests/cases/compiler/bluebirdStaticThis.ts(90,12): error TS2323: Cannot redeclare exported variable 'reduce'.
+tests/cases/compiler/bluebirdStaticThis.ts(92,12): error TS2323: Cannot redeclare exported variable 'reduce'.
+tests/cases/compiler/bluebirdStaticThis.ts(93,12): error TS2323: Cannot redeclare exported variable 'reduce'.
+tests/cases/compiler/bluebirdStaticThis.ts(95,12): error TS2323: Cannot redeclare exported variable 'reduce'.
+tests/cases/compiler/bluebirdStaticThis.ts(96,12): error TS2323: Cannot redeclare exported variable 'reduce'.
+tests/cases/compiler/bluebirdStaticThis.ts(98,12): error TS2323: Cannot redeclare exported variable 'reduce'.
+tests/cases/compiler/bluebirdStaticThis.ts(99,12): error TS2323: Cannot redeclare exported variable 'reduce'.
+tests/cases/compiler/bluebirdStaticThis.ts(101,12): error TS2323: Cannot redeclare exported variable 'filter'.
+tests/cases/compiler/bluebirdStaticThis.ts(102,12): error TS2323: Cannot redeclare exported variable 'filter'.
+tests/cases/compiler/bluebirdStaticThis.ts(103,12): error TS2323: Cannot redeclare exported variable 'filter'.
+tests/cases/compiler/bluebirdStaticThis.ts(104,12): error TS2323: Cannot redeclare exported variable 'filter'.
+tests/cases/compiler/bluebirdStaticThis.ts(105,12): error TS2323: Cannot redeclare exported variable 'filter'.
+tests/cases/compiler/bluebirdStaticThis.ts(106,12): error TS2323: Cannot redeclare exported variable 'filter'.
+tests/cases/compiler/bluebirdStaticThis.ts(107,12): error TS2323: Cannot redeclare exported variable 'filter'.
+tests/cases/compiler/bluebirdStaticThis.ts(108,12): error TS2323: Cannot redeclare exported variable 'filter'.
 
 
-==== tests/cases/compiler/bluebirdStaticThis.ts (6 errors) ====
+==== tests/cases/compiler/bluebirdStaticThis.ts (68 errors) ====
     // This version is reduced from the full d.ts by removing almost all the tests
     // and all the comments.
     // Then it adds explicit `this` arguments to the static members.
@@ -18,26 +80,48 @@ tests/cases/compiler/bluebirdStaticThis.ts(60,73): error TS2694: Namespace 'Prom
 !!! error TS2420:   Property 'then' is missing in type 'Promise<R>'.
     	constructor(callback: (resolve: (thenableOrResult: R | Promise.Thenable<R>) => void, reject: (error: any) => void) => void);
         static try<R>(dit: typeof Promise, fn: () => Promise.Thenable<R>, args?: any[], ctx?: any): Promise<R>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'try'.
         static try<R>(dit: typeof Promise, fn: () => R, args?: any[], ctx?: any): Promise<R>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'try'.
     
         static attempt<R>(dit: typeof Promise, fn: () => Promise.Thenable<R>, args?: any[], ctx?: any): Promise<R>;
+               ~~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'attempt'.
         static attempt<R>(dit: typeof Promise, fn: () => R, args?: any[], ctx?: any): Promise<R>;
+               ~~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'attempt'.
     
         static method(dit: typeof Promise, fn: Function): Function;
     
         static resolve(dit: typeof Promise): Promise<void>;
+               ~~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'resolve'.
         static resolve<R>(dit: typeof Promise, value: Promise.Thenable<R>): Promise<R>;
+               ~~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'resolve'.
         static resolve<R>(dit: typeof Promise, value: R): Promise<R>;
+               ~~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'resolve'.
     
         static reject(dit: typeof Promise, reason: any): Promise<any>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'reject'.
         static reject<R>(dit: typeof Promise, reason: any): Promise<R>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'reject'.
     
         static defer<R>(dit: typeof Promise): Promise.Resolver<R>;
                                                       ~~~~~~~~
 !!! error TS2694: Namespace 'Promise' has no exported member 'Resolver'.
     
         static cast<R>(dit: typeof Promise, value: Promise.Thenable<R>): Promise<R>;
+               ~~~~
+!!! error TS2323: Cannot redeclare exported variable 'cast'.
         static cast<R>(dit: typeof Promise, value: R): Promise<R>;
+               ~~~~
+!!! error TS2323: Cannot redeclare exported variable 'cast'.
     
         static bind(dit: typeof Promise, thisArg: any): Promise<void>;
     
@@ -46,8 +130,14 @@ tests/cases/compiler/bluebirdStaticThis.ts(60,73): error TS2694: Namespace 'Prom
         static longStackTraces(dit: typeof Promise): void;
     
         static delay<R>(dit: typeof Promise, value: Promise.Thenable<R>, ms: number): Promise<R>;
+               ~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'delay'.
         static delay<R>(dit: typeof Promise, value: R, ms: number): Promise<R>;
+               ~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'delay'.
         static delay(dit: typeof Promise, ms: number): Promise<void>;
+               ~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'delay'.
     
         static promisify(dit: typeof Promise, nodeFunction: Function, receiver?: any): Function;
     
@@ -62,73 +152,169 @@ tests/cases/compiler/bluebirdStaticThis.ts(60,73): error TS2694: Namespace 'Prom
         static onPossiblyUnhandledRejection(dit: typeof Promise, handler: (reason: any) => any): void;
     
         static all<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<R[]>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'all'.
         static all<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<R[]>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'all'.
         static all<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<R[]>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'all'.
         static all<R>(dit: typeof Promise, values: R[]): Promise<R[]>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'all'.
     
         static props(dit: typeof Promise, object: Promise<Object>): Promise<Object>;
+               ~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'props'.
         static props(dit: typeof Promise, object: Object): Promise<Object>;
+               ~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'props'.
     
         static settle<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<Promise.Inspection<R>[]>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'settle'.
                                                                                                                 ~~~~~~~~~~
 !!! error TS2694: Namespace 'Promise' has no exported member 'Inspection'.
         static settle<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<Promise.Inspection<R>[]>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'settle'.
                                                                                               ~~~~~~~~~~
 !!! error TS2694: Namespace 'Promise' has no exported member 'Inspection'.
         static settle<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<Promise.Inspection<R>[]>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'settle'.
                                                                                               ~~~~~~~~~~
 !!! error TS2694: Namespace 'Promise' has no exported member 'Inspection'.
         static settle<R>(dit: typeof Promise, values: R[]): Promise<Promise.Inspection<R>[]>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'settle'.
                                                                             ~~~~~~~~~~
 !!! error TS2694: Namespace 'Promise' has no exported member 'Inspection'.
     
         static any<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<R>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'any'.
         static any<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<R>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'any'.
         static any<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<R>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'any'.
         static any<R>(dit: typeof Promise, values: R[]): Promise<R>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'any'.
     
         static race<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>): Promise<R>;
+               ~~~~
+!!! error TS2323: Cannot redeclare exported variable 'race'.
         static race<R>(dit: typeof Promise, values: Promise.Thenable<R[]>): Promise<R>;
+               ~~~~
+!!! error TS2323: Cannot redeclare exported variable 'race'.
         static race<R>(dit: typeof Promise, values: Promise.Thenable<R>[]): Promise<R>;
+               ~~~~
+!!! error TS2323: Cannot redeclare exported variable 'race'.
         static race<R>(dit: typeof Promise, values: R[]): Promise<R>;
+               ~~~~
+!!! error TS2323: Cannot redeclare exported variable 'race'.
     
         static some<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, count: number): Promise<R[]>;
+               ~~~~
+!!! error TS2323: Cannot redeclare exported variable 'some'.
         static some<R>(dit: typeof Promise, values: Promise.Thenable<R[]>, count: number): Promise<R[]>;
+               ~~~~
+!!! error TS2323: Cannot redeclare exported variable 'some'.
         static some<R>(dit: typeof Promise, values: Promise.Thenable<R>[], count: number): Promise<R[]>;
+               ~~~~
+!!! error TS2323: Cannot redeclare exported variable 'some'.
         static some<R>(dit: typeof Promise, values: R[], count: number): Promise<R[]>;
+               ~~~~
+!!! error TS2323: Cannot redeclare exported variable 'some'.
     
         static join<R>(dit: typeof Promise, ...values: Promise.Thenable<R>[]): Promise<R[]>;
+               ~~~~
+!!! error TS2323: Cannot redeclare exported variable 'join'.
         static join<R>(dit: typeof Promise, ...values: R[]): Promise<R[]>;
+               ~~~~
+!!! error TS2323: Cannot redeclare exported variable 'join'.
     
         static map<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'map'.
         static map<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'map'.
         static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'map'.
         static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'map'.
         static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'map'.
         static map<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'map'.
         static map<R, U>(dit: typeof Promise, values: R[], mapper: (item: R, index: number, arrayLength: number) => Promise.Thenable<U>): Promise<U[]>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'map'.
         static map<R, U>(dit: typeof Promise, values: R[], mapper: (item: R, index: number, arrayLength: number) => U): Promise<U[]>;
+               ~~~
+!!! error TS2323: Cannot redeclare exported variable 'map'.
     
         static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'reduce'.
         static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'reduce'.
     
         static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'reduce'.
         static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R[]>, reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'reduce'.
     
         static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'reduce'.
         static reduce<R, U>(dit: typeof Promise, values: Promise.Thenable<R>[], reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'reduce'.
     
         static reduce<R, U>(dit: typeof Promise, values: R[], reducer: (total: U, current: R, index: number, arrayLength: number) => Promise.Thenable<U>, initialValue?: U): Promise<U>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'reduce'.
         static reduce<R, U>(dit: typeof Promise, values: R[], reducer: (total: U, current: R, index: number, arrayLength: number) => U, initialValue?: U): Promise<U>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'reduce'.
     
         static filter<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'filter'.
         static filter<R>(dit: typeof Promise, values: Promise.Thenable<Promise.Thenable<R>[]>, filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'filter'.
         static filter<R>(dit: typeof Promise, values: Promise.Thenable<R[]>, filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'filter'.
         static filter<R>(dit: typeof Promise, values: Promise.Thenable<R[]>, filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'filter'.
         static filter<R>(dit: typeof Promise, values: Promise.Thenable<R>[], filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'filter'.
         static filter<R>(dit: typeof Promise, values: Promise.Thenable<R>[], filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'filter'.
         static filter<R>(dit: typeof Promise, values: R[], filterer: (item: R, index: number, arrayLength: number) => Promise.Thenable<boolean>): Promise<R[]>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'filter'.
         static filter<R>(dit: typeof Promise, values: R[], filterer: (item: R, index: number, arrayLength: number) => boolean): Promise<R[]>;
+               ~~~~~~
+!!! error TS2323: Cannot redeclare exported variable 'filter'.
     }
     
     declare module Promise {

--- a/tests/cases/fourslash/completionListInImportClause04.ts
+++ b/tests/cases/fourslash/completionListInImportClause04.ts
@@ -1,0 +1,20 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: foo.d.ts
+//// declare class Foo {
+////     static prop1(x: number): number;
+////     static prop1(x: string): string;
+////     static prop2(x: boolean): boolean;
+//// }
+//// export = Foo; /*2*/
+
+// @Filename: app.ts
+////import {/*1*/} from './foo';
+
+goTo.marker('1');
+verify.completionListContains('prop1');
+verify.completionListContains('prop2');
+verify.not.completionListContains('Foo');
+verify.numberOfErrorsInCurrentFile(0);
+goTo.marker('2');
+verify.numberOfErrorsInCurrentFile(0);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Addresses an issue where the completion list would be empty for an import list for an imported module. This turned out to be for module defined using `export=`. (Not sure where this regressed, but I'm sure it used to work).

Putting this up early for feedback to ensure the approach is right. All tests pass except some new errors in a bluebird test (which seem legit to me - I don't see how you can have multiple exports for the same name that differ by signature only).

@mhegazy @vladima @RyanCavanaugh Let me know if I've overlooked any complications or have taken an incorrect approach. (As this doesn't seem to be a code path only hit in the completions scenarios, so could have broader impact).