### PR TITLE
Automatically generate protocol.d.ts by pulling in necessary dependencies

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -735,7 +735,7 @@ task("generate-spec", [specMd]);
 // Makes a new LKG. This target does not build anything, but errors if not all the outputs are present in the built/local directory
 desc("Makes a new LKG out of the built js files");
 task("LKG", ["clean", "release", "local"].concat(libraryTargets), function () {
-    var expectedFiles = [tscFile, servicesFile, serverFile, nodePackageFile, nodeDefinitionsFile, standaloneDefinitionsFile, tsserverLibraryFile, tsserverLibraryDefinitionFile, cancellationTokenFile, typingsInstallerFile].concat(libraryTargets);
+    var expectedFiles = [tscFile, servicesFile, serverFile, nodePackageFile, nodeDefinitionsFile, standaloneDefinitionsFile, tsserverLibraryFile, tsserverLibraryDefinitionFile, cancellationTokenFile, typingsInstallerFile, buildProtocolDts].concat(libraryTargets);
     var missingFiles = expectedFiles.filter(function (f) {
         return !fs.existsSync(f);
     });

--- a/Jakefile.js
+++ b/Jakefile.js
@@ -134,7 +134,7 @@ var serverCoreSources = [
     "lsHost.ts",
     "project.ts",
     "editorServices.ts",
-    "protocol.d.ts",
+    "protocol.ts",
     "session.ts",
     "server.ts"
 ].map(function (f) {
@@ -158,14 +158,13 @@ var typingsInstallerSources = [
 var serverSources = serverCoreSources.concat(servicesSources);
 
 var languageServiceLibrarySources = [
-    "protocol.d.ts",
+    "protocol.ts",
     "utilities.ts",
     "scriptVersionCache.ts",
     "scriptInfo.ts",
     "lsHost.ts",
     "project.ts",
     "editorServices.ts",
-    "protocol.d.ts",
     "session.ts",
 
 ].map(function (f) {
@@ -218,7 +217,7 @@ var harnessSources = harnessCoreSources.concat([
 ].map(function (f) {
     return path.join(unittestsDirectory, f);
 })).concat([
-    "protocol.d.ts",
+    "protocol.ts",
     "utilities.ts",
     "scriptVersionCache.ts",
     "scriptInfo.ts",
@@ -226,7 +225,6 @@ var harnessSources = harnessCoreSources.concat([
     "project.ts",
     "typingsCache.ts",
     "editorServices.ts",
-    "protocol.d.ts",
     "session.ts",
 ].map(function (f) {
     return path.join(serverDirectory, f);
@@ -474,6 +472,40 @@ compileFile(processDiagnosticMessagesJs,
     [],
             /*useBuiltCompiler*/ false);
 
+var buildProtocolTs = path.join(scriptsDirectory, "buildProtocol.ts");
+var buildProtocolJs = path.join(scriptsDirectory, "buildProtocol.js");
+var buildProtocolDts = path.join(builtLocalDirectory, "protocol.d.ts");
+var typescriptServicesDts = path.join(builtLocalDirectory, "typescriptServices.d.ts");
+
+file(buildProtocolTs);
+
+compileFile(buildProtocolJs,
+    [buildProtocolTs],
+    [buildProtocolTs],
+    [],
+    /*useBuiltCompiler*/ false,
+    {noOutFile: true});
+
+file(buildProtocolDts, [buildProtocolTs, buildProtocolJs, typescriptServicesDts], function() {
+
+    var protocolTs = path.join(serverDirectory, "protocol.ts");
+
+    var cmd = host + " " + buildProtocolJs + " "+ protocolTs + " " + typescriptServicesDts + " " + buildProtocolDts;
+    console.log(cmd);
+    var ex = jake.createExec([cmd]);
+    // Add listeners for output and error
+    ex.addListener("stdout", function (output) {
+        process.stdout.write(output);
+    });
+    ex.addListener("stderr", function (error) {
+        process.stderr.write(error);
+    });
+    ex.addListener("cmdEnd", function () {
+        complete();
+    });
+    ex.run();
+}, { async: true })
+
 // The generated diagnostics map; built for the compiler and for the 'generate-diagnostics' task
 file(diagnosticInfoMapTs, [processDiagnosticMessagesJs, diagnosticMessagesJson], function () {
     var cmd = host + " " + processDiagnosticMessagesJs + " " + diagnosticMessagesJson;
@@ -611,6 +643,8 @@ compileFile(
         inlineSourceMap: true
     });
 
+file(typescriptServicesDts, [servicesFile]);
+
 var cancellationTokenFile = path.join(builtLocalDirectory, "cancellationToken.js");
 compileFile(cancellationTokenFile, cancellationTokenSources, [builtLocalDirectory].concat(cancellationTokenSources), /*prefixes*/ [copyright], /*useBuiltCompiler*/ true, { outDir: builtLocalDirectory, noOutFile: true });
 
@@ -645,7 +679,7 @@ task("build-fold-end", [], function () {
 
 // Local target to build the compiler and services
 desc("Builds the full compiler and services");
-task("local", ["build-fold-start", "generate-diagnostics", "lib", tscFile, servicesFile, nodeDefinitionsFile, serverFile, builtGeneratedDiagnosticMessagesJSON, "lssl", "build-fold-end"]);
+task("local", ["build-fold-start", "generate-diagnostics", "lib", tscFile, servicesFile, nodeDefinitionsFile, serverFile, buildProtocolDts, builtGeneratedDiagnosticMessagesJSON, "lssl", "build-fold-end"]);
 
 // Local target to build only tsc.js
 desc("Builds only the compiler");

--- a/scripts/buildProtocol.ts
+++ b/scripts/buildProtocol.ts
@@ -1,0 +1,143 @@
+/// <reference types="node"/>
+
+import * as ts from "../lib/typescript";
+import * as path from "path";
+
+function endsWith(s: string, suffix: string) {
+    return s.lastIndexOf(suffix, s.length - suffix.length) !== -1;
+}
+
+class DeclarationsWalker {
+    private visitedTypes: ts.Type[] = [];
+    private text = "";
+    private constructor(private typeChecker: ts.TypeChecker, private protocolFile: ts.SourceFile) {
+    }
+
+    static getExtraDeclarations(typeChecker: ts.TypeChecker, protocolFile: ts.SourceFile): string {
+        let text = "declare namespace ts.server.protocol {\n";
+        var walker = new DeclarationsWalker(typeChecker, protocolFile);
+        walker.visitTypeNodes(protocolFile);
+        return walker.text 
+            ? `declare namespace ts.server.protocol {\n${walker.text}}`
+            : "";
+    }
+
+    private processType(type: ts.Type): void {
+        if (this.visitedTypes.indexOf(type) >= 0) {
+            return;
+        }
+        this.visitedTypes.push(type);
+        let s = type.aliasSymbol || type.getSymbol();
+        if (!s) {
+            return;
+        }
+        if (s.name === "Array") {
+            // we should process type argument instead
+            return this.processType((<any>type).typeArguments[0]);
+        }
+        else {
+            for (const decl of s.getDeclarations()) {
+                const sourceFile = decl.getSourceFile();
+                if (sourceFile === this.protocolFile || path.basename(sourceFile.fileName) === "lib.d.ts") {
+                    return;
+                }
+                // splice declaration in final d.ts file
+                const text = decl.getFullText();
+                this.text += `${text}\n`;
+
+                // recursively pull all dependencies into result dts file
+                this.visitTypeNodes(decl);
+            }
+        }
+    }
+
+    private visitTypeNodes(node: ts.Node) {
+        if (node.parent) {
+            switch (node.parent.kind) {
+                case ts.SyntaxKind.VariableDeclaration:
+                case ts.SyntaxKind.MethodDeclaration:
+                case ts.SyntaxKind.MethodSignature:
+                case ts.SyntaxKind.PropertyDeclaration:
+                case ts.SyntaxKind.PropertySignature:
+                case ts.SyntaxKind.Parameter:
+                case ts.SyntaxKind.IndexSignature:
+                    if (((<ts.VariableDeclaration | ts.MethodDeclaration | ts.PropertyDeclaration | ts.ParameterDeclaration | ts.PropertySignature | ts.MethodSignature | ts.IndexSignatureDeclaration>node.parent).type) === node) {
+                        const type = this.typeChecker.getTypeAtLocation(node);
+                        if (type && !(type.flags & ts.TypeFlags.TypeParameter)) {
+                            this.processType(type);
+                        }
+                    }
+                    break;
+            }
+        }
+        ts.forEachChild(node, n => this.visitTypeNodes(n));
+    } 
+}
+
+function generateProtocolFile(protocolTs: string, typeScriptServicesDts: string): string {
+    const options = { target: ts.ScriptTarget.ES5, declaration: true, noResolve: true, types: <string[]>[], stripInternal: true };
+
+    /**
+     * 1st pass - generate a program from protocol.ts and typescriptservices.d.ts and emit core version of protocol.d.ts with all internal members stripped
+     * @return text of protocol.d.t.s
+     */
+    function getInitialDtsFileForProtocol() {
+        const program = ts.createProgram([protocolTs, typeScriptServicesDts], options);
+
+        let protocolDts: string;
+        program.emit(program.getSourceFile(protocolTs), (file, content) => {
+            if (endsWith(file, ".d.ts")) {
+                protocolDts = content;
+            }
+        });
+        if (protocolDts === undefined) {
+            throw new Error(`Declaration file for protocol.ts is not generated`)
+        }
+        return protocolDts;
+    }
+
+    const protocolFileName = "protocol.d.ts";
+    /**
+     * Second pass - generate a program from protocol.d.ts and typescriptservices.d.ts, then augment core protocol.d.ts with extra types from typescriptservices.d.ts
+     */
+    function getProgramWithProtocolText(protocolDts: string, includeTypeScriptServices: boolean) {
+        const host = ts.createCompilerHost(options);
+        const originalGetSourceFile = host.getSourceFile;
+        host.getSourceFile = (fileName) => {
+            if (fileName === protocolFileName) {
+                return ts.createSourceFile(fileName, protocolDts, options.target);
+            }
+            return originalGetSourceFile.apply(host, [fileName]);
+        }
+        const rootFiles = includeTypeScriptServices ? [protocolFileName, typeScriptServicesDts] : [protocolFileName];
+        return ts.createProgram(rootFiles, options, host);
+    }
+
+    let protocolDts = getInitialDtsFileForProtocol();
+    const program = getProgramWithProtocolText(protocolDts, /*includeTypeScriptServices*/ true);
+
+    const protocolFile = program.getSourceFile("protocol.d.ts");
+    const extraDeclarations = DeclarationsWalker.getExtraDeclarations(program.getTypeChecker(), protocolFile);
+    if (extraDeclarations) {
+        protocolDts += extraDeclarations;
+    }
+    // do sanity check and try to compile generated text as standalone program
+    const sanityCheckProgram = getProgramWithProtocolText(protocolDts, /*includeTypeScriptServices*/ false);
+    const diagnostics = [...program.getSyntacticDiagnostics(), ...program.getSemanticDiagnostics(), ...program.getGlobalDiagnostics()];
+    if (diagnostics.length) {
+        const flattenedDiagnostics = diagnostics.map(d => ts.flattenDiagnosticMessageText(d.messageText, "\n")).join("\n");
+        throw new Error(`Unexpected errors during sanity check: ${flattenedDiagnostics}`);
+    }
+    return protocolDts;
+}
+
+if (process.argv.length < 5) {
+    console.log(`Expected 3 arguments: path to 'protocol.ts', path to 'typescriptservices.d.ts' and path to output file`);
+    process.exit(1);
+}
+
+const protocolTs = process.argv[2];
+const typeScriptServicesDts = process.argv[3];
+const outputFile = process.argv[4];
+const generatedProtocolDts = generateProtocolFile(protocolTs, typeScriptServicesDts);
+ts.sys.writeFile(outputFile, generatedProtocolDts);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2574,11 +2574,7 @@ namespace ts {
         NodeJs   = 2
     }
 
-    export type RootPaths = string[];
-    export type PathSubstitutions = MapLike<string[]>;
-    export type TsConfigOnlyOptions = RootPaths | PathSubstitutions;
-
-    export type CompilerOptionsValue = string | number | boolean | (string | number)[] | TsConfigOnlyOptions;
+    export type CompilerOptionsValue = string | number | boolean | (string | number)[] | string[] | MapLike<string[]>;
 
     export interface CompilerOptions {
         allowJs?: boolean;
@@ -2629,14 +2625,14 @@ namespace ts {
         out?: string;
         outDir?: string;
         outFile?: string;
-        paths?: PathSubstitutions;
+        paths?: MapLike<string[]>;
         preserveConstEnums?: boolean;
         project?: string;
         /* @internal */ pretty?: DiagnosticStyle;
         reactNamespace?: string;
         removeComments?: boolean;
         rootDir?: string;
-        rootDirs?: RootPaths;
+        rootDirs?: string[];
         skipLibCheck?: boolean;
         skipDefaultLibCheck?: boolean;
         sourceMap?: boolean;

--- a/src/harness/unittests/compileOnSave.ts
+++ b/src/harness/unittests/compileOnSave.ts
@@ -3,6 +3,8 @@
 /// <reference path="../../server/typingsInstaller/typingsInstaller.ts" />
 
 namespace ts.projectSystem {
+    import CommandNames = server.protocol.CommandNames;
+
     function createTestTypingsInstaller(host: server.ServerHost) {
         return new TestTypingsInstaller("/a/data/", /*throttleLimit*/5, host);
     }
@@ -75,7 +77,7 @@ namespace ts.projectSystem {
                 };
 
                 // Change the content of file1 to `export var T: number;export function Foo() { };`
-                changeModuleFile1ShapeRequest1 = makeSessionRequest<server.protocol.ChangeRequestArgs>(server.CommandNames.Change, {
+                changeModuleFile1ShapeRequest1 = makeSessionRequest<server.protocol.ChangeRequestArgs>(CommandNames.Change, {
                     file: moduleFile1.path,
                     line: 1,
                     offset: 1,
@@ -85,7 +87,7 @@ namespace ts.projectSystem {
                 });
 
                 // Change the content of file1 to `export var T: number;export function Foo() { };`
-                changeModuleFile1InternalRequest1 = makeSessionRequest<server.protocol.ChangeRequestArgs>(server.CommandNames.Change, {
+                changeModuleFile1InternalRequest1 = makeSessionRequest<server.protocol.ChangeRequestArgs>(CommandNames.Change, {
                     file: moduleFile1.path,
                     line: 1,
                     offset: 1,
@@ -95,7 +97,7 @@ namespace ts.projectSystem {
                 });
 
                 // Change the content of file1 to `export var T: number;export function Foo() { };`
-                changeModuleFile1ShapeRequest2 = makeSessionRequest<server.protocol.ChangeRequestArgs>(server.CommandNames.Change, {
+                changeModuleFile1ShapeRequest2 = makeSessionRequest<server.protocol.ChangeRequestArgs>(CommandNames.Change, {
                     file: moduleFile1.path,
                     line: 1,
                     offset: 1,
@@ -104,7 +106,7 @@ namespace ts.projectSystem {
                     insertString: `export var T2: number;`
                 });
 
-                moduleFile1FileListRequest = makeSessionRequest<server.protocol.FileRequestArgs>(server.CommandNames.CompileOnSaveAffectedFileList, { file: moduleFile1.path, projectFileName: configFile.path });
+                moduleFile1FileListRequest = makeSessionRequest<server.protocol.FileRequestArgs>(CommandNames.CompileOnSaveAffectedFileList, { file: moduleFile1.path, projectFileName: configFile.path });
             });
 
             it("should contains only itself if a module file's shape didn't change, and all files referencing it if its shape changed", () => {
@@ -120,7 +122,7 @@ namespace ts.projectSystem {
                 sendAffectedFileRequestAndCheckResult(session, moduleFile1FileListRequest, [{ projectFileName: configFile.path, files: [moduleFile1, file1Consumer1, file1Consumer2] }]);
 
                 // Change the content of file1 to `export var T: number;export function Foo() { console.log('hi'); };`
-                const changeFile1InternalRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(server.CommandNames.Change, {
+                const changeFile1InternalRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(CommandNames.Change, {
                     file: moduleFile1.path,
                     line: 1,
                     offset: 46,
@@ -143,7 +145,7 @@ namespace ts.projectSystem {
                 sendAffectedFileRequestAndCheckResult(session, moduleFile1FileListRequest, [{ projectFileName: configFile.path, files: [moduleFile1, file1Consumer1, file1Consumer2] }]);
 
                 // Change file2 content to `let y = Foo();`
-                const removeFile1Consumer1ImportRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(server.CommandNames.Change, {
+                const removeFile1Consumer1ImportRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(CommandNames.Change, {
                     file: file1Consumer1.path,
                     line: 1,
                     offset: 1,
@@ -156,7 +158,7 @@ namespace ts.projectSystem {
                 sendAffectedFileRequestAndCheckResult(session, moduleFile1FileListRequest, [{ projectFileName: configFile.path, files: [moduleFile1, file1Consumer2] }]);
 
                 // Add the import statements back to file2
-                const addFile2ImportRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(server.CommandNames.Change, {
+                const addFile2ImportRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(CommandNames.Change, {
                     file: file1Consumer1.path,
                     line: 1,
                     offset: 1,
@@ -167,7 +169,7 @@ namespace ts.projectSystem {
                 session.executeCommand(addFile2ImportRequest);
 
                 // Change the content of file1 to `export var T2: string;export var T: number;export function Foo() { };`
-                const changeModuleFile1ShapeRequest2 = makeSessionRequest<server.protocol.ChangeRequestArgs>(server.CommandNames.Change, {
+                const changeModuleFile1ShapeRequest2 = makeSessionRequest<server.protocol.ChangeRequestArgs>(CommandNames.Change, {
                     file: moduleFile1.path,
                     line: 1,
                     offset: 1,
@@ -272,7 +274,7 @@ namespace ts.projectSystem {
                 const session = new server.Session(host, nullCancellationToken, /*useSingleInferredProject*/ false, typingsInstaller, Utils.byteLength, process.hrtime, nullLogger, /*canUseEvents*/ false);
 
                 openFilesForSession([globalFile3], session);
-                const changeGlobalFile3ShapeRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(server.CommandNames.Change, {
+                const changeGlobalFile3ShapeRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(CommandNames.Change, {
                     file: globalFile3.path,
                     line: 1,
                     offset: 1,
@@ -283,7 +285,7 @@ namespace ts.projectSystem {
 
                 // check after file1 shape changes
                 session.executeCommand(changeGlobalFile3ShapeRequest);
-                const globalFile3FileListRequest = makeSessionRequest<server.protocol.FileRequestArgs>(server.CommandNames.CompileOnSaveAffectedFileList, { file: globalFile3.path });
+                const globalFile3FileListRequest = makeSessionRequest<server.protocol.FileRequestArgs>(CommandNames.CompileOnSaveAffectedFileList, { file: globalFile3.path });
                 sendAffectedFileRequestAndCheckResult(session, globalFile3FileListRequest, [{ projectFileName: configFile.path, files: [moduleFile1, file1Consumer1, file1Consumer2, globalFile3, moduleFile2] }]);
             });
 
@@ -316,7 +318,7 @@ namespace ts.projectSystem {
                 const session = new server.Session(host, nullCancellationToken, /*useSingleInferredProject*/ false, typingsInstaller, Utils.byteLength, process.hrtime, nullLogger, /*canUseEvents*/ false);
                 openFilesForSession([moduleFile1], session);
 
-                const file1ChangeShapeRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(server.CommandNames.Change, {
+                const file1ChangeShapeRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(CommandNames.Change, {
                     file: moduleFile1.path,
                     line: 1,
                     offset: 27,
@@ -345,7 +347,7 @@ namespace ts.projectSystem {
                 const session = new server.Session(host, nullCancellationToken, /*useSingleInferredProject*/ false, typingsInstaller, Utils.byteLength, process.hrtime, nullLogger, /*canUseEvents*/ false);
                 openFilesForSession([moduleFile1], session);
 
-                const file1ChangeShapeRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(server.CommandNames.Change, {
+                const file1ChangeShapeRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(CommandNames.Change, {
                     file: moduleFile1.path,
                     line: 1,
                     offset: 27,
@@ -369,7 +371,7 @@ namespace ts.projectSystem {
                 openFilesForSession([moduleFile1, file1Consumer1], session);
                 sendAffectedFileRequestAndCheckResult(session, moduleFile1FileListRequest, [{ projectFileName: configFile.path, files: [moduleFile1, file1Consumer1, file1Consumer1Consumer1] }]);
 
-                const changeFile1Consumer1ShapeRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(server.CommandNames.Change, {
+                const changeFile1Consumer1ShapeRequest = makeSessionRequest<server.protocol.ChangeRequestArgs>(CommandNames.Change, {
                     file: file1Consumer1.path,
                     line: 2,
                     offset: 1,
@@ -400,7 +402,7 @@ namespace ts.projectSystem {
                 const session = new server.Session(host, nullCancellationToken, /*useSingleInferredProject*/ false, typingsInstaller, Utils.byteLength, process.hrtime, nullLogger, /*canUseEvents*/ false);
 
                 openFilesForSession([file1, file2], session);
-                const file1AffectedListRequest = makeSessionRequest<server.protocol.FileRequestArgs>(server.CommandNames.CompileOnSaveAffectedFileList, { file: file1.path });
+                const file1AffectedListRequest = makeSessionRequest<server.protocol.FileRequestArgs>(CommandNames.CompileOnSaveAffectedFileList, { file: file1.path });
                 sendAffectedFileRequestAndCheckResult(session, file1AffectedListRequest, [{ projectFileName: configFile.path, files: [file1, file2] }]);
             });
 
@@ -415,7 +417,7 @@ namespace ts.projectSystem {
                 const session = createSession(host);
 
                 openFilesForSession([file1, file2, file3], session);
-                const file1AffectedListRequest = makeSessionRequest<server.protocol.FileRequestArgs>(server.CommandNames.CompileOnSaveAffectedFileList, { file: file1.path });
+                const file1AffectedListRequest = makeSessionRequest<server.protocol.FileRequestArgs>(CommandNames.CompileOnSaveAffectedFileList, { file: file1.path });
 
                 sendAffectedFileRequestAndCheckResult(session, file1AffectedListRequest, [
                     { projectFileName: configFile1.path, files: [file1, file2] },
@@ -437,11 +439,11 @@ namespace ts.projectSystem {
                 host.reloadFS([referenceFile1, configFile]);
                 host.triggerFileWatcherCallback(moduleFile1.path, /*removed*/ true);
 
-                const request = makeSessionRequest<server.protocol.FileRequestArgs>(server.CommandNames.CompileOnSaveAffectedFileList, { file: referenceFile1.path });
+                const request = makeSessionRequest<server.protocol.FileRequestArgs>(CommandNames.CompileOnSaveAffectedFileList, { file: referenceFile1.path });
                 sendAffectedFileRequestAndCheckResult(session, request, [
                     { projectFileName: configFile.path, files: [referenceFile1] }
                 ]);
-                const requestForMissingFile = makeSessionRequest<server.protocol.FileRequestArgs>(server.CommandNames.CompileOnSaveAffectedFileList, { file: moduleFile1.path });
+                const requestForMissingFile = makeSessionRequest<server.protocol.FileRequestArgs>(CommandNames.CompileOnSaveAffectedFileList, { file: moduleFile1.path });
                 sendAffectedFileRequestAndCheckResult(session, requestForMissingFile, []);
             });
 
@@ -456,7 +458,7 @@ namespace ts.projectSystem {
                 const session = createSession(host);
 
                 openFilesForSession([referenceFile1], session);
-                const request = makeSessionRequest<server.protocol.FileRequestArgs>(server.CommandNames.CompileOnSaveAffectedFileList, { file: referenceFile1.path });
+                const request = makeSessionRequest<server.protocol.FileRequestArgs>(CommandNames.CompileOnSaveAffectedFileList, { file: referenceFile1.path });
                 sendAffectedFileRequestAndCheckResult(session, request, [
                     { projectFileName: configFile.path, files: [referenceFile1] }
                 ]);
@@ -483,7 +485,7 @@ namespace ts.projectSystem {
             const session = new server.Session(host, nullCancellationToken, /*useSingleInferredProject*/ false, typingsInstaller, Utils.byteLength, process.hrtime, nullLogger, /*canUseEvents*/ false);
 
             openFilesForSession([file1, file2], session);
-            const compileFileRequest = makeSessionRequest<server.protocol.CompileOnSaveEmitFileRequestArgs>(server.CommandNames.CompileOnSaveEmitFile, { file: file1.path, projectFileName: configFile.path });
+            const compileFileRequest = makeSessionRequest<server.protocol.CompileOnSaveEmitFileRequestArgs>(CommandNames.CompileOnSaveEmitFile, { file: file1.path, projectFileName: configFile.path });
             session.executeCommand(compileFileRequest);
 
             const expectedEmittedFileName = "/a/b/f1.js";

--- a/src/harness/unittests/compileOnSave.ts
+++ b/src/harness/unittests/compileOnSave.ts
@@ -3,7 +3,7 @@
 /// <reference path="../../server/typingsInstaller/typingsInstaller.ts" />
 
 namespace ts.projectSystem {
-    import CommandNames = server.protocol.CommandNames;
+    import CommandNames = server.CommandNames;
 
     function createTestTypingsInstaller(host: server.ServerHost) {
         return new TestTypingsInstaller("/a/data/", /*throttleLimit*/5, host);

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -3,8 +3,6 @@
 const expect: typeof _chai.expect = _chai.expect;
 
 namespace ts.server {
-    import CommandNames = protocol.CommandNames;
-
     let lastWrittenToHost: string;
     const mockHost: ServerHost = {
         args: [],

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -3,6 +3,8 @@
 const expect: typeof _chai.expect = _chai.expect;
 
 namespace ts.server {
+    import CommandNames = protocol.CommandNames;
+
     let lastWrittenToHost: string;
     const mockHost: ServerHost = {
         args: [],

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -3,7 +3,7 @@
 
 namespace ts.projectSystem {
     import TI = server.typingsInstaller;
-    import CommandNames = server.protocol.CommandNames;
+    import CommandNames = server.CommandNames;
 
     const safeList = {
         path: <Path>"/safeList.json",

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -3,6 +3,7 @@
 
 namespace ts.projectSystem {
     import TI = server.typingsInstaller;
+    import CommandNames = server.protocol.CommandNames;
 
     const safeList = {
         path: <Path>"/safeList.json",
@@ -544,7 +545,7 @@ namespace ts.projectSystem {
 
     export function openFilesForSession(files: FileOrFolder[], session: server.Session) {
         for (const file of files) {
-            const request = makeSessionRequest<server.protocol.OpenRequestArgs>(server.CommandNames.Open, { file: file.path });
+            const request = makeSessionRequest<server.protocol.OpenRequestArgs>(CommandNames.Open, { file: file.path });
             session.executeCommand(request);
         }
     }
@@ -1775,11 +1776,11 @@ namespace ts.projectSystem {
             openFilesForSession([file1], session);
 
             // Try to find some interface type defined in lib.d.ts
-            const libTypeNavToRequest = makeSessionRequest<server.protocol.NavtoRequestArgs>(server.CommandNames.Navto, { searchValue: "Document", file: file1.path, projectFileName: configFile.path });
+            const libTypeNavToRequest = makeSessionRequest<server.protocol.NavtoRequestArgs>(CommandNames.Navto, { searchValue: "Document", file: file1.path, projectFileName: configFile.path });
             const items: server.protocol.NavtoItem[] = session.executeCommand(libTypeNavToRequest).response;
             assert.isFalse(containsNavToItem(items, "Document", "interface"), `Found lib.d.ts symbol in JavaScript project nav to request result.`);
 
-            const localFunctionNavToRequst = makeSessionRequest<server.protocol.NavtoRequestArgs>(server.CommandNames.Navto, { searchValue: "foo", file: file1.path, projectFileName: configFile.path });
+            const localFunctionNavToRequst = makeSessionRequest<server.protocol.NavtoRequestArgs>(CommandNames.Navto, { searchValue: "foo", file: file1.path, projectFileName: configFile.path });
             const items2: server.protocol.NavtoItem[] = session.executeCommand(localFunctionNavToRequst).response;
             assert.isTrue(containsNavToItem(items2, "foo", "function"), `Cannot find function symbol "foo".`);
         });

--- a/src/server/builder.ts
+++ b/src/server/builder.ts
@@ -1,6 +1,5 @@
 ﻿/// <reference path="..\compiler\commandLineParser.ts" />
 /// <reference path="..\services\services.ts" />
-/// <reference path="protocol.d.ts" />
 /// <reference path="session.ts" />
 /// <reference types="node" />
 

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -1,8 +1,6 @@
 /// <reference path="session.ts" />
 
 namespace ts.server {
-    import CommandNames = protocol.CommandNames;
-    
     export interface SessionClientHost extends LanguageServiceHost {
         writeMessage(message: string): void;
     }

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -1,7 +1,8 @@
 /// <reference path="session.ts" />
 
 namespace ts.server {
-
+    import CommandNames = protocol.CommandNames;
+    
     export interface SessionClientHost extends LanguageServiceHost {
         writeMessage(message: string): void;
     }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -1,6 +1,5 @@
 /// <reference path="..\compiler\commandLineParser.ts" />
 /// <reference path="..\services\services.ts" />
-/// <reference path="protocol.d.ts" />
 /// <reference path="utilities.ts" />
 /// <reference path="session.ts" />
 /// <reference path="scriptVersionCache.ts"/>

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1219,6 +1219,7 @@ namespace ts.server.protocol {
         /**
          * End position of the range for which to format text in file.
          */
+        /* @internal */
         endPosition?: number;
         /**
          * Format options to be used.

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2,87 +2,89 @@
   * Declaration module describing the TypeScript Server protocol
   */
 namespace ts.server.protocol {
-    export namespace CommandNames {
-        export const Brace = "brace";
+    export namespace CommandTypes {
+        export type Brace = "brace";
         /* @internal */
-        export const BraceFull = "brace-full";
-        export const BraceCompletion = "braceCompletion";
-        export const Change = "change";
-        export const Close = "close";
-        export const Completions = "completions";
+        export type BraceFull = "brace-full";
+        export type BraceCompletion = "braceCompletion";
+        export type Change = "change";
+        export type Close = "close";
+        export type Completions = "completions";
         /* @internal */
-        export const CompletionsFull = "completions-full";
-        export const CompletionDetails = "completionEntryDetails";
-        export const CompileOnSaveAffectedFileList = "compileOnSaveAffectedFileList";
-        export const CompileOnSaveEmitFile = "compileOnSaveEmitFile";
-        export const Configure = "configure";
-        export const Definition = "definition";
+        export type CompletionsFull = "completions-full";
+        export type CompletionDetails = "completionEntryDetails";
+        export type CompileOnSaveAffectedFileList = "compileOnSaveAffectedFileList";
+        export type CompileOnSaveEmitFile = "compileOnSaveEmitFile";
+        export type Configure = "configure";
+        export type Definition = "definition";
         /* @internal */
-        export const DefinitionFull = "definition-full";
-        export const Exit = "exit";
-        export const Format = "format";
-        export const Formatonkey = "formatonkey";
+        export type DefinitionFull = "definition-full";
+        export type Exit = "exit";
+        export type Format = "format";
+        export type Formatonkey = "formatonkey";
         /* @internal */
-        export const FormatFull = "format-full";
+        export type FormatFull = "format-full";
         /* @internal */
-        export const FormatonkeyFull = "formatonkey-full";
+        export type FormatonkeyFull = "formatonkey-full";
         /* @internal */
-        export const FormatRangeFull = "formatRange-full";
-        export const Geterr = "geterr";
-        export const GeterrForProject = "geterrForProject";
-        export const SemanticDiagnosticsSync = "semanticDiagnosticsSync";
-        export const SyntacticDiagnosticsSync = "syntacticDiagnosticsSync";
-        export const NavBar = "navbar";
+        export type FormatRangeFull = "formatRange-full";
+        export type Geterr = "geterr";
+        export type GeterrForProject = "geterrForProject";
+        export type SemanticDiagnosticsSync = "semanticDiagnosticsSync";
+        export type SyntacticDiagnosticsSync = "syntacticDiagnosticsSync";
+        export type NavBar = "navbar";
         /* @internal */
-        export const NavBarFull = "navbar-full";
-        export const Navto = "navto";
+        export type NavBarFull = "navbar-full";
+        export type Navto = "navto";
         /* @internal */
-        export const NavtoFull = "navto-full";
-        export const Occurrences = "occurrences";
-        export const DocumentHighlights = "documentHighlights";
+        export type NavtoFull = "navto-full";
+        export type Occurrences = "occurrences";
+        export type DocumentHighlights = "documentHighlights";
         /* @internal */
-        export const DocumentHighlightsFull = "documentHighlights-full";
-        export const Open = "open";
-        export const Quickinfo = "quickinfo";
+        export type DocumentHighlightsFull = "documentHighlights-full";
+        export type Open = "open";
+        export type Quickinfo = "quickinfo";
         /* @internal */
-        export const QuickinfoFull = "quickinfo-full";
-        export const References = "references";
+        export type QuickinfoFull = "quickinfo-full";
+        export type References = "references";
         /* @internal */
-        export const ReferencesFull = "references-full";
-        export const Reload = "reload";
-        export const Rename = "rename";
+        export type ReferencesFull = "references-full";
+        export type Reload = "reload";
+        export type Rename = "rename";
         /* @internal */
-        export const RenameInfoFull = "rename-full";
+        export type RenameInfoFull = "rename-full";
         /* @internal */
-        export const RenameLocationsFull = "renameLocations-full";
-        export const Saveto = "saveto";
-        export const SignatureHelp = "signatureHelp";
+        export type RenameLocationsFull = "renameLocations-full";
+        export type Saveto = "saveto";
+        export type SignatureHelp = "signatureHelp";
         /* @internal */
-        export const SignatureHelpFull = "signatureHelp-full";
-        export const TypeDefinition = "typeDefinition";
-        export const ProjectInfo = "projectInfo";
-        export const ReloadProjects = "reloadProjects";
-        export const Unknown = "unknown";
-        export const OpenExternalProject = "openExternalProject";
-        export const OpenExternalProjects = "openExternalProjects";
-        export const CloseExternalProject = "closeExternalProject";
-        export const SynchronizeProjectList = "synchronizeProjectList";
+        export type SignatureHelpFull = "signatureHelp-full";
+        export type TypeDefinition = "typeDefinition";
+        export type ProjectInfo = "projectInfo";
+        export type ReloadProjects = "reloadProjects";
+        export type Unknown = "unknown";
+        export type OpenExternalProject = "openExternalProject";
+        export type OpenExternalProjects = "openExternalProjects";
+        export type CloseExternalProject = "closeExternalProject";
         /* @internal */
-        export const ApplyChangedToOpenFiles = "applyChangedToOpenFiles";
+        export type SynchronizeProjectList = "synchronizeProjectList";
         /* @internal */
-        export const EncodedSemanticClassificationsFull = "encodedSemanticClassifications-full";
-        export const Cleanup = "cleanup";
-        export const OutliningSpans = "outliningSpans";
-        export const TodoComments = "todoComments";
-        export const Indentation = "indentation";
-        export const DocCommentTemplate = "docCommentTemplate";
+        export type ApplyChangedToOpenFiles = "applyChangedToOpenFiles";
         /* @internal */
-        export const CompilerOptionsDiagnosticsFull = "compilerOptionsDiagnostics-full";
+        export type EncodedSemanticClassificationsFull = "encodedSemanticClassifications-full";
         /* @internal */
-        export const NameOrDottedNameSpan = "nameOrDottedNameSpan";
+        export type Cleanup = "cleanup";
+        export type OutliningSpans = "outliningSpans";
+        export type TodoComments = "todoComments";
+        export type Indentation = "indentation";
+        export type DocCommentTemplate = "docCommentTemplate";
         /* @internal */
-        export const BreakpointStatement = "breakpointStatement";
-        export const CompilerOptionsForInferredProjects = "compilerOptionsForInferredProjects";
+        export type CompilerOptionsDiagnosticsFull = "compilerOptionsDiagnostics-full";
+        /* @internal */
+        export type NameOrDottedNameSpan = "nameOrDottedNameSpan";
+        /* @internal */
+        export type BreakpointStatement = "breakpointStatement";
+        export type CompilerOptionsForInferredProjects = "compilerOptionsForInferredProjects";
     }
 
     /**
@@ -119,6 +121,7 @@ namespace ts.server.protocol {
       * Request to reload the project structure for all the opened files
       */
     export interface ReloadProjectsRequest extends Message {
+        command: CommandTypes.ReloadProjects;
     }
 
     /**
@@ -182,9 +185,24 @@ namespace ts.server.protocol {
     }
 
     /**
+     * Requests a JS Doc comment template for a given position
+     */
+    export interface DocCommentTemplateRequest extends FileLocationRequest {
+        command: CommandTypes.DocCommentTemplate;
+    }
+
+    /**
+     * Response to DocCommentTemplateRequest
+     */
+    export interface DocCommandTemplateResponse extends Response {
+        body?: TextInsertion;
+    }
+
+    /**
      * A request to get TODO comments from the file
      */
     export interface TodoCommentRequest extends FileRequest {
+        command: CommandTypes.TodoComments;
         arguments: TodoCommentRequestArgs;
     }
 
@@ -199,10 +217,53 @@ namespace ts.server.protocol {
     }
 
     /**
+     * Response for TodoCommentRequest request.
+     */
+    export interface TodoCommentsResponse extends Response {
+        body?: TodoComment[];
+    }
+
+    /**
+     * Request to obtain outlining spans in file.
+     */
+    export interface OutliningSpansRequest extends FileRequest {
+        command: CommandTypes.OutliningSpans;
+    }
+
+    /**
+     * Response to OutliningSpansRequest request.
+     */
+    export interface OutliningSpansResponse extends Response {
+        body?: OutliningSpan[];
+    }
+
+    /**
      * A request to get indentation for a location in file
      */
     export interface IndentationRequest extends FileLocationRequest {
+        command: CommandTypes.Indentation;
         arguments: IndentationRequestArgs;
+    }
+
+    /**
+     * Response for IndentationRequest request.
+     */
+    export interface IndentationResponse extends Response {
+        body?: IndentationResult;
+    }
+
+    /**
+     * Indentation result representing where indentation should be placed
+     */
+    export interface IndentationResult {
+        /**
+         * The base position in the document that the indent should be relative to
+         */
+        position: number;
+        /**
+         * The number of columns the indent should be at relative to the position's column.
+         */
+        indentation: number;
     }
 
     /**
@@ -230,6 +291,7 @@ namespace ts.server.protocol {
       * A request to get the project information of the current file.
       */
     export interface ProjectInfoRequest extends Request {
+        command: CommandTypes.ProjectInfo;
         arguments: ProjectInfoRequestArgs;
     }
 
@@ -328,16 +390,17 @@ namespace ts.server.protocol {
     }
 
     /**
-     * A request to get semantic diagnostics for a span in the file
+     * A request to get encoded semantic classifications for a span in the file
      */
-    export interface SemanticDiagnosticsRequest extends FileRequest {
-        arguments: SemanticDiagnosticsRequestArgs;
+    /** @internal */
+    export interface EncodedSemanticClassificationsRequest extends FileRequest {
+        arguments: EncodedSemanticClassificationsRequestArgs;
     }
 
     /**
-     * Arguments for SemanticDiagnosticsRequest request.
+     * Arguments for EncodedSemanticClassificationsRequest request.
      */
-    export interface SemanticDiagnosticsRequestArgs extends FileRequestArgs {
+    export interface EncodedSemanticClassificationsRequestArgs extends FileRequestArgs {
         /**
          * Start position of the span.
          */
@@ -365,6 +428,7 @@ namespace ts.server.protocol {
       * define the symbol found in file at location line, col.
       */
     export interface DefinitionRequest extends FileLocationRequest {
+        command: CommandTypes.Definition;
     }
 
     /**
@@ -373,6 +437,7 @@ namespace ts.server.protocol {
       * define the type for the symbol found in file at location line, col.
       */
     export interface TypeDefinitionRequest extends FileLocationRequest {
+        command: CommandTypes.TypeDefinition;
     }
 
     /**
@@ -433,6 +498,7 @@ namespace ts.server.protocol {
      * Request to get brace completion for a location in the file.
      */
     export interface BraceCompletionRequest extends FileLocationRequest {
+        command: CommandTypes.BraceCompletion;
         arguments: BraceCompletionRequestArgs;
     }
 
@@ -452,6 +518,7 @@ namespace ts.server.protocol {
       * in the file at a given line and column.
       */
     export interface OccurrencesRequest extends FileLocationRequest {
+        command: CommandTypes.Occurrences;
     }
 
     export interface OccurrencesResponseItem extends FileSpan {
@@ -471,6 +538,7 @@ namespace ts.server.protocol {
       * in the file at a given line and column.
       */
     export interface DocumentHighlightsRequest extends FileLocationRequest {
+        command: CommandTypes.DocumentHighlights;
         arguments: DocumentHighlightsRequestArgs;
     }
 
@@ -510,6 +578,7 @@ namespace ts.server.protocol {
       * reference the symbol found in file at location line, col.
       */
     export interface ReferencesRequest extends FileLocationRequest {
+        command: CommandTypes.References;
     }
 
     export interface ReferencesResponseItem extends FileSpan {
@@ -584,6 +653,7 @@ namespace ts.server.protocol {
       * name of the symbol so that client can print it unambiguously.
       */
     export interface RenameRequest extends FileLocationRequest {
+        command: CommandTypes.Rename;
         arguments: RenameRequestArgs;
     }
 
@@ -823,6 +893,7 @@ namespace ts.server.protocol {
       *  host information, such as host type, tab size, and indent size.
       */
     export interface ConfigureRequest extends Request {
+        command: CommandTypes.Configure;
         arguments: ConfigureRequestArguments;
     }
 
@@ -858,6 +929,7 @@ namespace ts.server.protocol {
       * send a response to an open request.
       */
     export interface OpenRequest extends Request {
+        command: CommandTypes.Open;
         arguments: OpenRequestArgs;
     }
 
@@ -865,6 +937,7 @@ namespace ts.server.protocol {
      * Request to open or update external project
      */
     export interface OpenExternalProjectRequest extends Request {
+        command: CommandTypes.OpenExternalProject;
         arguments: OpenExternalProjectArgs;
     }
 
@@ -877,6 +950,7 @@ namespace ts.server.protocol {
      * Request to open multiple external projects
      */
     export interface OpenExternalProjectsRequest extends Request {
+        command: CommandTypes.OpenExternalProjects;
         arguments: OpenExternalProjectsArgs;
     }
 
@@ -891,9 +965,24 @@ namespace ts.server.protocol {
     }
 
     /**
+     * Response to OpenExternalProjectRequest request. This is just an acknowledgement, so
+     * no body field is required.
+     */
+    export interface OpenExternalProjectResponse extends Response {
+    }
+
+    /**
+     * Response to OpenExternalProjectsRequest request. This is just an acknowledgement, so
+     * no body field is required.
+     */
+    export interface OpenExternalProjectsResponse extends Response {
+    }
+
+    /**
      * Request to close external project.
      */
     export interface CloseExternalProjectRequest extends Request {
+        command: CommandTypes.CloseExternalProject;
         arguments: CloseExternalProjectRequestArgs;
     }
 
@@ -908,8 +997,16 @@ namespace ts.server.protocol {
     }
 
     /**
+     * Response to CloseExternalProjectRequest request. This is just an acknowledgement, so
+     * no body field is required.
+     */
+    export interface CloseExternalProjectResponse extends Response {
+    }
+
+    /**
      * Request to check if given list of projects is up-to-date and synchronize them if necessary
      */
+    /* @internal */
     export interface SynchronizeProjectListRequest extends Request {
         arguments: SynchronizeProjectListRequestArgs;
     }
@@ -961,6 +1058,7 @@ namespace ts.server.protocol {
      * or all open loose files and its transitive closure of referenced files if 'useOneInferredProject' is true.
      */
     export interface SetCompilerOptionsForInferredProjectsRequest extends Request {
+        command: CommandTypes.CompilerOptionsForInferredProjects;
         arguments: SetCompilerOptionsForInferredProjectsArgs;
     }
 
@@ -975,10 +1073,18 @@ namespace ts.server.protocol {
     }
 
     /**
+      * Response to SetCompilerOptionsForInferredProjectsResponse request. This is just an acknowledgement, so
+      * no body field is required.
+      */
+    export interface SetCompilerOptionsForInferredProjectsResponse extends Response {
+    }
+
+    /**
       *  Exit request; value of command field is "exit".  Ask the server process
       *  to exit.
       */
     export interface ExitRequest extends Request {
+        command: CommandTypes.Exit;
     }
 
     /**
@@ -989,6 +1095,7 @@ namespace ts.server.protocol {
       * currently send a response to a close request.
       */
     export interface CloseRequest extends FileRequest {
+        command: CommandTypes.Close;
     }
 
     /**
@@ -996,6 +1103,7 @@ namespace ts.server.protocol {
      * NOTE: this us query-only operation and does not generate any output on disk.
      */
     export interface CompileOnSaveAffectedFileListRequest extends FileRequest {
+        command: CommandTypes.CompileOnSaveAffectedFileList;
     }
 
     /**
@@ -1023,7 +1131,8 @@ namespace ts.server.protocol {
      * Request to recompile the file. All generated outputs (.js, .d.ts or .js.map files) is written on disk.
      */
     export interface CompileOnSaveEmitFileRequest extends FileRequest {
-        args: CompileOnSaveEmitFileRequestArgs;
+        command: CommandTypes.CompileOnSaveEmitFile;
+        arguments: CompileOnSaveEmitFileRequestArgs;
     }
 
     /**
@@ -1043,6 +1152,7 @@ namespace ts.server.protocol {
       * line, col.
       */
     export interface QuickInfoRequest extends FileLocationRequest {
+        command: CommandTypes.Quickinfo;
     }
 
     /**
@@ -1119,6 +1229,7 @@ namespace ts.server.protocol {
       * reformatted text.
       */
     export interface FormatRequest extends FileLocationRequest {
+        command: CommandTypes.Format;
         arguments: FormatRequestArgs;
     }
 
@@ -1175,6 +1286,7 @@ namespace ts.server.protocol {
       * reformatted text.
       */
     export interface FormatOnKeyRequest extends FileLocationRequest {
+        command: CommandTypes.Formatonkey;
         arguments: FormatOnKeyRequestArgs;
     }
 
@@ -1195,6 +1307,7 @@ namespace ts.server.protocol {
       * begin with prefix.
       */
     export interface CompletionsRequest extends FileLocationRequest {
+        command: CommandTypes.Completions;
         arguments: CompletionsRequestArgs;
     }
 
@@ -1215,6 +1328,7 @@ namespace ts.server.protocol {
       * detailed information for each completion entry.
       */
     export interface CompletionDetailsRequest extends FileLocationRequest {
+        command: CommandTypes.CompletionDetails;
         arguments: CompletionDetailsRequestArgs;
     }
 
@@ -1401,6 +1515,7 @@ namespace ts.server.protocol {
       * help.
       */
     export interface SignatureHelpRequest extends FileLocationRequest {
+        command: CommandTypes.SignatureHelp;
         arguments: SignatureHelpRequestArgs;
     }
 
@@ -1415,6 +1530,7 @@ namespace ts.server.protocol {
       * Synchronous request for semantic diagnostics of one file.
       */
     export interface SemanticDiagnosticsSyncRequest extends FileRequest {
+        command: CommandTypes.SemanticDiagnosticsSync;
         arguments: SemanticDiagnosticsSyncRequestArgs;
     }
 
@@ -1433,6 +1549,7 @@ namespace ts.server.protocol {
       * Synchronous request for syntactic diagnostics of one file.
       */
     export interface SyntacticDiagnosticsSyncRequest extends FileRequest {
+        command: CommandTypes.SyntacticDiagnosticsSync;
         arguments: SyntacticDiagnosticsSyncRequestArgs;
     }
 
@@ -1469,6 +1586,7 @@ namespace ts.server.protocol {
       * it request for every file in this project.
       */
     export interface GeterrForProjectRequest extends Request {
+        command: CommandTypes.GeterrForProject;
         arguments: GeterrForProjectRequestArgs;
     }
 
@@ -1500,6 +1618,7 @@ namespace ts.server.protocol {
       * file that is currently visible, in most-recently-used order.
       */
     export interface GeterrRequest extends Request {
+        command: CommandTypes.Geterr;
         arguments: GeterrRequestArgs;
     }
 
@@ -1587,11 +1706,12 @@ namespace ts.server.protocol {
       * The two names can be identical.
       */
     export interface ReloadRequest extends FileRequest {
+        command: CommandTypes.Reload;
         arguments: ReloadRequestArgs;
     }
 
     /**
-      * Response to "reload" request.  This is just an acknowledgement, so
+      * Response to "reload" request. This is just an acknowledgement, so
       * no body field is required.
       */
     export interface ReloadResponse extends Response {
@@ -1616,6 +1736,7 @@ namespace ts.server.protocol {
       * "saveto" request.
       */
     export interface SavetoRequest extends FileRequest {
+        command: CommandTypes.Saveto;
         arguments: SavetoRequestArgs;
     }
 
@@ -1643,6 +1764,7 @@ namespace ts.server.protocol {
       * context for the search is given by the named file.
       */
     export interface NavtoRequest extends FileRequest {
+        command: CommandTypes.Navto;
         arguments: NavtoRequestArgs;
     }
 
@@ -1726,6 +1848,7 @@ namespace ts.server.protocol {
       * Server does not currently send a response to a change request.
       */
     export interface ChangeRequest extends FileLocationRequest {
+        command: CommandTypes.Change;
         arguments: ChangeRequestArgs;
     }
 
@@ -1742,6 +1865,7 @@ namespace ts.server.protocol {
       * found in file at location line, offset.
       */
     export interface BraceRequest extends FileLocationRequest {
+        command: CommandTypes.Brace;
     }
 
     /**
@@ -1750,6 +1874,7 @@ namespace ts.server.protocol {
       * extracted from the requested file.
       */
     export interface NavBarRequest extends FileRequest {
+        command: CommandTypes.NavBar;
     }
 
     export interface NavigationBarItem {

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1,7 +1,90 @@
 /**
   * Declaration module describing the TypeScript Server protocol
   */
-declare namespace ts.server.protocol {
+namespace ts.server.protocol {
+    export namespace CommandNames {
+        export const Brace = "brace";
+        /* @internal */
+        export const BraceFull = "brace-full";
+        export const BraceCompletion = "braceCompletion";
+        export const Change = "change";
+        export const Close = "close";
+        export const Completions = "completions";
+        /* @internal */
+        export const CompletionsFull = "completions-full";
+        export const CompletionDetails = "completionEntryDetails";
+        export const CompileOnSaveAffectedFileList = "compileOnSaveAffectedFileList";
+        export const CompileOnSaveEmitFile = "compileOnSaveEmitFile";
+        export const Configure = "configure";
+        export const Definition = "definition";
+        /* @internal */
+        export const DefinitionFull = "definition-full";
+        export const Exit = "exit";
+        export const Format = "format";
+        export const Formatonkey = "formatonkey";
+        /* @internal */
+        export const FormatFull = "format-full";
+        /* @internal */
+        export const FormatonkeyFull = "formatonkey-full";
+        /* @internal */
+        export const FormatRangeFull = "formatRange-full";
+        export const Geterr = "geterr";
+        export const GeterrForProject = "geterrForProject";
+        export const SemanticDiagnosticsSync = "semanticDiagnosticsSync";
+        export const SyntacticDiagnosticsSync = "syntacticDiagnosticsSync";
+        export const NavBar = "navbar";
+        /* @internal */
+        export const NavBarFull = "navbar-full";
+        export const Navto = "navto";
+        /* @internal */
+        export const NavtoFull = "navto-full";
+        export const Occurrences = "occurrences";
+        export const DocumentHighlights = "documentHighlights";
+        /* @internal */
+        export const DocumentHighlightsFull = "documentHighlights-full";
+        export const Open = "open";
+        export const Quickinfo = "quickinfo";
+        /* @internal */
+        export const QuickinfoFull = "quickinfo-full";
+        export const References = "references";
+        /* @internal */
+        export const ReferencesFull = "references-full";
+        export const Reload = "reload";
+        export const Rename = "rename";
+        /* @internal */
+        export const RenameInfoFull = "rename-full";
+        /* @internal */
+        export const RenameLocationsFull = "renameLocations-full";
+        export const Saveto = "saveto";
+        export const SignatureHelp = "signatureHelp";
+        /* @internal */
+        export const SignatureHelpFull = "signatureHelp-full";
+        export const TypeDefinition = "typeDefinition";
+        export const ProjectInfo = "projectInfo";
+        export const ReloadProjects = "reloadProjects";
+        export const Unknown = "unknown";
+        export const OpenExternalProject = "openExternalProject";
+        export const OpenExternalProjects = "openExternalProjects";
+        export const CloseExternalProject = "closeExternalProject";
+        export const SynchronizeProjectList = "synchronizeProjectList";
+        /* @internal */
+        export const ApplyChangedToOpenFiles = "applyChangedToOpenFiles";
+        /* @internal */
+        export const EncodedSemanticClassificationsFull = "encodedSemanticClassifications-full";
+        export const Cleanup = "cleanup";
+        export const OutliningSpans = "outliningSpans";
+        export const TodoComments = "todoComments";
+        export const Indentation = "indentation";
+        export const DocCommentTemplate = "docCommentTemplate";
+        /* @internal */
+        export const CompilerOptionsDiagnosticsFull = "compilerOptionsDiagnostics-full";
+        /* @internal */
+        export const NameOrDottedNameSpan = "nameOrDottedNameSpan";
+        /* @internal */
+        export const BreakpointStatement = "breakpointStatement";
+        export const CompilerOptionsForInferredProjects = "compilerOptionsForInferredProjects";
+    }
+
     /**
       * A TypeScript Server message
       */
@@ -190,16 +273,17 @@ declare namespace ts.server.protocol {
         /**
           * The line number for the request (1-based).
           */
-        line?: number;
+        line: number;
 
         /**
           * The character offset (on the line) for the request (1-based).
           */
-        offset?: number;
+        offset: number;
 
         /**
          * Position (can be specified instead of line/offset pair) 
          */
+        /* @internal */
         position?: number;
     }
 
@@ -539,70 +623,12 @@ declare namespace ts.server.protocol {
         projectErrors: DiagnosticWithLinePosition[];
     }
 
+    /* @internal */
     export interface ChangedOpenFile {
         fileName: string;
         changes: ts.TextChange[];
     }
 
-    /**
-     * Editor options
-     */
-    export interface EditorOptions {
-
-        /** Number of spaces for each tab. Default value is 4. */
-        tabSize?: number;
-
-        /** Number of spaces to indent during formatting. Default value is 4. */
-        indentSize?: number;
-
-        /** Number of additional spaces to indent during formatting to preserve base indentation (ex. script block indentation). Default value is 0. */
-        baseIndentSize?: number;
-
-        /** The new line character to be used. Default value is the OS line delimiter. */
-        newLineCharacter?: string;
-
-        /** Whether tabs should be converted to spaces. Default value is true. */
-        convertTabsToSpaces?: boolean;
-    }
-
-    /**
-     * Format options
-     */
-    export interface FormatOptions extends EditorOptions {
-
-        /** Defines space handling after a comma delimiter. Default value is true. */
-        insertSpaceAfterCommaDelimiter?: boolean;
-
-        /** Defines space handling after a semicolon in a for statement. Default value is true */
-        insertSpaceAfterSemicolonInForStatements?: boolean;
-
-        /** Defines space handling after a binary operator. Default value is true. */
-        insertSpaceBeforeAndAfterBinaryOperators?: boolean;
-
-        /** Defines space handling after keywords in control flow statement. Default value is true. */
-        insertSpaceAfterKeywordsInControlFlowStatements?: boolean;
-
-        /** Defines space handling after function keyword for anonymous functions. Default value is false. */
-        insertSpaceAfterFunctionKeywordForAnonymousFunctions?: boolean;
-
-        /** Defines space handling after opening and before closing non empty parenthesis. Default value is false. */
-        insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis?: boolean;
-
-        /** Defines space handling after opening and before closing non empty brackets. Default value is false. */
-        insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets?: boolean;
-
-        /** Defines space handling before and after template string braces. Default value is false. */
-        insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces?: boolean;
-
-        /** Defines space handling before and after JSX expression braces. Default value is false. */
-        insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces?: boolean;
-
-        /** Defines whether an open brace is put onto a new line for functions or not. Default value is false. */
-        placeOpenBraceOnNewLineForFunctions?: boolean;
-
-        /** Defines whether an open brace is put onto a new line for control blocks or not. Default value is false. */
-        placeOpenBraceOnNewLineForControlBlocks?: boolean;
-    }
 
     /**
       * Information found in a configure request.
@@ -623,7 +649,7 @@ declare namespace ts.server.protocol {
         /**
          * The format options to use during formatting and other code editing features.
          */
-        formatOptions?: FormatOptions;
+        formatOptions?: FormatCodeSettings;
     }
 
     /**
@@ -669,7 +695,7 @@ declare namespace ts.server.protocol {
         arguments: OpenRequestArgs;
     }
 
-    type OpenExternalProjectArgs = ExternalProject;
+    export type OpenExternalProjectArgs = ExternalProject;
 
     export interface OpenExternalProjectRequest extends Request {
         arguments: OpenExternalProjectArgs;
@@ -699,10 +725,12 @@ declare namespace ts.server.protocol {
         knownProjects: protocol.ProjectVersionInfo[];
     }
 
+    /* @internal */
     export interface ApplyChangedToOpenFilesRequest extends Request {
         arguments: ApplyChangedToOpenFilesRequestArgs;
     }
 
+    /* @internal */
     export interface ApplyChangedToOpenFilesRequestArgs {
         openFiles?: ExternalFile[];
         changedFiles?: ChangedOpenFile[];
@@ -820,7 +848,7 @@ declare namespace ts.server.protocol {
         endOffset: number;
 
         endPosition?: number;
-        options?: ts.FormatCodeOptions;
+        options?: FormatCodeSettings;
     }
 
     /**
@@ -875,7 +903,7 @@ declare namespace ts.server.protocol {
           */
         key: string;
 
-        options?: ts.FormatCodeOptions;
+        options?: FormatCodeSettings;
     }
 
     /**

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -91,7 +91,7 @@ namespace ts.server {
             return this.containingProjects[0];
         }
 
-        setFormatOptions(formatSettings: protocol.FormatOptions): void {
+        setFormatOptions(formatSettings: FormatCodeSettings): void {
             if (formatSettings) {
                 if (!this.formatCodeSettings) {
                     this.formatCodeSettings = getDefaultFormatCodeSettings(this.host);

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -1,6 +1,5 @@
 /// <reference path="..\compiler\commandLineParser.ts" />
 /// <reference path="..\services\services.ts" />
-/// <reference path="protocol.d.ts" />
 /// <reference path="session.ts" />
 
 namespace ts.server {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -70,7 +70,69 @@ namespace ts.server {
         return true;
     }
 
-    import CommandNames = protocol.CommandNames;
+    export namespace CommandNames {
+        export const Brace: protocol.CommandTypes.Brace = "brace";
+        export const BraceFull: protocol.CommandTypes.BraceFull = "brace-full";
+        export const BraceCompletion: protocol.CommandTypes.BraceCompletion = "braceCompletion";
+        export const Change: protocol.CommandTypes.Change = "change";
+        export const Close: protocol.CommandTypes.Close = "close";
+        export const Completions: protocol.CommandTypes.Completions = "completions";
+        export const CompletionsFull: protocol.CommandTypes.CompletionsFull = "completions-full";
+        export const CompletionDetails: protocol.CommandTypes.CompletionDetails = "completionEntryDetails";
+        export const CompileOnSaveAffectedFileList: protocol.CommandTypes.CompileOnSaveAffectedFileList = "compileOnSaveAffectedFileList";
+        export const CompileOnSaveEmitFile: protocol.CommandTypes.CompileOnSaveEmitFile = "compileOnSaveEmitFile";
+        export const Configure: protocol.CommandTypes.Configure = "configure";
+        export const Definition: protocol.CommandTypes.Definition = "definition";
+        export const DefinitionFull: protocol.CommandTypes.DefinitionFull = "definition-full";
+        export const Exit: protocol.CommandTypes.Exit = "exit";
+        export const Format: protocol.CommandTypes.Format = "format";
+        export const Formatonkey: protocol.CommandTypes.Formatonkey = "formatonkey";
+        export const FormatFull: protocol.CommandTypes.FormatFull = "format-full";
+        export const FormatonkeyFull: protocol.CommandTypes.FormatonkeyFull = "formatonkey-full";
+        export const FormatRangeFull: protocol.CommandTypes.FormatRangeFull = "formatRange-full";
+        export const Geterr: protocol.CommandTypes.Geterr = "geterr";
+        export const GeterrForProject: protocol.CommandTypes.GeterrForProject = "geterrForProject";
+        export const SemanticDiagnosticsSync: protocol.CommandTypes.SemanticDiagnosticsSync = "semanticDiagnosticsSync";
+        export const SyntacticDiagnosticsSync: protocol.CommandTypes.SyntacticDiagnosticsSync = "syntacticDiagnosticsSync";
+        export const NavBar: protocol.CommandTypes.NavBar = "navbar";
+        export const NavBarFull: protocol.CommandTypes.NavBarFull = "navbar-full";
+        export const Navto: protocol.CommandTypes.Navto = "navto";
+        export const NavtoFull: protocol.CommandTypes.NavtoFull = "navto-full";
+        export const Occurrences: protocol.CommandTypes.Occurrences = "occurrences";
+        export const DocumentHighlights: protocol.CommandTypes.DocumentHighlights = "documentHighlights";
+        export const DocumentHighlightsFull: protocol.CommandTypes.DocumentHighlightsFull = "documentHighlights-full";
+        export const Open: protocol.CommandTypes.Open = "open";
+        export const Quickinfo: protocol.CommandTypes.Quickinfo = "quickinfo";
+        export const QuickinfoFull: protocol.CommandTypes.QuickinfoFull = "quickinfo-full";
+        export const References: protocol.CommandTypes.References = "references";
+        export const ReferencesFull: protocol.CommandTypes.ReferencesFull = "references-full";
+        export const Reload: protocol.CommandTypes.Reload = "reload";
+        export const Rename: protocol.CommandTypes.Rename = "rename";
+        export const RenameInfoFull: protocol.CommandTypes.RenameInfoFull = "rename-full";
+        export const RenameLocationsFull: protocol.CommandTypes.RenameLocationsFull = "renameLocations-full";
+        export const Saveto: protocol.CommandTypes.Saveto = "saveto";
+        export const SignatureHelp: protocol.CommandTypes.SignatureHelp = "signatureHelp";
+        export const SignatureHelpFull: protocol.CommandTypes.SignatureHelpFull = "signatureHelp-full";
+        export const TypeDefinition: protocol.CommandTypes.TypeDefinition = "typeDefinition";
+        export const ProjectInfo: protocol.CommandTypes.ProjectInfo = "projectInfo";
+        export const ReloadProjects: protocol.CommandTypes.ReloadProjects = "reloadProjects";
+        export const Unknown: protocol.CommandTypes.Unknown = "unknown";
+        export const OpenExternalProject: protocol.CommandTypes.OpenExternalProject = "openExternalProject";
+        export const OpenExternalProjects: protocol.CommandTypes.OpenExternalProjects = "openExternalProjects";
+        export const CloseExternalProject: protocol.CommandTypes.CloseExternalProject = "closeExternalProject";
+        export const SynchronizeProjectList: protocol.CommandTypes.SynchronizeProjectList = "synchronizeProjectList";
+        export const ApplyChangedToOpenFiles: protocol.CommandTypes.ApplyChangedToOpenFiles = "applyChangedToOpenFiles";
+        export const EncodedSemanticClassificationsFull: protocol.CommandTypes.EncodedSemanticClassificationsFull = "encodedSemanticClassifications-full";
+        export const Cleanup: protocol.CommandTypes.Cleanup = "cleanup";
+        export const OutliningSpans: protocol.CommandTypes.OutliningSpans = "outliningSpans";
+        export const TodoComments: protocol.CommandTypes.TodoComments = "todoComments";
+        export const Indentation: protocol.CommandTypes.Indentation = "indentation";
+        export const DocCommentTemplate: protocol.CommandTypes.DocCommentTemplate = "docCommentTemplate";
+        export const CompilerOptionsDiagnosticsFull: protocol.CommandTypes.CompilerOptionsDiagnosticsFull = "compilerOptionsDiagnostics-full";
+        export const NameOrDottedNameSpan: protocol.CommandTypes.NameOrDottedNameSpan = "nameOrDottedNameSpan";
+        export const BreakpointStatement: protocol.CommandTypes.BreakpointStatement = "breakpointStatement";
+        export const CompilerOptionsForInferredProjects: protocol.CommandTypes.CompilerOptionsForInferredProjects = "compilerOptionsForInferredProjects";
+    }
 
     export function formatMessage<T extends protocol.Message>(msg: T, logger: server.Logger, byteLength: (s: string, encoding: string) => number, newLine: string): string {
         const verboseLogging = logger.hasLevel(LogLevel.verbose);
@@ -278,7 +340,7 @@ namespace ts.server {
             }
         }
 
-        private getEncodedSemanticClassifications(args: protocol.SemanticDiagnosticsRequestArgs) {
+        private getEncodedSemanticClassifications(args: protocol.EncodedSemanticClassificationsRequestArgs) {
             const { file, project } = this.getFileAndProject(args);
             return project.getLanguageService().getEncodedSemanticClassifications(file, args);
         }
@@ -1308,7 +1370,7 @@ namespace ts.server {
             [CommandNames.BraceCompletion]: (request: protocol.BraceCompletionRequest) => {
                 return this.requiredResponse(this.isValidBraceCompletion(request.arguments));
             },
-            [CommandNames.DocCommentTemplate]: (request: protocol.FileLocationRequest) => {
+            [CommandNames.DocCommentTemplate]: (request: protocol.DocCommentTemplateRequest) => {
                 return this.requiredResponse(this.getDocCommentTemplate(request.arguments));
             },
             [CommandNames.Format]: (request: protocol.FormatRequest) => {
@@ -1350,7 +1412,7 @@ namespace ts.server {
             [CommandNames.CompilerOptionsDiagnosticsFull]: (request: protocol.CompilerOptionsDiagnosticsRequest) => {
                 return this.requiredResponse(this.getCompilerOptionsDiagnostics(request.arguments));
             },
-            [CommandNames.EncodedSemanticClassificationsFull]: (request: protocol.SemanticDiagnosticsRequest) => {
+            [CommandNames.EncodedSemanticClassificationsFull]: (request: protocol.EncodedSemanticClassificationsRequest) => {
                 return this.requiredResponse(this.getEncodedSemanticClassifications(request.arguments));
             },
             [CommandNames.Cleanup]: (request: protocol.Request) => {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1,6 +1,6 @@
 ﻿/// <reference path="..\compiler\commandLineParser.ts" />
 /// <reference path="..\services\services.ts" />
-/// <reference path="protocol.d.ts" />
+/// <reference path="protocol.ts" />
 /// <reference path="editorServices.ts" />
 
 namespace ts.server {
@@ -70,69 +70,7 @@ namespace ts.server {
         return true;
     }
 
-    export namespace CommandNames {
-        export const Brace = "brace";
-        export const BraceFull = "brace-full";
-        export const BraceCompletion = "braceCompletion";
-        export const Change = "change";
-        export const Close = "close";
-        export const Completions = "completions";
-        export const CompletionsFull = "completions-full";
-        export const CompletionDetails = "completionEntryDetails";
-        export const CompileOnSaveAffectedFileList = "compileOnSaveAffectedFileList";
-        export const CompileOnSaveEmitFile = "compileOnSaveEmitFile";
-        export const Configure = "configure";
-        export const Definition = "definition";
-        export const DefinitionFull = "definition-full";
-        export const Exit = "exit";
-        export const Format = "format";
-        export const Formatonkey = "formatonkey";
-        export const FormatFull = "format-full";
-        export const FormatonkeyFull = "formatonkey-full";
-        export const FormatRangeFull = "formatRange-full";
-        export const Geterr = "geterr";
-        export const GeterrForProject = "geterrForProject";
-        export const SemanticDiagnosticsSync = "semanticDiagnosticsSync";
-        export const SyntacticDiagnosticsSync = "syntacticDiagnosticsSync";
-        export const NavBar = "navbar";
-        export const NavBarFull = "navbar-full";
-        export const Navto = "navto";
-        export const NavtoFull = "navto-full";
-        export const Occurrences = "occurrences";
-        export const DocumentHighlights = "documentHighlights";
-        export const DocumentHighlightsFull = "documentHighlights-full";
-        export const Open = "open";
-        export const Quickinfo = "quickinfo";
-        export const QuickinfoFull = "quickinfo-full";
-        export const References = "references";
-        export const ReferencesFull = "references-full";
-        export const Reload = "reload";
-        export const Rename = "rename";
-        export const RenameInfoFull = "rename-full";
-        export const RenameLocationsFull = "renameLocations-full";
-        export const Saveto = "saveto";
-        export const SignatureHelp = "signatureHelp";
-        export const SignatureHelpFull = "signatureHelp-full";
-        export const TypeDefinition = "typeDefinition";
-        export const ProjectInfo = "projectInfo";
-        export const ReloadProjects = "reloadProjects";
-        export const Unknown = "unknown";
-        export const OpenExternalProject = "openExternalProject";
-        export const OpenExternalProjects = "openExternalProjects";
-        export const CloseExternalProject = "closeExternalProject";
-        export const SynchronizeProjectList = "synchronizeProjectList";
-        export const ApplyChangedToOpenFiles = "applyChangedToOpenFiles";
-        export const EncodedSemanticClassificationsFull = "encodedSemanticClassifications-full";
-        export const Cleanup = "cleanup";
-        export const OutliningSpans = "outliningSpans";
-        export const TodoComments = "todoComments";
-        export const Indentation = "indentation";
-        export const DocCommentTemplate = "docCommentTemplate";
-        export const CompilerOptionsDiagnosticsFull = "compilerOptionsDiagnostics-full";
-        export const NameOrDottedNameSpan = "nameOrDottedNameSpan";
-        export const BreakpointStatement = "breakpointStatement";
-        export const CompilerOptionsForInferredProjects = "compilerOptionsForInferredProjects";
-    }
+    import CommandNames = protocol.CommandNames;
 
     export function formatMessage<T extends protocol.Message>(msg: T, logger: server.Logger, byteLength: (s: string, encoding: string) => number, newLine: string): string {
         const verboseLogging = logger.hasLevel(LogLevel.verbose);

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -22,7 +22,7 @@
         "typingsCache.ts",
         "project.ts",
         "editorServices.ts",
-        "protocol.d.ts",
+        "protocol.ts",
         "session.ts",
         "server.ts"
     ]

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1380,11 +1380,11 @@ namespace ts {
 
     export interface EditorSettings {
         baseIndentSize?: number;
-        indentSize: number;
-        tabSize: number;
-        newLineCharacter: string;
-        convertTabsToSpaces: boolean;
-        indentStyle: IndentStyle;
+        indentSize?: number;
+        tabSize?: number;
+        newLineCharacter?: string;
+        convertTabsToSpaces?: boolean;
+        indentStyle?: IndentStyle;
     }
 
     export enum IndentStyle {
@@ -1409,17 +1409,17 @@ namespace ts {
     }
 
     export interface FormatCodeSettings extends EditorSettings {
-        insertSpaceAfterCommaDelimiter: boolean;
-        insertSpaceAfterSemicolonInForStatements: boolean;
-        insertSpaceBeforeAndAfterBinaryOperators: boolean;
-        insertSpaceAfterKeywordsInControlFlowStatements: boolean;
-        insertSpaceAfterFunctionKeywordForAnonymousFunctions: boolean;
-        insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: boolean;
-        insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: boolean;
-        insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: boolean;
-        insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: boolean;
-        placeOpenBraceOnNewLineForFunctions: boolean;
-        placeOpenBraceOnNewLineForControlBlocks: boolean;
+        insertSpaceAfterCommaDelimiter?: boolean;
+        insertSpaceAfterSemicolonInForStatements?: boolean;
+        insertSpaceBeforeAndAfterBinaryOperators?: boolean;
+        insertSpaceAfterKeywordsInControlFlowStatements?: boolean;
+        insertSpaceAfterFunctionKeywordForAnonymousFunctions?: boolean;
+        insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis?: boolean;
+        insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets?: boolean;
+        insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces?: boolean;
+        insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces?: boolean;
+        placeOpenBraceOnNewLineForFunctions?: boolean;
+        placeOpenBraceOnNewLineForControlBlocks?: boolean;
     }
 
     /* @internal */


### PR DESCRIPTION
As a result `protocol.d.ts` can be compiled as a standalone file (modulo `lib.d.ts`)
Also in this PR 
- added a few missing request/response types 
- assign string literal command types to requests
- hide VS specific command that should not be part of the protocol
- hide position argument on `FileLocationRequest` - we'll do work to properly split messages to line/offset-based and position-based later

Example of generated `protocol.d.ts`: https://gist.github.com/vladima/411ec6893d4e07a08c4804afbf0d754a

pending work: reflect changes made in `Jakefile.js` in `gulp` script
fixes: #11520, #11519, #11518, #11516, #11515, #11514. #11482, #11487

// CC: @mhegazy, @dbaeumer 