### PR TITLE
Partial Types (#11233)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2228,7 +2228,8 @@ namespace ts {
                         writer.writeKeyword("this");
                     }
                     else if (type.flags & TypeFlags.Partial) {
-                        writer.writeKeyword("partial ");
+                        writer.writeKeyword("partial");
+                        writeSpace(writer);
                         writeType((type as PartialType).type, flags);
                     }
                     else if (getObjectFlags(type) & ObjectFlags.Reference) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4475,6 +4475,8 @@ namespace ts {
                     }
                     else if ((<ObjectType>type).objectFlags & ObjectFlags.Anonymous) {
                         resolveAnonymousTypeMembers(<AnonymousType>type);
+                    } else if ((<ObjectType>type).objectFlags & ObjectFlags.Partial) {
+                        resolvePartialTypeMembers(<PartialType>type);
                     }
                     else if ((<ObjectType>type).flags & TypeFlags.Partial) {
                     resolvePartialTypeMembers(<PartialType>type);
@@ -5753,6 +5755,7 @@ namespace ts {
             return links.resolvedType;
         }
 
+<<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
 <<<<<<< 7b34b612beda66b0812462a3feeabc63852cd842
         function getIndexTypeForTypeParameter(type: TypeParameter) {
             if (!type.resolvedIndexType) {
@@ -5899,6 +5902,14 @@ namespace ts {
             const links = getNodeLinks(node);
             if (!links.resolvedType) {
                 links.resolvedType = getIndexedAccessType(getTypeFromTypeNodeNoAlias(node.objectType), getTypeFromTypeNodeNoAlias(node.indexType), node);
+            }
+            return links.resolvedType;
+        }
+
+        function getTypeFromPartialTypeNode(node: PartialTypeNode): Type {
+            const links = getNodeLinks(node);
+            if (!links.resolvedType) {
+                links.resolvedType = getPartialType(getTypeOfNode(node.type));
             }
             return links.resolvedType;
         }

--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -428,6 +428,8 @@ namespace ts {
                     return emitEntityName(<QualifiedName>type);
                 case SyntaxKind.TypePredicate:
                     return emitTypePredicate(<TypePredicateNode>type);
+                case SyntaxKind.PartialType:
+                    return emitPartialType(<PartialTypeNode>type);
             }
 
             function writeEntityName(entityName: EntityName | Expression) {
@@ -477,6 +479,11 @@ namespace ts {
             function emitTypePredicate(type: TypePredicateNode) {
                 writeTextOfNode(currentText, type.parameterName);
                 write(" is ");
+                emitType(type.type);
+            }
+
+            function emitPartialType(type: PartialTypeNode) {
+                write("partial ");
                 emitType(type.type);
             }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -133,6 +133,8 @@ namespace ts {
             case SyntaxKind.UnionType:
             case SyntaxKind.IntersectionType:
                 return visitNodes(cbNodes, (<UnionOrIntersectionTypeNode>node).types);
+            case SyntaxKind.PartialType:
+                return visitNode(cbNode, (<PartialTypeNode>node).type);
             case SyntaxKind.ParenthesizedType:
             case SyntaxKind.TypeOperator:
                 return visitNode(cbNode, (<ParenthesizedTypeNode | TypeOperatorNode>node).type);
@@ -426,9 +428,10 @@ namespace ts {
             case SyntaxKind.PartiallyEmittedExpression:
                 return visitNode(cbNode, (<PartiallyEmittedExpression>node).expression);
             case SyntaxKind.JSDocLiteralType:
-                    return visitNode(cbNode, (<JSDocLiteralType>node).literal);
+                return visitNode(cbNode, (<JSDocLiteralType>node).literal);
         }
     }
+
 
     export function createSourceFile(fileName: string, sourceText: string, languageVersion: ScriptTarget, setParentNodes = false, scriptKind?: ScriptKind): SourceFile {
         performance.mark("beforeParse");
@@ -2042,6 +2045,13 @@ namespace ts {
             return finishNode(node);
         }
 
+        function parsePartialType(): PartialTypeNode {
+            const node = <PartialTypeNode>createNode(SyntaxKind.PartialType);
+            parseExpected(SyntaxKind.PartialKeyword);
+            node.type = parseType();
+            return finishNode(node);
+        }
+
         function parseTypeParameter(): TypeParameterDeclaration {
             const node = <TypeParameterDeclaration>createNode(SyntaxKind.TypeParameter);
             node.name = parseIdentifier();
@@ -2477,6 +2487,9 @@ namespace ts {
                     return parseTupleType();
                 case SyntaxKind.OpenParenToken:
                     return parseParenthesizedType();
+                case SyntaxKind.PartialKeyword:
+                    const partialNode = tryParse(parsePartialType);
+                    return partialNode || parseTypeReference();
                 default:
                     return parseTypeReference();
             }

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -99,6 +99,7 @@ namespace ts {
         "null": SyntaxKind.NullKeyword,
         "number": SyntaxKind.NumberKeyword,
         "package": SyntaxKind.PackageKeyword,
+        "partial": SyntaxKind.PartialKeyword,
         "private": SyntaxKind.PrivateKeyword,
         "protected": SyntaxKind.ProtectedKeyword,
         "public": SyntaxKind.PublicKeyword,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -887,6 +887,7 @@ namespace ts {
         type: TypeNode;
     }
 
+<<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
     export interface TypeOperatorNode extends TypeNode {
         kind: SyntaxKind.TypeOperator;
         operator: SyntaxKind.KeyOfKeyword;
@@ -899,6 +900,14 @@ namespace ts {
         indexType: TypeNode;
     }
 
+=======
+    // @kind(SyntaxKind.PartialType)
+    export interface PartialTypeNode extends TypeNode {
+        type: TypeNode;
+    }
+
+    // @kind(SyntaxKind.StringLiteralType)
+>>>>>>> Partial Types (#11233)
     export interface LiteralTypeNode extends TypeNode {
         kind: SyntaxKind.LiteralType;
         literal: Expression;
@@ -2692,8 +2701,8 @@ namespace ts {
         /* @internal */
         ContainsObjectLiteral   = 1 << 22,  // Type is or contains object literal type
         /* @internal */
-        ContainsAnyFunctionType = 1 << 23,  // Type is or contains object literal type
-        Partial                 = 1 << 24,  // Partial type
+        ContainsAnyFunctionType = 1 << 21,  // Type is or contains object literal type
+        Partial                 = 1 << 22,  // Partial type
 
         /* @internal */
         Nullable = Undefined | Null,

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -58,7 +58,6 @@ namespace ts.SymbolDisplay {
                     if (rootSymbolFlags & (SymbolFlags.PropertyOrAccessor | SymbolFlags.Variable)) {
                         return ScriptElementKind.memberVariableElement;
                     }
-                    Debug.assert(!!(rootSymbolFlags & SymbolFlags.Method));
                 });
                 if (!unionPropertyKind) {
                     // If this was union of all methods,

--- a/tests/baselines/reference/partialType1.errors.txt
+++ b/tests/baselines/reference/partialType1.errors.txt
@@ -1,0 +1,66 @@
+tests/cases/compiler/partialType1.ts(13,10): error TS2345: Argument of type '{ flarp: number; }' is not assignable to parameter of type 'partial State'.
+  Object literal may only specify known properties, and 'flarp' does not exist in type 'partial State'.
+tests/cases/compiler/partialType1.ts(14,8): error TS2345: Argument of type '{ name: number; }' is not assignable to parameter of type 'partial State'.
+  Types of property 'name' are incompatible.
+    Type 'number' is not assignable to type 'string'.
+tests/cases/compiler/partialType1.ts(16,8): error TS2345: Argument of type '{ foo: string; }' is not assignable to parameter of type 'partial State'.
+  Types of property 'foo' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/partialType1.ts(21,19): error TS2345: Argument of type '{ flarp: number; }' is not assignable to parameter of type 'partial State'.
+  Object literal may only specify known properties, and 'flarp' does not exist in type 'partial State'.
+tests/cases/compiler/partialType1.ts(22,17): error TS2345: Argument of type '{ name: number; }' is not assignable to parameter of type 'partial State'.
+  Types of property 'name' are incompatible.
+    Type 'number' is not assignable to type 'string'.
+tests/cases/compiler/partialType1.ts(24,17): error TS2345: Argument of type '{ foo: string; }' is not assignable to parameter of type 'partial State'.
+  Types of property 'foo' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+
+
+==== tests/cases/compiler/partialType1.ts (6 errors) ====
+    interface State {
+        name: string;
+        length: number;
+        foo?: number;
+    }
+    
+    function setState<T>(state: T, updates: partial T) {} 
+    
+    function update(s: partial State) { }
+    
+    update({ name: "bob" });
+    update({ length: 10 });
+    update({ flarp: 5 });
+             ~~~~~~~~
+!!! error TS2345: Argument of type '{ flarp: number; }' is not assignable to parameter of type 'partial State'.
+!!! error TS2345:   Object literal may only specify known properties, and 'flarp' does not exist in type 'partial State'.
+    update({ name: 100 });
+           ~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ name: number; }' is not assignable to parameter of type 'partial State'.
+!!! error TS2345:   Types of property 'name' are incompatible.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+    update({ foo: 34 });
+    update({ foo: 'oops' });
+           ~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ foo: string; }' is not assignable to parameter of type 'partial State'.
+!!! error TS2345:   Types of property 'foo' are incompatible.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+    
+    const state: State = <any>null;
+    setState(state, { name: "bob" });
+    setState(state, { length: 10 });
+    setState(state, { flarp: 5 });
+                      ~~~~~~~~
+!!! error TS2345: Argument of type '{ flarp: number; }' is not assignable to parameter of type 'partial State'.
+!!! error TS2345:   Object literal may only specify known properties, and 'flarp' does not exist in type 'partial State'.
+    setState(state, { name: 100 });
+                    ~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ name: number; }' is not assignable to parameter of type 'partial State'.
+!!! error TS2345:   Types of property 'name' are incompatible.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+    setState(state, { foo: 34 });
+    setState(state, { foo: 'oops' });
+                    ~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ foo: string; }' is not assignable to parameter of type 'partial State'.
+!!! error TS2345:   Types of property 'foo' are incompatible.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+    

--- a/tests/baselines/reference/partialType1.js
+++ b/tests/baselines/reference/partialType1.js
@@ -1,0 +1,43 @@
+//// [partialType1.ts]
+interface State {
+    name: string;
+    length: number;
+    foo?: number;
+}
+
+function setState<T>(state: T, updates: partial T) {} 
+
+function update(s: partial State) { }
+
+update({ name: "bob" });
+update({ length: 10 });
+update({ flarp: 5 });
+update({ name: 100 });
+update({ foo: 34 });
+update({ foo: 'oops' });
+
+const state: State = <any>null;
+setState(state, { name: "bob" });
+setState(state, { length: 10 });
+setState(state, { flarp: 5 });
+setState(state, { name: 100 });
+setState(state, { foo: 34 });
+setState(state, { foo: 'oops' });
+
+
+//// [partialType1.js]
+function setState(state, updates: ) { }
+function update(s: ) { }
+update({ name: "bob" });
+update({ length: 10 });
+update({ flarp: 5 });
+update({ name: 100 });
+update({ foo: 34 });
+update({ foo: 'oops' });
+var state = null;
+setState(state, { name: "bob" });
+setState(state, { length: 10 });
+setState(state, { flarp: 5 });
+setState(state, { name: 100 });
+setState(state, { foo: 34 });
+setState(state, { foo: 'oops' });

--- a/tests/baselines/reference/partialType2.errors.txt
+++ b/tests/baselines/reference/partialType2.errors.txt
@@ -1,0 +1,44 @@
+tests/cases/compiler/partialType2.ts(8,12): error TS2304: Cannot find name 'subset'.
+tests/cases/compiler/partialType2.ts(8,19): error TS1005: '=' expected.
+tests/cases/compiler/partialType2.ts(8,19): error TS2693: 'T' only refers to a type, but is being used as a value here.
+tests/cases/compiler/partialType2.ts(16,5): error TS2322: Type '{ name: string; length: number; foo: number; }' is not assignable to type 'partial T'.
+tests/cases/compiler/partialType2.ts(18,11): error TS2339: Property 'name' does not exist on type 'partial T'.
+
+
+==== tests/cases/compiler/partialType2.ts (5 errors) ====
+    interface State {
+        name: string;
+        length: number;
+        foo?: number;
+    }
+    
+    function doSomething1<T>(x: T) {
+        let y: subset T = <any>null;
+               ~~~~~~
+!!! error TS2304: Cannot find name 'subset'.
+                      ~
+!!! error TS1005: '=' expected.
+                      ~
+!!! error TS2693: 'T' only refers to a type, but is being used as a value here.
+        y = x; // Should be OK
+        x = y; // Error
+    }
+    
+    function doSomething2<T extends State>(x: T) {
+        let y: partial T = <any>null;
+        // Should error
+        y = { name: '', length: 10, foo: 3};
+        ~
+!!! error TS2322: Type '{ name: string; length: number; foo: number; }' is not assignable to type 'partial T'.
+        y = x; // OK
+        if (y.name) {
+              ~~~~
+!!! error TS2339: Property 'name' does not exist on type 'partial T'.
+    
+        }
+    }
+     let ss: partial State;
+     if (ss.foo) {
+              
+     }
+    

--- a/tests/baselines/reference/partialType2.errors.txt
+++ b/tests/baselines/reference/partialType2.errors.txt
@@ -1,3 +1,4 @@
+<<<<<<< 57a95d24ca1cca41e009f5eb0285db73cd3b2bff
 <<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
 tests/cases/compiler/partialType2.ts(10,5): error TS2322: Type 'partial T' is not assignable to type 'T'.
 =======
@@ -5,15 +6,22 @@ tests/cases/compiler/partialType2.ts(8,12): error TS2304: Cannot find name 'subs
 tests/cases/compiler/partialType2.ts(8,19): error TS1005: '=' expected.
 tests/cases/compiler/partialType2.ts(8,19): error TS2693: 'T' only refers to a type, but is being used as a value here.
 >>>>>>> Partial Types (#11233)
+=======
+tests/cases/compiler/partialType2.ts(10,5): error TS2322: Type 'partial T' is not assignable to type 'T'.
+>>>>>>> Update test
 tests/cases/compiler/partialType2.ts(16,5): error TS2322: Type '{ name: string; length: number; foo: number; }' is not assignable to type 'partial T'.
 tests/cases/compiler/partialType2.ts(18,11): error TS2339: Property 'name' does not exist on type 'partial T'.
 
 
+<<<<<<< 57a95d24ca1cca41e009f5eb0285db73cd3b2bff
 <<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
 ==== tests/cases/compiler/partialType2.ts (3 errors) ====
 =======
 ==== tests/cases/compiler/partialType2.ts (5 errors) ====
 >>>>>>> Partial Types (#11233)
+=======
+==== tests/cases/compiler/partialType2.ts (3 errors) ====
+>>>>>>> Update test
     interface State {
         name: string;
         length: number;
@@ -21,6 +29,7 @@ tests/cases/compiler/partialType2.ts(18,11): error TS2339: Property 'name' does 
     }
     
     function doSomething1<T>(x: T) {
+<<<<<<< 57a95d24ca1cca41e009f5eb0285db73cd3b2bff
 <<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
         let y: partial T = <any>null;
         y = x; // Should be OK
@@ -38,6 +47,13 @@ tests/cases/compiler/partialType2.ts(18,11): error TS2339: Property 'name' does 
         y = x; // Should be OK
         x = y; // Error
 >>>>>>> Partial Types (#11233)
+=======
+        let y: partial T = <any>null;
+        y = x; // Should be OK
+        x = y; // Error
+        ~
+!!! error TS2322: Type 'partial T' is not assignable to type 'T'.
+>>>>>>> Update test
     }
     
     function doSomething2<T extends State>(x: T) {

--- a/tests/baselines/reference/partialType2.errors.txt
+++ b/tests/baselines/reference/partialType2.errors.txt
@@ -1,11 +1,9 @@
-tests/cases/compiler/partialType2.ts(8,12): error TS2304: Cannot find name 'subset'.
-tests/cases/compiler/partialType2.ts(8,19): error TS1005: '=' expected.
-tests/cases/compiler/partialType2.ts(8,19): error TS2693: 'T' only refers to a type, but is being used as a value here.
+tests/cases/compiler/partialType2.ts(10,5): error TS2322: Type 'partial T' is not assignable to type 'T'.
 tests/cases/compiler/partialType2.ts(16,5): error TS2322: Type '{ name: string; length: number; foo: number; }' is not assignable to type 'partial T'.
 tests/cases/compiler/partialType2.ts(18,11): error TS2339: Property 'name' does not exist on type 'partial T'.
 
 
-==== tests/cases/compiler/partialType2.ts (5 errors) ====
+==== tests/cases/compiler/partialType2.ts (3 errors) ====
     interface State {
         name: string;
         length: number;
@@ -13,15 +11,11 @@ tests/cases/compiler/partialType2.ts(18,11): error TS2339: Property 'name' does 
     }
     
     function doSomething1<T>(x: T) {
-        let y: subset T = <any>null;
-               ~~~~~~
-!!! error TS2304: Cannot find name 'subset'.
-                      ~
-!!! error TS1005: '=' expected.
-                      ~
-!!! error TS2693: 'T' only refers to a type, but is being used as a value here.
+        let y: partial T = <any>null;
         y = x; // Should be OK
         x = y; // Error
+        ~
+!!! error TS2322: Type 'partial T' is not assignable to type 'T'.
     }
     
     function doSomething2<T extends State>(x: T) {

--- a/tests/baselines/reference/partialType2.errors.txt
+++ b/tests/baselines/reference/partialType2.errors.txt
@@ -1,9 +1,19 @@
+<<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
 tests/cases/compiler/partialType2.ts(10,5): error TS2322: Type 'partial T' is not assignable to type 'T'.
+=======
+tests/cases/compiler/partialType2.ts(8,12): error TS2304: Cannot find name 'subset'.
+tests/cases/compiler/partialType2.ts(8,19): error TS1005: '=' expected.
+tests/cases/compiler/partialType2.ts(8,19): error TS2693: 'T' only refers to a type, but is being used as a value here.
+>>>>>>> Partial Types (#11233)
 tests/cases/compiler/partialType2.ts(16,5): error TS2322: Type '{ name: string; length: number; foo: number; }' is not assignable to type 'partial T'.
 tests/cases/compiler/partialType2.ts(18,11): error TS2339: Property 'name' does not exist on type 'partial T'.
 
 
+<<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
 ==== tests/cases/compiler/partialType2.ts (3 errors) ====
+=======
+==== tests/cases/compiler/partialType2.ts (5 errors) ====
+>>>>>>> Partial Types (#11233)
     interface State {
         name: string;
         length: number;
@@ -11,11 +21,23 @@ tests/cases/compiler/partialType2.ts(18,11): error TS2339: Property 'name' does 
     }
     
     function doSomething1<T>(x: T) {
+<<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
         let y: partial T = <any>null;
         y = x; // Should be OK
         x = y; // Error
         ~
 !!! error TS2322: Type 'partial T' is not assignable to type 'T'.
+=======
+        let y: subset T = <any>null;
+               ~~~~~~
+!!! error TS2304: Cannot find name 'subset'.
+                      ~
+!!! error TS1005: '=' expected.
+                      ~
+!!! error TS2693: 'T' only refers to a type, but is being used as a value here.
+        y = x; // Should be OK
+        x = y; // Error
+>>>>>>> Partial Types (#11233)
     }
     
     function doSomething2<T extends State>(x: T) {

--- a/tests/baselines/reference/partialType2.js
+++ b/tests/baselines/reference/partialType2.js
@@ -6,7 +6,7 @@ interface State {
 }
 
 function doSomething1<T>(x: T) {
-    let y: subset T = <any>null;
+    let y: partial T = <any>null;
     y = x; // Should be OK
     x = y; // Error
 }
@@ -28,7 +28,7 @@ function doSomething2<T extends State>(x: T) {
 
 //// [partialType2.js]
 function doSomething1(x) {
-    var y = T = null;
+    var y = null;
     y = x; // Should be OK
     x = y; // Error
 }

--- a/tests/baselines/reference/partialType2.js
+++ b/tests/baselines/reference/partialType2.js
@@ -6,7 +6,11 @@ interface State {
 }
 
 function doSomething1<T>(x: T) {
+<<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
     let y: partial T = <any>null;
+=======
+    let y: subset T = <any>null;
+>>>>>>> Partial Types (#11233)
     y = x; // Should be OK
     x = y; // Error
 }
@@ -28,7 +32,11 @@ function doSomething2<T extends State>(x: T) {
 
 //// [partialType2.js]
 function doSomething1(x) {
+<<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
     var y = null;
+=======
+    var y = T = null;
+>>>>>>> Partial Types (#11233)
     y = x; // Should be OK
     x = y; // Error
 }

--- a/tests/baselines/reference/partialType2.js
+++ b/tests/baselines/reference/partialType2.js
@@ -1,0 +1,45 @@
+//// [partialType2.ts]
+interface State {
+    name: string;
+    length: number;
+    foo?: number;
+}
+
+function doSomething1<T>(x: T) {
+    let y: subset T = <any>null;
+    y = x; // Should be OK
+    x = y; // Error
+}
+
+function doSomething2<T extends State>(x: T) {
+    let y: partial T = <any>null;
+    // Should error
+    y = { name: '', length: 10, foo: 3};
+    y = x; // OK
+    if (y.name) {
+
+    }
+}
+ let ss: partial State;
+ if (ss.foo) {
+          
+ }
+
+
+//// [partialType2.js]
+function doSomething1(x) {
+    var y = T = null;
+    y = x; // Should be OK
+    x = y; // Error
+}
+function doSomething2(x) {
+    var y = null;
+    // Should error
+    y = { name: '', length: 10, foo: 3 };
+    y = x; // OK
+    if (y.name) {
+    }
+}
+var ss;
+if (ss.foo) {
+}

--- a/tests/baselines/reference/partialType2.js
+++ b/tests/baselines/reference/partialType2.js
@@ -6,11 +6,15 @@ interface State {
 }
 
 function doSomething1<T>(x: T) {
+<<<<<<< 57a95d24ca1cca41e009f5eb0285db73cd3b2bff
 <<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
     let y: partial T = <any>null;
 =======
     let y: subset T = <any>null;
 >>>>>>> Partial Types (#11233)
+=======
+    let y: partial T = <any>null;
+>>>>>>> Update test
     y = x; // Should be OK
     x = y; // Error
 }
@@ -32,11 +36,15 @@ function doSomething2<T extends State>(x: T) {
 
 //// [partialType2.js]
 function doSomething1(x) {
+<<<<<<< 57a95d24ca1cca41e009f5eb0285db73cd3b2bff
 <<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
     var y = null;
 =======
     var y = T = null;
 >>>>>>> Partial Types (#11233)
+=======
+    var y = null;
+>>>>>>> Update test
     y = x; // Should be OK
     x = y; // Error
 }

--- a/tests/baselines/reference/partialType3.errors.txt
+++ b/tests/baselines/reference/partialType3.errors.txt
@@ -1,0 +1,22 @@
+tests/cases/compiler/partialType3.ts(11,1): error TS2322: Type 'false' is not assignable to type 'string | number'.
+tests/cases/compiler/partialType3.ts(12,1): error TS2322: Type 'false' is not assignable to type 'string | number'.
+
+
+==== tests/cases/compiler/partialType3.ts (2 errors) ====
+    interface State1 {
+        name: string;
+        length: number;
+        [key: string]: string | number;
+    }
+    
+    const subs: partial State1 = {};
+    subs['foo'] = 32;
+    subs['bar'] = 'ok';
+    // Errors
+    subs['err'] = false;
+    ~~~~~~~~~~~
+!!! error TS2322: Type 'false' is not assignable to type 'string | number'.
+    subs[12] = false;
+    ~~~~~~~~
+!!! error TS2322: Type 'false' is not assignable to type 'string | number'.
+    

--- a/tests/baselines/reference/partialType3.js
+++ b/tests/baselines/reference/partialType3.js
@@ -1,0 +1,22 @@
+//// [partialType3.ts]
+interface State1 {
+    name: string;
+    length: number;
+    [key: string]: string | number;
+}
+
+const subs: partial State1 = {};
+subs['foo'] = 32;
+subs['bar'] = 'ok';
+// Errors
+subs['err'] = false;
+subs[12] = false;
+
+
+//// [partialType3.js]
+var subs = {};
+subs['foo'] = 32;
+subs['bar'] = 'ok';
+// Errors
+subs['err'] = false;
+subs[12] = false;

--- a/tests/baselines/reference/partialType4.errors.txt
+++ b/tests/baselines/reference/partialType4.errors.txt
@@ -1,0 +1,29 @@
+tests/cases/compiler/partialType4.ts(13,1): error TS2322: Type 'false' is not assignable to type 'string | undefined'.
+tests/cases/compiler/partialType4.ts(15,1): error TS2322: Type 'false' is not assignable to type 'string | number | undefined'.
+tests/cases/compiler/partialType4.ts(16,1): error TS2322: Type 'false' is not assignable to type 'string | number | undefined'.
+
+
+==== tests/cases/compiler/partialType4.ts (3 errors) ====
+    
+    interface State1 {
+        name: string;
+        length: number;
+        [key: string]: string | number;
+    }
+    
+    const subs: partial State1 = {};
+    subs['foo'] = 32;
+    subs['bar'] = 'ok';
+    subs['ok'] = undefined;
+    subs.name = undefined; // ok
+    subs.name = false; // not ok
+    ~~~~~~~~~
+!!! error TS2322: Type 'false' is not assignable to type 'string | undefined'.
+    // Errors
+    subs['err'] = false;
+    ~~~~~~~~~~~
+!!! error TS2322: Type 'false' is not assignable to type 'string | number | undefined'.
+    subs[12] = false;
+    ~~~~~~~~
+!!! error TS2322: Type 'false' is not assignable to type 'string | number | undefined'.
+    

--- a/tests/baselines/reference/partialType4.js
+++ b/tests/baselines/reference/partialType4.js
@@ -1,0 +1,29 @@
+//// [partialType4.ts]
+
+interface State1 {
+    name: string;
+    length: number;
+    [key: string]: string | number;
+}
+
+const subs: partial State1 = {};
+subs['foo'] = 32;
+subs['bar'] = 'ok';
+subs['ok'] = undefined;
+subs.name = undefined; // ok
+subs.name = false; // not ok
+// Errors
+subs['err'] = false;
+subs[12] = false;
+
+
+//// [partialType4.js]
+var subs = {};
+subs['foo'] = 32;
+subs['bar'] = 'ok';
+subs['ok'] = undefined;
+subs.name = undefined; // ok
+subs.name = false; // not ok
+// Errors
+subs['err'] = false;
+subs[12] = false;

--- a/tests/baselines/reference/partialType4.js
+++ b/tests/baselines/reference/partialType4.js
@@ -27,6 +27,7 @@ subs.name = false; // not ok
 // Errors
 subs['err'] = false;
 subs[12] = false;
+<<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
 
 
 //// [partialType4.d.ts]
@@ -36,3 +37,5 @@ interface State1 {
     [key: string]: string | number;
 }
 declare const subs: partial State1;
+=======
+>>>>>>> Partial Types (#11233)

--- a/tests/baselines/reference/partialType4.js
+++ b/tests/baselines/reference/partialType4.js
@@ -27,3 +27,12 @@ subs.name = false; // not ok
 // Errors
 subs['err'] = false;
 subs[12] = false;
+
+
+//// [partialType4.d.ts]
+interface State1 {
+    name: string;
+    length: number;
+    [key: string]: string | number;
+}
+declare const subs: partial State1;

--- a/tests/baselines/reference/partialType4.js
+++ b/tests/baselines/reference/partialType4.js
@@ -27,7 +27,10 @@ subs.name = false; // not ok
 // Errors
 subs['err'] = false;
 subs[12] = false;
+<<<<<<< 5a0ba57342ea1e785cf69aa91a93fa378c2c53ab
 <<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
+=======
+>>>>>>> Forgot baseline
 
 
 //// [partialType4.d.ts]
@@ -37,5 +40,8 @@ interface State1 {
     [key: string]: string | number;
 }
 declare const subs: partial State1;
+<<<<<<< 5a0ba57342ea1e785cf69aa91a93fa378c2c53ab
 =======
 >>>>>>> Partial Types (#11233)
+=======
+>>>>>>> Forgot baseline

--- a/tests/baselines/reference/subsetType1.errors.txt
+++ b/tests/baselines/reference/subsetType1.errors.txt
@@ -1,0 +1,66 @@
+tests/cases/compiler/subsetType1.ts(13,10): error TS2345: Argument of type '{ flarp: number; }' is not assignable to parameter of type 'partial State'.
+  Object literal may only specify known properties, and 'flarp' does not exist in type 'partial State'.
+tests/cases/compiler/subsetType1.ts(14,8): error TS2345: Argument of type '{ name: number; }' is not assignable to parameter of type 'partial State'.
+  Types of property 'name' are incompatible.
+    Type 'number' is not assignable to type 'string'.
+tests/cases/compiler/subsetType1.ts(16,8): error TS2345: Argument of type '{ foo: string; }' is not assignable to parameter of type 'partial State'.
+  Types of property 'foo' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+tests/cases/compiler/subsetType1.ts(21,19): error TS2345: Argument of type '{ flarp: number; }' is not assignable to parameter of type 'partial State'.
+  Object literal may only specify known properties, and 'flarp' does not exist in type 'partial State'.
+tests/cases/compiler/subsetType1.ts(22,17): error TS2345: Argument of type '{ name: number; }' is not assignable to parameter of type 'partial State'.
+  Types of property 'name' are incompatible.
+    Type 'number' is not assignable to type 'string'.
+tests/cases/compiler/subsetType1.ts(24,17): error TS2345: Argument of type '{ foo: string; }' is not assignable to parameter of type 'partial State'.
+  Types of property 'foo' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+
+
+==== tests/cases/compiler/subsetType1.ts (6 errors) ====
+    interface State {
+        name: string;
+        length: number;
+        foo?: number;
+    }
+    
+    function setState<T>(state: T, updates: partial T) {} 
+    
+    function update(s: partial State) { }
+    
+    update({ name: "bob" });
+    update({ length: 10 });
+    update({ flarp: 5 });
+             ~~~~~~~~
+!!! error TS2345: Argument of type '{ flarp: number; }' is not assignable to parameter of type 'partial State'.
+!!! error TS2345:   Object literal may only specify known properties, and 'flarp' does not exist in type 'partial State'.
+    update({ name: 100 });
+           ~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ name: number; }' is not assignable to parameter of type 'partial State'.
+!!! error TS2345:   Types of property 'name' are incompatible.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+    update({ foo: 34 });
+    update({ foo: 'oops' });
+           ~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ foo: string; }' is not assignable to parameter of type 'partial State'.
+!!! error TS2345:   Types of property 'foo' are incompatible.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+    
+    const state: State = <any>null;
+    setState(state, { name: "bob" });
+    setState(state, { length: 10 });
+    setState(state, { flarp: 5 });
+                      ~~~~~~~~
+!!! error TS2345: Argument of type '{ flarp: number; }' is not assignable to parameter of type 'partial State'.
+!!! error TS2345:   Object literal may only specify known properties, and 'flarp' does not exist in type 'partial State'.
+    setState(state, { name: 100 });
+                    ~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ name: number; }' is not assignable to parameter of type 'partial State'.
+!!! error TS2345:   Types of property 'name' are incompatible.
+!!! error TS2345:     Type 'number' is not assignable to type 'string'.
+    setState(state, { foo: 34 });
+    setState(state, { foo: 'oops' });
+                    ~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ foo: string; }' is not assignable to parameter of type 'partial State'.
+!!! error TS2345:   Types of property 'foo' are incompatible.
+!!! error TS2345:     Type 'string' is not assignable to type 'number'.
+    

--- a/tests/baselines/reference/subsetType1.js
+++ b/tests/baselines/reference/subsetType1.js
@@ -1,0 +1,43 @@
+//// [subsetType1.ts]
+interface State {
+    name: string;
+    length: number;
+    foo?: number;
+}
+
+function setState<T>(state: T, updates: partial T) {} 
+
+function update(s: partial State) { }
+
+update({ name: "bob" });
+update({ length: 10 });
+update({ flarp: 5 });
+update({ name: 100 });
+update({ foo: 34 });
+update({ foo: 'oops' });
+
+const state: State = <any>null;
+setState(state, { name: "bob" });
+setState(state, { length: 10 });
+setState(state, { flarp: 5 });
+setState(state, { name: 100 });
+setState(state, { foo: 34 });
+setState(state, { foo: 'oops' });
+
+
+//// [subsetType1.js]
+function setState(state, updates: ) { }
+function update(s: ) { }
+update({ name: "bob" });
+update({ length: 10 });
+update({ flarp: 5 });
+update({ name: 100 });
+update({ foo: 34 });
+update({ foo: 'oops' });
+var state = null;
+setState(state, { name: "bob" });
+setState(state, { length: 10 });
+setState(state, { flarp: 5 });
+setState(state, { name: 100 });
+setState(state, { foo: 34 });
+setState(state, { foo: 'oops' });

--- a/tests/baselines/reference/subsetType2.errors.txt
+++ b/tests/baselines/reference/subsetType2.errors.txt
@@ -1,0 +1,44 @@
+tests/cases/compiler/subsetType2.ts(8,12): error TS2304: Cannot find name 'subset'.
+tests/cases/compiler/subsetType2.ts(8,19): error TS1005: '=' expected.
+tests/cases/compiler/subsetType2.ts(8,19): error TS2693: 'T' only refers to a type, but is being used as a value here.
+tests/cases/compiler/subsetType2.ts(16,5): error TS2322: Type '{ name: string; length: number; foo: number; }' is not assignable to type 'partial T'.
+tests/cases/compiler/subsetType2.ts(18,11): error TS2339: Property 'name' does not exist on type 'partial T'.
+
+
+==== tests/cases/compiler/subsetType2.ts (5 errors) ====
+    interface State {
+        name: string;
+        length: number;
+        foo?: number;
+    }
+    
+    function doSomething1<T>(x: T) {
+        let y: subset T = <any>null;
+               ~~~~~~
+!!! error TS2304: Cannot find name 'subset'.
+                      ~
+!!! error TS1005: '=' expected.
+                      ~
+!!! error TS2693: 'T' only refers to a type, but is being used as a value here.
+        y = x; // Should be OK
+        x = y; // Error
+    }
+    
+    function doSomething2<T extends State>(x: T) {
+        let y: partial T = <any>null;
+        // Should error
+        y = { name: '', length: 10, foo: 3};
+        ~
+!!! error TS2322: Type '{ name: string; length: number; foo: number; }' is not assignable to type 'partial T'.
+        y = x; // OK
+        if (y.name) {
+              ~~~~
+!!! error TS2339: Property 'name' does not exist on type 'partial T'.
+    
+        }
+    }
+     let ss: partial State;
+     if (ss.foo) {
+              
+     }
+    

--- a/tests/baselines/reference/subsetType2.js
+++ b/tests/baselines/reference/subsetType2.js
@@ -1,0 +1,45 @@
+//// [subsetType2.ts]
+interface State {
+    name: string;
+    length: number;
+    foo?: number;
+}
+
+function doSomething1<T>(x: T) {
+    let y: subset T = <any>null;
+    y = x; // Should be OK
+    x = y; // Error
+}
+
+function doSomething2<T extends State>(x: T) {
+    let y: partial T = <any>null;
+    // Should error
+    y = { name: '', length: 10, foo: 3};
+    y = x; // OK
+    if (y.name) {
+
+    }
+}
+ let ss: partial State;
+ if (ss.foo) {
+          
+ }
+
+
+//// [subsetType2.js]
+function doSomething1(x) {
+    var y = T = null;
+    y = x; // Should be OK
+    x = y; // Error
+}
+function doSomething2(x) {
+    var y = null;
+    // Should error
+    y = { name: '', length: 10, foo: 3 };
+    y = x; // OK
+    if (y.name) {
+    }
+}
+var ss;
+if (ss.foo) {
+}

--- a/tests/baselines/reference/subsetType3.errors.txt
+++ b/tests/baselines/reference/subsetType3.errors.txt
@@ -1,0 +1,25 @@
+tests/cases/compiler/subsetType3.ts(11,1): error TS2322: Type 'false' is not assignable to type 'string | number'.
+tests/cases/compiler/subsetType3.ts(12,1): error TS2322: Type 'false' is not assignable to type 'string | number'.
+
+
+==== tests/cases/compiler/subsetType3.ts (2 errors) ====
+    interface State {
+        name: string;
+        length: number;
+        [key: string]: string | number;
+    }
+    
+    const subs: partial State = {};
+    subs['foo'] = 32;
+    subs['bar'] = 'ok';
+    // Errors
+    subs['err'] = false;
+    ~~~~~~~~~~~
+!!! error TS2322: Type 'false' is not assignable to type 'string | number'.
+    subs[12] = false;
+    ~~~~~~~~
+!!! error TS2322: Type 'false' is not assignable to type 'string | number'.
+    
+    
+    
+    

--- a/tests/baselines/reference/subsetType3.js
+++ b/tests/baselines/reference/subsetType3.js
@@ -1,0 +1,25 @@
+//// [subsetType3.ts]
+interface State {
+    name: string;
+    length: number;
+    [key: string]: string | number;
+}
+
+const subs: partial State = {};
+subs['foo'] = 32;
+subs['bar'] = 'ok';
+// Errors
+subs['err'] = false;
+subs[12] = false;
+
+
+
+
+
+//// [subsetType3.js]
+var subs = {};
+subs['foo'] = 32;
+subs['bar'] = 'ok';
+// Errors
+subs['err'] = false;
+subs[12] = false;

--- a/tests/cases/compiler/partialType1.ts
+++ b/tests/cases/compiler/partialType1.ts
@@ -1,0 +1,24 @@
+interface State {
+    name: string;
+    length: number;
+    foo?: number;
+}
+
+function setState<T>(state: T, updates: partial T) {} 
+
+function update(s: partial State) { }
+
+update({ name: "bob" });
+update({ length: 10 });
+update({ flarp: 5 });
+update({ name: 100 });
+update({ foo: 34 });
+update({ foo: 'oops' });
+
+const state: State = <any>null;
+setState(state, { name: "bob" });
+setState(state, { length: 10 });
+setState(state, { flarp: 5 });
+setState(state, { name: 100 });
+setState(state, { foo: 34 });
+setState(state, { foo: 'oops' });

--- a/tests/cases/compiler/partialType2.ts
+++ b/tests/cases/compiler/partialType2.ts
@@ -1,0 +1,25 @@
+interface State {
+    name: string;
+    length: number;
+    foo?: number;
+}
+
+function doSomething1<T>(x: T) {
+    let y: subset T = <any>null;
+    y = x; // Should be OK
+    x = y; // Error
+}
+
+function doSomething2<T extends State>(x: T) {
+    let y: partial T = <any>null;
+    // Should error
+    y = { name: '', length: 10, foo: 3};
+    y = x; // OK
+    if (y.name) {
+
+    }
+}
+ let ss: partial State;
+ if (ss.foo) {
+          
+ }

--- a/tests/cases/compiler/partialType2.ts
+++ b/tests/cases/compiler/partialType2.ts
@@ -5,7 +5,7 @@ interface State {
 }
 
 function doSomething1<T>(x: T) {
-    let y: subset T = <any>null;
+    let y: partial T = <any>null;
     y = x; // Should be OK
     x = y; // Error
 }

--- a/tests/cases/compiler/partialType2.ts
+++ b/tests/cases/compiler/partialType2.ts
@@ -5,11 +5,15 @@ interface State {
 }
 
 function doSomething1<T>(x: T) {
+<<<<<<< 57a95d24ca1cca41e009f5eb0285db73cd3b2bff
 <<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
     let y: partial T = <any>null;
 =======
     let y: subset T = <any>null;
 >>>>>>> Partial Types (#11233)
+=======
+    let y: partial T = <any>null;
+>>>>>>> Update test
     y = x; // Should be OK
     x = y; // Error
 }

--- a/tests/cases/compiler/partialType2.ts
+++ b/tests/cases/compiler/partialType2.ts
@@ -5,7 +5,11 @@ interface State {
 }
 
 function doSomething1<T>(x: T) {
+<<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
     let y: partial T = <any>null;
+=======
+    let y: subset T = <any>null;
+>>>>>>> Partial Types (#11233)
     y = x; // Should be OK
     x = y; // Error
 }

--- a/tests/cases/compiler/partialType3.ts
+++ b/tests/cases/compiler/partialType3.ts
@@ -1,0 +1,12 @@
+interface State1 {
+    name: string;
+    length: number;
+    [key: string]: string | number;
+}
+
+const subs: partial State1 = {};
+subs['foo'] = 32;
+subs['bar'] = 'ok';
+// Errors
+subs['err'] = false;
+subs[12] = false;

--- a/tests/cases/compiler/partialType4.ts
+++ b/tests/cases/compiler/partialType4.ts
@@ -1,5 +1,8 @@
 // @strictNullChecks: true
+<<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
 // @declaration: true
+=======
+>>>>>>> Partial Types (#11233)
 
 interface State1 {
     name: string;

--- a/tests/cases/compiler/partialType4.ts
+++ b/tests/cases/compiler/partialType4.ts
@@ -1,8 +1,12 @@
 // @strictNullChecks: true
+<<<<<<< 4c6bf657250405beb9bb7edaf3bd10d3db165690
 <<<<<<< d147616ccc57b7c9f6418074c8edffd3ee258961
 // @declaration: true
 =======
 >>>>>>> Partial Types (#11233)
+=======
+// @declaration: true
+>>>>>>> Update test for --d
 
 interface State1 {
     name: string;

--- a/tests/cases/compiler/partialType4.ts
+++ b/tests/cases/compiler/partialType4.ts
@@ -1,0 +1,17 @@
+// @strictNullChecks: true
+
+interface State1 {
+    name: string;
+    length: number;
+    [key: string]: string | number;
+}
+
+const subs: partial State1 = {};
+subs['foo'] = 32;
+subs['bar'] = 'ok';
+subs['ok'] = undefined;
+subs.name = undefined; // ok
+subs.name = false; // not ok
+// Errors
+subs['err'] = false;
+subs[12] = false;

--- a/tests/cases/compiler/partialType4.ts
+++ b/tests/cases/compiler/partialType4.ts
@@ -1,4 +1,5 @@
 // @strictNullChecks: true
+// @declaration: true
 
 interface State1 {
     name: string;

--- a/tests/cases/fourslash/partialTypes.ts
+++ b/tests/cases/fourslash/partialTypes.ts
@@ -1,0 +1,22 @@
+/// <reference path="fourslash.ts" />
+
+//// interface State {
+////     name: string;
+////     length: number;
+////     foo?: number;
+//// }
+//// 
+//// let ss: partial State;
+//// if (ss.name/*1*/) {
+////     ss/*2*/
+//// }
+
+goTo.marker('1');
+edit.insert('.');
+verify.completionListContains('substr');
+edit.backspace();
+goTo.marker('2');
+edit.insert('.');
+verify.completionListContains('name');
+verify.completionListContains('length');
+verify.completionListContains('foo');


### PR DESCRIPTION
Fixes #11233 - `partial T`

A _partial_ type is a shallow copy of an existing type which:
- Makes all properties optional
- Removes any call or construct signatures
- Adds `undefined` to the domains of string or numeric indexers (in strict null checks)

The `partial` operator distributes into other types:
- `partial (T & U) === (partial T) & (partial U)`
- `partial (T | U) === (partial T) | (partial U)`
- `partial (partial T) === partial T`

For an object type `T`, `partial T` type follows the rules implied by the structural rules of the resulting partial type.

For a generic type parameter `T`, `partial T` is:
- Only a valid source according to normal structural rules of partial form of its constraint
- Only a valid target when the source is:
  - `partial T`
  - `T`
  - `{}`
