### PR TITLE
enable -per-request cancellation

### DIFF
--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -722,11 +722,7 @@ namespace Harness.LanguageService {
             // host to answer server queries about files on disk
             const serverHost = new SessionServerHost(clientHost);
             const server = new ts.server.Session(serverHost,
-                {
-                    isCancellationRequested: () => false,
-                    attachToRequest: (): void => void 0,
-                    detachFromRequest: (): void => void 0
-                },
+                ts.server.nullCancellationToken,
                 /*useOneInferredProject*/ false,
                 /*typingsInstaller*/ undefined,
                 Utils.byteLength,

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -722,7 +722,11 @@ namespace Harness.LanguageService {
             // host to answer server queries about files on disk
             const serverHost = new SessionServerHost(clientHost);
             const server = new ts.server.Session(serverHost,
-                { isCancellationRequested: () => false },
+                {
+                    isCancellationRequested: () => false,
+                    attachToRequest: (): void => void 0,
+                    detachFromRequest: (): void => void 0
+                },
                 /*useOneInferredProject*/ false,
                 /*typingsInstaller*/ undefined,
                 Utils.byteLength,

--- a/src/harness/unittests/compileOnSave.ts
+++ b/src/harness/unittests/compileOnSave.ts
@@ -4,6 +4,7 @@
 
 namespace ts.projectSystem {
     import CommandNames = server.CommandNames;
+    const nullCancellationToken = server.nullCancellationToken;
 
     function createTestTypingsInstaller(host: server.ServerHost) {
         return new TestTypingsInstaller("/a/data/", /*throttleLimit*/5, host);

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -25,7 +25,13 @@ namespace ts.server {
         setImmediate: () => 0,
         clearImmediate() {}
     };
-    const nullCancellationToken: HostCancellationToken = { isCancellationRequested: () => false };
+
+    const nullCancellationToken: ServerCancellationToken = {
+        isCancellationRequested: () => false,
+        attachToRequest: (): void => void 0,
+        detachFromRequest: (): void => void 0
+    };
+
     const mockLogger: Logger = {
         close(): void {},
         hasLevel(): boolean { return false; },

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -26,12 +26,6 @@ namespace ts.server {
         clearImmediate() {}
     };
 
-    const nullCancellationToken: ServerCancellationToken = {
-        isCancellationRequested: () => false,
-        attachToRequest: (): void => void 0,
-        detachFromRequest: (): void => void 0
-    };
-
     const mockLogger: Logger = {
         close(): void {},
         hasLevel(): boolean { return false; },

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -40,12 +40,6 @@ namespace ts.projectSystem {
         getLogFileName: (): string => undefined
     };
 
-    export const nullCancellationToken: server.ServerCancellationToken = {
-        isCancellationRequested: () => false,
-        attachToRequest: (): void => void 0,
-        detachFromRequest: (): void => void 0
-    };
-
     export const { content: libFileContent } = Harness.getDefaultLibraryFile(Harness.IO);
     export const libFile: FileOrFolder = {
         path: "/a/lib/lib.d.ts",
@@ -179,7 +173,7 @@ namespace ts.projectSystem {
         if (typingsInstaller === undefined) {
             typingsInstaller = new TestTypingsInstaller("/a/data/", /*throttleLimit*/5, host);
         }
-        return new server.Session(host, nullCancellationToken, /*useSingleInferredProject*/ false, typingsInstaller, Utils.byteLength, process.hrtime, nullLogger, /*canUseEvents*/ projectServiceEventHandler !== undefined, projectServiceEventHandler);
+        return new server.Session(host, server.nullCancellationToken, /*useSingleInferredProject*/ false, typingsInstaller, Utils.byteLength, process.hrtime, nullLogger, /*canUseEvents*/ projectServiceEventHandler !== undefined, projectServiceEventHandler);
     }
 
     export interface CreateProjectServiceParameters {
@@ -202,7 +196,7 @@ namespace ts.projectSystem {
         }
     }
     export function createProjectService(host: server.ServerHost, parameters: CreateProjectServiceParameters = {}) {
-        const cancellationToken = parameters.cancellationToken || nullCancellationToken;
+        const cancellationToken = parameters.cancellationToken || server.nullCancellationToken;
         const logger = parameters.logger || nullLogger;
         const useSingleInferredProject = parameters.useSingleInferredProject !== undefined ? parameters.useSingleInferredProject : false;
         return new TestProjectService(host, logger, cancellationToken, useSingleInferredProject, parameters.typingsInstaller, parameters.eventHandler);

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -40,8 +40,10 @@ namespace ts.projectSystem {
         getLogFileName: (): string => undefined
     };
 
-    export const nullCancellationToken: HostCancellationToken = {
-        isCancellationRequested: () => false
+    export const nullCancellationToken: server.ServerCancellationToken = {
+        isCancellationRequested: () => false,
+        attachToRequest: (): void => void 0,
+        detachFromRequest: (): void => void 0
     };
 
     export const { content: libFileContent } = Harness.getDefaultLibraryFile(Harness.IO);

--- a/src/server/cancellationToken/cancellationToken.ts
+++ b/src/server/cancellationToken/cancellationToken.ts
@@ -1,14 +1,25 @@
-/// <reference types="node" />
-
-
-// TODO: extract services types 
-interface HostCancellationToken {
-    isCancellationRequested(): boolean;
-}
+/// <reference types="node"/>
 
 import fs = require("fs");
 
-function createCancellationToken(args: string[]): HostCancellationToken {
+// TODO: remove after extrating services types into separate .d.ts file
+interface ServerCancellationToken {
+    isCancellationRequested(): boolean;
+    attachToRequest(requestId: number): void;
+    detachFromRequest(requestId: number): void;
+}
+
+function isPipeExist(name: string): boolean {
+    try {
+        fs.statSync(name);
+        return true;
+    }
+    catch (e) {
+        return false;
+    }
+}
+
+function createCancellationToken(args: string[]): ServerCancellationToken {
     let cancellationPipeName: string;
     for (let i = 0; i < args.length - 1; i++) {
         if (args[i] === "--cancellationPipeName") {
@@ -17,18 +28,34 @@ function createCancellationToken(args: string[]): HostCancellationToken {
         }
     }
     if (!cancellationPipeName) {
-        return { isCancellationRequested: () => false };
+        return {
+            isCancellationRequested: () => false,
+            attachToRequest: (requestId: number): void => void 0,
+            detachFromRequest: (requestId: number): void => void 0
+        };
     }
-    return {
-        isCancellationRequested() {
-            try {
-                fs.statSync(cancellationPipeName);
-                return true;
-            }
-            catch (e) {
-                return false;
-            }
+    if (cancellationPipeName.charAt(cancellationPipeName.length - 1) === "*") {
+        const namePrefix = cancellationPipeName.substring(0, cancellationPipeName.length - 1);
+        if (namePrefix.length === 0 || namePrefix.indexOf("*") >= 0) {
+            throw new Error("Invalid name for template cancellation pipe: it should have length greater than 2 characters and contain only one '*'.");
         }
-    };
+        let perRequestPipeName: string;
+        return {
+            isCancellationRequested: () =>  perRequestPipeName !== undefined && isPipeExist(perRequestPipeName),
+            attachToRequest(requestId: number) {
+                perRequestPipeName = namePrefix + requestId;
+            },
+            detachFromRequest(requestId: number) {
+                perRequestPipeName = undefined;
+            }
+        };
+    }
+    else {
+        return {
+            isCancellationRequested: () => isPipeExist(cancellationPipeName),
+            attachToRequest: (requestId: number): void => void 0,
+            detachFromRequest: (requestId: number): void => void 0
+        };
+    }
 }
 export = createCancellationToken;

--- a/src/server/cancellationToken/cancellationToken.ts
+++ b/src/server/cancellationToken/cancellationToken.ts
@@ -5,8 +5,8 @@ import fs = require("fs");
 // TODO: remove after extrating services types into separate .d.ts file
 interface ServerCancellationToken {
     isCancellationRequested(): boolean;
-    attachToRequest(requestId: number): void;
-    detachFromRequest(requestId: number): void;
+    setRequest(requestId: number): void;
+    resetRequest(requestId: number): void;
 }
 
 function isPipeExist(name: string): boolean {
@@ -30,8 +30,8 @@ function createCancellationToken(args: string[]): ServerCancellationToken {
     if (!cancellationPipeName) {
         return {
             isCancellationRequested: () => false,
-            attachToRequest: (requestId: number): void => void 0,
-            detachFromRequest: (requestId: number): void => void 0
+            setRequest: (requestId: number): void => void 0,
+            resetRequest: (requestId: number): void => void 0
         };
     }
     if (cancellationPipeName.charAt(cancellationPipeName.length - 1) === "*") {
@@ -40,12 +40,17 @@ function createCancellationToken(args: string[]): ServerCancellationToken {
             throw new Error("Invalid name for template cancellation pipe: it should have length greater than 2 characters and contain only one '*'.");
         }
         let perRequestPipeName: string;
+        let currentRequestId: number;
         return {
             isCancellationRequested: () =>  perRequestPipeName !== undefined && isPipeExist(perRequestPipeName),
-            attachToRequest(requestId: number) {
+            setRequest(requestId: number) {
+                currentRequestId = currentRequestId;
                 perRequestPipeName = namePrefix + requestId;
             },
-            detachFromRequest(requestId: number) {
+            resetRequest(requestId: number) {
+                if (currentRequestId !== requestId) {
+                    throw new Error(`Mismatched request id, expected ${currentRequestId}, actual ${requestId}`);
+                }
                 perRequestPipeName = undefined;
             }
         };
@@ -53,8 +58,8 @@ function createCancellationToken(args: string[]): ServerCancellationToken {
     else {
         return {
             isCancellationRequested: () => isPipeExist(cancellationPipeName),
-            attachToRequest: (requestId: number): void => void 0,
-            detachFromRequest: (requestId: number): void => void 0
+            setRequest: (requestId: number): void => void 0,
+            resetRequest: (requestId: number): void => void 0
         };
     }
 }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -261,7 +261,7 @@ namespace ts.server {
     class IOSession extends Session {
         constructor(
             host: ServerHost,
-            cancellationToken: HostCancellationToken,
+            cancellationToken: ServerCancellationToken,
             installerEventPort: number,
             canUseEvents: boolean,
             useSingleInferredProject: boolean,
@@ -489,14 +489,16 @@ namespace ts.server {
         sys.gc = () => global.gc();
     }
 
-    let cancellationToken: HostCancellationToken;
+    let cancellationToken: ServerCancellationToken;
     try {
         const factory = require("./cancellationToken");
         cancellationToken = factory(sys.args);
     }
     catch (e) {
         cancellationToken = {
-            isCancellationRequested: () => false
+            isCancellationRequested: () => false,
+            attachToRequest: () => void 0,
+            detachFromRequest: () => void 0
         };
     };
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -495,11 +495,7 @@ namespace ts.server {
         cancellationToken = factory(sys.args);
     }
     catch (e) {
-        cancellationToken = {
-            isCancellationRequested: () => false,
-            attachToRequest: () => void 0,
-            detachFromRequest: () => void 0
-        };
+        cancellationToken = nullCancellationToken;
     };
 
     let eventPort: number;

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -9,9 +9,15 @@ namespace ts.server {
     }
 
     export interface ServerCancellationToken extends HostCancellationToken {
-        attachToRequest(requestId: number): void;
-        detachFromRequest(requestId: number): void;
+        setRequest(requestId: number): void;
+        resetRequest(requestId: number): void;
     }
+
+    export const nullCancellationToken: ServerCancellationToken = {
+        isCancellationRequested: () => false,
+        setRequest: () => void 0,
+        resetRequest: () => void 0
+    };
 
     function hrTimeToMilliseconds(time: number[]): number {
         const seconds = time[0];
@@ -159,6 +165,7 @@ namespace ts.server {
         private errorTimer: any; /*NodeJS.Timer | number*/
         private immediateId: any;
         private changeSeq = 0;
+        private currentRequestId: number;
 
         private eventHander: ProjectServiceEventHandler;
 
@@ -173,12 +180,38 @@ namespace ts.server {
             protected readonly canUseEvents: boolean,
             eventHandler?: ProjectServiceEventHandler) {
 
+            if (cancellationToken !== nullCancellationToken) {
+                host.setImmediate = this.wrapDeferredCall(this.host, this.host.setImmediate);
+                host.setTimeout = this.wrapDeferredCall(this.host, this.host.setTimeout);
+            }
+
             this.eventHander = canUseEvents
                 ? eventHandler || (event => this.defaultEventHandler(event))
                 : undefined;
 
             this.projectService = new ProjectService(host, logger, cancellationToken, useSingleInferredProject, typingsInstaller, this.eventHander);
             this.gcTimer = new GcTimer(host, /*delay*/ 7000, logger);
+        }
+
+        private wrapDeferredCall<T extends (cb: (...args: any[]) => void, ...rest: any[]) => any>(thisArg: any, originalCall: T): T {
+            return <T>((cb, rest) => {
+                Debug.assert(this.currentRequestId !== undefined, "No in-flight request");
+                const capturedRequestId = this.currentRequestId;
+                const wrapped: typeof cb = a => {
+                    Debug.assert(this.currentRequestId === undefined, `Request ${this.currentRequestId} is in-flight`);
+                    // restore captured request id
+                    try {
+                        this.setCurrentRequest(capturedRequestId);
+                        cb(a);
+                    }
+                    finally {
+                        this.resetCurrentRequest(capturedRequestId);
+                    }
+                };
+                // substiture callback with wrapper function that will restore the request id
+                // before invoking the original callback
+                return originalCall.call(thisArg, wrapped, ...rest);
+            });
         }
 
         private defaultEventHandler(event: ProjectServiceEvent) {
@@ -1522,15 +1555,27 @@ namespace ts.server {
             this.handlers[command] = handler;
         }
 
+        private setCurrentRequest(requestId: number): void {
+            Debug.assert(this.currentRequestId === undefined);
+            this.currentRequestId = requestId;
+            this.cancellationToken.setRequest(requestId);
+        }
+
+        private resetCurrentRequest(requestId: number): void {
+            Debug.assert(this.currentRequestId === requestId);
+            this.currentRequestId = undefined;
+            this.cancellationToken.resetRequest(requestId);
+        }
+
         public executeCommand(request: protocol.Request): { response?: any, responseRequired?: boolean } {
             const handler = this.handlers[request.command];
             if (handler) {
                 try {
-                    this.cancellationToken.attachToRequest(request.seq);
+                    this.setCurrentRequest(request.seq);
                     return handler(request);
                 }
                 finally {
-                    this.cancellationToken.detachFromRequest(request.seq);
+                    this.resetCurrentRequest(request.seq);
                 }
             }
             else {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -8,6 +8,11 @@ namespace ts.server {
         stack?: string;
     }
 
+    export interface ServerCancellationToken extends HostCancellationToken {
+        attachToRequest(requestId: number): void;
+        detachFromRequest(requestId: number): void;
+    }
+
     function hrTimeToMilliseconds(time: number[]): number {
         const seconds = time[0];
         const nanoseconds = time[1];
@@ -159,7 +164,7 @@ namespace ts.server {
 
         constructor(
             private host: ServerHost,
-            cancellationToken: HostCancellationToken,
+            private readonly cancellationToken: ServerCancellationToken,
             useSingleInferredProject: boolean,
             protected readonly typingsInstaller: ITypingsInstaller,
             private byteLength: (buf: string, encoding?: string) => number,
@@ -1520,7 +1525,13 @@ namespace ts.server {
         public executeCommand(request: protocol.Request): { response?: any, responseRequired?: boolean } {
             const handler = this.handlers[request.command];
             if (handler) {
-                return handler(request);
+                try {
+                    this.cancellationToken.attachToRequest(request.seq);
+                    return handler(request);
+                }
+                finally {
+                    this.cancellationToken.detachFromRequest(request.seq);
+                }
             }
             else {
                 this.logger.msg(`Unrecognized JSON command: ${JSON.stringify(request)}`, Msg.Err);


### PR DESCRIPTION
proposal for #11524

// cc @mhegazy, @dbaeumer 

with this PR if client spawns server with `--cancellationPipeName`  that ends with "*" (i.e. `/tmp/ct-*`) then server will check cancellation per request building pipe name dynamically as `<value of cancellation pipe name><asterisk replaced with request id>` (i.e for request with seq 42 and cancellation pipe name `/tmp/ct-*` pipe name will be `/tmp/ct-42`). This way cancellation of one request will not collide with other requests assuming that `seq` numbers are unique for all requests.
