### PR TITLE
Narrow string and number types in literal equality checks

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8791,6 +8791,10 @@ namespace ts {
                             assumeTrue ? TypeFacts.EQUndefined : TypeFacts.NEUndefined;
                     return getTypeWithFacts(type, facts);
                 }
+                if (type.flags & TypeFlags.String && isTypeOfKind(valueType, TypeFlags.StringLiteral) ||
+                    type.flags & TypeFlags.Number && isTypeOfKind(valueType, TypeFlags.NumberLiteral)) {
+                    return assumeTrue? valueType : type;
+                }
                 if (type.flags & TypeFlags.NotUnionOrUnit) {
                     return type;
                 }
@@ -8843,7 +8847,11 @@ namespace ts {
                 const clauseTypes = switchTypes.slice(clauseStart, clauseEnd);
                 const hasDefaultClause = clauseStart === clauseEnd || contains(clauseTypes, neverType);
                 const discriminantType = getUnionType(clauseTypes);
-                const caseType = discriminantType.flags & TypeFlags.Never ? neverType : filterType(type, t => isTypeComparableTo(discriminantType, t));
+                const caseType =
+                    discriminantType.flags & TypeFlags.Never ? neverType :
+                    type.flags & TypeFlags.String && isTypeOfKind(discriminantType, TypeFlags.StringLiteral) ? discriminantType :
+                    type.flags & TypeFlags.Number && isTypeOfKind(discriminantType, TypeFlags.NumberLiteral) ? discriminantType :
+                    filterType(type, t => isTypeComparableTo(discriminantType, t));
                 if (!hasDefaultClause) {
                     return caseType;
                 }

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1190,7 +1190,7 @@ namespace ts {
         }
 
         function scanBinaryOrOctalDigits(base: number): number {
-            Debug.assert(base !== 2 || base !== 8, "Expected either base 2 or base 8");
+            Debug.assert(base === 2 || base === 8, "Expected either base 2 or base 8");
 
             let value = 0;
             // For counting number of digits; Valid binaryIntegerLiteral must have at least one binary digit following B or b.

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2644,7 +2644,7 @@ namespace ts {
         // 'Narrowable' types are types where narrowing actually narrows.
         // This *should* be every type other than null, undefined, void, and never
         Narrowable = Any | StructuredType | TypeParameter | StringLike | NumberLike | BooleanLike | ESSymbol,
-        NotUnionOrUnit = Any | String | Number | ESSymbol | ObjectType,
+        NotUnionOrUnit = Any | ESSymbol | ObjectType,
         /* @internal */
         RequiresWidening = ContainsWideningType | ContainsObjectLiteral,
         /* @internal */

--- a/tests/baselines/reference/declFileTypeAnnotationStringLiteral.types
+++ b/tests/baselines/reference/declFileTypeAnnotationStringLiteral.types
@@ -23,7 +23,7 @@ function foo(a: string): string | number {
 
         return a.length;
 >a.length : number
->a : string
+>a : "hello"
 >length : number
     }
 

--- a/tests/baselines/reference/literalTypes1.types
+++ b/tests/baselines/reference/literalTypes1.types
@@ -129,7 +129,7 @@ function f4(x: 0 | 1 | true | string) {
 >"def" : "def"
 
             x;
->x : string
+>x : "abc" | "def"
 
             break;
         case null:
@@ -163,7 +163,7 @@ function f5(x: string | number | boolean) {
 >"abc" : "abc"
 
             x;
->x : string
+>x : "abc"
 
             break;
         case 0:
@@ -173,7 +173,7 @@ function f5(x: string | number | boolean) {
 >1 : 1
 
             x;
->x : number
+>x : 0 | 1
 
             break;
         case true:
@@ -190,7 +190,7 @@ function f5(x: string | number | boolean) {
 >123 : 123
 
             x;
->x : string | number
+>x : "hello" | 123
 
             break;
         default:

--- a/tests/baselines/reference/literalTypes3.js
+++ b/tests/baselines/reference/literalTypes3.js
@@ -1,0 +1,125 @@
+//// [literalTypes3.ts]
+
+function f1(s: string) {
+    if (s === "foo") {
+        s;  // "foo"
+    }
+    if (s === "foo" || s === "bar") {
+        s;  // "foo" | "bar"
+    }
+}
+
+function f2(s: string) {
+    switch (s) {
+        case "foo":
+        case "bar":
+            s;  // "foo" | "bar"
+        case "baz":
+            s;  // "foo" | "bar" | "baz"
+            break;
+        default:
+            s;  // string
+    }
+}
+
+function f3(s: string) {
+    return s === "foo" || s === "bar" ? s : undefined;  // "foo" | "bar" | undefined
+}
+
+function f4(x: number) {
+    if (x === 1 || x === 2) {
+        return x;  // 1 | 2
+    }
+    throw new Error();
+}
+
+function f5(x: number, y: 1 | 2) {
+    if (x === 0 || x === y) {
+        x;  // 0 | 1 | 2
+    }
+}
+
+function f6(x: number, y: 1 | 2) {
+    if (y === x || 0 === x) {
+        x;  // 0 | 1 | 2
+    }
+}
+
+function f7(x: number | "foo" | "bar", y: 1 | 2 | string) {
+    if (x === y) {
+        x;  // "foo" | "bar" | 1 | 2
+    }
+}
+
+function f8(x: number | "foo" | "bar") {
+    switch (x) {
+        case 1:
+        case 2:
+            x;  // 1 | 2
+            break;
+        case "foo":
+            x;  // "foo"
+            break;
+        default:
+            x;  // number | "bar"
+    }
+}
+
+//// [literalTypes3.js]
+function f1(s) {
+    if (s === "foo") {
+        s; // "foo"
+    }
+    if (s === "foo" || s === "bar") {
+        s; // "foo" | "bar"
+    }
+}
+function f2(s) {
+    switch (s) {
+        case "foo":
+        case "bar":
+            s; // "foo" | "bar"
+        case "baz":
+            s; // "foo" | "bar" | "baz"
+            break;
+        default:
+            s; // string
+    }
+}
+function f3(s) {
+    return s === "foo" || s === "bar" ? s : undefined; // "foo" | "bar" | undefined
+}
+function f4(x) {
+    if (x === 1 || x === 2) {
+        return x; // 1 | 2
+    }
+    throw new Error();
+}
+function f5(x, y) {
+    if (x === 0 || x === y) {
+        x; // 0 | 1 | 2
+    }
+}
+function f6(x, y) {
+    if (y === x || 0 === x) {
+        x; // 0 | 1 | 2
+    }
+}
+function f7(x, y) {
+    if (x === y) {
+        x; // "foo" | "bar" | 1 | 2
+    }
+}
+function f8(x) {
+    switch (x) {
+        case 1:
+        case 2:
+            x; // 1 | 2
+            break;
+        case "foo":
+            x; // "foo"
+            break;
+        default:
+            x; // number | "bar"
+    }
+}

--- a/tests/baselines/reference/literalTypes3.symbols
+++ b/tests/baselines/reference/literalTypes3.symbols
@@ -1,0 +1,137 @@
+=== tests/cases/conformance/types/literal/literalTypes3.ts ===
+
+function f1(s: string) {
+>f1 : Symbol(f1, Decl(literalTypes3.ts, 0, 0))
+>s : Symbol(s, Decl(literalTypes3.ts, 1, 12))
+
+    if (s === "foo") {
+>s : Symbol(s, Decl(literalTypes3.ts, 1, 12))
+
+        s;  // "foo"
+>s : Symbol(s, Decl(literalTypes3.ts, 1, 12))
+    }
+    if (s === "foo" || s === "bar") {
+>s : Symbol(s, Decl(literalTypes3.ts, 1, 12))
+>s : Symbol(s, Decl(literalTypes3.ts, 1, 12))
+
+        s;  // "foo" | "bar"
+>s : Symbol(s, Decl(literalTypes3.ts, 1, 12))
+    }
+}
+
+function f2(s: string) {
+>f2 : Symbol(f2, Decl(literalTypes3.ts, 8, 1))
+>s : Symbol(s, Decl(literalTypes3.ts, 10, 12))
+
+    switch (s) {
+>s : Symbol(s, Decl(literalTypes3.ts, 10, 12))
+
+        case "foo":
+        case "bar":
+            s;  // "foo" | "bar"
+>s : Symbol(s, Decl(literalTypes3.ts, 10, 12))
+
+        case "baz":
+            s;  // "foo" | "bar" | "baz"
+>s : Symbol(s, Decl(literalTypes3.ts, 10, 12))
+
+            break;
+        default:
+            s;  // string
+>s : Symbol(s, Decl(literalTypes3.ts, 10, 12))
+    }
+}
+
+function f3(s: string) {
+>f3 : Symbol(f3, Decl(literalTypes3.ts, 21, 1))
+>s : Symbol(s, Decl(literalTypes3.ts, 23, 12))
+
+    return s === "foo" || s === "bar" ? s : undefined;  // "foo" | "bar" | undefined
+>s : Symbol(s, Decl(literalTypes3.ts, 23, 12))
+>s : Symbol(s, Decl(literalTypes3.ts, 23, 12))
+>s : Symbol(s, Decl(literalTypes3.ts, 23, 12))
+>undefined : Symbol(undefined)
+}
+
+function f4(x: number) {
+>f4 : Symbol(f4, Decl(literalTypes3.ts, 25, 1))
+>x : Symbol(x, Decl(literalTypes3.ts, 27, 12))
+
+    if (x === 1 || x === 2) {
+>x : Symbol(x, Decl(literalTypes3.ts, 27, 12))
+>x : Symbol(x, Decl(literalTypes3.ts, 27, 12))
+
+        return x;  // 1 | 2
+>x : Symbol(x, Decl(literalTypes3.ts, 27, 12))
+    }
+    throw new Error();
+>Error : Symbol(Error, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+}
+
+function f5(x: number, y: 1 | 2) {
+>f5 : Symbol(f5, Decl(literalTypes3.ts, 32, 1))
+>x : Symbol(x, Decl(literalTypes3.ts, 34, 12))
+>y : Symbol(y, Decl(literalTypes3.ts, 34, 22))
+
+    if (x === 0 || x === y) {
+>x : Symbol(x, Decl(literalTypes3.ts, 34, 12))
+>x : Symbol(x, Decl(literalTypes3.ts, 34, 12))
+>y : Symbol(y, Decl(literalTypes3.ts, 34, 22))
+
+        x;  // 0 | 1 | 2
+>x : Symbol(x, Decl(literalTypes3.ts, 34, 12))
+    }
+}
+
+function f6(x: number, y: 1 | 2) {
+>f6 : Symbol(f6, Decl(literalTypes3.ts, 38, 1))
+>x : Symbol(x, Decl(literalTypes3.ts, 40, 12))
+>y : Symbol(y, Decl(literalTypes3.ts, 40, 22))
+
+    if (y === x || 0 === x) {
+>y : Symbol(y, Decl(literalTypes3.ts, 40, 22))
+>x : Symbol(x, Decl(literalTypes3.ts, 40, 12))
+>x : Symbol(x, Decl(literalTypes3.ts, 40, 12))
+
+        x;  // 0 | 1 | 2
+>x : Symbol(x, Decl(literalTypes3.ts, 40, 12))
+    }
+}
+
+function f7(x: number | "foo" | "bar", y: 1 | 2 | string) {
+>f7 : Symbol(f7, Decl(literalTypes3.ts, 44, 1))
+>x : Symbol(x, Decl(literalTypes3.ts, 46, 12))
+>y : Symbol(y, Decl(literalTypes3.ts, 46, 38))
+
+    if (x === y) {
+>x : Symbol(x, Decl(literalTypes3.ts, 46, 12))
+>y : Symbol(y, Decl(literalTypes3.ts, 46, 38))
+
+        x;  // "foo" | "bar" | 1 | 2
+>x : Symbol(x, Decl(literalTypes3.ts, 46, 12))
+    }
+}
+
+function f8(x: number | "foo" | "bar") {
+>f8 : Symbol(f8, Decl(literalTypes3.ts, 50, 1))
+>x : Symbol(x, Decl(literalTypes3.ts, 52, 12))
+
+    switch (x) {
+>x : Symbol(x, Decl(literalTypes3.ts, 52, 12))
+
+        case 1:
+        case 2:
+            x;  // 1 | 2
+>x : Symbol(x, Decl(literalTypes3.ts, 52, 12))
+
+            break;
+        case "foo":
+            x;  // "foo"
+>x : Symbol(x, Decl(literalTypes3.ts, 52, 12))
+
+            break;
+        default:
+            x;  // number | "bar"
+>x : Symbol(x, Decl(literalTypes3.ts, 52, 12))
+    }
+}

--- a/tests/baselines/reference/literalTypes3.types
+++ b/tests/baselines/reference/literalTypes3.types
@@ -1,0 +1,177 @@
+=== tests/cases/conformance/types/literal/literalTypes3.ts ===
+
+function f1(s: string) {
+>f1 : (s: string) => void
+>s : string
+
+    if (s === "foo") {
+>s === "foo" : boolean
+>s : string
+>"foo" : "foo"
+
+        s;  // "foo"
+>s : "foo"
+    }
+    if (s === "foo" || s === "bar") {
+>s === "foo" || s === "bar" : boolean
+>s === "foo" : boolean
+>s : string
+>"foo" : "foo"
+>s === "bar" : boolean
+>s : string
+>"bar" : "bar"
+
+        s;  // "foo" | "bar"
+>s : "foo" | "bar"
+    }
+}
+
+function f2(s: string) {
+>f2 : (s: string) => void
+>s : string
+
+    switch (s) {
+>s : string
+
+        case "foo":
+>"foo" : "foo"
+
+        case "bar":
+>"bar" : "bar"
+
+            s;  // "foo" | "bar"
+>s : "foo" | "bar"
+
+        case "baz":
+>"baz" : "baz"
+
+            s;  // "foo" | "bar" | "baz"
+>s : "foo" | "bar" | "baz"
+
+            break;
+        default:
+            s;  // string
+>s : string
+    }
+}
+
+function f3(s: string) {
+>f3 : (s: string) => "foo" | "bar" | undefined
+>s : string
+
+    return s === "foo" || s === "bar" ? s : undefined;  // "foo" | "bar" | undefined
+>s === "foo" || s === "bar" ? s : undefined : "foo" | "bar" | undefined
+>s === "foo" || s === "bar" : boolean
+>s === "foo" : boolean
+>s : string
+>"foo" : "foo"
+>s === "bar" : boolean
+>s : string
+>"bar" : "bar"
+>s : "foo" | "bar"
+>undefined : undefined
+}
+
+function f4(x: number) {
+>f4 : (x: number) => 1 | 2
+>x : number
+
+    if (x === 1 || x === 2) {
+>x === 1 || x === 2 : boolean
+>x === 1 : boolean
+>x : number
+>1 : 1
+>x === 2 : boolean
+>x : number
+>2 : 2
+
+        return x;  // 1 | 2
+>x : 1 | 2
+    }
+    throw new Error();
+>new Error() : Error
+>Error : ErrorConstructor
+}
+
+function f5(x: number, y: 1 | 2) {
+>f5 : (x: number, y: 1 | 2) => void
+>x : number
+>y : 1 | 2
+
+    if (x === 0 || x === y) {
+>x === 0 || x === y : boolean
+>x === 0 : boolean
+>x : number
+>0 : 0
+>x === y : boolean
+>x : number
+>y : 1 | 2
+
+        x;  // 0 | 1 | 2
+>x : 1 | 2 | 0
+    }
+}
+
+function f6(x: number, y: 1 | 2) {
+>f6 : (x: number, y: 1 | 2) => void
+>x : number
+>y : 1 | 2
+
+    if (y === x || 0 === x) {
+>y === x || 0 === x : boolean
+>y === x : boolean
+>y : 1 | 2
+>x : number
+>0 === x : boolean
+>0 : 0
+>x : number
+
+        x;  // 0 | 1 | 2
+>x : 1 | 2 | 0
+    }
+}
+
+function f7(x: number | "foo" | "bar", y: 1 | 2 | string) {
+>f7 : (x: number | "foo" | "bar", y: string | 1 | 2) => void
+>x : number | "foo" | "bar"
+>y : string | 1 | 2
+
+    if (x === y) {
+>x === y : boolean
+>x : number | "foo" | "bar"
+>y : string | 1 | 2
+
+        x;  // "foo" | "bar" | 1 | 2
+>x : "foo" | "bar" | 1 | 2
+    }
+}
+
+function f8(x: number | "foo" | "bar") {
+>f8 : (x: number | "foo" | "bar") => void
+>x : number | "foo" | "bar"
+
+    switch (x) {
+>x : number | "foo" | "bar"
+
+        case 1:
+>1 : 1
+
+        case 2:
+>2 : 2
+
+            x;  // 1 | 2
+>x : 1 | 2
+
+            break;
+        case "foo":
+>"foo" : "foo"
+
+            x;  // "foo"
+>x : "foo"
+
+            break;
+        default:
+            x;  // number | "bar"
+>x : number | "bar"
+    }
+}

--- a/tests/baselines/reference/sourceMapValidationIfElse.types
+++ b/tests/baselines/reference/sourceMapValidationIfElse.types
@@ -10,7 +10,7 @@ if (i == 10) {
 
     i++;
 >i++ : number
->i : number
+>i : 10
 
 } else
 {
@@ -22,7 +22,7 @@ if (i == 10)
 {
     i++;
 >i++ : number
->i : number
+>i : 10
 }
 else if (i == 20) {
 >i == 20 : boolean
@@ -31,7 +31,7 @@ else if (i == 20) {
 
     i--;
 >i-- : number
->i : number
+>i : 20
 
 } else if (i == 30) {
 >i == 30 : boolean

--- a/tests/baselines/reference/sourceMapValidationSwitch.types
+++ b/tests/baselines/reference/sourceMapValidationSwitch.types
@@ -11,7 +11,7 @@ switch (x) {
 
         x++;
 >x++ : number
->x : number
+>x : 5
 
         break;
     case 10:
@@ -19,7 +19,7 @@ switch (x) {
         {
             x--;
 >x-- : number
->x : number
+>x : 10
 
             break;
         }
@@ -39,7 +39,7 @@ switch (x)
 
         x++;
 >x++ : number
->x : number
+>x : 5
 
         break;
     case 10:
@@ -47,7 +47,7 @@ switch (x)
         {
             x--;
 >x-- : number
->x : number
+>x : 10
 
             break;
         }

--- a/tests/baselines/reference/sourceMapValidationWhile.types
+++ b/tests/baselines/reference/sourceMapValidationWhile.types
@@ -10,7 +10,7 @@ while (a == 10) {
 
     a++;
 >a++ : number
->a : number
+>a : 10
 }
 while (a == 10)
 >a == 10 : boolean
@@ -19,5 +19,5 @@ while (a == 10)
 {
     a++;
 >a++ : number
->a : number
+>a : 10
 }

--- a/tests/baselines/reference/stringLiteralTypesInUnionTypes02.types
+++ b/tests/baselines/reference/stringLiteralTypesInUnionTypes02.types
@@ -19,7 +19,7 @@ if (x === "foo") {
 
     let a = x;
 >a : string
->x : string
+>x : "foo"
 }
 else if (x !== "bar") {
 >x !== "bar" : boolean
@@ -35,7 +35,7 @@ else if (x !== "bar") {
 else {
     let c = x;
 >c : string
->x : string
+>x : "bar"
 
     let d = y;
 >d : string
@@ -43,7 +43,7 @@ else {
 
     let e: (typeof x) | (typeof y) = c || d;
 >e : string
->x : string
+>x : "bar"
 >y : string
 >c || d : string
 >c : string

--- a/tests/baselines/reference/throwInEnclosingStatements.types
+++ b/tests/baselines/reference/throwInEnclosingStatements.types
@@ -25,7 +25,7 @@ switch (y) {
 >'a' : "a"
 
         throw y;
->y : string
+>y : "a"
 
     default:
         throw y;

--- a/tests/cases/conformance/types/literal/literalTypes3.ts
+++ b/tests/cases/conformance/types/literal/literalTypes3.ts
@@ -1,0 +1,66 @@
+// @strictNullChecks: true
+
+function f1(s: string) {
+    if (s === "foo") {
+        s;  // "foo"
+    }
+    if (s === "foo" || s === "bar") {
+        s;  // "foo" | "bar"
+    }
+}
+
+function f2(s: string) {
+    switch (s) {
+        case "foo":
+        case "bar":
+            s;  // "foo" | "bar"
+        case "baz":
+            s;  // "foo" | "bar" | "baz"
+            break;
+        default:
+            s;  // string
+    }
+}
+
+function f3(s: string) {
+    return s === "foo" || s === "bar" ? s : undefined;  // "foo" | "bar" | undefined
+}
+
+function f4(x: number) {
+    if (x === 1 || x === 2) {
+        return x;  // 1 | 2
+    }
+    throw new Error();
+}
+
+function f5(x: number, y: 1 | 2) {
+    if (x === 0 || x === y) {
+        x;  // 0 | 1 | 2
+    }
+}
+
+function f6(x: number, y: 1 | 2) {
+    if (y === x || 0 === x) {
+        x;  // 0 | 1 | 2
+    }
+}
+
+function f7(x: number | "foo" | "bar", y: 1 | 2 | string) {
+    if (x === y) {
+        x;  // "foo" | "bar" | 1 | 2
+    }
+}
+
+function f8(x: number | "foo" | "bar") {
+    switch (x) {
+        case 1:
+        case 2:
+            x;  // 1 | 2
+            break;
+        case "foo":
+            x;  // "foo"
+            break;
+        default:
+            x;  // number | "bar"
+    }
+}


### PR DESCRIPTION
With this PR we narrow the `string` and `number` types as appropriate when they are compared with values of literal types.

```ts
function move(direction: "up" | "down") {
    // ...
}

function do1(command: string) {
    if (command === "up" || command === "down") {
        move(command);  // Narrowed to type "up" | "down"
    }
}

function do2(command: string) {
    switch (command) {
        case "up":
        case "down":
            move(command);  // Narrowed to type "up" | "down"
            break;
    }
}

function f1(x: number, y: 1 | 2) {
    if (x === 0 || x === y) {
        x;  // Narrowed to type 0 | 1 | 2
    }
}

function f2(x: number | "foo" | "bar", y: 1 | 2 | string) {
    if (x === y) {
        x;  // Narrowed to type "foo" | "bar" | 1 | 2
        y;  // Narrowed to type "foo" | "bar" | 1 | 2
    }
}
```

Interestingly this found a [bug in our scanner](https://github.com/Microsoft/TypeScript/pull/11587/commits/4c581def93d9d1dbeeb0528901f083cf05f198c3), pointing out that type `2` is not comparable to type `8`.

Fixes #7447.
Fixes #10417.
Fixes #11306.