### PR TITLE
return result from SetCompilerOptionsForInferredProject request

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1499,7 +1499,8 @@ namespace ts.server {
                 return this.requiredResponse(this.getDocumentHighlights(request.arguments, /*simplifiedResult*/ false));
             },
             [CommandNames.CompilerOptionsForInferredProjects]: (request: protocol.SetCompilerOptionsForInferredProjectsRequest) => {
-                return this.requiredResponse(this.setCompilerOptionsForInferredProjects(request.arguments));
+                this.setCompilerOptionsForInferredProjects(request.arguments);
+                return this.requiredResponse(true);
             },
             [CommandNames.ProjectInfo]: (request: protocol.ProjectInfoRequest) => {
                 return this.requiredResponse(this.getProjectInfo(request.arguments));


### PR DESCRIPTION
fixes #11590

reason: VS does not support asynchronous requests and expects results to be always returned so that is why we need to return something.

// cc @mhegazy 