### PR TITLE
Give correct info for contextually typed this

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4776,9 +4776,6 @@ namespace ts {
                 if (isJSConstructSignature) {
                     minArgumentCount--;
                 }
-                if (!thisParameter && isObjectLiteralMethod(declaration)) {
-                    thisParameter = getContextualThisParameter(declaration);
-                }
 
                 const classType = declaration.kind === SyntaxKind.Constructor ?
                     getDeclaredTypeOfClassOrInterface(getMergedSymbol((<ClassDeclaration>declaration.parent).symbol))
@@ -9429,8 +9426,13 @@ namespace ts {
                         return getInferredClassType(classSymbol);
                     }
                 }
+                let thisType = getThisTypeOfDeclaration(container);
+                if (thisType) {
+                    return thisType;
+                }
 
-                const thisType = getThisTypeOfDeclaration(container);
+                const thisParameter = getContextualThisParameter(container);
+                thisType = thisParameter && getTypeOfSymbol(thisParameter);
                 if (thisType) {
                     return thisType;
                 }

--- a/tests/cases/fourslash/memberListOnContextualThis.ts
+++ b/tests/cases/fourslash/memberListOnContextualThis.ts
@@ -1,0 +1,12 @@
+/// <reference path='fourslash.ts'/>
+////interface A {
+////    a: string;
+////}
+////declare function ctx(callback: (this: A) => string): string;
+////ctx(function () { return th/*1*/is./*2*/a });
+
+goTo.marker('1');
+verify.quickInfoIs("this: A");
+goTo.marker('2');
+verify.memberListContains('a', '(property) A.a: string');
+


### PR DESCRIPTION
Fixes #10972 

This essentially undoes #9746, which only contextually typed object literal methods, but did so early, during `getSignatureFromDeclaration`. The compiler now contextually types everything, as it did before, but only looks for a contextual type if there is no declared `this` type.

After #9746, a member list request from the language service would call `getSignatureFromDeclaration`, but it would never get a contextual this-type, because contextual typing was only enabled for object literal methods.