### PR TITLE
Consolidate Import/Export Elision

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -399,6 +399,17 @@ namespace ts {
         return result;
     }
 
+    export function some<T>(array: T[], predicate?: (value: T) => boolean): boolean {
+        if (array) {
+            for (const v of array) {
+                if (!predicate || predicate(v)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
     export function concatenate<T>(array1: T[], array2: T[]): T[] {
         if (!array2 || !array2.length) return array1;
         if (!array1 || !array1.length) return array2;
@@ -1177,7 +1188,7 @@ namespace ts {
 
     /**
      * Returns the path except for its basename. Eg:
-     * 
+     *
      * /path/to/file.ext -> /path/to
      */
     export function getDirectoryPath(path: Path): Path;

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -2206,7 +2206,7 @@ namespace ts {
      * @param visitor: Optional callback used to visit any custom prologue directives.
      */
     export function addPrologueDirectives(target: Statement[], source: Statement[], ensureUseStrict?: boolean, visitor?: (node: Node) => VisitResult<Node>): number {
-        Debug.assert(target.length === 0, "PrologueDirectives should be at the first statement in the target statements array");
+        Debug.assert(target.length === 0, "Prologue directives should be at the first statement in the target statements array");
         let foundUseStrict = false;
         let statementOffset = 0;
         const numStatements = source.length;
@@ -2219,16 +2219,20 @@ namespace ts {
                 target.push(statement);
             }
             else {
-                if (ensureUseStrict && !foundUseStrict) {
-                    target.push(startOnNewLine(createStatement(createLiteral("use strict"))));
-                    foundUseStrict = true;
-                }
-                if (getEmitFlags(statement) & EmitFlags.CustomPrologue) {
-                    target.push(visitor ? visitNode(statement, visitor, isStatement) : statement);
-                }
-                else {
-                    break;
-                }
+                break;
+            }
+            statementOffset++;
+        }
+        if (ensureUseStrict && !foundUseStrict) {
+            target.push(startOnNewLine(createStatement(createLiteral("use strict"))));
+        }
+        while (statementOffset < numStatements) {
+            const statement = source[statementOffset];
+            if (getEmitFlags(statement) & EmitFlags.CustomPrologue) {
+                target.push(visitor ? visitNode(statement, visitor, isStatement) : statement);
+            }
+            else {
+                break;
             }
             statementOffset++;
         }

--- a/src/compiler/transformers/module/es6.ts
+++ b/src/compiler/transformers/module/es6.ts
@@ -5,10 +5,6 @@
 namespace ts {
     export function transformES6Module(context: TransformationContext) {
         const compilerOptions = context.getCompilerOptions();
-        const resolver = context.getEmitResolver();
-
-        let currentSourceFile: SourceFile;
-
         return transformSourceFile;
 
         function transformSourceFile(node: SourceFile) {
@@ -17,128 +13,31 @@ namespace ts {
             }
 
             if (isExternalModule(node) || compilerOptions.isolatedModules) {
-                currentSourceFile = node;
                 return visitEachChild(node, visitor, context);
             }
+
             return node;
         }
 
         function visitor(node: Node): VisitResult<Node> {
             switch (node.kind) {
-                case SyntaxKind.ImportDeclaration:
-                    return visitImportDeclaration(<ImportDeclaration>node);
                 case SyntaxKind.ImportEqualsDeclaration:
                     return visitImportEqualsDeclaration(<ImportEqualsDeclaration>node);
-                case SyntaxKind.ImportClause:
-                    return visitImportClause(<ImportClause>node);
-                case SyntaxKind.NamedImports:
-                case SyntaxKind.NamespaceImport:
-                    return visitNamedBindings(<NamedImportBindings>node);
-                case SyntaxKind.ImportSpecifier:
-                    return visitImportSpecifier(<ImportSpecifier>node);
                 case SyntaxKind.ExportAssignment:
                     return visitExportAssignment(<ExportAssignment>node);
-                case SyntaxKind.ExportDeclaration:
-                    return visitExportDeclaration(<ExportDeclaration>node);
-                case SyntaxKind.NamedExports:
-                    return visitNamedExports(<NamedExports>node);
-                case SyntaxKind.ExportSpecifier:
-                    return visitExportSpecifier(<ExportSpecifier>node);
             }
 
             return node;
         }
 
-        function visitExportAssignment(node: ExportAssignment): ExportAssignment {
-            if (node.isExportEquals) {
-                return undefined; // do not emit export equals for ES6
-            }
-            const original = getOriginalNode(node);
-            return nodeIsSynthesized(original) || resolver.isValueAliasDeclaration(original) ? node : undefined;
+        function visitImportEqualsDeclaration(node: ImportEqualsDeclaration): VisitResult<ImportEqualsDeclaration> {
+            // Elide `import=` as it is not legal with --module ES6
+            return undefined;
         }
 
-        function visitExportDeclaration(node: ExportDeclaration): ExportDeclaration {
-            if (!node.exportClause) {
-                return resolver.moduleExportsSomeValue(node.moduleSpecifier) ? node : undefined;
-            }
-            if (!resolver.isValueAliasDeclaration(node)) {
-                return undefined;
-            }
-            const newExportClause = visitNode(node.exportClause, visitor, isNamedExports, /*optional*/ true);
-            if (node.exportClause === newExportClause) {
-                return node;
-            }
-            return newExportClause
-                ? createExportDeclaration(
-                    /*decorators*/ undefined,
-                    /*modifiers*/ undefined,
-                    newExportClause,
-                    node.moduleSpecifier)
-                : undefined;
-        }
-
-        function visitNamedExports(node: NamedExports): NamedExports {
-            const newExports = visitNodes(node.elements, visitor, isExportSpecifier);
-            if (node.elements === newExports) {
-                return node;
-            }
-            return newExports.length ? createNamedExports(newExports) : undefined;
-        }
-
-        function visitExportSpecifier(node: ExportSpecifier): ExportSpecifier {
-            return resolver.isValueAliasDeclaration(node) ? node : undefined;
-        }
-
-        function visitImportEqualsDeclaration(node: ImportEqualsDeclaration): ImportEqualsDeclaration {
-            return !isExternalModuleImportEqualsDeclaration(node) || resolver.isReferencedAliasDeclaration(node) ? node : undefined;
-        }
-
-        function visitImportDeclaration(node: ImportDeclaration) {
-            if (node.importClause) {
-                const newImportClause = visitNode(node.importClause, visitor, isImportClause);
-                if (!newImportClause.name && !newImportClause.namedBindings) {
-                    return undefined;
-                }
-                else if (newImportClause !== node.importClause) {
-                    return createImportDeclaration(
-                        /*decorators*/ undefined,
-                        /*modifiers*/ undefined,
-                        newImportClause,
-                        node.moduleSpecifier);
-                }
-            }
-            return node;
-        }
-
-        function visitImportClause(node: ImportClause): ImportClause {
-            let newDefaultImport = node.name;
-            if (!resolver.isReferencedAliasDeclaration(node)) {
-                newDefaultImport = undefined;
-            }
-            const newNamedBindings = visitNode(node.namedBindings, visitor, isNamedImportBindings, /*optional*/ true);
-            return newDefaultImport !== node.name || newNamedBindings !== node.namedBindings
-                ? createImportClause(newDefaultImport, newNamedBindings)
-                : node;
-        }
-
-        function visitNamedBindings(node: NamedImportBindings): VisitResult<NamedImportBindings> {
-            if (node.kind === SyntaxKind.NamespaceImport) {
-                return resolver.isReferencedAliasDeclaration(node) ? node : undefined;
-            }
-            else {
-                const newNamedImportElements = visitNodes((<NamedImports>node).elements, visitor, isImportSpecifier);
-                if (!newNamedImportElements || newNamedImportElements.length == 0) {
-                    return undefined;
-                }
-                if (newNamedImportElements === (<NamedImports>node).elements) {
-                    return node;
-                }
-                return createNamedImports(newNamedImportElements);
-            }
-        }
-
-        function visitImportSpecifier(node: ImportSpecifier) {
-            return resolver.isReferencedAliasDeclaration(node) ? node : undefined;
+        function visitExportAssignment(node: ExportAssignment): VisitResult<ExportAssignment> {
+            // Elide `export=` as it is not legal with --module ES6
+            return node.isExportEquals ? undefined : node;
         }
     }
 }

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -91,7 +91,7 @@ namespace ts {
             Debug.assert(!exportFunctionForFile);
 
             // Collect information about the external module and dependency groups.
-            ({ externalImports, exportSpecifiers, exportEquals, hasExportStarsToExportValues } = collectExternalModuleInfo(node, resolver));
+            ({ externalImports, exportSpecifiers, exportEquals, hasExportStarsToExportValues } = collectExternalModuleInfo(node));
 
             // Make sure that the name of the 'exports' function does not conflict with
             // existing identifiers.
@@ -573,28 +573,23 @@ namespace ts {
         }
 
         function visitExportSpecifier(specifier: ExportSpecifier): Statement {
-            if (resolver.getReferencedValueDeclaration(specifier.propertyName || specifier.name)
-                || resolver.isValueAliasDeclaration(specifier)) {
-                recordExportName(specifier.name);
-                return createExportStatement(
-                    specifier.name,
-                    specifier.propertyName || specifier.name
-                );
-            }
-            return undefined;
+            recordExportName(specifier.name);
+            return createExportStatement(
+                specifier.name,
+                specifier.propertyName || specifier.name
+            );
         }
 
         function visitExportAssignment(node: ExportAssignment): Statement {
-            if (!node.isExportEquals) {
-                if (nodeIsSynthesized(node) || resolver.isValueAliasDeclaration(node)) {
-                    return createExportStatement(
-                        createLiteral("default"),
-                        node.expression
-                    );
-                }
+            if (node.isExportEquals) {
+                // Elide `export=` as it is illegal in a SystemJS module.
+                return undefined;
             }
 
-            return undefined;
+            return createExportStatement(
+                createLiteral("default"),
+                node.expression
+            );
         }
 
         /**

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3496,7 +3496,7 @@ namespace ts {
         return positionIsSynthesized(range.pos) ? -1 : skipTrivia(sourceFile.text, range.pos);
     }
 
-    export function collectExternalModuleInfo(sourceFile: SourceFile, resolver: EmitResolver) {
+    export function collectExternalModuleInfo(sourceFile: SourceFile) {
         const externalImports: (ImportDeclaration | ImportEqualsDeclaration | ExportDeclaration)[] = [];
         const exportSpecifiers = createMap<ExportSpecifier[]>();
         let exportEquals: ExportAssignment = undefined;
@@ -3504,19 +3504,16 @@ namespace ts {
         for (const node of sourceFile.statements) {
             switch (node.kind) {
                 case SyntaxKind.ImportDeclaration:
-                    if (!(<ImportDeclaration>node).importClause ||
-                        resolver.isReferencedAliasDeclaration((<ImportDeclaration>node).importClause, /*checkChildren*/ true)) {
-                        // import "mod"
-                        // import x from "mod" where x is referenced
-                        // import * as x from "mod" where x is referenced
-                        // import { x, y } from "mod" where at least one import is referenced
-                        externalImports.push(<ImportDeclaration>node);
-                    }
+                    // import "mod"
+                    // import x from "mod"
+                    // import * as x from "mod"
+                    // import { x, y } from "mod"
+                    externalImports.push(<ImportDeclaration>node);
                     break;
 
                 case SyntaxKind.ImportEqualsDeclaration:
-                    if ((<ImportEqualsDeclaration>node).moduleReference.kind === SyntaxKind.ExternalModuleReference && resolver.isReferencedAliasDeclaration(node)) {
-                        // import x = require("mod") where x is referenced
+                    if ((<ImportEqualsDeclaration>node).moduleReference.kind === SyntaxKind.ExternalModuleReference) {
+                        // import x = require("mod")
                         externalImports.push(<ImportEqualsDeclaration>node);
                     }
                     break;
@@ -3525,13 +3522,11 @@ namespace ts {
                     if ((<ExportDeclaration>node).moduleSpecifier) {
                         if (!(<ExportDeclaration>node).exportClause) {
                             // export * from "mod"
-                            if (resolver.moduleExportsSomeValue((<ExportDeclaration>node).moduleSpecifier)) {
-                                externalImports.push(<ExportDeclaration>node);
-                                hasExportStarsToExportValues = true;
-                            }
+                            externalImports.push(<ExportDeclaration>node);
+                            hasExportStarsToExportValues = true;
                         }
-                        else if (resolver.isValueAliasDeclaration(node)) {
-                            // export { x, y } from "mod" where at least one export is a value symbol
+                        else {
+                            // export { x, y } from "mod"
                             externalImports.push(<ExportDeclaration>node);
                         }
                     }

--- a/tests/baselines/reference/declareModifierOnImport1.js
+++ b/tests/baselines/reference/declareModifierOnImport1.js
@@ -2,3 +2,4 @@
 declare import a = b;
 
 //// [declareModifierOnImport1.js]
+var a = b;

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBinding1InEs5.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBinding1InEs5.js
@@ -16,7 +16,7 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.default = a;
 //// [es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_1.js]
 "use strict";
-var es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0_1 = require("./es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0"), nameSpaceBinding = es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0_1;
+var es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0_1 = require("./es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0");
 var x = es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0_1.default;
 
 

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBinding1WithExport.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBinding1WithExport.js
@@ -19,7 +19,6 @@ define(["require", "exports"], function (require, exports) {
 //// [client.js]
 define(["require", "exports", "server"], function (require, exports, server_1) {
     "use strict";
-    var nameSpaceBinding = server_1;
     exports.x = server_1.default;
 });
 

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBindingDts.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBindingDts.js
@@ -18,7 +18,7 @@ var a = (function () {
 exports.a = a;
 //// [client.js]
 "use strict";
-var server_1 = require("./server"), nameSpaceBinding = server_1;
+var nameSpaceBinding = require("./server");
 exports.x = new nameSpaceBinding.a();
 
 

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBindingDts1.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBindingDts1.js
@@ -23,7 +23,6 @@ define(["require", "exports"], function (require, exports) {
 //// [client.js]
 define(["require", "exports", "server"], function (require, exports, server_1) {
     "use strict";
-    var nameSpaceBinding = server_1;
     exports.x = new server_1.default();
 });
 

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5.js
@@ -13,7 +13,7 @@ var x: number = nameSpaceBinding.a;
 exports.a = 10;
 //// [es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_1.js]
 "use strict";
-var es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0_1 = require("./es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0"), nameSpaceBinding = es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0_1;
+var nameSpaceBinding = require("./es6ImportDefaultBindingFollowedWithNamespaceBindingInEs5_0");
 var x = nameSpaceBinding.a;
 
 

--- a/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBindingWithExport.js
+++ b/tests/baselines/reference/es6ImportDefaultBindingFollowedWithNamespaceBindingWithExport.js
@@ -13,7 +13,7 @@ export var x: number = nameSpaceBinding.a;
 exports.a = 10;
 //// [client.js]
 "use strict";
-var server_1 = require("./server"), nameSpaceBinding = server_1;
+var nameSpaceBinding = require("./server");
 exports.x = nameSpaceBinding.a;
 
 

--- a/tests/baselines/reference/importDeclWithDeclareModifier.js
+++ b/tests/baselines/reference/importDeclWithDeclareModifier.js
@@ -9,4 +9,5 @@ var b: a;
 
 //// [importDeclWithDeclareModifier.js]
 "use strict";
+exports.a = x.c;
 var b;

--- a/tests/baselines/reference/transpile/Report an error when compiler-options module-kind is out-of-range.js
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options module-kind is out-of-range.js
@@ -1,1 +1,2 @@
+"use strict";
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Report an error when compiler-options target-script is out-of-range.js
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options target-script is out-of-range.js
@@ -1,1 +1,2 @@
+"use strict";
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/typeAliasDeclarationEmit.js
+++ b/tests/baselines/reference/typeAliasDeclarationEmit.js
@@ -6,6 +6,7 @@ export type CallbackArray<T extends callback> = () => T;
 
 //// [typeAliasDeclarationEmit.js]
 define(["require", "exports"], function (require, exports) {
+    "use strict";
 });
 
 

--- a/tests/baselines/reference/typeAliasDeclarationEmit2.js
+++ b/tests/baselines/reference/typeAliasDeclarationEmit2.js
@@ -4,6 +4,7 @@ export type A<a> = { value: a };
 
 //// [typeAliasDeclarationEmit2.js]
 define(["require", "exports"], function (require, exports) {
+    "use strict";
 });
 
 


### PR DESCRIPTION
This change consolidates Import and Export elision into the `ts` transformation, rather than duplicating the effort in the `es6`, `module`, and `system` module transforms.