### PR TITLE
Add restrictions to IsGlobalCompletion

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1082,6 +1082,7 @@ namespace ts.Completions {
                 isGlobalCompletion =
                     scopeNode.kind === SyntaxKind.SourceFile ||
                     scopeNode.kind === SyntaxKind.TemplateExpression ||
+                    scopeNode.kind === SyntaxKind.JsxExpression ||
                     isStatement(scopeNode);
             }
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1,3 +1,5 @@
+/// <reference path='../compiler/utilities.ts' />
+
 /* @internal */
 namespace ts.Completions {
     export function getCompletionsAtPosition(host: LanguageServiceHost, typeChecker: TypeChecker, log: (message: string) => void, compilerOptions: CompilerOptions, sourceFile: SourceFile, position: number): CompletionInfo {
@@ -951,7 +953,6 @@ namespace ts.Completions {
             if (!tryGetGlobalSymbols()) {
                 return undefined;
             }
-            isGlobalCompletion = true;
         }
 
         log("getCompletionData: Semantic work: " + (timestamp() - semanticStart));
@@ -1030,7 +1031,6 @@ namespace ts.Completions {
                 if ((jsxContainer.kind === SyntaxKind.JsxSelfClosingElement) || (jsxContainer.kind === SyntaxKind.JsxOpeningElement)) {
                     // Cursor is inside a JSX self-closing element or opening element
                     attrsType = typeChecker.getJsxElementAttributesType(<JsxOpeningLikeElement>jsxContainer);
-                    isGlobalCompletion = false;
 
                     if (attrsType) {
                         symbols = filterJsxAttributes(typeChecker.getPropertiesOfType(attrsType), (<JsxOpeningLikeElement>jsxContainer).attributes);
@@ -1038,7 +1038,6 @@ namespace ts.Completions {
                         isNewIdentifierLocation = false;
                         return true;
                     }
-
                 }
             }
 
@@ -1079,6 +1078,12 @@ namespace ts.Completions {
                 position;
 
             const scopeNode = getScopeNode(contextToken, adjustedPosition, sourceFile) || sourceFile;
+            if (scopeNode) {
+                isGlobalCompletion =
+                    scopeNode.kind === SyntaxKind.SourceFile ||
+                    scopeNode.kind === SyntaxKind.TemplateExpression ||
+                    isStatement(scopeNode);
+            }
 
             /// TODO filter meaning based on the current context
             const symbolMeanings = SymbolFlags.Type | SymbolFlags.Value | SymbolFlags.Namespace | SymbolFlags.Alias;

--- a/tests/cases/fourslash/completionListIsGlobalCompletion.ts
+++ b/tests/cases/fourslash/completionListIsGlobalCompletion.ts
@@ -33,6 +33,7 @@
 ////const y = <div /*12*/ />; // no globals in jsx attribute found
 ////const z = <div =/*13*/ />; // no globals in jsx attribute with syntax error
 ////const x = `/*14*/ ${/*15*/}`; // globals only in template expression
+////var user = </*16*/User name=/*17*/{ /*18*/window.isLoggedIn ? window.name : '/*19*/'} />; // globals only in JSX expression (but not in JSX expression strings)
 goTo.marker("1");
 verify.completionListIsGlobal(false);
 goTo.marker("2");
@@ -63,3 +64,11 @@ goTo.marker("14");
 verify.completionListIsGlobal(false);
 goTo.marker("15");
 verify.completionListIsGlobal(true);
+goTo.marker("16");
+verify.completionListIsGlobal(false);
+goTo.marker("17");
+verify.completionListIsGlobal(false);
+goTo.marker("18");
+verify.completionListIsGlobal(true);
+goTo.marker("19");
+verify.completionListIsGlobal(false);

--- a/tests/cases/fourslash/completionListIsGlobalCompletion.ts
+++ b/tests/cases/fourslash/completionListIsGlobalCompletion.ts
@@ -1,27 +1,38 @@
 /// <reference path='fourslash.ts'/>
 
+// @Filename: file.ts
+////export var x = 10;
+////export var y = 10;
+////export default class C {
+////}
+
+// @Filename: a.ts
+////import { /*1*/ } from "./file.ts";  // no globals in imports - export found
+
 //@Filename: file.tsx
-/////// <reference path="/*1*/..\services\services.ts" /> // no globals in reference paths
-////import { /*2*/ } from "./file.ts";  // no globals in imports
-////var test = "/*3*/"; // no globals in strings
-/////*4*/class A { // insert globals
+/////// <reference path="/*2*/..\services\services.ts" /> // no globals in reference paths
+////import { /*3*/ } from "./file1.ts";  // no globals in imports - export not found
+////var test = "/*4*/"; // no globals in strings
+/////*5*/class A { // insert globals
 ////    foo(): string { return ''; }
 ////}
 ////
-////class /*5*/B extends A { // no globals after class keyword
+////class /*6*/B extends A { // no globals after class keyword
 ////    bar(): string {
-//// /*6*/ // insert globals
+//// /*7*/ // insert globals
 ////        return '';
 ////    }
 ////}
 ////
-////class C</*7*/ U extends A, T extends A> { // no globals at beginning of generics
+////class C</*8*/ U extends A, T extends A> { // no globals at beginning of generics
 ////    x: U;
-////    y = this./*8*/x; // no globals inserted for member completions
-////   /*9*/ // insert globals
+////    y = this./*9*/x; // no globals inserted for member completions
+////   /*10*/ // insert globals
 ////}
-/////*10*/ // insert globals
-////const y = <div /*11*/ />;
+/////*11*/ // insert globals
+////const y = <div /*12*/ />; // no globals in jsx attribute found
+////const z = <div =/*13*/ />; // no globals in jsx attribute with syntax error
+////const x = `/*14*/ ${/*15*/}`; // globals only in template expression
 goTo.marker("1");
 verify.completionListIsGlobal(false);
 goTo.marker("2");
@@ -29,18 +40,26 @@ verify.completionListIsGlobal(false);
 goTo.marker("3");
 verify.completionListIsGlobal(false);
 goTo.marker("4");
-verify.completionListIsGlobal(true);
+verify.completionListIsGlobal(false);
 goTo.marker("5");
-verify.completionListIsGlobal(false);
-goTo.marker("6");
 verify.completionListIsGlobal(true);
-goTo.marker("7");
+goTo.marker("6");
 verify.completionListIsGlobal(false);
+goTo.marker("7");
+verify.completionListIsGlobal(true);
 goTo.marker("8");
 verify.completionListIsGlobal(false);
 goTo.marker("9");
-verify.completionListIsGlobal(true);
+verify.completionListIsGlobal(false);
 goTo.marker("10");
 verify.completionListIsGlobal(true);
 goTo.marker("11");
+verify.completionListIsGlobal(true);
+goTo.marker("12");
 verify.completionListIsGlobal(false);
+goTo.marker("13");
+verify.completionListIsGlobal(false);
+goTo.marker("14");
+verify.completionListIsGlobal(false);
+goTo.marker("15");
+verify.completionListIsGlobal(true);


### PR DESCRIPTION
JS/TS snippets are showing up in undesirable locations in VS
ex:  import { | } from "./files1"

Restrict IsGlobalCompletion to:
- SourceFile
- Template Expression
- Statements