### PR TITLE
Include the correct file by default

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4172,7 +4172,7 @@ namespace ts {
             case ScriptTarget.ES2016:
                 return "lib.es2016.d.ts";
             case ScriptTarget.ES2015:
-                return "lib.es2015.d.ts";
+                return "lib.es6.d.ts";
 
             default:
                 return "lib.d.ts";


### PR DESCRIPTION
https://github.com/Microsoft/TypeScript/pull/11407 changed the default lib file for `--target ES6` to be lib.es2015.d.ts instead of `lib.es6.d.ts` and that broke DT tests. restoring the default.

// cc @zhengbli 