### PR TITLE
TSServer: Add isSemantic check to getDiagnosticsWorker

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -389,9 +389,9 @@ namespace ts.server {
             });
         }
 
-        private getDiagnosticsWorker(args: protocol.FileRequestArgs, selector: (project: Project, file: string) => Diagnostic[], includeLinePosition: boolean) {
+        private getDiagnosticsWorker(args: protocol.FileRequestArgs, isSemantic: boolean, selector: (project: Project, file: string) => Diagnostic[], includeLinePosition: boolean) {
             const { project, file } = this.getFileAndProject(args);
-            if (shouldSkipSematicCheck(project)) {
+            if (isSemantic && shouldSkipSematicCheck(project)) {
                 return [];
             }
             const scriptInfo = project.getScriptInfoForNormalizedPath(file);
@@ -492,11 +492,11 @@ namespace ts.server {
         }
 
         private getSyntacticDiagnosticsSync(args: protocol.SyntacticDiagnosticsSyncRequestArgs): protocol.Diagnostic[] | protocol.DiagnosticWithLinePosition[] {
-            return this.getDiagnosticsWorker(args, (project, file) => project.getLanguageService().getSyntacticDiagnostics(file), args.includeLinePosition);
+            return this.getDiagnosticsWorker(args, /*isSemantic*/ false, (project, file) => project.getLanguageService().getSyntacticDiagnostics(file), args.includeLinePosition);
         }
 
         private getSemanticDiagnosticsSync(args: protocol.SemanticDiagnosticsSyncRequestArgs): protocol.Diagnostic[] | protocol.DiagnosticWithLinePosition[] {
-            return this.getDiagnosticsWorker(args, (project, file) => project.getLanguageService().getSemanticDiagnostics(file), args.includeLinePosition);
+            return this.getDiagnosticsWorker(args, /*isSemantic*/ true, (project, file) => project.getLanguageService().getSemanticDiagnostics(file), args.includeLinePosition);
         }
 
         private getDocumentHighlights(args: protocol.DocumentHighlightsRequestArgs, simplifiedResult: boolean): protocol.DocumentHighlightsItem[] | DocumentHighlights[] {

--- a/tests/cases/fourslash/server/getJavaScriptSyntacticDiagnostics01.ts
+++ b/tests/cases/fourslash/server/getJavaScriptSyntacticDiagnostics01.ts
@@ -1,0 +1,23 @@
+/// <reference path="../fourslash.ts" />
+
+// @allowJs: true
+// @Filename: a.js
+//// var ===;
+
+verify.getSyntacticDiagnostics(`[
+  {
+    "message": "Variable declaration expected.",
+    "start": 4,
+    "length": 3,
+    "category": "error",
+    "code": 1134
+  },
+  {
+    "message": "Expression expected.",
+    "start": 7,
+    "length": 1,
+    "category": "error",
+    "code": 1109
+  }
+]`);
+verify.getSemanticDiagnostics(`[]`);


### PR DESCRIPTION
Adding isSemantic check to getDiagnosticsWorker() so that the shouldSkipSematicCheck is only applied to semantic diagnostics. 