### PR TITLE
Support dotted name in @typedef tag

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -434,8 +434,8 @@ namespace ts {
                 //       during global merging in the checker. Why? The only case when ambient module is permitted inside another module is module augmentation
                 //       and this case is specially handled. Module augmentations should only be merged with original module definition
                 //       and should never be merged directly with other augmentation, and the latter case would be possible if automatic merge is allowed.
-                const isJSDocTypedefInJSDocNamespace = node.kind === SyntaxKind.JSDocTypedefTag && 
-                    node.name && 
+                const isJSDocTypedefInJSDocNamespace = node.kind === SyntaxKind.JSDocTypedefTag &&
+                    node.name &&
                     node.name.kind === SyntaxKind.Identifier &&
                     (<Identifier>node.name).isInJSDocNamespace;
                 if ((!isAmbientModule(node) && (hasExportModifier || container.flags & NodeFlags.ExportContext)) || isJSDocTypedefInJSDocNamespace) {
@@ -1798,7 +1798,7 @@ namespace ts {
                 case SyntaxKind.Identifier:
                     // for typedef type names with namespaces, bind the new jsdoc type symbol here
                     // because it requires all containing namespaces to be in effect, namely the
-                    // current "blockScopeContainer" needs to be set to its immediate namespace parent. 
+                    // current "blockScopeContainer" needs to be set to its immediate namespace parent.
                     if ((<Identifier>node).isInJSDocNamespace) {
                         let parentNode = node.parent;
                         while (parentNode && parentNode.kind !== SyntaxKind.JSDocTypedefTag) {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -411,6 +411,7 @@ namespace ts {
                 return visitNodes(cbNodes, (<JSDocTemplateTag>node).typeParameters);
             case SyntaxKind.JSDocTypedefTag:
                 return visitNode(cbNode, (<JSDocTypedefTag>node).typeExpression) ||
+                    visitNode(cbNode, (<JSDocTypedefTag>node).fullName) ||
                     visitNode(cbNode, (<JSDocTypedefTag>node).name) ||
                     visitNode(cbNode, (<JSDocTypedefTag>node).jsDocTypeLiteral);
             case SyntaxKind.JSDocTypeLiteral:
@@ -6552,7 +6553,14 @@ namespace ts {
                     const typedefTag = <JSDocTypedefTag>createNode(SyntaxKind.JSDocTypedefTag, atToken.pos);
                     typedefTag.atToken = atToken;
                     typedefTag.tagName = tagName;
-                    typedefTag.name = parseJSDocIdentifierName();
+                    typedefTag.fullName = parseJSDocTypeNameWithNamespace(/*flags*/ 0);
+                    if (typedefTag.fullName) {
+                        let rightNode = typedefTag.fullName;
+                        while (rightNode.kind !== SyntaxKind.Identifier) {
+                            rightNode = rightNode.body;
+                        }
+                        typedefTag.name = rightNode;
+                    }
                     typedefTag.typeExpression = typeExpression;
                     skipWhitespace();
 
@@ -6614,6 +6622,22 @@ namespace ts {
                         }
                         scanner.setTextPos(resumePos);
                         return finishNode(jsDocTypeLiteral);
+                    }
+
+                    function parseJSDocTypeNameWithNamespace(flags: NodeFlags) {
+                        const pos = scanner.getTokenPos();
+                        const typeNameOrNamespaceName = parseJSDocIdentifierName();
+
+                        if (typeNameOrNamespaceName && parseOptional(SyntaxKind.DotToken)) {
+                            const jsDocNamespaceNode = <JSDocNamespaceDeclaration>createNode(SyntaxKind.ModuleDeclaration, pos);
+                            jsDocNamespaceNode.flags |= flags;
+                            jsDocNamespaceNode.name = typeNameOrNamespaceName;
+                            jsDocNamespaceNode.body = parseJSDocTypeNameWithNamespace(NodeFlags.NestedNamespace | flags);
+                            return jsDocNamespaceNode;
+                        }
+                        else {
+                            return typeNameOrNamespaceName;
+                        }
                     }
                 }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6637,7 +6637,7 @@ namespace ts {
                         }
 
                         if (typeNameOrNamespaceName && flags & NodeFlags.NestedNamespace) {
-                            typeNameOrNamespaceName.flags |= NodeFlags.InJSDocNamespace;
+                            typeNameOrNamespaceName.isInJSDocNamespace = true;
                         }
                         return typeNameOrNamespaceName;
                     }

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6632,14 +6632,17 @@ namespace ts {
                             const jsDocNamespaceNode = <JSDocNamespaceDeclaration>createNode(SyntaxKind.ModuleDeclaration, pos);
                             jsDocNamespaceNode.flags |= flags;
                             jsDocNamespaceNode.name = typeNameOrNamespaceName;
-                            jsDocNamespaceNode.body = parseJSDocTypeNameWithNamespace(NodeFlags.NestedNamespace | flags);
+                            jsDocNamespaceNode.body = parseJSDocTypeNameWithNamespace(NodeFlags.NestedNamespace);
                             return jsDocNamespaceNode;
                         }
-                        else {
-                            return typeNameOrNamespaceName;
+
+                        if (typeNameOrNamespaceName && flags & NodeFlags.NestedNamespace) {
+                            typeNameOrNamespaceName.flags |= NodeFlags.InJSDocNamespace;
                         }
+                        return typeNameOrNamespaceName;
                     }
                 }
+
 
                 function tryParseChildTag(parentTag: JSDocTypeLiteral): boolean {
                     Debug.assert(token() === SyntaxKind.AtToken);

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1799,6 +1799,9 @@ namespace ts {
                 case CharacterCodes.comma:
                     pos++;
                     return token = SyntaxKind.CommaToken;
+                case CharacterCodes.dot:
+                    pos++;
+                    return token = SyntaxKind.DotToken;
             }
 
             if (isIdentifierStart(ch, ScriptTarget.Latest)) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1632,12 +1632,17 @@ namespace ts {
     export interface ModuleDeclaration extends DeclarationStatement {
         kind: SyntaxKind.ModuleDeclaration;
         name: Identifier | LiteralExpression;
-        body?: ModuleBlock | NamespaceDeclaration;
+        body?: ModuleBlock | NamespaceDeclaration | JSDocNamespaceDeclaration | Identifier;
     }
 
     export interface NamespaceDeclaration extends ModuleDeclaration {
         name: Identifier;
         body: ModuleBlock | NamespaceDeclaration;
+    }
+
+    export interface JSDocNamespaceDeclaration extends ModuleDeclaration {
+        name: Identifier;
+        body: JSDocNamespaceDeclaration | Identifier;
     }
 
     export interface ModuleBlock extends Node, Statement {
@@ -1869,6 +1874,7 @@ namespace ts {
 
     export interface JSDocTypedefTag extends JSDocTag, Declaration {
         kind: SyntaxKind.JSDocTypedefTag;
+        fullName?: JSDocNamespaceDeclaration | Identifier;
         name?: Identifier;
         typeExpression?: JSDocTypeExpression;
         jsDocTypeLiteral?: JSDocTypeLiteral;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -422,6 +422,7 @@ namespace ts {
         JavaScriptFile =     1 << 20, // If node was parsed in a JavaScript
         ThisNodeOrAnySubNodesHasError = 1 << 21, // If this node or any of its children had an error
         HasAggregatedChildData = 1 << 22, // If we've computed data from children and cached it in this node
+        InJSDocNamespace = 1 << 23, // if the node is a member in a JSDoc namespace
 
         BlockScoped = Let | Const,
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -421,8 +421,7 @@ namespace ts {
         ThisNodeHasError =   1 << 19, // If the parser encountered an error when parsing the code that created this node
         JavaScriptFile =     1 << 20, // If node was parsed in a JavaScript
         ThisNodeOrAnySubNodesHasError = 1 << 21, // If this node or any of its children had an error
-        HasAggregatedChildData = 1 << 22, // If we've computed data from children and cached it in this node
-        InJSDocNamespace = 1 << 23, // if the node is a member in a JSDoc namespace
+        HasAggregatedChildData = 1 << 22, // If we've computed data from children and cached it in this node 
 
         BlockScoped = Let | Const,
 
@@ -544,6 +543,7 @@ namespace ts {
         originalKeywordKind?: SyntaxKind;              // Original syntaxKind which get set so that we can report an error later
         /*@internal*/ autoGenerateKind?: GeneratedIdentifierKind; // Specifies whether to auto-generate the text for an identifier.
         /*@internal*/ autoGenerateId?: number;         // Ensures unique generated identifiers get unique names, but clones get the same name.
+        isInJSDocNamespace?: boolean;                  // if the node is a member in a JSDoc namespace
     }
 
     // Transient identifier node (marked by id === -1)

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3034,7 +3034,7 @@ namespace ts {
             }
         }
 
-        if (node.flags & NodeFlags.NestedNamespace) {
+        if (node.flags & (NodeFlags.NestedNamespace | NodeFlags.InJSDocNamespace)) {
             flags |= ModifierFlags.Export;
         }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -3034,7 +3034,7 @@ namespace ts {
             }
         }
 
-        if (node.flags & (NodeFlags.NestedNamespace | NodeFlags.InJSDocNamespace)) {
+        if (node.flags & NodeFlags.NestedNamespace || (node.kind === SyntaxKind.Identifier && (<Identifier>node).isInJSDocNamespace)) {
             flags |= ModifierFlags.Export;
         }
 

--- a/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typedefTagWithChildrenTags.json
+++ b/tests/baselines/reference/JSDocParsing/DocComments.parsesCorrectly.typedefTagWithChildrenTags.json
@@ -18,6 +18,12 @@
                 "end": 16,
                 "text": "typedef"
             },
+            "fullName": {
+                "kind": "Identifier",
+                "pos": 17,
+                "end": 23,
+                "text": "People"
+            },
             "name": {
                 "kind": "Identifier",
                 "pos": 17,

--- a/tests/cases/fourslash/server/jsdocTypedefTagNamespace.ts
+++ b/tests/cases/fourslash/server/jsdocTypedefTagNamespace.ts
@@ -1,0 +1,27 @@
+/// <reference path="../fourslash.ts"/>
+
+// @allowNonTsExtensions: true
+// @Filename: jsdocCompletion_typedef.js
+
+//// /**
+////  * @typedef {string | number} T.NumberLike
+////  * @typedef {{age: number}} T.People
+////  * @typedef {string | number} T.O.Q.NumberLike
+////  * @type {T.NumberLike}
+////  */
+//// var x; x./*1*/;
+//// /** @type {T.O.Q.NumberLike} */
+//// var x1; x1./*2*/;
+//// /** @type {T.People} */
+//// var x1; x1./*3*/;
+
+goTo.marker("1");
+verify.memberListContains('charAt');
+verify.memberListContains('toExponential');
+
+goTo.marker("2");
+verify.memberListContains('age');
+
+goTo.marker("3");
+verify.memberListContains('charAt');
+verify.memberListContains('toExponential');


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
Adding support for qualified names as type names in JSDoc @typedef declarations.
So
```js
/** @typedef {string | number} A.B.TypeName */
```
is equal to
```ts
namespace A.B {
     export type TypeName = string | number;
}
```

Fixes #11413

