### PR TITLE
Use an ES5 target

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -448,6 +448,8 @@ function compileFile(outFile, sources, prereqs, prefixes, useBuiltCompiler, opts
             options += " --stripInternal";
         }
 
+        options += " --target es5";
+
         var cmd = host + " " + compilerPath + " " + options + " ";
         cmd = cmd + sources.join(" ");
         console.log(cmd + "\n");

--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -8,7 +8,8 @@
         "outFile": "../../built/local/tsc.js",
         "sourceMap": true,
         "declaration": true,
-        "stripInternal": true
+        "stripInternal": true,
+        "target": "es5"
     },
     "files": [
         "core.ts",

--- a/src/harness/tsconfig.json
+++ b/src/harness/tsconfig.json
@@ -10,7 +10,8 @@
         "stripInternal": true,
         "types": [
             "node", "mocha", "chai"
-        ]
+        ],
+        "target": "es5"
     },
     "files": [
         "../compiler/core.ts",

--- a/src/server/cancellationToken/tsconfig.json
+++ b/src/server/cancellationToken/tsconfig.json
@@ -10,7 +10,8 @@
         "stripInternal": true,
         "types": [
             "node"
-        ]
+        ],
+        "target": "es5"
     },
     "files": [
         "cancellationToken.ts"

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -10,7 +10,8 @@
         "stripInternal": true,
         "types": [
             "node"
-        ]
+        ],
+        "target": "es5"
     },
     "files": [
         "../services/shims.ts",

--- a/src/server/tsconfig.library.json
+++ b/src/server/tsconfig.library.json
@@ -7,7 +7,8 @@
         "sourceMap": true,
         "stripInternal": true,
         "declaration": true,
-        "types": []
+        "types": [],
+        "target": "es5"
     },
     "files": [
         "../services/shims.ts",

--- a/src/server/typingsInstaller/tsconfig.json
+++ b/src/server/typingsInstaller/tsconfig.json
@@ -10,7 +10,8 @@
         "stripInternal": true,
         "types": [
             "node"
-        ]
+        ],
+        "target": "es5"
     },
     "files": [
         "../types.d.ts",

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -9,7 +9,8 @@
         "sourceMap": true,
         "stripInternal": true,
         "noResolve": false,
-        "declaration": true
+        "declaration": true,
+        "target": "es5"
     },
     "files": [
         "../compiler/core.ts",


### PR DESCRIPTION
This doesn't have much of an effect other than adding trailing commas to output object literals. But since we're using ES5-specific functionality already (`Object.create`), we might as well make it official.

Incidentally, I noticed that our gulp output doesn't include comments but our jake output does. Also, our jake output has `//# sourceMappingURL=file:///C:/Users/anhans/work/TypeScript/built/local/tsc.js.map` while our gulp output just has `//# sourceMappingURL=tsc.js.map`.