### PR TITLE
Use single `concat` call instead of repeated calls

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -766,7 +766,7 @@ namespace ts {
                 const fileProcessingDiagnosticsInFile = fileProcessingDiagnostics.getDiagnostics(sourceFile.fileName);
                 const programDiagnosticsInFile = programDiagnostics.getDiagnostics(sourceFile.fileName);
 
-                return bindDiagnostics.concat(checkDiagnostics).concat(fileProcessingDiagnosticsInFile).concat(programDiagnosticsInFile);
+                return bindDiagnostics.concat(checkDiagnostics, fileProcessingDiagnosticsInFile, programDiagnosticsInFile);
             });
         }
 


### PR DESCRIPTION
We already do this in `getPreEmitDiagnostics`.
