### PR TITLE
Don't perform ASI before `as` if it's followed by an identifier (allow `foo \n as Foo`)

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3247,7 +3247,7 @@ namespace ts {
                     //    as (Bar)
                     // This should be parsed as an initialized variable, followed
                     // by a function call to 'as' with the argument 'Bar'
-                    if (scanner.hasPrecedingLineBreak()) {
+                    if (scanner.hasPrecedingLineBreak() && !lookAhead(nextTokenIsIdentifierOnSameLine)) {
                         break;
                     }
                     else {

--- a/tests/baselines/reference/asOperatorASI.js
+++ b/tests/baselines/reference/asOperatorASI.js
@@ -10,6 +10,9 @@ as `Hello world`; // should not error
 var y = 20
 as(Foo); // should emit
 
+var z = 30
+as number; // should be a type assertion
+
 
 //// [asOperatorASI.js]
 var Foo = (function () {
@@ -23,4 +26,5 @@ var x = 10;
 // Example 2
 var y = 20;
 as(Foo); // should emit
+var z = 30; // should be a type assertion
 var _a;

--- a/tests/baselines/reference/asOperatorASI.symbols
+++ b/tests/baselines/reference/asOperatorASI.symbols
@@ -21,3 +21,8 @@ as(Foo); // should emit
 >as : Symbol(as, Decl(asOperatorASI.ts, 0, 13))
 >Foo : Symbol(Foo, Decl(asOperatorASI.ts, 0, 0))
 
+var z = 30
+>z : Symbol(z, Decl(asOperatorASI.ts, 11, 3))
+
+as number; // should be a type assertion
+

--- a/tests/baselines/reference/asOperatorASI.types
+++ b/tests/baselines/reference/asOperatorASI.types
@@ -26,3 +26,10 @@ as(Foo); // should emit
 >as : (...args: any[]) => any
 >Foo : typeof Foo
 
+var z = 30
+>z : number
+>30as number : number
+>30 : 30
+
+as number; // should be a type assertion
+

--- a/tests/cases/conformance/expressions/asOperator/asOperatorASI.ts
+++ b/tests/cases/conformance/expressions/asOperator/asOperatorASI.ts
@@ -8,3 +8,6 @@ as `Hello world`; // should not error
 // Example 2
 var y = 20
 as(Foo); // should emit
+
+var z = 30
+as number; // should be a type assertion


### PR DESCRIPTION
Fixes #11369