### PR TITLE
Use symbol fully-qualified name instead of node text in error message

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17189,7 +17189,7 @@ namespace ts {
                 if (declaration && getModifierFlags(declaration) & ModifierFlags.Private) {
                     const typeClassDeclaration = <ClassLikeDeclaration>getClassLikeDeclarationOfSymbol(type.symbol);
                     if (!isNodeWithinClass(node, typeClassDeclaration)) {
-                        error(node, Diagnostics.Cannot_extend_a_class_0_Class_constructor_is_marked_as_private, (<Identifier>node.expression).text);
+                        error(node, Diagnostics.Cannot_extend_a_class_0_Class_constructor_is_marked_as_private, getFullyQualifiedName(type.symbol));
                     }
                 }
             }

--- a/tests/baselines/reference/extendPrivateConstructorClass.errors.txt
+++ b/tests/baselines/reference/extendPrivateConstructorClass.errors.txt
@@ -1,0 +1,15 @@
+tests/cases/compiler/extendPrivateConstructorClass.ts(7,17): error TS2675: Cannot extend a class 'abc.XYZ'. Class constructor is marked as private.
+
+
+==== tests/cases/compiler/extendPrivateConstructorClass.ts (1 errors) ====
+    declare namespace abc {
+        class XYZ {
+            private constructor();
+        }
+    }
+    
+    class C extends abc.XYZ {
+                    ~~~~~~~
+!!! error TS2675: Cannot extend a class 'abc.XYZ'. Class constructor is marked as private.
+    }
+    

--- a/tests/baselines/reference/extendPrivateConstructorClass.js
+++ b/tests/baselines/reference/extendPrivateConstructorClass.js
@@ -1,0 +1,24 @@
+//// [extendPrivateConstructorClass.ts]
+declare namespace abc {
+    class XYZ {
+        private constructor();
+    }
+}
+
+class C extends abc.XYZ {
+}
+
+
+//// [extendPrivateConstructorClass.js]
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var C = (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super.apply(this, arguments) || this;
+    }
+    return C;
+}(abc.XYZ));

--- a/tests/cases/compiler/extendPrivateConstructorClass.ts
+++ b/tests/cases/compiler/extendPrivateConstructorClass.ts
@@ -1,0 +1,8 @@
+declare namespace abc {
+    class XYZ {
+        private constructor();
+    }
+}
+
+class C extends abc.XYZ {
+}


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[x ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[x ] Code is up-to-date with the `master` branch
[x ] You've successfully run `jake runtests` locally (*gulp runtests-browser)
[x ] You've signed the CLA
[x ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

The error message when extending a private constructor shows "undefined" when property-access expressions are used in the extends clause. Using the fully qualified name of the symbol instead fixes it.

Fixes #11726.
