### PR TITLE
Fix #11545 ('export as namespace foo' occurs EOF without semicolon)

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -5472,7 +5472,7 @@ namespace ts {
 
             exportDeclaration.name = parseIdentifier();
 
-            parseExpected(SyntaxKind.SemicolonToken);
+            parseSemicolon();
 
             return finishNode(exportDeclaration);
         }

--- a/tests/baselines/reference/exportAsNamespace.d.symbols
+++ b/tests/baselines/reference/exportAsNamespace.d.symbols
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/exportAsNamespace.d.ts ===
+// issue: https://github.com/Microsoft/TypeScript/issues/11545
+
+export var X;
+>X : Symbol(X, Decl(exportAsNamespace.d.ts, 2, 10))
+
+export as namespace N
+>N : Symbol(N, Decl(exportAsNamespace.d.ts, 2, 13))
+

--- a/tests/baselines/reference/exportAsNamespace.d.types
+++ b/tests/baselines/reference/exportAsNamespace.d.types
@@ -1,0 +1,9 @@
+=== tests/cases/compiler/exportAsNamespace.d.ts ===
+// issue: https://github.com/Microsoft/TypeScript/issues/11545
+
+export var X;
+>X : any
+
+export as namespace N
+>N : typeof N
+

--- a/tests/cases/compiler/exportAsNamespace.d.ts
+++ b/tests/cases/compiler/exportAsNamespace.d.ts
@@ -1,0 +1,4 @@
+// issue: https://github.com/Microsoft/TypeScript/issues/11545
+
+export var X;
+export as namespace N


### PR DESCRIPTION
#11545 