### PR TITLE
Fix #10108 (Completion suggestion for object literal with getter)

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1591,7 +1591,8 @@ namespace ts.Completions {
                     m.kind !== SyntaxKind.ShorthandPropertyAssignment &&
                     m.kind !== SyntaxKind.BindingElement &&
                     m.kind !== SyntaxKind.MethodDeclaration &&
-                    m.kind !== SyntaxKind.GetAccessor) {
+                    m.kind !== SyntaxKind.GetAccessor &&
+                    m.kind !== SyntaxKind.SetAccessor) {
                     continue;
                 }
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1590,7 +1590,8 @@ namespace ts.Completions {
                 if (m.kind !== SyntaxKind.PropertyAssignment &&
                     m.kind !== SyntaxKind.ShorthandPropertyAssignment &&
                     m.kind !== SyntaxKind.BindingElement &&
-                    m.kind !== SyntaxKind.MethodDeclaration) {
+                    m.kind !== SyntaxKind.MethodDeclaration &&
+                    m.kind !== SyntaxKind.GetAccessor) {
                     continue;
                 }
 

--- a/tests/cases/fourslash/server/completions03.ts
+++ b/tests/cases/fourslash/server/completions03.ts
@@ -5,13 +5,16 @@
 //// interface Foo {
 ////    one: any;
 ////    two: any;
+////    three: any;
 //// }
 ////
 //// let x: Foo = {
 ////     get one() { return "" },
+////     set two(t) {},
 ////     /**/
 //// }
 
 goTo.marker("");
-verify.completionListContains("two");
+verify.completionListContains("three");
 verify.not.completionListContains("one");
+verify.not.completionListContains("two");

--- a/tests/cases/fourslash/server/completions03.ts
+++ b/tests/cases/fourslash/server/completions03.ts
@@ -1,0 +1,17 @@
+/// <reference path="../fourslash.ts"/>
+
+// issue: https://github.com/Microsoft/TypeScript/issues/10108
+
+//// interface Foo {
+////    one: any;
+////    two: any;
+//// }
+////
+//// let x: Foo = {
+////     get one() { return "" },
+////     /**/
+//// }
+
+goTo.marker("");
+verify.completionListContains("two");
+verify.not.completionListContains("one");


### PR DESCRIPTION
Fixes #10108

Test looks strange. But it has a reason. I want test it via `verify.completionListIsEmpty()`, but I have error:
```
1) fourslash-server tests tests/cases/fourslash/server/completions03.ts fourslash-server test completions03.ts runs correctly:
     Error: Error No content available.
      at SessionClient.processResponse (built/local/run.js:82207:27)
```
So I use interface with two properties in test.