### PR TITLE
Allow untyped imports

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1401,7 +1401,7 @@ namespace ts {
                 if (compilerOptions.noImplicitAny) {
                     if (moduleNotFoundError) {
                         error(errorNode,
-                            Diagnostics.A_package_for_0_was_found_at_1_but_is_untyped_Because_noImplicitAny_is_enabled_this_package_must_have_a_declaration,
+                            Diagnostics.Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type,
                             moduleReference,
                             resolvedModule.resolvedFileName);
                     }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2869,10 +2869,6 @@
         "category": "Error",
         "code": 6143
     },
-    "A package for '{0}' was found at '{1}', but is untyped. Because '--noImplicitAny' is enabled, this package must have a declaration.": {
-        "category": "Error",
-        "code": 6144
-    },
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",
         "code": 7005
@@ -2904,6 +2900,10 @@
     "Element implicitly has an 'any' type because index expression is not of type 'number'.": {
         "category": "Error",
         "code": 7015
+    },
+    "Could not find a declaration file for module '{0}'. '{1}' implicitly has an 'any' type.": {
+        "category": "Error",
+        "code": 7016
     },
     "Index signature of object type implicitly has an 'any' type.": {
         "category": "Error",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2869,6 +2869,10 @@
         "category": "Error",
         "code": 6143
     },
+    "A package for '{0}' was found at '{1}', but is untyped. Because '--noImplicitAny' is enabled, this package must have a declaration.": {
+        "category": "Error",
+        "code": 6144
+    },
     "Variable '{0}' implicitly has an '{1}' type.": {
         "category": "Error",
         "code": 7005

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1324,6 +1324,7 @@ namespace ts {
                     // - it's not a top level JavaScript module that exceeded the search max
                     const elideImport = isJsFileFromNodeModules && currentNodeModulesDepth > maxNodeModuleJsDepth;
                     // Don't add the file if it has a bad extension (e.g. 'tsx' if we don't have '--allowJs')
+                    // This may still end up being an untyped module -- the file won't be included but imports will be allowed.
                     const shouldAddFile = resolvedFileName && !getResolutionDiagnostic(options, resolution) && !options.noResolve && i < file.imports.length && !elideImport;
 
                     if (elideImport) {
@@ -1571,8 +1572,9 @@ namespace ts {
 
     /* @internal */
     /**
-     * Returns a DiagnosticMessage if we can't use a resolved module due to its extension.
+     * Returns a DiagnosticMessage if we won't include a resolved module due to its extension.
      * The DiagnosticMessage's parameters are the imported module name, and the filename it resolved to.
+     * This returns a diagnostic even if the module will be an untyped module.
      */
     export function getResolutionDiagnostic(options: CompilerOptions, { extension }: ResolvedModule): DiagnosticMessage | undefined {
         switch (extension) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -406,8 +406,9 @@ namespace ts {
             ((<ModuleDeclaration>node).name.kind === SyntaxKind.StringLiteral || isGlobalScopeAugmentation(<ModuleDeclaration>node));
     }
 
-    export function isShorthandAmbientModuleSymbol(moduleSymbol: Symbol): boolean {
-        return isShorthandAmbientModule(moduleSymbol.valueDeclaration);
+    /** Given a symbol for a module, checks that it is either an untyped import or a shorthand ambient module. */
+    export function isUntypedModuleSymbol(moduleSymbol: Symbol): boolean {
+        return !moduleSymbol.valueDeclaration || isShorthandAmbientModule(moduleSymbol.valueDeclaration);
     }
 
     function isShorthandAmbientModule(node: Node): boolean {

--- a/tests/baselines/reference/untypedModuleImport.js
+++ b/tests/baselines/reference/untypedModuleImport.js
@@ -1,0 +1,37 @@
+//// [tests/cases/conformance/moduleResolution/untypedModuleImport.ts] ////
+
+//// [index.js]
+// This tests that importing from a JS file globally works in an untyped way.
+// (Assuming we don't have `--noImplicitAny` or `--allowJs`.)
+
+This file is not processed.
+
+//// [a.ts]
+import * as foo from "foo";
+foo.bar();
+
+//// [b.ts]
+import foo = require("foo");
+foo();
+
+//// [c.ts]
+import foo, { bar } from "foo";
+import "./a";
+import "./b";
+foo(bar());
+
+
+//// [a.js]
+"use strict";
+var foo = require("foo");
+foo.bar();
+//// [b.js]
+"use strict";
+var foo = require("foo");
+foo();
+//// [c.js]
+"use strict";
+var foo_1 = require("foo");
+require("./a");
+require("./b");
+foo_1["default"](foo_1.bar());

--- a/tests/baselines/reference/untypedModuleImport.symbols
+++ b/tests/baselines/reference/untypedModuleImport.symbols
@@ -1,0 +1,25 @@
+=== /c.ts ===
+import foo, { bar } from "foo";
+>foo : Symbol(foo, Decl(c.ts, 0, 6))
+>bar : Symbol(bar, Decl(c.ts, 0, 13))
+
+import "./a";
+import "./b";
+foo(bar());
+>foo : Symbol(foo, Decl(c.ts, 0, 6))
+>bar : Symbol(bar, Decl(c.ts, 0, 13))
+
+=== /a.ts ===
+import * as foo from "foo";
+>foo : Symbol(foo, Decl(a.ts, 0, 6))
+
+foo.bar();
+>foo : Symbol(foo, Decl(a.ts, 0, 6))
+
+=== /b.ts ===
+import foo = require("foo");
+>foo : Symbol(foo, Decl(b.ts, 0, 0))
+
+foo();
+>foo : Symbol(foo, Decl(b.ts, 0, 0))
+

--- a/tests/baselines/reference/untypedModuleImport.types
+++ b/tests/baselines/reference/untypedModuleImport.types
@@ -1,0 +1,31 @@
+=== /c.ts ===
+import foo, { bar } from "foo";
+>foo : any
+>bar : any
+
+import "./a";
+import "./b";
+foo(bar());
+>foo(bar()) : any
+>foo : any
+>bar() : any
+>bar : any
+
+=== /a.ts ===
+import * as foo from "foo";
+>foo : any
+
+foo.bar();
+>foo.bar() : any
+>foo.bar : any
+>foo : any
+>bar : any
+
+=== /b.ts ===
+import foo = require("foo");
+>foo : any
+
+foo();
+>foo() : any
+>foo : any
+

--- a/tests/baselines/reference/untypedModuleImport_allowJs.js
+++ b/tests/baselines/reference/untypedModuleImport_allowJs.js
@@ -1,0 +1,16 @@
+//// [tests/cases/conformance/moduleResolution/untypedModuleImport_allowJs.ts] ////
+
+//// [index.js]
+// Same as untypedModuleImport.ts but with --allowJs, so the package will actually be typed.
+
+exports.default = { bar() { return 0; } }
+
+//// [a.ts]
+import foo from "foo";
+foo.bar();
+
+
+//// [a.js]
+"use strict";
+var foo_1 = require("foo");
+foo_1["default"].bar();

--- a/tests/baselines/reference/untypedModuleImport_allowJs.symbols
+++ b/tests/baselines/reference/untypedModuleImport_allowJs.symbols
@@ -1,0 +1,17 @@
+=== /a.ts ===
+import foo from "foo";
+>foo : Symbol(foo, Decl(a.ts, 0, 6))
+
+foo.bar();
+>foo.bar : Symbol(bar, Decl(index.js, 2, 19))
+>foo : Symbol(foo, Decl(a.ts, 0, 6))
+>bar : Symbol(bar, Decl(index.js, 2, 19))
+
+=== /node_modules/foo/index.js ===
+// Same as untypedModuleImport.ts but with --allowJs, so the package will actually be typed.
+
+exports.default = { bar() { return 0; } }
+>exports : Symbol(default, Decl(index.js, 0, 0))
+>default : Symbol(default, Decl(index.js, 0, 0))
+>bar : Symbol(bar, Decl(index.js, 2, 19))
+

--- a/tests/baselines/reference/untypedModuleImport_allowJs.types
+++ b/tests/baselines/reference/untypedModuleImport_allowJs.types
@@ -1,0 +1,22 @@
+=== /a.ts ===
+import foo from "foo";
+>foo : { bar(): number; }
+
+foo.bar();
+>foo.bar() : number
+>foo.bar : () => number
+>foo : { bar(): number; }
+>bar : () => number
+
+=== /node_modules/foo/index.js ===
+// Same as untypedModuleImport.ts but with --allowJs, so the package will actually be typed.
+
+exports.default = { bar() { return 0; } }
+>exports.default = { bar() { return 0; } } : { bar(): number; }
+>exports.default : any
+>exports : any
+>default : any
+>{ bar() { return 0; } } : { bar(): number; }
+>bar : () => number
+>0 : 0
+

--- a/tests/baselines/reference/untypedModuleImport_noImplicitAny.errors.txt
+++ b/tests/baselines/reference/untypedModuleImport_noImplicitAny.errors.txt
@@ -1,10 +1,10 @@
-/a.ts(1,22): error TS6144: A package for 'foo' was found at '/node_modules/foo/index.js', but is untyped. Because '--noImplicitAny' is enabled, this package must have a declaration.
+/a.ts(1,22): error TS7016: Could not find a declaration file for module 'foo'. '/node_modules/foo/index.js' implicitly has an 'any' type.
 
 
 ==== /a.ts (1 errors) ====
     import * as foo from "foo";
                          ~~~~~
-!!! error TS6144: A package for 'foo' was found at '/node_modules/foo/index.js', but is untyped. Because '--noImplicitAny' is enabled, this package must have a declaration.
+!!! error TS7016: Could not find a declaration file for module 'foo'. '/node_modules/foo/index.js' implicitly has an 'any' type.
     
 ==== /node_modules/foo/index.js (0 errors) ====
     // This tests that `--noImplicitAny` disables untyped modules.

--- a/tests/baselines/reference/untypedModuleImport_noImplicitAny.errors.txt
+++ b/tests/baselines/reference/untypedModuleImport_noImplicitAny.errors.txt
@@ -1,0 +1,13 @@
+/a.ts(1,22): error TS6144: A package for 'foo' was found at '/node_modules/foo/index.js', but is untyped. Because '--noImplicitAny' is enabled, this package must have a declaration.
+
+
+==== /a.ts (1 errors) ====
+    import * as foo from "foo";
+                         ~~~~~
+!!! error TS6144: A package for 'foo' was found at '/node_modules/foo/index.js', but is untyped. Because '--noImplicitAny' is enabled, this package must have a declaration.
+    
+==== /node_modules/foo/index.js (0 errors) ====
+    // This tests that `--noImplicitAny` disables untyped modules.
+    
+    This file is not processed.
+    

--- a/tests/baselines/reference/untypedModuleImport_noImplicitAny.js
+++ b/tests/baselines/reference/untypedModuleImport_noImplicitAny.js
@@ -1,0 +1,13 @@
+//// [tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny.ts] ////
+
+//// [index.js]
+// This tests that `--noImplicitAny` disables untyped modules.
+
+This file is not processed.
+
+//// [a.ts]
+import * as foo from "foo";
+
+
+//// [a.js]
+"use strict";

--- a/tests/baselines/reference/untypedModuleImport_noLocalImports.errors.txt
+++ b/tests/baselines/reference/untypedModuleImport_noLocalImports.errors.txt
@@ -1,0 +1,13 @@
+/a.ts(1,22): error TS6143: Module './foo' was resolved to '/foo.js', but '--allowJs' is not set.
+
+
+==== /a.ts (1 errors) ====
+    import * as foo from "./foo";
+                         ~~~~~~~
+!!! error TS6143: Module './foo' was resolved to '/foo.js', but '--allowJs' is not set.
+    
+==== /foo.js (0 errors) ====
+    // This tests that untyped module imports don't happen with local imports.
+    
+    This file is not processed.
+    

--- a/tests/baselines/reference/untypedModuleImport_noLocalImports.js
+++ b/tests/baselines/reference/untypedModuleImport_noLocalImports.js
@@ -1,0 +1,13 @@
+//// [tests/cases/conformance/moduleResolution/untypedModuleImport_noLocalImports.ts] ////
+
+//// [foo.js]
+// This tests that untyped module imports don't happen with local imports.
+
+This file is not processed.
+
+//// [a.ts]
+import * as foo from "./foo";
+
+
+//// [a.js]
+"use strict";

--- a/tests/baselines/reference/untypedModuleImport_vsAmbient.js
+++ b/tests/baselines/reference/untypedModuleImport_vsAmbient.js
@@ -1,0 +1,23 @@
+//// [tests/cases/conformance/moduleResolution/untypedModuleImport_vsAmbient.ts] ////
+
+//// [index.js]
+// This tests that an ambient module declaration overrides an untyped import.
+
+This file is not processed.
+
+//// [declarations.d.ts]
+declare module "foo" {
+    export const x: number;
+}
+
+//// [a.ts]
+/// <reference path="./declarations.d.ts" />
+import { x } from "foo";
+x;
+
+
+//// [a.js]
+"use strict";
+/// <reference path="./declarations.d.ts" />
+var foo_1 = require("foo");
+foo_1.x;

--- a/tests/baselines/reference/untypedModuleImport_vsAmbient.symbols
+++ b/tests/baselines/reference/untypedModuleImport_vsAmbient.symbols
@@ -1,0 +1,14 @@
+=== /a.ts ===
+/// <reference path="./declarations.d.ts" />
+import { x } from "foo";
+>x : Symbol(x, Decl(a.ts, 1, 8))
+
+x;
+>x : Symbol(x, Decl(a.ts, 1, 8))
+
+=== /declarations.d.ts ===
+declare module "foo" {
+    export const x: number;
+>x : Symbol(x, Decl(declarations.d.ts, 1, 16))
+}
+

--- a/tests/baselines/reference/untypedModuleImport_vsAmbient.types
+++ b/tests/baselines/reference/untypedModuleImport_vsAmbient.types
@@ -1,0 +1,14 @@
+=== /a.ts ===
+/// <reference path="./declarations.d.ts" />
+import { x } from "foo";
+>x : number
+
+x;
+>x : number
+
+=== /declarations.d.ts ===
+declare module "foo" {
+    export const x: number;
+>x : number
+}
+

--- a/tests/cases/conformance/moduleResolution/untypedModuleImport.ts
+++ b/tests/cases/conformance/moduleResolution/untypedModuleImport.ts
@@ -1,0 +1,21 @@
+// @noImplicitReferences: true
+// @currentDirectory: /
+// This tests that importing from a JS file globally works in an untyped way.
+// (Assuming we don't have `--noImplicitAny` or `--allowJs`.)
+
+// @filename: /node_modules/foo/index.js
+This file is not processed.
+
+// @filename: /a.ts
+import * as foo from "foo";
+foo.bar();
+
+// @filename: /b.ts
+import foo = require("foo");
+foo();
+
+// @filename: /c.ts
+import foo, { bar } from "foo";
+import "./a";
+import "./b";
+foo(bar());

--- a/tests/cases/conformance/moduleResolution/untypedModuleImport_allowJs.ts
+++ b/tests/cases/conformance/moduleResolution/untypedModuleImport_allowJs.ts
@@ -1,0 +1,12 @@
+// @noImplicitReferences: true
+// @currentDirectory: /
+// @allowJs: true
+// @maxNodeModuleJsDepth: 1
+// Same as untypedModuleImport.ts but with --allowJs, so the package will actually be typed.
+
+// @filename: /node_modules/foo/index.js
+exports.default = { bar() { return 0; } }
+
+// @filename: /a.ts
+import foo from "foo";
+foo.bar();

--- a/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny.ts
+++ b/tests/cases/conformance/moduleResolution/untypedModuleImport_noImplicitAny.ts
@@ -1,0 +1,10 @@
+// @noImplicitReferences: true
+// @currentDirectory: /
+// @noImplicitAny: true
+// This tests that `--noImplicitAny` disables untyped modules.
+
+// @filename: /node_modules/foo/index.js
+This file is not processed.
+
+// @filename: /a.ts
+import * as foo from "foo";

--- a/tests/cases/conformance/moduleResolution/untypedModuleImport_noLocalImports.ts
+++ b/tests/cases/conformance/moduleResolution/untypedModuleImport_noLocalImports.ts
@@ -1,0 +1,9 @@
+// @noImplicitReferences: true
+// @currentDirectory: /
+// This tests that untyped module imports don't happen with local imports.
+
+// @filename: /foo.js
+This file is not processed.
+
+// @filename: /a.ts
+import * as foo from "./foo";

--- a/tests/cases/conformance/moduleResolution/untypedModuleImport_vsAmbient.ts
+++ b/tests/cases/conformance/moduleResolution/untypedModuleImport_vsAmbient.ts
@@ -1,0 +1,16 @@
+// @noImplicitReferences: true
+// @currentDirectory: /
+// This tests that an ambient module declaration overrides an untyped import.
+
+// @filename: /node_modules/foo/index.js
+This file is not processed.
+
+// @filename: /declarations.d.ts
+declare module "foo" {
+    export const x: number;
+}
+
+// @filename: /a.ts
+/// <reference path="./declarations.d.ts" />
+import { x } from "foo";
+x;

--- a/tests/cases/fourslash/untypedModuleImport.ts
+++ b/tests/cases/fourslash/untypedModuleImport.ts
@@ -1,0 +1,22 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: node_modules/foo/index.js
+////{}
+
+// @Filename: a.ts
+////import /*foo*/[|foo|] from /*fooModule*/"foo";
+////[|foo|]();
+
+goTo.file("a.ts");
+debug.printErrorList();
+verify.numberOfErrorsInCurrentFile(0);
+
+goTo.marker("fooModule");
+verify.goToDefinitionIs([]);
+verify.quickInfoIs('module "foo"');
+verify.referencesAre([])
+
+goTo.marker("foo");
+verify.goToDefinitionIs([]);
+verify.quickInfoIs("import foo");
+verify.rangesReferenceEachOther();


### PR DESCRIPTION
Fixes #11106
Replaces #11446
Made easier by #11704. No longer has to touch `moduleNameResolver.ts`.

