### PR TITLE
Make `extension` property of `ResolvedModule` optional

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -45,7 +45,7 @@ namespace ts {
     }
 
     /** Adds `isExernalLibraryImport` to a Resolved to get a ResolvedModule. */
-    function resolvedModuleFromResolved({ path, extension }: Resolved, isExternalLibraryImport: boolean): ResolvedModule {
+    function resolvedModuleFromResolved({ path, extension }: Resolved, isExternalLibraryImport: boolean): ResolvedModuleFull {
         return { resolvedFileName: path, extension, isExternalLibraryImport };
     }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -423,7 +423,7 @@ namespace ts {
         ThisNodeHasError =   1 << 19, // If the parser encountered an error when parsing the code that created this node
         JavaScriptFile =     1 << 20, // If node was parsed in a JavaScript
         ThisNodeOrAnySubNodesHasError = 1 << 21, // If this node or any of its children had an error
-        HasAggregatedChildData = 1 << 22, // If we've computed data from children and cached it in this node 
+        HasAggregatedChildData = 1 << 22, // If we've computed data from children and cached it in this node
 
         BlockScoped = Let | Const,
 
@@ -2083,7 +2083,7 @@ namespace ts {
         // Stores a mapping 'external module reference text' -> 'resolved file name' | undefined
         // It is used to resolve module names in the checker.
         // Content of this field should never be used directly - use getResolvedModuleFileName/setResolvedModuleFileName functions instead
-        /* @internal */ resolvedModules: Map<ResolvedModule>;
+        /* @internal */ resolvedModules: Map<ResolvedModuleFull>;
         /* @internal */ resolvedTypeReferenceDirectiveNames: Map<ResolvedTypeReferenceDirective>;
         /* @internal */ imports: LiteralExpression[];
         /* @internal */ moduleAugmentations: LiteralExpression[];
@@ -3352,14 +3352,11 @@ namespace ts {
      * Module resolution will pick up tsx/jsx/js files even if '--jsx' and '--allowJs' are turned off.
      * The Program will then filter results based on these flags.
      *
-     * At least one of `resolvedTsFileName` or `resolvedJsFileName` must be defined,
-     * else resolution should just return `undefined` instead of a ResolvedModule.
+     * Prefer to return a `ResolvedModuleFull` so that the file type does not have to be inferred.
      */
     export interface ResolvedModule {
         /** Path of the file the module was resolved to. */
         resolvedFileName: string;
-        /** Extension of resolvedFileName. This must match what's at the end of resolvedFileName. */
-        extension: Extension;
         /**
          * Denotes if 'resolvedFileName' is isExternalLibraryImport and thus should be a proper external module:
          * - be a .d.ts file
@@ -3367,6 +3364,18 @@ namespace ts {
          * - don't use tripleslash references
          */
         isExternalLibraryImport?: boolean;
+    }
+
+    /**
+     * ResolvedModule with an explicitly provided `extension` property.
+     * Prefer this over `ResolvedModule`.
+     */
+    export interface ResolvedModuleFull extends ResolvedModule {
+        /**
+         * Extension of resolvedFileName. This must match what's at the end of resolvedFileName.
+         * This is optional for backwards-compatibility, but will be added if not provided.
+         */
+        extension: Extension;
     }
 
     export enum Extension {
@@ -3379,7 +3388,7 @@ namespace ts {
     }
 
     export interface ResolvedModuleWithFailedLookupLocations {
-        resolvedModule: ResolvedModule | undefined;
+        resolvedModule: ResolvedModuleFull | undefined;
         failedLookupLocations: string[];
     }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -87,13 +87,13 @@ namespace ts {
         return !!(sourceFile && sourceFile.resolvedModules && sourceFile.resolvedModules[moduleNameText]);
     }
 
-    export function getResolvedModule(sourceFile: SourceFile, moduleNameText: string): ResolvedModule {
+    export function getResolvedModule(sourceFile: SourceFile, moduleNameText: string): ResolvedModuleFull {
         return hasResolvedModule(sourceFile, moduleNameText) ? sourceFile.resolvedModules[moduleNameText] : undefined;
     }
 
-    export function setResolvedModule(sourceFile: SourceFile, moduleNameText: string, resolvedModule: ResolvedModule): void {
+    export function setResolvedModule(sourceFile: SourceFile, moduleNameText: string, resolvedModule: ResolvedModuleFull): void {
         if (!sourceFile.resolvedModules) {
-            sourceFile.resolvedModules = createMap<ResolvedModule>();
+            sourceFile.resolvedModules = createMap<ResolvedModuleFull>();
         }
 
         sourceFile.resolvedModules[moduleNameText] = resolvedModule;
@@ -108,11 +108,7 @@ namespace ts {
     }
 
     /* @internal */
-    /**
-     * Considers two ResolvedModules equal if they have the same `resolvedFileName`.
-     * Thus `{ ts: foo, js: bar }` is equal to `{ ts: foo, js: baz }` because `ts` is preferred.
-     */
-    export function moduleResolutionIsEqualTo(oldResolution: ResolvedModule, newResolution: ResolvedModule): boolean {
+    export function moduleResolutionIsEqualTo(oldResolution: ResolvedModuleFull, newResolution: ResolvedModuleFull): boolean {
         return oldResolution.isExternalLibraryImport === newResolution.isExternalLibraryImport &&
             oldResolution.extension === newResolution.extension &&
             oldResolution.resolvedFileName === newResolution.resolvedFileName;

--- a/src/harness/unittests/moduleResolution.ts
+++ b/src/harness/unittests/moduleResolution.ts
@@ -1,7 +1,7 @@
 /// <reference path="..\harness.ts" />
 
 namespace ts {
-    export function checkResolvedModule(expected: ResolvedModule, actual: ResolvedModule): boolean {
+    export function checkResolvedModule(expected: ResolvedModuleFull, actual: ResolvedModuleFull): boolean {
         if (!expected === !actual) {
             if (expected) {
                 assert.isTrue(expected.resolvedFileName === actual.resolvedFileName, `'resolvedFileName': expected '${expected.resolvedFileName}' to be equal to '${actual.resolvedFileName}'`);
@@ -13,13 +13,13 @@ namespace ts {
         return false;
     }
 
-    export function checkResolvedModuleWithFailedLookupLocations(actual: ResolvedModuleWithFailedLookupLocations, expectedResolvedModule: ResolvedModule, expectedFailedLookupLocations: string[]): void {
+    export function checkResolvedModuleWithFailedLookupLocations(actual: ResolvedModuleWithFailedLookupLocations, expectedResolvedModule: ResolvedModuleFull, expectedFailedLookupLocations: string[]): void {
         assert.isTrue(actual.resolvedModule !== undefined, "module should be resolved");
         checkResolvedModule(actual.resolvedModule, expectedResolvedModule);
         assert.deepEqual(actual.failedLookupLocations, expectedFailedLookupLocations);
     }
 
-    export function createResolvedModule(resolvedFileName: string, isExternalLibraryImport = false): ResolvedModule {
+    export function createResolvedModule(resolvedFileName: string, isExternalLibraryImport = false): ResolvedModuleFull {
         return { resolvedFileName, extension: extensionFromPath(resolvedFileName), isExternalLibraryImport };
     }
 

--- a/src/server/lsHost.ts
+++ b/src/server/lsHost.ts
@@ -151,7 +151,7 @@ namespace ts.server {
                 m => m.resolvedTypeReferenceDirective, r => r.resolvedFileName,  /*logChanges*/ false);
         }
 
-        resolveModuleNames(moduleNames: string[], containingFile: string): ResolvedModule[] {
+        resolveModuleNames(moduleNames: string[], containingFile: string): ResolvedModuleFull[] {
             return this.resolveNamesWithLocalCache(moduleNames, containingFile, this.resolvedModuleNames, this.resolveModuleName,
                 m => m.resolvedModule, r => r.resolvedFileName, /*logChanges*/ true);
         }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -467,7 +467,7 @@ namespace ts {
         public languageVariant: LanguageVariant;
         public identifiers: Map<string>;
         public nameTable: Map<number>;
-        public resolvedModules: Map<ResolvedModule>;
+        public resolvedModules: Map<ResolvedModuleFull>;
         public resolvedTypeReferenceDirectiveNames: Map<ResolvedTypeReferenceDirective>;
         public imports: LiteralExpression[];
         public moduleAugmentations: LiteralExpression[];

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -316,7 +316,7 @@ namespace ts {
         private loggingEnabled = false;
         private tracingEnabled = false;
 
-        public resolveModuleNames: (moduleName: string[], containingFile: string) => ResolvedModule[];
+        public resolveModuleNames: (moduleName: string[], containingFile: string) => ResolvedModuleFull[];
         public resolveTypeReferenceDirectives: (typeDirectiveNames: string[], containingFile: string) => ResolvedTypeReferenceDirective[];
         public directoryExists: (directoryName: string) => boolean;
 


### PR DESCRIPTION
Introduce `ResolvedModuleFull` interface for when the extension is provided.

This is a followup to #11704 to keep the API fully backwards compatible.
