### PR TITLE
Skip overloads with too short function parameters

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11891,7 +11891,8 @@ namespace ts {
                     // for the argument. In that case, we should check the argument.
                     if (argType === undefined) {
                         // If the parameter and argument are both functions and the parameter has fewer arguments than the argument,
-                        // then this signature is not applicable. Exit early.
+                        // then this signature is not applicable. Exit early to avoid fixing incorrect
+                        // contextual types to the function expression parameters.
                         if (!reportErrors && isAritySmaller(paramType, arg)) {
                             return false;
                         }
@@ -11922,6 +11923,8 @@ namespace ts {
                 const sourceLengths = sourceSignatures.map(sig => !sig.hasRestParameter ? sig.parameters.length : Number.MAX_VALUE);
                 return forEach(sourceLengths, len => len < targetParameterCount);
             }
+
+            return false;
         }
 
         /**

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11912,16 +11912,9 @@ namespace ts {
 
         function isAritySmaller(sourceType: Type, target: Expression) {
             if (isFunctionExpressionOrArrowFunction(target) && isFunctionType(sourceType)) {
-                let targetParameterCount = 0;
-                for (; targetParameterCount < target.parameters.length; targetParameterCount++) {
-                    const param = target.parameters[targetParameterCount];
-                    if (param.initializer || param.questionToken || param.dotDotDotToken || isJSDocOptionalParameter(param)) {
-                        break;
-                    }
-                }
                 const sourceSignatures = getSignaturesOfType(sourceType, SignatureKind.Call);
                 const sourceLengths = sourceSignatures.map(sig => !sig.hasRestParameter ? sig.parameters.length : Number.MAX_VALUE);
-                return forEach(sourceLengths, len => len < targetParameterCount);
+                return forEach(sourceLengths, len => len < target.parameters.length);
             }
 
             return false;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11890,6 +11890,11 @@ namespace ts {
                     // If the effective argument type is 'undefined', there is no synthetic type
                     // for the argument. In that case, we should check the argument.
                     if (argType === undefined) {
+                        // If the parameter and argument are both functions and the parameter has fewer arguments than the argument,
+                        // then this signature is not applicable. Exit early.
+                        if (!reportErrors && isAritySmaller(paramType, arg)) {
+                            return false;
+                        }
                         argType = checkExpressionWithContextualType(arg, paramType, excludeArgument && excludeArgument[i] ? identityMapper : undefined);
                     }
 
@@ -11902,6 +11907,21 @@ namespace ts {
             }
 
             return true;
+        }
+
+        function isAritySmaller(sourceType: Type, target: Expression) {
+            if (isFunctionExpressionOrArrowFunction(target) && isFunctionType(sourceType)) {
+                let targetParameterCount = 0;
+                for (; targetParameterCount < target.parameters.length; targetParameterCount++) {
+                    const param = target.parameters[targetParameterCount];
+                    if (param.initializer || param.questionToken || param.dotDotDotToken || isJSDocOptionalParameter(param)) {
+                        break;
+                    }
+                }
+                const sourceSignatures = getSignaturesOfType(sourceType, SignatureKind.Call);
+                const sourceLengths = sourceSignatures.map(sig => !sig.hasRestParameter ? sig.parameters.length : Number.MAX_VALUE);
+                return forEach(sourceLengths, len => len < targetParameterCount);
+            }
         }
 
         /**

--- a/tests/baselines/reference/contextualTypingOfTooShortOverloads.js
+++ b/tests/baselines/reference/contextualTypingOfTooShortOverloads.js
@@ -1,0 +1,59 @@
+//// [contextualTypingOfTooShortOverloads.ts]
+// small repro from #11875
+var use: Overload;
+use((req, res) => {});
+
+interface Overload {
+    (handler1: (req1: string) => void): void;
+    (handler2: (req2: number, res2: number) => void): void;
+}
+// larger repro from #11875
+let app: MyApp;
+app.use((err: any, req, res, next) => { return; });
+
+
+interface MyApp {
+    use: IRouterHandler<this> & IRouterMatcher<this>;
+}
+
+interface IRouterHandler<T> {
+    (...handlers: RequestHandler[]): T;
+    (...handlers: RequestHandlerParams[]): T;
+}
+
+interface IRouterMatcher<T> {
+    (path: PathParams, ...handlers: RequestHandler[]): T;
+    (path: PathParams, ...handlers: RequestHandlerParams[]): T;
+}
+
+type PathParams = string | RegExp | (string | RegExp)[];
+type RequestHandlerParams = RequestHandler | ErrorRequestHandler | (RequestHandler | ErrorRequestHandler)[];
+
+interface RequestHandler {
+    (req: Request, res: Response, next: NextFunction): any;
+}
+
+interface ErrorRequestHandler {
+    (err: any, req: Request, res: Response, next: NextFunction): any;
+}
+
+interface Request {
+    method: string;
+}
+
+interface Response {
+    statusCode: number;
+}
+
+interface NextFunction {
+    (err?: any): void;
+}
+
+
+//// [contextualTypingOfTooShortOverloads.js]
+// small repro from #11875
+var use;
+use(function (req, res) { });
+// larger repro from #11875
+var app;
+app.use(function (err, req, res, next) { return; });

--- a/tests/baselines/reference/contextualTypingOfTooShortOverloads.symbols
+++ b/tests/baselines/reference/contextualTypingOfTooShortOverloads.symbols
@@ -1,0 +1,139 @@
+=== tests/cases/compiler/contextualTypingOfTooShortOverloads.ts ===
+// small repro from #11875
+var use: Overload;
+>use : Symbol(use, Decl(contextualTypingOfTooShortOverloads.ts, 1, 3))
+>Overload : Symbol(Overload, Decl(contextualTypingOfTooShortOverloads.ts, 2, 22))
+
+use((req, res) => {});
+>use : Symbol(use, Decl(contextualTypingOfTooShortOverloads.ts, 1, 3))
+>req : Symbol(req, Decl(contextualTypingOfTooShortOverloads.ts, 2, 5))
+>res : Symbol(res, Decl(contextualTypingOfTooShortOverloads.ts, 2, 9))
+
+interface Overload {
+>Overload : Symbol(Overload, Decl(contextualTypingOfTooShortOverloads.ts, 2, 22))
+
+    (handler1: (req1: string) => void): void;
+>handler1 : Symbol(handler1, Decl(contextualTypingOfTooShortOverloads.ts, 5, 5))
+>req1 : Symbol(req1, Decl(contextualTypingOfTooShortOverloads.ts, 5, 16))
+
+    (handler2: (req2: number, res2: number) => void): void;
+>handler2 : Symbol(handler2, Decl(contextualTypingOfTooShortOverloads.ts, 6, 5))
+>req2 : Symbol(req2, Decl(contextualTypingOfTooShortOverloads.ts, 6, 16))
+>res2 : Symbol(res2, Decl(contextualTypingOfTooShortOverloads.ts, 6, 29))
+}
+// larger repro from #11875
+let app: MyApp;
+>app : Symbol(app, Decl(contextualTypingOfTooShortOverloads.ts, 9, 3))
+>MyApp : Symbol(MyApp, Decl(contextualTypingOfTooShortOverloads.ts, 10, 51))
+
+app.use((err: any, req, res, next) => { return; });
+>app.use : Symbol(MyApp.use, Decl(contextualTypingOfTooShortOverloads.ts, 13, 17))
+>app : Symbol(app, Decl(contextualTypingOfTooShortOverloads.ts, 9, 3))
+>use : Symbol(MyApp.use, Decl(contextualTypingOfTooShortOverloads.ts, 13, 17))
+>err : Symbol(err, Decl(contextualTypingOfTooShortOverloads.ts, 10, 9))
+>req : Symbol(req, Decl(contextualTypingOfTooShortOverloads.ts, 10, 18))
+>res : Symbol(res, Decl(contextualTypingOfTooShortOverloads.ts, 10, 23))
+>next : Symbol(next, Decl(contextualTypingOfTooShortOverloads.ts, 10, 28))
+
+
+interface MyApp {
+>MyApp : Symbol(MyApp, Decl(contextualTypingOfTooShortOverloads.ts, 10, 51))
+
+    use: IRouterHandler<this> & IRouterMatcher<this>;
+>use : Symbol(MyApp.use, Decl(contextualTypingOfTooShortOverloads.ts, 13, 17))
+>IRouterHandler : Symbol(IRouterHandler, Decl(contextualTypingOfTooShortOverloads.ts, 15, 1))
+>IRouterMatcher : Symbol(IRouterMatcher, Decl(contextualTypingOfTooShortOverloads.ts, 20, 1))
+}
+
+interface IRouterHandler<T> {
+>IRouterHandler : Symbol(IRouterHandler, Decl(contextualTypingOfTooShortOverloads.ts, 15, 1))
+>T : Symbol(T, Decl(contextualTypingOfTooShortOverloads.ts, 17, 25))
+
+    (...handlers: RequestHandler[]): T;
+>handlers : Symbol(handlers, Decl(contextualTypingOfTooShortOverloads.ts, 18, 5))
+>RequestHandler : Symbol(RequestHandler, Decl(contextualTypingOfTooShortOverloads.ts, 28, 108))
+>T : Symbol(T, Decl(contextualTypingOfTooShortOverloads.ts, 17, 25))
+
+    (...handlers: RequestHandlerParams[]): T;
+>handlers : Symbol(handlers, Decl(contextualTypingOfTooShortOverloads.ts, 19, 5))
+>RequestHandlerParams : Symbol(RequestHandlerParams, Decl(contextualTypingOfTooShortOverloads.ts, 27, 56))
+>T : Symbol(T, Decl(contextualTypingOfTooShortOverloads.ts, 17, 25))
+}
+
+interface IRouterMatcher<T> {
+>IRouterMatcher : Symbol(IRouterMatcher, Decl(contextualTypingOfTooShortOverloads.ts, 20, 1))
+>T : Symbol(T, Decl(contextualTypingOfTooShortOverloads.ts, 22, 25))
+
+    (path: PathParams, ...handlers: RequestHandler[]): T;
+>path : Symbol(path, Decl(contextualTypingOfTooShortOverloads.ts, 23, 5))
+>PathParams : Symbol(PathParams, Decl(contextualTypingOfTooShortOverloads.ts, 25, 1))
+>handlers : Symbol(handlers, Decl(contextualTypingOfTooShortOverloads.ts, 23, 22))
+>RequestHandler : Symbol(RequestHandler, Decl(contextualTypingOfTooShortOverloads.ts, 28, 108))
+>T : Symbol(T, Decl(contextualTypingOfTooShortOverloads.ts, 22, 25))
+
+    (path: PathParams, ...handlers: RequestHandlerParams[]): T;
+>path : Symbol(path, Decl(contextualTypingOfTooShortOverloads.ts, 24, 5))
+>PathParams : Symbol(PathParams, Decl(contextualTypingOfTooShortOverloads.ts, 25, 1))
+>handlers : Symbol(handlers, Decl(contextualTypingOfTooShortOverloads.ts, 24, 22))
+>RequestHandlerParams : Symbol(RequestHandlerParams, Decl(contextualTypingOfTooShortOverloads.ts, 27, 56))
+>T : Symbol(T, Decl(contextualTypingOfTooShortOverloads.ts, 22, 25))
+}
+
+type PathParams = string | RegExp | (string | RegExp)[];
+>PathParams : Symbol(PathParams, Decl(contextualTypingOfTooShortOverloads.ts, 25, 1))
+>RegExp : Symbol(RegExp, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>RegExp : Symbol(RegExp, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+type RequestHandlerParams = RequestHandler | ErrorRequestHandler | (RequestHandler | ErrorRequestHandler)[];
+>RequestHandlerParams : Symbol(RequestHandlerParams, Decl(contextualTypingOfTooShortOverloads.ts, 27, 56))
+>RequestHandler : Symbol(RequestHandler, Decl(contextualTypingOfTooShortOverloads.ts, 28, 108))
+>ErrorRequestHandler : Symbol(ErrorRequestHandler, Decl(contextualTypingOfTooShortOverloads.ts, 32, 1))
+>RequestHandler : Symbol(RequestHandler, Decl(contextualTypingOfTooShortOverloads.ts, 28, 108))
+>ErrorRequestHandler : Symbol(ErrorRequestHandler, Decl(contextualTypingOfTooShortOverloads.ts, 32, 1))
+
+interface RequestHandler {
+>RequestHandler : Symbol(RequestHandler, Decl(contextualTypingOfTooShortOverloads.ts, 28, 108))
+
+    (req: Request, res: Response, next: NextFunction): any;
+>req : Symbol(req, Decl(contextualTypingOfTooShortOverloads.ts, 31, 5))
+>Request : Symbol(Request, Decl(contextualTypingOfTooShortOverloads.ts, 36, 1))
+>res : Symbol(res, Decl(contextualTypingOfTooShortOverloads.ts, 31, 18))
+>Response : Symbol(Response, Decl(contextualTypingOfTooShortOverloads.ts, 40, 1))
+>next : Symbol(next, Decl(contextualTypingOfTooShortOverloads.ts, 31, 33))
+>NextFunction : Symbol(NextFunction, Decl(contextualTypingOfTooShortOverloads.ts, 44, 1))
+}
+
+interface ErrorRequestHandler {
+>ErrorRequestHandler : Symbol(ErrorRequestHandler, Decl(contextualTypingOfTooShortOverloads.ts, 32, 1))
+
+    (err: any, req: Request, res: Response, next: NextFunction): any;
+>err : Symbol(err, Decl(contextualTypingOfTooShortOverloads.ts, 35, 5))
+>req : Symbol(req, Decl(contextualTypingOfTooShortOverloads.ts, 35, 14))
+>Request : Symbol(Request, Decl(contextualTypingOfTooShortOverloads.ts, 36, 1))
+>res : Symbol(res, Decl(contextualTypingOfTooShortOverloads.ts, 35, 28))
+>Response : Symbol(Response, Decl(contextualTypingOfTooShortOverloads.ts, 40, 1))
+>next : Symbol(next, Decl(contextualTypingOfTooShortOverloads.ts, 35, 43))
+>NextFunction : Symbol(NextFunction, Decl(contextualTypingOfTooShortOverloads.ts, 44, 1))
+}
+
+interface Request {
+>Request : Symbol(Request, Decl(contextualTypingOfTooShortOverloads.ts, 36, 1))
+
+    method: string;
+>method : Symbol(Request.method, Decl(contextualTypingOfTooShortOverloads.ts, 38, 19))
+}
+
+interface Response {
+>Response : Symbol(Response, Decl(contextualTypingOfTooShortOverloads.ts, 40, 1))
+
+    statusCode: number;
+>statusCode : Symbol(Response.statusCode, Decl(contextualTypingOfTooShortOverloads.ts, 42, 20))
+}
+
+interface NextFunction {
+>NextFunction : Symbol(NextFunction, Decl(contextualTypingOfTooShortOverloads.ts, 44, 1))
+
+    (err?: any): void;
+>err : Symbol(err, Decl(contextualTypingOfTooShortOverloads.ts, 47, 5))
+}
+

--- a/tests/baselines/reference/contextualTypingOfTooShortOverloads.types
+++ b/tests/baselines/reference/contextualTypingOfTooShortOverloads.types
@@ -7,9 +7,9 @@ var use: Overload;
 use((req, res) => {});
 >use((req, res) => {}) : void
 >use : Overload
->(req, res) => {} : (req: number, res: number) => void
->req : number
->res : number
+>(req, res) => {} : (req: any, res: any) => void
+>req : any
+>res : any
 
 interface Overload {
 >Overload : Overload

--- a/tests/baselines/reference/contextualTypingOfTooShortOverloads.types
+++ b/tests/baselines/reference/contextualTypingOfTooShortOverloads.types
@@ -1,0 +1,143 @@
+=== tests/cases/compiler/contextualTypingOfTooShortOverloads.ts ===
+// small repro from #11875
+var use: Overload;
+>use : Overload
+>Overload : Overload
+
+use((req, res) => {});
+>use((req, res) => {}) : void
+>use : Overload
+>(req, res) => {} : (req: number, res: number) => void
+>req : number
+>res : number
+
+interface Overload {
+>Overload : Overload
+
+    (handler1: (req1: string) => void): void;
+>handler1 : (req1: string) => void
+>req1 : string
+
+    (handler2: (req2: number, res2: number) => void): void;
+>handler2 : (req2: number, res2: number) => void
+>req2 : number
+>res2 : number
+}
+// larger repro from #11875
+let app: MyApp;
+>app : MyApp
+>MyApp : MyApp
+
+app.use((err: any, req, res, next) => { return; });
+>app.use((err: any, req, res, next) => { return; }) : MyApp
+>app.use : IRouterHandler<MyApp> & IRouterMatcher<MyApp>
+>app : MyApp
+>use : IRouterHandler<MyApp> & IRouterMatcher<MyApp>
+>(err: any, req, res, next) => { return; } : (err: any, req: any, res: any, next: any) => void
+>err : any
+>req : any
+>res : any
+>next : any
+
+
+interface MyApp {
+>MyApp : MyApp
+
+    use: IRouterHandler<this> & IRouterMatcher<this>;
+>use : IRouterHandler<this> & IRouterMatcher<this>
+>IRouterHandler : IRouterHandler<T>
+>IRouterMatcher : IRouterMatcher<T>
+}
+
+interface IRouterHandler<T> {
+>IRouterHandler : IRouterHandler<T>
+>T : T
+
+    (...handlers: RequestHandler[]): T;
+>handlers : RequestHandler[]
+>RequestHandler : RequestHandler
+>T : T
+
+    (...handlers: RequestHandlerParams[]): T;
+>handlers : RequestHandlerParams[]
+>RequestHandlerParams : RequestHandlerParams
+>T : T
+}
+
+interface IRouterMatcher<T> {
+>IRouterMatcher : IRouterMatcher<T>
+>T : T
+
+    (path: PathParams, ...handlers: RequestHandler[]): T;
+>path : PathParams
+>PathParams : PathParams
+>handlers : RequestHandler[]
+>RequestHandler : RequestHandler
+>T : T
+
+    (path: PathParams, ...handlers: RequestHandlerParams[]): T;
+>path : PathParams
+>PathParams : PathParams
+>handlers : RequestHandlerParams[]
+>RequestHandlerParams : RequestHandlerParams
+>T : T
+}
+
+type PathParams = string | RegExp | (string | RegExp)[];
+>PathParams : PathParams
+>RegExp : RegExp
+>RegExp : RegExp
+
+type RequestHandlerParams = RequestHandler | ErrorRequestHandler | (RequestHandler | ErrorRequestHandler)[];
+>RequestHandlerParams : RequestHandlerParams
+>RequestHandler : RequestHandler
+>ErrorRequestHandler : ErrorRequestHandler
+>RequestHandler : RequestHandler
+>ErrorRequestHandler : ErrorRequestHandler
+
+interface RequestHandler {
+>RequestHandler : RequestHandler
+
+    (req: Request, res: Response, next: NextFunction): any;
+>req : Request
+>Request : Request
+>res : Response
+>Response : Response
+>next : NextFunction
+>NextFunction : NextFunction
+}
+
+interface ErrorRequestHandler {
+>ErrorRequestHandler : ErrorRequestHandler
+
+    (err: any, req: Request, res: Response, next: NextFunction): any;
+>err : any
+>req : Request
+>Request : Request
+>res : Response
+>Response : Response
+>next : NextFunction
+>NextFunction : NextFunction
+}
+
+interface Request {
+>Request : Request
+
+    method: string;
+>method : string
+}
+
+interface Response {
+>Response : Response
+
+    statusCode: number;
+>statusCode : number
+}
+
+interface NextFunction {
+>NextFunction : NextFunction
+
+    (err?: any): void;
+>err : any
+}
+

--- a/tests/baselines/reference/genericCallWithOverloadedFunctionTypedArguments.types
+++ b/tests/baselines/reference/genericCallWithOverloadedFunctionTypedArguments.types
@@ -122,8 +122,8 @@ module GenericParameter {
 >'' : ""
 
     var r11 = foo6(<T>(x: T, y?: T) => ''); // any => string (+1 overload)
->r11 : { (x: any): string; (x: any, y?: any): string; }
->foo6(<T>(x: T, y?: T) => '') : { (x: any): string; (x: any, y?: any): string; }
+>r11 : any
+>foo6(<T>(x: T, y?: T) => '') : any
 >foo6 : <T>(cb: { (x: T): string; (x: T, y?: T): string; }) => { (x: T): string; (x: T, y?: T): string; }
 ><T>(x: T, y?: T) => '' : <T>(x: T, y?: T) => string
 >T : T

--- a/tests/baselines/reference/genericCallWithOverloadedFunctionTypedArguments.types
+++ b/tests/baselines/reference/genericCallWithOverloadedFunctionTypedArguments.types
@@ -122,8 +122,8 @@ module GenericParameter {
 >'' : ""
 
     var r11 = foo6(<T>(x: T, y?: T) => ''); // any => string (+1 overload)
->r11 : any
->foo6(<T>(x: T, y?: T) => '') : any
+>r11 : { (x: any): string; (x: any, y?: any): string; }
+>foo6(<T>(x: T, y?: T) => '') : { (x: any): string; (x: any, y?: any): string; }
 >foo6 : <T>(cb: { (x: T): string; (x: T, y?: T): string; }) => { (x: T): string; (x: T, y?: T): string; }
 ><T>(x: T, y?: T) => '' : <T>(x: T, y?: T) => string
 >T : T

--- a/tests/baselines/reference/partiallyAnnotatedFunctionInferenceError.errors.txt
+++ b/tests/baselines/reference/partiallyAnnotatedFunctionInferenceError.errors.txt
@@ -1,5 +1,5 @@
-tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts(12,11): error TS2345: Argument of type '(t1: D, t2: D, t3: any) => void' is not assignable to parameter of type '(t: D, t1: D) => void'.
-tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts(13,11): error TS2345: Argument of type '(t1: D, t2: D, t3: any) => void' is not assignable to parameter of type '(t: D, t1: D) => void'.
+tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts(12,11): error TS2345: Argument of type '(t1: D, t2: C, t3: any) => void' is not assignable to parameter of type '(t: C, t1: C) => void'.
+tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts(13,11): error TS2345: Argument of type '(t1: C, t2: D, t3: any) => void' is not assignable to parameter of type '(t: C, t1: C) => void'.
 tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts(14,11): error TS2345: Argument of type '(t1: C, t2: C, t3: D) => void' is not assignable to parameter of type '(t: C, t1: C) => void'.
 
 
@@ -17,10 +17,10 @@ tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partial
     // more args
     testError((t1: D, t2, t3) => {})
               ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(t1: D, t2: D, t3: any) => void' is not assignable to parameter of type '(t: D, t1: D) => void'.
+!!! error TS2345: Argument of type '(t1: D, t2: C, t3: any) => void' is not assignable to parameter of type '(t: C, t1: C) => void'.
     testError((t1, t2: D, t3) => {})
               ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(t1: D, t2: D, t3: any) => void' is not assignable to parameter of type '(t: D, t1: D) => void'.
+!!! error TS2345: Argument of type '(t1: C, t2: D, t3: any) => void' is not assignable to parameter of type '(t: C, t1: C) => void'.
     testError((t1, t2, t3: D) => {})
               ~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(t1: C, t2: C, t3: D) => void' is not assignable to parameter of type '(t: C, t1: C) => void'.

--- a/tests/baselines/reference/partiallyAnnotatedFunctionInferenceError.errors.txt
+++ b/tests/baselines/reference/partiallyAnnotatedFunctionInferenceError.errors.txt
@@ -1,6 +1,6 @@
-tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts(12,11): error TS2345: Argument of type '(t1: D, t2: C, t3: any) => void' is not assignable to parameter of type '(t: C, t1: C) => void'.
-tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts(13,11): error TS2345: Argument of type '(t1: C, t2: D, t3: any) => void' is not assignable to parameter of type '(t: C, t1: C) => void'.
-tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts(14,11): error TS2345: Argument of type '(t1: C, t2: C, t3: D) => void' is not assignable to parameter of type '(t: C, t1: C) => void'.
+tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts(12,11): error TS2345: Argument of type '(t1: D, t2: any, t3: any) => void' is not assignable to parameter of type '(t: any, t1: any) => void'.
+tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts(13,11): error TS2345: Argument of type '(t1: any, t2: D, t3: any) => void' is not assignable to parameter of type '(t: any, t1: any) => void'.
+tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts(14,11): error TS2345: Argument of type '(t1: any, t2: any, t3: D) => void' is not assignable to parameter of type '(t: any, t1: any) => void'.
 
 
 ==== tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partiallyAnnotatedFunctionInferenceError.ts (3 errors) ====
@@ -17,11 +17,11 @@ tests/cases/conformance/types/contextualTypes/partiallyAnnotatedFunction/partial
     // more args
     testError((t1: D, t2, t3) => {})
               ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(t1: D, t2: C, t3: any) => void' is not assignable to parameter of type '(t: C, t1: C) => void'.
+!!! error TS2345: Argument of type '(t1: D, t2: any, t3: any) => void' is not assignable to parameter of type '(t: any, t1: any) => void'.
     testError((t1, t2: D, t3) => {})
               ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(t1: C, t2: D, t3: any) => void' is not assignable to parameter of type '(t: C, t1: C) => void'.
+!!! error TS2345: Argument of type '(t1: any, t2: D, t3: any) => void' is not assignable to parameter of type '(t: any, t1: any) => void'.
     testError((t1, t2, t3: D) => {})
               ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2345: Argument of type '(t1: C, t2: C, t3: D) => void' is not assignable to parameter of type '(t: C, t1: C) => void'.
+!!! error TS2345: Argument of type '(t1: any, t2: any, t3: D) => void' is not assignable to parameter of type '(t: any, t1: any) => void'.
     

--- a/tests/cases/compiler/contextualTypingOfTooShortOverloads.ts
+++ b/tests/cases/compiler/contextualTypingOfTooShortOverloads.ts
@@ -1,0 +1,49 @@
+// small repro from #11875
+var use: Overload;
+use((req, res) => {});
+
+interface Overload {
+    (handler1: (req1: string) => void): void;
+    (handler2: (req2: number, res2: number) => void): void;
+}
+// larger repro from #11875
+let app: MyApp;
+app.use((err: any, req, res, next) => { return; });
+
+
+interface MyApp {
+    use: IRouterHandler<this> & IRouterMatcher<this>;
+}
+
+interface IRouterHandler<T> {
+    (...handlers: RequestHandler[]): T;
+    (...handlers: RequestHandlerParams[]): T;
+}
+
+interface IRouterMatcher<T> {
+    (path: PathParams, ...handlers: RequestHandler[]): T;
+    (path: PathParams, ...handlers: RequestHandlerParams[]): T;
+}
+
+type PathParams = string | RegExp | (string | RegExp)[];
+type RequestHandlerParams = RequestHandler | ErrorRequestHandler | (RequestHandler | ErrorRequestHandler)[];
+
+interface RequestHandler {
+    (req: Request, res: Response, next: NextFunction): any;
+}
+
+interface ErrorRequestHandler {
+    (err: any, req: Request, res: Response, next: NextFunction): any;
+}
+
+interface Request {
+    method: string;
+}
+
+interface Response {
+    statusCode: number;
+}
+
+interface NextFunction {
+    (err?: any): void;
+}


### PR DESCRIPTION
Fixes #11875 

If the parameter of an overload is a function and the argument is also a
function, skip the overload if the parameter has fewer arguments than
the argument does. That overload cannot possibly apply, and should not
participate in, for example, contextual typing.

Example:

```ts
interface I {
  (a: number): void;
  (b: string, c): void;
}
declare function f(i: I): void;
f((x, y) => {});
```

This code now skips the first overload instead of considering it.

This was a longstanding bug but was only uncovered now that more function expressions are context sensitive.

@mhegazy @RyanCavanaugh do you mind taking a look? I need to skip `checkExpressionWithContextualType` so I think the code has to be here, but it seems like it is operating at the wrong level of abstraction overall.