### PR TITLE
enable non-ts extensions in inferred projects by default

### DIFF
--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -149,7 +149,8 @@ namespace ts.server {
                         target: ScriptTarget.ES5,
                         jsx: JsxEmit.React,
                         newLine: NewLineKind.LineFeed,
-                        moduleResolution: ModuleResolutionKind.NodeJs
+                        moduleResolution: ModuleResolutionKind.NodeJs,
+                        allowNonTsExtensions: true // injected by tsserver
                     });
             });
         });

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -2248,4 +2248,38 @@ namespace ts.projectSystem {
 
         });
     });
+
+    describe("Inferred projects", () => {
+        it("should support files without extensions", () => {
+            const f = {
+                path: "/a/compile",
+                content: "let x = 1"
+            };
+            const host = createServerHost([f]);
+            const session = createSession(host);
+            session.executeCommand(<server.protocol.SetCompilerOptionsForInferredProjectsRequest>{
+                seq: 1,
+                type: "request",
+                command: "compilerOptionsForInferredProjects",
+                arguments: {
+                    options: {
+                        allowJs: true
+                    }
+                }
+            });
+            session.executeCommand(<server.protocol.OpenRequest>{
+                seq: 2,
+                type: "request",
+                command: "open",
+                arguments: {
+                    file: f.path,
+                    fileContent: f.content,
+                    scriptKindName: "JS"
+                }
+            });
+            const projectService = session.getProjectService();
+            checkNumberOfProjects(projectService, { inferredProjects: 1 });
+            checkProjectActualFiles(projectService.inferredProjects[0], [f.path]);
+        });
+    });
 }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -296,6 +296,9 @@ namespace ts.server {
 
         setCompilerOptionsForInferredProjects(projectCompilerOptions: protocol.ExternalProjectCompilerOptions): void {
             this.compilerOptionsForInferredProjects = convertCompilerOptions(projectCompilerOptions);
+            // always set 'allowNonTsExtensions' for inferred projects since user cannot configure it from the outside
+            // previously we did not expose a way for user to change these settings and this option was enabled by default
+            this.compilerOptionsForInferredProjects.allowNonTsExtensions = true;
             this.compileOnSaveForInferredProjects = projectCompilerOptions.compileOnSave;
             for (const proj of this.inferredProjects) {
                 proj.setCompilerOptions(this.compilerOptionsForInferredProjects);


### PR DESCRIPTION
fixes #11883

// cc @dbaeumer 
@mhegazy - what branch should be used given that VSCode guys want this fix for their 1.7 release