### PR TITLE
Flag for not overwrite js files by default without generating errors

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1538,18 +1538,18 @@ namespace ts {
                     // Report error if the output overwrites input file
                     if (filesByName.contains(emitFilePath)) {
                         const sourceFile = filesByName.get(emitFilePath);
-                        if (isSourceFileJavaScript(sourceFile) && options.noEmitForJsFiles) {
-                            createEmitBlockingDiagnostics(emitFileName);
+                        if (isSourceFileJavaScript(sourceFile) && options.noEmitOverwriteForJsFiles) {
+                            blockEmitingOfFile(emitFileName);
                         }
                         else {
-                            createEmitBlockingDiagnostics(emitFileName, Diagnostics.Cannot_write_file_0_because_it_would_overwrite_input_file);
+                            blockEmitingOfFile(emitFileName, Diagnostics.Cannot_write_file_0_because_it_would_overwrite_input_file);
                         }
                     }
 
                     // Report error if multiple files write into same file
                     if (emitFilesSeen.contains(emitFilePath)) {
                         // Already seen the same emit file - report error
-                        createEmitBlockingDiagnostics(emitFileName, Diagnostics.Cannot_write_file_0_because_it_would_be_overwritten_by_multiple_input_files);
+                        blockEmitingOfFile(emitFileName, Diagnostics.Cannot_write_file_0_because_it_would_be_overwritten_by_multiple_input_files);
                     }
                     else {
                         emitFilesSeen.set(emitFilePath, true);
@@ -1558,7 +1558,7 @@ namespace ts {
             }
         }
 
-        function createEmitBlockingDiagnostics(emitFileName: string, message?: DiagnosticMessage) {
+        function blockEmitingOfFile(emitFileName: string, message?: DiagnosticMessage) {
             hasEmitBlockingDiagnostics.set(toPath(emitFileName, currentDirectory, getCanonicalFileName), true);
             if (message) {
                 programDiagnostics.add(createCompilerDiagnostic(message, emitFileName));

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1538,18 +1538,13 @@ namespace ts {
                     // Report error if the output overwrites input file
                     if (filesByName.contains(emitFilePath)) {
                         const sourceFile = filesByName.get(emitFilePath);
-                        if (isSourceFileJavaScript(sourceFile) && options.noEmitOverwriteForJsFiles) {
-                            blockEmitingOfFile(emitFileName);
-                        }
-                        else {
-                            blockEmitingOfFile(emitFileName, Diagnostics.Cannot_write_file_0_because_it_would_overwrite_input_file);
-                        }
+                        blockEmittingOfFile(emitFileName, !(options.noEmitOverwriteForJsFiles && isSourceFileJavaScript(sourceFile)) && Diagnostics.Cannot_write_file_0_because_it_would_overwrite_input_file);
                     }
 
                     // Report error if multiple files write into same file
                     if (emitFilesSeen.contains(emitFilePath)) {
                         // Already seen the same emit file - report error
-                        blockEmitingOfFile(emitFileName, Diagnostics.Cannot_write_file_0_because_it_would_be_overwritten_by_multiple_input_files);
+                        blockEmittingOfFile(emitFileName, Diagnostics.Cannot_write_file_0_because_it_would_be_overwritten_by_multiple_input_files);
                     }
                     else {
                         emitFilesSeen.set(emitFilePath, true);
@@ -1558,7 +1553,7 @@ namespace ts {
             }
         }
 
-        function blockEmitingOfFile(emitFileName: string, message?: DiagnosticMessage) {
+        function blockEmittingOfFile(emitFileName: string, message?: DiagnosticMessage) {
             hasEmitBlockingDiagnostics.set(toPath(emitFileName, currentDirectory, getCanonicalFileName), true);
             if (message) {
                 programDiagnostics.add(createCompilerDiagnostic(message, emitFileName));

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1537,7 +1537,13 @@ namespace ts {
                     const emitFilePath = toPath(emitFileName, currentDirectory, getCanonicalFileName);
                     // Report error if the output overwrites input file
                     if (filesByName.contains(emitFilePath)) {
-                        createEmitBlockingDiagnostics(emitFileName, Diagnostics.Cannot_write_file_0_because_it_would_overwrite_input_file);
+                        const sourceFile = filesByName.get(emitFilePath);
+                        if (isSourceFileJavaScript(sourceFile) && options.noEmitForJsFiles) {
+                            createEmitBlockingDiagnostics(emitFileName);
+                        }
+                        else {
+                            createEmitBlockingDiagnostics(emitFileName, Diagnostics.Cannot_write_file_0_because_it_would_overwrite_input_file);
+                        }
                     }
 
                     // Report error if multiple files write into same file
@@ -1552,9 +1558,11 @@ namespace ts {
             }
         }
 
-        function createEmitBlockingDiagnostics(emitFileName: string, message: DiagnosticMessage) {
+        function createEmitBlockingDiagnostics(emitFileName: string, message?: DiagnosticMessage) {
             hasEmitBlockingDiagnostics.set(toPath(emitFileName, currentDirectory, getCanonicalFileName), true);
-            programDiagnostics.add(createCompilerDiagnostic(message, emitFileName));
+            if (message) {
+                programDiagnostics.add(createCompilerDiagnostic(message, emitFileName));
+            }
         }
     }
 }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1537,8 +1537,7 @@ namespace ts {
                     const emitFilePath = toPath(emitFileName, currentDirectory, getCanonicalFileName);
                     // Report error if the output overwrites input file
                     if (filesByName.contains(emitFilePath)) {
-                        const sourceFile = filesByName.get(emitFilePath);
-                        if (options.noEmitOverwriteForJsFiles && isSourceFileJavaScript(sourceFile)) {
+                        if (options.noEmitOverwritenFiles && !options.out && !options.outDir && !options.outFile) {
                             blockEmittingOfFile(emitFileName);
                         }
                         else {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2984,6 +2984,7 @@ namespace ts {
         moduleResolution?: ModuleResolutionKind;
         newLine?: NewLineKind;
         noEmit?: boolean;
+        /*@internal*/noEmitForJsFiles?: boolean;
         noEmitHelpers?: boolean;
         noEmitOnError?: boolean;
         noErrorTruncation?: boolean;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2984,7 +2984,7 @@ namespace ts {
         moduleResolution?: ModuleResolutionKind;
         newLine?: NewLineKind;
         noEmit?: boolean;
-        /*@internal*/noEmitOverwriteForJsFiles?: boolean;
+        /*@internal*/noEmitOverwritenFiles?: boolean;
         noEmitHelpers?: boolean;
         noEmitOnError?: boolean;
         noErrorTruncation?: boolean;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2984,7 +2984,7 @@ namespace ts {
         moduleResolution?: ModuleResolutionKind;
         newLine?: NewLineKind;
         noEmit?: boolean;
-        /*@internal*/noEmitForJsFiles?: boolean;
+        /*@internal*/noEmitOverwriteForJsFiles?: boolean;
         noEmitHelpers?: boolean;
         noEmitOnError?: boolean;
         noErrorTruncation?: boolean;

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -161,6 +161,10 @@ namespace ts.server {
                 this.compilerOptions.allowNonTsExtensions = true;
             }
 
+            if (this.projectKind === ProjectKind.Inferred) {
+                this.compilerOptions.noEmitForJsFiles = true;
+            }
+
             if (languageServiceEnabled) {
                 this.enableLanguageService();
             }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -162,7 +162,7 @@ namespace ts.server {
             }
 
             if (this.projectKind === ProjectKind.Inferred) {
-                this.compilerOptions.noEmitOverwriteForJsFiles = true;
+                this.compilerOptions.noEmitOverwritenFiles = true;
             }
 
             if (languageServiceEnabled) {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -162,7 +162,7 @@ namespace ts.server {
             }
 
             if (this.projectKind === ProjectKind.Inferred) {
-                this.compilerOptions.noEmitForJsFiles = true;
+                this.compilerOptions.noEmitOverwriteForJsFiles = true;
             }
 
             if (languageServiceEnabled) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

This PR adds a new internal flag to by default not overwrite js files, without generating the compiler diagnostic message. 

// cc @mhegazy @vladima 
