### PR TITLE
Fix #11396: Make error message referene `Promise` explicitly

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13073,7 +13073,7 @@ namespace ts {
         function createPromiseReturnType(func: FunctionLikeDeclaration, promisedType: Type) {
             const promiseType = createPromiseType(promisedType);
             if (promiseType === emptyObjectType) {
-                error(func, Diagnostics.An_async_function_or_method_must_have_a_valid_awaitable_return_type);
+                error(func, Diagnostics.An_async_function_or_method_must_return_a_Promise_Make_sure_you_have_a_declaration_for_Promise_or_include_ES2015_in_your_lib_option);
                 return unknownType;
             }
 

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1967,6 +1967,10 @@
         "category": "Error",
         "code": 2696
     },
+    "An async function or method must return a 'Promise'. Make sure you have a declaration for 'Promise' or include 'ES2015' in your `--lib` option.": {
+        "category": "Error",
+        "code": 2697
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/tests/baselines/reference/asyncFunctionNoReturnType.errors.txt
+++ b/tests/baselines/reference/asyncFunctionNoReturnType.errors.txt
@@ -1,5 +1,5 @@
 error TS2318: Cannot find global type 'Promise'.
-tests/cases/compiler/asyncFunctionNoReturnType.ts(1,1): error TS1057: An async function or method must have a valid awaitable return type.
+tests/cases/compiler/asyncFunctionNoReturnType.ts(1,1): error TS2697: An async function or method must return a 'Promise'. Make sure you have a declaration for 'Promise' or include 'ES2015' in your `--lib` option.
 tests/cases/compiler/asyncFunctionNoReturnType.ts(1,1): error TS7030: Not all code paths return a value.
 tests/cases/compiler/asyncFunctionNoReturnType.ts(2,9): error TS2304: Cannot find name 'window'.
 tests/cases/compiler/asyncFunctionNoReturnType.ts(3,9): error TS7030: Not all code paths return a value.
@@ -9,7 +9,7 @@ tests/cases/compiler/asyncFunctionNoReturnType.ts(3,9): error TS7030: Not all co
 ==== tests/cases/compiler/asyncFunctionNoReturnType.ts (4 errors) ====
     async () => {
     ~~~~~~~~~~~~~
-!!! error TS1057: An async function or method must have a valid awaitable return type.
+!!! error TS2697: An async function or method must return a 'Promise'. Make sure you have a declaration for 'Promise' or include 'ES2015' in your `--lib` option.
     ~~~~~~~~~~~~~
 !!! error TS7030: Not all code paths return a value.
         if (window)


### PR DESCRIPTION
Fixes #11396

Also simplify the checking for async function return type 