### PR TITLE
Lock tslint version to 4.0.0-dev.0, because 4.0.0-dev.1 complains about unnecessary semicolons following properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "travis-fold": "latest",
         "ts-node": "latest",
         "tsd": "latest",
-        "tslint": "next",
+        "tslint": "4.0.0-dev.0",
         "typescript": "next"
     },
     "scripts": {


### PR DESCRIPTION
This should fix my broken build in #11993. (Jenkins correctly uses the latest tslint and errors, while travis seems to be using the old tslint.)