### PR TITLE
Fix 'keyof' for constrained type parameters

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6825,6 +6825,27 @@ namespace ts {
                     }
                 }
 
+                if (target.flags & TypeFlags.TypeParameter) {
+                    // Given a type parameter K with a constraint keyof T, a type S is
+                    // assignable to K if S is assignable to keyof T.
+                    let constraint = getConstraintOfTypeParameter(<TypeParameter>target);
+                    if (constraint && constraint.flags & TypeFlags.Index) {
+                        if (result = isRelatedTo(source, constraint, reportErrors)) {
+                            return result;
+                        }
+                    }
+                }
+                else if (target.flags & TypeFlags.Index) {
+                    // Given a type parameter T with a constraint C, a type S is assignable to
+                    // keyof T if S is assignable to keyof C.
+                    let constraint = getConstraintOfTypeParameter((<IndexType>target).type);
+                    if (constraint) {
+                        if (result = isRelatedTo(source, getIndexType(constraint), reportErrors)) {
+                            return result;
+                        }
+                    }
+                }
+
                 if (source.flags & TypeFlags.TypeParameter) {
                     let constraint = getConstraintOfTypeParameter(<TypeParameter>source);
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6828,7 +6828,7 @@ namespace ts {
                 if (target.flags & TypeFlags.TypeParameter) {
                     // Given a type parameter K with a constraint keyof T, a type S is
                     // assignable to K if S is assignable to keyof T.
-                    let constraint = getConstraintOfTypeParameter(<TypeParameter>target);
+                    const constraint = getConstraintOfTypeParameter(<TypeParameter>target);
                     if (constraint && constraint.flags & TypeFlags.Index) {
                         if (result = isRelatedTo(source, constraint, reportErrors)) {
                             return result;
@@ -6838,7 +6838,7 @@ namespace ts {
                 else if (target.flags & TypeFlags.Index) {
                     // Given a type parameter T with a constraint C, a type S is assignable to
                     // keyof T if S is assignable to keyof C.
-                    let constraint = getConstraintOfTypeParameter((<IndexType>target).type);
+                    const constraint = getConstraintOfTypeParameter((<IndexType>target).type);
                     if (constraint) {
                         if (result = isRelatedTo(source, getIndexType(constraint), reportErrors)) {
                             return result;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2709,7 +2709,7 @@ namespace ts {
         EnumLike = Enum | EnumLiteral,
         UnionOrIntersection = Union | Intersection,
         StructuredType = Object | Union | Intersection,
-        StructuredOrTypeParameter = StructuredType | TypeParameter,
+        StructuredOrTypeParameter = StructuredType | TypeParameter | Index,
 
         // 'Narrowable' types are types where narrowing actually narrows.
         // This *should* be every type other than null, undefined, void, and never

--- a/tests/baselines/reference/keyofAndIndexedAccess.js
+++ b/tests/baselines/reference/keyofAndIndexedAccess.js
@@ -7,6 +7,10 @@ class Shape {
     visible: boolean;
 }
 
+class TaggedShape extends Shape {
+    tag: string;
+}
+
 class Item {
     name: string;
     price: number;
@@ -149,6 +153,17 @@ function f32<K extends "width" | "height">(key: K) {
     return shape[key];  // Shape[K]
 }
 
+function f33<S extends Shape, K extends keyof S>(shape: S, key: K) {
+    let name = getProperty(shape, "name");
+    let prop = getProperty(shape, key);
+    return prop;
+}
+
+function f34(ts: TaggedShape) {
+    let tag1 = f33(ts, "tag");
+    let tag2 = getProperty(ts, "tag");
+}
+
 class C {
     public x: string;
     protected y: string;
@@ -166,12 +181,56 @@ function f40(c: C) {
     let z: Z = c["z"];
 }
 
+// Repros from #12011
+
+class Base {
+    get<K extends keyof this>(prop: K) {
+        return this[prop];
+    }
+    set<K extends keyof this>(prop: K, value: this[K]) {
+        this[prop] = value;
+    }
+}
+
+class Person extends Base {
+    parts: number;
+    constructor(parts: number) {
+        super();
+        this.set("parts", parts);
+    }
+    getParts() {
+        return this.get("parts")
+    }
+}
+
+class OtherPerson {
+    parts: number;
+    constructor(parts: number) {
+        setProperty(this, "parts", parts);
+    }
+    getParts() {
+        return getProperty(this, "parts")
+    }
+}
+
 //// [keyofAndIndexedAccess.js]
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
 var Shape = (function () {
     function Shape() {
     }
     return Shape;
 }());
+var TaggedShape = (function (_super) {
+    __extends(TaggedShape, _super);
+    function TaggedShape() {
+        return _super.apply(this, arguments) || this;
+    }
+    return TaggedShape;
+}(Shape));
 var Item = (function () {
     function Item() {
     }
@@ -249,6 +308,15 @@ function f32(key) {
     var shape = { name: "foo", width: 5, height: 10, visible: true };
     return shape[key]; // Shape[K]
 }
+function f33(shape, key) {
+    var name = getProperty(shape, "name");
+    var prop = getProperty(shape, key);
+    return prop;
+}
+function f34(ts) {
+    var tag1 = f33(ts, "tag");
+    var tag2 = getProperty(ts, "tag");
+}
 var C = (function () {
     function C() {
     }
@@ -261,6 +329,39 @@ function f40(c) {
     var y = c["y"];
     var z = c["z"];
 }
+// Repros from #12011
+var Base = (function () {
+    function Base() {
+    }
+    Base.prototype.get = function (prop) {
+        return this[prop];
+    };
+    Base.prototype.set = function (prop, value) {
+        this[prop] = value;
+    };
+    return Base;
+}());
+var Person = (function (_super) {
+    __extends(Person, _super);
+    function Person(parts) {
+        var _this = _super.call(this) || this;
+        _this.set("parts", parts);
+        return _this;
+    }
+    Person.prototype.getParts = function () {
+        return this.get("parts");
+    };
+    return Person;
+}(Base));
+var OtherPerson = (function () {
+    function OtherPerson(parts) {
+        setProperty(this, "parts", parts);
+    }
+    OtherPerson.prototype.getParts = function () {
+        return getProperty(this, "parts");
+    };
+    return OtherPerson;
+}());
 
 
 //// [keyofAndIndexedAccess.d.ts]
@@ -269,6 +370,9 @@ declare class Shape {
     width: number;
     height: number;
     visible: boolean;
+}
+declare class TaggedShape extends Shape {
+    tag: string;
 }
 declare class Item {
     name: string;
@@ -342,9 +446,25 @@ declare function pluck<T, K extends keyof T>(array: T[], key: K): T[K][];
 declare function f30(shapes: Shape[]): void;
 declare function f31<K extends keyof Shape>(key: K): Shape[K];
 declare function f32<K extends "width" | "height">(key: K): Shape[K];
+declare function f33<S extends Shape, K extends keyof S>(shape: S, key: K): S[K];
+declare function f34(ts: TaggedShape): void;
 declare class C {
     x: string;
     protected y: string;
     private z;
 }
 declare function f40(c: C): void;
+declare class Base {
+    get<K extends keyof this>(prop: K): this[K];
+    set<K extends keyof this>(prop: K, value: this[K]): void;
+}
+declare class Person extends Base {
+    parts: number;
+    constructor(parts: number);
+    getParts(): number;
+}
+declare class OtherPerson {
+    parts: number;
+    constructor(parts: number);
+    getParts(): number;
+}

--- a/tests/baselines/reference/keyofAndIndexedAccess.symbols
+++ b/tests/baselines/reference/keyofAndIndexedAccess.symbols
@@ -16,562 +16,694 @@ class Shape {
 >visible : Symbol(Shape.visible, Decl(keyofAndIndexedAccess.ts, 4, 19))
 }
 
+class TaggedShape extends Shape {
+>TaggedShape : Symbol(TaggedShape, Decl(keyofAndIndexedAccess.ts, 6, 1))
+>Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
+
+    tag: string;
+>tag : Symbol(TaggedShape.tag, Decl(keyofAndIndexedAccess.ts, 8, 33))
+}
+
 class Item {
->Item : Symbol(Item, Decl(keyofAndIndexedAccess.ts, 6, 1))
+>Item : Symbol(Item, Decl(keyofAndIndexedAccess.ts, 10, 1))
 
     name: string;
->name : Symbol(Item.name, Decl(keyofAndIndexedAccess.ts, 8, 12))
+>name : Symbol(Item.name, Decl(keyofAndIndexedAccess.ts, 12, 12))
 
     price: number;
->price : Symbol(Item.price, Decl(keyofAndIndexedAccess.ts, 9, 17))
+>price : Symbol(Item.price, Decl(keyofAndIndexedAccess.ts, 13, 17))
 }
 
 class Options {
->Options : Symbol(Options, Decl(keyofAndIndexedAccess.ts, 11, 1))
+>Options : Symbol(Options, Decl(keyofAndIndexedAccess.ts, 15, 1))
 
     visible: "yes" | "no";
->visible : Symbol(Options.visible, Decl(keyofAndIndexedAccess.ts, 13, 15))
+>visible : Symbol(Options.visible, Decl(keyofAndIndexedAccess.ts, 17, 15))
 }
 
 type Dictionary<T> = { [x: string]: T };
->Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 15, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 17, 16))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 17, 24))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 17, 16))
+>Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 19, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 21, 16))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 21, 24))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 21, 16))
 
 const enum E { A, B, C }
->E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 17, 40))
->A : Symbol(E.A, Decl(keyofAndIndexedAccess.ts, 19, 14))
->B : Symbol(E.B, Decl(keyofAndIndexedAccess.ts, 19, 17))
->C : Symbol(E.C, Decl(keyofAndIndexedAccess.ts, 19, 20))
+>E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 21, 40))
+>A : Symbol(E.A, Decl(keyofAndIndexedAccess.ts, 23, 14))
+>B : Symbol(E.B, Decl(keyofAndIndexedAccess.ts, 23, 17))
+>C : Symbol(E.C, Decl(keyofAndIndexedAccess.ts, 23, 20))
 
 type K00 = keyof any;  // string | number
->K00 : Symbol(K00, Decl(keyofAndIndexedAccess.ts, 19, 24))
+>K00 : Symbol(K00, Decl(keyofAndIndexedAccess.ts, 23, 24))
 
 type K01 = keyof string;  // number | "toString" | "charAt" | ...
->K01 : Symbol(K01, Decl(keyofAndIndexedAccess.ts, 21, 21))
+>K01 : Symbol(K01, Decl(keyofAndIndexedAccess.ts, 25, 21))
 
 type K02 = keyof number;  // "toString" | "toFixed" | "toExponential" | ...
->K02 : Symbol(K02, Decl(keyofAndIndexedAccess.ts, 22, 24))
+>K02 : Symbol(K02, Decl(keyofAndIndexedAccess.ts, 26, 24))
 
 type K03 = keyof boolean;  // "valueOf"
->K03 : Symbol(K03, Decl(keyofAndIndexedAccess.ts, 23, 24))
+>K03 : Symbol(K03, Decl(keyofAndIndexedAccess.ts, 27, 24))
 
 type K04 = keyof void;  // never
->K04 : Symbol(K04, Decl(keyofAndIndexedAccess.ts, 24, 25))
+>K04 : Symbol(K04, Decl(keyofAndIndexedAccess.ts, 28, 25))
 
 type K05 = keyof undefined;  // never
->K05 : Symbol(K05, Decl(keyofAndIndexedAccess.ts, 25, 22))
+>K05 : Symbol(K05, Decl(keyofAndIndexedAccess.ts, 29, 22))
 
 type K06 = keyof null;  // never
->K06 : Symbol(K06, Decl(keyofAndIndexedAccess.ts, 26, 27))
+>K06 : Symbol(K06, Decl(keyofAndIndexedAccess.ts, 30, 27))
 
 type K07 = keyof never;  // never
->K07 : Symbol(K07, Decl(keyofAndIndexedAccess.ts, 27, 22))
+>K07 : Symbol(K07, Decl(keyofAndIndexedAccess.ts, 31, 22))
 
 type K10 = keyof Shape;  // "name" | "width" | "height" | "visible"
->K10 : Symbol(K10, Decl(keyofAndIndexedAccess.ts, 28, 23))
+>K10 : Symbol(K10, Decl(keyofAndIndexedAccess.ts, 32, 23))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type K11 = keyof Shape[];  // number | "length" | "toString" | ...
->K11 : Symbol(K11, Decl(keyofAndIndexedAccess.ts, 30, 23))
+>K11 : Symbol(K11, Decl(keyofAndIndexedAccess.ts, 34, 23))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type K12 = keyof Dictionary<Shape>;  // string | number
->K12 : Symbol(K12, Decl(keyofAndIndexedAccess.ts, 31, 25))
->Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 15, 1))
+>K12 : Symbol(K12, Decl(keyofAndIndexedAccess.ts, 35, 25))
+>Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 19, 1))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type K13 = keyof {};  // never
->K13 : Symbol(K13, Decl(keyofAndIndexedAccess.ts, 32, 35))
+>K13 : Symbol(K13, Decl(keyofAndIndexedAccess.ts, 36, 35))
 
 type K14 = keyof Object;  // "constructor" | "toString" | ...
->K14 : Symbol(K14, Decl(keyofAndIndexedAccess.ts, 33, 20))
+>K14 : Symbol(K14, Decl(keyofAndIndexedAccess.ts, 37, 20))
 >Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
 type K15 = keyof E;  // "toString" | "toFixed" | "toExponential" | ...
->K15 : Symbol(K15, Decl(keyofAndIndexedAccess.ts, 34, 24))
->E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 17, 40))
+>K15 : Symbol(K15, Decl(keyofAndIndexedAccess.ts, 38, 24))
+>E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 21, 40))
 
 type K16 = keyof [string, number];  // number | "0" | "1" | "length" | "toString" | ...
->K16 : Symbol(K16, Decl(keyofAndIndexedAccess.ts, 35, 19))
+>K16 : Symbol(K16, Decl(keyofAndIndexedAccess.ts, 39, 19))
 
 type K17 = keyof (Shape | Item);  // "name"
->K17 : Symbol(K17, Decl(keyofAndIndexedAccess.ts, 36, 34))
+>K17 : Symbol(K17, Decl(keyofAndIndexedAccess.ts, 40, 34))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->Item : Symbol(Item, Decl(keyofAndIndexedAccess.ts, 6, 1))
+>Item : Symbol(Item, Decl(keyofAndIndexedAccess.ts, 10, 1))
 
 type K18 = keyof (Shape & Item);  // "name" | "width" | "height" | "visible" | "price"
->K18 : Symbol(K18, Decl(keyofAndIndexedAccess.ts, 37, 32))
+>K18 : Symbol(K18, Decl(keyofAndIndexedAccess.ts, 41, 32))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->Item : Symbol(Item, Decl(keyofAndIndexedAccess.ts, 6, 1))
+>Item : Symbol(Item, Decl(keyofAndIndexedAccess.ts, 10, 1))
 
 type KeyOf<T> = keyof T;
->KeyOf : Symbol(KeyOf, Decl(keyofAndIndexedAccess.ts, 38, 32))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 40, 11))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 40, 11))
+>KeyOf : Symbol(KeyOf, Decl(keyofAndIndexedAccess.ts, 42, 32))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 44, 11))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 44, 11))
 
 type K20 = KeyOf<Shape>;  // "name" | "width" | "height" | "visible"
->K20 : Symbol(K20, Decl(keyofAndIndexedAccess.ts, 40, 24))
->KeyOf : Symbol(KeyOf, Decl(keyofAndIndexedAccess.ts, 38, 32))
+>K20 : Symbol(K20, Decl(keyofAndIndexedAccess.ts, 44, 24))
+>KeyOf : Symbol(KeyOf, Decl(keyofAndIndexedAccess.ts, 42, 32))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type K21 = KeyOf<Dictionary<Shape>>;  // string | number
->K21 : Symbol(K21, Decl(keyofAndIndexedAccess.ts, 42, 24))
->KeyOf : Symbol(KeyOf, Decl(keyofAndIndexedAccess.ts, 38, 32))
->Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 15, 1))
+>K21 : Symbol(K21, Decl(keyofAndIndexedAccess.ts, 46, 24))
+>KeyOf : Symbol(KeyOf, Decl(keyofAndIndexedAccess.ts, 42, 32))
+>Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 19, 1))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type NAME = "name";
->NAME : Symbol(NAME, Decl(keyofAndIndexedAccess.ts, 43, 36))
+>NAME : Symbol(NAME, Decl(keyofAndIndexedAccess.ts, 47, 36))
 
 type WIDTH_OR_HEIGHT = "width" | "height";
->WIDTH_OR_HEIGHT : Symbol(WIDTH_OR_HEIGHT, Decl(keyofAndIndexedAccess.ts, 45, 19))
+>WIDTH_OR_HEIGHT : Symbol(WIDTH_OR_HEIGHT, Decl(keyofAndIndexedAccess.ts, 49, 19))
 
 type Q10 = Shape["name"];  // string
->Q10 : Symbol(Q10, Decl(keyofAndIndexedAccess.ts, 46, 42))
+>Q10 : Symbol(Q10, Decl(keyofAndIndexedAccess.ts, 50, 42))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type Q11 = Shape["width" | "height"];  // number
->Q11 : Symbol(Q11, Decl(keyofAndIndexedAccess.ts, 48, 25))
+>Q11 : Symbol(Q11, Decl(keyofAndIndexedAccess.ts, 52, 25))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type Q12 = Shape["name" | "visible"];  // string | boolean
->Q12 : Symbol(Q12, Decl(keyofAndIndexedAccess.ts, 49, 37))
+>Q12 : Symbol(Q12, Decl(keyofAndIndexedAccess.ts, 53, 37))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type Q20 = Shape[NAME];  // string
->Q20 : Symbol(Q20, Decl(keyofAndIndexedAccess.ts, 50, 37))
+>Q20 : Symbol(Q20, Decl(keyofAndIndexedAccess.ts, 54, 37))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->NAME : Symbol(NAME, Decl(keyofAndIndexedAccess.ts, 43, 36))
+>NAME : Symbol(NAME, Decl(keyofAndIndexedAccess.ts, 47, 36))
 
 type Q21 = Shape[WIDTH_OR_HEIGHT];  // number
->Q21 : Symbol(Q21, Decl(keyofAndIndexedAccess.ts, 52, 23))
+>Q21 : Symbol(Q21, Decl(keyofAndIndexedAccess.ts, 56, 23))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->WIDTH_OR_HEIGHT : Symbol(WIDTH_OR_HEIGHT, Decl(keyofAndIndexedAccess.ts, 45, 19))
+>WIDTH_OR_HEIGHT : Symbol(WIDTH_OR_HEIGHT, Decl(keyofAndIndexedAccess.ts, 49, 19))
 
 type Q30 = [string, number][0];  // string
->Q30 : Symbol(Q30, Decl(keyofAndIndexedAccess.ts, 53, 34))
+>Q30 : Symbol(Q30, Decl(keyofAndIndexedAccess.ts, 57, 34))
 
 type Q31 = [string, number][1];  // number
->Q31 : Symbol(Q31, Decl(keyofAndIndexedAccess.ts, 55, 31))
+>Q31 : Symbol(Q31, Decl(keyofAndIndexedAccess.ts, 59, 31))
 
 type Q32 = [string, number][2];  // string | number
->Q32 : Symbol(Q32, Decl(keyofAndIndexedAccess.ts, 56, 31))
+>Q32 : Symbol(Q32, Decl(keyofAndIndexedAccess.ts, 60, 31))
 
 type Q33 = [string, number][E.A];  // string
->Q33 : Symbol(Q33, Decl(keyofAndIndexedAccess.ts, 57, 31))
->E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 17, 40))
->A : Symbol(E.A, Decl(keyofAndIndexedAccess.ts, 19, 14))
+>Q33 : Symbol(Q33, Decl(keyofAndIndexedAccess.ts, 61, 31))
+>E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 21, 40))
+>A : Symbol(E.A, Decl(keyofAndIndexedAccess.ts, 23, 14))
 
 type Q34 = [string, number][E.B];  // number
->Q34 : Symbol(Q34, Decl(keyofAndIndexedAccess.ts, 58, 33))
->E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 17, 40))
->B : Symbol(E.B, Decl(keyofAndIndexedAccess.ts, 19, 17))
+>Q34 : Symbol(Q34, Decl(keyofAndIndexedAccess.ts, 62, 33))
+>E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 21, 40))
+>B : Symbol(E.B, Decl(keyofAndIndexedAccess.ts, 23, 17))
 
 type Q35 = [string, number][E.C];  // string | number
->Q35 : Symbol(Q35, Decl(keyofAndIndexedAccess.ts, 59, 33))
->E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 17, 40))
->C : Symbol(E.C, Decl(keyofAndIndexedAccess.ts, 19, 20))
+>Q35 : Symbol(Q35, Decl(keyofAndIndexedAccess.ts, 63, 33))
+>E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 21, 40))
+>C : Symbol(E.C, Decl(keyofAndIndexedAccess.ts, 23, 20))
 
 type Q36 = [string, number]["0"];  // string
->Q36 : Symbol(Q36, Decl(keyofAndIndexedAccess.ts, 60, 33))
+>Q36 : Symbol(Q36, Decl(keyofAndIndexedAccess.ts, 64, 33))
 
 type Q37 = [string, number]["1"];  // string
->Q37 : Symbol(Q37, Decl(keyofAndIndexedAccess.ts, 61, 33))
+>Q37 : Symbol(Q37, Decl(keyofAndIndexedAccess.ts, 65, 33))
 
 type Q40 = (Shape | Options)["visible"];  // boolean | "yes" | "no"
->Q40 : Symbol(Q40, Decl(keyofAndIndexedAccess.ts, 62, 33))
+>Q40 : Symbol(Q40, Decl(keyofAndIndexedAccess.ts, 66, 33))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->Options : Symbol(Options, Decl(keyofAndIndexedAccess.ts, 11, 1))
+>Options : Symbol(Options, Decl(keyofAndIndexedAccess.ts, 15, 1))
 
 type Q41 = (Shape & Options)["visible"];  // true & "yes" | true & "no" | false & "yes" | false & "no"
->Q41 : Symbol(Q41, Decl(keyofAndIndexedAccess.ts, 64, 40))
+>Q41 : Symbol(Q41, Decl(keyofAndIndexedAccess.ts, 68, 40))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->Options : Symbol(Options, Decl(keyofAndIndexedAccess.ts, 11, 1))
+>Options : Symbol(Options, Decl(keyofAndIndexedAccess.ts, 15, 1))
 
 type Q50 = Dictionary<Shape>["howdy"];  // Shape
->Q50 : Symbol(Q50, Decl(keyofAndIndexedAccess.ts, 65, 40))
->Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 15, 1))
+>Q50 : Symbol(Q50, Decl(keyofAndIndexedAccess.ts, 69, 40))
+>Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 19, 1))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type Q51 = Dictionary<Shape>[123];  // Shape
->Q51 : Symbol(Q51, Decl(keyofAndIndexedAccess.ts, 67, 38))
->Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 15, 1))
+>Q51 : Symbol(Q51, Decl(keyofAndIndexedAccess.ts, 71, 38))
+>Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 19, 1))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type Q52 = Dictionary<Shape>[E.B];  // Shape
->Q52 : Symbol(Q52, Decl(keyofAndIndexedAccess.ts, 68, 34))
->Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 15, 1))
+>Q52 : Symbol(Q52, Decl(keyofAndIndexedAccess.ts, 72, 34))
+>Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 19, 1))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 17, 40))
->B : Symbol(E.B, Decl(keyofAndIndexedAccess.ts, 19, 17))
+>E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 21, 40))
+>B : Symbol(E.B, Decl(keyofAndIndexedAccess.ts, 23, 17))
 
 declare let cond: boolean;
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 71, 11))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
 
 function getProperty<T, K extends keyof T>(obj: T, key: K) {
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 71, 26))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 73, 21))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 73, 23))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 73, 21))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 73, 43))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 73, 21))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 73, 50))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 73, 23))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 77, 21))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 77, 23))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 77, 21))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 77, 43))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 77, 21))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 77, 50))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 77, 23))
 
     return obj[key];
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 73, 43))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 73, 50))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 77, 43))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 77, 50))
 }
 
 function setProperty<T, K extends keyof T>(obj: T, key: K, value: T[K]) {
->setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 75, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 77, 21))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 77, 23))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 77, 21))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 77, 43))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 77, 21))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 77, 50))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 77, 23))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 77, 58))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 77, 21))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 77, 23))
+>setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 79, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 81, 21))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 81, 23))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 81, 21))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 81, 43))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 81, 21))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 81, 50))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 81, 23))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 81, 58))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 81, 21))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 81, 23))
 
     obj[key] = value;
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 77, 43))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 77, 50))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 77, 58))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 81, 43))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 81, 50))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 81, 58))
 }
 
 function f10(shape: Shape) {
->f10 : Symbol(f10, Decl(keyofAndIndexedAccess.ts, 79, 1))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 81, 13))
+>f10 : Symbol(f10, Decl(keyofAndIndexedAccess.ts, 83, 1))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 85, 13))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
     let name = getProperty(shape, "name");  // string
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 82, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 71, 26))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 81, 13))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 86, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 85, 13))
 
     let widthOrHeight = getProperty(shape, cond ? "width" : "height");  // number
->widthOrHeight : Symbol(widthOrHeight, Decl(keyofAndIndexedAccess.ts, 83, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 71, 26))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 81, 13))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 71, 11))
+>widthOrHeight : Symbol(widthOrHeight, Decl(keyofAndIndexedAccess.ts, 87, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 85, 13))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
 
     let nameOrVisible = getProperty(shape, cond ? "name" : "visible");  // string | boolean
->nameOrVisible : Symbol(nameOrVisible, Decl(keyofAndIndexedAccess.ts, 84, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 71, 26))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 81, 13))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 71, 11))
+>nameOrVisible : Symbol(nameOrVisible, Decl(keyofAndIndexedAccess.ts, 88, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 85, 13))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
 
     setProperty(shape, "name", "rectangle");
->setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 75, 1))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 81, 13))
+>setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 79, 1))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 85, 13))
 
     setProperty(shape, cond ? "width" : "height", 10);
->setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 75, 1))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 81, 13))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 71, 11))
+>setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 79, 1))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 85, 13))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
 
     setProperty(shape, cond ? "name" : "visible", true);  // Technically not safe
->setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 75, 1))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 81, 13))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 71, 11))
+>setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 79, 1))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 85, 13))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
 }
 
 function f11(a: Shape[]) {
->f11 : Symbol(f11, Decl(keyofAndIndexedAccess.ts, 88, 1))
->a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 90, 13))
+>f11 : Symbol(f11, Decl(keyofAndIndexedAccess.ts, 92, 1))
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 94, 13))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
     let len = getProperty(a, "length");  // number
->len : Symbol(len, Decl(keyofAndIndexedAccess.ts, 91, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 71, 26))
->a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 90, 13))
+>len : Symbol(len, Decl(keyofAndIndexedAccess.ts, 95, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 94, 13))
 
     let shape = getProperty(a, 1000);    // Shape
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 92, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 71, 26))
->a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 90, 13))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 96, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 94, 13))
 
     setProperty(a, 1000, getProperty(a, 1001));
->setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 75, 1))
->a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 90, 13))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 71, 26))
->a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 90, 13))
+>setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 79, 1))
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 94, 13))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 94, 13))
 }
 
 function f12(t: [Shape, boolean]) {
->f12 : Symbol(f12, Decl(keyofAndIndexedAccess.ts, 94, 1))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 96, 13))
+>f12 : Symbol(f12, Decl(keyofAndIndexedAccess.ts, 98, 1))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 100, 13))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
     let len = getProperty(t, "length");
->len : Symbol(len, Decl(keyofAndIndexedAccess.ts, 97, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 71, 26))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 96, 13))
+>len : Symbol(len, Decl(keyofAndIndexedAccess.ts, 101, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 100, 13))
 
     let s1 = getProperty(t, 0);    // Shape
->s1 : Symbol(s1, Decl(keyofAndIndexedAccess.ts, 98, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 71, 26))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 96, 13))
+>s1 : Symbol(s1, Decl(keyofAndIndexedAccess.ts, 102, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 100, 13))
 
     let s2 = getProperty(t, "0");  // Shape
->s2 : Symbol(s2, Decl(keyofAndIndexedAccess.ts, 99, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 71, 26))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 96, 13))
+>s2 : Symbol(s2, Decl(keyofAndIndexedAccess.ts, 103, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 100, 13))
 
     let b1 = getProperty(t, 1);    // boolean
->b1 : Symbol(b1, Decl(keyofAndIndexedAccess.ts, 100, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 71, 26))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 96, 13))
+>b1 : Symbol(b1, Decl(keyofAndIndexedAccess.ts, 104, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 100, 13))
 
     let b2 = getProperty(t, "1");  // boolean
->b2 : Symbol(b2, Decl(keyofAndIndexedAccess.ts, 101, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 71, 26))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 96, 13))
+>b2 : Symbol(b2, Decl(keyofAndIndexedAccess.ts, 105, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 100, 13))
 
     let x1 = getProperty(t, 2);    // Shape | boolean
->x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 102, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 71, 26))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 96, 13))
+>x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 106, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 100, 13))
 }
 
 function f13(foo: any, bar: any) {
->f13 : Symbol(f13, Decl(keyofAndIndexedAccess.ts, 103, 1))
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 105, 13))
->bar : Symbol(bar, Decl(keyofAndIndexedAccess.ts, 105, 22))
+>f13 : Symbol(f13, Decl(keyofAndIndexedAccess.ts, 107, 1))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 109, 13))
+>bar : Symbol(bar, Decl(keyofAndIndexedAccess.ts, 109, 22))
 
     let x = getProperty(foo, "x");  // any
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 106, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 71, 26))
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 105, 13))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 110, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 109, 13))
 
     let y = getProperty(foo, 100);  // any
->y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 107, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 71, 26))
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 105, 13))
+>y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 111, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 109, 13))
 
     let z = getProperty(foo, bar);  // any
->z : Symbol(z, Decl(keyofAndIndexedAccess.ts, 108, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 71, 26))
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 105, 13))
->bar : Symbol(bar, Decl(keyofAndIndexedAccess.ts, 105, 22))
+>z : Symbol(z, Decl(keyofAndIndexedAccess.ts, 112, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 109, 13))
+>bar : Symbol(bar, Decl(keyofAndIndexedAccess.ts, 109, 22))
 }
 
 class Component<PropType> {
->Component : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 109, 1))
->PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 111, 16))
+>Component : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 113, 1))
+>PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 115, 16))
 
     props: PropType;
->props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 111, 27))
->PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 111, 16))
+>props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 115, 27))
+>PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 115, 16))
 
     getProperty<K extends keyof PropType>(key: K) {
->getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 113, 16))
->PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 111, 16))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 113, 42))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 113, 16))
+>getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 116, 20))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 117, 16))
+>PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 115, 16))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 117, 42))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 117, 16))
 
         return this.props[key];
->this.props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 111, 27))
->this : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 109, 1))
->props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 111, 27))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 113, 42))
+>this.props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 115, 27))
+>this : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 113, 1))
+>props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 115, 27))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 117, 42))
     }
     setProperty<K extends keyof PropType>(key: K, value: PropType[K]) {
->setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 116, 16))
->PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 111, 16))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 116, 42))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 116, 16))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 116, 49))
->PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 111, 16))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 116, 16))
+>setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 119, 5))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 120, 16))
+>PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 115, 16))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 120, 42))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 120, 16))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 120, 49))
+>PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 115, 16))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 120, 16))
 
         this.props[key] = value;
->this.props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 111, 27))
->this : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 109, 1))
->props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 111, 27))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 116, 42))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 116, 49))
+>this.props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 115, 27))
+>this : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 113, 1))
+>props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 115, 27))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 120, 42))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 120, 49))
     }
 }
 
 function f20(component: Component<Shape>) {
->f20 : Symbol(f20, Decl(keyofAndIndexedAccess.ts, 119, 1))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
->Component : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 109, 1))
+>f20 : Symbol(f20, Decl(keyofAndIndexedAccess.ts, 123, 1))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 125, 13))
+>Component : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 113, 1))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
     let name = component.getProperty("name");  // string
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 122, 7))
->component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
->getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 126, 7))
+>component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 116, 20))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 125, 13))
+>getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 116, 20))
 
     let widthOrHeight = component.getProperty(cond ? "width" : "height");  // number
->widthOrHeight : Symbol(widthOrHeight, Decl(keyofAndIndexedAccess.ts, 123, 7))
->component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
->getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 71, 11))
+>widthOrHeight : Symbol(widthOrHeight, Decl(keyofAndIndexedAccess.ts, 127, 7))
+>component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 116, 20))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 125, 13))
+>getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 116, 20))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
 
     let nameOrVisible = component.getProperty(cond ? "name" : "visible");  // string | boolean
->nameOrVisible : Symbol(nameOrVisible, Decl(keyofAndIndexedAccess.ts, 124, 7))
->component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
->getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 71, 11))
+>nameOrVisible : Symbol(nameOrVisible, Decl(keyofAndIndexedAccess.ts, 128, 7))
+>component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 116, 20))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 125, 13))
+>getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 116, 20))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
 
     component.setProperty("name", "rectangle");
->component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
->setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
+>component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 119, 5))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 125, 13))
+>setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 119, 5))
 
     component.setProperty(cond ? "width" : "height", 10)
->component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
->setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 71, 11))
+>component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 119, 5))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 125, 13))
+>setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 119, 5))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
 
     component.setProperty(cond ? "name" : "visible", true);  // Technically not safe
->component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
->setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 71, 11))
+>component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 119, 5))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 125, 13))
+>setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 119, 5))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
 }
 
 function pluck<T, K extends keyof T>(array: T[], key: K) {
->pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 128, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 130, 15))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 130, 17))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 130, 15))
->array : Symbol(array, Decl(keyofAndIndexedAccess.ts, 130, 37))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 130, 15))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 130, 48))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 130, 17))
+>pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 132, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 134, 15))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 134, 17))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 134, 15))
+>array : Symbol(array, Decl(keyofAndIndexedAccess.ts, 134, 37))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 134, 15))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 134, 48))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 134, 17))
 
     return array.map(x => x[key]);
 >array.map : Symbol(Array.map, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->array : Symbol(array, Decl(keyofAndIndexedAccess.ts, 130, 37))
+>array : Symbol(array, Decl(keyofAndIndexedAccess.ts, 134, 37))
 >map : Symbol(Array.map, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 131, 21))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 131, 21))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 130, 48))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 135, 21))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 135, 21))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 134, 48))
 }
 
 function f30(shapes: Shape[]) {
->f30 : Symbol(f30, Decl(keyofAndIndexedAccess.ts, 132, 1))
->shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 134, 13))
+>f30 : Symbol(f30, Decl(keyofAndIndexedAccess.ts, 136, 1))
+>shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 138, 13))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
     let names = pluck(shapes, "name");    // string[]
->names : Symbol(names, Decl(keyofAndIndexedAccess.ts, 135, 7))
->pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 128, 1))
->shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 134, 13))
+>names : Symbol(names, Decl(keyofAndIndexedAccess.ts, 139, 7))
+>pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 132, 1))
+>shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 138, 13))
 
     let widths = pluck(shapes, "width");  // number[]
->widths : Symbol(widths, Decl(keyofAndIndexedAccess.ts, 136, 7))
->pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 128, 1))
->shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 134, 13))
+>widths : Symbol(widths, Decl(keyofAndIndexedAccess.ts, 140, 7))
+>pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 132, 1))
+>shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 138, 13))
 
     let nameOrVisibles = pluck(shapes, cond ? "name" : "visible");  // (string | boolean)[]
->nameOrVisibles : Symbol(nameOrVisibles, Decl(keyofAndIndexedAccess.ts, 137, 7))
->pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 128, 1))
->shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 134, 13))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 71, 11))
+>nameOrVisibles : Symbol(nameOrVisibles, Decl(keyofAndIndexedAccess.ts, 141, 7))
+>pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 132, 1))
+>shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 138, 13))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
 }
 
 function f31<K extends keyof Shape>(key: K) {
->f31 : Symbol(f31, Decl(keyofAndIndexedAccess.ts, 138, 1))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 140, 13))
+>f31 : Symbol(f31, Decl(keyofAndIndexedAccess.ts, 142, 1))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 144, 13))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 140, 36))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 140, 13))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 144, 36))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 144, 13))
 
     const shape: Shape = { name: "foo", width: 5, height: 10, visible: true };
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 141, 9))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 145, 9))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 141, 26))
->width : Symbol(width, Decl(keyofAndIndexedAccess.ts, 141, 39))
->height : Symbol(height, Decl(keyofAndIndexedAccess.ts, 141, 49))
->visible : Symbol(visible, Decl(keyofAndIndexedAccess.ts, 141, 61))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 145, 26))
+>width : Symbol(width, Decl(keyofAndIndexedAccess.ts, 145, 39))
+>height : Symbol(height, Decl(keyofAndIndexedAccess.ts, 145, 49))
+>visible : Symbol(visible, Decl(keyofAndIndexedAccess.ts, 145, 61))
 
     return shape[key];  // Shape[K]
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 141, 9))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 140, 36))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 145, 9))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 144, 36))
 }
 
 function f32<K extends "width" | "height">(key: K) {
->f32 : Symbol(f32, Decl(keyofAndIndexedAccess.ts, 143, 1))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 145, 13))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 145, 43))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 145, 13))
+>f32 : Symbol(f32, Decl(keyofAndIndexedAccess.ts, 147, 1))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 149, 13))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 149, 43))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 149, 13))
 
     const shape: Shape = { name: "foo", width: 5, height: 10, visible: true };
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 146, 9))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 150, 9))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 146, 26))
->width : Symbol(width, Decl(keyofAndIndexedAccess.ts, 146, 39))
->height : Symbol(height, Decl(keyofAndIndexedAccess.ts, 146, 49))
->visible : Symbol(visible, Decl(keyofAndIndexedAccess.ts, 146, 61))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 150, 26))
+>width : Symbol(width, Decl(keyofAndIndexedAccess.ts, 150, 39))
+>height : Symbol(height, Decl(keyofAndIndexedAccess.ts, 150, 49))
+>visible : Symbol(visible, Decl(keyofAndIndexedAccess.ts, 150, 61))
 
     return shape[key];  // Shape[K]
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 146, 9))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 145, 43))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 150, 9))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 149, 43))
+}
+
+function f33<S extends Shape, K extends keyof S>(shape: S, key: K) {
+>f33 : Symbol(f33, Decl(keyofAndIndexedAccess.ts, 152, 1))
+>S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 154, 13))
+>Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 154, 29))
+>S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 154, 13))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 154, 49))
+>S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 154, 13))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 154, 58))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 154, 29))
+
+    let name = getProperty(shape, "name");
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 155, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 154, 49))
+
+    let prop = getProperty(shape, key);
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 156, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 154, 49))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 154, 58))
+
+    return prop;
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 156, 7))
+}
+
+function f34(ts: TaggedShape) {
+>f34 : Symbol(f34, Decl(keyofAndIndexedAccess.ts, 158, 1))
+>ts : Symbol(ts, Decl(keyofAndIndexedAccess.ts, 160, 13))
+>TaggedShape : Symbol(TaggedShape, Decl(keyofAndIndexedAccess.ts, 6, 1))
+
+    let tag1 = f33(ts, "tag");
+>tag1 : Symbol(tag1, Decl(keyofAndIndexedAccess.ts, 161, 7))
+>f33 : Symbol(f33, Decl(keyofAndIndexedAccess.ts, 152, 1))
+>ts : Symbol(ts, Decl(keyofAndIndexedAccess.ts, 160, 13))
+
+    let tag2 = getProperty(ts, "tag");
+>tag2 : Symbol(tag2, Decl(keyofAndIndexedAccess.ts, 162, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>ts : Symbol(ts, Decl(keyofAndIndexedAccess.ts, 160, 13))
 }
 
 class C {
->C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 148, 1))
+>C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 163, 1))
 
     public x: string;
->x : Symbol(C.x, Decl(keyofAndIndexedAccess.ts, 150, 9))
+>x : Symbol(C.x, Decl(keyofAndIndexedAccess.ts, 165, 9))
 
     protected y: string;
->y : Symbol(C.y, Decl(keyofAndIndexedAccess.ts, 151, 21))
+>y : Symbol(C.y, Decl(keyofAndIndexedAccess.ts, 166, 21))
 
     private z: string;
->z : Symbol(C.z, Decl(keyofAndIndexedAccess.ts, 152, 24))
+>z : Symbol(C.z, Decl(keyofAndIndexedAccess.ts, 167, 24))
 }
 
 // Indexed access expressions have always permitted access to private and protected members.
 // For consistency we also permit such access in indexed access types.
 function f40(c: C) {
->f40 : Symbol(f40, Decl(keyofAndIndexedAccess.ts, 154, 1))
->c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 158, 13))
->C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 148, 1))
+>f40 : Symbol(f40, Decl(keyofAndIndexedAccess.ts, 169, 1))
+>c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 173, 13))
+>C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 163, 1))
 
     type X = C["x"];
->X : Symbol(X, Decl(keyofAndIndexedAccess.ts, 158, 20))
->C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 148, 1))
+>X : Symbol(X, Decl(keyofAndIndexedAccess.ts, 173, 20))
+>C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 163, 1))
 
     type Y = C["y"];
->Y : Symbol(Y, Decl(keyofAndIndexedAccess.ts, 159, 20))
->C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 148, 1))
+>Y : Symbol(Y, Decl(keyofAndIndexedAccess.ts, 174, 20))
+>C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 163, 1))
 
     type Z = C["z"];
->Z : Symbol(Z, Decl(keyofAndIndexedAccess.ts, 160, 20))
->C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 148, 1))
+>Z : Symbol(Z, Decl(keyofAndIndexedAccess.ts, 175, 20))
+>C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 163, 1))
 
     let x: X = c["x"];
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 162, 7))
->X : Symbol(X, Decl(keyofAndIndexedAccess.ts, 158, 20))
->c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 158, 13))
->"x" : Symbol(C.x, Decl(keyofAndIndexedAccess.ts, 150, 9))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 177, 7))
+>X : Symbol(X, Decl(keyofAndIndexedAccess.ts, 173, 20))
+>c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 173, 13))
+>"x" : Symbol(C.x, Decl(keyofAndIndexedAccess.ts, 165, 9))
 
     let y: Y = c["y"];
->y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 163, 7))
->Y : Symbol(Y, Decl(keyofAndIndexedAccess.ts, 159, 20))
->c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 158, 13))
->"y" : Symbol(C.y, Decl(keyofAndIndexedAccess.ts, 151, 21))
+>y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 178, 7))
+>Y : Symbol(Y, Decl(keyofAndIndexedAccess.ts, 174, 20))
+>c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 173, 13))
+>"y" : Symbol(C.y, Decl(keyofAndIndexedAccess.ts, 166, 21))
 
     let z: Z = c["z"];
->z : Symbol(z, Decl(keyofAndIndexedAccess.ts, 164, 7))
->Z : Symbol(Z, Decl(keyofAndIndexedAccess.ts, 160, 20))
->c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 158, 13))
->"z" : Symbol(C.z, Decl(keyofAndIndexedAccess.ts, 152, 24))
+>z : Symbol(z, Decl(keyofAndIndexedAccess.ts, 179, 7))
+>Z : Symbol(Z, Decl(keyofAndIndexedAccess.ts, 175, 20))
+>c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 173, 13))
+>"z" : Symbol(C.z, Decl(keyofAndIndexedAccess.ts, 167, 24))
+}
+
+// Repros from #12011
+
+class Base {
+>Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 180, 1))
+
+    get<K extends keyof this>(prop: K) {
+>get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 184, 12))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 185, 8))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 185, 30))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 185, 8))
+
+        return this[prop];
+>this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 180, 1))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 185, 30))
+    }
+    set<K extends keyof this>(prop: K, value: this[K]) {
+>set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 187, 5))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 188, 8))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 188, 30))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 188, 8))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 188, 38))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 188, 8))
+
+        this[prop] = value;
+>this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 180, 1))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 188, 30))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 188, 38))
+    }
+}
+
+class Person extends Base {
+>Person : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 191, 1))
+>Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 180, 1))
+
+    parts: number;
+>parts : Symbol(Person.parts, Decl(keyofAndIndexedAccess.ts, 193, 27))
+
+    constructor(parts: number) {
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 195, 16))
+
+        super();
+>super : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 180, 1))
+
+        this.set("parts", parts);
+>this.set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 187, 5))
+>this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 191, 1))
+>set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 187, 5))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 195, 16))
+    }
+    getParts() {
+>getParts : Symbol(Person.getParts, Decl(keyofAndIndexedAccess.ts, 198, 5))
+
+        return this.get("parts")
+>this.get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 184, 12))
+>this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 191, 1))
+>get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 184, 12))
+    }
+}
+
+class OtherPerson {
+>OtherPerson : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 202, 1))
+
+    parts: number;
+>parts : Symbol(OtherPerson.parts, Decl(keyofAndIndexedAccess.ts, 204, 19))
+
+    constructor(parts: number) {
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 206, 16))
+
+        setProperty(this, "parts", parts);
+>setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 79, 1))
+>this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 202, 1))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 206, 16))
+    }
+    getParts() {
+>getParts : Symbol(OtherPerson.getParts, Decl(keyofAndIndexedAccess.ts, 208, 5))
+
+        return getProperty(this, "parts")
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
+>this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 202, 1))
+    }
 }

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -16,6 +16,14 @@ class Shape {
 >visible : boolean
 }
 
+class TaggedShape extends Shape {
+>TaggedShape : TaggedShape
+>Shape : Shape
+
+    tag: string;
+>tag : string
+}
+
 class Item {
 >Item : Item
 
@@ -626,6 +634,55 @@ function f32<K extends "width" | "height">(key: K) {
 >key : K
 }
 
+function f33<S extends Shape, K extends keyof S>(shape: S, key: K) {
+>f33 : <S extends Shape, K extends keyof S>(shape: S, key: K) => S[K]
+>S : S
+>Shape : Shape
+>K : K
+>S : S
+>shape : S
+>S : S
+>key : K
+>K : K
+
+    let name = getProperty(shape, "name");
+>name : string
+>getProperty(shape, "name") : string
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
+>shape : S
+>"name" : "name"
+
+    let prop = getProperty(shape, key);
+>prop : S[K]
+>getProperty(shape, key) : S[K]
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
+>shape : S
+>key : K
+
+    return prop;
+>prop : S[K]
+}
+
+function f34(ts: TaggedShape) {
+>f34 : (ts: TaggedShape) => void
+>ts : TaggedShape
+>TaggedShape : TaggedShape
+
+    let tag1 = f33(ts, "tag");
+>tag1 : string
+>f33(ts, "tag") : string
+>f33 : <S extends Shape, K extends keyof S>(shape: S, key: K) => S[K]
+>ts : TaggedShape
+>"tag" : "tag"
+
+    let tag2 = getProperty(ts, "tag");
+>tag2 : string
+>getProperty(ts, "tag") : string
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
+>ts : TaggedShape
+>"tag" : "tag"
+}
+
 class C {
 >C : C
 
@@ -678,4 +735,98 @@ function f40(c: C) {
 >c["z"] : string
 >c : C
 >"z" : "z"
+}
+
+// Repros from #12011
+
+class Base {
+>Base : Base
+
+    get<K extends keyof this>(prop: K) {
+>get : <K extends keyof this>(prop: K) => this[K]
+>K : K
+>prop : K
+>K : K
+
+        return this[prop];
+>this[prop] : this[K]
+>this : this
+>prop : K
+    }
+    set<K extends keyof this>(prop: K, value: this[K]) {
+>set : <K extends keyof this>(prop: K, value: this[K]) => void
+>K : K
+>prop : K
+>K : K
+>value : this[K]
+>K : K
+
+        this[prop] = value;
+>this[prop] = value : this[K]
+>this[prop] : this[K]
+>this : this
+>prop : K
+>value : this[K]
+    }
+}
+
+class Person extends Base {
+>Person : Person
+>Base : Base
+
+    parts: number;
+>parts : number
+
+    constructor(parts: number) {
+>parts : number
+
+        super();
+>super() : void
+>super : typeof Base
+
+        this.set("parts", parts);
+>this.set("parts", parts) : void
+>this.set : <K extends keyof this>(prop: K, value: this[K]) => void
+>this : this
+>set : <K extends keyof this>(prop: K, value: this[K]) => void
+>"parts" : "parts"
+>parts : number
+    }
+    getParts() {
+>getParts : () => number
+
+        return this.get("parts")
+>this.get("parts") : number
+>this.get : <K extends keyof this>(prop: K) => this[K]
+>this : this
+>get : <K extends keyof this>(prop: K) => this[K]
+>"parts" : "parts"
+    }
+}
+
+class OtherPerson {
+>OtherPerson : OtherPerson
+
+    parts: number;
+>parts : number
+
+    constructor(parts: number) {
+>parts : number
+
+        setProperty(this, "parts", parts);
+>setProperty(this, "parts", parts) : void
+>setProperty : <T, K extends keyof T>(obj: T, key: K, value: T[K]) => void
+>this : this
+>"parts" : "parts"
+>parts : number
+    }
+    getParts() {
+>getParts : () => number
+
+        return getProperty(this, "parts")
+>getProperty(this, "parts") : number
+>getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
+>this : this
+>"parts" : "parts"
+    }
 }

--- a/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
+++ b/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
@@ -7,6 +7,10 @@ class Shape {
     visible: boolean;
 }
 
+class TaggedShape extends Shape {
+    tag: string;
+}
+
 class Item {
     name: string;
     price: number;
@@ -149,6 +153,17 @@ function f32<K extends "width" | "height">(key: K) {
     return shape[key];  // Shape[K]
 }
 
+function f33<S extends Shape, K extends keyof S>(shape: S, key: K) {
+    let name = getProperty(shape, "name");
+    let prop = getProperty(shape, key);
+    return prop;
+}
+
+function f34(ts: TaggedShape) {
+    let tag1 = f33(ts, "tag");
+    let tag2 = getProperty(ts, "tag");
+}
+
 class C {
     public x: string;
     protected y: string;
@@ -164,4 +179,36 @@ function f40(c: C) {
     let x: X = c["x"];
     let y: Y = c["y"];
     let z: Z = c["z"];
+}
+
+// Repros from #12011
+
+class Base {
+    get<K extends keyof this>(prop: K) {
+        return this[prop];
+    }
+    set<K extends keyof this>(prop: K, value: this[K]) {
+        this[prop] = value;
+    }
+}
+
+class Person extends Base {
+    parts: number;
+    constructor(parts: number) {
+        super();
+        this.set("parts", parts);
+    }
+    getParts() {
+        return this.get("parts")
+    }
+}
+
+class OtherPerson {
+    parts: number;
+    constructor(parts: number) {
+        setProperty(this, "parts", parts);
+    }
+    getParts() {
+        return getProperty(this, "parts")
+    }
 }


### PR DESCRIPTION
This PR introduces two assignability rules to properly support constrained type parameters in conjunction with the `keyof` type operator:

* Given a type parameter `K` with a constraint `keyof T`, a type `S` is assignable to `K` if `S` is assignable to `keyof T`.
* Given a type parameter `T` with a constraint `C`, a type `S` is assignable to `keyof T` if `S` is assignable to `keyof C`.

Fixes #12011.