### PR TITLE
Ensure transformFlags are correct before visiting a node.

### DIFF
--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -553,6 +553,7 @@ namespace ts {
             return undefined;
         }
 
+        aggregateTransformFlags(node);
         const visited = visitor(node);
         if (visited === node) {
             return node;
@@ -621,6 +622,7 @@ namespace ts {
         // Visit each original node.
         for (let i = 0; i < count; i++) {
             const node = nodes[i + start];
+            aggregateTransformFlags(node);
             const visited = node !== undefined ? visitor(node) : undefined;
             if (updated !== undefined || visited === undefined || visited !== node) {
                 if (updated === undefined) {

--- a/tests/baselines/reference/callWithSpread.js
+++ b/tests/baselines/reference/callWithSpread.js
@@ -1,6 +1,6 @@
 //// [callWithSpread.ts]
 interface X {
-    foo(x: number, y: number, ...z: string[]);
+    foo(x: number, y: number, ...z: string[]): X;
 }
 
 function foo(x: number, y: number, ...z: string[]) {
@@ -19,9 +19,17 @@ obj.foo(1, 2, "abc");
 obj.foo(1, 2, ...a);
 obj.foo(1, 2, ...a, "abc");
 
+obj.foo(1, 2, ...a).foo(1, 2, "abc");
+obj.foo(1, 2, ...a).foo(1, 2, ...a);
+obj.foo(1, 2, ...a).foo(1, 2, ...a, "abc");
+
 (obj.foo)(1, 2, "abc");
 (obj.foo)(1, 2, ...a);
 (obj.foo)(1, 2, ...a, "abc");
+
+((obj.foo)(1, 2, ...a).foo)(1, 2, "abc");
+((obj.foo)(1, 2, ...a).foo)(1, 2, ...a);
+((obj.foo)(1, 2, ...a).foo)(1, 2, ...a, "abc");
 
 xa[1].foo(1, 2, "abc");
 xa[1].foo(1, 2, ...a);
@@ -72,13 +80,19 @@ foo.apply(void 0, [1, 2].concat(a, ["abc"]));
 obj.foo(1, 2, "abc");
 obj.foo.apply(obj, [1, 2].concat(a));
 obj.foo.apply(obj, [1, 2].concat(a, ["abc"]));
+obj.foo.apply(obj, [1, 2].concat(a)).foo(1, 2, "abc");
+(_a = obj.foo.apply(obj, [1, 2].concat(a))).foo.apply(_a, [1, 2].concat(a));
+(_b = obj.foo.apply(obj, [1, 2].concat(a))).foo.apply(_b, [1, 2].concat(a, ["abc"]));
 (obj.foo)(1, 2, "abc");
 obj.foo.apply(obj, [1, 2].concat(a));
 obj.foo.apply(obj, [1, 2].concat(a, ["abc"]));
+(obj.foo.apply(obj, [1, 2].concat(a)).foo)(1, 2, "abc");
+(_c = obj.foo.apply(obj, [1, 2].concat(a))).foo.apply(_c, [1, 2].concat(a));
+(_d = obj.foo.apply(obj, [1, 2].concat(a))).foo.apply(_d, [1, 2].concat(a, ["abc"]));
 xa[1].foo(1, 2, "abc");
-(_a = xa[1]).foo.apply(_a, [1, 2].concat(a));
-(_b = xa[1]).foo.apply(_b, [1, 2].concat(a, ["abc"]));
-(_c = xa[1]).foo.apply(_c, [1, 2, "abc"]);
+(_e = xa[1]).foo.apply(_e, [1, 2].concat(a));
+(_f = xa[1]).foo.apply(_f, [1, 2].concat(a, ["abc"]));
+(_g = xa[1]).foo.apply(_g, [1, 2, "abc"]);
 var C = (function () {
     function C(x, y) {
         var z = [];
@@ -109,4 +123,4 @@ var D = (function (_super) {
     };
     return D;
 }(C));
-var _a, _b, _c;
+var _a, _b, _c, _d, _e, _f, _g;

--- a/tests/baselines/reference/callWithSpread.symbols
+++ b/tests/baselines/reference/callWithSpread.symbols
@@ -2,11 +2,12 @@
 interface X {
 >X : Symbol(X, Decl(callWithSpread.ts, 0, 0))
 
-    foo(x: number, y: number, ...z: string[]);
+    foo(x: number, y: number, ...z: string[]): X;
 >foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
 >x : Symbol(x, Decl(callWithSpread.ts, 1, 8))
 >y : Symbol(y, Decl(callWithSpread.ts, 1, 18))
 >z : Symbol(z, Decl(callWithSpread.ts, 1, 29))
+>X : Symbol(X, Decl(callWithSpread.ts, 0, 0))
 }
 
 function foo(x: number, y: number, ...z: string[]) {
@@ -58,6 +59,32 @@ obj.foo(1, 2, ...a, "abc");
 >foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
 >a : Symbol(a, Decl(callWithSpread.ts, 7, 3))
 
+obj.foo(1, 2, ...a).foo(1, 2, "abc");
+>obj.foo(1, 2, ...a).foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>obj.foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>obj : Symbol(obj, Decl(callWithSpread.ts, 9, 3))
+>foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>a : Symbol(a, Decl(callWithSpread.ts, 7, 3))
+>foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+
+obj.foo(1, 2, ...a).foo(1, 2, ...a);
+>obj.foo(1, 2, ...a).foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>obj.foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>obj : Symbol(obj, Decl(callWithSpread.ts, 9, 3))
+>foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>a : Symbol(a, Decl(callWithSpread.ts, 7, 3))
+>foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>a : Symbol(a, Decl(callWithSpread.ts, 7, 3))
+
+obj.foo(1, 2, ...a).foo(1, 2, ...a, "abc");
+>obj.foo(1, 2, ...a).foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>obj.foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>obj : Symbol(obj, Decl(callWithSpread.ts, 9, 3))
+>foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>a : Symbol(a, Decl(callWithSpread.ts, 7, 3))
+>foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>a : Symbol(a, Decl(callWithSpread.ts, 7, 3))
+
 (obj.foo)(1, 2, "abc");
 >obj.foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
 >obj : Symbol(obj, Decl(callWithSpread.ts, 9, 3))
@@ -72,6 +99,32 @@ obj.foo(1, 2, ...a, "abc");
 (obj.foo)(1, 2, ...a, "abc");
 >obj.foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
 >obj : Symbol(obj, Decl(callWithSpread.ts, 9, 3))
+>foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>a : Symbol(a, Decl(callWithSpread.ts, 7, 3))
+
+((obj.foo)(1, 2, ...a).foo)(1, 2, "abc");
+>(obj.foo)(1, 2, ...a).foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>obj.foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>obj : Symbol(obj, Decl(callWithSpread.ts, 9, 3))
+>foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>a : Symbol(a, Decl(callWithSpread.ts, 7, 3))
+>foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+
+((obj.foo)(1, 2, ...a).foo)(1, 2, ...a);
+>(obj.foo)(1, 2, ...a).foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>obj.foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>obj : Symbol(obj, Decl(callWithSpread.ts, 9, 3))
+>foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>a : Symbol(a, Decl(callWithSpread.ts, 7, 3))
+>foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>a : Symbol(a, Decl(callWithSpread.ts, 7, 3))
+
+((obj.foo)(1, 2, ...a).foo)(1, 2, ...a, "abc");
+>(obj.foo)(1, 2, ...a).foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>obj.foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>obj : Symbol(obj, Decl(callWithSpread.ts, 9, 3))
+>foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
+>a : Symbol(a, Decl(callWithSpread.ts, 7, 3))
 >foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
 >a : Symbol(a, Decl(callWithSpread.ts, 7, 3))
 
@@ -99,60 +152,60 @@ xa[1].foo(1, 2, ...a, "abc");
 >foo : Symbol(X.foo, Decl(callWithSpread.ts, 0, 13))
 
 class C {
->C : Symbol(C, Decl(callWithSpread.ts, 28, 40))
+>C : Symbol(C, Decl(callWithSpread.ts, 36, 40))
 
     constructor(x: number, y: number, ...z: string[]) {
->x : Symbol(x, Decl(callWithSpread.ts, 31, 16))
->y : Symbol(y, Decl(callWithSpread.ts, 31, 26))
->z : Symbol(z, Decl(callWithSpread.ts, 31, 37))
+>x : Symbol(x, Decl(callWithSpread.ts, 39, 16))
+>y : Symbol(y, Decl(callWithSpread.ts, 39, 26))
+>z : Symbol(z, Decl(callWithSpread.ts, 39, 37))
 
         this.foo(x, y);
->this.foo : Symbol(C.foo, Decl(callWithSpread.ts, 34, 5))
->this : Symbol(C, Decl(callWithSpread.ts, 28, 40))
->foo : Symbol(C.foo, Decl(callWithSpread.ts, 34, 5))
->x : Symbol(x, Decl(callWithSpread.ts, 31, 16))
->y : Symbol(y, Decl(callWithSpread.ts, 31, 26))
+>this.foo : Symbol(C.foo, Decl(callWithSpread.ts, 42, 5))
+>this : Symbol(C, Decl(callWithSpread.ts, 36, 40))
+>foo : Symbol(C.foo, Decl(callWithSpread.ts, 42, 5))
+>x : Symbol(x, Decl(callWithSpread.ts, 39, 16))
+>y : Symbol(y, Decl(callWithSpread.ts, 39, 26))
 
         this.foo(x, y, ...z);
->this.foo : Symbol(C.foo, Decl(callWithSpread.ts, 34, 5))
->this : Symbol(C, Decl(callWithSpread.ts, 28, 40))
->foo : Symbol(C.foo, Decl(callWithSpread.ts, 34, 5))
->x : Symbol(x, Decl(callWithSpread.ts, 31, 16))
->y : Symbol(y, Decl(callWithSpread.ts, 31, 26))
->z : Symbol(z, Decl(callWithSpread.ts, 31, 37))
+>this.foo : Symbol(C.foo, Decl(callWithSpread.ts, 42, 5))
+>this : Symbol(C, Decl(callWithSpread.ts, 36, 40))
+>foo : Symbol(C.foo, Decl(callWithSpread.ts, 42, 5))
+>x : Symbol(x, Decl(callWithSpread.ts, 39, 16))
+>y : Symbol(y, Decl(callWithSpread.ts, 39, 26))
+>z : Symbol(z, Decl(callWithSpread.ts, 39, 37))
     }
     foo(x: number, y: number, ...z: string[]) {
->foo : Symbol(C.foo, Decl(callWithSpread.ts, 34, 5))
->x : Symbol(x, Decl(callWithSpread.ts, 35, 8))
->y : Symbol(y, Decl(callWithSpread.ts, 35, 18))
->z : Symbol(z, Decl(callWithSpread.ts, 35, 29))
+>foo : Symbol(C.foo, Decl(callWithSpread.ts, 42, 5))
+>x : Symbol(x, Decl(callWithSpread.ts, 43, 8))
+>y : Symbol(y, Decl(callWithSpread.ts, 43, 18))
+>z : Symbol(z, Decl(callWithSpread.ts, 43, 29))
     }
 }
 
 class D extends C {
->D : Symbol(D, Decl(callWithSpread.ts, 37, 1))
->C : Symbol(C, Decl(callWithSpread.ts, 28, 40))
+>D : Symbol(D, Decl(callWithSpread.ts, 45, 1))
+>C : Symbol(C, Decl(callWithSpread.ts, 36, 40))
 
     constructor() {
         super(1, 2);
->super : Symbol(C, Decl(callWithSpread.ts, 28, 40))
+>super : Symbol(C, Decl(callWithSpread.ts, 36, 40))
 
         super(1, 2, ...a);
->super : Symbol(C, Decl(callWithSpread.ts, 28, 40))
+>super : Symbol(C, Decl(callWithSpread.ts, 36, 40))
 >a : Symbol(a, Decl(callWithSpread.ts, 7, 3))
     }
     foo() {
->foo : Symbol(D.foo, Decl(callWithSpread.ts, 43, 5))
+>foo : Symbol(D.foo, Decl(callWithSpread.ts, 51, 5))
 
         super.foo(1, 2);
->super.foo : Symbol(C.foo, Decl(callWithSpread.ts, 34, 5))
->super : Symbol(C, Decl(callWithSpread.ts, 28, 40))
->foo : Symbol(C.foo, Decl(callWithSpread.ts, 34, 5))
+>super.foo : Symbol(C.foo, Decl(callWithSpread.ts, 42, 5))
+>super : Symbol(C, Decl(callWithSpread.ts, 36, 40))
+>foo : Symbol(C.foo, Decl(callWithSpread.ts, 42, 5))
 
         super.foo(1, 2, ...a);
->super.foo : Symbol(C.foo, Decl(callWithSpread.ts, 34, 5))
->super : Symbol(C, Decl(callWithSpread.ts, 28, 40))
->foo : Symbol(C.foo, Decl(callWithSpread.ts, 34, 5))
+>super.foo : Symbol(C.foo, Decl(callWithSpread.ts, 42, 5))
+>super : Symbol(C, Decl(callWithSpread.ts, 36, 40))
+>foo : Symbol(C.foo, Decl(callWithSpread.ts, 42, 5))
 >a : Symbol(a, Decl(callWithSpread.ts, 7, 3))
     }
 }

--- a/tests/baselines/reference/callWithSpread.types
+++ b/tests/baselines/reference/callWithSpread.types
@@ -2,11 +2,12 @@
 interface X {
 >X : X
 
-    foo(x: number, y: number, ...z: string[]);
->foo : (x: number, y: number, ...z: string[]) => any
+    foo(x: number, y: number, ...z: string[]): X;
+>foo : (x: number, y: number, ...z: string[]) => X
 >x : number
 >y : number
 >z : string[]
+>X : X
 }
 
 function foo(x: number, y: number, ...z: string[]) {
@@ -55,29 +56,80 @@ foo(1, 2, ...a, "abc");
 >"abc" : "abc"
 
 obj.foo(1, 2, "abc");
->obj.foo(1, 2, "abc") : any
->obj.foo : (x: number, y: number, ...z: string[]) => any
+>obj.foo(1, 2, "abc") : X
+>obj.foo : (x: number, y: number, ...z: string[]) => X
 >obj : X
->foo : (x: number, y: number, ...z: string[]) => any
+>foo : (x: number, y: number, ...z: string[]) => X
 >1 : 1
 >2 : 2
 >"abc" : "abc"
 
 obj.foo(1, 2, ...a);
->obj.foo(1, 2, ...a) : any
->obj.foo : (x: number, y: number, ...z: string[]) => any
+>obj.foo(1, 2, ...a) : X
+>obj.foo : (x: number, y: number, ...z: string[]) => X
 >obj : X
->foo : (x: number, y: number, ...z: string[]) => any
+>foo : (x: number, y: number, ...z: string[]) => X
 >1 : 1
 >2 : 2
 >...a : string
 >a : string[]
 
 obj.foo(1, 2, ...a, "abc");
->obj.foo(1, 2, ...a, "abc") : any
->obj.foo : (x: number, y: number, ...z: string[]) => any
+>obj.foo(1, 2, ...a, "abc") : X
+>obj.foo : (x: number, y: number, ...z: string[]) => X
 >obj : X
->foo : (x: number, y: number, ...z: string[]) => any
+>foo : (x: number, y: number, ...z: string[]) => X
+>1 : 1
+>2 : 2
+>...a : string
+>a : string[]
+>"abc" : "abc"
+
+obj.foo(1, 2, ...a).foo(1, 2, "abc");
+>obj.foo(1, 2, ...a).foo(1, 2, "abc") : X
+>obj.foo(1, 2, ...a).foo : (x: number, y: number, ...z: string[]) => X
+>obj.foo(1, 2, ...a) : X
+>obj.foo : (x: number, y: number, ...z: string[]) => X
+>obj : X
+>foo : (x: number, y: number, ...z: string[]) => X
+>1 : 1
+>2 : 2
+>...a : string
+>a : string[]
+>foo : (x: number, y: number, ...z: string[]) => X
+>1 : 1
+>2 : 2
+>"abc" : "abc"
+
+obj.foo(1, 2, ...a).foo(1, 2, ...a);
+>obj.foo(1, 2, ...a).foo(1, 2, ...a) : X
+>obj.foo(1, 2, ...a).foo : (x: number, y: number, ...z: string[]) => X
+>obj.foo(1, 2, ...a) : X
+>obj.foo : (x: number, y: number, ...z: string[]) => X
+>obj : X
+>foo : (x: number, y: number, ...z: string[]) => X
+>1 : 1
+>2 : 2
+>...a : string
+>a : string[]
+>foo : (x: number, y: number, ...z: string[]) => X
+>1 : 1
+>2 : 2
+>...a : string
+>a : string[]
+
+obj.foo(1, 2, ...a).foo(1, 2, ...a, "abc");
+>obj.foo(1, 2, ...a).foo(1, 2, ...a, "abc") : X
+>obj.foo(1, 2, ...a).foo : (x: number, y: number, ...z: string[]) => X
+>obj.foo(1, 2, ...a) : X
+>obj.foo : (x: number, y: number, ...z: string[]) => X
+>obj : X
+>foo : (x: number, y: number, ...z: string[]) => X
+>1 : 1
+>2 : 2
+>...a : string
+>a : string[]
+>foo : (x: number, y: number, ...z: string[]) => X
 >1 : 1
 >2 : 2
 >...a : string
@@ -85,32 +137,89 @@ obj.foo(1, 2, ...a, "abc");
 >"abc" : "abc"
 
 (obj.foo)(1, 2, "abc");
->(obj.foo)(1, 2, "abc") : any
->(obj.foo) : (x: number, y: number, ...z: string[]) => any
->obj.foo : (x: number, y: number, ...z: string[]) => any
+>(obj.foo)(1, 2, "abc") : X
+>(obj.foo) : (x: number, y: number, ...z: string[]) => X
+>obj.foo : (x: number, y: number, ...z: string[]) => X
 >obj : X
->foo : (x: number, y: number, ...z: string[]) => any
+>foo : (x: number, y: number, ...z: string[]) => X
 >1 : 1
 >2 : 2
 >"abc" : "abc"
 
 (obj.foo)(1, 2, ...a);
->(obj.foo)(1, 2, ...a) : any
->(obj.foo) : (x: number, y: number, ...z: string[]) => any
->obj.foo : (x: number, y: number, ...z: string[]) => any
+>(obj.foo)(1, 2, ...a) : X
+>(obj.foo) : (x: number, y: number, ...z: string[]) => X
+>obj.foo : (x: number, y: number, ...z: string[]) => X
 >obj : X
->foo : (x: number, y: number, ...z: string[]) => any
+>foo : (x: number, y: number, ...z: string[]) => X
 >1 : 1
 >2 : 2
 >...a : string
 >a : string[]
 
 (obj.foo)(1, 2, ...a, "abc");
->(obj.foo)(1, 2, ...a, "abc") : any
->(obj.foo) : (x: number, y: number, ...z: string[]) => any
->obj.foo : (x: number, y: number, ...z: string[]) => any
+>(obj.foo)(1, 2, ...a, "abc") : X
+>(obj.foo) : (x: number, y: number, ...z: string[]) => X
+>obj.foo : (x: number, y: number, ...z: string[]) => X
 >obj : X
->foo : (x: number, y: number, ...z: string[]) => any
+>foo : (x: number, y: number, ...z: string[]) => X
+>1 : 1
+>2 : 2
+>...a : string
+>a : string[]
+>"abc" : "abc"
+
+((obj.foo)(1, 2, ...a).foo)(1, 2, "abc");
+>((obj.foo)(1, 2, ...a).foo)(1, 2, "abc") : X
+>((obj.foo)(1, 2, ...a).foo) : (x: number, y: number, ...z: string[]) => X
+>(obj.foo)(1, 2, ...a).foo : (x: number, y: number, ...z: string[]) => X
+>(obj.foo)(1, 2, ...a) : X
+>(obj.foo) : (x: number, y: number, ...z: string[]) => X
+>obj.foo : (x: number, y: number, ...z: string[]) => X
+>obj : X
+>foo : (x: number, y: number, ...z: string[]) => X
+>1 : 1
+>2 : 2
+>...a : string
+>a : string[]
+>foo : (x: number, y: number, ...z: string[]) => X
+>1 : 1
+>2 : 2
+>"abc" : "abc"
+
+((obj.foo)(1, 2, ...a).foo)(1, 2, ...a);
+>((obj.foo)(1, 2, ...a).foo)(1, 2, ...a) : X
+>((obj.foo)(1, 2, ...a).foo) : (x: number, y: number, ...z: string[]) => X
+>(obj.foo)(1, 2, ...a).foo : (x: number, y: number, ...z: string[]) => X
+>(obj.foo)(1, 2, ...a) : X
+>(obj.foo) : (x: number, y: number, ...z: string[]) => X
+>obj.foo : (x: number, y: number, ...z: string[]) => X
+>obj : X
+>foo : (x: number, y: number, ...z: string[]) => X
+>1 : 1
+>2 : 2
+>...a : string
+>a : string[]
+>foo : (x: number, y: number, ...z: string[]) => X
+>1 : 1
+>2 : 2
+>...a : string
+>a : string[]
+
+((obj.foo)(1, 2, ...a).foo)(1, 2, ...a, "abc");
+>((obj.foo)(1, 2, ...a).foo)(1, 2, ...a, "abc") : X
+>((obj.foo)(1, 2, ...a).foo) : (x: number, y: number, ...z: string[]) => X
+>(obj.foo)(1, 2, ...a).foo : (x: number, y: number, ...z: string[]) => X
+>(obj.foo)(1, 2, ...a) : X
+>(obj.foo) : (x: number, y: number, ...z: string[]) => X
+>obj.foo : (x: number, y: number, ...z: string[]) => X
+>obj : X
+>foo : (x: number, y: number, ...z: string[]) => X
+>1 : 1
+>2 : 2
+>...a : string
+>a : string[]
+>foo : (x: number, y: number, ...z: string[]) => X
 >1 : 1
 >2 : 2
 >...a : string
@@ -118,35 +227,35 @@ obj.foo(1, 2, ...a, "abc");
 >"abc" : "abc"
 
 xa[1].foo(1, 2, "abc");
->xa[1].foo(1, 2, "abc") : any
->xa[1].foo : (x: number, y: number, ...z: string[]) => any
+>xa[1].foo(1, 2, "abc") : X
+>xa[1].foo : (x: number, y: number, ...z: string[]) => X
 >xa[1] : X
 >xa : X[]
 >1 : 1
->foo : (x: number, y: number, ...z: string[]) => any
+>foo : (x: number, y: number, ...z: string[]) => X
 >1 : 1
 >2 : 2
 >"abc" : "abc"
 
 xa[1].foo(1, 2, ...a);
->xa[1].foo(1, 2, ...a) : any
->xa[1].foo : (x: number, y: number, ...z: string[]) => any
+>xa[1].foo(1, 2, ...a) : X
+>xa[1].foo : (x: number, y: number, ...z: string[]) => X
 >xa[1] : X
 >xa : X[]
 >1 : 1
->foo : (x: number, y: number, ...z: string[]) => any
+>foo : (x: number, y: number, ...z: string[]) => X
 >1 : 1
 >2 : 2
 >...a : string
 >a : string[]
 
 xa[1].foo(1, 2, ...a, "abc");
->xa[1].foo(1, 2, ...a, "abc") : any
->xa[1].foo : (x: number, y: number, ...z: string[]) => any
+>xa[1].foo(1, 2, ...a, "abc") : X
+>xa[1].foo : (x: number, y: number, ...z: string[]) => X
 >xa[1] : X
 >xa : X[]
 >1 : 1
->foo : (x: number, y: number, ...z: string[]) => any
+>foo : (x: number, y: number, ...z: string[]) => X
 >1 : 1
 >2 : 2
 >...a : string
@@ -158,11 +267,11 @@ xa[1].foo(1, 2, ...a, "abc");
 >(<Function>xa[1].foo) : Function
 ><Function>xa[1].foo : Function
 >Function : Function
->xa[1].foo : (x: number, y: number, ...z: string[]) => any
+>xa[1].foo : (x: number, y: number, ...z: string[]) => X
 >xa[1] : X
 >xa : X[]
 >1 : 1
->foo : (x: number, y: number, ...z: string[]) => any
+>foo : (x: number, y: number, ...z: string[]) => X
 >...[1, 2, "abc"] : string | number
 >[1, 2, "abc"] : (string | number)[]
 >1 : 1

--- a/tests/cases/conformance/expressions/functionCalls/callWithSpread.ts
+++ b/tests/cases/conformance/expressions/functionCalls/callWithSpread.ts
@@ -1,5 +1,5 @@
 interface X {
-    foo(x: number, y: number, ...z: string[]);
+    foo(x: number, y: number, ...z: string[]): X;
 }
 
 function foo(x: number, y: number, ...z: string[]) {
@@ -18,9 +18,17 @@ obj.foo(1, 2, "abc");
 obj.foo(1, 2, ...a);
 obj.foo(1, 2, ...a, "abc");
 
+obj.foo(1, 2, ...a).foo(1, 2, "abc");
+obj.foo(1, 2, ...a).foo(1, 2, ...a);
+obj.foo(1, 2, ...a).foo(1, 2, ...a, "abc");
+
 (obj.foo)(1, 2, "abc");
 (obj.foo)(1, 2, ...a);
 (obj.foo)(1, 2, ...a, "abc");
+
+((obj.foo)(1, 2, ...a).foo)(1, 2, "abc");
+((obj.foo)(1, 2, ...a).foo)(1, 2, ...a);
+((obj.foo)(1, 2, ...a).foo)(1, 2, ...a, "abc");
 
 xa[1].foo(1, 2, "abc");
 xa[1].foo(1, 2, ...a);


### PR DESCRIPTION
When transforming a `SpreadElementExpression` in a `CallExpression`, we call `createCallBinding` which may return a new expression containing an existing subtree. However, this new expression has not had its transform flags computed. Then, when we go to visit the target, our visitor thinks there is nothing to do since no flags are set. To fix this, and catch any future instances of this issue, we will now call `aggregateTransformFlags` prior to visiting any node to ensure the flags are computed.

Fixes #12010

