### PR TITLE
use createHash from ServerHost instead of explicit require

### DIFF
--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -720,6 +720,10 @@ namespace Harness.LanguageService {
         clearImmediate(timeoutId: any): void {
             clearImmediate(timeoutId);
         }
+
+        createHash(s: string) {
+            return s;
+        }
     }
 
     export class ServerLanguageServiceAdapter implements LanguageServiceAdapter {

--- a/src/harness/unittests/cachingInServerLSHost.ts
+++ b/src/harness/unittests/cachingInServerLSHost.ts
@@ -43,7 +43,8 @@ namespace ts {
             setTimeout,
             clearTimeout,
             setImmediate: typeof setImmediate !== "undefined" ? setImmediate : action => setTimeout(action, 0),
-            clearImmediate: typeof clearImmediate !== "undefined" ? clearImmediate : clearTimeout
+            clearImmediate: typeof clearImmediate !== "undefined" ? clearImmediate : clearTimeout,
+            createHash: s => s
         };
     }
 

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -24,7 +24,8 @@ namespace ts.server {
         setTimeout() { return 0; },
         clearTimeout: noop,
         setImmediate: () => 0,
-        clearImmediate: noop
+        clearImmediate: noop,
+        createHash: s => s
     };
     const nullCancellationToken: HostCancellationToken = { isCancellationRequested: () => false };
     const mockLogger: Logger = {

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -439,6 +439,10 @@ namespace ts.projectSystem {
             };
         }
 
+        createHash(s: string): string {
+            return s;
+        }
+
         triggerDirectoryWatcherCallback(directoryName: string, fileName: string): void {
             const path = this.toPath(directoryName);
             const callbacks = this.watchedDirectories[path];

--- a/src/server/builder.ts
+++ b/src/server/builder.ts
@@ -5,15 +5,6 @@
 
 namespace ts.server {
 
-    interface Hash {
-        update(data: any, input_encoding?: string): Hash;
-        digest(encoding: string): any;
-    }
-
-    const crypto: {
-        createHash(algorithm: string): Hash
-    } = require("crypto");
-
     export function shouldEmitFile(scriptInfo: ScriptInfo) {
         return !scriptInfo.hasMixedContent;
     }
@@ -49,9 +40,7 @@ namespace ts.server {
         }
 
         private computeHash(text: string): string {
-            return crypto.createHash("md5")
-                .update(text)
-                .digest("base64");
+            return this.project.projectService.host.createHash(text);
         }
 
         private getSourceFile(): SourceFile {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -250,6 +250,8 @@ namespace ts.server {
             readonly typingsInstaller: ITypingsInstaller = nullTypingsInstaller,
             private readonly eventHandler?: ProjectServiceEventHandler) {
 
+            Debug.assert(!!host.createHash, "'ServerHost.createHash' is required for ProjectService");
+
             this.toCanonicalFileName = createGetCanonicalFileName(host.useCaseSensitiveFileNames);
             this.directoryWatchers = new DirectoryWatchers(this);
             this.throttledOperations = new ThrottledOperations(host);


### PR DESCRIPTION
`ServerHost` already exports `createHash` function which is implemented for node-based hosts. Using an explicit `require` is redundant plus it makes server code less host agnostic (by adding requirement to have globally accessible `require`)