### PR TITLE
reduce set of files being watched, increase polling interval

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -596,6 +596,7 @@ namespace ts {
             getTypeCount: () => getDiagnosticsProducingTypeChecker().getTypeCount(),
             getFileProcessingDiagnostics: () => fileProcessingDiagnostics,
             getResolvedTypeReferenceDirectives: () => resolvedTypeReferenceDirectives,
+            isSourceFileFromExternalLibrary,
             dropDiagnosticsProducingTypeChecker
         };
 
@@ -781,11 +782,15 @@ namespace ts {
                 getSourceFile: program.getSourceFile,
                 getSourceFileByPath: program.getSourceFileByPath,
                 getSourceFiles: program.getSourceFiles,
-                isSourceFileFromExternalLibrary: (file: SourceFile) => !!sourceFilesFoundSearchingNodeModules[file.path],
+                isSourceFileFromExternalLibrary,
                 writeFile: writeFileCallback || (
                     (fileName, data, writeByteOrderMark, onError, sourceFiles) => host.writeFile(fileName, data, writeByteOrderMark, onError, sourceFiles)),
                 isEmitBlocked,
             };
+        }
+
+        function isSourceFileFromExternalLibrary(file: SourceFile): boolean {
+            return sourceFilesFoundSearchingNodeModules[file.path];
         }
 
         function getDiagnosticsProducingTypeChecker() {

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -17,7 +17,11 @@ namespace ts {
         readFile(path: string, encoding?: string): string;
         getFileSize?(path: string): number;
         writeFile(path: string, data: string, writeByteOrderMark?: boolean): void;
-        watchFile?(path: string, callback: FileWatcherCallback): FileWatcher;
+        /**
+         * @pollingInterval - this parameter is used in polling-based watchers and ignored in watchers that 
+         * use native OS file watching
+         */
+        watchFile?(path: string, callback: FileWatcherCallback, pollingInterval?: number): FileWatcher;
         watchDirectory?(path: string, callback: DirectoryWatcherCallback, recursive?: boolean): FileWatcher;
         resolvePath(path: string): string;
         fileExists(path: string): boolean;
@@ -444,7 +448,7 @@ namespace ts {
                 },
                 readFile,
                 writeFile,
-                watchFile: (fileName, callback) => {
+                watchFile: (fileName, callback, pollingInterval) => {
                     if (useNonPollingWatchers) {
                         const watchedFile = watchedFileSet.addFile(fileName, callback);
                         return {
@@ -452,7 +456,7 @@ namespace ts {
                         };
                     }
                     else {
-                        _fs.watchFile(fileName, { persistent: true, interval: 250 }, fileChanged);
+                        _fs.watchFile(fileName, { persistent: true, interval: pollingInterval || 250 }, fileChanged);
                         return {
                             close: () => _fs.unwatchFile(fileName, fileChanged)
                         };

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1788,6 +1788,7 @@ namespace ts {
 
         /* @internal */ getFileProcessingDiagnostics(): DiagnosticCollection;
         /* @internal */ getResolvedTypeReferenceDirectives(): Map<ResolvedTypeReferenceDirective>;
+        /* @internal */ isSourceFileFromExternalLibrary(file: SourceFile): boolean;
         // For testing purposes only.
         /* @internal */ structureIsReused?: boolean;
     }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -225,7 +225,7 @@ namespace ts.server {
             return this.getLanguageService().getEmitOutput(info.fileName, emitOnlyDtsFiles);
         }
 
-        getFileNames() {
+        getFileNames(excludeFilesFromExternalLibraries?: boolean) {
             if (!this.program) {
                 return [];
             }
@@ -241,8 +241,14 @@ namespace ts.server {
                 }
                 return rootFiles;
             }
-            const sourceFiles = this.program.getSourceFiles();
-            return sourceFiles.map(sourceFile => asNormalizedPath(sourceFile.fileName));
+            const result: NormalizedPath[] = [];
+            for (const f of this.program.getSourceFiles()) {
+                if (excludeFilesFromExternalLibraries && this.program.isSourceFileFromExternalLibrary(f)) {
+                    continue;
+                }
+                result.push(asNormalizedPath(f.fileName));
+            }
+            return result;
         }
 
         getAllEmittableFiles() {

--- a/src/server/types.d.ts
+++ b/src/server/types.d.ts
@@ -67,6 +67,6 @@ declare namespace ts.server {
     export interface InstallTypingHost extends JsTyping.TypingResolutionHost {
         writeFile(path: string, content: string): void;
         createDirectory(path: string): void;
-        watchFile?(path: string, callback: FileWatcherCallback): FileWatcher;
+        watchFile?(path: string, callback: FileWatcherCallback, pollingInterval?: number): FileWatcher;
     }
 }

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -361,7 +361,7 @@ namespace ts.server.typingsInstaller {
                         this.sendResponse({ projectName: projectName, kind: server.ActionInvalidate });
                         isInvoked = true;
                     }
-                });
+                }, /*pollingInterval*/ 2000);
                 watchers.push(w);
             }
             this.projectWatchers[projectName] = watchers;

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -50,7 +50,7 @@ namespace ts.server {
     export function createInstallTypingsRequest(project: Project, typingOptions: TypingOptions, cachePath?: string): DiscoverTypings {
         return {
             projectName: project.getProjectName(),
-            fileNames: project.getFileNames(),
+            fileNames: project.getFileNames(/*excludeFilesFromExternalLibraries*/ true),
             compilerOptions: project.getCompilerOptions(),
             typingOptions,
             projectRootPath: getProjectRootPath(project),

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -77,7 +77,7 @@ namespace ts.JsTyping {
         exclude = typingOptions.exclude || [];
 
         const possibleSearchDirs = map(fileNames, getDirectoryPath);
-        if (projectRootPath !== undefined) {
+        if (projectRootPath) {
             possibleSearchDirs.push(projectRootPath);
         }
         searchDirs = deduplicate(possibleSearchDirs);


### PR DESCRIPTION
fixes #12047.

Reason of permanent CPU activity of `typingsInstaller` process is polling fs watchers. This PR 
- trims amount of source files that we pass to typings installer to infer typings from to only root files and files that were not loaded from `node_modules` folder thus reducing the amount of `package.json` that will be polled. 
- sets explicit polling interval to 2 s instead of 250 ms which is default - typings installer can afford doing thing with some delay.