### PR TITLE
Cache generic signature instantiations

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4232,7 +4232,7 @@ namespace ts {
             for (const baseSig of baseSignatures) {
                 const typeParamCount = baseSig.typeParameters ? baseSig.typeParameters.length : 0;
                 if (typeParamCount === typeArgCount) {
-                    const sig = typeParamCount ? getSignatureInstantiation(baseSig, typeArguments) : cloneSignature(baseSig);
+                    const sig = typeParamCount ? createSignatureInstantiation(baseSig, typeArguments) : cloneSignature(baseSig);
                     sig.typeParameters = classType.localTypeParameters;
                     sig.resolvedReturnType = classType;
                     result.push(sig);
@@ -4982,6 +4982,12 @@ namespace ts {
         }
 
         function getSignatureInstantiation(signature: Signature, typeArguments: Type[]): Signature {
+            const instantiations = signature.instantiations || (signature.instantiations = createMap<Signature>());
+            const id = getTypeListId(typeArguments);
+            return instantiations[id] || (instantiations[id] = createSignatureInstantiation(signature, typeArguments));
+        }
+
+        function createSignatureInstantiation(signature: Signature, typeArguments: Type[]): Signature {
             return instantiateSignature(signature, createTypeMapper(signature.typeParameters, typeArguments), /*eraseTypeParameters*/ true);
         }
 

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2923,6 +2923,8 @@ namespace ts {
         isolatedSignatureType?: ObjectType; // A manufactured type that just contains the signature for purposes of signature comparison
         /* @internal */
         typePredicate?: TypePredicate;
+        /* @internal */
+        instantiations?: Map<Signature>;    // Generic signature instantiation cache
     }
 
     export const enum IndexKind {

--- a/tests/baselines/reference/promisePermutations.errors.txt
+++ b/tests/baselines/reference/promisePermutations.errors.txt
@@ -25,8 +25,6 @@ tests/cases/compiler/promisePermutations.ts(106,19): error TS2345: Argument of t
   Types of parameters 'cb' and 'value' are incompatible.
     Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations.ts(109,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
-  Types of parameters 'cb' and 'value' are incompatible.
-    Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations.ts(110,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
     Type 'string' is not assignable to type '<T>(a: T) => T'.
@@ -229,8 +227,6 @@ tests/cases/compiler/promisePermutations.ts(160,21): error TS2345: Argument of t
     var s7a = r7.then(testFunction7, testFunction7, testFunction7); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
-!!! error TS2345:   Types of parameters 'cb' and 'value' are incompatible.
-!!! error TS2345:     Type 'string' is not assignable to type '<T>(a: T) => T'.
     var s7b = r7.then(testFunction7P, testFunction7P, testFunction7P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.

--- a/tests/baselines/reference/promisePermutations2.errors.txt
+++ b/tests/baselines/reference/promisePermutations2.errors.txt
@@ -25,8 +25,6 @@ tests/cases/compiler/promisePermutations2.ts(105,19): error TS2345: Argument of 
   Types of parameters 'cb' and 'value' are incompatible.
     Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations2.ts(108,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
-  Types of parameters 'cb' and 'value' are incompatible.
-    Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations2.ts(109,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
     Type 'string' is not assignable to type '<T>(a: T) => T'.
@@ -228,8 +226,6 @@ tests/cases/compiler/promisePermutations2.ts(159,21): error TS2345: Argument of 
     var s7a = r7.then(testFunction7, testFunction7, testFunction7); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
-!!! error TS2345:   Types of parameters 'cb' and 'value' are incompatible.
-!!! error TS2345:     Type 'string' is not assignable to type '<T>(a: T) => T'.
     var s7b = r7.then(testFunction7P, testFunction7P, testFunction7P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.

--- a/tests/baselines/reference/promisePermutations3.errors.txt
+++ b/tests/baselines/reference/promisePermutations3.errors.txt
@@ -28,8 +28,6 @@ tests/cases/compiler/promisePermutations3.ts(105,19): error TS2345: Argument of 
   Types of parameters 'cb' and 'value' are incompatible.
     Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations3.ts(108,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
-  Types of parameters 'cb' and 'value' are incompatible.
-    Type 'string' is not assignable to type '<T>(a: T) => T'.
 tests/cases/compiler/promisePermutations3.ts(109,19): error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.
   Types of parameters 'cb' and 'value' are incompatible.
     Type 'string' is not assignable to type '<T>(a: T) => T'.
@@ -240,8 +238,6 @@ tests/cases/compiler/promisePermutations3.ts(165,21): error TS2345: Argument of 
     var s7a = r7.then(testFunction7, testFunction7, testFunction7); // error
                       ~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => IPromise<string>' is not assignable to parameter of type '(value: string) => IPromise<string>'.
-!!! error TS2345:   Types of parameters 'cb' and 'value' are incompatible.
-!!! error TS2345:     Type 'string' is not assignable to type '<T>(a: T) => T'.
     var s7b = r7.then(testFunction7P, testFunction7P, testFunction7P); // error
                       ~~~~~~~~~~~~~~
 !!! error TS2345: Argument of type '(cb: <T>(a: T) => T) => Promise<string>' is not assignable to parameter of type '(value: string) => Promise<string>'.


### PR DESCRIPTION
This PR adds caching of generic signature instantiations. We already cache instantiations of generic classes, interfaces, and type aliases, but oddly we have never done similar caching of generic signature instantiations. Other than just reducing redundant work, this should have a positive effect on generic signatures that return anonymous types (or instantiations of type aliases for anonymous types) since those continually manufacture new type identities.