### PR TITLE
Import helpers reports errors for __rest

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1553,7 +1553,7 @@ namespace ts {
                 const seen = createMap<ElementKind>();
 
                 for (const prop of node.properties) {
-                    if (prop.name.kind !== SyntaxKind.Identifier) {
+                    if (prop.kind === SyntaxKind.SpreadAssignment || prop.name.kind !== SyntaxKind.Identifier) {
                         continue;
                     }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19970,8 +19970,12 @@ namespace ts {
                     if (requestedExternalEmitHelpers & NodeFlags.HasClassExtends && languageVersion < ScriptTarget.ES2015) {
                         verifyHelperSymbol(exports, "__extends", SymbolFlags.Value);
                     }
-                    if (requestedExternalEmitHelpers & NodeFlags.HasSpreadAttribute && compilerOptions.jsx !== JsxEmit.Preserve) {
+                    if (requestedExternalEmitHelpers & NodeFlags.HasSpreadAttribute &&
+                        (languageVersion < ScriptTarget.ESNext || compilerOptions.jsx === JsxEmit.React)) {
                         verifyHelperSymbol(exports, "__assign", SymbolFlags.Value);
+                    }
+                    if (languageVersion < ScriptTarget.ESNext && requestedExternalEmitHelpers & NodeFlags.HasRestAttribute) {
+                        verifyHelperSymbol(exports, "__rest", SymbolFlags.Value);
                     }
                     if (requestedExternalEmitHelpers & NodeFlags.HasDecorators) {
                         verifyHelperSymbol(exports, "__decorate", SymbolFlags.Value);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -433,7 +433,7 @@ namespace ts {
         BlockScoped = Let | Const,
 
         ReachabilityCheckFlags = HasImplicitReturn | HasExplicitReturn,
-        EmitHelperFlags = HasClassExtends | HasDecorators | HasParamDecorators | HasAsyncFunctions | HasSpreadAttribute,
+        EmitHelperFlags = HasClassExtends | HasDecorators | HasParamDecorators | HasAsyncFunctions | HasSpreadAttribute | HasRestAttribute,
         ReachabilityAndEmitFlags = ReachabilityCheckFlags | EmitHelperFlags,
 
         // Parsing context flags

--- a/tests/baselines/reference/importHelpersNoHelpers.errors.txt
+++ b/tests/baselines/reference/importHelpersNoHelpers.errors.txt
@@ -1,13 +1,17 @@
+error TS2305: Module 'tslib' has no exported member '__assign'.
 error TS2305: Module 'tslib' has no exported member '__decorate'.
 error TS2305: Module 'tslib' has no exported member '__extends'.
 error TS2305: Module 'tslib' has no exported member '__metadata'.
 error TS2305: Module 'tslib' has no exported member '__param'.
+error TS2305: Module 'tslib' has no exported member '__rest'.
 
 
+!!! error TS2305: Module 'tslib' has no exported member '__assign'.
 !!! error TS2305: Module 'tslib' has no exported member '__decorate'.
 !!! error TS2305: Module 'tslib' has no exported member '__extends'.
 !!! error TS2305: Module 'tslib' has no exported member '__metadata'.
 !!! error TS2305: Module 'tslib' has no exported member '__param'.
+!!! error TS2305: Module 'tslib' has no exported member '__rest'.
 ==== tests/cases/compiler/external.ts (0 errors) ====
     export class A { }
     export class B extends A { }
@@ -19,6 +23,10 @@ error TS2305: Module 'tslib' has no exported member '__param'.
         method(@dec x: number) {
         }
     }
+    
+    const o = { a: 1 };
+    const y = { ...o };
+    const { ...x } = y;
     
 ==== tests/cases/compiler/script.ts (0 errors) ====
     class A { }
@@ -34,3 +42,4 @@ error TS2305: Module 'tslib' has no exported member '__param'.
     
 ==== tests/cases/compiler/tslib.d.ts (0 errors) ====
     export {}
+    

--- a/tests/baselines/reference/importHelpersNoHelpers.js
+++ b/tests/baselines/reference/importHelpersNoHelpers.js
@@ -12,6 +12,10 @@ class C {
     }
 }
 
+const o = { a: 1 };
+const y = { ...o };
+const { ...x } = y;
+
 //// [script.ts]
 class A { }
 class B extends A { }
@@ -26,6 +30,7 @@ class C {
 
 //// [tslib.d.ts]
 export {}
+
 
 //// [external.js]
 "use strict";
@@ -61,6 +66,9 @@ C = tslib_1.__decorate([
     dec,
     tslib_1.__metadata("design:paramtypes", [])
 ], C);
+var o = { a: 1 };
+var y = __assign({}, o);
+var x = __rest(y, []);
 //// [script.js]
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];

--- a/tests/cases/compiler/importHelpersNoHelpers.ts
+++ b/tests/cases/compiler/importHelpersNoHelpers.ts
@@ -16,6 +16,10 @@ class C {
     }
 }
 
+const o = { a: 1 };
+const y = { ...o };
+const { ...x } = y;
+
 // @filename: script.ts
 class A { }
 class B extends A { }


### PR DESCRIPTION
Also fixes a crash in binder when checking spreads in object literals in strict mode.

I may wait to merge this until after @rbuckton finishes the refactoring of verifyHelperSymbol and surroundings. @mhegazy you requested this so you may want to take a look too.