### PR TITLE
RFC: <script type="ts/module">

### DIFF
--- a/hello-world.ts.html
+++ b/hello-world.ts.html
@@ -1,0 +1,32 @@
+<html>
+<title>node built/local/tsc.js --html hello-world.ts.html</title>
+<body>
+  <template>
+    <style>
+      :host {
+        display: block;
+        box-sizing: border-box;
+        border: 1px solid red;
+        margin-top: 10px;
+        padding: 0px 5px;
+      }
+    </style>
+    <p>Test <slot></slot></p>
+  </template>
+  <script type="ts/module">
+    class HelloWorld extends HTMLElement {
+      _hello: string = "Hello World"
+      constructor() {
+        super()
+        const t = document.querySelector('template')
+        if (t == null) return;
+        const instance = t.content.cloneNode(true)
+        const shadowRoot = this.attachShadow({ mode: 'open' })
+        shadowRoot.appendChild(instance)
+      }
+    }
+    customElements.define('hello-world', HelloWorld);  
+  </script>
+  <hello-world>Hello World</hello-world>
+</body>
+</html>

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -51,6 +51,12 @@ namespace ts {
             type: "boolean"
         },
         {
+            name: "html",
+            type: "boolean"
+            // TODO
+            // description: "<script type=\"ts/module\">...</script>"
+        },
+        {
             name: "init",
             type: "boolean",
             description: Diagnostics.Initializes_a_TypeScript_project_and_creates_a_tsconfig_json_file,

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1898,6 +1898,8 @@ namespace ts {
                 return ScriptKind.TS;
             case ".tsx":
                 return ScriptKind.TSX;
+            case ".html":
+                return ScriptKind.HTML;
             default:
                 return ScriptKind.Unknown;
         }
@@ -1906,9 +1908,9 @@ namespace ts {
     /**
      *  List of supported extensions in order of file resolution precedence.
      */
-    export const supportedTypeScriptExtensions = [".ts", ".tsx", ".d.ts"];
+    export const supportedTypeScriptExtensions = [".ts", ".tsx", ".ts.html", ".d.ts"];
     /** Must have ".d.ts" first because if ".ts" goes first, that will be detected as the extension instead of ".d.ts". */
-    export const supportedTypescriptExtensionsForExtractExtension = [".d.ts", ".ts", ".tsx"];
+    export const supportedTypescriptExtensionsForExtractExtension = [".d.ts", ".ts.html", ".ts", ".tsx"];
     export const supportedJavascriptExtensions = [".js", ".jsx"];
     const allSupportedExtensions = supportedTypeScriptExtensions.concat(supportedJavascriptExtensions);
 
@@ -1988,7 +1990,7 @@ namespace ts {
         }
     }
 
-    const extensionsToRemove = [".d.ts", ".ts", ".js", ".tsx", ".jsx"];
+    const extensionsToRemove = [".d.ts", ".ts.html", ".ts", ".js", ".tsx", ".jsx"];
     export function removeFileExtension(path: string): string {
         for (const ext of extensionsToRemove) {
             const extensionless = tryRemoveExtension(path, ext);
@@ -2212,6 +2214,9 @@ namespace ts {
     export function extensionFromPath(path: string): Extension {
         if (fileExtensionIs(path, ".d.ts")) {
             return Extension.Dts;
+        }
+        if (fileExtensionIs(path, ".ts.html")) {
+            return Extension.tsHTML;
         }
         if (fileExtensionIs(path, ".ts")) {
             return Extension.Ts;

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1673,6 +1673,11 @@ namespace ts {
                 programDiagnostics.add(createCompilerDiagnostic(Diagnostics.Option_0_cannot_be_specified_without_specifying_option_1, "emitDecoratorMetadata", "experimentalDecorators"));
             }
 
+            if (options.html) {
+                // TODO
+                // programDiagnostics.add(createCompilerDiagnostic(Diagnostics..., "HTML"));
+            }
+
             if (options.jsxFactory) {
                 if (options.reactNamespace) {
                     programDiagnostics.add(createCompilerDiagnostic(Diagnostics.Option_0_cannot_be_specified_with_option_1, "reactNamespace", "jsxFactory"));

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3059,6 +3059,7 @@ namespace ts {
         experimentalDecorators?: boolean;
         forceConsistentCasingInFileNames?: boolean;
         /*@internal*/help?: boolean;
+        html?: boolean;
         importHelpers?: boolean;
         /*@internal*/init?: boolean;
         inlineSourceMap?: boolean;
@@ -3170,7 +3171,8 @@ namespace ts {
         JS = 1,
         JSX = 2,
         TS = 3,
-        TSX = 4
+        TSX = 4,
+        HTML = 5
     }
 
     export const enum ScriptTarget {
@@ -3434,6 +3436,7 @@ namespace ts {
     export enum Extension {
         Ts,
         Tsx,
+        tsHTML,
         Dts,
         Js,
         Jsx,


### PR DESCRIPTION
https://github.com/Microsoft/TypeScript/issues/11739

I am going trough the source code to try to see if I can do it, but I got stuck fairly quickly, I got `.ts.html` extension in but where do i go tell `tsc` to first look for the `<script>` tag when it parses a `.ts.html` ? 

This question doesn't fit for stackoverflow so I was hoping we could collaborate in a pull request
