### PR TITLE
fix #12137, correct ProxyHandler signatures

### DIFF
--- a/src/lib/es2015.proxy.d.ts
+++ b/src/lib/es2015.proxy.d.ts
@@ -1,5 +1,5 @@
 interface ProxyHandler<T> {
-    getPrototypeOf? (target: T): any;
+    getPrototypeOf? (target: T): Object | null;
     setPrototypeOf? (target: T, v: any): boolean;
     isExtensible? (target: T): boolean;
     preventExtensions? (target: T): boolean;
@@ -12,7 +12,7 @@ interface ProxyHandler<T> {
     enumerate? (target: T): PropertyKey[];
     ownKeys? (target: T): PropertyKey[];
     apply? (target: T, thisArg: any, argArray?: any): any;
-    construct? (target: T, thisArg: any, argArray?: any): any;
+    construct? (target: T, argArray: any, newTarget?: any): Object;
 }
 
 interface ProxyConstructor {

--- a/src/lib/es2015.proxy.d.ts
+++ b/src/lib/es2015.proxy.d.ts
@@ -1,5 +1,5 @@
 interface ProxyHandler<T> {
-    getPrototypeOf? (target: T): Object | null;
+    getPrototypeOf? (target: T): {} | null;
     setPrototypeOf? (target: T, v: any): boolean;
     isExtensible? (target: T): boolean;
     preventExtensions? (target: T): boolean;
@@ -12,7 +12,7 @@ interface ProxyHandler<T> {
     enumerate? (target: T): PropertyKey[];
     ownKeys? (target: T): PropertyKey[];
     apply? (target: T, thisArg: any, argArray?: any): any;
-    construct? (target: T, argArray: any, newTarget?: any): Object;
+    construct? (target: T, argArray: any, newTarget?: any): {};
 }
 
 interface ProxyConstructor {


### PR DESCRIPTION
The correction is according to: 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/getPrototypeOf
 and 
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/construct

`getPrototypeOf` trap should return a nullable `Object` and `construct` should return an `Object`.

Though `Object` is treated as `{}` in TypeScript which does include primitive value, this change is enough for preventing user from forgetting to return value.