### PR TITLE
remove tsd dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
         "through2": "latest",
         "travis-fold": "latest",
         "ts-node": "latest",
-        "tsd": "latest",
         "tslint": "4.0.0-dev.0",
         "typescript": "next"
     },


### PR DESCRIPTION
remove `tsd` dependency. We don't seem to use it after switching to `@types` and it also reduces the final size of `node_modules` folder from ~56 MB to ~43 MB