### PR TITLE
More precise Object.entries type declarations

### DIFF
--- a/src/lib/es2017.object.d.ts
+++ b/src/lib/es2017.object.d.ts
@@ -9,6 +9,6 @@ interface ObjectConstructor {
       * Returns an array of key/values of the enumerable properties of an object
       * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
       */
-    entries<T>(o: { [s: string]: T }): [string, T][];
+    entries<T extends { [key: string]: any }, K extends keyof T>(o: T): [keyof T, T[K]][];
     entries(o: any): [string, any][];
 }

--- a/tests/baselines/reference/useObjectValuesAndEntries1.js
+++ b/tests/baselines/reference/useObjectValuesAndEntries1.js
@@ -6,8 +6,11 @@ for (var x of Object.values(o)) {
     let y = x;
 }
 
-var entries = Object.entries(o);
+var entries = Object.entries(o);  // <-- entries: ['a' | 'b', number][]
 var entries1 = Object.entries(1); // <-- entries: [string, any][]
+var entries2 = Object.entries({a: true, b: 2}) // ['a' | 'b', number | boolean][]
+var entries3 = Object.entries({}) // [never, any][]
+
 
 //// [useObjectValuesAndEntries1.js]
 var o = { a: 1, b: 2 };
@@ -15,5 +18,7 @@ for (var _i = 0, _a = Object.values(o); _i < _a.length; _i++) {
     var x = _a[_i];
     var y = x;
 }
-var entries = Object.entries(o);
+var entries = Object.entries(o); // <-- entries: ['a' | 'b', number][]
 var entries1 = Object.entries(1); // <-- entries: [string, any][]
+var entries2 = Object.entries({ a: true, b: 2 }); // ['a' | 'b', number | boolean][]
+var entries3 = Object.entries({}); // [never, any][]

--- a/tests/baselines/reference/useObjectValuesAndEntries1.symbols
+++ b/tests/baselines/reference/useObjectValuesAndEntries1.symbols
@@ -17,7 +17,7 @@ for (var x of Object.values(o)) {
 >x : Symbol(x, Decl(useObjectValuesAndEntries1.ts, 3, 8))
 }
 
-var entries = Object.entries(o);
+var entries = Object.entries(o);  // <-- entries: ['a' | 'b', number][]
 >entries : Symbol(entries, Decl(useObjectValuesAndEntries1.ts, 7, 3))
 >Object.entries : Symbol(ObjectConstructor.entries, Decl(lib.es2017.object.d.ts, --, --), Decl(lib.es2017.object.d.ts, --, --))
 >Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
@@ -26,6 +26,20 @@ var entries = Object.entries(o);
 
 var entries1 = Object.entries(1); // <-- entries: [string, any][]
 >entries1 : Symbol(entries1, Decl(useObjectValuesAndEntries1.ts, 8, 3))
+>Object.entries : Symbol(ObjectConstructor.entries, Decl(lib.es2017.object.d.ts, --, --), Decl(lib.es2017.object.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>entries : Symbol(ObjectConstructor.entries, Decl(lib.es2017.object.d.ts, --, --), Decl(lib.es2017.object.d.ts, --, --))
+
+var entries2 = Object.entries({a: true, b: 2}) // ['a' | 'b', number | boolean][]
+>entries2 : Symbol(entries2, Decl(useObjectValuesAndEntries1.ts, 9, 3))
+>Object.entries : Symbol(ObjectConstructor.entries, Decl(lib.es2017.object.d.ts, --, --), Decl(lib.es2017.object.d.ts, --, --))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
+>entries : Symbol(ObjectConstructor.entries, Decl(lib.es2017.object.d.ts, --, --), Decl(lib.es2017.object.d.ts, --, --))
+>a : Symbol(a, Decl(useObjectValuesAndEntries1.ts, 9, 31))
+>b : Symbol(b, Decl(useObjectValuesAndEntries1.ts, 9, 39))
+
+var entries3 = Object.entries({}) // [never, any][]
+>entries3 : Symbol(entries3, Decl(useObjectValuesAndEntries1.ts, 10, 3))
 >Object.entries : Symbol(ObjectConstructor.entries, Decl(lib.es2017.object.d.ts, --, --), Decl(lib.es2017.object.d.ts, --, --))
 >Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --))
 >entries : Symbol(ObjectConstructor.entries, Decl(lib.es2017.object.d.ts, --, --), Decl(lib.es2017.object.d.ts, --, --))

--- a/tests/baselines/reference/useObjectValuesAndEntries1.types
+++ b/tests/baselines/reference/useObjectValuesAndEntries1.types
@@ -21,19 +21,39 @@ for (var x of Object.values(o)) {
 >x : number
 }
 
-var entries = Object.entries(o);
->entries : [string, number][]
->Object.entries(o) : [string, number][]
->Object.entries : { <T>(o: { [s: string]: T; }): [string, T][]; (o: any): [string, any][]; }
+var entries = Object.entries(o);  // <-- entries: ['a' | 'b', number][]
+>entries : ["a" | "b", number][]
+>Object.entries(o) : ["a" | "b", number][]
+>Object.entries : { <T extends { [key: string]: any; }, K extends keyof T>(o: T): [keyof T, T[K]][]; (o: any): [string, any][]; }
 >Object : ObjectConstructor
->entries : { <T>(o: { [s: string]: T; }): [string, T][]; (o: any): [string, any][]; }
+>entries : { <T extends { [key: string]: any; }, K extends keyof T>(o: T): [keyof T, T[K]][]; (o: any): [string, any][]; }
 >o : { a: number; b: number; }
 
 var entries1 = Object.entries(1); // <-- entries: [string, any][]
 >entries1 : [string, any][]
 >Object.entries(1) : [string, any][]
->Object.entries : { <T>(o: { [s: string]: T; }): [string, T][]; (o: any): [string, any][]; }
+>Object.entries : { <T extends { [key: string]: any; }, K extends keyof T>(o: T): [keyof T, T[K]][]; (o: any): [string, any][]; }
 >Object : ObjectConstructor
->entries : { <T>(o: { [s: string]: T; }): [string, T][]; (o: any): [string, any][]; }
+>entries : { <T extends { [key: string]: any; }, K extends keyof T>(o: T): [keyof T, T[K]][]; (o: any): [string, any][]; }
 >1 : 1
+
+var entries2 = Object.entries({a: true, b: 2}) // ['a' | 'b', number | boolean][]
+>entries2 : ["a" | "b", number | boolean][]
+>Object.entries({a: true, b: 2}) : ["a" | "b", number | boolean][]
+>Object.entries : { <T extends { [key: string]: any; }, K extends keyof T>(o: T): [keyof T, T[K]][]; (o: any): [string, any][]; }
+>Object : ObjectConstructor
+>entries : { <T extends { [key: string]: any; }, K extends keyof T>(o: T): [keyof T, T[K]][]; (o: any): [string, any][]; }
+>{a: true, b: 2} : { a: true; b: number; }
+>a : boolean
+>true : true
+>b : number
+>2 : 2
+
+var entries3 = Object.entries({}) // [never, any][]
+>entries3 : [never, any][]
+>Object.entries({}) : [never, any][]
+>Object.entries : { <T extends { [key: string]: any; }, K extends keyof T>(o: T): [keyof T, T[K]][]; (o: any): [string, any][]; }
+>Object : ObjectConstructor
+>entries : { <T extends { [key: string]: any; }, K extends keyof T>(o: T): [keyof T, T[K]][]; (o: any): [string, any][]; }
+>{} : {}
 

--- a/tests/baselines/reference/useObjectValuesAndEntries4.types
+++ b/tests/baselines/reference/useObjectValuesAndEntries4.types
@@ -22,10 +22,10 @@ for (var x of Object.values(o)) {
 }
 
 var entries = Object.entries(o);
->entries : [string, number][]
->Object.entries(o) : [string, number][]
->Object.entries : { <T>(o: { [s: string]: T; }): [string, T][]; (o: any): [string, any][]; }
+>entries : ["a" | "b", number][]
+>Object.entries(o) : ["a" | "b", number][]
+>Object.entries : { <T extends { [key: string]: any; }, K extends keyof T>(o: T): [keyof T, T[K]][]; (o: any): [string, any][]; }
 >Object : ObjectConstructor
->entries : { <T>(o: { [s: string]: T; }): [string, T][]; (o: any): [string, any][]; }
+>entries : { <T extends { [key: string]: any; }, K extends keyof T>(o: T): [keyof T, T[K]][]; (o: any): [string, any][]; }
 >o : { a: number; b: number; }
 

--- a/tests/cases/conformance/es2017/useObjectValuesAndEntries1.ts
+++ b/tests/cases/conformance/es2017/useObjectValuesAndEntries1.ts
@@ -7,5 +7,7 @@ for (var x of Object.values(o)) {
     let y = x;
 }
 
-var entries = Object.entries(o);
+var entries = Object.entries(o);  // <-- entries: ['a' | 'b', number][]
 var entries1 = Object.entries(1); // <-- entries: [string, any][]
+var entries2 = Object.entries({a: true, b: 2}) // ['a' | 'b', number | boolean][]
+var entries3 = Object.entries({}) // [never, any][]


### PR DESCRIPTION
Uses the new index type queries and indexed access types from #11929 to get better type inference for Object.entries.

Before:

```js
Object.entries({a: 1, b: 2}) // [string, number][]
Object.entries({a: true, b: 2}) // [string, number | boolean][]
Object.entries("foo") // [string, any][]
```

After:
```js
Object.entries({a: 1, b: 2}) // ['a' | 'b', number][]
Object.entries({a: true, b: 2}) // ['a' | 'b', number | boolean][]
Object.entries("foo") // [string, any][]
```

One edge case is `Object.entries({})`. Before, that was inferred as `[string, {}][]`; with this change it'd be `[never, any][]`. That might be a problem, although I don't think it is, since never is assignable to string.