### PR TITLE
Fix object spread+async emit

### DIFF
--- a/tests/baselines/reference/objectRest2.js
+++ b/tests/baselines/reference/objectRest2.js
@@ -1,0 +1,42 @@
+//// [objectRest2.ts]
+// test for #12203
+declare function connectionFromArray(objects: number, args: any): {};
+function rootConnection(name: string) {
+  return {
+    resolve: async (context, args) => {
+        const { objects } = await { objects: 12 };
+      return {
+        ...connectionFromArray(objects, args)
+      };
+    }
+  };
+}
+rootConnection('test');
+
+
+//// [objectRest2.js]
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
+    }
+    return t;
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments)).next());
+    });
+};
+function rootConnection(name) {
+    return {
+        resolve: (context, args) => __awaiter(this, void 0, void 0, function* () {
+            const { objects } = yield { objects: 12 };
+            return __assign({}, connectionFromArray(objects, args));
+        })
+    };
+}
+rootConnection('test');

--- a/tests/baselines/reference/objectRest2.symbols
+++ b/tests/baselines/reference/objectRest2.symbols
@@ -1,0 +1,34 @@
+=== tests/cases/conformance/types/rest/objectRest2.ts ===
+// test for #12203
+declare function connectionFromArray(objects: number, args: any): {};
+>connectionFromArray : Symbol(connectionFromArray, Decl(objectRest2.ts, 0, 0))
+>objects : Symbol(objects, Decl(objectRest2.ts, 1, 37))
+>args : Symbol(args, Decl(objectRest2.ts, 1, 53))
+
+function rootConnection(name: string) {
+>rootConnection : Symbol(rootConnection, Decl(objectRest2.ts, 1, 69))
+>name : Symbol(name, Decl(objectRest2.ts, 2, 24))
+
+  return {
+    resolve: async (context, args) => {
+>resolve : Symbol(resolve, Decl(objectRest2.ts, 3, 10))
+>context : Symbol(context, Decl(objectRest2.ts, 4, 20))
+>args : Symbol(args, Decl(objectRest2.ts, 4, 28))
+
+        const { objects } = await { objects: 12 };
+>objects : Symbol(objects, Decl(objectRest2.ts, 5, 15))
+>objects : Symbol(objects, Decl(objectRest2.ts, 5, 35))
+
+      return {
+        ...connectionFromArray(objects, args)
+>connectionFromArray : Symbol(connectionFromArray, Decl(objectRest2.ts, 0, 0))
+>objects : Symbol(objects, Decl(objectRest2.ts, 5, 15))
+>args : Symbol(args, Decl(objectRest2.ts, 4, 28))
+
+      };
+    }
+  };
+}
+rootConnection('test');
+>rootConnection : Symbol(rootConnection, Decl(objectRest2.ts, 1, 69))
+

--- a/tests/baselines/reference/objectRest2.types
+++ b/tests/baselines/reference/objectRest2.types
@@ -1,0 +1,45 @@
+=== tests/cases/conformance/types/rest/objectRest2.ts ===
+// test for #12203
+declare function connectionFromArray(objects: number, args: any): {};
+>connectionFromArray : (objects: number, args: any) => {}
+>objects : number
+>args : any
+
+function rootConnection(name: string) {
+>rootConnection : (name: string) => { resolve: (context: any, args: any) => Promise<{}>; }
+>name : string
+
+  return {
+>{    resolve: async (context, args) => {        const { objects } = await { objects: 12 };      return {        ...connectionFromArray(objects, args)      };    }  } : { resolve: (context: any, args: any) => Promise<{}>; }
+
+    resolve: async (context, args) => {
+>resolve : (context: any, args: any) => Promise<{}>
+>async (context, args) => {        const { objects } = await { objects: 12 };      return {        ...connectionFromArray(objects, args)      };    } : (context: any, args: any) => Promise<{}>
+>context : any
+>args : any
+
+        const { objects } = await { objects: 12 };
+>objects : number
+>await { objects: 12 } : { objects: number; }
+>{ objects: 12 } : { objects: number; }
+>objects : number
+>12 : 12
+
+      return {
+>{        ...connectionFromArray(objects, args)      } : {}
+
+        ...connectionFromArray(objects, args)
+>connectionFromArray(objects, args) : {}
+>connectionFromArray : (objects: number, args: any) => {}
+>objects : number
+>args : any
+
+      };
+    }
+  };
+}
+rootConnection('test');
+>rootConnection('test') : { resolve: (context: any, args: any) => Promise<{}>; }
+>rootConnection : (name: string) => { resolve: (context: any, args: any) => Promise<{}>; }
+>'test' : "test"
+

--- a/tests/baselines/reference/objectSpread.js
+++ b/tests/baselines/reference/objectSpread.js
@@ -105,7 +105,7 @@ var combinedMid = __assign({}, o, { b: 'ok' }, o2);
 var combinedAfter = __assign({}, o, o2, { b: 'ok' });
 var combinedNested = __assign({}, __assign({ a: 4 }, { b: false, c: 'overriden' }), { d: 'actually new' }, { a: 5, d: 'maybe new' });
 var combinedNestedChangeType = __assign({}, __assign({ a: 1 }, { b: false, c: 'overriden' }), { c: -1 });
-var propertyNested = __assign({ a: __assign({}, o) });
+var propertyNested = { a: __assign({}, o) };
 // accessors don't copy the descriptor
 // (which means that readonly getters become read/write properties)
 var op = { get a() { return 6; } };

--- a/tests/cases/conformance/types/rest/objectRest2.ts
+++ b/tests/cases/conformance/types/rest/objectRest2.ts
@@ -1,0 +1,15 @@
+// @lib: es2015
+// @target: es2015
+// test for #12203
+declare function connectionFromArray(objects: number, args: any): {};
+function rootConnection(name: string) {
+  return {
+    resolve: async (context, args) => {
+        const { objects } = await { objects: 12 };
+      return {
+        ...connectionFromArray(objects, args)
+      };
+    }
+  };
+}
+rootConnection('test');


### PR DESCRIPTION
Fixes #12203 

1. Retain function modifiers. They were previously dropped, breaking async transforms in ES2017.
2. Do not emit __assign for object literals with no spreads, just visit children.
3. Call aggregateTransformFlags after creating an __assign call.
