### PR TITLE
Fix missing alias for decorated classes in es5

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9936,8 +9936,7 @@ namespace ts {
                 // Due to the emit for class decorators, any reference to the class from inside of the class body
                 // must instead be rewritten to point to a temporary variable to avoid issues with the double-bind
                 // behavior of class names in ES6.
-                if (languageVersion === ScriptTarget.ES2015
-                    && declaration.kind === SyntaxKind.ClassDeclaration
+                if (declaration.kind === SyntaxKind.ClassDeclaration
                     && nodeIsDecorated(declaration)) {
                     let container = getContainingClass(node);
                     while (container !== undefined) {

--- a/tests/baselines/reference/es6modulekindWithES5Target11.js
+++ b/tests/baselines/reference/es6modulekindWithES5Target11.js
@@ -16,16 +16,17 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-var C = (function () {
+var C = C_1 = (function () {
     function C() {
         this.p = 1;
     }
-    C.x = function () { return C.y; };
+    C.x = function () { return C_1.y; };
     C.prototype.method = function () { };
     return C;
 }());
 C.y = 1;
-C = __decorate([
+C = C_1 = __decorate([
     foo
 ], C);
 export default C;
+var C_1;


### PR DESCRIPTION
The new emitter runs decorators outside of the IIFE created to emulate a class declaration in ES5, and as a result we need to emit the same class alias we emit for ES6.

Fixes #10840 

// cc: @mhegazy, @yuit 