### PR TITLE
switch to execSync to ensure that no install requests are interleaved

### DIFF
--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -61,17 +61,12 @@ namespace ts.server.typingsInstaller {
         return combinePaths(normalizeSlashes(globalTypingsCacheLocation), `node_modules/${TypesRegistryPackageName}/index.json`);
     }
 
-
-    type Exec = {
-        (command: string, options: { cwd: string }, callback?: (error: Error, stdout: string, stderr: string) => void): any
-    }
-
     type ExecSync = {
-        (command: string, options: { cwd: string, stdio: "ignore" }): any
+        (command: string, options: { cwd: string, stdio?: "ignore" }): any
     }
 
     export class NodeTypingsInstaller extends TypingsInstaller {
-        private readonly exec: Exec;
+        private readonly execSync: ExecSync;
         private readonly npmPath: string;
         readonly typesRegistry: Map<void>;
 
@@ -87,8 +82,7 @@ namespace ts.server.typingsInstaller {
                 this.log.writeLine(`Process id: ${process.pid}`);
             }
             this.npmPath = getNPMLocation(process.argv[0]);
-            let execSync: ExecSync;
-            ({ exec: this.exec, execSync } = require("child_process"));
+            ({ execSync: this.execSync } = require("child_process"));
 
             this.ensurePackageDirectoryExists(globalTypingsCacheLocation);
 
@@ -96,7 +90,7 @@ namespace ts.server.typingsInstaller {
                 if (this.log.isEnabled()) {
                     this.log.writeLine(`Updating ${TypesRegistryPackageName} npm package...`);
                 }
-                execSync(`${this.npmPath} install ${TypesRegistryPackageName}`, { cwd: globalTypingsCacheLocation, stdio: "ignore" });
+                this.execSync(`${this.npmPath} install ${TypesRegistryPackageName}`, { cwd: globalTypingsCacheLocation, stdio: "ignore" });
             }
             catch (e) {
                 if (this.log.isEnabled()) {
@@ -135,13 +129,21 @@ namespace ts.server.typingsInstaller {
             }
             const command = `${this.npmPath} install ${args.join(" ")} --save-dev`;
             const start = Date.now();
-            this.exec(command, { cwd }, (err, stdout, stderr) => {
-                if (this.log.isEnabled()) {
-                    this.log.writeLine(`npm install #${requestId} took: ${Date.now() - start} ms${sys.newLine}stdout: ${stdout}${sys.newLine}stderr: ${stderr}`);
-                }
-                // treat absence of error as success
-                onRequestCompleted(!err);
-            });
+            let stdout: Buffer;
+            let stderr: Buffer;
+            let hasError = false;
+            try {
+                stdout = this.execSync(command, { cwd });
+            }
+            catch (e) {
+                stdout = e.stdout;
+                stderr = e.stderr;
+                hasError = true;
+            }
+            if (this.log.isEnabled()) {
+                this.log.writeLine(`npm install #${requestId} took: ${Date.now() - start} ms${sys.newLine}stdout: ${stdout && stdout.toString()}${sys.newLine}stderr: ${stderr && stderr.toString()}`);
+            }
+            onRequestCompleted(!hasError);
         }
     }
 


### PR DESCRIPTION
// CC @mhegazy, @billti 

Currently typings installer processes requests one by one and runs installation asyncronously. Cache of installed typings is updated after `npm install` is done. This means that there might be an interesting situation when installer receives two requests in a row to install typings for different projects. After first request installer will discover that typings are not yet there and will kick off `npm install`. However if second request will come before `npm install` is completed then installer will think that typings are not installed and will run second instance of `npm install` process. Simplest way to deal with this issue is to switch `npm install` to be synchronous so all requests are processed serially. 