### PR TITLE
Object rest emit for method and accessor parameters

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2771,6 +2771,11 @@ namespace ts {
             transformFlags |= TransformFlags.AssertTypeScript;
         }
 
+        // a method declaration with object rest destructuring is ES Next syntax
+        if (subtreeFlags & TransformFlags.ContainsSpreadExpression) {
+            transformFlags |= TransformFlags.AssertESNext;
+        }
+
         // An async method declaration is ES2017 syntax.
         if (hasModifier(node, ModifierFlags.Async)) {
             transformFlags |= TransformFlags.AssertES2017;
@@ -2795,6 +2800,11 @@ namespace ts {
             || node.type
             || !node.body) {
             transformFlags |= TransformFlags.AssertTypeScript;
+        }
+
+        // a method declaration with object rest destructuring is ES Next syntax
+        if (subtreeFlags & TransformFlags.ContainsSpreadExpression) {
+            transformFlags |= TransformFlags.AssertESNext;
         }
 
         node.transformFlags = transformFlags | TransformFlags.HasComputedFlags;

--- a/tests/baselines/reference/objectRestParameter.js
+++ b/tests/baselines/reference/objectRestParameter.js
@@ -6,6 +6,15 @@ declare function suddenly(f: (a: { x: { z, ka }, y: string }) => void);
 suddenly(({ x: a, ...rest }) => rest.y);
 suddenly(({ x: { z = 12, ...nested }, ...rest } = { x: { z: 1, ka: 1 }, y: 'noo' }) => rest.y + nested.ka);
 
+class C {
+    m({ a, ...clone }: { a: number, b: string}): void {
+        // actually, never mind, don't clone
+    }
+    set p({ a, ...clone }: { a: number, b: string}) {
+        // actually, never mind, don't clone
+    }
+}
+
 
 
 //// [objectRestParameter.js]
@@ -26,3 +35,13 @@ suddenly((_a = { x: { z: 1, ka: 1 }, y: 'noo' }) => {
     var _b = _a.x, { z = 12 } = _b, nested = __rest(_b, ["z"]), rest = __rest(_a, ["x"]);
     return rest.y + nested.ka;
 });
+class C {
+    m(_a) {
+        var { a } = _a, clone = __rest(_a, ["a"]);
+        // actually, never mind, don't clone
+    }
+    set p(_a) {
+        var { a } = _a, clone = __rest(_a, ["a"]);
+        // actually, never mind, don't clone
+    }
+}

--- a/tests/baselines/reference/objectRestParameter.symbols
+++ b/tests/baselines/reference/objectRestParameter.symbols
@@ -42,4 +42,27 @@ suddenly(({ x: { z = 12, ...nested }, ...rest } = { x: { z: 1, ka: 1 }, y: 'noo'
 >nested : Symbol(nested, Decl(objectRestParameter.ts, 5, 24))
 >ka : Symbol(ka, Decl(objectRestParameter.ts, 3, 42))
 
+class C {
+>C : Symbol(C, Decl(objectRestParameter.ts, 5, 107))
+
+    m({ a, ...clone }: { a: number, b: string}): void {
+>m : Symbol(C.m, Decl(objectRestParameter.ts, 7, 9))
+>a : Symbol(a, Decl(objectRestParameter.ts, 8, 7))
+>clone : Symbol(clone, Decl(objectRestParameter.ts, 8, 10))
+>a : Symbol(a, Decl(objectRestParameter.ts, 8, 24))
+>b : Symbol(b, Decl(objectRestParameter.ts, 8, 35))
+
+        // actually, never mind, don't clone
+    }
+    set p({ a, ...clone }: { a: number, b: string}) {
+>p : Symbol(C.p, Decl(objectRestParameter.ts, 10, 5))
+>a : Symbol(a, Decl(objectRestParameter.ts, 11, 11))
+>clone : Symbol(clone, Decl(objectRestParameter.ts, 11, 14))
+>a : Symbol(a, Decl(objectRestParameter.ts, 11, 28))
+>b : Symbol(b, Decl(objectRestParameter.ts, 11, 39))
+
+        // actually, never mind, don't clone
+    }
+}
+
 

--- a/tests/baselines/reference/objectRestParameter.types
+++ b/tests/baselines/reference/objectRestParameter.types
@@ -53,4 +53,27 @@ suddenly(({ x: { z = 12, ...nested }, ...rest } = { x: { z: 1, ka: 1 }, y: 'noo'
 >nested : { ka: any; }
 >ka : any
 
+class C {
+>C : C
+
+    m({ a, ...clone }: { a: number, b: string}): void {
+>m : ({a, ...clone}: { a: number; b: string; }) => void
+>a : number
+>clone : { b: string; }
+>a : number
+>b : string
+
+        // actually, never mind, don't clone
+    }
+    set p({ a, ...clone }: { a: number, b: string}) {
+>p : { a: number; b: string; }
+>a : number
+>clone : { b: string; }
+>a : number
+>b : string
+
+        // actually, never mind, don't clone
+    }
+}
+
 

--- a/tests/cases/conformance/types/rest/objectRestParameter.ts
+++ b/tests/cases/conformance/types/rest/objectRestParameter.ts
@@ -6,3 +6,12 @@ declare function suddenly(f: (a: { x: { z, ka }, y: string }) => void);
 suddenly(({ x: a, ...rest }) => rest.y);
 suddenly(({ x: { z = 12, ...nested }, ...rest } = { x: { z: 1, ka: 1 }, y: 'noo' }) => rest.y + nested.ka);
 
+class C {
+    m({ a, ...clone }: { a: number, b: string}): void {
+        // actually, never mind, don't clone
+    }
+    set p({ a, ...clone }: { a: number, b: string}) {
+        // actually, never mind, don't clone
+    }
+}
+


### PR DESCRIPTION
I missed these before, so emit was incorrect for object rest in a method or accessor parameter. Thanks @rbuckton for noticing it.