### PR TITLE
Predefined mapped types in lib.d.ts

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4550,6 +4550,10 @@ namespace ts {
                     unknownType);
         }
 
+        function getErasedTemplateTypeFromMappedType(type: MappedType) {
+            return instantiateType(getTemplateTypeFromMappedType(type), createUnaryTypeMapper(getTypeParameterFromMappedType(type), anyType));
+        }
+
         function isGenericMappedType(type: Type) {
             if (getObjectFlags(type) & ObjectFlags.Mapped) {
                 const constraintType = getConstraintTypeFromMappedType(<MappedType>type);
@@ -7190,29 +7194,18 @@ namespace ts {
                             return result;
                         }
                     }
-                    if (isGenericMappedType(target)) {
-                        // A type [P in S]: X is related to a type [P in T]: Y if T is related to S and X is related to Y.
-                        if (isGenericMappedType(source)) {
-                            if ((result = isRelatedTo(getConstraintTypeFromMappedType(<MappedType>target), getConstraintTypeFromMappedType(<MappedType>source), reportErrors)) &&
-                                (result = isRelatedTo(getTemplateTypeFromMappedType(<MappedType>source), getTemplateTypeFromMappedType(<MappedType>target), reportErrors))) {
-                                return result;
-                            }
-                        }
-                    }
-                    else {
-                        // Even if relationship doesn't hold for unions, intersections, or generic type references,
-                        // it may hold in a structural comparison.
-                        const apparentSource = getApparentType(source);
-                        // In a check of the form X = A & B, we will have previously checked if A relates to X or B relates
-                        // to X. Failing both of those we want to check if the aggregation of A and B's members structurally
-                        // relates to X. Thus, we include intersection types on the source side here.
-                        if (apparentSource.flags & (TypeFlags.Object | TypeFlags.Intersection) && target.flags & TypeFlags.Object) {
-                            // Report structural errors only if we haven't reported any errors yet
-                            const reportStructuralErrors = reportErrors && errorInfo === saveErrorInfo && !(source.flags & TypeFlags.Primitive);
-                            if (result = objectTypeRelatedTo(apparentSource, source, target, reportStructuralErrors)) {
-                                errorInfo = saveErrorInfo;
-                                return result;
-                            }
+                    // Even if relationship doesn't hold for unions, intersections, or generic type references,
+                    // it may hold in a structural comparison.
+                    const apparentSource = getApparentType(source);
+                    // In a check of the form X = A & B, we will have previously checked if A relates to X or B relates
+                    // to X. Failing both of those we want to check if the aggregation of A and B's members structurally
+                    // relates to X. Thus, we include intersection types on the source side here.
+                    if (apparentSource.flags & (TypeFlags.Object | TypeFlags.Intersection) && target.flags & TypeFlags.Object) {
+                        // Report structural errors only if we haven't reported any errors yet
+                        const reportStructuralErrors = reportErrors && errorInfo === saveErrorInfo && !(source.flags & TypeFlags.Primitive);
+                        if (result = objectTypeRelatedTo(apparentSource, source, target, reportStructuralErrors)) {
+                            errorInfo = saveErrorInfo;
+                            return result;
                         }
                     }
                 }
@@ -7441,6 +7434,9 @@ namespace ts {
                 if (expandingFlags === 3) {
                     result = Ternary.Maybe;
                 }
+                else if (isGenericMappedType(source) || isGenericMappedType(target)) {
+                    result = mappedTypeRelatedTo(source, target, reportErrors);
+                }
                 else {
                     result = propertiesRelatedTo(source, target, reportErrors);
                     if (result) {
@@ -7470,6 +7466,30 @@ namespace ts {
                     relation[id] = reportErrors ? RelationComparisonResult.FailedAndReported : RelationComparisonResult.Failed;
                 }
                 return result;
+            }
+
+            // A type [P in S]: X is related to a type [P in T]: Y if T is related to S and X is related to Y.
+            function mappedTypeRelatedTo(source: Type, target: Type, reportErrors: boolean): Ternary {
+                if (isGenericMappedType(source) && isGenericMappedType(target)) {
+                    let result: Ternary;
+                    if (relation === identityRelation) {
+                        const readonlyMatches = !(<MappedType>source).declaration.readonlyToken === !(<MappedType>target).declaration.readonlyToken;
+                        const optionalMatches = !(<MappedType>source).declaration.questionToken === !(<MappedType>target).declaration.questionToken;
+                        if (readonlyMatches && optionalMatches) {
+                            if (result = isRelatedTo(getConstraintTypeFromMappedType(<MappedType>target), getConstraintTypeFromMappedType(<MappedType>source), reportErrors)) {
+                                return result & isRelatedTo(getErasedTemplateTypeFromMappedType(<MappedType>source), getErasedTemplateTypeFromMappedType(<MappedType>target), reportErrors);
+                            }
+                        }
+                    }
+                    else {
+                        if (relation === comparableRelation || !(<MappedType>source).declaration.questionToken || (<MappedType>target).declaration.questionToken) {
+                            if (result = isRelatedTo(getConstraintTypeFromMappedType(<MappedType>target), getConstraintTypeFromMappedType(<MappedType>source), reportErrors)) {
+                                return result & isRelatedTo(getTemplateTypeFromMappedType(<MappedType>source), getTemplateTypeFromMappedType(<MappedType>target), reportErrors);
+                            }
+                        }
+                    }
+                }
+                return Ternary.False;
             }
 
             function propertiesRelatedTo(source: Type, target: Type, reportErrors: boolean): Ternary {

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -180,7 +180,7 @@ interface ObjectConstructor {
       * Prevents the modification of existing property attributes and values, and prevents the addition of new properties.
       * @param o Object on which to lock the attributes.
       */
-    freeze<T>(o: T): T;
+    freeze<T>(o: T): Readonly<T>;
 
     /**
       * Prevents the addition of new properties to an object.
@@ -1341,6 +1341,34 @@ interface PromiseLike<T> {
 interface ArrayLike<T> {
     readonly length: number;
     readonly [n: number]: T;
+}
+
+/**
+ * Make all properties in T optional
+ */
+type Partial<T> = {
+    [P in keyof T]?: T[P];
+};
+
+/**
+ * Make all properties in T readonly
+ */
+type Readonly<T> = {
+    readonly [P in keyof T]: T[P];
+};
+
+/**
+ * From T pick a set of properties K
+ */
+type Pick<T, K extends keyof T> = {
+    [P in K]: T[P];
+}
+
+/**
+ * Construct a type with a set of properties K of type T
+ */
+type Record<K extends string | number, T> = {
+    [P in K]: T;
 }
 
 /**

--- a/tests/baselines/reference/mappedTypeErrors.errors.txt
+++ b/tests/baselines/reference/mappedTypeErrors.errors.txt
@@ -1,41 +1,29 @@
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(34,20): error TS2313: Type parameter 'P' has a circular constraint.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(35,20): error TS2322: Type 'Date' is not assignable to type 'string | number'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(20,20): error TS2313: Type parameter 'P' has a circular constraint.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(21,20): error TS2322: Type 'Date' is not assignable to type 'string | number'.
   Type 'Date' is not assignable to type 'number'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(36,19): error TS2344: Type 'Date' does not satisfy the constraint 'string | number'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(22,19): error TS2344: Type 'Date' does not satisfy the constraint 'string | number'.
   Type 'Date' is not assignable to type 'number'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(39,24): error TS2344: Type '"foo"' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(40,24): error TS2344: Type '"name" | "foo"' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(25,24): error TS2344: Type '"foo"' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(26,24): error TS2344: Type '"name" | "foo"' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
   Type '"foo"' is not assignable to type '"name" | "width" | "height" | "visible"'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(42,24): error TS2344: Type '"x" | "y"' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(28,24): error TS2344: Type '"x" | "y"' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
   Type '"x"' is not assignable to type '"name" | "width" | "height" | "visible"'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(44,24): error TS2344: Type 'undefined' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(47,24): error TS2344: Type 'T' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(30,24): error TS2344: Type 'undefined' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(33,24): error TS2344: Type 'T' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
   Type 'T' is not assignable to type '"visible"'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(51,24): error TS2344: Type 'T' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(37,24): error TS2344: Type 'T' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
   Type 'string | number' is not assignable to type '"name" | "width" | "height" | "visible"'.
     Type 'string' is not assignable to type '"name" | "width" | "height" | "visible"'.
       Type 'T' is not assignable to type '"visible"'.
         Type 'string | number' is not assignable to type '"visible"'.
           Type 'string' is not assignable to type '"visible"'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(59,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ [P in keyof T]?: T[P]; }'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(60,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ readonly [P in keyof T]: T[P]; }'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(61,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ readonly [P in keyof T]?: T[P]; }'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(66,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ [P in keyof T]: T[P][]; }'.
 
 
-==== tests/cases/conformance/types/mapped/mappedTypeErrors.ts (9 errors) ====
-    
-    type Partial<T> = {
-        [P in keyof T]?: T[P];
-    };
-    
-    type Readonly<T> = {
-        readonly [P in keyof T]: T[P];
-    };
-    
-    type Pick<T, K extends keyof T> = {
-        [P in K]: T[P];
-    }
-    
-    type Record<K extends string | number, T> = {
-        [_ in K]: T;
-    }
+==== tests/cases/conformance/types/mapped/mappedTypeErrors.ts (13 errors) ====
     
     interface Shape {
         name: string;
@@ -52,6 +40,8 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(51,24): error TS2344: T
         x: number;
         y: number;
     }
+    
+    // Constraint checking
     
     type T00 = { [P in P]: string };  // Error
                        ~
@@ -107,4 +97,33 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(51,24): error TS2344: T
     
     function f4<T extends keyof Named>(x: T) {
         let y: Pick<Shape, T>;
+    }
+    
+    // Type identity checking
+    
+    function f10<T>() {
+        type K = keyof T;
+        var x: { [P in keyof T]: T[P] };
+        var x: { [Q in keyof T]: T[Q] };
+        var x: { [R in K]: T[R] };
+    }
+    
+    function f11<T>() {
+        var x: { [P in keyof T]: T[P] };
+        var x: { [P in keyof T]?: T[P] };  // Error
+            ~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ [P in keyof T]?: T[P]; }'.
+        var x: { readonly [P in keyof T]: T[P] };  // Error
+            ~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ readonly [P in keyof T]: T[P]; }'.
+        var x: { readonly [P in keyof T]?: T[P] };  // Error
+            ~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ readonly [P in keyof T]?: T[P]; }'.
+    }
+    
+    function f12<T>() {
+        var x: { [P in keyof T]: T[P] };
+        var x: { [P in keyof T]: T[P][] };  // Error
+            ~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ [P in keyof T]: T[P][]; }'.
     }

--- a/tests/baselines/reference/mappedTypeErrors.js
+++ b/tests/baselines/reference/mappedTypeErrors.js
@@ -1,21 +1,5 @@
 //// [mappedTypeErrors.ts]
 
-type Partial<T> = {
-    [P in keyof T]?: T[P];
-};
-
-type Readonly<T> = {
-    readonly [P in keyof T]: T[P];
-};
-
-type Pick<T, K extends keyof T> = {
-    [P in K]: T[P];
-}
-
-type Record<K extends string | number, T> = {
-    [_ in K]: T;
-}
-
 interface Shape {
     name: string;
     width: number;
@@ -31,6 +15,8 @@ interface Point {
     x: number;
     y: number;
 }
+
+// Constraint checking
 
 type T00 = { [P in P]: string };  // Error
 type T01 = { [P in Date]: number };  // Error
@@ -60,6 +46,27 @@ function f4<T extends keyof Named>(x: T) {
     let y: Pick<Shape, T>;
 }
 
+// Type identity checking
+
+function f10<T>() {
+    type K = keyof T;
+    var x: { [P in keyof T]: T[P] };
+    var x: { [Q in keyof T]: T[Q] };
+    var x: { [R in K]: T[R] };
+}
+
+function f11<T>() {
+    var x: { [P in keyof T]: T[P] };
+    var x: { [P in keyof T]?: T[P] };  // Error
+    var x: { readonly [P in keyof T]: T[P] };  // Error
+    var x: { readonly [P in keyof T]?: T[P] };  // Error
+}
+
+function f12<T>() {
+    var x: { [P in keyof T]: T[P] };
+    var x: { [P in keyof T]: T[P][] };  // Error
+}
+
 //// [mappedTypeErrors.js]
 function f1(x) {
     var y; // Error
@@ -73,21 +80,25 @@ function f3(x) {
 function f4(x) {
     var y;
 }
+// Type identity checking
+function f10() {
+    var x;
+    var x;
+    var x;
+}
+function f11() {
+    var x;
+    var x; // Error
+    var x; // Error
+    var x; // Error
+}
+function f12() {
+    var x;
+    var x; // Error
+}
 
 
 //// [mappedTypeErrors.d.ts]
-declare type Partial<T> = {
-    [P in keyof T]?: T[P];
-};
-declare type Readonly<T> = {
-    readonly [P in keyof T]: T[P];
-};
-declare type Pick<T, K extends keyof T> = {
-    [P in K]: T[P];
-};
-declare type Record<K extends string | number, T> = {
-    [_ in K]: T;
-};
 interface Shape {
     name: string;
     width: number;
@@ -119,3 +130,6 @@ declare function f1<T>(x: T): void;
 declare function f2<T extends string | number>(x: T): void;
 declare function f3<T extends keyof Shape>(x: T): void;
 declare function f4<T extends keyof Named>(x: T): void;
+declare function f10<T>(): void;
+declare function f11<T>(): void;
+declare function f12<T>(): void;

--- a/tests/baselines/reference/mappedTypes2.js
+++ b/tests/baselines/reference/mappedTypes2.js
@@ -1,19 +1,14 @@
 //// [mappedTypes2.ts]
 
-type Partial<T> = {
-    [P in keyof T]?: T[P];
-};
-
-type Readonly<T> = {
-    readonly [P in keyof T]: T[P];
-};
-
-type Pick<T, K extends keyof T> = {
-    [P in K]: T[P];
-}
-
-type Record<K extends string | number, T> = {
-    [_ in K]: T;
+function verifyLibTypes<T, K extends keyof T, U>() {
+    var x1: Partial<T>;
+    var x1: { [P in keyof T]?: T[P] };
+    var x2: Readonly<T>;
+    var x2: { readonly [P in keyof T]: T[P] };
+    var x3: Pick<T, K>;
+    var x3: { [P in K]: T[P] };
+    var x4: Record<K, U>;
+    var x4: { [P in K]: U };
 }
 
 type Proxy<T> = {
@@ -95,6 +90,16 @@ function f6(shape: DeepReadonly<Shape>) {
 }
 
 //// [mappedTypes2.js]
+function verifyLibTypes() {
+    var x1;
+    var x1;
+    var x2;
+    var x2;
+    var x3;
+    var x3;
+    var x4;
+    var x4;
+}
 function f0(s1, s2) {
     assign(s1, { name: "circle" });
     assign(s2, { width: 10, height: 20 });
@@ -129,18 +134,7 @@ function f6(shape) {
 
 
 //// [mappedTypes2.d.ts]
-declare type Partial<T> = {
-    [P in keyof T]?: T[P];
-};
-declare type Readonly<T> = {
-    readonly [P in keyof T]: T[P];
-};
-declare type Pick<T, K extends keyof T> = {
-    [P in K]: T[P];
-};
-declare type Record<K extends string | number, T> = {
-    [_ in K]: T;
-};
+declare function verifyLibTypes<T, K extends keyof T, U>(): void;
 declare type Proxy<T> = {
     get(): T;
     set(value: T): void;

--- a/tests/baselines/reference/mappedTypes2.symbols
+++ b/tests/baselines/reference/mappedTypes2.symbols
@@ -1,331 +1,340 @@
 === tests/cases/conformance/types/mapped/mappedTypes2.ts ===
 
-type Partial<T> = {
->Partial : Symbol(Partial, Decl(mappedTypes2.ts, 0, 0))
->T : Symbol(T, Decl(mappedTypes2.ts, 1, 13))
+function verifyLibTypes<T, K extends keyof T, U>() {
+>verifyLibTypes : Symbol(verifyLibTypes, Decl(mappedTypes2.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypes2.ts, 1, 24))
+>K : Symbol(K, Decl(mappedTypes2.ts, 1, 26))
+>T : Symbol(T, Decl(mappedTypes2.ts, 1, 24))
+>U : Symbol(U, Decl(mappedTypes2.ts, 1, 45))
 
-    [P in keyof T]?: T[P];
->P : Symbol(P, Decl(mappedTypes2.ts, 2, 5))
->T : Symbol(T, Decl(mappedTypes2.ts, 1, 13))
->T : Symbol(T, Decl(mappedTypes2.ts, 1, 13))
->P : Symbol(P, Decl(mappedTypes2.ts, 2, 5))
+    var x1: Partial<T>;
+>x1 : Symbol(x1, Decl(mappedTypes2.ts, 2, 7), Decl(mappedTypes2.ts, 3, 7))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypes2.ts, 1, 24))
 
-};
+    var x1: { [P in keyof T]?: T[P] };
+>x1 : Symbol(x1, Decl(mappedTypes2.ts, 2, 7), Decl(mappedTypes2.ts, 3, 7))
+>P : Symbol(P, Decl(mappedTypes2.ts, 3, 15))
+>T : Symbol(T, Decl(mappedTypes2.ts, 1, 24))
+>T : Symbol(T, Decl(mappedTypes2.ts, 1, 24))
+>P : Symbol(P, Decl(mappedTypes2.ts, 3, 15))
 
-type Readonly<T> = {
->Readonly : Symbol(Readonly, Decl(mappedTypes2.ts, 3, 2))
->T : Symbol(T, Decl(mappedTypes2.ts, 5, 14))
+    var x2: Readonly<T>;
+>x2 : Symbol(x2, Decl(mappedTypes2.ts, 4, 7), Decl(mappedTypes2.ts, 5, 7))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypes2.ts, 1, 24))
 
-    readonly [P in keyof T]: T[P];
->P : Symbol(P, Decl(mappedTypes2.ts, 6, 14))
->T : Symbol(T, Decl(mappedTypes2.ts, 5, 14))
->T : Symbol(T, Decl(mappedTypes2.ts, 5, 14))
->P : Symbol(P, Decl(mappedTypes2.ts, 6, 14))
+    var x2: { readonly [P in keyof T]: T[P] };
+>x2 : Symbol(x2, Decl(mappedTypes2.ts, 4, 7), Decl(mappedTypes2.ts, 5, 7))
+>P : Symbol(P, Decl(mappedTypes2.ts, 5, 24))
+>T : Symbol(T, Decl(mappedTypes2.ts, 1, 24))
+>T : Symbol(T, Decl(mappedTypes2.ts, 1, 24))
+>P : Symbol(P, Decl(mappedTypes2.ts, 5, 24))
 
-};
+    var x3: Pick<T, K>;
+>x3 : Symbol(x3, Decl(mappedTypes2.ts, 6, 7), Decl(mappedTypes2.ts, 7, 7))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypes2.ts, 1, 24))
+>K : Symbol(K, Decl(mappedTypes2.ts, 1, 26))
 
-type Pick<T, K extends keyof T> = {
->Pick : Symbol(Pick, Decl(mappedTypes2.ts, 7, 2))
->T : Symbol(T, Decl(mappedTypes2.ts, 9, 10))
->K : Symbol(K, Decl(mappedTypes2.ts, 9, 12))
->T : Symbol(T, Decl(mappedTypes2.ts, 9, 10))
+    var x3: { [P in K]: T[P] };
+>x3 : Symbol(x3, Decl(mappedTypes2.ts, 6, 7), Decl(mappedTypes2.ts, 7, 7))
+>P : Symbol(P, Decl(mappedTypes2.ts, 7, 15))
+>K : Symbol(K, Decl(mappedTypes2.ts, 1, 26))
+>T : Symbol(T, Decl(mappedTypes2.ts, 1, 24))
+>P : Symbol(P, Decl(mappedTypes2.ts, 7, 15))
 
-    [P in K]: T[P];
->P : Symbol(P, Decl(mappedTypes2.ts, 10, 5))
->K : Symbol(K, Decl(mappedTypes2.ts, 9, 12))
->T : Symbol(T, Decl(mappedTypes2.ts, 9, 10))
->P : Symbol(P, Decl(mappedTypes2.ts, 10, 5))
-}
+    var x4: Record<K, U>;
+>x4 : Symbol(x4, Decl(mappedTypes2.ts, 8, 7), Decl(mappedTypes2.ts, 9, 7))
+>Record : Symbol(Record, Decl(lib.d.ts, --, --))
+>K : Symbol(K, Decl(mappedTypes2.ts, 1, 26))
+>U : Symbol(U, Decl(mappedTypes2.ts, 1, 45))
 
-type Record<K extends string | number, T> = {
->Record : Symbol(Record, Decl(mappedTypes2.ts, 11, 1))
->K : Symbol(K, Decl(mappedTypes2.ts, 13, 12))
->T : Symbol(T, Decl(mappedTypes2.ts, 13, 38))
-
-    [_ in K]: T;
->_ : Symbol(_, Decl(mappedTypes2.ts, 14, 5))
->K : Symbol(K, Decl(mappedTypes2.ts, 13, 12))
->T : Symbol(T, Decl(mappedTypes2.ts, 13, 38))
+    var x4: { [P in K]: U };
+>x4 : Symbol(x4, Decl(mappedTypes2.ts, 8, 7), Decl(mappedTypes2.ts, 9, 7))
+>P : Symbol(P, Decl(mappedTypes2.ts, 9, 15))
+>K : Symbol(K, Decl(mappedTypes2.ts, 1, 26))
+>U : Symbol(U, Decl(mappedTypes2.ts, 1, 45))
 }
 
 type Proxy<T> = {
->Proxy : Symbol(Proxy, Decl(mappedTypes2.ts, 15, 1))
->T : Symbol(T, Decl(mappedTypes2.ts, 17, 11))
+>Proxy : Symbol(Proxy, Decl(mappedTypes2.ts, 10, 1))
+>T : Symbol(T, Decl(mappedTypes2.ts, 12, 11))
 
     get(): T;
->get : Symbol(get, Decl(mappedTypes2.ts, 17, 17))
->T : Symbol(T, Decl(mappedTypes2.ts, 17, 11))
+>get : Symbol(get, Decl(mappedTypes2.ts, 12, 17))
+>T : Symbol(T, Decl(mappedTypes2.ts, 12, 11))
 
     set(value: T): void;
->set : Symbol(set, Decl(mappedTypes2.ts, 18, 13))
->value : Symbol(value, Decl(mappedTypes2.ts, 19, 8))
->T : Symbol(T, Decl(mappedTypes2.ts, 17, 11))
+>set : Symbol(set, Decl(mappedTypes2.ts, 13, 13))
+>value : Symbol(value, Decl(mappedTypes2.ts, 14, 8))
+>T : Symbol(T, Decl(mappedTypes2.ts, 12, 11))
 }
 
 type Proxify<T> = {
->Proxify : Symbol(Proxify, Decl(mappedTypes2.ts, 20, 1))
->T : Symbol(T, Decl(mappedTypes2.ts, 22, 13))
+>Proxify : Symbol(Proxify, Decl(mappedTypes2.ts, 15, 1))
+>T : Symbol(T, Decl(mappedTypes2.ts, 17, 13))
 
     [P in keyof T]: Proxy<T[P]>;
->P : Symbol(P, Decl(mappedTypes2.ts, 23, 5))
->T : Symbol(T, Decl(mappedTypes2.ts, 22, 13))
->Proxy : Symbol(Proxy, Decl(mappedTypes2.ts, 15, 1))
->T : Symbol(T, Decl(mappedTypes2.ts, 22, 13))
->P : Symbol(P, Decl(mappedTypes2.ts, 23, 5))
+>P : Symbol(P, Decl(mappedTypes2.ts, 18, 5))
+>T : Symbol(T, Decl(mappedTypes2.ts, 17, 13))
+>Proxy : Symbol(Proxy, Decl(mappedTypes2.ts, 10, 1))
+>T : Symbol(T, Decl(mappedTypes2.ts, 17, 13))
+>P : Symbol(P, Decl(mappedTypes2.ts, 18, 5))
 }
 
 type DeepReadonly<T> = {
->DeepReadonly : Symbol(DeepReadonly, Decl(mappedTypes2.ts, 24, 1))
->T : Symbol(T, Decl(mappedTypes2.ts, 26, 18))
+>DeepReadonly : Symbol(DeepReadonly, Decl(mappedTypes2.ts, 19, 1))
+>T : Symbol(T, Decl(mappedTypes2.ts, 21, 18))
 
     readonly [P in keyof T]: DeepReadonly<T[P]>;
->P : Symbol(P, Decl(mappedTypes2.ts, 27, 14))
->T : Symbol(T, Decl(mappedTypes2.ts, 26, 18))
->DeepReadonly : Symbol(DeepReadonly, Decl(mappedTypes2.ts, 24, 1))
->T : Symbol(T, Decl(mappedTypes2.ts, 26, 18))
->P : Symbol(P, Decl(mappedTypes2.ts, 27, 14))
+>P : Symbol(P, Decl(mappedTypes2.ts, 22, 14))
+>T : Symbol(T, Decl(mappedTypes2.ts, 21, 18))
+>DeepReadonly : Symbol(DeepReadonly, Decl(mappedTypes2.ts, 19, 1))
+>T : Symbol(T, Decl(mappedTypes2.ts, 21, 18))
+>P : Symbol(P, Decl(mappedTypes2.ts, 22, 14))
 
 };
 
 declare function assign<T>(obj: T, props: Partial<T>): void;
->assign : Symbol(assign, Decl(mappedTypes2.ts, 28, 2))
->T : Symbol(T, Decl(mappedTypes2.ts, 30, 24))
->obj : Symbol(obj, Decl(mappedTypes2.ts, 30, 27))
->T : Symbol(T, Decl(mappedTypes2.ts, 30, 24))
->props : Symbol(props, Decl(mappedTypes2.ts, 30, 34))
->Partial : Symbol(Partial, Decl(mappedTypes2.ts, 0, 0))
->T : Symbol(T, Decl(mappedTypes2.ts, 30, 24))
+>assign : Symbol(assign, Decl(mappedTypes2.ts, 23, 2))
+>T : Symbol(T, Decl(mappedTypes2.ts, 25, 24))
+>obj : Symbol(obj, Decl(mappedTypes2.ts, 25, 27))
+>T : Symbol(T, Decl(mappedTypes2.ts, 25, 24))
+>props : Symbol(props, Decl(mappedTypes2.ts, 25, 34))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypes2.ts, 25, 24))
 
 declare function freeze<T>(obj: T): Readonly<T>;
->freeze : Symbol(freeze, Decl(mappedTypes2.ts, 30, 60))
->T : Symbol(T, Decl(mappedTypes2.ts, 31, 24))
->obj : Symbol(obj, Decl(mappedTypes2.ts, 31, 27))
->T : Symbol(T, Decl(mappedTypes2.ts, 31, 24))
->Readonly : Symbol(Readonly, Decl(mappedTypes2.ts, 3, 2))
->T : Symbol(T, Decl(mappedTypes2.ts, 31, 24))
+>freeze : Symbol(freeze, Decl(mappedTypes2.ts, 25, 60))
+>T : Symbol(T, Decl(mappedTypes2.ts, 26, 24))
+>obj : Symbol(obj, Decl(mappedTypes2.ts, 26, 27))
+>T : Symbol(T, Decl(mappedTypes2.ts, 26, 24))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypes2.ts, 26, 24))
 
 declare function pick<T, K extends keyof T>(obj: T, ...keys: K[]): Pick<T, K>;
->pick : Symbol(pick, Decl(mappedTypes2.ts, 31, 48))
->T : Symbol(T, Decl(mappedTypes2.ts, 32, 22))
->K : Symbol(K, Decl(mappedTypes2.ts, 32, 24))
->T : Symbol(T, Decl(mappedTypes2.ts, 32, 22))
->obj : Symbol(obj, Decl(mappedTypes2.ts, 32, 44))
->T : Symbol(T, Decl(mappedTypes2.ts, 32, 22))
->keys : Symbol(keys, Decl(mappedTypes2.ts, 32, 51))
->K : Symbol(K, Decl(mappedTypes2.ts, 32, 24))
->Pick : Symbol(Pick, Decl(mappedTypes2.ts, 7, 2))
->T : Symbol(T, Decl(mappedTypes2.ts, 32, 22))
->K : Symbol(K, Decl(mappedTypes2.ts, 32, 24))
+>pick : Symbol(pick, Decl(mappedTypes2.ts, 26, 48))
+>T : Symbol(T, Decl(mappedTypes2.ts, 27, 22))
+>K : Symbol(K, Decl(mappedTypes2.ts, 27, 24))
+>T : Symbol(T, Decl(mappedTypes2.ts, 27, 22))
+>obj : Symbol(obj, Decl(mappedTypes2.ts, 27, 44))
+>T : Symbol(T, Decl(mappedTypes2.ts, 27, 22))
+>keys : Symbol(keys, Decl(mappedTypes2.ts, 27, 51))
+>K : Symbol(K, Decl(mappedTypes2.ts, 27, 24))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypes2.ts, 27, 22))
+>K : Symbol(K, Decl(mappedTypes2.ts, 27, 24))
 
 declare function mapObject<K extends string | number, T, U>(obj: Record<K, T>, f: (x: T) => U): Record<K, U>;
->mapObject : Symbol(mapObject, Decl(mappedTypes2.ts, 32, 78))
->K : Symbol(K, Decl(mappedTypes2.ts, 33, 27))
->T : Symbol(T, Decl(mappedTypes2.ts, 33, 53))
->U : Symbol(U, Decl(mappedTypes2.ts, 33, 56))
->obj : Symbol(obj, Decl(mappedTypes2.ts, 33, 60))
->Record : Symbol(Record, Decl(mappedTypes2.ts, 11, 1))
->K : Symbol(K, Decl(mappedTypes2.ts, 33, 27))
->T : Symbol(T, Decl(mappedTypes2.ts, 33, 53))
->f : Symbol(f, Decl(mappedTypes2.ts, 33, 78))
->x : Symbol(x, Decl(mappedTypes2.ts, 33, 83))
->T : Symbol(T, Decl(mappedTypes2.ts, 33, 53))
->U : Symbol(U, Decl(mappedTypes2.ts, 33, 56))
->Record : Symbol(Record, Decl(mappedTypes2.ts, 11, 1))
->K : Symbol(K, Decl(mappedTypes2.ts, 33, 27))
->U : Symbol(U, Decl(mappedTypes2.ts, 33, 56))
+>mapObject : Symbol(mapObject, Decl(mappedTypes2.ts, 27, 78))
+>K : Symbol(K, Decl(mappedTypes2.ts, 28, 27))
+>T : Symbol(T, Decl(mappedTypes2.ts, 28, 53))
+>U : Symbol(U, Decl(mappedTypes2.ts, 28, 56))
+>obj : Symbol(obj, Decl(mappedTypes2.ts, 28, 60))
+>Record : Symbol(Record, Decl(lib.d.ts, --, --))
+>K : Symbol(K, Decl(mappedTypes2.ts, 28, 27))
+>T : Symbol(T, Decl(mappedTypes2.ts, 28, 53))
+>f : Symbol(f, Decl(mappedTypes2.ts, 28, 78))
+>x : Symbol(x, Decl(mappedTypes2.ts, 28, 83))
+>T : Symbol(T, Decl(mappedTypes2.ts, 28, 53))
+>U : Symbol(U, Decl(mappedTypes2.ts, 28, 56))
+>Record : Symbol(Record, Decl(lib.d.ts, --, --))
+>K : Symbol(K, Decl(mappedTypes2.ts, 28, 27))
+>U : Symbol(U, Decl(mappedTypes2.ts, 28, 56))
 
 declare function proxify<T>(obj: T): Proxify<T>;
->proxify : Symbol(proxify, Decl(mappedTypes2.ts, 33, 109))
->T : Symbol(T, Decl(mappedTypes2.ts, 34, 25))
->obj : Symbol(obj, Decl(mappedTypes2.ts, 34, 28))
->T : Symbol(T, Decl(mappedTypes2.ts, 34, 25))
->Proxify : Symbol(Proxify, Decl(mappedTypes2.ts, 20, 1))
->T : Symbol(T, Decl(mappedTypes2.ts, 34, 25))
+>proxify : Symbol(proxify, Decl(mappedTypes2.ts, 28, 109))
+>T : Symbol(T, Decl(mappedTypes2.ts, 29, 25))
+>obj : Symbol(obj, Decl(mappedTypes2.ts, 29, 28))
+>T : Symbol(T, Decl(mappedTypes2.ts, 29, 25))
+>Proxify : Symbol(Proxify, Decl(mappedTypes2.ts, 15, 1))
+>T : Symbol(T, Decl(mappedTypes2.ts, 29, 25))
 
 interface Shape {
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 48))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
 
     name: string;
->name : Symbol(Shape.name, Decl(mappedTypes2.ts, 36, 17))
+>name : Symbol(Shape.name, Decl(mappedTypes2.ts, 31, 17))
 
     width: number;
->width : Symbol(Shape.width, Decl(mappedTypes2.ts, 37, 17))
+>width : Symbol(Shape.width, Decl(mappedTypes2.ts, 32, 17))
 
     height: number;
->height : Symbol(Shape.height, Decl(mappedTypes2.ts, 38, 18))
+>height : Symbol(Shape.height, Decl(mappedTypes2.ts, 33, 18))
 
     visible: boolean;
->visible : Symbol(Shape.visible, Decl(mappedTypes2.ts, 39, 19))
+>visible : Symbol(Shape.visible, Decl(mappedTypes2.ts, 34, 19))
 }
 
 interface PartialShape {
->PartialShape : Symbol(PartialShape, Decl(mappedTypes2.ts, 41, 1))
+>PartialShape : Symbol(PartialShape, Decl(mappedTypes2.ts, 36, 1))
 
     name?: string;
->name : Symbol(PartialShape.name, Decl(mappedTypes2.ts, 43, 24))
+>name : Symbol(PartialShape.name, Decl(mappedTypes2.ts, 38, 24))
 
     width?: number;
->width : Symbol(PartialShape.width, Decl(mappedTypes2.ts, 44, 18))
+>width : Symbol(PartialShape.width, Decl(mappedTypes2.ts, 39, 18))
 
     height?: number;
->height : Symbol(PartialShape.height, Decl(mappedTypes2.ts, 45, 19))
+>height : Symbol(PartialShape.height, Decl(mappedTypes2.ts, 40, 19))
 
     visible?: boolean;
->visible : Symbol(PartialShape.visible, Decl(mappedTypes2.ts, 46, 20))
+>visible : Symbol(PartialShape.visible, Decl(mappedTypes2.ts, 41, 20))
 }
 
 interface ReadonlyShape {
->ReadonlyShape : Symbol(ReadonlyShape, Decl(mappedTypes2.ts, 48, 1))
+>ReadonlyShape : Symbol(ReadonlyShape, Decl(mappedTypes2.ts, 43, 1))
 
     readonly name: string;
->name : Symbol(ReadonlyShape.name, Decl(mappedTypes2.ts, 50, 25))
+>name : Symbol(ReadonlyShape.name, Decl(mappedTypes2.ts, 45, 25))
 
     readonly width: number;
->width : Symbol(ReadonlyShape.width, Decl(mappedTypes2.ts, 51, 26))
+>width : Symbol(ReadonlyShape.width, Decl(mappedTypes2.ts, 46, 26))
 
     readonly height: number;
->height : Symbol(ReadonlyShape.height, Decl(mappedTypes2.ts, 52, 27))
+>height : Symbol(ReadonlyShape.height, Decl(mappedTypes2.ts, 47, 27))
 
     readonly visible: boolean;
->visible : Symbol(ReadonlyShape.visible, Decl(mappedTypes2.ts, 53, 28))
+>visible : Symbol(ReadonlyShape.visible, Decl(mappedTypes2.ts, 48, 28))
 }
 
 function f0(s1: Shape, s2: Shape) {
->f0 : Symbol(f0, Decl(mappedTypes2.ts, 55, 1))
->s1 : Symbol(s1, Decl(mappedTypes2.ts, 57, 12))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 48))
->s2 : Symbol(s2, Decl(mappedTypes2.ts, 57, 22))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 48))
+>f0 : Symbol(f0, Decl(mappedTypes2.ts, 50, 1))
+>s1 : Symbol(s1, Decl(mappedTypes2.ts, 52, 12))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
+>s2 : Symbol(s2, Decl(mappedTypes2.ts, 52, 22))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
 
     assign(s1, { name: "circle" });
->assign : Symbol(assign, Decl(mappedTypes2.ts, 28, 2))
->s1 : Symbol(s1, Decl(mappedTypes2.ts, 57, 12))
->name : Symbol(name, Decl(mappedTypes2.ts, 58, 16))
+>assign : Symbol(assign, Decl(mappedTypes2.ts, 23, 2))
+>s1 : Symbol(s1, Decl(mappedTypes2.ts, 52, 12))
+>name : Symbol(name, Decl(mappedTypes2.ts, 53, 16))
 
     assign(s2, { width: 10, height: 20 });
->assign : Symbol(assign, Decl(mappedTypes2.ts, 28, 2))
->s2 : Symbol(s2, Decl(mappedTypes2.ts, 57, 22))
->width : Symbol(width, Decl(mappedTypes2.ts, 59, 16))
->height : Symbol(height, Decl(mappedTypes2.ts, 59, 27))
+>assign : Symbol(assign, Decl(mappedTypes2.ts, 23, 2))
+>s2 : Symbol(s2, Decl(mappedTypes2.ts, 52, 22))
+>width : Symbol(width, Decl(mappedTypes2.ts, 54, 16))
+>height : Symbol(height, Decl(mappedTypes2.ts, 54, 27))
 }
 
 function f1(shape: Shape) {
->f1 : Symbol(f1, Decl(mappedTypes2.ts, 60, 1))
->shape : Symbol(shape, Decl(mappedTypes2.ts, 62, 12))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 48))
+>f1 : Symbol(f1, Decl(mappedTypes2.ts, 55, 1))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 57, 12))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
 
     var frozen: ReadonlyShape;
->frozen : Symbol(frozen, Decl(mappedTypes2.ts, 63, 7), Decl(mappedTypes2.ts, 64, 7), Decl(mappedTypes2.ts, 65, 7))
->ReadonlyShape : Symbol(ReadonlyShape, Decl(mappedTypes2.ts, 48, 1))
+>frozen : Symbol(frozen, Decl(mappedTypes2.ts, 58, 7), Decl(mappedTypes2.ts, 59, 7), Decl(mappedTypes2.ts, 60, 7))
+>ReadonlyShape : Symbol(ReadonlyShape, Decl(mappedTypes2.ts, 43, 1))
 
     var frozen: Readonly<Shape>;
->frozen : Symbol(frozen, Decl(mappedTypes2.ts, 63, 7), Decl(mappedTypes2.ts, 64, 7), Decl(mappedTypes2.ts, 65, 7))
->Readonly : Symbol(Readonly, Decl(mappedTypes2.ts, 3, 2))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 48))
+>frozen : Symbol(frozen, Decl(mappedTypes2.ts, 58, 7), Decl(mappedTypes2.ts, 59, 7), Decl(mappedTypes2.ts, 60, 7))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
 
     var frozen = freeze(shape);
->frozen : Symbol(frozen, Decl(mappedTypes2.ts, 63, 7), Decl(mappedTypes2.ts, 64, 7), Decl(mappedTypes2.ts, 65, 7))
->freeze : Symbol(freeze, Decl(mappedTypes2.ts, 30, 60))
->shape : Symbol(shape, Decl(mappedTypes2.ts, 62, 12))
+>frozen : Symbol(frozen, Decl(mappedTypes2.ts, 58, 7), Decl(mappedTypes2.ts, 59, 7), Decl(mappedTypes2.ts, 60, 7))
+>freeze : Symbol(freeze, Decl(mappedTypes2.ts, 25, 60))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 57, 12))
 }
 
 function f2(shape: Shape) {
->f2 : Symbol(f2, Decl(mappedTypes2.ts, 66, 1))
->shape : Symbol(shape, Decl(mappedTypes2.ts, 68, 12))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 48))
+>f2 : Symbol(f2, Decl(mappedTypes2.ts, 61, 1))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 63, 12))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
 
     var partial: PartialShape;
->partial : Symbol(partial, Decl(mappedTypes2.ts, 69, 7), Decl(mappedTypes2.ts, 70, 7), Decl(mappedTypes2.ts, 71, 7))
->PartialShape : Symbol(PartialShape, Decl(mappedTypes2.ts, 41, 1))
+>partial : Symbol(partial, Decl(mappedTypes2.ts, 64, 7), Decl(mappedTypes2.ts, 65, 7), Decl(mappedTypes2.ts, 66, 7))
+>PartialShape : Symbol(PartialShape, Decl(mappedTypes2.ts, 36, 1))
 
     var partial: Partial<Shape>;
->partial : Symbol(partial, Decl(mappedTypes2.ts, 69, 7), Decl(mappedTypes2.ts, 70, 7), Decl(mappedTypes2.ts, 71, 7))
->Partial : Symbol(Partial, Decl(mappedTypes2.ts, 0, 0))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 48))
+>partial : Symbol(partial, Decl(mappedTypes2.ts, 64, 7), Decl(mappedTypes2.ts, 65, 7), Decl(mappedTypes2.ts, 66, 7))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
 
     var partial: Partial<Shape> = {};
->partial : Symbol(partial, Decl(mappedTypes2.ts, 69, 7), Decl(mappedTypes2.ts, 70, 7), Decl(mappedTypes2.ts, 71, 7))
->Partial : Symbol(Partial, Decl(mappedTypes2.ts, 0, 0))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 48))
+>partial : Symbol(partial, Decl(mappedTypes2.ts, 64, 7), Decl(mappedTypes2.ts, 65, 7), Decl(mappedTypes2.ts, 66, 7))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
 }
 
 function f3(shape: Shape) {
->f3 : Symbol(f3, Decl(mappedTypes2.ts, 72, 1))
->shape : Symbol(shape, Decl(mappedTypes2.ts, 74, 12))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 48))
+>f3 : Symbol(f3, Decl(mappedTypes2.ts, 67, 1))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 69, 12))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
 
     const x = pick(shape, "name", "visible");  // { name: string, visible: boolean }
->x : Symbol(x, Decl(mappedTypes2.ts, 75, 9))
->pick : Symbol(pick, Decl(mappedTypes2.ts, 31, 48))
->shape : Symbol(shape, Decl(mappedTypes2.ts, 74, 12))
+>x : Symbol(x, Decl(mappedTypes2.ts, 70, 9))
+>pick : Symbol(pick, Decl(mappedTypes2.ts, 26, 48))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 69, 12))
 }
 
 function f4() {
->f4 : Symbol(f4, Decl(mappedTypes2.ts, 76, 1))
+>f4 : Symbol(f4, Decl(mappedTypes2.ts, 71, 1))
 
     const rec = { foo: "hello", bar: "world", baz: "bye" };
->rec : Symbol(rec, Decl(mappedTypes2.ts, 79, 9))
->foo : Symbol(foo, Decl(mappedTypes2.ts, 79, 17))
->bar : Symbol(bar, Decl(mappedTypes2.ts, 79, 31))
->baz : Symbol(baz, Decl(mappedTypes2.ts, 79, 45))
+>rec : Symbol(rec, Decl(mappedTypes2.ts, 74, 9))
+>foo : Symbol(foo, Decl(mappedTypes2.ts, 74, 17))
+>bar : Symbol(bar, Decl(mappedTypes2.ts, 74, 31))
+>baz : Symbol(baz, Decl(mappedTypes2.ts, 74, 45))
 
     const lengths = mapObject(rec, s => s.length);  // { foo: number, bar: number, baz: number }
->lengths : Symbol(lengths, Decl(mappedTypes2.ts, 80, 9))
->mapObject : Symbol(mapObject, Decl(mappedTypes2.ts, 32, 78))
->rec : Symbol(rec, Decl(mappedTypes2.ts, 79, 9))
->s : Symbol(s, Decl(mappedTypes2.ts, 80, 34))
+>lengths : Symbol(lengths, Decl(mappedTypes2.ts, 75, 9))
+>mapObject : Symbol(mapObject, Decl(mappedTypes2.ts, 27, 78))
+>rec : Symbol(rec, Decl(mappedTypes2.ts, 74, 9))
+>s : Symbol(s, Decl(mappedTypes2.ts, 75, 34))
 >s.length : Symbol(String.length, Decl(lib.d.ts, --, --))
->s : Symbol(s, Decl(mappedTypes2.ts, 80, 34))
+>s : Symbol(s, Decl(mappedTypes2.ts, 75, 34))
 >length : Symbol(String.length, Decl(lib.d.ts, --, --))
 }
 
 function f5(shape: Shape) {
->f5 : Symbol(f5, Decl(mappedTypes2.ts, 81, 1))
->shape : Symbol(shape, Decl(mappedTypes2.ts, 83, 12))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 48))
+>f5 : Symbol(f5, Decl(mappedTypes2.ts, 76, 1))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 78, 12))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
 
     const p = proxify(shape);
->p : Symbol(p, Decl(mappedTypes2.ts, 84, 9))
->proxify : Symbol(proxify, Decl(mappedTypes2.ts, 33, 109))
->shape : Symbol(shape, Decl(mappedTypes2.ts, 83, 12))
+>p : Symbol(p, Decl(mappedTypes2.ts, 79, 9))
+>proxify : Symbol(proxify, Decl(mappedTypes2.ts, 28, 109))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 78, 12))
 
     let name = p.name.get();
->name : Symbol(name, Decl(mappedTypes2.ts, 85, 7))
->p.name.get : Symbol(get, Decl(mappedTypes2.ts, 17, 17))
+>name : Symbol(name, Decl(mappedTypes2.ts, 80, 7))
+>p.name.get : Symbol(get, Decl(mappedTypes2.ts, 12, 17))
 >p.name : Symbol(name)
->p : Symbol(p, Decl(mappedTypes2.ts, 84, 9))
+>p : Symbol(p, Decl(mappedTypes2.ts, 79, 9))
 >name : Symbol(name)
->get : Symbol(get, Decl(mappedTypes2.ts, 17, 17))
+>get : Symbol(get, Decl(mappedTypes2.ts, 12, 17))
 
     p.visible.set(false);
->p.visible.set : Symbol(set, Decl(mappedTypes2.ts, 18, 13))
+>p.visible.set : Symbol(set, Decl(mappedTypes2.ts, 13, 13))
 >p.visible : Symbol(visible)
->p : Symbol(p, Decl(mappedTypes2.ts, 84, 9))
+>p : Symbol(p, Decl(mappedTypes2.ts, 79, 9))
 >visible : Symbol(visible)
->set : Symbol(set, Decl(mappedTypes2.ts, 18, 13))
+>set : Symbol(set, Decl(mappedTypes2.ts, 13, 13))
 }
 
 function f6(shape: DeepReadonly<Shape>) {
->f6 : Symbol(f6, Decl(mappedTypes2.ts, 87, 1))
->shape : Symbol(shape, Decl(mappedTypes2.ts, 89, 12))
->DeepReadonly : Symbol(DeepReadonly, Decl(mappedTypes2.ts, 24, 1))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 48))
+>f6 : Symbol(f6, Decl(mappedTypes2.ts, 82, 1))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 84, 12))
+>DeepReadonly : Symbol(DeepReadonly, Decl(mappedTypes2.ts, 19, 1))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
 
     let name = shape.name;  // DeepReadonly<string>
->name : Symbol(name, Decl(mappedTypes2.ts, 90, 7))
+>name : Symbol(name, Decl(mappedTypes2.ts, 85, 7))
 >shape.name : Symbol(name)
->shape : Symbol(shape, Decl(mappedTypes2.ts, 89, 12))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 84, 12))
 >name : Symbol(name)
 
     let length = name.length;  // DeepReadonly<number>
->length : Symbol(length, Decl(mappedTypes2.ts, 91, 7))
+>length : Symbol(length, Decl(mappedTypes2.ts, 86, 7))
 >name.length : Symbol(length)
->name : Symbol(name, Decl(mappedTypes2.ts, 90, 7))
+>name : Symbol(name, Decl(mappedTypes2.ts, 85, 7))
 >length : Symbol(length)
 
     let toString = length.toString;  // DeepReadonly<(radix?: number) => string>
->toString : Symbol(toString, Decl(mappedTypes2.ts, 92, 7))
+>toString : Symbol(toString, Decl(mappedTypes2.ts, 87, 7))
 >length.toString : Symbol(toString)
->length : Symbol(length, Decl(mappedTypes2.ts, 91, 7))
+>length : Symbol(length, Decl(mappedTypes2.ts, 86, 7))
 >toString : Symbol(toString)
 }

--- a/tests/baselines/reference/mappedTypes2.types
+++ b/tests/baselines/reference/mappedTypes2.types
@@ -1,51 +1,60 @@
 === tests/cases/conformance/types/mapped/mappedTypes2.ts ===
 
-type Partial<T> = {
+function verifyLibTypes<T, K extends keyof T, U>() {
+>verifyLibTypes : <T, K extends keyof T, U>() => void
+>T : T
+>K : K
+>T : T
+>U : U
+
+    var x1: Partial<T>;
+>x1 : Partial<T>
 >Partial : Partial<T>
 >T : T
 
-    [P in keyof T]?: T[P];
+    var x1: { [P in keyof T]?: T[P] };
+>x1 : Partial<T>
 >P : P
 >T : T
 >T : T
 >P : P
 
-};
-
-type Readonly<T> = {
+    var x2: Readonly<T>;
+>x2 : Readonly<T>
 >Readonly : Readonly<T>
 >T : T
 
-    readonly [P in keyof T]: T[P];
+    var x2: { readonly [P in keyof T]: T[P] };
+>x2 : Readonly<T>
 >P : P
 >T : T
 >T : T
 >P : P
 
-};
-
-type Pick<T, K extends keyof T> = {
+    var x3: Pick<T, K>;
+>x3 : Pick<T, K>
 >Pick : Pick<T, K>
 >T : T
 >K : K
->T : T
 
-    [P in K]: T[P];
+    var x3: { [P in K]: T[P] };
+>x3 : Pick<T, K>
 >P : P
 >K : K
 >T : T
 >P : P
-}
 
-type Record<K extends string | number, T> = {
+    var x4: Record<K, U>;
+>x4 : Record<K, U>
 >Record : Record<K, T>
 >K : K
->T : T
+>U : U
 
-    [_ in K]: T;
->_ : _
+    var x4: { [P in K]: U };
+>x4 : Record<K, U>
+>P : P
 >K : K
->T : T
+>U : U
 }
 
 type Proxy<T> = {

--- a/tests/cases/conformance/types/mapped/mappedTypeErrors.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypeErrors.ts
@@ -1,22 +1,6 @@
 // @strictNullChecks: true
 // @declaration: true
 
-type Partial<T> = {
-    [P in keyof T]?: T[P];
-};
-
-type Readonly<T> = {
-    readonly [P in keyof T]: T[P];
-};
-
-type Pick<T, K extends keyof T> = {
-    [P in K]: T[P];
-}
-
-type Record<K extends string | number, T> = {
-    [_ in K]: T;
-}
-
 interface Shape {
     name: string;
     width: number;
@@ -32,6 +16,8 @@ interface Point {
     x: number;
     y: number;
 }
+
+// Constraint checking
 
 type T00 = { [P in P]: string };  // Error
 type T01 = { [P in Date]: number };  // Error
@@ -59,4 +45,25 @@ function f3<T extends keyof Shape>(x: T) {
 
 function f4<T extends keyof Named>(x: T) {
     let y: Pick<Shape, T>;
+}
+
+// Type identity checking
+
+function f10<T>() {
+    type K = keyof T;
+    var x: { [P in keyof T]: T[P] };
+    var x: { [Q in keyof T]: T[Q] };
+    var x: { [R in K]: T[R] };
+}
+
+function f11<T>() {
+    var x: { [P in keyof T]: T[P] };
+    var x: { [P in keyof T]?: T[P] };  // Error
+    var x: { readonly [P in keyof T]: T[P] };  // Error
+    var x: { readonly [P in keyof T]?: T[P] };  // Error
+}
+
+function f12<T>() {
+    var x: { [P in keyof T]: T[P] };
+    var x: { [P in keyof T]: T[P][] };  // Error
 }

--- a/tests/cases/conformance/types/mapped/mappedTypes2.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypes2.ts
@@ -1,20 +1,15 @@
 // @strictNullChecks: true
 // @declaration: true
 
-type Partial<T> = {
-    [P in keyof T]?: T[P];
-};
-
-type Readonly<T> = {
-    readonly [P in keyof T]: T[P];
-};
-
-type Pick<T, K extends keyof T> = {
-    [P in K]: T[P];
-}
-
-type Record<K extends string | number, T> = {
-    [_ in K]: T;
+function verifyLibTypes<T, K extends keyof T, U>() {
+    var x1: Partial<T>;
+    var x1: { [P in keyof T]?: T[P] };
+    var x2: Readonly<T>;
+    var x2: { readonly [P in keyof T]: T[P] };
+    var x3: Pick<T, K>;
+    var x3: { [P in K]: T[P] };
+    var x4: Record<K, U>;
+    var x4: { [P in K]: U };
 }
 
 type Proxy<T> = {


### PR DESCRIPTION
This PR adds the following predefined mapped types to lib.d.ts:

```ts
// Make all properties in T optional
type Partial<T> = {
    [P in keyof T]?: T[P];
};

// Make all properties in T readonly
type Readonly<T> = {
    readonly [P in keyof T]: T[P];
};

// From T pick a set of properties K
type Pick<T, K extends keyof T> = {
    [P in K]: T[P];
}

// Construct a type with a set of properties K of type T
type Record<K extends string | number, T> = {
    [P in K]: T;
}
```

The PR also property implements the identity relation for mapped types.