### PR TITLE
Make "exclude" default to empty if "include" is present.

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -951,8 +951,8 @@ namespace ts {
                 errors.push(createCompilerDiagnostic(Diagnostics.Unknown_option_excludes_Did_you_mean_exclude));
             }
             else {
-                // By default, exclude common package folders and the outDir
-                excludeSpecs = ["node_modules", "bower_components", "jspm_packages"];
+                // If no includes were specified, exclude common package folders and the outDir
+                excludeSpecs = includeSpecs ? [] : ["node_modules", "bower_components", "jspm_packages"];
 
                 const outDir = json["compilerOptions"] && json["compilerOptions"]["outDir"];
                 if (outDir) {

--- a/src/harness/unittests/matchFiles.ts
+++ b/src/harness/unittests/matchFiles.ts
@@ -89,8 +89,6 @@ namespace ts {
         "c:/dev/g.min.js/.g/g.ts"
     ]);
 
-    const defaultExcludes = ["node_modules", "bower_components", "jspm_packages"];
-
     function assertParsed(actual: ts.ParsedCommandLine, expected: ts.ParsedCommandLine): void {
         assert.deepEqual(actual.fileNames, expected.fileNames);
         assert.deepEqual(actual.wildcardDirectories, expected.wildcardDirectories);
@@ -98,6 +96,23 @@ namespace ts {
     }
 
     describe("matchFiles", () => {
+        it("with defaults", () => {
+            const json = {};
+            const expected: ts.ParsedCommandLine = {
+                options: {},
+                errors: [],
+                fileNames: [
+                    "c:/dev/a.ts",
+                    "c:/dev/b.ts"
+                ],
+                wildcardDirectories: {
+                    "c:/dev": ts.WatchDirectoryFlags.Recursive
+                },
+            };
+            const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveCommonFoldersHost, caseInsensitiveBasePath);
+            assertParsed(actual, expected);
+        });
+
         describe("with literal file list", () => {
             it("without exclusions", () => {
                 const json = {
@@ -192,7 +207,7 @@ namespace ts {
                     options: {},
                     errors: [
                         ts.createCompilerDiagnostic(ts.Diagnostics.No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2,
-                            caseInsensitiveTsconfigPath, JSON.stringify(json.include), JSON.stringify(defaultExcludes))
+                            caseInsensitiveTsconfigPath, JSON.stringify(json.include), "[]")
                     ],
                     fileNames: [],
                     wildcardDirectories: {},
@@ -211,7 +226,7 @@ namespace ts {
                     options: {},
                     errors: [
                         ts.createCompilerDiagnostic(ts.Diagnostics.No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2,
-                            caseInsensitiveTsconfigPath, JSON.stringify(json.include), JSON.stringify(defaultExcludes))
+                            caseInsensitiveTsconfigPath, JSON.stringify(json.include), "[]")
                     ],
                     fileNames: [],
                     wildcardDirectories: {},
@@ -330,7 +345,10 @@ namespace ts {
                     errors: [],
                     fileNames: [
                         "c:/dev/a.ts",
-                        "c:/dev/b.ts"
+                        "c:/dev/b.ts",
+                        "c:/dev/bower_components/a.ts",
+                        "c:/dev/jspm_packages/a.ts",
+                        "c:/dev/node_modules/a.ts"
                     ],
                     wildcardDirectories: {},
                 };
@@ -372,8 +390,7 @@ namespace ts {
                         "node_modules/a.ts",
                         "bower_components/a.ts",
                         "jspm_packages/a.ts"
-                    ],
-                    exclude: <string[]>[]
+                    ]
                 };
                 const expected: ts.ParsedCommandLine = {
                     options: {},
@@ -530,7 +547,7 @@ namespace ts {
                     options: {},
                     errors: [
                         ts.createCompilerDiagnostic(ts.Diagnostics.No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2,
-                            caseInsensitiveTsconfigPath, JSON.stringify(json.include), JSON.stringify(defaultExcludes))
+                            caseInsensitiveTsconfigPath, JSON.stringify(json.include), "[]")
                     ],
                     fileNames: [],
                     wildcardDirectories: {
@@ -600,7 +617,10 @@ namespace ts {
                     options: {},
                     errors: [],
                     fileNames: [
-                        "c:/dev/a.ts"
+                        "c:/dev/a.ts",
+                        "c:/dev/bower_components/a.ts",
+                        "c:/dev/jspm_packages/a.ts",
+                        "c:/dev/node_modules/a.ts"
                     ],
                     wildcardDirectories: {
                         "c:/dev": ts.WatchDirectoryFlags.Recursive
@@ -671,7 +691,7 @@ namespace ts {
                     },
                     errors: [
                         ts.createCompilerDiagnostic(ts.Diagnostics.No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2,
-                            caseInsensitiveTsconfigPath, JSON.stringify(json.include), JSON.stringify(defaultExcludes))
+                            caseInsensitiveTsconfigPath, JSON.stringify(json.include), "[]")
                     ],
                     fileNames: [],
                     wildcardDirectories: {
@@ -980,7 +1000,7 @@ namespace ts {
                         errors: [
                             ts.createCompilerDiagnostic(ts.Diagnostics.File_specification_cannot_end_in_a_recursive_directory_wildcard_Asterisk_Asterisk_Colon_0, "**"),
                             ts.createCompilerDiagnostic(ts.Diagnostics.No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2,
-                                caseInsensitiveTsconfigPath, JSON.stringify(json.include), JSON.stringify(defaultExcludes))
+                                caseInsensitiveTsconfigPath, JSON.stringify(json.include), "[]")
                         ],
                         fileNames: [],
                         wildcardDirectories: {}
@@ -1022,7 +1042,7 @@ namespace ts {
                         errors: [
                             ts.createCompilerDiagnostic(ts.Diagnostics.File_specification_cannot_contain_multiple_recursive_directory_wildcards_Asterisk_Asterisk_Colon_0, "**/x/**/*"),
                             ts.createCompilerDiagnostic(ts.Diagnostics.No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2,
-                                caseInsensitiveTsconfigPath, JSON.stringify(json.include), JSON.stringify(defaultExcludes))
+                                caseInsensitiveTsconfigPath, JSON.stringify(json.include), "[]")
                         ],
                         fileNames: [],
                         wildcardDirectories: {}
@@ -1071,7 +1091,7 @@ namespace ts {
                         errors: [
                             ts.createCompilerDiagnostic(ts.Diagnostics.File_specification_cannot_contain_a_parent_directory_that_appears_after_a_recursive_directory_wildcard_Asterisk_Asterisk_Colon_0, "**/../*"),
                             ts.createCompilerDiagnostic(ts.Diagnostics.No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2,
-                                caseInsensitiveTsconfigPath, JSON.stringify(json.include), JSON.stringify(defaultExcludes))
+                                caseInsensitiveTsconfigPath, JSON.stringify(json.include), "[]")
                         ],
                         fileNames: [],
                         wildcardDirectories: {}
@@ -1091,7 +1111,7 @@ namespace ts {
                         errors: [
                             ts.createCompilerDiagnostic(ts.Diagnostics.File_specification_cannot_contain_a_parent_directory_that_appears_after_a_recursive_directory_wildcard_Asterisk_Asterisk_Colon_0, "**/y/../*"),
                             ts.createCompilerDiagnostic(ts.Diagnostics.No_inputs_were_found_in_config_file_0_Specified_include_paths_were_1_and_exclude_paths_were_2,
-                                caseInsensitiveTsconfigPath, JSON.stringify(json.include), JSON.stringify(defaultExcludes))
+                                caseInsensitiveTsconfigPath, JSON.stringify(json.include), "[]")
                         ],
                         fileNames: [],
                         wildcardDirectories: {}


### PR DESCRIPTION
Fixes #12334.

We included several tests asserting the old behavior, so we should make sure this is what we really want.