### PR TITLE
Higher order type relations for mapped types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4667,12 +4667,21 @@ namespace ts {
         }
 
         /**
+         * The apparent type of an indexed access T[K] is the type of T's string index signature, if any.
+         */
+        function getApparentTypeOfIndexedAccess(type: IndexedAccessType) {
+            return getIndexTypeOfType(getApparentType(type.objectType), IndexKind.String) || type;
+        }
+
+        /**
          * For a type parameter, return the base constraint of the type parameter. For the string, number,
          * boolean, and symbol primitive types, return the corresponding object types. Otherwise return the
          * type itself. Note that the apparent type of a union type is the union type itself.
          */
         function getApparentType(type: Type): Type {
-            const t = type.flags & TypeFlags.TypeParameter ? getApparentTypeOfTypeParameter(<TypeParameter>type) : type;
+            const t = type.flags & TypeFlags.TypeParameter ? getApparentTypeOfTypeParameter(<TypeParameter>type) :
+                type.flags & TypeFlags.IndexedAccess ? getApparentTypeOfIndexedAccess(<IndexedAccessType>type) :
+                type;
             return t.flags & TypeFlags.StringLike ? globalStringType :
                 t.flags & TypeFlags.NumberLike ? globalNumberType :
                 t.flags & TypeFlags.BooleanLike ? globalBooleanType :

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6059,6 +6059,9 @@ namespace ts {
                 type.aliasSymbol = getAliasSymbolForTypeNode(node);
                 type.aliasTypeArguments = getAliasTypeArgumentsForTypeNode(node);
                 links.resolvedType = type;
+                // Eagerly resolve the constraint type which forces an error if the constraint type circularly
+                // references itself through one or more type aliases.
+                getConstraintTypeFromMappedType(type);
             }
             return links.resolvedType;
         }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1731,7 +1731,7 @@
         "category": "Error",
         "code": 2535
     },
-    "Type '{0}' is not constrained to 'keyof {1}'.": {
+    "Type '{0}' cannot be used to index type '{1}'.": {
         "category": "Error",
         "code": 2536
     },

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2974,8 +2974,6 @@ namespace ts {
         /* @internal */
         resolvedIndexType: IndexType;
         /* @internal */
-        resolvedIndexedAccessTypes: IndexedAccessType[];
-        /* @internal */
         isThisType?: boolean;
     }
 
@@ -2985,7 +2983,7 @@ namespace ts {
 
     export interface IndexedAccessType extends Type {
         objectType: Type;
-        indexType: TypeParameter;
+        indexType: Type;
     }
 
     export const enum SignatureKind {

--- a/tests/baselines/reference/mappedTypeRelationships.errors.txt
+++ b/tests/baselines/reference/mappedTypeRelationships.errors.txt
@@ -1,0 +1,165 @@
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(12,5): error TS2322: Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
+  Type 'T' is not assignable to type 'U'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(17,5): error TS2322: Type 'T[K]' is not assignable to type 'U[K]'.
+  Type 'T' is not assignable to type 'U'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(21,5): error TS2536: Type 'keyof U' cannot be used to index type 'T'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(22,12): error TS2536: Type 'keyof U' cannot be used to index type 'T'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(26,5): error TS2536: Type 'K' cannot be used to index type 'T'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(27,12): error TS2536: Type 'K' cannot be used to index type 'T'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(31,5): error TS2322: Type 'T[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
+  Type 'undefined' is not assignable to type 'T[keyof T]'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(36,5): error TS2322: Type 'T[K] | undefined' is not assignable to type 'T[K]'.
+  Type 'undefined' is not assignable to type 'T[K]'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(41,5): error TS2322: Type 'U[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
+  Type 'undefined' is not assignable to type 'T[keyof T]'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(42,5): error TS2322: Type 'T[keyof T]' is not assignable to type 'U[keyof T] | undefined'.
+  Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
+    Type 'T' is not assignable to type 'U'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(46,5): error TS2322: Type 'U[K] | undefined' is not assignable to type 'T[K]'.
+  Type 'undefined' is not assignable to type 'T[K]'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(47,5): error TS2322: Type 'T[K]' is not assignable to type 'U[K] | undefined'.
+  Type 'T[K]' is not assignable to type 'U[K]'.
+    Type 'T' is not assignable to type 'U'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(52,5): error TS2542: Index signature in type 'Readonly<T>' only permits reading.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(57,5): error TS2542: Index signature in type 'Readonly<T>' only permits reading.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(62,5): error TS2542: Index signature in type 'Readonly<U>' only permits reading.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(67,5): error TS2542: Index signature in type 'Readonly<U>' only permits reading.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(71,5): error TS2322: Type 'Partial<T>' is not assignable to type 'T'.
+tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(76,5): error TS2322: Type 'Partial<T>' is not assignable to type 'T'.
+
+
+==== tests/cases/conformance/types/mapped/mappedTypeRelationships.ts (18 errors) ====
+    
+    function f1<T>(x: T, k: keyof T) {
+        return x[k];
+    }
+    
+    function f2<T, K extends keyof T>(x: T, k: K) {
+        return x[k];
+    }
+    
+    function f3<T, U extends T>(x: T, y: U, k: keyof T) {
+        x[k] = y[k];
+        y[k] = x[k];  // Error
+        ~~~~
+!!! error TS2322: Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
+!!! error TS2322:   Type 'T' is not assignable to type 'U'.
+    }
+    
+    function f4<T, U extends T, K extends keyof T>(x: T, y: U, k: K) {
+        x[k] = y[k];
+        y[k] = x[k];  // Error
+        ~~~~
+!!! error TS2322: Type 'T[K]' is not assignable to type 'U[K]'.
+!!! error TS2322:   Type 'T' is not assignable to type 'U'.
+    }
+    
+    function f5<T, U extends T>(x: T, y: U, k: keyof U) {
+        x[k] = y[k];  // Error
+        ~~~~
+!!! error TS2536: Type 'keyof U' cannot be used to index type 'T'.
+        y[k] = x[k];  // Error
+               ~~~~
+!!! error TS2536: Type 'keyof U' cannot be used to index type 'T'.
+    }
+    
+    function f6<T, U extends T, K extends keyof U>(x: T, y: U, k: K) {
+        x[k] = y[k];  // Error
+        ~~~~
+!!! error TS2536: Type 'K' cannot be used to index type 'T'.
+        y[k] = x[k];  // Error
+               ~~~~
+!!! error TS2536: Type 'K' cannot be used to index type 'T'.
+    }
+    
+    function f10<T>(x: T, y: Partial<T>, k: keyof T) {
+        x[k] = y[k];  // Error
+        ~~~~
+!!! error TS2322: Type 'T[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
+!!! error TS2322:   Type 'undefined' is not assignable to type 'T[keyof T]'.
+        y[k] = x[k];
+    }
+    
+    function f11<T, K extends keyof T>(x: T, y: Partial<T>, k: K) {
+        x[k] = y[k];  // Error
+        ~~~~
+!!! error TS2322: Type 'T[K] | undefined' is not assignable to type 'T[K]'.
+!!! error TS2322:   Type 'undefined' is not assignable to type 'T[K]'.
+        y[k] = x[k];
+    }
+    
+    function f12<T, U extends T>(x: T, y: Partial<U>, k: keyof T) {
+        x[k] = y[k];  // Error
+        ~~~~
+!!! error TS2322: Type 'U[keyof T] | undefined' is not assignable to type 'T[keyof T]'.
+!!! error TS2322:   Type 'undefined' is not assignable to type 'T[keyof T]'.
+        y[k] = x[k];  // Error
+        ~~~~
+!!! error TS2322: Type 'T[keyof T]' is not assignable to type 'U[keyof T] | undefined'.
+!!! error TS2322:   Type 'T[keyof T]' is not assignable to type 'U[keyof T]'.
+!!! error TS2322:     Type 'T' is not assignable to type 'U'.
+    }
+    
+    function f13<T, U extends T, K extends keyof T>(x: T, y: Partial<U>, k: K) {
+        x[k] = y[k];  // Error
+        ~~~~
+!!! error TS2322: Type 'U[K] | undefined' is not assignable to type 'T[K]'.
+!!! error TS2322:   Type 'undefined' is not assignable to type 'T[K]'.
+        y[k] = x[k];  // Error
+        ~~~~
+!!! error TS2322: Type 'T[K]' is not assignable to type 'U[K] | undefined'.
+!!! error TS2322:   Type 'T[K]' is not assignable to type 'U[K]'.
+!!! error TS2322:     Type 'T' is not assignable to type 'U'.
+    }
+    
+    function f20<T>(x: T, y: Readonly<T>, k: keyof T) {
+        x[k] = y[k];
+        y[k] = x[k];  // Error
+        ~~~~
+!!! error TS2542: Index signature in type 'Readonly<T>' only permits reading.
+    }
+    
+    function f21<T, K extends keyof T>(x: T, y: Readonly<T>, k: K) {
+        x[k] = y[k];
+        y[k] = x[k];  // Error
+        ~~~~
+!!! error TS2542: Index signature in type 'Readonly<T>' only permits reading.
+    }
+    
+    function f22<T, U extends T>(x: T, y: Readonly<U>, k: keyof T) {
+        x[k] = y[k];
+        y[k] = x[k];  // Error
+        ~~~~
+!!! error TS2542: Index signature in type 'Readonly<U>' only permits reading.
+    }
+    
+    function f23<T, U extends T, K extends keyof T>(x: T, y: Readonly<U>, k: K) {
+        x[k] = y[k];
+        y[k] = x[k];  // Error
+        ~~~~
+!!! error TS2542: Index signature in type 'Readonly<U>' only permits reading.
+    }
+    
+    function f30<T>(x: T, y: Partial<T>) {
+        x = y;  // Error
+        ~
+!!! error TS2322: Type 'Partial<T>' is not assignable to type 'T'.
+        y = x;
+    }
+    
+    function f31<T>(x: T, y: Partial<T>) {
+        x = y;  // Error
+        ~
+!!! error TS2322: Type 'Partial<T>' is not assignable to type 'T'.
+        y = x;
+    }
+    
+    function f40<T>(x: T, y: Readonly<T>) {
+        x = y;
+        y = x;
+    }
+    
+    function f41<T>(x: T, y: Readonly<T>) {
+        x = y;
+        y = x;
+    }

--- a/tests/baselines/reference/mappedTypeRelationships.errors.txt
+++ b/tests/baselines/reference/mappedTypeRelationships.errors.txt
@@ -163,3 +163,21 @@ tests/cases/conformance/types/mapped/mappedTypeRelationships.ts(76,5): error TS2
         x = y;
         y = x;
     }
+    
+    type Item = {
+        name: string;
+    }
+    
+    type ItemMap = {
+        [x: string]: Item;
+    }
+    
+    function f50<T extends ItemMap>(obj: T, key: keyof T) {
+        let item: Item = obj[key];
+        return obj[key].name;
+    }
+    
+    function f51<T extends ItemMap, K extends keyof T>(obj: T, key: K) {
+        let item: Item = obj[key];
+        return obj[key].name;
+    }

--- a/tests/baselines/reference/mappedTypeRelationships.js
+++ b/tests/baselines/reference/mappedTypeRelationships.js
@@ -1,0 +1,182 @@
+//// [mappedTypeRelationships.ts]
+
+function f1<T>(x: T, k: keyof T) {
+    return x[k];
+}
+
+function f2<T, K extends keyof T>(x: T, k: K) {
+    return x[k];
+}
+
+function f3<T, U extends T>(x: T, y: U, k: keyof T) {
+    x[k] = y[k];
+    y[k] = x[k];  // Error
+}
+
+function f4<T, U extends T, K extends keyof T>(x: T, y: U, k: K) {
+    x[k] = y[k];
+    y[k] = x[k];  // Error
+}
+
+function f5<T, U extends T>(x: T, y: U, k: keyof U) {
+    x[k] = y[k];  // Error
+    y[k] = x[k];  // Error
+}
+
+function f6<T, U extends T, K extends keyof U>(x: T, y: U, k: K) {
+    x[k] = y[k];  // Error
+    y[k] = x[k];  // Error
+}
+
+function f10<T>(x: T, y: Partial<T>, k: keyof T) {
+    x[k] = y[k];  // Error
+    y[k] = x[k];
+}
+
+function f11<T, K extends keyof T>(x: T, y: Partial<T>, k: K) {
+    x[k] = y[k];  // Error
+    y[k] = x[k];
+}
+
+function f12<T, U extends T>(x: T, y: Partial<U>, k: keyof T) {
+    x[k] = y[k];  // Error
+    y[k] = x[k];  // Error
+}
+
+function f13<T, U extends T, K extends keyof T>(x: T, y: Partial<U>, k: K) {
+    x[k] = y[k];  // Error
+    y[k] = x[k];  // Error
+}
+
+function f20<T>(x: T, y: Readonly<T>, k: keyof T) {
+    x[k] = y[k];
+    y[k] = x[k];  // Error
+}
+
+function f21<T, K extends keyof T>(x: T, y: Readonly<T>, k: K) {
+    x[k] = y[k];
+    y[k] = x[k];  // Error
+}
+
+function f22<T, U extends T>(x: T, y: Readonly<U>, k: keyof T) {
+    x[k] = y[k];
+    y[k] = x[k];  // Error
+}
+
+function f23<T, U extends T, K extends keyof T>(x: T, y: Readonly<U>, k: K) {
+    x[k] = y[k];
+    y[k] = x[k];  // Error
+}
+
+function f30<T>(x: T, y: Partial<T>) {
+    x = y;  // Error
+    y = x;
+}
+
+function f31<T>(x: T, y: Partial<T>) {
+    x = y;  // Error
+    y = x;
+}
+
+function f40<T>(x: T, y: Readonly<T>) {
+    x = y;
+    y = x;
+}
+
+function f41<T>(x: T, y: Readonly<T>) {
+    x = y;
+    y = x;
+}
+
+//// [mappedTypeRelationships.js]
+function f1(x, k) {
+    return x[k];
+}
+function f2(x, k) {
+    return x[k];
+}
+function f3(x, y, k) {
+    x[k] = y[k];
+    y[k] = x[k]; // Error
+}
+function f4(x, y, k) {
+    x[k] = y[k];
+    y[k] = x[k]; // Error
+}
+function f5(x, y, k) {
+    x[k] = y[k]; // Error
+    y[k] = x[k]; // Error
+}
+function f6(x, y, k) {
+    x[k] = y[k]; // Error
+    y[k] = x[k]; // Error
+}
+function f10(x, y, k) {
+    x[k] = y[k]; // Error
+    y[k] = x[k];
+}
+function f11(x, y, k) {
+    x[k] = y[k]; // Error
+    y[k] = x[k];
+}
+function f12(x, y, k) {
+    x[k] = y[k]; // Error
+    y[k] = x[k]; // Error
+}
+function f13(x, y, k) {
+    x[k] = y[k]; // Error
+    y[k] = x[k]; // Error
+}
+function f20(x, y, k) {
+    x[k] = y[k];
+    y[k] = x[k]; // Error
+}
+function f21(x, y, k) {
+    x[k] = y[k];
+    y[k] = x[k]; // Error
+}
+function f22(x, y, k) {
+    x[k] = y[k];
+    y[k] = x[k]; // Error
+}
+function f23(x, y, k) {
+    x[k] = y[k];
+    y[k] = x[k]; // Error
+}
+function f30(x, y) {
+    x = y; // Error
+    y = x;
+}
+function f31(x, y) {
+    x = y; // Error
+    y = x;
+}
+function f40(x, y) {
+    x = y;
+    y = x;
+}
+function f41(x, y) {
+    x = y;
+    y = x;
+}
+
+
+//// [mappedTypeRelationships.d.ts]
+declare function f1<T>(x: T, k: keyof T): T[keyof T];
+declare function f2<T, K extends keyof T>(x: T, k: K): T[K];
+declare function f3<T, U extends T>(x: T, y: U, k: keyof T): void;
+declare function f4<T, U extends T, K extends keyof T>(x: T, y: U, k: K): void;
+declare function f5<T, U extends T>(x: T, y: U, k: keyof U): void;
+declare function f6<T, U extends T, K extends keyof U>(x: T, y: U, k: K): void;
+declare function f10<T>(x: T, y: Partial<T>, k: keyof T): void;
+declare function f11<T, K extends keyof T>(x: T, y: Partial<T>, k: K): void;
+declare function f12<T, U extends T>(x: T, y: Partial<U>, k: keyof T): void;
+declare function f13<T, U extends T, K extends keyof T>(x: T, y: Partial<U>, k: K): void;
+declare function f20<T>(x: T, y: Readonly<T>, k: keyof T): void;
+declare function f21<T, K extends keyof T>(x: T, y: Readonly<T>, k: K): void;
+declare function f22<T, U extends T>(x: T, y: Readonly<U>, k: keyof T): void;
+declare function f23<T, U extends T, K extends keyof T>(x: T, y: Readonly<U>, k: K): void;
+declare function f30<T>(x: T, y: Partial<T>): void;
+declare function f31<T>(x: T, y: Partial<T>): void;
+declare function f40<T>(x: T, y: Readonly<T>): void;
+declare function f41<T>(x: T, y: Readonly<T>): void;

--- a/tests/baselines/reference/mappedTypeRelationships.js
+++ b/tests/baselines/reference/mappedTypeRelationships.js
@@ -88,6 +88,24 @@ function f41<T>(x: T, y: Readonly<T>) {
     y = x;
 }
 
+type Item = {
+    name: string;
+}
+
+type ItemMap = {
+    [x: string]: Item;
+}
+
+function f50<T extends ItemMap>(obj: T, key: keyof T) {
+    let item: Item = obj[key];
+    return obj[key].name;
+}
+
+function f51<T extends ItemMap, K extends keyof T>(obj: T, key: K) {
+    let item: Item = obj[key];
+    return obj[key].name;
+}
+
 //// [mappedTypeRelationships.js]
 function f1(x, k) {
     return x[k];
@@ -159,6 +177,14 @@ function f41(x, y) {
     x = y;
     y = x;
 }
+function f50(obj, key) {
+    var item = obj[key];
+    return obj[key].name;
+}
+function f51(obj, key) {
+    var item = obj[key];
+    return obj[key].name;
+}
 
 
 //// [mappedTypeRelationships.d.ts]
@@ -180,3 +206,11 @@ declare function f30<T>(x: T, y: Partial<T>): void;
 declare function f31<T>(x: T, y: Partial<T>): void;
 declare function f40<T>(x: T, y: Readonly<T>): void;
 declare function f41<T>(x: T, y: Readonly<T>): void;
+declare type Item = {
+    name: string;
+};
+declare type ItemMap = {
+    [x: string]: Item;
+};
+declare function f50<T extends ItemMap>(obj: T, key: keyof T): string;
+declare function f51<T extends ItemMap, K extends keyof T>(obj: T, key: K): string;

--- a/tests/baselines/reference/recursiveMappedTypes.errors.txt
+++ b/tests/baselines/reference/recursiveMappedTypes.errors.txt
@@ -1,0 +1,26 @@
+tests/cases/conformance/types/mapped/recursiveMappedTypes.ts(4,6): error TS2456: Type alias 'Recurse' circularly references itself.
+tests/cases/conformance/types/mapped/recursiveMappedTypes.ts(8,6): error TS2456: Type alias 'Recurse1' circularly references itself.
+tests/cases/conformance/types/mapped/recursiveMappedTypes.ts(12,6): error TS2456: Type alias 'Recurse2' circularly references itself.
+
+
+==== tests/cases/conformance/types/mapped/recursiveMappedTypes.ts (3 errors) ====
+    
+    // Recursive mapped types simply appear empty
+    
+    type Recurse = {
+         ~~~~~~~
+!!! error TS2456: Type alias 'Recurse' circularly references itself.
+        [K in keyof Recurse]: Recurse[K]
+    }
+    
+    type Recurse1 = {
+         ~~~~~~~~
+!!! error TS2456: Type alias 'Recurse1' circularly references itself.
+        [K in keyof Recurse2]: Recurse2[K]
+    }
+    
+    type Recurse2 = {
+         ~~~~~~~~
+!!! error TS2456: Type alias 'Recurse2' circularly references itself.
+        [K in keyof Recurse1]: Recurse1[K]
+    }

--- a/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
@@ -1,0 +1,90 @@
+// @strictNullChecks: true
+// @declaration: true
+
+function f1<T>(x: T, k: keyof T) {
+    return x[k];
+}
+
+function f2<T, K extends keyof T>(x: T, k: K) {
+    return x[k];
+}
+
+function f3<T, U extends T>(x: T, y: U, k: keyof T) {
+    x[k] = y[k];
+    y[k] = x[k];  // Error
+}
+
+function f4<T, U extends T, K extends keyof T>(x: T, y: U, k: K) {
+    x[k] = y[k];
+    y[k] = x[k];  // Error
+}
+
+function f5<T, U extends T>(x: T, y: U, k: keyof U) {
+    x[k] = y[k];  // Error
+    y[k] = x[k];  // Error
+}
+
+function f6<T, U extends T, K extends keyof U>(x: T, y: U, k: K) {
+    x[k] = y[k];  // Error
+    y[k] = x[k];  // Error
+}
+
+function f10<T>(x: T, y: Partial<T>, k: keyof T) {
+    x[k] = y[k];  // Error
+    y[k] = x[k];
+}
+
+function f11<T, K extends keyof T>(x: T, y: Partial<T>, k: K) {
+    x[k] = y[k];  // Error
+    y[k] = x[k];
+}
+
+function f12<T, U extends T>(x: T, y: Partial<U>, k: keyof T) {
+    x[k] = y[k];  // Error
+    y[k] = x[k];  // Error
+}
+
+function f13<T, U extends T, K extends keyof T>(x: T, y: Partial<U>, k: K) {
+    x[k] = y[k];  // Error
+    y[k] = x[k];  // Error
+}
+
+function f20<T>(x: T, y: Readonly<T>, k: keyof T) {
+    x[k] = y[k];
+    y[k] = x[k];  // Error
+}
+
+function f21<T, K extends keyof T>(x: T, y: Readonly<T>, k: K) {
+    x[k] = y[k];
+    y[k] = x[k];  // Error
+}
+
+function f22<T, U extends T>(x: T, y: Readonly<U>, k: keyof T) {
+    x[k] = y[k];
+    y[k] = x[k];  // Error
+}
+
+function f23<T, U extends T, K extends keyof T>(x: T, y: Readonly<U>, k: K) {
+    x[k] = y[k];
+    y[k] = x[k];  // Error
+}
+
+function f30<T>(x: T, y: Partial<T>) {
+    x = y;  // Error
+    y = x;
+}
+
+function f31<T>(x: T, y: Partial<T>) {
+    x = y;  // Error
+    y = x;
+}
+
+function f40<T>(x: T, y: Readonly<T>) {
+    x = y;
+    y = x;
+}
+
+function f41<T>(x: T, y: Readonly<T>) {
+    x = y;
+    y = x;
+}

--- a/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypeRelationships.ts
@@ -88,3 +88,21 @@ function f41<T>(x: T, y: Readonly<T>) {
     x = y;
     y = x;
 }
+
+type Item = {
+    name: string;
+}
+
+type ItemMap = {
+    [x: string]: Item;
+}
+
+function f50<T extends ItemMap>(obj: T, key: keyof T) {
+    let item: Item = obj[key];
+    return obj[key].name;
+}
+
+function f51<T extends ItemMap, K extends keyof T>(obj: T, key: K) {
+    let item: Item = obj[key];
+    return obj[key].name;
+}


### PR DESCRIPTION
This PR adds a number of type relations for higher order mapped types and indexed access types (i.e. un-instantiated generic forms of the types).

* A type `S[K]` is related to a type `T[K]` if `S` is related to `T`.
* A type `T` is related to a type `{ [P in keyof T]: X }` if `T[P]` is related to `X`.
* A type `{ [P in keyof T]: X }` is related to a type `T` if `X` is related to `T[P]`.

The PR furthermore adds the following rules:

* The operation `keyof { [P in K]: X }` is equivalent to just `K`. For example, `keyof Partial<T>` is equivalent to `keyof T`.
* The operation `{ [P in K]: T}[X]` is equivalent to an instantiation of `T` where `X` is substituted for every occurrence of `P`. For example, `{ [P in K]: Box<T[P]> }[X]` is equivalent to `Box<T[X]>`.
* In `type T = { [P in K]: X }` it is an error for `K` to directly or indirectly reference `T`.
* Given a type parameter `T` with a constraint that includes a string index signature of type `X`, the apparent type of an indexed access type `T[K]` is `X`.

Fixes #12311.
Fixes #12315.