### PR TITLE
[Release 2.1] Fixes for #12291 and #12326: Declaration emit when there are errors in the source file

### DIFF
--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -1143,7 +1143,10 @@ namespace ts {
             const prevEnclosingDeclaration = enclosingDeclaration;
             enclosingDeclaration = node;
             emitTypeParameters(node.typeParameters);
-            emitHeritageClause(getInterfaceBaseTypeNodes(node), /*isImplementsList*/ false);
+            const interfaceExtendsTypes = filter(getInterfaceBaseTypeNodes(node), base => isEntityNameExpression(base.expression));
+            if (interfaceExtendsTypes && interfaceExtendsTypes.length) {
+                emitHeritageClause(interfaceExtendsTypes, /*isImplementsList*/ false);
+            }
             write(" {");
             writeLine();
             increaseIndent();

--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -1037,6 +1037,10 @@ namespace ts {
                             diagnosticMessage = Diagnostics.Type_parameter_0_of_exported_function_has_or_is_using_private_name_1;
                             break;
 
+                        case SyntaxKind.TypeAliasDeclaration:
+                            diagnosticMessage = Diagnostics.Type_parameter_0_of_exported_type_alias_has_or_is_using_private_name_1;
+                            break;
+
                         default:
                             Debug.fail("This is unknown parent for type parameter: " + node.parent.kind);
                     }

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2276,6 +2276,10 @@
         "category": "Error",
         "code": 4082
     },
+    "Type parameter '{0}' of exported type alias has or is using private name '{1}'.": {
+        "category": "Error",
+        "code": 4083
+    },
     "Conflicting definitions for '{0}' found at '{1}' and '{2}'. Consider installing a specific version of this library to resolve the conflict.": {
         "category": "Message",
         "code": 4090

--- a/tests/baselines/reference/declarationEmitInterfaceWithNonEntityNameExpressionHeritage.errors.txt
+++ b/tests/baselines/reference/declarationEmitInterfaceWithNonEntityNameExpressionHeritage.errors.txt
@@ -1,0 +1,9 @@
+tests/cases/compiler/declarationEmitInterfaceWithNonEntityNameExpressionHeritage.ts(3,25): error TS2499: An interface can only extend an identifier/qualified-name with optional type arguments.
+
+
+==== tests/cases/compiler/declarationEmitInterfaceWithNonEntityNameExpressionHeritage.ts (1 errors) ====
+    
+    class A { }
+    interface Class extends (typeof A) { }
+                            ~~~~~~~~~~
+!!! error TS2499: An interface can only extend an identifier/qualified-name with optional type arguments.

--- a/tests/baselines/reference/declarationEmitInterfaceWithNonEntityNameExpressionHeritage.js
+++ b/tests/baselines/reference/declarationEmitInterfaceWithNonEntityNameExpressionHeritage.js
@@ -1,0 +1,18 @@
+//// [declarationEmitInterfaceWithNonEntityNameExpressionHeritage.ts]
+
+class A { }
+interface Class extends (typeof A) { }
+
+//// [declarationEmitInterfaceWithNonEntityNameExpressionHeritage.js]
+var A = (function () {
+    function A() {
+    }
+    return A;
+}());
+
+
+//// [declarationEmitInterfaceWithNonEntityNameExpressionHeritage.d.ts]
+declare class A {
+}
+interface Class {
+}

--- a/tests/baselines/reference/declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.errors.txt
+++ b/tests/baselines/reference/declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.ts(2,18): error TS2304: Cannot find name 'Unknown'.
+tests/cases/compiler/declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.ts(2,18): error TS4083: Type parameter 'T' of exported type alias has or is using private name 'Unknown'.
+
+
+==== tests/cases/compiler/declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.ts (2 errors) ====
+    
+    type A<T extends Unknown> = {}
+                     ~~~~~~~
+!!! error TS2304: Cannot find name 'Unknown'.
+                     ~~~~~~~
+!!! error TS4083: Type parameter 'T' of exported type alias has or is using private name 'Unknown'.

--- a/tests/baselines/reference/declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.js
+++ b/tests/baselines/reference/declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.js
@@ -1,0 +1,5 @@
+//// [declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.ts]
+
+type A<T extends Unknown> = {}
+
+//// [declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.js]

--- a/tests/cases/compiler/declarationEmitInterfaceWithNonEntityNameExpressionHeritage.ts
+++ b/tests/cases/compiler/declarationEmitInterfaceWithNonEntityNameExpressionHeritage.ts
@@ -1,0 +1,4 @@
+// @declaration: true
+
+class A { }
+interface Class extends (typeof A) { }

--- a/tests/cases/compiler/declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.ts
+++ b/tests/cases/compiler/declarationEmitTypeAliasTypeParameterExtendingUnknownSymbol.ts
@@ -1,0 +1,3 @@
+﻿// @declaration: true
+
+type A<T extends Unknown> = {}


### PR DESCRIPTION
- Handle the scenario when heritage clause of interface is not entity name expression
   Fixes #12291
- Handle when type alias's type parameter extends type that wont get emitted in .d.ts
  Fixes #12326