### PR TITLE
Add locale options to tsserver

### DIFF
--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -43,66 +43,6 @@ namespace ts {
         }
     }
 
-    /**
-     * Checks to see if the locale is in the appropriate format,
-     * and if it is, attempts to set the appropriate language.
-     */
-    function validateLocaleAndSetLanguage(locale: string, errors: Diagnostic[]): boolean {
-        const matchResult = /^([a-z]+)([_\-]([a-z]+))?$/.exec(locale.toLowerCase());
-
-        if (!matchResult) {
-            errors.push(createCompilerDiagnostic(Diagnostics.Locale_must_be_of_the_form_language_or_language_territory_For_example_0_or_1, "en", "ja-jp"));
-            return false;
-        }
-
-        const language = matchResult[1];
-        const territory = matchResult[3];
-
-        // First try the entire locale, then fall back to just language if that's all we have.
-        // Either ways do not fail, and fallback to the English diagnostic strings.
-        if (!trySetLanguageAndTerritory(language, territory, errors)) {
-            trySetLanguageAndTerritory(language, undefined, errors);
-        }
-
-        return true;
-    }
-
-    function trySetLanguageAndTerritory(language: string, territory: string, errors: Diagnostic[]): boolean {
-        const compilerFilePath = normalizePath(sys.getExecutingFilePath());
-        const containingDirectoryPath = getDirectoryPath(compilerFilePath);
-
-        let filePath = combinePaths(containingDirectoryPath, language);
-
-        if (territory) {
-            filePath = filePath + "-" + territory;
-        }
-
-        filePath = sys.resolvePath(combinePaths(filePath, "diagnosticMessages.generated.json"));
-
-        if (!sys.fileExists(filePath)) {
-            return false;
-        }
-
-        // TODO: Add codePage support for readFile?
-        let fileContents = "";
-        try {
-            fileContents = sys.readFile(filePath);
-        }
-        catch (e) {
-            errors.push(createCompilerDiagnostic(Diagnostics.Unable_to_open_file_0, filePath));
-            return false;
-        }
-        try {
-            ts.localizedDiagnosticMessages = JSON.parse(fileContents);
-        }
-        catch (e) {
-            errors.push(createCompilerDiagnostic(Diagnostics.Corrupted_locale_file_0, filePath));
-            return false;
-        }
-
-        return true;
-    }
-
     function countLines(program: Program): number {
         let count = 0;
         forEach(program.getSourceFiles(), file => {

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -203,7 +203,7 @@ namespace ts {
                 reportDiagnostic(createCompilerDiagnostic(Diagnostics.The_current_host_does_not_support_the_0_option, "--locale"), /* host */ undefined);
                 return sys.exit(ExitStatus.DiagnosticsPresent_OutputsSkipped);
             }
-            validateLocaleAndSetLanguage(commandLine.options.locale, commandLine.errors);
+            validateLocaleAndSetLanguage(commandLine.options.locale, sys, commandLine.errors);
         }
 
         // If there are any errors due to command line parsing and/or

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4554,4 +4554,70 @@ namespace ts {
 
         return flags;
     }
+
+   /**
+     * Checks to see if the locale is in the appropriate format,
+     * and if it is, attempts to set the appropriate language.
+     */
+    export function validateLocaleAndSetLanguage(locale: string, errors?: Diagnostic[]): boolean {
+        const matchResult = /^([a-z]+)([_\-]([a-z]+))?$/.exec(locale.toLowerCase());
+
+        if (!matchResult) {
+            if (errors) {
+                errors.push(createCompilerDiagnostic(Diagnostics.Locale_must_be_of_the_form_language_or_language_territory_For_example_0_or_1, "en", "ja-jp"));
+            }
+            return false;
+        }
+
+        const language = matchResult[1];
+        const territory = matchResult[3];
+
+        // First try the entire locale, then fall back to just language if that's all we have.
+        // Either ways do not fail, and fallback to the English diagnostic strings.
+        if (!trySetLanguageAndTerritory(language, territory, errors)) {
+            trySetLanguageAndTerritory(language, undefined, errors);
+        }
+
+        return true;
+    }
+
+    export function trySetLanguageAndTerritory(language: string, territory: string, errors?: Diagnostic[]): boolean {
+        const compilerFilePath = normalizePath(sys.getExecutingFilePath());
+        const containingDirectoryPath = getDirectoryPath(compilerFilePath);
+
+        let filePath = combinePaths(containingDirectoryPath, language);
+
+        if (territory) {
+            filePath = filePath + "-" + territory;
+        }
+
+        filePath = sys.resolvePath(combinePaths(filePath, "diagnosticMessages.generated.json"));
+
+        if (!sys.fileExists(filePath)) {
+            return false;
+        }
+
+        // TODO: Add codePage support for readFile?
+        let fileContents = "";
+        try {
+            fileContents = sys.readFile(filePath);
+        }
+        catch (e) {
+            if (errors) {
+                errors.push(createCompilerDiagnostic(Diagnostics.Unable_to_open_file_0, filePath));
+            }
+            return false;
+        }
+        try {
+            ts.localizedDiagnosticMessages = JSON.parse(fileContents);
+        }
+        catch (e) {
+            if (errors) {
+                errors.push(createCompilerDiagnostic(Diagnostics.Corrupted_locale_file_0, filePath));
+            }
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4559,7 +4559,7 @@ namespace ts {
      * Checks to see if the locale is in the appropriate format,
      * and if it is, attempts to set the appropriate language.
      */
-    export function validateLocaleAndSetLanguage(locale: string, errors?: Diagnostic[]): boolean {
+    export function validateLocaleAndSetLanguage(locale: string, sys: System, errors?: Diagnostic[]): boolean {
         const matchResult = /^([a-z]+)([_\-]([a-z]+))?$/.exec(locale.toLowerCase());
 
         if (!matchResult) {
@@ -4574,14 +4574,14 @@ namespace ts {
 
         // First try the entire locale, then fall back to just language if that's all we have.
         // Either ways do not fail, and fallback to the English diagnostic strings.
-        if (!trySetLanguageAndTerritory(language, territory, errors)) {
-            trySetLanguageAndTerritory(language, undefined, errors);
+        if (!trySetLanguageAndTerritory(language, territory, sys, errors)) {
+            trySetLanguageAndTerritory(language, /*territory*/ undefined, sys, errors);
         }
 
         return true;
     }
 
-    export function trySetLanguageAndTerritory(language: string, territory: string, errors?: Diagnostic[]): boolean {
+    export function trySetLanguageAndTerritory(language: string, territory: string, sys: System, errors?: Diagnostic[]): boolean {
         const compilerFilePath = normalizePath(sys.getExecutingFilePath());
         const containingDirectoryPath = getDirectoryPath(compilerFilePath);
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -578,7 +578,7 @@ namespace ts.server {
     }
 
     const localeStr = findArgument("--locale");
-    if (localeStr && validateLocaleAndSetLanguage(localeStr, sys)) {
+    if (localeStr) {
         validateLocaleAndSetLanguage(localeStr, sys);
     }
 

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -578,8 +578,8 @@ namespace ts.server {
     }
 
     const localeStr = findArgument("--locale");
-    if (localeStr && validateLocaleAndSetLanguage(localeStr)) {
-        validateLocaleAndSetLanguage(localeStr);
+    if (localeStr && validateLocaleAndSetLanguage(localeStr, sys)) {
+        validateLocaleAndSetLanguage(localeStr, sys);
     }
 
     const useSingleInferredProject = hasArgument("--useSingleInferredProject");

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -577,6 +577,11 @@ namespace ts.server {
         }
     }
 
+    const localeStr = findArgument("--locale");
+    if (localeStr && validateLocaleAndSetLanguage(localeStr)) {
+        validateLocaleAndSetLanguage(localeStr);
+    }
+
     const useSingleInferredProject = hasArgument("--useSingleInferredProject");
     const disableAutomaticTypingAcquisition = hasArgument("--disableAutomaticTypingAcquisition");
     const telemetryEnabled = hasArgument(Arguments.EnableTelemetry);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Currently the server is always using English diagnostics messages. This PR adds the support to use messages in other locales.
