### PR TITLE
recompute character to column when comparing indentations

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -886,10 +886,18 @@ namespace ts.formatting {
             else {
                 const tokenStart = sourceFile.getLineAndCharacterOfPosition(pos);
                 const startLinePosition = getStartPositionOfLine(tokenStart.line, sourceFile);
-                if (indentation !== tokenStart.character || indentationIsDifferent(indentationString, startLinePosition)) {
+                if (indentation !== characterToColumn(startLinePosition, tokenStart.character) || indentationIsDifferent(indentationString, startLinePosition)) {
                     recordReplace(startLinePosition, tokenStart.character, indentationString);
                 }
             }
+        }
+
+        function characterToColumn(startLinePosition: number, characterInLine: number): number {
+            let column = 0;
+            for (let i = 0; i < characterInLine; i++) {
+                column += sourceFile.text.charCodeAt(startLinePosition + i) === CharacterCodes.tab ? options.tabSize : 1;
+            }
+            return column;
         }
 
         function indentationIsDifferent(indentationString: string, startLinePosition: number): boolean {

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -895,7 +895,12 @@ namespace ts.formatting {
         function characterToColumn(startLinePosition: number, characterInLine: number): number {
             let column = 0;
             for (let i = 0; i < characterInLine; i++) {
-                column += sourceFile.text.charCodeAt(startLinePosition + i) === CharacterCodes.tab ? options.tabSize : 1;
+                if (sourceFile.text.charCodeAt(startLinePosition + i) === CharacterCodes.tab) {
+                    column += options.tabSize - column % options.tabSize;
+                }
+                else {
+                    column++;
+                }
             }
             return column;
         }

--- a/tests/cases/fourslash/formatWithTabs.ts
+++ b/tests/cases/fourslash/formatWithTabs.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts"/>
+
+////const foo = [
+////		1
+////];
+
+const options = format.copyFormatOptions();
+options.IndentSize = 2;
+options.TabSize = 2;
+options.ConvertTabsToSpaces = false;
+format.setFormatOptions(options);
+format.document();
+verify.currentFileContentIs(
+`const foo = [
+	1
+];`);

--- a/tests/cases/fourslash/formatWithTabs2.ts
+++ b/tests/cases/fourslash/formatWithTabs2.ts
@@ -1,0 +1,16 @@
+/// <reference path="fourslash.ts"/>
+
+////const foo = [
+//// 	1
+////];
+
+const options = format.copyFormatOptions();
+options.IndentSize = 2;
+options.TabSize = 2;
+options.ConvertTabsToSpaces = false;
+format.setFormatOptions(options);
+format.document();
+verify.currentFileContentIs(
+`const foo = [
+	1
+];`);


### PR DESCRIPTION
we always compute indentation as column so in order to compare it with character position in line - character position must be converted to column as well.

fixes #12175 