### PR TITLE
Union and intersection types with leading operator

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2556,6 +2556,8 @@ namespace ts {
                 case SyntaxKind.OpenBraceToken:
                 case SyntaxKind.OpenBracketToken:
                 case SyntaxKind.LessThanToken:
+                case SyntaxKind.BarToken:
+                case SyntaxKind.AmpersandToken:
                 case SyntaxKind.NewKeyword:
                 case SyntaxKind.StringLiteral:
                 case SyntaxKind.NumericLiteral:

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2615,6 +2615,7 @@ namespace ts {
         }
 
         function parseUnionOrIntersectionType(kind: SyntaxKind, parseConstituentType: () => TypeNode, operator: SyntaxKind): TypeNode {
+            parseOptional(operator);
             let type = parseConstituentType();
             if (token() === operator) {
                 const types = createNodeArray<TypeNode>([type], type.pos);

--- a/tests/baselines/reference/intersectionTypeWithLeadingOperator.js
+++ b/tests/baselines/reference/intersectionTypeWithLeadingOperator.js
@@ -4,5 +4,7 @@ type B =
   & { foo: string }
   & { bar: number };
 
+type C = [& { foo: 1 } & { bar: 2 }, & { foo: 3 } & { bar: 4 }];
+
 
 //// [intersectionTypeWithLeadingOperator.js]

--- a/tests/baselines/reference/intersectionTypeWithLeadingOperator.js
+++ b/tests/baselines/reference/intersectionTypeWithLeadingOperator.js
@@ -1,0 +1,8 @@
+//// [intersectionTypeWithLeadingOperator.ts]
+type A = & string;
+type B =
+  & { foo: string }
+  & { bar: number };
+
+
+//// [intersectionTypeWithLeadingOperator.js]

--- a/tests/baselines/reference/intersectionTypeWithLeadingOperator.symbols
+++ b/tests/baselines/reference/intersectionTypeWithLeadingOperator.symbols
@@ -11,3 +11,10 @@ type B =
   & { bar: number };
 >bar : Symbol(bar, Decl(intersectionTypeWithLeadingOperator.ts, 3, 5))
 
+type C = [& { foo: 1 } & { bar: 2 }, & { foo: 3 } & { bar: 4 }];
+>C : Symbol(C, Decl(intersectionTypeWithLeadingOperator.ts, 3, 20))
+>foo : Symbol(foo, Decl(intersectionTypeWithLeadingOperator.ts, 5, 13))
+>bar : Symbol(bar, Decl(intersectionTypeWithLeadingOperator.ts, 5, 26))
+>foo : Symbol(foo, Decl(intersectionTypeWithLeadingOperator.ts, 5, 40))
+>bar : Symbol(bar, Decl(intersectionTypeWithLeadingOperator.ts, 5, 53))
+

--- a/tests/baselines/reference/intersectionTypeWithLeadingOperator.symbols
+++ b/tests/baselines/reference/intersectionTypeWithLeadingOperator.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/intersectionTypeWithLeadingOperator.ts ===
+type A = & string;
+>A : Symbol(A, Decl(intersectionTypeWithLeadingOperator.ts, 0, 0))
+
+type B =
+>B : Symbol(B, Decl(intersectionTypeWithLeadingOperator.ts, 0, 18))
+
+  & { foo: string }
+>foo : Symbol(foo, Decl(intersectionTypeWithLeadingOperator.ts, 2, 5))
+
+  & { bar: number };
+>bar : Symbol(bar, Decl(intersectionTypeWithLeadingOperator.ts, 3, 5))
+

--- a/tests/baselines/reference/intersectionTypeWithLeadingOperator.types
+++ b/tests/baselines/reference/intersectionTypeWithLeadingOperator.types
@@ -11,3 +11,10 @@ type B =
   & { bar: number };
 >bar : number
 
+type C = [& { foo: 1 } & { bar: 2 }, & { foo: 3 } & { bar: 4 }];
+>C : [{ foo: 1; } & { bar: 2; }, { foo: 3; } & { bar: 4; }]
+>foo : 1
+>bar : 2
+>foo : 3
+>bar : 4
+

--- a/tests/baselines/reference/intersectionTypeWithLeadingOperator.types
+++ b/tests/baselines/reference/intersectionTypeWithLeadingOperator.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/intersectionTypeWithLeadingOperator.ts ===
+type A = & string;
+>A : string
+
+type B =
+>B : B
+
+  & { foo: string }
+>foo : string
+
+  & { bar: number };
+>bar : number
+

--- a/tests/baselines/reference/unionTypeWithLeadingOperator.js
+++ b/tests/baselines/reference/unionTypeWithLeadingOperator.js
@@ -1,0 +1,8 @@
+//// [unionTypeWithLeadingOperator.ts]
+type A = | string;
+type B =
+  | { type: "INCREMENT" }
+  | { type: "DECREMENT" };
+
+
+//// [unionTypeWithLeadingOperator.js]

--- a/tests/baselines/reference/unionTypeWithLeadingOperator.js
+++ b/tests/baselines/reference/unionTypeWithLeadingOperator.js
@@ -4,5 +4,7 @@ type B =
   | { type: "INCREMENT" }
   | { type: "DECREMENT" };
 
+type C = [| 0 | 1, | "foo" | "bar"];
+
 
 //// [unionTypeWithLeadingOperator.js]

--- a/tests/baselines/reference/unionTypeWithLeadingOperator.symbols
+++ b/tests/baselines/reference/unionTypeWithLeadingOperator.symbols
@@ -11,3 +11,6 @@ type B =
   | { type: "DECREMENT" };
 >type : Symbol(type, Decl(unionTypeWithLeadingOperator.ts, 3, 5))
 
+type C = [| 0 | 1, | "foo" | "bar"];
+>C : Symbol(C, Decl(unionTypeWithLeadingOperator.ts, 3, 26))
+

--- a/tests/baselines/reference/unionTypeWithLeadingOperator.symbols
+++ b/tests/baselines/reference/unionTypeWithLeadingOperator.symbols
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/unionTypeWithLeadingOperator.ts ===
+type A = | string;
+>A : Symbol(A, Decl(unionTypeWithLeadingOperator.ts, 0, 0))
+
+type B =
+>B : Symbol(B, Decl(unionTypeWithLeadingOperator.ts, 0, 18))
+
+  | { type: "INCREMENT" }
+>type : Symbol(type, Decl(unionTypeWithLeadingOperator.ts, 2, 5))
+
+  | { type: "DECREMENT" };
+>type : Symbol(type, Decl(unionTypeWithLeadingOperator.ts, 3, 5))
+

--- a/tests/baselines/reference/unionTypeWithLeadingOperator.types
+++ b/tests/baselines/reference/unionTypeWithLeadingOperator.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/unionTypeWithLeadingOperator.ts ===
+type A = | string;
+>A : string
+
+type B =
+>B : B
+
+  | { type: "INCREMENT" }
+>type : "INCREMENT"
+
+  | { type: "DECREMENT" };
+>type : "DECREMENT"
+

--- a/tests/baselines/reference/unionTypeWithLeadingOperator.types
+++ b/tests/baselines/reference/unionTypeWithLeadingOperator.types
@@ -11,3 +11,6 @@ type B =
   | { type: "DECREMENT" };
 >type : "DECREMENT"
 
+type C = [| 0 | 1, | "foo" | "bar"];
+>C : [0 | 1, "foo" | "bar"]
+

--- a/tests/cases/compiler/intersectionTypeWithLeadingOperator.ts
+++ b/tests/cases/compiler/intersectionTypeWithLeadingOperator.ts
@@ -2,3 +2,5 @@ type A = & string;
 type B =
   & { foo: string }
   & { bar: number };
+
+type C = [& { foo: 1 } & { bar: 2 }, & { foo: 3 } & { bar: 4 }];

--- a/tests/cases/compiler/intersectionTypeWithLeadingOperator.ts
+++ b/tests/cases/compiler/intersectionTypeWithLeadingOperator.ts
@@ -1,0 +1,4 @@
+type A = & string;
+type B =
+  & { foo: string }
+  & { bar: number };

--- a/tests/cases/compiler/unionTypeWithLeadingOperator.ts
+++ b/tests/cases/compiler/unionTypeWithLeadingOperator.ts
@@ -1,0 +1,4 @@
+type A = | string;
+type B =
+  | { type: "INCREMENT" }
+  | { type: "DECREMENT" };

--- a/tests/cases/compiler/unionTypeWithLeadingOperator.ts
+++ b/tests/cases/compiler/unionTypeWithLeadingOperator.ts
@@ -2,3 +2,5 @@ type A = | string;
 type B =
   | { type: "INCREMENT" }
   | { type: "DECREMENT" };
+
+type C = [| 0 | 1, | "foo" | "bar"];


### PR DESCRIPTION
Fixes #12071

This pull request allows an ignored leading `|` or `&` in a type position to give developers more formatting freedom, e.g. like this:

```ts
type ReduxAction =
  | { type: "INCREMENT" }
  | { type: "DECREMENT" }
  | { type: "SET_VALUE", value: number };
```
