### PR TITLE
Introduce 'getTypeOfExpression' function

### DIFF
--- a/tests/baselines/reference/ambientRequireFunction.types
+++ b/tests/baselines/reference/ambientRequireFunction.types
@@ -3,7 +3,7 @@
 
 const fs = require("fs");
 >fs : typeof "fs"
->require("fs") : typeof "fs"
+>require("fs") : any
 >require : (moduleName: string) => any
 >"fs" : "fs"
 

--- a/tests/baselines/reference/controlFlowSelfReferentialLoop.errors.txt
+++ b/tests/baselines/reference/controlFlowSelfReferentialLoop.errors.txt
@@ -1,0 +1,188 @@
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(6,17): error TS7006: Parameter 'a' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(6,19): error TS7006: Parameter 'b' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(6,21): error TS7006: Parameter 'c' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(6,23): error TS7006: Parameter 'd' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(6,25): error TS7006: Parameter 'x' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(6,27): error TS7006: Parameter 's' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(6,29): error TS7006: Parameter 'ac' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(10,17): error TS7006: Parameter 'a' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(10,19): error TS7006: Parameter 'b' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(10,21): error TS7006: Parameter 'c' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(10,23): error TS7006: Parameter 'd' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(10,25): error TS7006: Parameter 'x' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(10,27): error TS7006: Parameter 's' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(10,29): error TS7006: Parameter 'ac' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(14,17): error TS7006: Parameter 'a' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(14,19): error TS7006: Parameter 'b' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(14,21): error TS7006: Parameter 'c' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(14,23): error TS7006: Parameter 'd' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(14,25): error TS7006: Parameter 'x' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(14,27): error TS7006: Parameter 's' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(14,29): error TS7006: Parameter 'ac' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(18,17): error TS7006: Parameter 'a' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(18,19): error TS7006: Parameter 'b' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(18,21): error TS7006: Parameter 'c' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(18,23): error TS7006: Parameter 'd' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(18,25): error TS7006: Parameter 'x' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(18,27): error TS7006: Parameter 's' implicitly has an 'any' type.
+tests/cases/compiler/controlFlowSelfReferentialLoop.ts(18,29): error TS7006: Parameter 'ac' implicitly has an 'any' type.
+
+
+==== tests/cases/compiler/controlFlowSelfReferentialLoop.ts (28 errors) ====
+    
+    // Repro from #12319
+    
+    function md5(string:string): void {
+    
+        function FF(a,b,c,d,x,s,ac) {
+                    ~
+!!! error TS7006: Parameter 'a' implicitly has an 'any' type.
+                      ~
+!!! error TS7006: Parameter 'b' implicitly has an 'any' type.
+                        ~
+!!! error TS7006: Parameter 'c' implicitly has an 'any' type.
+                          ~
+!!! error TS7006: Parameter 'd' implicitly has an 'any' type.
+                            ~
+!!! error TS7006: Parameter 'x' implicitly has an 'any' type.
+                              ~
+!!! error TS7006: Parameter 's' implicitly has an 'any' type.
+                                ~~
+!!! error TS7006: Parameter 'ac' implicitly has an 'any' type.
+            return 0;
+        };
+    
+        function GG(a,b,c,d,x,s,ac) {
+                    ~
+!!! error TS7006: Parameter 'a' implicitly has an 'any' type.
+                      ~
+!!! error TS7006: Parameter 'b' implicitly has an 'any' type.
+                        ~
+!!! error TS7006: Parameter 'c' implicitly has an 'any' type.
+                          ~
+!!! error TS7006: Parameter 'd' implicitly has an 'any' type.
+                            ~
+!!! error TS7006: Parameter 'x' implicitly has an 'any' type.
+                              ~
+!!! error TS7006: Parameter 's' implicitly has an 'any' type.
+                                ~~
+!!! error TS7006: Parameter 'ac' implicitly has an 'any' type.
+            return 0;
+        };
+    
+        function HH(a,b,c,d,x,s,ac) {
+                    ~
+!!! error TS7006: Parameter 'a' implicitly has an 'any' type.
+                      ~
+!!! error TS7006: Parameter 'b' implicitly has an 'any' type.
+                        ~
+!!! error TS7006: Parameter 'c' implicitly has an 'any' type.
+                          ~
+!!! error TS7006: Parameter 'd' implicitly has an 'any' type.
+                            ~
+!!! error TS7006: Parameter 'x' implicitly has an 'any' type.
+                              ~
+!!! error TS7006: Parameter 's' implicitly has an 'any' type.
+                                ~~
+!!! error TS7006: Parameter 'ac' implicitly has an 'any' type.
+            return 0;
+        };
+    
+        function II(a,b,c,d,x,s,ac) {
+                    ~
+!!! error TS7006: Parameter 'a' implicitly has an 'any' type.
+                      ~
+!!! error TS7006: Parameter 'b' implicitly has an 'any' type.
+                        ~
+!!! error TS7006: Parameter 'c' implicitly has an 'any' type.
+                          ~
+!!! error TS7006: Parameter 'd' implicitly has an 'any' type.
+                            ~
+!!! error TS7006: Parameter 'x' implicitly has an 'any' type.
+                              ~
+!!! error TS7006: Parameter 's' implicitly has an 'any' type.
+                                ~~
+!!! error TS7006: Parameter 'ac' implicitly has an 'any' type.
+            return 0;
+        };
+    
+        var x=Array();
+        var k,AA,BB,CC,DD,a,b,c,d;
+        var S11=7, S12=12, S13=17, S14=22;
+        var S21=5, S22=9 , S23=14, S24=20;
+        var S31=4, S32=11, S33=16, S34=23;
+        var S41=6, S42=10, S43=15, S44=21;
+    
+        x = [1];
+    
+        a = 0x67452301; b = 0xEFCDAB89; c = 0x98BADCFE; d = 0x10325476;
+    
+        for (k=0;k<x.length;k+=16) {
+            AA=a; BB=b; CC=c; DD=d;
+            a=FF(a,b,c,d,x[k+0], S11,0xD76AA478);
+            d=FF(d,a,b,c,x[k+1], S12,0xE8C7B756);
+            c=FF(c,d,a,b,x[k+2], S13,0x242070DB);
+            b=FF(b,c,d,a,x[k+3], S14,0xC1BDCEEE);
+            a=FF(a,b,c,d,x[k+4], S11,0xF57C0FAF);
+            d=FF(d,a,b,c,x[k+5], S12,0x4787C62A);
+            c=FF(c,d,a,b,x[k+6], S13,0xA8304613);
+            b=FF(b,c,d,a,x[k+7], S14,0xFD469501);
+            a=FF(a,b,c,d,x[k+8], S11,0x698098D8);
+            d=FF(d,a,b,c,x[k+9], S12,0x8B44F7AF);
+            c=FF(c,d,a,b,x[k+10],S13,0xFFFF5BB1);
+            b=FF(b,c,d,a,x[k+11],S14,0x895CD7BE);
+            a=FF(a,b,c,d,x[k+12],S11,0x6B901122);
+            d=FF(d,a,b,c,x[k+13],S12,0xFD987193);
+            c=FF(c,d,a,b,x[k+14],S13,0xA679438E);
+            b=FF(b,c,d,a,x[k+15],S14,0x49B40821);
+            a=GG(a,b,c,d,x[k+1], S21,0xF61E2562);
+            d=GG(d,a,b,c,x[k+6], S22,0xC040B340);
+            c=GG(c,d,a,b,x[k+11],S23,0x265E5A51);
+            b=GG(b,c,d,a,x[k+0], S24,0xE9B6C7AA);
+            a=GG(a,b,c,d,x[k+5], S21,0xD62F105D);
+            d=GG(d,a,b,c,x[k+10],S22,0x2441453);
+            c=GG(c,d,a,b,x[k+15],S23,0xD8A1E681);
+            b=GG(b,c,d,a,x[k+4], S24,0xE7D3FBC8);
+            a=GG(a,b,c,d,x[k+9], S21,0x21E1CDE6);
+            d=GG(d,a,b,c,x[k+14],S22,0xC33707D6);
+            c=GG(c,d,a,b,x[k+3], S23,0xF4D50D87);
+            b=GG(b,c,d,a,x[k+8], S24,0x455A14ED);
+            a=GG(a,b,c,d,x[k+13],S21,0xA9E3E905);
+            d=GG(d,a,b,c,x[k+2], S22,0xFCEFA3F8);
+            c=GG(c,d,a,b,x[k+7], S23,0x676F02D9);
+            b=GG(b,c,d,a,x[k+12],S24,0x8D2A4C8A);
+            a=HH(a,b,c,d,x[k+5], S31,0xFFFA3942);
+            d=HH(d,a,b,c,x[k+8], S32,0x8771F681);
+            c=HH(c,d,a,b,x[k+11],S33,0x6D9D6122);
+            b=HH(b,c,d,a,x[k+14],S34,0xFDE5380C);
+            a=HH(a,b,c,d,x[k+1], S31,0xA4BEEA44);
+            d=HH(d,a,b,c,x[k+4], S32,0x4BDECFA9);
+            c=HH(c,d,a,b,x[k+7], S33,0xF6BB4B60);
+            b=HH(b,c,d,a,x[k+10],S34,0xBEBFBC70);
+            a=HH(a,b,c,d,x[k+13],S31,0x289B7EC6);
+            d=HH(d,a,b,c,x[k+0], S32,0xEAA127FA);
+            c=HH(c,d,a,b,x[k+3], S33,0xD4EF3085);
+            b=HH(b,c,d,a,x[k+6], S34,0x4881D05);
+            a=HH(a,b,c,d,x[k+9], S31,0xD9D4D039);
+            d=HH(d,a,b,c,x[k+12],S32,0xE6DB99E5);
+            c=HH(c,d,a,b,x[k+15],S33,0x1FA27CF8);
+            b=HH(b,c,d,a,x[k+2], S34,0xC4AC5665);
+            a=II(a,b,c,d,x[k+0], S41,0xF4292244);
+            d=II(d,a,b,c,x[k+7], S42,0x432AFF97);
+            c=II(c,d,a,b,x[k+14],S43,0xAB9423A7);
+            b=II(b,c,d,a,x[k+5], S44,0xFC93A039);
+            a=II(a,b,c,d,x[k+12],S41,0x655B59C3);
+            d=II(d,a,b,c,x[k+3], S42,0x8F0CCC92);
+            c=II(c,d,a,b,x[k+10],S43,0xFFEFF47D);
+            b=II(b,c,d,a,x[k+1], S44,0x85845DD1);
+            a=II(a,b,c,d,x[k+8], S41,0x6FA87E4F);
+            d=II(d,a,b,c,x[k+15],S42,0xFE2CE6E0);
+            c=II(c,d,a,b,x[k+6], S43,0xA3014314);
+            b=II(b,c,d,a,x[k+13],S44,0x4E0811A1);
+            a=II(a,b,c,d,x[k+4], S41,0xF7537E82);
+            d=II(d,a,b,c,x[k+11],S42,0xBD3AF235);
+            c=II(c,d,a,b,x[k+2], S43,0x2AD7D2BB);
+            b=II(b,c,d,a,x[k+9], S44,0xEB86D391);
+        }
+    }
+    export default md5;

--- a/tests/baselines/reference/controlFlowSelfReferentialLoop.js
+++ b/tests/baselines/reference/controlFlowSelfReferentialLoop.js
@@ -1,0 +1,207 @@
+//// [controlFlowSelfReferentialLoop.ts]
+
+// Repro from #12319
+
+function md5(string:string): void {
+
+    function FF(a,b,c,d,x,s,ac) {
+        return 0;
+    };
+
+    function GG(a,b,c,d,x,s,ac) {
+        return 0;
+    };
+
+    function HH(a,b,c,d,x,s,ac) {
+        return 0;
+    };
+
+    function II(a,b,c,d,x,s,ac) {
+        return 0;
+    };
+
+    var x=Array();
+    var k,AA,BB,CC,DD,a,b,c,d;
+    var S11=7, S12=12, S13=17, S14=22;
+    var S21=5, S22=9 , S23=14, S24=20;
+    var S31=4, S32=11, S33=16, S34=23;
+    var S41=6, S42=10, S43=15, S44=21;
+
+    x = [1];
+
+    a = 0x67452301; b = 0xEFCDAB89; c = 0x98BADCFE; d = 0x10325476;
+
+    for (k=0;k<x.length;k+=16) {
+        AA=a; BB=b; CC=c; DD=d;
+        a=FF(a,b,c,d,x[k+0], S11,0xD76AA478);
+        d=FF(d,a,b,c,x[k+1], S12,0xE8C7B756);
+        c=FF(c,d,a,b,x[k+2], S13,0x242070DB);
+        b=FF(b,c,d,a,x[k+3], S14,0xC1BDCEEE);
+        a=FF(a,b,c,d,x[k+4], S11,0xF57C0FAF);
+        d=FF(d,a,b,c,x[k+5], S12,0x4787C62A);
+        c=FF(c,d,a,b,x[k+6], S13,0xA8304613);
+        b=FF(b,c,d,a,x[k+7], S14,0xFD469501);
+        a=FF(a,b,c,d,x[k+8], S11,0x698098D8);
+        d=FF(d,a,b,c,x[k+9], S12,0x8B44F7AF);
+        c=FF(c,d,a,b,x[k+10],S13,0xFFFF5BB1);
+        b=FF(b,c,d,a,x[k+11],S14,0x895CD7BE);
+        a=FF(a,b,c,d,x[k+12],S11,0x6B901122);
+        d=FF(d,a,b,c,x[k+13],S12,0xFD987193);
+        c=FF(c,d,a,b,x[k+14],S13,0xA679438E);
+        b=FF(b,c,d,a,x[k+15],S14,0x49B40821);
+        a=GG(a,b,c,d,x[k+1], S21,0xF61E2562);
+        d=GG(d,a,b,c,x[k+6], S22,0xC040B340);
+        c=GG(c,d,a,b,x[k+11],S23,0x265E5A51);
+        b=GG(b,c,d,a,x[k+0], S24,0xE9B6C7AA);
+        a=GG(a,b,c,d,x[k+5], S21,0xD62F105D);
+        d=GG(d,a,b,c,x[k+10],S22,0x2441453);
+        c=GG(c,d,a,b,x[k+15],S23,0xD8A1E681);
+        b=GG(b,c,d,a,x[k+4], S24,0xE7D3FBC8);
+        a=GG(a,b,c,d,x[k+9], S21,0x21E1CDE6);
+        d=GG(d,a,b,c,x[k+14],S22,0xC33707D6);
+        c=GG(c,d,a,b,x[k+3], S23,0xF4D50D87);
+        b=GG(b,c,d,a,x[k+8], S24,0x455A14ED);
+        a=GG(a,b,c,d,x[k+13],S21,0xA9E3E905);
+        d=GG(d,a,b,c,x[k+2], S22,0xFCEFA3F8);
+        c=GG(c,d,a,b,x[k+7], S23,0x676F02D9);
+        b=GG(b,c,d,a,x[k+12],S24,0x8D2A4C8A);
+        a=HH(a,b,c,d,x[k+5], S31,0xFFFA3942);
+        d=HH(d,a,b,c,x[k+8], S32,0x8771F681);
+        c=HH(c,d,a,b,x[k+11],S33,0x6D9D6122);
+        b=HH(b,c,d,a,x[k+14],S34,0xFDE5380C);
+        a=HH(a,b,c,d,x[k+1], S31,0xA4BEEA44);
+        d=HH(d,a,b,c,x[k+4], S32,0x4BDECFA9);
+        c=HH(c,d,a,b,x[k+7], S33,0xF6BB4B60);
+        b=HH(b,c,d,a,x[k+10],S34,0xBEBFBC70);
+        a=HH(a,b,c,d,x[k+13],S31,0x289B7EC6);
+        d=HH(d,a,b,c,x[k+0], S32,0xEAA127FA);
+        c=HH(c,d,a,b,x[k+3], S33,0xD4EF3085);
+        b=HH(b,c,d,a,x[k+6], S34,0x4881D05);
+        a=HH(a,b,c,d,x[k+9], S31,0xD9D4D039);
+        d=HH(d,a,b,c,x[k+12],S32,0xE6DB99E5);
+        c=HH(c,d,a,b,x[k+15],S33,0x1FA27CF8);
+        b=HH(b,c,d,a,x[k+2], S34,0xC4AC5665);
+        a=II(a,b,c,d,x[k+0], S41,0xF4292244);
+        d=II(d,a,b,c,x[k+7], S42,0x432AFF97);
+        c=II(c,d,a,b,x[k+14],S43,0xAB9423A7);
+        b=II(b,c,d,a,x[k+5], S44,0xFC93A039);
+        a=II(a,b,c,d,x[k+12],S41,0x655B59C3);
+        d=II(d,a,b,c,x[k+3], S42,0x8F0CCC92);
+        c=II(c,d,a,b,x[k+10],S43,0xFFEFF47D);
+        b=II(b,c,d,a,x[k+1], S44,0x85845DD1);
+        a=II(a,b,c,d,x[k+8], S41,0x6FA87E4F);
+        d=II(d,a,b,c,x[k+15],S42,0xFE2CE6E0);
+        c=II(c,d,a,b,x[k+6], S43,0xA3014314);
+        b=II(b,c,d,a,x[k+13],S44,0x4E0811A1);
+        a=II(a,b,c,d,x[k+4], S41,0xF7537E82);
+        d=II(d,a,b,c,x[k+11],S42,0xBD3AF235);
+        c=II(c,d,a,b,x[k+2], S43,0x2AD7D2BB);
+        b=II(b,c,d,a,x[k+9], S44,0xEB86D391);
+    }
+}
+export default md5;
+
+//// [controlFlowSelfReferentialLoop.js]
+// Repro from #12319
+"use strict";
+function md5(string) {
+    function FF(a, b, c, d, x, s, ac) {
+        return 0;
+    }
+    ;
+    function GG(a, b, c, d, x, s, ac) {
+        return 0;
+    }
+    ;
+    function HH(a, b, c, d, x, s, ac) {
+        return 0;
+    }
+    ;
+    function II(a, b, c, d, x, s, ac) {
+        return 0;
+    }
+    ;
+    var x = Array();
+    var k, AA, BB, CC, DD, a, b, c, d;
+    var S11 = 7, S12 = 12, S13 = 17, S14 = 22;
+    var S21 = 5, S22 = 9, S23 = 14, S24 = 20;
+    var S31 = 4, S32 = 11, S33 = 16, S34 = 23;
+    var S41 = 6, S42 = 10, S43 = 15, S44 = 21;
+    x = [1];
+    a = 0x67452301;
+    b = 0xEFCDAB89;
+    c = 0x98BADCFE;
+    d = 0x10325476;
+    for (k = 0; k < x.length; k += 16) {
+        AA = a;
+        BB = b;
+        CC = c;
+        DD = d;
+        a = FF(a, b, c, d, x[k + 0], S11, 0xD76AA478);
+        d = FF(d, a, b, c, x[k + 1], S12, 0xE8C7B756);
+        c = FF(c, d, a, b, x[k + 2], S13, 0x242070DB);
+        b = FF(b, c, d, a, x[k + 3], S14, 0xC1BDCEEE);
+        a = FF(a, b, c, d, x[k + 4], S11, 0xF57C0FAF);
+        d = FF(d, a, b, c, x[k + 5], S12, 0x4787C62A);
+        c = FF(c, d, a, b, x[k + 6], S13, 0xA8304613);
+        b = FF(b, c, d, a, x[k + 7], S14, 0xFD469501);
+        a = FF(a, b, c, d, x[k + 8], S11, 0x698098D8);
+        d = FF(d, a, b, c, x[k + 9], S12, 0x8B44F7AF);
+        c = FF(c, d, a, b, x[k + 10], S13, 0xFFFF5BB1);
+        b = FF(b, c, d, a, x[k + 11], S14, 0x895CD7BE);
+        a = FF(a, b, c, d, x[k + 12], S11, 0x6B901122);
+        d = FF(d, a, b, c, x[k + 13], S12, 0xFD987193);
+        c = FF(c, d, a, b, x[k + 14], S13, 0xA679438E);
+        b = FF(b, c, d, a, x[k + 15], S14, 0x49B40821);
+        a = GG(a, b, c, d, x[k + 1], S21, 0xF61E2562);
+        d = GG(d, a, b, c, x[k + 6], S22, 0xC040B340);
+        c = GG(c, d, a, b, x[k + 11], S23, 0x265E5A51);
+        b = GG(b, c, d, a, x[k + 0], S24, 0xE9B6C7AA);
+        a = GG(a, b, c, d, x[k + 5], S21, 0xD62F105D);
+        d = GG(d, a, b, c, x[k + 10], S22, 0x2441453);
+        c = GG(c, d, a, b, x[k + 15], S23, 0xD8A1E681);
+        b = GG(b, c, d, a, x[k + 4], S24, 0xE7D3FBC8);
+        a = GG(a, b, c, d, x[k + 9], S21, 0x21E1CDE6);
+        d = GG(d, a, b, c, x[k + 14], S22, 0xC33707D6);
+        c = GG(c, d, a, b, x[k + 3], S23, 0xF4D50D87);
+        b = GG(b, c, d, a, x[k + 8], S24, 0x455A14ED);
+        a = GG(a, b, c, d, x[k + 13], S21, 0xA9E3E905);
+        d = GG(d, a, b, c, x[k + 2], S22, 0xFCEFA3F8);
+        c = GG(c, d, a, b, x[k + 7], S23, 0x676F02D9);
+        b = GG(b, c, d, a, x[k + 12], S24, 0x8D2A4C8A);
+        a = HH(a, b, c, d, x[k + 5], S31, 0xFFFA3942);
+        d = HH(d, a, b, c, x[k + 8], S32, 0x8771F681);
+        c = HH(c, d, a, b, x[k + 11], S33, 0x6D9D6122);
+        b = HH(b, c, d, a, x[k + 14], S34, 0xFDE5380C);
+        a = HH(a, b, c, d, x[k + 1], S31, 0xA4BEEA44);
+        d = HH(d, a, b, c, x[k + 4], S32, 0x4BDECFA9);
+        c = HH(c, d, a, b, x[k + 7], S33, 0xF6BB4B60);
+        b = HH(b, c, d, a, x[k + 10], S34, 0xBEBFBC70);
+        a = HH(a, b, c, d, x[k + 13], S31, 0x289B7EC6);
+        d = HH(d, a, b, c, x[k + 0], S32, 0xEAA127FA);
+        c = HH(c, d, a, b, x[k + 3], S33, 0xD4EF3085);
+        b = HH(b, c, d, a, x[k + 6], S34, 0x4881D05);
+        a = HH(a, b, c, d, x[k + 9], S31, 0xD9D4D039);
+        d = HH(d, a, b, c, x[k + 12], S32, 0xE6DB99E5);
+        c = HH(c, d, a, b, x[k + 15], S33, 0x1FA27CF8);
+        b = HH(b, c, d, a, x[k + 2], S34, 0xC4AC5665);
+        a = II(a, b, c, d, x[k + 0], S41, 0xF4292244);
+        d = II(d, a, b, c, x[k + 7], S42, 0x432AFF97);
+        c = II(c, d, a, b, x[k + 14], S43, 0xAB9423A7);
+        b = II(b, c, d, a, x[k + 5], S44, 0xFC93A039);
+        a = II(a, b, c, d, x[k + 12], S41, 0x655B59C3);
+        d = II(d, a, b, c, x[k + 3], S42, 0x8F0CCC92);
+        c = II(c, d, a, b, x[k + 10], S43, 0xFFEFF47D);
+        b = II(b, c, d, a, x[k + 1], S44, 0x85845DD1);
+        a = II(a, b, c, d, x[k + 8], S41, 0x6FA87E4F);
+        d = II(d, a, b, c, x[k + 15], S42, 0xFE2CE6E0);
+        c = II(c, d, a, b, x[k + 6], S43, 0xA3014314);
+        b = II(b, c, d, a, x[k + 13], S44, 0x4E0811A1);
+        a = II(a, b, c, d, x[k + 4], S41, 0xF7537E82);
+        d = II(d, a, b, c, x[k + 11], S42, 0xBD3AF235);
+        c = II(c, d, a, b, x[k + 2], S43, 0x2AD7D2BB);
+        b = II(b, c, d, a, x[k + 9], S44, 0xEB86D391);
+    }
+}
+exports.__esModule = true;
+exports["default"] = md5;

--- a/tests/cases/compiler/controlFlowSelfReferentialLoop.ts
+++ b/tests/cases/compiler/controlFlowSelfReferentialLoop.ts
@@ -1,0 +1,102 @@
+// @noimplicitany: true
+
+// Repro from #12319
+
+function md5(string:string): void {
+
+    function FF(a,b,c,d,x,s,ac) {
+        return 0;
+    };
+
+    function GG(a,b,c,d,x,s,ac) {
+        return 0;
+    };
+
+    function HH(a,b,c,d,x,s,ac) {
+        return 0;
+    };
+
+    function II(a,b,c,d,x,s,ac) {
+        return 0;
+    };
+
+    var x=Array();
+    var k,AA,BB,CC,DD,a,b,c,d;
+    var S11=7, S12=12, S13=17, S14=22;
+    var S21=5, S22=9 , S23=14, S24=20;
+    var S31=4, S32=11, S33=16, S34=23;
+    var S41=6, S42=10, S43=15, S44=21;
+
+    x = [1];
+
+    a = 0x67452301; b = 0xEFCDAB89; c = 0x98BADCFE; d = 0x10325476;
+
+    for (k=0;k<x.length;k+=16) {
+        AA=a; BB=b; CC=c; DD=d;
+        a=FF(a,b,c,d,x[k+0], S11,0xD76AA478);
+        d=FF(d,a,b,c,x[k+1], S12,0xE8C7B756);
+        c=FF(c,d,a,b,x[k+2], S13,0x242070DB);
+        b=FF(b,c,d,a,x[k+3], S14,0xC1BDCEEE);
+        a=FF(a,b,c,d,x[k+4], S11,0xF57C0FAF);
+        d=FF(d,a,b,c,x[k+5], S12,0x4787C62A);
+        c=FF(c,d,a,b,x[k+6], S13,0xA8304613);
+        b=FF(b,c,d,a,x[k+7], S14,0xFD469501);
+        a=FF(a,b,c,d,x[k+8], S11,0x698098D8);
+        d=FF(d,a,b,c,x[k+9], S12,0x8B44F7AF);
+        c=FF(c,d,a,b,x[k+10],S13,0xFFFF5BB1);
+        b=FF(b,c,d,a,x[k+11],S14,0x895CD7BE);
+        a=FF(a,b,c,d,x[k+12],S11,0x6B901122);
+        d=FF(d,a,b,c,x[k+13],S12,0xFD987193);
+        c=FF(c,d,a,b,x[k+14],S13,0xA679438E);
+        b=FF(b,c,d,a,x[k+15],S14,0x49B40821);
+        a=GG(a,b,c,d,x[k+1], S21,0xF61E2562);
+        d=GG(d,a,b,c,x[k+6], S22,0xC040B340);
+        c=GG(c,d,a,b,x[k+11],S23,0x265E5A51);
+        b=GG(b,c,d,a,x[k+0], S24,0xE9B6C7AA);
+        a=GG(a,b,c,d,x[k+5], S21,0xD62F105D);
+        d=GG(d,a,b,c,x[k+10],S22,0x2441453);
+        c=GG(c,d,a,b,x[k+15],S23,0xD8A1E681);
+        b=GG(b,c,d,a,x[k+4], S24,0xE7D3FBC8);
+        a=GG(a,b,c,d,x[k+9], S21,0x21E1CDE6);
+        d=GG(d,a,b,c,x[k+14],S22,0xC33707D6);
+        c=GG(c,d,a,b,x[k+3], S23,0xF4D50D87);
+        b=GG(b,c,d,a,x[k+8], S24,0x455A14ED);
+        a=GG(a,b,c,d,x[k+13],S21,0xA9E3E905);
+        d=GG(d,a,b,c,x[k+2], S22,0xFCEFA3F8);
+        c=GG(c,d,a,b,x[k+7], S23,0x676F02D9);
+        b=GG(b,c,d,a,x[k+12],S24,0x8D2A4C8A);
+        a=HH(a,b,c,d,x[k+5], S31,0xFFFA3942);
+        d=HH(d,a,b,c,x[k+8], S32,0x8771F681);
+        c=HH(c,d,a,b,x[k+11],S33,0x6D9D6122);
+        b=HH(b,c,d,a,x[k+14],S34,0xFDE5380C);
+        a=HH(a,b,c,d,x[k+1], S31,0xA4BEEA44);
+        d=HH(d,a,b,c,x[k+4], S32,0x4BDECFA9);
+        c=HH(c,d,a,b,x[k+7], S33,0xF6BB4B60);
+        b=HH(b,c,d,a,x[k+10],S34,0xBEBFBC70);
+        a=HH(a,b,c,d,x[k+13],S31,0x289B7EC6);
+        d=HH(d,a,b,c,x[k+0], S32,0xEAA127FA);
+        c=HH(c,d,a,b,x[k+3], S33,0xD4EF3085);
+        b=HH(b,c,d,a,x[k+6], S34,0x4881D05);
+        a=HH(a,b,c,d,x[k+9], S31,0xD9D4D039);
+        d=HH(d,a,b,c,x[k+12],S32,0xE6DB99E5);
+        c=HH(c,d,a,b,x[k+15],S33,0x1FA27CF8);
+        b=HH(b,c,d,a,x[k+2], S34,0xC4AC5665);
+        a=II(a,b,c,d,x[k+0], S41,0xF4292244);
+        d=II(d,a,b,c,x[k+7], S42,0x432AFF97);
+        c=II(c,d,a,b,x[k+14],S43,0xAB9423A7);
+        b=II(b,c,d,a,x[k+5], S44,0xFC93A039);
+        a=II(a,b,c,d,x[k+12],S41,0x655B59C3);
+        d=II(d,a,b,c,x[k+3], S42,0x8F0CCC92);
+        c=II(c,d,a,b,x[k+10],S43,0xFFEFF47D);
+        b=II(b,c,d,a,x[k+1], S44,0x85845DD1);
+        a=II(a,b,c,d,x[k+8], S41,0x6FA87E4F);
+        d=II(d,a,b,c,x[k+15],S42,0xFE2CE6E0);
+        c=II(c,d,a,b,x[k+6], S43,0xA3014314);
+        b=II(b,c,d,a,x[k+13],S44,0x4E0811A1);
+        a=II(a,b,c,d,x[k+4], S41,0xF7537E82);
+        d=II(d,a,b,c,x[k+11],S42,0xBD3AF235);
+        c=II(c,d,a,b,x[k+2], S43,0x2AD7D2BB);
+        b=II(b,c,d,a,x[k+9], S44,0xEB86D391);
+    }
+}
+export default md5;


### PR DESCRIPTION
This PR introduces a new `getTypeOfExpression` function in the checker. Unlike `checkExpression`, this function is simply concerned with computing the type and may not fully check all contained sub-expressions for errors. In `getTypeOfExpression` we optimize for the common case of a call to a function with a single non-generic call signature where we can just fetch the return type without checking the arguments. Ideally, over time the entire family of `checkXXX` functions whould have a parameter that indicates whether full error checking is required such that we can perform more optimizations locally.

Fixes #12319. Actually, #12319 was sort of fixed by #12362, but only when `--noImplicitAny` is not specified. For that reason we have the flag on in the regression test.