### PR TITLE
Change 'keyof T' to always be string-like

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -142,7 +142,6 @@ namespace ts {
         const voidType = createIntrinsicType(TypeFlags.Void, "void");
         const neverType = createIntrinsicType(TypeFlags.Never, "never");
         const silentNeverType = createIntrinsicType(TypeFlags.Never, "never");
-        const stringOrNumberType = getUnionType([stringType, numberType]);
 
         const emptyObjectType = createAnonymousType(undefined, emptySymbols, emptyArray, emptyArray, undefined, undefined);
 
@@ -3219,6 +3218,8 @@ namespace ts {
 
             // A variable declared in a for..in statement is always of type string
             if (declaration.parent.parent.kind === SyntaxKind.ForInStatement) {
+                // const indexType = getIndexType(checkNonNullExpression((<ForInStatement>declaration.parent.parent).expression));
+                // return indexType.flags & TypeFlags.Index ? indexType : stringType;
                 return stringType;
             }
 
@@ -4688,7 +4689,6 @@ namespace ts {
                 t.flags & TypeFlags.NumberLike ? globalNumberType :
                 t.flags & TypeFlags.BooleanLike ? globalBooleanType :
                 t.flags & TypeFlags.ESSymbol ? getGlobalESSymbolType() :
-                t.flags & TypeFlags.Index ? stringOrNumberType :
                 t;
         }
 
@@ -5920,8 +5920,7 @@ namespace ts {
         function getIndexType(type: Type): Type {
             return type.flags & TypeFlags.TypeParameter ? getIndexTypeForTypeParameter(<TypeParameter>type) :
                 getObjectFlags(type) & ObjectFlags.Mapped ? getConstraintTypeFromMappedType(<MappedType>type) :
-                type.flags & TypeFlags.Any || getIndexInfoOfType(type, IndexKind.String) ? stringOrNumberType :
-                getIndexInfoOfType(type, IndexKind.Number) ? getUnionType([numberType, getLiteralTypeFromPropertyNames(type)]) :
+                type.flags & TypeFlags.Any || getIndexInfoOfType(type, IndexKind.String) ? stringType :
                 getLiteralTypeFromPropertyNames(type);
         }
 
@@ -6040,10 +6039,9 @@ namespace ts {
                 return indexedAccessTypes[id] || (indexedAccessTypes[id] = createIndexedAccessType(objectType, indexType));
             }
             const apparentObjectType = getApparentType(objectType);
-            const apparentIndexType = indexType.flags & TypeFlags.Index ? stringOrNumberType : indexType;
-            if (apparentIndexType.flags & TypeFlags.Union && !(apparentIndexType.flags & TypeFlags.Primitive)) {
+            if (indexType.flags & TypeFlags.Union && !(indexType.flags & TypeFlags.Primitive)) {
                 const propTypes: Type[] = [];
-                for (const t of (<UnionType>apparentIndexType).types) {
+                for (const t of (<UnionType>indexType).types) {
                     const propType = getPropertyTypeForIndexType(apparentObjectType, t, accessNode, /*cacheSymbol*/ false);
                     if (propType === unknownType) {
                         return unknownType;
@@ -6052,7 +6050,7 @@ namespace ts {
                 }
                 return getUnionType(propTypes);
             }
-            return getPropertyTypeForIndexType(apparentObjectType, apparentIndexType, accessNode, /*cacheSymbol*/ true);
+            return getPropertyTypeForIndexType(apparentObjectType, indexType, accessNode, /*cacheSymbol*/ true);
         }
 
         function getTypeFromIndexedAccessTypeNode(node: IndexedAccessTypeNode) {
@@ -7123,16 +7121,6 @@ namespace ts {
                 }
 
                 if (isSimpleTypeRelatedTo(source, target, relation, reportErrors ? reportError : undefined)) return Ternary.True;
-
-                if (source.flags & TypeFlags.Index) {
-                    // A keyof T is related to a union type containing both string and number
-                    const related = relation === comparableRelation ?
-                        maybeTypeOfKind(target, TypeFlags.String | TypeFlags.Number) :
-                        maybeTypeOfKind(target, TypeFlags.String) && maybeTypeOfKind(target, TypeFlags.Number);
-                    if (related) {
-                        return Ternary.True;
-                    }
-                }
 
                 if (getObjectFlags(source) & ObjectFlags.ObjectLiteral && source.flags & TypeFlags.FreshLiteral) {
                     if (hasExcessProperties(<FreshObjectLiteralType>source, target, reportErrors)) {
@@ -15654,7 +15642,7 @@ namespace ts {
             const type = <MappedType>getTypeFromMappedTypeNode(node);
             const constraintType = getConstraintTypeFromMappedType(type);
             const keyType = constraintType.flags & TypeFlags.TypeParameter ? getApparentTypeOfTypeParameter(<TypeParameter>constraintType) : constraintType;
-            checkTypeAssignableTo(keyType, stringOrNumberType, node.typeParameter.constraint);
+            checkTypeAssignableTo(keyType, stringType, node.typeParameter.constraint);
         }
 
         function isPrivateWithinAmbient(node: Node): boolean {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3216,11 +3216,11 @@ namespace ts {
                 }
             }
 
-            // A variable declared in a for..in statement is always of type string
+            // A variable declared in a for..in statement is of type string, or of type keyof T when the
+            // right hand expression is of a type parameter type.
             if (declaration.parent.parent.kind === SyntaxKind.ForInStatement) {
-                // const indexType = getIndexType(checkNonNullExpression((<ForInStatement>declaration.parent.parent).expression));
-                // return indexType.flags & TypeFlags.Index ? indexType : stringType;
-                return stringType;
+                const indexType = getIndexType(checkNonNullExpression((<ForInStatement>declaration.parent.parent).expression));
+                return indexType.flags & TypeFlags.Index ? indexType : stringType;
             }
 
             if (declaration.parent.parent.kind === SyntaxKind.ForOfStatement) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2789,7 +2789,7 @@ namespace ts {
         Intrinsic = Any | String | Number | Boolean | BooleanLiteral | ESSymbol | Void | Undefined | Null | Never,
         /* @internal */
         Primitive = String | Number | Boolean | Enum | ESSymbol | Void | Undefined | Null | Literal,
-        StringLike = String | StringLiteral,
+        StringLike = String | StringLiteral | Index,
         NumberLike = Number | NumberLiteral | Enum | EnumLiteral,
         BooleanLike = Boolean | BooleanLiteral,
         EnumLike = Enum | EnumLiteral,

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1367,7 +1367,7 @@ type Pick<T, K extends keyof T> = {
 /**
  * Construct a type with a set of properties K of type T
  */
-type Record<K extends string | number, T> = {
+type Record<K extends string, T> = {
     [P in K]: T;
 }
 

--- a/tests/baselines/reference/for-inStatements.errors.txt
+++ b/tests/baselines/reference/for-inStatements.errors.txt
@@ -1,7 +1,9 @@
+tests/cases/conformance/statements/for-inStatements/for-inStatements.ts(33,18): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'keyof this'.
+tests/cases/conformance/statements/for-inStatements/for-inStatements.ts(50,18): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'keyof this'.
 tests/cases/conformance/statements/for-inStatements/for-inStatements.ts(79,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 
 
-==== tests/cases/conformance/statements/for-inStatements/for-inStatements.ts (1 errors) ====
+==== tests/cases/conformance/statements/for-inStatements/for-inStatements.ts (3 errors) ====
     var aString: string;
     for (aString in {}) { }
     
@@ -35,6 +37,8 @@ tests/cases/conformance/statements/for-inStatements/for-inStatements.ts(79,15): 
             for (var x in this.biz()) { }
             for (var x in this.biz) { }
             for (var x in this) { }
+                     ~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'keyof this'.
             return null;
         }
     
@@ -52,6 +56,8 @@ tests/cases/conformance/statements/for-inStatements/for-inStatements.ts(79,15): 
             for (var x in this.biz()) { }
             for (var x in this.biz) { }
             for (var x in this) { }
+                     ~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'keyof this'.
     
             for (var x in super.biz) { }
             for (var x in super.biz()) { }

--- a/tests/baselines/reference/for-inStatementsInvalid.errors.txt
+++ b/tests/baselines/reference/for-inStatementsInvalid.errors.txt
@@ -9,13 +9,15 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(1
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(20,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(22,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(29,23): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
+tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(31,18): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'keyof this'.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(38,23): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(46,23): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
+tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(48,18): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'keyof this'.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(51,23): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(62,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 
 
-==== tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts (15 errors) ====
+==== tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts (17 errors) ====
     var aNumber: number;
     for (aNumber in {}) { }
          ~~~~~~~
@@ -69,6 +71,8 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(6
 !!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
             for (var x in this.biz) { }
             for (var x in this) { }
+                     ~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'keyof this'.
             return null;
         }
     
@@ -90,6 +94,8 @@ tests/cases/conformance/statements/for-inStatements/for-inStatementsInvalid.ts(6
 !!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
             for (var x in this.biz) { }
             for (var x in this) { }
+                     ~
+!!! error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type 'string', but here has type 'keyof this'.
     
             for (var x in super.biz) { }
             for (var x in super.biz()) { }

--- a/tests/baselines/reference/forInStatement3.types
+++ b/tests/baselines/reference/forInStatement3.types
@@ -8,7 +8,7 @@ function F<T>() {
 >T : T
 
   for (var a in expr) {
->a : string
+>a : keyof T
 >expr : T
   }
 }

--- a/tests/baselines/reference/implicitAnyInCatch.types
+++ b/tests/baselines/reference/implicitAnyInCatch.types
@@ -22,7 +22,7 @@ class C {
 >temp : () => void
 
         for (var x in this) {
->x : string
+>x : keyof this
 >this : this
         }
     }

--- a/tests/baselines/reference/inOperatorWithGeneric.types
+++ b/tests/baselines/reference/inOperatorWithGeneric.types
@@ -9,7 +9,7 @@ class C<T> {
 >T : T
 
         for (var p in x) {
->p : string
+>p : keyof T
 >x : T
         }
     }

--- a/tests/baselines/reference/keyofAndIndexedAccess.js
+++ b/tests/baselines/reference/keyofAndIndexedAccess.js
@@ -211,6 +211,12 @@ function f55<T, K extends keyof T>(obj: T, key: K) {
     const b = "foo" in obj[key];
 }
 
+function f60<T>(source: T, target: T) {
+    for (let k in source) {
+        target[k] = source[k];
+    }
+}
+
 // Repros from #12011
 
 class Base {
@@ -383,6 +389,11 @@ function f55(obj, key) {
     }
     var b = "foo" in obj[key];
 }
+function f60(source, target) {
+    for (var k in source) {
+        target[k] = source[k];
+    }
+}
 // Repros from #12011
 var Base = (function () {
     function Base() {
@@ -518,6 +529,7 @@ declare function f53<T, K extends keyof T>(obj: {
 }, k: K, s: string, n: number): void;
 declare function f54<T>(obj: T, key: keyof T): void;
 declare function f55<T, K extends keyof T>(obj: T, key: K): void;
+declare function f60<T>(source: T, target: T): void;
 declare class Base {
     get<K extends keyof this>(prop: K): this[K];
     set<K extends keyof this>(prop: K, value: this[K]): void;

--- a/tests/baselines/reference/keyofAndIndexedAccess.js
+++ b/tests/baselines/reference/keyofAndIndexedAccess.js
@@ -95,22 +95,18 @@ function f10(shape: Shape) {
 
 function f11(a: Shape[]) {
     let len = getProperty(a, "length");  // number
-    let shape = getProperty(a, 1000);    // Shape
-    setProperty(a, 1000, getProperty(a, 1001));
+    setProperty(a, "length", len);
 }
 
 function f12(t: [Shape, boolean]) {
     let len = getProperty(t, "length");
-    let s1 = getProperty(t, 0);    // Shape
     let s2 = getProperty(t, "0");  // Shape
-    let b1 = getProperty(t, 1);    // boolean
     let b2 = getProperty(t, "1");  // boolean
-    let x1 = getProperty(t, 2);    // Shape | boolean
 }
 
 function f13(foo: any, bar: any) {
     let x = getProperty(foo, "x");  // any
-    let y = getProperty(foo, 100);  // any
+    let y = getProperty(foo, "100");  // any
     let z = getProperty(foo, bar);  // any
 }
 
@@ -181,20 +177,14 @@ function f40(c: C) {
     let z: Z = c["z"];
 }
 
-function f50<T>(k: keyof T, s: string, n: number) {
+function f50<T>(k: keyof T, s: string) {
     const x1 = s as keyof T;
-    const x2 = n as keyof T;
-    const x3 = k as string;
-    const x4 = k as number;
-    const x5 = k as string | number;
+    const x2 = k as string;
 }
 
-function f51<T, K extends keyof T>(k: K, s: string, n: number) {
+function f51<T, K extends keyof T>(k: K, s: string) {
     const x1 = s as keyof T;
-    const x2 = n as keyof T;
-    const x3 = k as string;
-    const x4 = k as number;
-    const x5 = k as string | number;
+    const x2 = k as string;
 }
 
 function f52<T>(obj: { [x: string]: boolean }, k: keyof T, s: string, n: number) {
@@ -297,20 +287,16 @@ function f10(shape) {
 }
 function f11(a) {
     var len = getProperty(a, "length"); // number
-    var shape = getProperty(a, 1000); // Shape
-    setProperty(a, 1000, getProperty(a, 1001));
+    setProperty(a, "length", len);
 }
 function f12(t) {
     var len = getProperty(t, "length");
-    var s1 = getProperty(t, 0); // Shape
     var s2 = getProperty(t, "0"); // Shape
-    var b1 = getProperty(t, 1); // boolean
     var b2 = getProperty(t, "1"); // boolean
-    var x1 = getProperty(t, 2); // Shape | boolean
 }
 function f13(foo, bar) {
     var x = getProperty(foo, "x"); // any
-    var y = getProperty(foo, 100); // any
+    var y = getProperty(foo, "100"); // any
     var z = getProperty(foo, bar); // any
 }
 var Component = (function () {
@@ -369,19 +355,13 @@ function f40(c) {
     var y = c["y"];
     var z = c["z"];
 }
-function f50(k, s, n) {
+function f50(k, s) {
     var x1 = s;
-    var x2 = n;
-    var x3 = k;
-    var x4 = k;
-    var x5 = k;
+    var x2 = k;
 }
-function f51(k, s, n) {
+function f51(k, s) {
     var x1 = s;
-    var x2 = n;
-    var x3 = k;
-    var x4 = k;
-    var x5 = k;
+    var x2 = k;
 }
 function f52(obj, k, s, n) {
     var x1 = obj[s];
@@ -528,8 +508,8 @@ declare class C {
     private z;
 }
 declare function f40(c: C): void;
-declare function f50<T>(k: keyof T, s: string, n: number): void;
-declare function f51<T, K extends keyof T>(k: K, s: string, n: number): void;
+declare function f50<T>(k: keyof T, s: string): void;
+declare function f51<T, K extends keyof T>(k: K, s: string): void;
 declare function f52<T>(obj: {
     [x: string]: boolean;
 }, k: keyof T, s: string, n: number): void;

--- a/tests/baselines/reference/keyofAndIndexedAccess.symbols
+++ b/tests/baselines/reference/keyofAndIndexedAccess.symbols
@@ -735,84 +735,104 @@ function f55<T, K extends keyof T>(obj: T, key: K) {
 >key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 206, 42))
 }
 
+function f60<T>(source: T, target: T) {
+>f60 : Symbol(f60, Decl(keyofAndIndexedAccess.ts, 210, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 212, 13))
+>source : Symbol(source, Decl(keyofAndIndexedAccess.ts, 212, 16))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 212, 13))
+>target : Symbol(target, Decl(keyofAndIndexedAccess.ts, 212, 26))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 212, 13))
+
+    for (let k in source) {
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 213, 12))
+>source : Symbol(source, Decl(keyofAndIndexedAccess.ts, 212, 16))
+
+        target[k] = source[k];
+>target : Symbol(target, Decl(keyofAndIndexedAccess.ts, 212, 26))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 213, 12))
+>source : Symbol(source, Decl(keyofAndIndexedAccess.ts, 212, 16))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 213, 12))
+    }
+}
+
 // Repros from #12011
 
 class Base {
->Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 210, 1))
+>Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 216, 1))
 
     get<K extends keyof this>(prop: K) {
->get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 214, 12))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 215, 8))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 215, 30))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 215, 8))
+>get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 220, 12))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 221, 8))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 221, 30))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 221, 8))
 
         return this[prop];
->this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 210, 1))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 215, 30))
+>this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 216, 1))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 221, 30))
     }
     set<K extends keyof this>(prop: K, value: this[K]) {
->set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 217, 5))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 218, 8))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 218, 30))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 218, 8))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 218, 38))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 218, 8))
+>set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 223, 5))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 224, 8))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 224, 30))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 224, 8))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 224, 38))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 224, 8))
 
         this[prop] = value;
->this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 210, 1))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 218, 30))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 218, 38))
+>this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 216, 1))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 224, 30))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 224, 38))
     }
 }
 
 class Person extends Base {
->Person : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 221, 1))
->Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 210, 1))
+>Person : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 227, 1))
+>Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 216, 1))
 
     parts: number;
->parts : Symbol(Person.parts, Decl(keyofAndIndexedAccess.ts, 223, 27))
+>parts : Symbol(Person.parts, Decl(keyofAndIndexedAccess.ts, 229, 27))
 
     constructor(parts: number) {
->parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 225, 16))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 231, 16))
 
         super();
->super : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 210, 1))
+>super : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 216, 1))
 
         this.set("parts", parts);
->this.set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 217, 5))
->this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 221, 1))
->set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 217, 5))
->parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 225, 16))
+>this.set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 223, 5))
+>this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 227, 1))
+>set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 223, 5))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 231, 16))
     }
     getParts() {
->getParts : Symbol(Person.getParts, Decl(keyofAndIndexedAccess.ts, 228, 5))
+>getParts : Symbol(Person.getParts, Decl(keyofAndIndexedAccess.ts, 234, 5))
 
         return this.get("parts")
->this.get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 214, 12))
->this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 221, 1))
->get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 214, 12))
+>this.get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 220, 12))
+>this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 227, 1))
+>get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 220, 12))
     }
 }
 
 class OtherPerson {
->OtherPerson : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 232, 1))
+>OtherPerson : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 238, 1))
 
     parts: number;
->parts : Symbol(OtherPerson.parts, Decl(keyofAndIndexedAccess.ts, 234, 19))
+>parts : Symbol(OtherPerson.parts, Decl(keyofAndIndexedAccess.ts, 240, 19))
 
     constructor(parts: number) {
->parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 236, 16))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 242, 16))
 
         setProperty(this, "parts", parts);
 >setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 79, 1))
->this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 232, 1))
->parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 236, 16))
+>this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 238, 1))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 242, 16))
     }
     getParts() {
->getParts : Symbol(OtherPerson.getParts, Decl(keyofAndIndexedAccess.ts, 238, 5))
+>getParts : Symbol(OtherPerson.getParts, Decl(keyofAndIndexedAccess.ts, 244, 5))
 
         return getProperty(this, "parts")
 >getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 232, 1))
+>this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 238, 1))
     }
 }

--- a/tests/baselines/reference/keyofAndIndexedAccess.symbols
+++ b/tests/baselines/reference/keyofAndIndexedAccess.symbols
@@ -299,569 +299,520 @@ function f11(a: Shape[]) {
 >getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
 >a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 94, 13))
 
-    let shape = getProperty(a, 1000);    // Shape
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 96, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 94, 13))
-
-    setProperty(a, 1000, getProperty(a, 1001));
+    setProperty(a, "length", len);
 >setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 79, 1))
 >a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 94, 13))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 94, 13))
+>len : Symbol(len, Decl(keyofAndIndexedAccess.ts, 95, 7))
 }
 
 function f12(t: [Shape, boolean]) {
->f12 : Symbol(f12, Decl(keyofAndIndexedAccess.ts, 98, 1))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 100, 13))
+>f12 : Symbol(f12, Decl(keyofAndIndexedAccess.ts, 97, 1))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 99, 13))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
     let len = getProperty(t, "length");
->len : Symbol(len, Decl(keyofAndIndexedAccess.ts, 101, 7))
+>len : Symbol(len, Decl(keyofAndIndexedAccess.ts, 100, 7))
 >getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 100, 13))
-
-    let s1 = getProperty(t, 0);    // Shape
->s1 : Symbol(s1, Decl(keyofAndIndexedAccess.ts, 102, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 100, 13))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 99, 13))
 
     let s2 = getProperty(t, "0");  // Shape
->s2 : Symbol(s2, Decl(keyofAndIndexedAccess.ts, 103, 7))
+>s2 : Symbol(s2, Decl(keyofAndIndexedAccess.ts, 101, 7))
 >getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 100, 13))
-
-    let b1 = getProperty(t, 1);    // boolean
->b1 : Symbol(b1, Decl(keyofAndIndexedAccess.ts, 104, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 100, 13))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 99, 13))
 
     let b2 = getProperty(t, "1");  // boolean
->b2 : Symbol(b2, Decl(keyofAndIndexedAccess.ts, 105, 7))
+>b2 : Symbol(b2, Decl(keyofAndIndexedAccess.ts, 102, 7))
 >getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 100, 13))
-
-    let x1 = getProperty(t, 2);    // Shape | boolean
->x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 106, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 100, 13))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 99, 13))
 }
 
 function f13(foo: any, bar: any) {
->f13 : Symbol(f13, Decl(keyofAndIndexedAccess.ts, 107, 1))
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 109, 13))
->bar : Symbol(bar, Decl(keyofAndIndexedAccess.ts, 109, 22))
+>f13 : Symbol(f13, Decl(keyofAndIndexedAccess.ts, 103, 1))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 105, 13))
+>bar : Symbol(bar, Decl(keyofAndIndexedAccess.ts, 105, 22))
 
     let x = getProperty(foo, "x");  // any
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 110, 7))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 106, 7))
 >getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 109, 13))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 105, 13))
 
-    let y = getProperty(foo, 100);  // any
->y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 111, 7))
+    let y = getProperty(foo, "100");  // any
+>y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 107, 7))
 >getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 109, 13))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 105, 13))
 
     let z = getProperty(foo, bar);  // any
->z : Symbol(z, Decl(keyofAndIndexedAccess.ts, 112, 7))
+>z : Symbol(z, Decl(keyofAndIndexedAccess.ts, 108, 7))
 >getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 109, 13))
->bar : Symbol(bar, Decl(keyofAndIndexedAccess.ts, 109, 22))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 105, 13))
+>bar : Symbol(bar, Decl(keyofAndIndexedAccess.ts, 105, 22))
 }
 
 class Component<PropType> {
->Component : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 113, 1))
->PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 115, 16))
+>Component : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 109, 1))
+>PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 111, 16))
 
     props: PropType;
->props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 115, 27))
->PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 115, 16))
+>props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 111, 27))
+>PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 111, 16))
 
     getProperty<K extends keyof PropType>(key: K) {
->getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 116, 20))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 117, 16))
->PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 115, 16))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 117, 42))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 117, 16))
+>getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 113, 16))
+>PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 111, 16))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 113, 42))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 113, 16))
 
         return this.props[key];
->this.props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 115, 27))
->this : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 113, 1))
->props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 115, 27))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 117, 42))
+>this.props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 111, 27))
+>this : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 109, 1))
+>props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 111, 27))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 113, 42))
     }
     setProperty<K extends keyof PropType>(key: K, value: PropType[K]) {
->setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 119, 5))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 120, 16))
->PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 115, 16))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 120, 42))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 120, 16))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 120, 49))
->PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 115, 16))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 120, 16))
+>setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 116, 16))
+>PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 111, 16))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 116, 42))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 116, 16))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 116, 49))
+>PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 111, 16))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 116, 16))
 
         this.props[key] = value;
->this.props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 115, 27))
->this : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 113, 1))
->props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 115, 27))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 120, 42))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 120, 49))
+>this.props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 111, 27))
+>this : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 109, 1))
+>props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 111, 27))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 116, 42))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 116, 49))
     }
 }
 
 function f20(component: Component<Shape>) {
->f20 : Symbol(f20, Decl(keyofAndIndexedAccess.ts, 123, 1))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 125, 13))
->Component : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 113, 1))
+>f20 : Symbol(f20, Decl(keyofAndIndexedAccess.ts, 119, 1))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
+>Component : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 109, 1))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
     let name = component.getProperty("name");  // string
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 126, 7))
->component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 116, 20))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 125, 13))
->getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 116, 20))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 122, 7))
+>component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
+>getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
 
     let widthOrHeight = component.getProperty(cond ? "width" : "height");  // number
->widthOrHeight : Symbol(widthOrHeight, Decl(keyofAndIndexedAccess.ts, 127, 7))
->component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 116, 20))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 125, 13))
->getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 116, 20))
+>widthOrHeight : Symbol(widthOrHeight, Decl(keyofAndIndexedAccess.ts, 123, 7))
+>component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
+>getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
 >cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
 
     let nameOrVisible = component.getProperty(cond ? "name" : "visible");  // string | boolean
->nameOrVisible : Symbol(nameOrVisible, Decl(keyofAndIndexedAccess.ts, 128, 7))
->component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 116, 20))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 125, 13))
->getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 116, 20))
+>nameOrVisible : Symbol(nameOrVisible, Decl(keyofAndIndexedAccess.ts, 124, 7))
+>component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
+>getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
 >cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
 
     component.setProperty("name", "rectangle");
->component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 119, 5))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 125, 13))
->setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 119, 5))
+>component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
+>setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
 
     component.setProperty(cond ? "width" : "height", 10)
->component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 119, 5))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 125, 13))
->setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 119, 5))
+>component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
+>setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
 >cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
 
     component.setProperty(cond ? "name" : "visible", true);  // Technically not safe
->component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 119, 5))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 125, 13))
->setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 119, 5))
+>component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
+>setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
 >cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
 }
 
 function pluck<T, K extends keyof T>(array: T[], key: K) {
->pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 132, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 134, 15))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 134, 17))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 134, 15))
->array : Symbol(array, Decl(keyofAndIndexedAccess.ts, 134, 37))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 134, 15))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 134, 48))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 134, 17))
+>pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 128, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 130, 15))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 130, 17))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 130, 15))
+>array : Symbol(array, Decl(keyofAndIndexedAccess.ts, 130, 37))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 130, 15))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 130, 48))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 130, 17))
 
     return array.map(x => x[key]);
 >array.map : Symbol(Array.map, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->array : Symbol(array, Decl(keyofAndIndexedAccess.ts, 134, 37))
+>array : Symbol(array, Decl(keyofAndIndexedAccess.ts, 130, 37))
 >map : Symbol(Array.map, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 135, 21))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 135, 21))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 134, 48))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 131, 21))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 131, 21))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 130, 48))
 }
 
 function f30(shapes: Shape[]) {
->f30 : Symbol(f30, Decl(keyofAndIndexedAccess.ts, 136, 1))
->shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 138, 13))
+>f30 : Symbol(f30, Decl(keyofAndIndexedAccess.ts, 132, 1))
+>shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 134, 13))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
     let names = pluck(shapes, "name");    // string[]
->names : Symbol(names, Decl(keyofAndIndexedAccess.ts, 139, 7))
->pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 132, 1))
->shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 138, 13))
+>names : Symbol(names, Decl(keyofAndIndexedAccess.ts, 135, 7))
+>pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 128, 1))
+>shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 134, 13))
 
     let widths = pluck(shapes, "width");  // number[]
->widths : Symbol(widths, Decl(keyofAndIndexedAccess.ts, 140, 7))
->pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 132, 1))
->shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 138, 13))
+>widths : Symbol(widths, Decl(keyofAndIndexedAccess.ts, 136, 7))
+>pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 128, 1))
+>shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 134, 13))
 
     let nameOrVisibles = pluck(shapes, cond ? "name" : "visible");  // (string | boolean)[]
->nameOrVisibles : Symbol(nameOrVisibles, Decl(keyofAndIndexedAccess.ts, 141, 7))
->pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 132, 1))
->shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 138, 13))
+>nameOrVisibles : Symbol(nameOrVisibles, Decl(keyofAndIndexedAccess.ts, 137, 7))
+>pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 128, 1))
+>shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 134, 13))
 >cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
 }
 
 function f31<K extends keyof Shape>(key: K) {
->f31 : Symbol(f31, Decl(keyofAndIndexedAccess.ts, 142, 1))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 144, 13))
+>f31 : Symbol(f31, Decl(keyofAndIndexedAccess.ts, 138, 1))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 140, 13))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 144, 36))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 144, 13))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 140, 36))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 140, 13))
 
     const shape: Shape = { name: "foo", width: 5, height: 10, visible: true };
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 145, 9))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 141, 9))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 145, 26))
->width : Symbol(width, Decl(keyofAndIndexedAccess.ts, 145, 39))
->height : Symbol(height, Decl(keyofAndIndexedAccess.ts, 145, 49))
->visible : Symbol(visible, Decl(keyofAndIndexedAccess.ts, 145, 61))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 141, 26))
+>width : Symbol(width, Decl(keyofAndIndexedAccess.ts, 141, 39))
+>height : Symbol(height, Decl(keyofAndIndexedAccess.ts, 141, 49))
+>visible : Symbol(visible, Decl(keyofAndIndexedAccess.ts, 141, 61))
 
     return shape[key];  // Shape[K]
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 145, 9))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 144, 36))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 141, 9))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 140, 36))
 }
 
 function f32<K extends "width" | "height">(key: K) {
->f32 : Symbol(f32, Decl(keyofAndIndexedAccess.ts, 147, 1))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 149, 13))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 149, 43))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 149, 13))
+>f32 : Symbol(f32, Decl(keyofAndIndexedAccess.ts, 143, 1))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 145, 13))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 145, 43))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 145, 13))
 
     const shape: Shape = { name: "foo", width: 5, height: 10, visible: true };
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 150, 9))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 146, 9))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 150, 26))
->width : Symbol(width, Decl(keyofAndIndexedAccess.ts, 150, 39))
->height : Symbol(height, Decl(keyofAndIndexedAccess.ts, 150, 49))
->visible : Symbol(visible, Decl(keyofAndIndexedAccess.ts, 150, 61))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 146, 26))
+>width : Symbol(width, Decl(keyofAndIndexedAccess.ts, 146, 39))
+>height : Symbol(height, Decl(keyofAndIndexedAccess.ts, 146, 49))
+>visible : Symbol(visible, Decl(keyofAndIndexedAccess.ts, 146, 61))
 
     return shape[key];  // Shape[K]
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 150, 9))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 149, 43))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 146, 9))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 145, 43))
 }
 
 function f33<S extends Shape, K extends keyof S>(shape: S, key: K) {
->f33 : Symbol(f33, Decl(keyofAndIndexedAccess.ts, 152, 1))
->S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 154, 13))
+>f33 : Symbol(f33, Decl(keyofAndIndexedAccess.ts, 148, 1))
+>S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 150, 13))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 154, 29))
->S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 154, 13))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 154, 49))
->S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 154, 13))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 154, 58))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 154, 29))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 150, 29))
+>S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 150, 13))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 150, 49))
+>S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 150, 13))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 150, 58))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 150, 29))
 
     let name = getProperty(shape, "name");
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 155, 7))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 151, 7))
 >getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 154, 49))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 150, 49))
 
     let prop = getProperty(shape, key);
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 156, 7))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 152, 7))
 >getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 154, 49))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 154, 58))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 150, 49))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 150, 58))
 
     return prop;
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 156, 7))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 152, 7))
 }
 
 function f34(ts: TaggedShape) {
->f34 : Symbol(f34, Decl(keyofAndIndexedAccess.ts, 158, 1))
->ts : Symbol(ts, Decl(keyofAndIndexedAccess.ts, 160, 13))
+>f34 : Symbol(f34, Decl(keyofAndIndexedAccess.ts, 154, 1))
+>ts : Symbol(ts, Decl(keyofAndIndexedAccess.ts, 156, 13))
 >TaggedShape : Symbol(TaggedShape, Decl(keyofAndIndexedAccess.ts, 6, 1))
 
     let tag1 = f33(ts, "tag");
->tag1 : Symbol(tag1, Decl(keyofAndIndexedAccess.ts, 161, 7))
->f33 : Symbol(f33, Decl(keyofAndIndexedAccess.ts, 152, 1))
->ts : Symbol(ts, Decl(keyofAndIndexedAccess.ts, 160, 13))
+>tag1 : Symbol(tag1, Decl(keyofAndIndexedAccess.ts, 157, 7))
+>f33 : Symbol(f33, Decl(keyofAndIndexedAccess.ts, 148, 1))
+>ts : Symbol(ts, Decl(keyofAndIndexedAccess.ts, 156, 13))
 
     let tag2 = getProperty(ts, "tag");
->tag2 : Symbol(tag2, Decl(keyofAndIndexedAccess.ts, 162, 7))
+>tag2 : Symbol(tag2, Decl(keyofAndIndexedAccess.ts, 158, 7))
 >getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->ts : Symbol(ts, Decl(keyofAndIndexedAccess.ts, 160, 13))
+>ts : Symbol(ts, Decl(keyofAndIndexedAccess.ts, 156, 13))
 }
 
 class C {
->C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 163, 1))
+>C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 159, 1))
 
     public x: string;
->x : Symbol(C.x, Decl(keyofAndIndexedAccess.ts, 165, 9))
+>x : Symbol(C.x, Decl(keyofAndIndexedAccess.ts, 161, 9))
 
     protected y: string;
->y : Symbol(C.y, Decl(keyofAndIndexedAccess.ts, 166, 21))
+>y : Symbol(C.y, Decl(keyofAndIndexedAccess.ts, 162, 21))
 
     private z: string;
->z : Symbol(C.z, Decl(keyofAndIndexedAccess.ts, 167, 24))
+>z : Symbol(C.z, Decl(keyofAndIndexedAccess.ts, 163, 24))
 }
 
 // Indexed access expressions have always permitted access to private and protected members.
 // For consistency we also permit such access in indexed access types.
 function f40(c: C) {
->f40 : Symbol(f40, Decl(keyofAndIndexedAccess.ts, 169, 1))
->c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 173, 13))
->C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 163, 1))
+>f40 : Symbol(f40, Decl(keyofAndIndexedAccess.ts, 165, 1))
+>c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 169, 13))
+>C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 159, 1))
 
     type X = C["x"];
->X : Symbol(X, Decl(keyofAndIndexedAccess.ts, 173, 20))
->C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 163, 1))
+>X : Symbol(X, Decl(keyofAndIndexedAccess.ts, 169, 20))
+>C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 159, 1))
 
     type Y = C["y"];
->Y : Symbol(Y, Decl(keyofAndIndexedAccess.ts, 174, 20))
->C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 163, 1))
+>Y : Symbol(Y, Decl(keyofAndIndexedAccess.ts, 170, 20))
+>C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 159, 1))
 
     type Z = C["z"];
->Z : Symbol(Z, Decl(keyofAndIndexedAccess.ts, 175, 20))
->C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 163, 1))
+>Z : Symbol(Z, Decl(keyofAndIndexedAccess.ts, 171, 20))
+>C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 159, 1))
 
     let x: X = c["x"];
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 177, 7))
->X : Symbol(X, Decl(keyofAndIndexedAccess.ts, 173, 20))
->c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 173, 13))
->"x" : Symbol(C.x, Decl(keyofAndIndexedAccess.ts, 165, 9))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 173, 7))
+>X : Symbol(X, Decl(keyofAndIndexedAccess.ts, 169, 20))
+>c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 169, 13))
+>"x" : Symbol(C.x, Decl(keyofAndIndexedAccess.ts, 161, 9))
 
     let y: Y = c["y"];
->y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 178, 7))
->Y : Symbol(Y, Decl(keyofAndIndexedAccess.ts, 174, 20))
->c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 173, 13))
->"y" : Symbol(C.y, Decl(keyofAndIndexedAccess.ts, 166, 21))
+>y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 174, 7))
+>Y : Symbol(Y, Decl(keyofAndIndexedAccess.ts, 170, 20))
+>c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 169, 13))
+>"y" : Symbol(C.y, Decl(keyofAndIndexedAccess.ts, 162, 21))
 
     let z: Z = c["z"];
->z : Symbol(z, Decl(keyofAndIndexedAccess.ts, 179, 7))
->Z : Symbol(Z, Decl(keyofAndIndexedAccess.ts, 175, 20))
->c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 173, 13))
->"z" : Symbol(C.z, Decl(keyofAndIndexedAccess.ts, 167, 24))
+>z : Symbol(z, Decl(keyofAndIndexedAccess.ts, 175, 7))
+>Z : Symbol(Z, Decl(keyofAndIndexedAccess.ts, 171, 20))
+>c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 169, 13))
+>"z" : Symbol(C.z, Decl(keyofAndIndexedAccess.ts, 163, 24))
 }
 
-function f50<T>(k: keyof T, s: string, n: number) {
->f50 : Symbol(f50, Decl(keyofAndIndexedAccess.ts, 180, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 182, 13))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 182, 16))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 182, 13))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 182, 27))
->n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 182, 38))
+function f50<T>(k: keyof T, s: string) {
+>f50 : Symbol(f50, Decl(keyofAndIndexedAccess.ts, 176, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 178, 13))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 178, 16))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 178, 13))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 178, 27))
 
     const x1 = s as keyof T;
->x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 183, 9))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 182, 27))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 182, 13))
+>x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 179, 9))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 178, 27))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 178, 13))
 
-    const x2 = n as keyof T;
->x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 184, 9))
->n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 182, 38))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 182, 13))
-
-    const x3 = k as string;
->x3 : Symbol(x3, Decl(keyofAndIndexedAccess.ts, 185, 9))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 182, 16))
-
-    const x4 = k as number;
->x4 : Symbol(x4, Decl(keyofAndIndexedAccess.ts, 186, 9))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 182, 16))
-
-    const x5 = k as string | number;
->x5 : Symbol(x5, Decl(keyofAndIndexedAccess.ts, 187, 9))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 182, 16))
+    const x2 = k as string;
+>x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 180, 9))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 178, 16))
 }
 
-function f51<T, K extends keyof T>(k: K, s: string, n: number) {
->f51 : Symbol(f51, Decl(keyofAndIndexedAccess.ts, 188, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 190, 13))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 190, 15))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 190, 13))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 190, 35))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 190, 15))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 190, 40))
->n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 190, 51))
+function f51<T, K extends keyof T>(k: K, s: string) {
+>f51 : Symbol(f51, Decl(keyofAndIndexedAccess.ts, 181, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 183, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 183, 15))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 183, 13))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 183, 35))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 183, 15))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 183, 40))
 
     const x1 = s as keyof T;
->x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 191, 9))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 190, 40))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 190, 13))
+>x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 184, 9))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 183, 40))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 183, 13))
 
-    const x2 = n as keyof T;
->x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 192, 9))
->n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 190, 51))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 190, 13))
-
-    const x3 = k as string;
->x3 : Symbol(x3, Decl(keyofAndIndexedAccess.ts, 193, 9))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 190, 35))
-
-    const x4 = k as number;
->x4 : Symbol(x4, Decl(keyofAndIndexedAccess.ts, 194, 9))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 190, 35))
-
-    const x5 = k as string | number;
->x5 : Symbol(x5, Decl(keyofAndIndexedAccess.ts, 195, 9))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 190, 35))
+    const x2 = k as string;
+>x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 185, 9))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 183, 35))
 }
 
 function f52<T>(obj: { [x: string]: boolean }, k: keyof T, s: string, n: number) {
->f52 : Symbol(f52, Decl(keyofAndIndexedAccess.ts, 196, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 198, 13))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 198, 16))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 198, 24))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 198, 46))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 198, 13))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 198, 58))
->n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 198, 69))
+>f52 : Symbol(f52, Decl(keyofAndIndexedAccess.ts, 186, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 188, 13))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 188, 16))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 188, 24))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 188, 46))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 188, 13))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 188, 58))
+>n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 188, 69))
 
     const x1 = obj[s];
->x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 199, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 198, 16))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 198, 58))
+>x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 189, 9))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 188, 16))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 188, 58))
 
     const x2 = obj[n];
->x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 200, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 198, 16))
->n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 198, 69))
+>x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 190, 9))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 188, 16))
+>n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 188, 69))
 
     const x3 = obj[k];
->x3 : Symbol(x3, Decl(keyofAndIndexedAccess.ts, 201, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 198, 16))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 198, 46))
+>x3 : Symbol(x3, Decl(keyofAndIndexedAccess.ts, 191, 9))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 188, 16))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 188, 46))
 }
 
 function f53<T, K extends keyof T>(obj: { [x: string]: boolean }, k: K, s: string, n: number) {
->f53 : Symbol(f53, Decl(keyofAndIndexedAccess.ts, 202, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 204, 13))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 204, 15))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 204, 13))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 204, 35))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 204, 43))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 204, 65))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 204, 15))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 204, 71))
->n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 204, 82))
+>f53 : Symbol(f53, Decl(keyofAndIndexedAccess.ts, 192, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 194, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 194, 15))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 194, 13))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 194, 35))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 194, 43))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 194, 65))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 194, 15))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 194, 71))
+>n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 194, 82))
 
     const x1 = obj[s];
->x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 205, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 204, 35))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 204, 71))
+>x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 195, 9))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 194, 35))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 194, 71))
 
     const x2 = obj[n];
->x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 206, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 204, 35))
->n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 204, 82))
+>x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 196, 9))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 194, 35))
+>n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 194, 82))
 
     const x3 = obj[k];
->x3 : Symbol(x3, Decl(keyofAndIndexedAccess.ts, 207, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 204, 35))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 204, 65))
+>x3 : Symbol(x3, Decl(keyofAndIndexedAccess.ts, 197, 9))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 194, 35))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 194, 65))
 }
 
 function f54<T>(obj: T, key: keyof T) {
->f54 : Symbol(f54, Decl(keyofAndIndexedAccess.ts, 208, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 210, 13))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 210, 16))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 210, 13))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 210, 23))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 210, 13))
+>f54 : Symbol(f54, Decl(keyofAndIndexedAccess.ts, 198, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 200, 13))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 200, 16))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 200, 13))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 200, 23))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 200, 13))
 
     for (let s in obj[key]) {
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 211, 12))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 210, 16))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 210, 23))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 201, 12))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 200, 16))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 200, 23))
     }
     const b = "foo" in obj[key];
->b : Symbol(b, Decl(keyofAndIndexedAccess.ts, 213, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 210, 16))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 210, 23))
+>b : Symbol(b, Decl(keyofAndIndexedAccess.ts, 203, 9))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 200, 16))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 200, 23))
 }
 
 function f55<T, K extends keyof T>(obj: T, key: K) {
->f55 : Symbol(f55, Decl(keyofAndIndexedAccess.ts, 214, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 216, 13))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 216, 15))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 216, 13))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 216, 35))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 216, 13))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 216, 42))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 216, 15))
+>f55 : Symbol(f55, Decl(keyofAndIndexedAccess.ts, 204, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 206, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 206, 15))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 206, 13))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 206, 35))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 206, 13))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 206, 42))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 206, 15))
 
     for (let s in obj[key]) {
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 217, 12))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 216, 35))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 216, 42))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 207, 12))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 206, 35))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 206, 42))
     }
     const b = "foo" in obj[key];
->b : Symbol(b, Decl(keyofAndIndexedAccess.ts, 219, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 216, 35))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 216, 42))
+>b : Symbol(b, Decl(keyofAndIndexedAccess.ts, 209, 9))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 206, 35))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 206, 42))
 }
 
 // Repros from #12011
 
 class Base {
->Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 220, 1))
+>Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 210, 1))
 
     get<K extends keyof this>(prop: K) {
->get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 224, 12))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 225, 8))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 225, 30))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 225, 8))
+>get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 214, 12))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 215, 8))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 215, 30))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 215, 8))
 
         return this[prop];
->this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 220, 1))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 225, 30))
+>this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 210, 1))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 215, 30))
     }
     set<K extends keyof this>(prop: K, value: this[K]) {
->set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 227, 5))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 228, 8))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 228, 30))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 228, 8))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 228, 38))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 228, 8))
+>set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 217, 5))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 218, 8))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 218, 30))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 218, 8))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 218, 38))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 218, 8))
 
         this[prop] = value;
->this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 220, 1))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 228, 30))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 228, 38))
+>this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 210, 1))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 218, 30))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 218, 38))
     }
 }
 
 class Person extends Base {
->Person : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 231, 1))
->Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 220, 1))
+>Person : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 221, 1))
+>Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 210, 1))
 
     parts: number;
->parts : Symbol(Person.parts, Decl(keyofAndIndexedAccess.ts, 233, 27))
+>parts : Symbol(Person.parts, Decl(keyofAndIndexedAccess.ts, 223, 27))
 
     constructor(parts: number) {
->parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 235, 16))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 225, 16))
 
         super();
->super : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 220, 1))
+>super : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 210, 1))
 
         this.set("parts", parts);
->this.set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 227, 5))
->this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 231, 1))
->set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 227, 5))
->parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 235, 16))
+>this.set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 217, 5))
+>this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 221, 1))
+>set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 217, 5))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 225, 16))
     }
     getParts() {
->getParts : Symbol(Person.getParts, Decl(keyofAndIndexedAccess.ts, 238, 5))
+>getParts : Symbol(Person.getParts, Decl(keyofAndIndexedAccess.ts, 228, 5))
 
         return this.get("parts")
->this.get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 224, 12))
->this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 231, 1))
->get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 224, 12))
+>this.get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 214, 12))
+>this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 221, 1))
+>get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 214, 12))
     }
 }
 
 class OtherPerson {
->OtherPerson : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 242, 1))
+>OtherPerson : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 232, 1))
 
     parts: number;
->parts : Symbol(OtherPerson.parts, Decl(keyofAndIndexedAccess.ts, 244, 19))
+>parts : Symbol(OtherPerson.parts, Decl(keyofAndIndexedAccess.ts, 234, 19))
 
     constructor(parts: number) {
->parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 246, 16))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 236, 16))
 
         setProperty(this, "parts", parts);
 >setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 79, 1))
->this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 242, 1))
->parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 246, 16))
+>this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 232, 1))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 236, 16))
     }
     getParts() {
->getParts : Symbol(OtherPerson.getParts, Decl(keyofAndIndexedAccess.ts, 248, 5))
+>getParts : Symbol(OtherPerson.getParts, Decl(keyofAndIndexedAccess.ts, 238, 5))
 
         return getProperty(this, "parts")
 >getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 242, 1))
+>this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 232, 1))
     }
 }

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -54,10 +54,10 @@ const enum E { A, B, C }
 >C : E.C
 
 type K00 = keyof any;  // string | number
->K00 : string | number
+>K00 : string
 
 type K01 = keyof string;  // number | "toString" | "charAt" | ...
->K01 : number | "length" | "toString" | "concat" | "slice" | "indexOf" | "lastIndexOf" | "charAt" | "charCodeAt" | "localeCompare" | "match" | "replace" | "search" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr" | "valueOf"
+>K01 : "length" | "toString" | "concat" | "slice" | "indexOf" | "lastIndexOf" | "charAt" | "charCodeAt" | "localeCompare" | "match" | "replace" | "search" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr" | "valueOf"
 
 type K02 = keyof number;  // "toString" | "toFixed" | "toExponential" | ...
 >K02 : "toString" | "toLocaleString" | "valueOf" | "toFixed" | "toExponential" | "toPrecision"
@@ -83,11 +83,11 @@ type K10 = keyof Shape;  // "name" | "width" | "height" | "visible"
 >Shape : Shape
 
 type K11 = keyof Shape[];  // number | "length" | "toString" | ...
->K11 : number | "length" | "toString" | "toLocaleString" | "push" | "pop" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight"
+>K11 : "length" | "toString" | "toLocaleString" | "push" | "pop" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight"
 >Shape : Shape
 
 type K12 = keyof Dictionary<Shape>;  // string | number
->K12 : string | number
+>K12 : string
 >Dictionary : Dictionary<T>
 >Shape : Shape
 
@@ -103,7 +103,7 @@ type K15 = keyof E;  // "toString" | "toFixed" | "toExponential" | ...
 >E : E
 
 type K16 = keyof [string, number];  // number | "0" | "1" | "length" | "toString" | ...
->K16 : number | "0" | "1" | "length" | "toString" | "toLocaleString" | "push" | "pop" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight"
+>K16 : "0" | "1" | "length" | "toString" | "toLocaleString" | "push" | "pop" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight"
 
 type K17 = keyof (Shape | Item);  // "name"
 >K17 : "name"
@@ -126,7 +126,7 @@ type K20 = KeyOf<Shape>;  // "name" | "width" | "height" | "visible"
 >Shape : Shape
 
 type K21 = KeyOf<Dictionary<Shape>>;  // string | number
->K21 : string | number
+>K21 : string
 >KeyOf : keyof T
 >Dictionary : Dictionary<T>
 >Shape : Shape
@@ -328,22 +328,12 @@ function f11(a: Shape[]) {
 >a : Shape[]
 >"length" : "length"
 
-    let shape = getProperty(a, 1000);    // Shape
->shape : Shape
->getProperty(a, 1000) : Shape
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->a : Shape[]
->1000 : 1000
-
-    setProperty(a, 1000, getProperty(a, 1001));
->setProperty(a, 1000, getProperty(a, 1001)) : void
+    setProperty(a, "length", len);
+>setProperty(a, "length", len) : void
 >setProperty : <T, K extends keyof T>(obj: T, key: K, value: T[K]) => void
 >a : Shape[]
->1000 : 1000
->getProperty(a, 1001) : Shape
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->a : Shape[]
->1001 : 1001
+>"length" : "length"
+>len : number
 }
 
 function f12(t: [Shape, boolean]) {
@@ -358,13 +348,6 @@ function f12(t: [Shape, boolean]) {
 >t : [Shape, boolean]
 >"length" : "length"
 
-    let s1 = getProperty(t, 0);    // Shape
->s1 : Shape
->getProperty(t, 0) : Shape
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->t : [Shape, boolean]
->0 : 0
-
     let s2 = getProperty(t, "0");  // Shape
 >s2 : Shape
 >getProperty(t, "0") : Shape
@@ -372,26 +355,12 @@ function f12(t: [Shape, boolean]) {
 >t : [Shape, boolean]
 >"0" : "0"
 
-    let b1 = getProperty(t, 1);    // boolean
->b1 : boolean
->getProperty(t, 1) : boolean
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->t : [Shape, boolean]
->1 : 1
-
     let b2 = getProperty(t, "1");  // boolean
 >b2 : boolean
 >getProperty(t, "1") : boolean
 >getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
 >t : [Shape, boolean]
 >"1" : "1"
-
-    let x1 = getProperty(t, 2);    // Shape | boolean
->x1 : boolean | Shape
->getProperty(t, 2) : boolean | Shape
->getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
->t : [Shape, boolean]
->2 : 2
 }
 
 function f13(foo: any, bar: any) {
@@ -406,12 +375,12 @@ function f13(foo: any, bar: any) {
 >foo : any
 >"x" : "x"
 
-    let y = getProperty(foo, 100);  // any
+    let y = getProperty(foo, "100");  // any
 >y : any
->getProperty(foo, 100) : any
+>getProperty(foo, "100") : any
 >getProperty : <T, K extends keyof T>(obj: T, key: K) => T[K]
 >foo : any
->100 : 100
+>"100" : "100"
 
     let z = getProperty(foo, bar);  // any
 >z : any
@@ -737,13 +706,12 @@ function f40(c: C) {
 >"z" : "z"
 }
 
-function f50<T>(k: keyof T, s: string, n: number) {
->f50 : <T>(k: keyof T, s: string, n: number) => void
+function f50<T>(k: keyof T, s: string) {
+>f50 : <T>(k: keyof T, s: string) => void
 >T : T
 >k : keyof T
 >T : T
 >s : string
->n : number
 
     const x1 = s as keyof T;
 >x1 : keyof T
@@ -751,37 +719,20 @@ function f50<T>(k: keyof T, s: string, n: number) {
 >s : string
 >T : T
 
-    const x2 = n as keyof T;
->x2 : keyof T
->n as keyof T : keyof T
->n : number
->T : T
-
-    const x3 = k as string;
->x3 : string
+    const x2 = k as string;
+>x2 : string
 >k as string : string
->k : keyof T
-
-    const x4 = k as number;
->x4 : number
->k as number : number
->k : keyof T
-
-    const x5 = k as string | number;
->x5 : string | number
->k as string | number : string | number
 >k : keyof T
 }
 
-function f51<T, K extends keyof T>(k: K, s: string, n: number) {
->f51 : <T, K extends keyof T>(k: K, s: string, n: number) => void
+function f51<T, K extends keyof T>(k: K, s: string) {
+>f51 : <T, K extends keyof T>(k: K, s: string) => void
 >T : T
 >K : K
 >T : T
 >k : K
 >K : K
 >s : string
->n : number
 
     const x1 = s as keyof T;
 >x1 : keyof T
@@ -789,25 +740,9 @@ function f51<T, K extends keyof T>(k: K, s: string, n: number) {
 >s : string
 >T : T
 
-    const x2 = n as keyof T;
->x2 : keyof T
->n as keyof T : keyof T
->n : number
->T : T
-
-    const x3 = k as string;
->x3 : string
+    const x2 = k as string;
+>x2 : string
 >k as string : string
->k : K
-
-    const x4 = k as number;
->x4 : number
->k as number : number
->k : K
-
-    const x5 = k as string | number;
->x5 : string | number
->k as string | number : string | number
 >k : K
 }
 

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -854,6 +854,29 @@ function f55<T, K extends keyof T>(obj: T, key: K) {
 >key : K
 }
 
+function f60<T>(source: T, target: T) {
+>f60 : <T>(source: T, target: T) => void
+>T : T
+>source : T
+>T : T
+>target : T
+>T : T
+
+    for (let k in source) {
+>k : keyof T
+>source : T
+
+        target[k] = source[k];
+>target[k] = source[k] : T[keyof T]
+>target[k] : T[keyof T]
+>target : T
+>k : keyof T
+>source[k] : T[keyof T]
+>source : T
+>k : keyof T
+    }
+}
+
 // Repros from #12011
 
 class Base {

--- a/tests/baselines/reference/mappedTypeErrors.errors.txt
+++ b/tests/baselines/reference/mappedTypeErrors.errors.txt
@@ -1,29 +1,28 @@
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(20,20): error TS2313: Type parameter 'P' has a circular constraint.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(21,20): error TS2322: Type 'Date' is not assignable to type 'string | number'.
-  Type 'Date' is not assignable to type 'number'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(22,19): error TS2344: Type 'Date' does not satisfy the constraint 'string | number'.
-  Type 'Date' is not assignable to type 'number'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(25,24): error TS2344: Type '"foo"' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(26,24): error TS2344: Type '"name" | "foo"' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(21,20): error TS2322: Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(22,20): error TS2322: Type 'Date' is not assignable to type 'string'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(23,19): error TS2344: Type 'Date' does not satisfy the constraint 'string'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(26,24): error TS2344: Type '"foo"' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(27,24): error TS2344: Type '"name" | "foo"' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
   Type '"foo"' is not assignable to type '"name" | "width" | "height" | "visible"'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(28,24): error TS2344: Type '"x" | "y"' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(29,24): error TS2344: Type '"x" | "y"' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
   Type '"x"' is not assignable to type '"name" | "width" | "height" | "visible"'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(30,24): error TS2344: Type 'undefined' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(33,24): error TS2344: Type 'T' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(31,24): error TS2344: Type 'undefined' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(34,24): error TS2344: Type 'T' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
   Type 'T' is not assignable to type '"visible"'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(37,24): error TS2344: Type 'T' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(38,24): error TS2344: Type 'T' does not satisfy the constraint '"name" | "width" | "height" | "visible"'.
   Type 'string | number' is not assignable to type '"name" | "width" | "height" | "visible"'.
     Type 'string' is not assignable to type '"name" | "width" | "height" | "visible"'.
       Type 'T' is not assignable to type '"visible"'.
         Type 'string | number' is not assignable to type '"visible"'.
           Type 'string' is not assignable to type '"visible"'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(59,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ [P in keyof T]?: T[P]; }'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(60,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ readonly [P in keyof T]: T[P]; }'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(61,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ readonly [P in keyof T]?: T[P]; }'.
-tests/cases/conformance/types/mapped/mappedTypeErrors.ts(66,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ [P in keyof T]: T[P][]; }'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(60,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ [P in keyof T]?: T[P]; }'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(61,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ readonly [P in keyof T]: T[P]; }'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(62,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ readonly [P in keyof T]?: T[P]; }'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(67,9): error TS2403: Subsequent variable declarations must have the same type.  Variable 'x' must be of type '{ [P in keyof T]: T[P]; }', but here has type '{ [P in keyof T]: T[P][]; }'.
 
 
-==== tests/cases/conformance/types/mapped/mappedTypeErrors.ts (13 errors) ====
+==== tests/cases/conformance/types/mapped/mappedTypeErrors.ts (14 errors) ====
     
     interface Shape {
         name: string;
@@ -46,14 +45,15 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(66,9): error TS2403: Su
     type T00 = { [P in P]: string };  // Error
                        ~
 !!! error TS2313: Type parameter 'P' has a circular constraint.
-    type T01 = { [P in Date]: number };  // Error
+    type T01 = { [P in number]: string };  // Error
+                       ~~~~~~
+!!! error TS2322: Type 'number' is not assignable to type 'string'.
+    type T02 = { [P in Date]: number };  // Error
                        ~~~~
-!!! error TS2322: Type 'Date' is not assignable to type 'string | number'.
-!!! error TS2322:   Type 'Date' is not assignable to type 'number'.
-    type T02 = Record<Date, number>;  // Error
+!!! error TS2322: Type 'Date' is not assignable to type 'string'.
+    type T03 = Record<Date, number>;  // Error
                       ~~~~
-!!! error TS2344: Type 'Date' does not satisfy the constraint 'string | number'.
-!!! error TS2344:   Type 'Date' is not assignable to type 'number'.
+!!! error TS2344: Type 'Date' does not satisfy the constraint 'string'.
     
     type T10 = Pick<Shape, "name">;
     type T11 = Pick<Shape, "foo">;  // Error

--- a/tests/baselines/reference/mappedTypeErrors.js
+++ b/tests/baselines/reference/mappedTypeErrors.js
@@ -19,8 +19,9 @@ interface Point {
 // Constraint checking
 
 type T00 = { [P in P]: string };  // Error
-type T01 = { [P in Date]: number };  // Error
-type T02 = Record<Date, number>;  // Error
+type T01 = { [P in number]: string };  // Error
+type T02 = { [P in Date]: number };  // Error
+type T03 = Record<Date, number>;  // Error
 
 type T10 = Pick<Shape, "name">;
 type T11 = Pick<Shape, "foo">;  // Error
@@ -116,9 +117,12 @@ declare type T00 = {
     [P in P]: string;
 };
 declare type T01 = {
+    [P in number]: string;
+};
+declare type T02 = {
     [P in Date]: number;
 };
-declare type T02 = Record<Date, number>;
+declare type T03 = Record<Date, number>;
 declare type T10 = Pick<Shape, "name">;
 declare type T11 = Pick<Shape, "foo">;
 declare type T12 = Pick<Shape, "name" | "foo">;

--- a/tests/baselines/reference/mappedTypes1.js
+++ b/tests/baselines/reference/mappedTypes1.js
@@ -26,13 +26,9 @@ type T37 = { [P in keyof symbol]: void };
 type T38 = { [P in keyof never]: void };
 
 type T40 = { [P in string]: void };
-type T41 = { [P in number]: void };
-type T42 = { [P in string | number]: void };
-type T43 = { [P in "a" | "b" | 0 | 1]: void };
+type T43 = { [P in "a" | "b"]: void };
 type T44 = { [P in "a" | "b" | "0" | "1"]: void };
-type T45 = { [P in "a" | "b" | "0" | "1" | 0 | 1]: void };
-type T46 = { [P in number | "a" | "b" | 0 | 1]: void };
-type T47 = { [P in string | number | "a" | "b" | 0 | 1]: void };
+type T47 = { [P in string | "a" | "b" | "0" | "1"]: void };
 
 declare function f1<T1>(): { [P in keyof T1]: void };
 declare function f2<T1 extends string>(): { [P in keyof T1]: void };
@@ -114,26 +110,14 @@ declare type T38 = {
 declare type T40 = {
     [P in string]: void;
 };
-declare type T41 = {
-    [P in number]: void;
-};
-declare type T42 = {
-    [P in string | number]: void;
-};
 declare type T43 = {
-    [P in "a" | "b" | 0 | 1]: void;
+    [P in "a" | "b"]: void;
 };
 declare type T44 = {
     [P in "a" | "b" | "0" | "1"]: void;
 };
-declare type T45 = {
-    [P in "a" | "b" | "0" | "1" | 0 | 1]: void;
-};
-declare type T46 = {
-    [P in number | "a" | "b" | 0 | 1]: void;
-};
 declare type T47 = {
-    [P in string | number | "a" | "b" | 0 | 1]: void;
+    [P in string | "a" | "b" | "0" | "1"]: void;
 };
 declare function f1<T1>(): {
     [P in keyof T1]: void;
@@ -146,7 +130,6 @@ declare function f3<T1 extends number>(): {
 };
 declare let x1: {};
 declare let x2: {
-    [x: number]: void;
     toString: void;
     charAt: void;
     charCodeAt: void;

--- a/tests/baselines/reference/mappedTypes1.symbols
+++ b/tests/baselines/reference/mappedTypes1.symbols
@@ -110,61 +110,45 @@ type T40 = { [P in string]: void };
 >T40 : Symbol(T40, Decl(mappedTypes1.ts, 24, 40))
 >P : Symbol(P, Decl(mappedTypes1.ts, 26, 14))
 
-type T41 = { [P in number]: void };
->T41 : Symbol(T41, Decl(mappedTypes1.ts, 26, 35))
+type T43 = { [P in "a" | "b"]: void };
+>T43 : Symbol(T43, Decl(mappedTypes1.ts, 26, 35))
 >P : Symbol(P, Decl(mappedTypes1.ts, 27, 14))
 
-type T42 = { [P in string | number]: void };
->T42 : Symbol(T42, Decl(mappedTypes1.ts, 27, 35))
+type T44 = { [P in "a" | "b" | "0" | "1"]: void };
+>T44 : Symbol(T44, Decl(mappedTypes1.ts, 27, 38))
 >P : Symbol(P, Decl(mappedTypes1.ts, 28, 14))
 
-type T43 = { [P in "a" | "b" | 0 | 1]: void };
->T43 : Symbol(T43, Decl(mappedTypes1.ts, 28, 44))
+type T47 = { [P in string | "a" | "b" | "0" | "1"]: void };
+>T47 : Symbol(T47, Decl(mappedTypes1.ts, 28, 50))
 >P : Symbol(P, Decl(mappedTypes1.ts, 29, 14))
 
-type T44 = { [P in "a" | "b" | "0" | "1"]: void };
->T44 : Symbol(T44, Decl(mappedTypes1.ts, 29, 46))
->P : Symbol(P, Decl(mappedTypes1.ts, 30, 14))
-
-type T45 = { [P in "a" | "b" | "0" | "1" | 0 | 1]: void };
->T45 : Symbol(T45, Decl(mappedTypes1.ts, 30, 50))
->P : Symbol(P, Decl(mappedTypes1.ts, 31, 14))
-
-type T46 = { [P in number | "a" | "b" | 0 | 1]: void };
->T46 : Symbol(T46, Decl(mappedTypes1.ts, 31, 58))
->P : Symbol(P, Decl(mappedTypes1.ts, 32, 14))
-
-type T47 = { [P in string | number | "a" | "b" | 0 | 1]: void };
->T47 : Symbol(T47, Decl(mappedTypes1.ts, 32, 55))
->P : Symbol(P, Decl(mappedTypes1.ts, 33, 14))
-
 declare function f1<T1>(): { [P in keyof T1]: void };
->f1 : Symbol(f1, Decl(mappedTypes1.ts, 33, 64))
->T1 : Symbol(T1, Decl(mappedTypes1.ts, 35, 20))
->P : Symbol(P, Decl(mappedTypes1.ts, 35, 30))
->T1 : Symbol(T1, Decl(mappedTypes1.ts, 35, 20))
+>f1 : Symbol(f1, Decl(mappedTypes1.ts, 29, 59))
+>T1 : Symbol(T1, Decl(mappedTypes1.ts, 31, 20))
+>P : Symbol(P, Decl(mappedTypes1.ts, 31, 30))
+>T1 : Symbol(T1, Decl(mappedTypes1.ts, 31, 20))
 
 declare function f2<T1 extends string>(): { [P in keyof T1]: void };
->f2 : Symbol(f2, Decl(mappedTypes1.ts, 35, 53))
->T1 : Symbol(T1, Decl(mappedTypes1.ts, 36, 20))
->P : Symbol(P, Decl(mappedTypes1.ts, 36, 45))
->T1 : Symbol(T1, Decl(mappedTypes1.ts, 36, 20))
+>f2 : Symbol(f2, Decl(mappedTypes1.ts, 31, 53))
+>T1 : Symbol(T1, Decl(mappedTypes1.ts, 32, 20))
+>P : Symbol(P, Decl(mappedTypes1.ts, 32, 45))
+>T1 : Symbol(T1, Decl(mappedTypes1.ts, 32, 20))
 
 declare function f3<T1 extends number>(): { [P in keyof T1]: void };
->f3 : Symbol(f3, Decl(mappedTypes1.ts, 36, 68))
->T1 : Symbol(T1, Decl(mappedTypes1.ts, 37, 20))
->P : Symbol(P, Decl(mappedTypes1.ts, 37, 45))
->T1 : Symbol(T1, Decl(mappedTypes1.ts, 37, 20))
+>f3 : Symbol(f3, Decl(mappedTypes1.ts, 32, 68))
+>T1 : Symbol(T1, Decl(mappedTypes1.ts, 33, 20))
+>P : Symbol(P, Decl(mappedTypes1.ts, 33, 45))
+>T1 : Symbol(T1, Decl(mappedTypes1.ts, 33, 20))
 
 let x1 = f1();
->x1 : Symbol(x1, Decl(mappedTypes1.ts, 39, 3))
->f1 : Symbol(f1, Decl(mappedTypes1.ts, 33, 64))
+>x1 : Symbol(x1, Decl(mappedTypes1.ts, 35, 3))
+>f1 : Symbol(f1, Decl(mappedTypes1.ts, 29, 59))
 
 let x2 = f2();
->x2 : Symbol(x2, Decl(mappedTypes1.ts, 40, 3))
->f2 : Symbol(f2, Decl(mappedTypes1.ts, 35, 53))
+>x2 : Symbol(x2, Decl(mappedTypes1.ts, 36, 3))
+>f2 : Symbol(f2, Decl(mappedTypes1.ts, 31, 53))
 
 let x3 = f3();
->x3 : Symbol(x3, Decl(mappedTypes1.ts, 41, 3))
->f3 : Symbol(f3, Decl(mappedTypes1.ts, 36, 68))
+>x3 : Symbol(x3, Decl(mappedTypes1.ts, 37, 3))
+>f3 : Symbol(f3, Decl(mappedTypes1.ts, 32, 68))
 

--- a/tests/baselines/reference/mappedTypes1.types
+++ b/tests/baselines/reference/mappedTypes1.types
@@ -112,15 +112,7 @@ type T40 = { [P in string]: void };
 >T40 : T40
 >P : P
 
-type T41 = { [P in number]: void };
->T41 : T41
->P : P
-
-type T42 = { [P in string | number]: void };
->T42 : T42
->P : P
-
-type T43 = { [P in "a" | "b" | 0 | 1]: void };
+type T43 = { [P in "a" | "b"]: void };
 >T43 : T43
 >P : P
 
@@ -128,15 +120,7 @@ type T44 = { [P in "a" | "b" | "0" | "1"]: void };
 >T44 : T44
 >P : P
 
-type T45 = { [P in "a" | "b" | "0" | "1" | 0 | 1]: void };
->T45 : T45
->P : P
-
-type T46 = { [P in number | "a" | "b" | 0 | 1]: void };
->T46 : T46
->P : P
-
-type T47 = { [P in string | number | "a" | "b" | 0 | 1]: void };
+type T47 = { [P in string | "a" | "b" | "0" | "1"]: void };
 >T47 : T47
 >P : P
 
@@ -164,8 +148,8 @@ let x1 = f1();
 >f1 : <T1>() => { [P in keyof T1]: void; }
 
 let x2 = f2();
->x2 : { [x: number]: void; toString: void; charAt: void; charCodeAt: void; concat: void; indexOf: void; lastIndexOf: void; localeCompare: void; match: void; replace: void; search: void; slice: void; split: void; substring: void; toLowerCase: void; toLocaleLowerCase: void; toUpperCase: void; toLocaleUpperCase: void; trim: void; length: void; substr: void; valueOf: void; }
->f2() : { [x: number]: void; toString: void; charAt: void; charCodeAt: void; concat: void; indexOf: void; lastIndexOf: void; localeCompare: void; match: void; replace: void; search: void; slice: void; split: void; substring: void; toLowerCase: void; toLocaleLowerCase: void; toUpperCase: void; toLocaleUpperCase: void; trim: void; length: void; substr: void; valueOf: void; }
+>x2 : { toString: void; charAt: void; charCodeAt: void; concat: void; indexOf: void; lastIndexOf: void; localeCompare: void; match: void; replace: void; search: void; slice: void; split: void; substring: void; toLowerCase: void; toLocaleLowerCase: void; toUpperCase: void; toLocaleUpperCase: void; trim: void; length: void; substr: void; valueOf: void; }
+>f2() : { toString: void; charAt: void; charCodeAt: void; concat: void; indexOf: void; lastIndexOf: void; localeCompare: void; match: void; replace: void; search: void; slice: void; split: void; substring: void; toLowerCase: void; toLocaleLowerCase: void; toUpperCase: void; toLocaleUpperCase: void; trim: void; length: void; substr: void; valueOf: void; }
 >f2 : <T1 extends string>() => { [P in keyof T1]: void; }
 
 let x3 = f3();

--- a/tests/baselines/reference/mappedTypes2.js
+++ b/tests/baselines/reference/mappedTypes2.js
@@ -27,7 +27,7 @@ type DeepReadonly<T> = {
 declare function assign<T>(obj: T, props: Partial<T>): void;
 declare function freeze<T>(obj: T): Readonly<T>;
 declare function pick<T, K extends keyof T>(obj: T, ...keys: K[]): Pick<T, K>;
-declare function mapObject<K extends string | number, T, U>(obj: Record<K, T>, f: (x: T) => U): Record<K, U>;
+declare function mapObject<K extends string, T, U>(obj: Record<K, T>, f: (x: T) => U): Record<K, U>;
 declare function proxify<T>(obj: T): Proxify<T>;
 
 interface Shape {
@@ -148,7 +148,7 @@ declare type DeepReadonly<T> = {
 declare function assign<T>(obj: T, props: Partial<T>): void;
 declare function freeze<T>(obj: T): Readonly<T>;
 declare function pick<T, K extends keyof T>(obj: T, ...keys: K[]): Pick<T, K>;
-declare function mapObject<K extends string | number, T, U>(obj: Record<K, T>, f: (x: T) => U): Record<K, U>;
+declare function mapObject<K extends string, T, U>(obj: Record<K, T>, f: (x: T) => U): Record<K, U>;
 declare function proxify<T>(obj: T): Proxify<T>;
 interface Shape {
     name: string;

--- a/tests/baselines/reference/mappedTypes2.symbols
+++ b/tests/baselines/reference/mappedTypes2.symbols
@@ -126,25 +126,25 @@ declare function pick<T, K extends keyof T>(obj: T, ...keys: K[]): Pick<T, K>;
 >T : Symbol(T, Decl(mappedTypes2.ts, 27, 22))
 >K : Symbol(K, Decl(mappedTypes2.ts, 27, 24))
 
-declare function mapObject<K extends string | number, T, U>(obj: Record<K, T>, f: (x: T) => U): Record<K, U>;
+declare function mapObject<K extends string, T, U>(obj: Record<K, T>, f: (x: T) => U): Record<K, U>;
 >mapObject : Symbol(mapObject, Decl(mappedTypes2.ts, 27, 78))
 >K : Symbol(K, Decl(mappedTypes2.ts, 28, 27))
->T : Symbol(T, Decl(mappedTypes2.ts, 28, 53))
->U : Symbol(U, Decl(mappedTypes2.ts, 28, 56))
->obj : Symbol(obj, Decl(mappedTypes2.ts, 28, 60))
+>T : Symbol(T, Decl(mappedTypes2.ts, 28, 44))
+>U : Symbol(U, Decl(mappedTypes2.ts, 28, 47))
+>obj : Symbol(obj, Decl(mappedTypes2.ts, 28, 51))
 >Record : Symbol(Record, Decl(lib.d.ts, --, --))
 >K : Symbol(K, Decl(mappedTypes2.ts, 28, 27))
->T : Symbol(T, Decl(mappedTypes2.ts, 28, 53))
->f : Symbol(f, Decl(mappedTypes2.ts, 28, 78))
->x : Symbol(x, Decl(mappedTypes2.ts, 28, 83))
->T : Symbol(T, Decl(mappedTypes2.ts, 28, 53))
->U : Symbol(U, Decl(mappedTypes2.ts, 28, 56))
+>T : Symbol(T, Decl(mappedTypes2.ts, 28, 44))
+>f : Symbol(f, Decl(mappedTypes2.ts, 28, 69))
+>x : Symbol(x, Decl(mappedTypes2.ts, 28, 74))
+>T : Symbol(T, Decl(mappedTypes2.ts, 28, 44))
+>U : Symbol(U, Decl(mappedTypes2.ts, 28, 47))
 >Record : Symbol(Record, Decl(lib.d.ts, --, --))
 >K : Symbol(K, Decl(mappedTypes2.ts, 28, 27))
->U : Symbol(U, Decl(mappedTypes2.ts, 28, 56))
+>U : Symbol(U, Decl(mappedTypes2.ts, 28, 47))
 
 declare function proxify<T>(obj: T): Proxify<T>;
->proxify : Symbol(proxify, Decl(mappedTypes2.ts, 28, 109))
+>proxify : Symbol(proxify, Decl(mappedTypes2.ts, 28, 100))
 >T : Symbol(T, Decl(mappedTypes2.ts, 29, 25))
 >obj : Symbol(obj, Decl(mappedTypes2.ts, 29, 28))
 >T : Symbol(T, Decl(mappedTypes2.ts, 29, 25))
@@ -295,7 +295,7 @@ function f5(shape: Shape) {
 
     const p = proxify(shape);
 >p : Symbol(p, Decl(mappedTypes2.ts, 79, 9))
->proxify : Symbol(proxify, Decl(mappedTypes2.ts, 28, 109))
+>proxify : Symbol(proxify, Decl(mappedTypes2.ts, 28, 100))
 >shape : Symbol(shape, Decl(mappedTypes2.ts, 78, 12))
 
     let name = p.name.get();

--- a/tests/baselines/reference/mappedTypes2.types
+++ b/tests/baselines/reference/mappedTypes2.types
@@ -126,8 +126,8 @@ declare function pick<T, K extends keyof T>(obj: T, ...keys: K[]): Pick<T, K>;
 >T : T
 >K : K
 
-declare function mapObject<K extends string | number, T, U>(obj: Record<K, T>, f: (x: T) => U): Record<K, U>;
->mapObject : <K extends string | number, T, U>(obj: Record<K, T>, f: (x: T) => U) => Record<K, U>
+declare function mapObject<K extends string, T, U>(obj: Record<K, T>, f: (x: T) => U): Record<K, U>;
+>mapObject : <K extends string, T, U>(obj: Record<K, T>, f: (x: T) => U) => Record<K, U>
 >K : K
 >T : T
 >U : U
@@ -297,7 +297,7 @@ function f4() {
     const lengths = mapObject(rec, s => s.length);  // { foo: number, bar: number, baz: number }
 >lengths : Record<"foo" | "bar" | "baz", number>
 >mapObject(rec, s => s.length) : Record<"foo" | "bar" | "baz", number>
->mapObject : <K extends string | number, T, U>(obj: Record<K, T>, f: (x: T) => U) => Record<K, U>
+>mapObject : <K extends string, T, U>(obj: Record<K, T>, f: (x: T) => U) => Record<K, U>
 >rec : { foo: string; bar: string; baz: string; }
 >s => s.length : (s: string) => number
 >s : string

--- a/tests/baselines/reference/parserES5ForOfStatement19.errors.txt
+++ b/tests/baselines/reference/parserES5ForOfStatement19.errors.txt
@@ -1,7 +1,0 @@
-tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement19.ts(1,16): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
-
-
-==== tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement19.ts (1 errors) ====
-    for (var of in of) { }
-                   ~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.

--- a/tests/baselines/reference/parserES5ForOfStatement19.symbols
+++ b/tests/baselines/reference/parserES5ForOfStatement19.symbols
@@ -1,0 +1,5 @@
+=== tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement19.ts ===
+for (var of in of) { }
+>of : Symbol(of, Decl(parserES5ForOfStatement19.ts, 0, 8))
+>of : Symbol(of, Decl(parserES5ForOfStatement19.ts, 0, 8))
+

--- a/tests/baselines/reference/parserES5ForOfStatement19.types
+++ b/tests/baselines/reference/parserES5ForOfStatement19.types
@@ -1,0 +1,5 @@
+=== tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement19.ts ===
+for (var of in of) { }
+>of : any
+>of : any
+

--- a/tests/baselines/reference/parserES5ForOfStatement20.errors.txt
+++ b/tests/baselines/reference/parserES5ForOfStatement20.errors.txt
@@ -1,10 +1,7 @@
 tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement20.ts(1,10): error TS1189: The variable declaration of a 'for...in' statement cannot have an initializer.
-tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement20.ts(1,20): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 
 
-==== tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement20.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/Statements/parserES5ForOfStatement20.ts (1 errors) ====
     for (var of = 0 in of) { }
              ~~
 !!! error TS1189: The variable declaration of a 'for...in' statement cannot have an initializer.
-                       ~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.

--- a/tests/baselines/reference/parserForOfStatement19.errors.txt
+++ b/tests/baselines/reference/parserForOfStatement19.errors.txt
@@ -1,7 +1,0 @@
-tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement19.ts(1,16): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
-
-
-==== tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement19.ts (1 errors) ====
-    for (var of in of) { }
-                   ~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.

--- a/tests/baselines/reference/parserForOfStatement19.symbols
+++ b/tests/baselines/reference/parserForOfStatement19.symbols
@@ -1,0 +1,5 @@
+=== tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement19.ts ===
+for (var of in of) { }
+>of : Symbol(of, Decl(parserForOfStatement19.ts, 0, 8))
+>of : Symbol(of, Decl(parserForOfStatement19.ts, 0, 8))
+

--- a/tests/baselines/reference/parserForOfStatement19.types
+++ b/tests/baselines/reference/parserForOfStatement19.types
@@ -1,0 +1,5 @@
+=== tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement19.ts ===
+for (var of in of) { }
+>of : any
+>of : any
+

--- a/tests/baselines/reference/parserForOfStatement20.errors.txt
+++ b/tests/baselines/reference/parserForOfStatement20.errors.txt
@@ -1,10 +1,7 @@
 tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement20.ts(1,10): error TS1189: The variable declaration of a 'for...in' statement cannot have an initializer.
-tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement20.ts(1,20): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 
 
-==== tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement20.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript6/Iterators/parserForOfStatement20.ts (1 errors) ====
     for (var of = 0 in of) { }
              ~~
 !!! error TS1189: The variable declaration of a 'for...in' statement cannot have an initializer.
-                       ~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.

--- a/tests/baselines/reference/recursiveLetConst.errors.txt
+++ b/tests/baselines/reference/recursiveLetConst.errors.txt
@@ -5,14 +5,13 @@ tests/cases/compiler/recursiveLetConst.ts(5,14): error TS2448: Block-scoped vari
 tests/cases/compiler/recursiveLetConst.ts(6,14): error TS2448: Block-scoped variable 'v' used before its declaration.
 tests/cases/compiler/recursiveLetConst.ts(7,1): error TS7027: Unreachable code detected.
 tests/cases/compiler/recursiveLetConst.ts(7,16): error TS2448: Block-scoped variable 'v' used before its declaration.
-tests/cases/compiler/recursiveLetConst.ts(8,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
 tests/cases/compiler/recursiveLetConst.ts(8,15): error TS2448: Block-scoped variable 'v' used before its declaration.
 tests/cases/compiler/recursiveLetConst.ts(9,15): error TS2448: Block-scoped variable 'v' used before its declaration.
 tests/cases/compiler/recursiveLetConst.ts(10,17): error TS2448: Block-scoped variable 'v' used before its declaration.
 tests/cases/compiler/recursiveLetConst.ts(11,11): error TS2448: Block-scoped variable 'x2' used before its declaration.
 
 
-==== tests/cases/compiler/recursiveLetConst.ts (12 errors) ====
+==== tests/cases/compiler/recursiveLetConst.ts (11 errors) ====
     'use strict'
     let x = x + 1;
             ~
@@ -35,8 +34,6 @@ tests/cases/compiler/recursiveLetConst.ts(11,11): error TS2448: Block-scoped var
                    ~
 !!! error TS2448: Block-scoped variable 'v' used before its declaration.
     for (let v in v) { }
-                  ~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
                   ~
 !!! error TS2448: Block-scoped variable 'v' used before its declaration.
     for (let v of v) { }

--- a/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
+++ b/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
@@ -95,22 +95,18 @@ function f10(shape: Shape) {
 
 function f11(a: Shape[]) {
     let len = getProperty(a, "length");  // number
-    let shape = getProperty(a, 1000);    // Shape
-    setProperty(a, 1000, getProperty(a, 1001));
+    setProperty(a, "length", len);
 }
 
 function f12(t: [Shape, boolean]) {
     let len = getProperty(t, "length");
-    let s1 = getProperty(t, 0);    // Shape
     let s2 = getProperty(t, "0");  // Shape
-    let b1 = getProperty(t, 1);    // boolean
     let b2 = getProperty(t, "1");  // boolean
-    let x1 = getProperty(t, 2);    // Shape | boolean
 }
 
 function f13(foo: any, bar: any) {
     let x = getProperty(foo, "x");  // any
-    let y = getProperty(foo, 100);  // any
+    let y = getProperty(foo, "100");  // any
     let z = getProperty(foo, bar);  // any
 }
 
@@ -181,20 +177,14 @@ function f40(c: C) {
     let z: Z = c["z"];
 }
 
-function f50<T>(k: keyof T, s: string, n: number) {
+function f50<T>(k: keyof T, s: string) {
     const x1 = s as keyof T;
-    const x2 = n as keyof T;
-    const x3 = k as string;
-    const x4 = k as number;
-    const x5 = k as string | number;
+    const x2 = k as string;
 }
 
-function f51<T, K extends keyof T>(k: K, s: string, n: number) {
+function f51<T, K extends keyof T>(k: K, s: string) {
     const x1 = s as keyof T;
-    const x2 = n as keyof T;
-    const x3 = k as string;
-    const x4 = k as number;
-    const x5 = k as string | number;
+    const x2 = k as string;
 }
 
 function f52<T>(obj: { [x: string]: boolean }, k: keyof T, s: string, n: number) {

--- a/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
+++ b/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
@@ -211,6 +211,12 @@ function f55<T, K extends keyof T>(obj: T, key: K) {
     const b = "foo" in obj[key];
 }
 
+function f60<T>(source: T, target: T) {
+    for (let k in source) {
+        target[k] = source[k];
+    }
+}
+
 // Repros from #12011
 
 class Base {

--- a/tests/cases/conformance/types/mapped/mappedTypeErrors.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypeErrors.ts
@@ -20,8 +20,9 @@ interface Point {
 // Constraint checking
 
 type T00 = { [P in P]: string };  // Error
-type T01 = { [P in Date]: number };  // Error
-type T02 = Record<Date, number>;  // Error
+type T01 = { [P in number]: string };  // Error
+type T02 = { [P in Date]: number };  // Error
+type T03 = Record<Date, number>;  // Error
 
 type T10 = Pick<Shape, "name">;
 type T11 = Pick<Shape, "foo">;  // Error

--- a/tests/cases/conformance/types/mapped/mappedTypes1.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypes1.ts
@@ -27,13 +27,9 @@ type T37 = { [P in keyof symbol]: void };
 type T38 = { [P in keyof never]: void };
 
 type T40 = { [P in string]: void };
-type T41 = { [P in number]: void };
-type T42 = { [P in string | number]: void };
-type T43 = { [P in "a" | "b" | 0 | 1]: void };
+type T43 = { [P in "a" | "b"]: void };
 type T44 = { [P in "a" | "b" | "0" | "1"]: void };
-type T45 = { [P in "a" | "b" | "0" | "1" | 0 | 1]: void };
-type T46 = { [P in number | "a" | "b" | 0 | 1]: void };
-type T47 = { [P in string | number | "a" | "b" | 0 | 1]: void };
+type T47 = { [P in string | "a" | "b" | "0" | "1"]: void };
 
 declare function f1<T1>(): { [P in keyof T1]: void };
 declare function f2<T1 extends string>(): { [P in keyof T1]: void };

--- a/tests/cases/conformance/types/mapped/mappedTypes2.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypes2.ts
@@ -28,7 +28,7 @@ type DeepReadonly<T> = {
 declare function assign<T>(obj: T, props: Partial<T>): void;
 declare function freeze<T>(obj: T): Readonly<T>;
 declare function pick<T, K extends keyof T>(obj: T, ...keys: K[]): Pick<T, K>;
-declare function mapObject<K extends string | number, T, U>(obj: Record<K, T>, f: (x: T) => U): Record<K, U>;
+declare function mapObject<K extends string, T, U>(obj: Record<K, T>, f: (x: T) => U): Record<K, U>;
 declare function proxify<T>(obj: T): Proxify<T>;
 
 interface Shape {


### PR DESCRIPTION
This PR revises `keyof T` to always be a subtype of `string` vs. a subtype of `string | number`. This more accurately reflects how properties work in JavaScript and allows us to use `keyof T` as the inferred type of a `for...in` variable when the object is of a type parameter type.

This change means that numeric index signatures are ignored by the `keyof T` operator and that it is never possible to use numbers as values for a `keyof T`.

Fixes #12314.