### PR TITLE
Isomorphic mapped types and unions

### DIFF
--- a/tests/baselines/reference/mappedTypes1.js
+++ b/tests/baselines/reference/mappedTypes1.js
@@ -33,15 +33,18 @@ type T47 = { [P in string | "a" | "b" | "0" | "1"]: void };
 declare function f1<T1>(): { [P in keyof T1]: void };
 declare function f2<T1 extends string>(): { [P in keyof T1]: void };
 declare function f3<T1 extends number>(): { [P in keyof T1]: void };
+declare function f4<T1 extends Number>(): { [P in keyof T1]: void };
 
 let x1 = f1();
 let x2 = f2();
 let x3 = f3();
+let x4 = f4();
 
 //// [mappedTypes1.js]
 var x1 = f1();
 var x2 = f2();
 var x3 = f3();
+var x4 = f4();
 
 
 //// [mappedTypes1.d.ts]
@@ -128,31 +131,13 @@ declare function f2<T1 extends string>(): {
 declare function f3<T1 extends number>(): {
     [P in keyof T1]: void;
 };
-declare let x1: {};
-declare let x2: {
-    toString: void;
-    charAt: void;
-    charCodeAt: void;
-    concat: void;
-    indexOf: void;
-    lastIndexOf: void;
-    localeCompare: void;
-    match: void;
-    replace: void;
-    search: void;
-    slice: void;
-    split: void;
-    substring: void;
-    toLowerCase: void;
-    toLocaleLowerCase: void;
-    toUpperCase: void;
-    toLocaleUpperCase: void;
-    trim: void;
-    length: void;
-    substr: void;
-    valueOf: void;
+declare function f4<T1 extends Number>(): {
+    [P in keyof T1]: void;
 };
-declare let x3: {
+declare let x1: {};
+declare let x2: string;
+declare let x3: number;
+declare let x4: {
     toString: void;
     valueOf: void;
     toFixed: void;

--- a/tests/baselines/reference/mappedTypes1.symbols
+++ b/tests/baselines/reference/mappedTypes1.symbols
@@ -140,15 +140,26 @@ declare function f3<T1 extends number>(): { [P in keyof T1]: void };
 >P : Symbol(P, Decl(mappedTypes1.ts, 33, 45))
 >T1 : Symbol(T1, Decl(mappedTypes1.ts, 33, 20))
 
+declare function f4<T1 extends Number>(): { [P in keyof T1]: void };
+>f4 : Symbol(f4, Decl(mappedTypes1.ts, 33, 68))
+>T1 : Symbol(T1, Decl(mappedTypes1.ts, 34, 20))
+>Number : Symbol(Number, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>P : Symbol(P, Decl(mappedTypes1.ts, 34, 45))
+>T1 : Symbol(T1, Decl(mappedTypes1.ts, 34, 20))
+
 let x1 = f1();
->x1 : Symbol(x1, Decl(mappedTypes1.ts, 35, 3))
+>x1 : Symbol(x1, Decl(mappedTypes1.ts, 36, 3))
 >f1 : Symbol(f1, Decl(mappedTypes1.ts, 29, 59))
 
 let x2 = f2();
->x2 : Symbol(x2, Decl(mappedTypes1.ts, 36, 3))
+>x2 : Symbol(x2, Decl(mappedTypes1.ts, 37, 3))
 >f2 : Symbol(f2, Decl(mappedTypes1.ts, 31, 53))
 
 let x3 = f3();
->x3 : Symbol(x3, Decl(mappedTypes1.ts, 37, 3))
+>x3 : Symbol(x3, Decl(mappedTypes1.ts, 38, 3))
 >f3 : Symbol(f3, Decl(mappedTypes1.ts, 32, 68))
+
+let x4 = f4();
+>x4 : Symbol(x4, Decl(mappedTypes1.ts, 39, 3))
+>f4 : Symbol(f4, Decl(mappedTypes1.ts, 33, 68))
 

--- a/tests/baselines/reference/mappedTypes1.types
+++ b/tests/baselines/reference/mappedTypes1.types
@@ -142,18 +142,30 @@ declare function f3<T1 extends number>(): { [P in keyof T1]: void };
 >P : P
 >T1 : T1
 
+declare function f4<T1 extends Number>(): { [P in keyof T1]: void };
+>f4 : <T1 extends Number>() => { [P in keyof T1]: void; }
+>T1 : T1
+>Number : Number
+>P : P
+>T1 : T1
+
 let x1 = f1();
 >x1 : {}
 >f1() : {}
 >f1 : <T1>() => { [P in keyof T1]: void; }
 
 let x2 = f2();
->x2 : { toString: void; charAt: void; charCodeAt: void; concat: void; indexOf: void; lastIndexOf: void; localeCompare: void; match: void; replace: void; search: void; slice: void; split: void; substring: void; toLowerCase: void; toLocaleLowerCase: void; toUpperCase: void; toLocaleUpperCase: void; trim: void; length: void; substr: void; valueOf: void; }
->f2() : { toString: void; charAt: void; charCodeAt: void; concat: void; indexOf: void; lastIndexOf: void; localeCompare: void; match: void; replace: void; search: void; slice: void; split: void; substring: void; toLowerCase: void; toLocaleLowerCase: void; toUpperCase: void; toLocaleUpperCase: void; trim: void; length: void; substr: void; valueOf: void; }
+>x2 : string
+>f2() : string
 >f2 : <T1 extends string>() => { [P in keyof T1]: void; }
 
 let x3 = f3();
->x3 : { toString: void; valueOf: void; toFixed: void; toExponential: void; toPrecision: void; toLocaleString: void; }
->f3() : { toString: void; valueOf: void; toFixed: void; toExponential: void; toPrecision: void; toLocaleString: void; }
+>x3 : number
+>f3() : number
 >f3 : <T1 extends number>() => { [P in keyof T1]: void; }
+
+let x4 = f4();
+>x4 : { toString: void; valueOf: void; toFixed: void; toExponential: void; toPrecision: void; toLocaleString: void; }
+>f4() : { toString: void; valueOf: void; toFixed: void; toExponential: void; toPrecision: void; toLocaleString: void; }
+>f4 : <T1 extends Number>() => { [P in keyof T1]: void; }
 

--- a/tests/baselines/reference/mappedTypes2.js
+++ b/tests/baselines/reference/mappedTypes2.js
@@ -30,25 +30,30 @@ declare function pick<T, K extends keyof T>(obj: T, ...keys: K[]): Pick<T, K>;
 declare function mapObject<K extends string, T, U>(obj: Record<K, T>, f: (x: T) => U): Record<K, U>;
 declare function proxify<T>(obj: T): Proxify<T>;
 
+interface Point {
+    x: number;
+    y: number;
+}
+
 interface Shape {
     name: string;
     width: number;
     height: number;
-    visible: boolean;
+    location: Point;
 }
 
 interface PartialShape {
     name?: string;
     width?: number;
     height?: number;
-    visible?: boolean;
+    location?: Point;
 }
 
 interface ReadonlyShape {
     readonly name: string;
     readonly width: number;
     readonly height: number;
-    readonly visible: boolean;
+    readonly location: Point;
 }
 
 function f0(s1: Shape, s2: Shape) {
@@ -69,7 +74,7 @@ function f2(shape: Shape) {
 }
 
 function f3(shape: Shape) {
-    const x = pick(shape, "name", "visible");  // { name: string, visible: boolean }
+    const x = pick(shape, "name", "location");  // { name: string, location: Point }
 }
 
 function f4() {
@@ -80,13 +85,13 @@ function f4() {
 function f5(shape: Shape) {
     const p = proxify(shape);
     let name = p.name.get();
-    p.visible.set(false);
+    p.width.set(42);
 }
 
 function f6(shape: DeepReadonly<Shape>) {
-    let name = shape.name;  // DeepReadonly<string>
-    let length = name.length;  // DeepReadonly<number>
-    let toString = length.toString;  // DeepReadonly<(radix?: number) => string>
+    let name = shape.name;  // string
+    let location = shape.location;  // DeepReadonly<Point>
+    let x = location.x;  // number
 }
 
 //// [mappedTypes2.js]
@@ -115,7 +120,7 @@ function f2(shape) {
     var partial = {};
 }
 function f3(shape) {
-    var x = pick(shape, "name", "visible"); // { name: string, visible: boolean }
+    var x = pick(shape, "name", "location"); // { name: string, location: Point }
 }
 function f4() {
     var rec = { foo: "hello", bar: "world", baz: "bye" };
@@ -124,12 +129,12 @@ function f4() {
 function f5(shape) {
     var p = proxify(shape);
     var name = p.name.get();
-    p.visible.set(false);
+    p.width.set(42);
 }
 function f6(shape) {
-    var name = shape.name; // DeepReadonly<string>
-    var length = name.length; // DeepReadonly<number>
-    var toString = length.toString; // DeepReadonly<(radix?: number) => string>
+    var name = shape.name; // string
+    var location = shape.location; // DeepReadonly<Point>
+    var x = location.x; // number
 }
 
 
@@ -150,23 +155,27 @@ declare function freeze<T>(obj: T): Readonly<T>;
 declare function pick<T, K extends keyof T>(obj: T, ...keys: K[]): Pick<T, K>;
 declare function mapObject<K extends string, T, U>(obj: Record<K, T>, f: (x: T) => U): Record<K, U>;
 declare function proxify<T>(obj: T): Proxify<T>;
+interface Point {
+    x: number;
+    y: number;
+}
 interface Shape {
     name: string;
     width: number;
     height: number;
-    visible: boolean;
+    location: Point;
 }
 interface PartialShape {
     name?: string;
     width?: number;
     height?: number;
-    visible?: boolean;
+    location?: Point;
 }
 interface ReadonlyShape {
     readonly name: string;
     readonly width: number;
     readonly height: number;
-    readonly visible: boolean;
+    readonly location: Point;
 }
 declare function f0(s1: Shape, s2: Shape): void;
 declare function f1(shape: Shape): void;

--- a/tests/baselines/reference/mappedTypes2.symbols
+++ b/tests/baselines/reference/mappedTypes2.symbols
@@ -151,190 +151,203 @@ declare function proxify<T>(obj: T): Proxify<T>;
 >Proxify : Symbol(Proxify, Decl(mappedTypes2.ts, 15, 1))
 >T : Symbol(T, Decl(mappedTypes2.ts, 29, 25))
 
+interface Point {
+>Point : Symbol(Point, Decl(mappedTypes2.ts, 29, 48))
+
+    x: number;
+>x : Symbol(Point.x, Decl(mappedTypes2.ts, 31, 17))
+
+    y: number;
+>y : Symbol(Point.y, Decl(mappedTypes2.ts, 32, 14))
+}
+
 interface Shape {
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 1))
 
     name: string;
->name : Symbol(Shape.name, Decl(mappedTypes2.ts, 31, 17))
+>name : Symbol(Shape.name, Decl(mappedTypes2.ts, 36, 17))
 
     width: number;
->width : Symbol(Shape.width, Decl(mappedTypes2.ts, 32, 17))
+>width : Symbol(Shape.width, Decl(mappedTypes2.ts, 37, 17))
 
     height: number;
->height : Symbol(Shape.height, Decl(mappedTypes2.ts, 33, 18))
+>height : Symbol(Shape.height, Decl(mappedTypes2.ts, 38, 18))
 
-    visible: boolean;
->visible : Symbol(Shape.visible, Decl(mappedTypes2.ts, 34, 19))
+    location: Point;
+>location : Symbol(Shape.location, Decl(mappedTypes2.ts, 39, 19))
+>Point : Symbol(Point, Decl(mappedTypes2.ts, 29, 48))
 }
 
 interface PartialShape {
->PartialShape : Symbol(PartialShape, Decl(mappedTypes2.ts, 36, 1))
+>PartialShape : Symbol(PartialShape, Decl(mappedTypes2.ts, 41, 1))
 
     name?: string;
->name : Symbol(PartialShape.name, Decl(mappedTypes2.ts, 38, 24))
+>name : Symbol(PartialShape.name, Decl(mappedTypes2.ts, 43, 24))
 
     width?: number;
->width : Symbol(PartialShape.width, Decl(mappedTypes2.ts, 39, 18))
+>width : Symbol(PartialShape.width, Decl(mappedTypes2.ts, 44, 18))
 
     height?: number;
->height : Symbol(PartialShape.height, Decl(mappedTypes2.ts, 40, 19))
+>height : Symbol(PartialShape.height, Decl(mappedTypes2.ts, 45, 19))
 
-    visible?: boolean;
->visible : Symbol(PartialShape.visible, Decl(mappedTypes2.ts, 41, 20))
+    location?: Point;
+>location : Symbol(PartialShape.location, Decl(mappedTypes2.ts, 46, 20))
+>Point : Symbol(Point, Decl(mappedTypes2.ts, 29, 48))
 }
 
 interface ReadonlyShape {
->ReadonlyShape : Symbol(ReadonlyShape, Decl(mappedTypes2.ts, 43, 1))
+>ReadonlyShape : Symbol(ReadonlyShape, Decl(mappedTypes2.ts, 48, 1))
 
     readonly name: string;
->name : Symbol(ReadonlyShape.name, Decl(mappedTypes2.ts, 45, 25))
+>name : Symbol(ReadonlyShape.name, Decl(mappedTypes2.ts, 50, 25))
 
     readonly width: number;
->width : Symbol(ReadonlyShape.width, Decl(mappedTypes2.ts, 46, 26))
+>width : Symbol(ReadonlyShape.width, Decl(mappedTypes2.ts, 51, 26))
 
     readonly height: number;
->height : Symbol(ReadonlyShape.height, Decl(mappedTypes2.ts, 47, 27))
+>height : Symbol(ReadonlyShape.height, Decl(mappedTypes2.ts, 52, 27))
 
-    readonly visible: boolean;
->visible : Symbol(ReadonlyShape.visible, Decl(mappedTypes2.ts, 48, 28))
+    readonly location: Point;
+>location : Symbol(ReadonlyShape.location, Decl(mappedTypes2.ts, 53, 28))
+>Point : Symbol(Point, Decl(mappedTypes2.ts, 29, 48))
 }
 
 function f0(s1: Shape, s2: Shape) {
->f0 : Symbol(f0, Decl(mappedTypes2.ts, 50, 1))
->s1 : Symbol(s1, Decl(mappedTypes2.ts, 52, 12))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
->s2 : Symbol(s2, Decl(mappedTypes2.ts, 52, 22))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
+>f0 : Symbol(f0, Decl(mappedTypes2.ts, 55, 1))
+>s1 : Symbol(s1, Decl(mappedTypes2.ts, 57, 12))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 1))
+>s2 : Symbol(s2, Decl(mappedTypes2.ts, 57, 22))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 1))
 
     assign(s1, { name: "circle" });
 >assign : Symbol(assign, Decl(mappedTypes2.ts, 23, 2))
->s1 : Symbol(s1, Decl(mappedTypes2.ts, 52, 12))
->name : Symbol(name, Decl(mappedTypes2.ts, 53, 16))
+>s1 : Symbol(s1, Decl(mappedTypes2.ts, 57, 12))
+>name : Symbol(name, Decl(mappedTypes2.ts, 58, 16))
 
     assign(s2, { width: 10, height: 20 });
 >assign : Symbol(assign, Decl(mappedTypes2.ts, 23, 2))
->s2 : Symbol(s2, Decl(mappedTypes2.ts, 52, 22))
->width : Symbol(width, Decl(mappedTypes2.ts, 54, 16))
->height : Symbol(height, Decl(mappedTypes2.ts, 54, 27))
+>s2 : Symbol(s2, Decl(mappedTypes2.ts, 57, 22))
+>width : Symbol(width, Decl(mappedTypes2.ts, 59, 16))
+>height : Symbol(height, Decl(mappedTypes2.ts, 59, 27))
 }
 
 function f1(shape: Shape) {
->f1 : Symbol(f1, Decl(mappedTypes2.ts, 55, 1))
->shape : Symbol(shape, Decl(mappedTypes2.ts, 57, 12))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
+>f1 : Symbol(f1, Decl(mappedTypes2.ts, 60, 1))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 62, 12))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 1))
 
     var frozen: ReadonlyShape;
->frozen : Symbol(frozen, Decl(mappedTypes2.ts, 58, 7), Decl(mappedTypes2.ts, 59, 7), Decl(mappedTypes2.ts, 60, 7))
->ReadonlyShape : Symbol(ReadonlyShape, Decl(mappedTypes2.ts, 43, 1))
+>frozen : Symbol(frozen, Decl(mappedTypes2.ts, 63, 7), Decl(mappedTypes2.ts, 64, 7), Decl(mappedTypes2.ts, 65, 7))
+>ReadonlyShape : Symbol(ReadonlyShape, Decl(mappedTypes2.ts, 48, 1))
 
     var frozen: Readonly<Shape>;
->frozen : Symbol(frozen, Decl(mappedTypes2.ts, 58, 7), Decl(mappedTypes2.ts, 59, 7), Decl(mappedTypes2.ts, 60, 7))
+>frozen : Symbol(frozen, Decl(mappedTypes2.ts, 63, 7), Decl(mappedTypes2.ts, 64, 7), Decl(mappedTypes2.ts, 65, 7))
 >Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 1))
 
     var frozen = freeze(shape);
->frozen : Symbol(frozen, Decl(mappedTypes2.ts, 58, 7), Decl(mappedTypes2.ts, 59, 7), Decl(mappedTypes2.ts, 60, 7))
+>frozen : Symbol(frozen, Decl(mappedTypes2.ts, 63, 7), Decl(mappedTypes2.ts, 64, 7), Decl(mappedTypes2.ts, 65, 7))
 >freeze : Symbol(freeze, Decl(mappedTypes2.ts, 25, 60))
->shape : Symbol(shape, Decl(mappedTypes2.ts, 57, 12))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 62, 12))
 }
 
 function f2(shape: Shape) {
->f2 : Symbol(f2, Decl(mappedTypes2.ts, 61, 1))
->shape : Symbol(shape, Decl(mappedTypes2.ts, 63, 12))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
+>f2 : Symbol(f2, Decl(mappedTypes2.ts, 66, 1))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 68, 12))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 1))
 
     var partial: PartialShape;
->partial : Symbol(partial, Decl(mappedTypes2.ts, 64, 7), Decl(mappedTypes2.ts, 65, 7), Decl(mappedTypes2.ts, 66, 7))
->PartialShape : Symbol(PartialShape, Decl(mappedTypes2.ts, 36, 1))
+>partial : Symbol(partial, Decl(mappedTypes2.ts, 69, 7), Decl(mappedTypes2.ts, 70, 7), Decl(mappedTypes2.ts, 71, 7))
+>PartialShape : Symbol(PartialShape, Decl(mappedTypes2.ts, 41, 1))
 
     var partial: Partial<Shape>;
->partial : Symbol(partial, Decl(mappedTypes2.ts, 64, 7), Decl(mappedTypes2.ts, 65, 7), Decl(mappedTypes2.ts, 66, 7))
+>partial : Symbol(partial, Decl(mappedTypes2.ts, 69, 7), Decl(mappedTypes2.ts, 70, 7), Decl(mappedTypes2.ts, 71, 7))
 >Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 1))
 
     var partial: Partial<Shape> = {};
->partial : Symbol(partial, Decl(mappedTypes2.ts, 64, 7), Decl(mappedTypes2.ts, 65, 7), Decl(mappedTypes2.ts, 66, 7))
+>partial : Symbol(partial, Decl(mappedTypes2.ts, 69, 7), Decl(mappedTypes2.ts, 70, 7), Decl(mappedTypes2.ts, 71, 7))
 >Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 1))
 }
 
 function f3(shape: Shape) {
->f3 : Symbol(f3, Decl(mappedTypes2.ts, 67, 1))
->shape : Symbol(shape, Decl(mappedTypes2.ts, 69, 12))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
+>f3 : Symbol(f3, Decl(mappedTypes2.ts, 72, 1))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 74, 12))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 1))
 
-    const x = pick(shape, "name", "visible");  // { name: string, visible: boolean }
->x : Symbol(x, Decl(mappedTypes2.ts, 70, 9))
+    const x = pick(shape, "name", "location");  // { name: string, location: Point }
+>x : Symbol(x, Decl(mappedTypes2.ts, 75, 9))
 >pick : Symbol(pick, Decl(mappedTypes2.ts, 26, 48))
->shape : Symbol(shape, Decl(mappedTypes2.ts, 69, 12))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 74, 12))
 }
 
 function f4() {
->f4 : Symbol(f4, Decl(mappedTypes2.ts, 71, 1))
+>f4 : Symbol(f4, Decl(mappedTypes2.ts, 76, 1))
 
     const rec = { foo: "hello", bar: "world", baz: "bye" };
->rec : Symbol(rec, Decl(mappedTypes2.ts, 74, 9))
->foo : Symbol(foo, Decl(mappedTypes2.ts, 74, 17))
->bar : Symbol(bar, Decl(mappedTypes2.ts, 74, 31))
->baz : Symbol(baz, Decl(mappedTypes2.ts, 74, 45))
+>rec : Symbol(rec, Decl(mappedTypes2.ts, 79, 9))
+>foo : Symbol(foo, Decl(mappedTypes2.ts, 79, 17))
+>bar : Symbol(bar, Decl(mappedTypes2.ts, 79, 31))
+>baz : Symbol(baz, Decl(mappedTypes2.ts, 79, 45))
 
     const lengths = mapObject(rec, s => s.length);  // { foo: number, bar: number, baz: number }
->lengths : Symbol(lengths, Decl(mappedTypes2.ts, 75, 9))
+>lengths : Symbol(lengths, Decl(mappedTypes2.ts, 80, 9))
 >mapObject : Symbol(mapObject, Decl(mappedTypes2.ts, 27, 78))
->rec : Symbol(rec, Decl(mappedTypes2.ts, 74, 9))
->s : Symbol(s, Decl(mappedTypes2.ts, 75, 34))
+>rec : Symbol(rec, Decl(mappedTypes2.ts, 79, 9))
+>s : Symbol(s, Decl(mappedTypes2.ts, 80, 34))
 >s.length : Symbol(String.length, Decl(lib.d.ts, --, --))
->s : Symbol(s, Decl(mappedTypes2.ts, 75, 34))
+>s : Symbol(s, Decl(mappedTypes2.ts, 80, 34))
 >length : Symbol(String.length, Decl(lib.d.ts, --, --))
 }
 
 function f5(shape: Shape) {
->f5 : Symbol(f5, Decl(mappedTypes2.ts, 76, 1))
->shape : Symbol(shape, Decl(mappedTypes2.ts, 78, 12))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
+>f5 : Symbol(f5, Decl(mappedTypes2.ts, 81, 1))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 83, 12))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 1))
 
     const p = proxify(shape);
->p : Symbol(p, Decl(mappedTypes2.ts, 79, 9))
+>p : Symbol(p, Decl(mappedTypes2.ts, 84, 9))
 >proxify : Symbol(proxify, Decl(mappedTypes2.ts, 28, 100))
->shape : Symbol(shape, Decl(mappedTypes2.ts, 78, 12))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 83, 12))
 
     let name = p.name.get();
->name : Symbol(name, Decl(mappedTypes2.ts, 80, 7))
+>name : Symbol(name, Decl(mappedTypes2.ts, 85, 7))
 >p.name.get : Symbol(get, Decl(mappedTypes2.ts, 12, 17))
 >p.name : Symbol(name)
->p : Symbol(p, Decl(mappedTypes2.ts, 79, 9))
+>p : Symbol(p, Decl(mappedTypes2.ts, 84, 9))
 >name : Symbol(name)
 >get : Symbol(get, Decl(mappedTypes2.ts, 12, 17))
 
-    p.visible.set(false);
->p.visible.set : Symbol(set, Decl(mappedTypes2.ts, 13, 13))
->p.visible : Symbol(visible)
->p : Symbol(p, Decl(mappedTypes2.ts, 79, 9))
->visible : Symbol(visible)
+    p.width.set(42);
+>p.width.set : Symbol(set, Decl(mappedTypes2.ts, 13, 13))
+>p.width : Symbol(width)
+>p : Symbol(p, Decl(mappedTypes2.ts, 84, 9))
+>width : Symbol(width)
 >set : Symbol(set, Decl(mappedTypes2.ts, 13, 13))
 }
 
 function f6(shape: DeepReadonly<Shape>) {
->f6 : Symbol(f6, Decl(mappedTypes2.ts, 82, 1))
->shape : Symbol(shape, Decl(mappedTypes2.ts, 84, 12))
+>f6 : Symbol(f6, Decl(mappedTypes2.ts, 87, 1))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 89, 12))
 >DeepReadonly : Symbol(DeepReadonly, Decl(mappedTypes2.ts, 19, 1))
->Shape : Symbol(Shape, Decl(mappedTypes2.ts, 29, 48))
+>Shape : Symbol(Shape, Decl(mappedTypes2.ts, 34, 1))
 
-    let name = shape.name;  // DeepReadonly<string>
->name : Symbol(name, Decl(mappedTypes2.ts, 85, 7))
+    let name = shape.name;  // string
+>name : Symbol(name, Decl(mappedTypes2.ts, 90, 7))
 >shape.name : Symbol(name)
->shape : Symbol(shape, Decl(mappedTypes2.ts, 84, 12))
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 89, 12))
 >name : Symbol(name)
 
-    let length = name.length;  // DeepReadonly<number>
->length : Symbol(length, Decl(mappedTypes2.ts, 86, 7))
->name.length : Symbol(length)
->name : Symbol(name, Decl(mappedTypes2.ts, 85, 7))
->length : Symbol(length)
+    let location = shape.location;  // DeepReadonly<Point>
+>location : Symbol(location, Decl(mappedTypes2.ts, 91, 7))
+>shape.location : Symbol(location)
+>shape : Symbol(shape, Decl(mappedTypes2.ts, 89, 12))
+>location : Symbol(location)
 
-    let toString = length.toString;  // DeepReadonly<(radix?: number) => string>
->toString : Symbol(toString, Decl(mappedTypes2.ts, 87, 7))
->length.toString : Symbol(toString)
->length : Symbol(length, Decl(mappedTypes2.ts, 86, 7))
->toString : Symbol(toString)
+    let x = location.x;  // number
+>x : Symbol(x, Decl(mappedTypes2.ts, 92, 7))
+>location.x : Symbol(x)
+>location : Symbol(location, Decl(mappedTypes2.ts, 91, 7))
+>x : Symbol(x)
 }

--- a/tests/baselines/reference/mappedTypes2.types
+++ b/tests/baselines/reference/mappedTypes2.types
@@ -151,6 +151,16 @@ declare function proxify<T>(obj: T): Proxify<T>;
 >Proxify : Proxify<T>
 >T : T
 
+interface Point {
+>Point : Point
+
+    x: number;
+>x : number
+
+    y: number;
+>y : number
+}
+
 interface Shape {
 >Shape : Shape
 
@@ -163,8 +173,9 @@ interface Shape {
     height: number;
 >height : number
 
-    visible: boolean;
->visible : boolean
+    location: Point;
+>location : Point
+>Point : Point
 }
 
 interface PartialShape {
@@ -179,8 +190,9 @@ interface PartialShape {
     height?: number;
 >height : number | undefined
 
-    visible?: boolean;
->visible : boolean | undefined
+    location?: Point;
+>location : Point | undefined
+>Point : Point
 }
 
 interface ReadonlyShape {
@@ -195,8 +207,9 @@ interface ReadonlyShape {
     readonly height: number;
 >height : number
 
-    readonly visible: boolean;
->visible : boolean
+    readonly location: Point;
+>location : Point
+>Point : Point
 }
 
 function f0(s1: Shape, s2: Shape) {
@@ -272,13 +285,13 @@ function f3(shape: Shape) {
 >shape : Shape
 >Shape : Shape
 
-    const x = pick(shape, "name", "visible");  // { name: string, visible: boolean }
->x : Pick<Shape, "name" | "visible">
->pick(shape, "name", "visible") : Pick<Shape, "name" | "visible">
+    const x = pick(shape, "name", "location");  // { name: string, location: Point }
+>x : Pick<Shape, "name" | "location">
+>pick(shape, "name", "location") : Pick<Shape, "name" | "location">
 >pick : <T, K extends keyof T>(obj: T, ...keys: K[]) => Pick<T, K>
 >shape : Shape
 >"name" : "name"
->"visible" : "visible"
+>"location" : "location"
 }
 
 function f4() {
@@ -326,14 +339,14 @@ function f5(shape: Shape) {
 >name : Proxy<string>
 >get : () => string
 
-    p.visible.set(false);
->p.visible.set(false) : void
->p.visible.set : (value: boolean) => void
->p.visible : Proxy<boolean>
+    p.width.set(42);
+>p.width.set(42) : void
+>p.width.set : (value: number) => void
+>p.width : Proxy<number>
 >p : Proxify<Shape>
->visible : Proxy<boolean>
->set : (value: boolean) => void
->false : false
+>width : Proxy<number>
+>set : (value: number) => void
+>42 : 42
 }
 
 function f6(shape: DeepReadonly<Shape>) {
@@ -342,21 +355,21 @@ function f6(shape: DeepReadonly<Shape>) {
 >DeepReadonly : DeepReadonly<T>
 >Shape : Shape
 
-    let name = shape.name;  // DeepReadonly<string>
->name : DeepReadonly<string>
->shape.name : DeepReadonly<string>
+    let name = shape.name;  // string
+>name : string
+>shape.name : string
 >shape : DeepReadonly<Shape>
->name : DeepReadonly<string>
+>name : string
 
-    let length = name.length;  // DeepReadonly<number>
->length : DeepReadonly<number>
->name.length : DeepReadonly<number>
->name : DeepReadonly<string>
->length : DeepReadonly<number>
+    let location = shape.location;  // DeepReadonly<Point>
+>location : DeepReadonly<Point>
+>shape.location : DeepReadonly<Point>
+>shape : DeepReadonly<Shape>
+>location : DeepReadonly<Point>
 
-    let toString = length.toString;  // DeepReadonly<(radix?: number) => string>
->toString : DeepReadonly<(radix?: number | undefined) => string>
->length.toString : DeepReadonly<(radix?: number | undefined) => string>
->length : DeepReadonly<number>
->toString : DeepReadonly<(radix?: number | undefined) => string>
+    let x = location.x;  // number
+>x : number
+>location.x : number
+>location : DeepReadonly<Point>
+>x : number
 }

--- a/tests/baselines/reference/mappedTypes4.js
+++ b/tests/baselines/reference/mappedTypes4.js
@@ -1,0 +1,129 @@
+//// [mappedTypes4.ts]
+
+type Box<T> = {
+};
+
+type Boxified<T> = {
+    [P in keyof T]: Box<T[P]>;
+};
+
+function boxify<T>(obj: T): Boxified<T> {
+    if (typeof obj === "object") {
+        let result = {} as Boxified<T>;
+        for (let k in obj) {
+            result[k] = { value: obj[k] };
+        }
+        return result;
+    }
+    return <any>obj;
+}
+
+type A = { a: string };
+type B = { b: string };
+type C = { c: string };
+
+function f1(x: A | B | C | undefined) {
+    return boxify(x);
+}
+
+type T00 = Partial<A | B | C>;
+type T01 = Readonly<A | B | C | null | undefined>;
+type T02 = Boxified<A | B[] | C | string>
+type T03 = Readonly<string | number | boolean | null | undefined | void>;
+type T04 = Boxified<string | number | boolean | null | undefined | void>;
+type T05 = Partial<"hello" | "world" | 42>;
+
+type BoxifiedWithSentinel<T, U> = {
+    [P in keyof T]: Box<T[P]> | U;
+}
+
+type T10 = BoxifiedWithSentinel<A | B | C, null>;
+type T11 = BoxifiedWithSentinel<A | B | C, undefined>;
+type T12 = BoxifiedWithSentinel<string, undefined>;
+
+type DeepReadonly<T> = {
+    readonly [P in keyof T]: DeepReadonly<T[P]>;
+};
+
+type Foo = {
+    x: number;
+    y: { a: string, b: number };
+    z: boolean;
+};
+
+type DeepReadonlyFoo = {
+    readonly x: number;
+    readonly y: { readonly a: string, readonly b: number };
+    readonly z: boolean;
+};
+
+var x1: DeepReadonly<Foo>;
+var x1: DeepReadonlyFoo;
+
+//// [mappedTypes4.js]
+function boxify(obj) {
+    if (typeof obj === "object") {
+        var result = {};
+        for (var k in obj) {
+            result[k] = { value: obj[k] };
+        }
+        return result;
+    }
+    return obj;
+}
+function f1(x) {
+    return boxify(x);
+}
+var x1;
+var x1;
+
+
+//// [mappedTypes4.d.ts]
+declare type Box<T> = {};
+declare type Boxified<T> = {
+    [P in keyof T]: Box<T[P]>;
+};
+declare function boxify<T>(obj: T): Boxified<T>;
+declare type A = {
+    a: string;
+};
+declare type B = {
+    b: string;
+};
+declare type C = {
+    c: string;
+};
+declare function f1(x: A | B | C | undefined): Boxified<A> | Boxified<B> | Boxified<C> | undefined;
+declare type T00 = Partial<A | B | C>;
+declare type T01 = Readonly<A | B | C | null | undefined>;
+declare type T02 = Boxified<A | B[] | C | string>;
+declare type T03 = Readonly<string | number | boolean | null | undefined | void>;
+declare type T04 = Boxified<string | number | boolean | null | undefined | void>;
+declare type T05 = Partial<"hello" | "world" | 42>;
+declare type BoxifiedWithSentinel<T, U> = {
+    [P in keyof T]: Box<T[P]> | U;
+};
+declare type T10 = BoxifiedWithSentinel<A | B | C, null>;
+declare type T11 = BoxifiedWithSentinel<A | B | C, undefined>;
+declare type T12 = BoxifiedWithSentinel<string, undefined>;
+declare type DeepReadonly<T> = {
+    readonly [P in keyof T]: DeepReadonly<T[P]>;
+};
+declare type Foo = {
+    x: number;
+    y: {
+        a: string;
+        b: number;
+    };
+    z: boolean;
+};
+declare type DeepReadonlyFoo = {
+    readonly x: number;
+    readonly y: {
+        readonly a: string;
+        readonly b: number;
+    };
+    readonly z: boolean;
+};
+declare var x1: DeepReadonly<Foo>;
+declare var x1: DeepReadonlyFoo;

--- a/tests/baselines/reference/mappedTypes4.symbols
+++ b/tests/baselines/reference/mappedTypes4.symbols
@@ -1,0 +1,198 @@
+=== tests/cases/conformance/types/mapped/mappedTypes4.ts ===
+
+type Box<T> = {
+>Box : Symbol(Box, Decl(mappedTypes4.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypes4.ts, 1, 9))
+
+};
+
+type Boxified<T> = {
+>Boxified : Symbol(Boxified, Decl(mappedTypes4.ts, 2, 2))
+>T : Symbol(T, Decl(mappedTypes4.ts, 4, 14))
+
+    [P in keyof T]: Box<T[P]>;
+>P : Symbol(P, Decl(mappedTypes4.ts, 5, 5))
+>T : Symbol(T, Decl(mappedTypes4.ts, 4, 14))
+>Box : Symbol(Box, Decl(mappedTypes4.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypes4.ts, 4, 14))
+>P : Symbol(P, Decl(mappedTypes4.ts, 5, 5))
+
+};
+
+function boxify<T>(obj: T): Boxified<T> {
+>boxify : Symbol(boxify, Decl(mappedTypes4.ts, 6, 2))
+>T : Symbol(T, Decl(mappedTypes4.ts, 8, 16))
+>obj : Symbol(obj, Decl(mappedTypes4.ts, 8, 19))
+>T : Symbol(T, Decl(mappedTypes4.ts, 8, 16))
+>Boxified : Symbol(Boxified, Decl(mappedTypes4.ts, 2, 2))
+>T : Symbol(T, Decl(mappedTypes4.ts, 8, 16))
+
+    if (typeof obj === "object") {
+>obj : Symbol(obj, Decl(mappedTypes4.ts, 8, 19))
+
+        let result = {} as Boxified<T>;
+>result : Symbol(result, Decl(mappedTypes4.ts, 10, 11))
+>Boxified : Symbol(Boxified, Decl(mappedTypes4.ts, 2, 2))
+>T : Symbol(T, Decl(mappedTypes4.ts, 8, 16))
+
+        for (let k in obj) {
+>k : Symbol(k, Decl(mappedTypes4.ts, 11, 16))
+>obj : Symbol(obj, Decl(mappedTypes4.ts, 8, 19))
+
+            result[k] = { value: obj[k] };
+>result : Symbol(result, Decl(mappedTypes4.ts, 10, 11))
+>k : Symbol(k, Decl(mappedTypes4.ts, 11, 16))
+>value : Symbol(value, Decl(mappedTypes4.ts, 12, 25))
+>obj : Symbol(obj, Decl(mappedTypes4.ts, 8, 19))
+>k : Symbol(k, Decl(mappedTypes4.ts, 11, 16))
+        }
+        return result;
+>result : Symbol(result, Decl(mappedTypes4.ts, 10, 11))
+    }
+    return <any>obj;
+>obj : Symbol(obj, Decl(mappedTypes4.ts, 8, 19))
+}
+
+type A = { a: string };
+>A : Symbol(A, Decl(mappedTypes4.ts, 17, 1))
+>a : Symbol(a, Decl(mappedTypes4.ts, 19, 10))
+
+type B = { b: string };
+>B : Symbol(B, Decl(mappedTypes4.ts, 19, 23))
+>b : Symbol(b, Decl(mappedTypes4.ts, 20, 10))
+
+type C = { c: string };
+>C : Symbol(C, Decl(mappedTypes4.ts, 20, 23))
+>c : Symbol(c, Decl(mappedTypes4.ts, 21, 10))
+
+function f1(x: A | B | C | undefined) {
+>f1 : Symbol(f1, Decl(mappedTypes4.ts, 21, 23))
+>x : Symbol(x, Decl(mappedTypes4.ts, 23, 12))
+>A : Symbol(A, Decl(mappedTypes4.ts, 17, 1))
+>B : Symbol(B, Decl(mappedTypes4.ts, 19, 23))
+>C : Symbol(C, Decl(mappedTypes4.ts, 20, 23))
+
+    return boxify(x);
+>boxify : Symbol(boxify, Decl(mappedTypes4.ts, 6, 2))
+>x : Symbol(x, Decl(mappedTypes4.ts, 23, 12))
+}
+
+type T00 = Partial<A | B | C>;
+>T00 : Symbol(T00, Decl(mappedTypes4.ts, 25, 1))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>A : Symbol(A, Decl(mappedTypes4.ts, 17, 1))
+>B : Symbol(B, Decl(mappedTypes4.ts, 19, 23))
+>C : Symbol(C, Decl(mappedTypes4.ts, 20, 23))
+
+type T01 = Readonly<A | B | C | null | undefined>;
+>T01 : Symbol(T01, Decl(mappedTypes4.ts, 27, 30))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>A : Symbol(A, Decl(mappedTypes4.ts, 17, 1))
+>B : Symbol(B, Decl(mappedTypes4.ts, 19, 23))
+>C : Symbol(C, Decl(mappedTypes4.ts, 20, 23))
+
+type T02 = Boxified<A | B[] | C | string>
+>T02 : Symbol(T02, Decl(mappedTypes4.ts, 28, 50))
+>Boxified : Symbol(Boxified, Decl(mappedTypes4.ts, 2, 2))
+>A : Symbol(A, Decl(mappedTypes4.ts, 17, 1))
+>B : Symbol(B, Decl(mappedTypes4.ts, 19, 23))
+>C : Symbol(C, Decl(mappedTypes4.ts, 20, 23))
+
+type T03 = Readonly<string | number | boolean | null | undefined | void>;
+>T03 : Symbol(T03, Decl(mappedTypes4.ts, 29, 41))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+
+type T04 = Boxified<string | number | boolean | null | undefined | void>;
+>T04 : Symbol(T04, Decl(mappedTypes4.ts, 30, 73))
+>Boxified : Symbol(Boxified, Decl(mappedTypes4.ts, 2, 2))
+
+type T05 = Partial<"hello" | "world" | 42>;
+>T05 : Symbol(T05, Decl(mappedTypes4.ts, 31, 73))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+
+type BoxifiedWithSentinel<T, U> = {
+>BoxifiedWithSentinel : Symbol(BoxifiedWithSentinel, Decl(mappedTypes4.ts, 32, 43))
+>T : Symbol(T, Decl(mappedTypes4.ts, 34, 26))
+>U : Symbol(U, Decl(mappedTypes4.ts, 34, 28))
+
+    [P in keyof T]: Box<T[P]> | U;
+>P : Symbol(P, Decl(mappedTypes4.ts, 35, 5))
+>T : Symbol(T, Decl(mappedTypes4.ts, 34, 26))
+>Box : Symbol(Box, Decl(mappedTypes4.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypes4.ts, 34, 26))
+>P : Symbol(P, Decl(mappedTypes4.ts, 35, 5))
+>U : Symbol(U, Decl(mappedTypes4.ts, 34, 28))
+}
+
+type T10 = BoxifiedWithSentinel<A | B | C, null>;
+>T10 : Symbol(T10, Decl(mappedTypes4.ts, 36, 1))
+>BoxifiedWithSentinel : Symbol(BoxifiedWithSentinel, Decl(mappedTypes4.ts, 32, 43))
+>A : Symbol(A, Decl(mappedTypes4.ts, 17, 1))
+>B : Symbol(B, Decl(mappedTypes4.ts, 19, 23))
+>C : Symbol(C, Decl(mappedTypes4.ts, 20, 23))
+
+type T11 = BoxifiedWithSentinel<A | B | C, undefined>;
+>T11 : Symbol(T11, Decl(mappedTypes4.ts, 38, 49))
+>BoxifiedWithSentinel : Symbol(BoxifiedWithSentinel, Decl(mappedTypes4.ts, 32, 43))
+>A : Symbol(A, Decl(mappedTypes4.ts, 17, 1))
+>B : Symbol(B, Decl(mappedTypes4.ts, 19, 23))
+>C : Symbol(C, Decl(mappedTypes4.ts, 20, 23))
+
+type T12 = BoxifiedWithSentinel<string, undefined>;
+>T12 : Symbol(T12, Decl(mappedTypes4.ts, 39, 54))
+>BoxifiedWithSentinel : Symbol(BoxifiedWithSentinel, Decl(mappedTypes4.ts, 32, 43))
+
+type DeepReadonly<T> = {
+>DeepReadonly : Symbol(DeepReadonly, Decl(mappedTypes4.ts, 40, 51))
+>T : Symbol(T, Decl(mappedTypes4.ts, 42, 18))
+
+    readonly [P in keyof T]: DeepReadonly<T[P]>;
+>P : Symbol(P, Decl(mappedTypes4.ts, 43, 14))
+>T : Symbol(T, Decl(mappedTypes4.ts, 42, 18))
+>DeepReadonly : Symbol(DeepReadonly, Decl(mappedTypes4.ts, 40, 51))
+>T : Symbol(T, Decl(mappedTypes4.ts, 42, 18))
+>P : Symbol(P, Decl(mappedTypes4.ts, 43, 14))
+
+};
+
+type Foo = {
+>Foo : Symbol(Foo, Decl(mappedTypes4.ts, 44, 2))
+
+    x: number;
+>x : Symbol(x, Decl(mappedTypes4.ts, 46, 12))
+
+    y: { a: string, b: number };
+>y : Symbol(y, Decl(mappedTypes4.ts, 47, 14))
+>a : Symbol(a, Decl(mappedTypes4.ts, 48, 8))
+>b : Symbol(b, Decl(mappedTypes4.ts, 48, 19))
+
+    z: boolean;
+>z : Symbol(z, Decl(mappedTypes4.ts, 48, 32))
+
+};
+
+type DeepReadonlyFoo = {
+>DeepReadonlyFoo : Symbol(DeepReadonlyFoo, Decl(mappedTypes4.ts, 50, 2))
+
+    readonly x: number;
+>x : Symbol(x, Decl(mappedTypes4.ts, 52, 24))
+
+    readonly y: { readonly a: string, readonly b: number };
+>y : Symbol(y, Decl(mappedTypes4.ts, 53, 23))
+>a : Symbol(a, Decl(mappedTypes4.ts, 54, 17))
+>b : Symbol(b, Decl(mappedTypes4.ts, 54, 37))
+
+    readonly z: boolean;
+>z : Symbol(z, Decl(mappedTypes4.ts, 54, 59))
+
+};
+
+var x1: DeepReadonly<Foo>;
+>x1 : Symbol(x1, Decl(mappedTypes4.ts, 58, 3), Decl(mappedTypes4.ts, 59, 3))
+>DeepReadonly : Symbol(DeepReadonly, Decl(mappedTypes4.ts, 40, 51))
+>Foo : Symbol(Foo, Decl(mappedTypes4.ts, 44, 2))
+
+var x1: DeepReadonlyFoo;
+>x1 : Symbol(x1, Decl(mappedTypes4.ts, 58, 3), Decl(mappedTypes4.ts, 59, 3))
+>DeepReadonlyFoo : Symbol(DeepReadonlyFoo, Decl(mappedTypes4.ts, 50, 2))
+

--- a/tests/baselines/reference/mappedTypes4.types
+++ b/tests/baselines/reference/mappedTypes4.types
@@ -1,0 +1,213 @@
+=== tests/cases/conformance/types/mapped/mappedTypes4.ts ===
+
+type Box<T> = {
+>Box : Box<T>
+>T : T
+
+};
+
+type Boxified<T> = {
+>Boxified : Boxified<T>
+>T : T
+
+    [P in keyof T]: Box<T[P]>;
+>P : P
+>T : T
+>Box : Box<T>
+>T : T
+>P : P
+
+};
+
+function boxify<T>(obj: T): Boxified<T> {
+>boxify : <T>(obj: T) => Boxified<T>
+>T : T
+>obj : T
+>T : T
+>Boxified : Boxified<T>
+>T : T
+
+    if (typeof obj === "object") {
+>typeof obj === "object" : boolean
+>typeof obj : string
+>obj : T
+>"object" : "object"
+
+        let result = {} as Boxified<T>;
+>result : Boxified<T>
+>{} as Boxified<T> : Boxified<T>
+>{} : {}
+>Boxified : Boxified<T>
+>T : T
+
+        for (let k in obj) {
+>k : keyof T
+>obj : T
+
+            result[k] = { value: obj[k] };
+>result[k] = { value: obj[k] } : { value: T[keyof T]; }
+>result[k] : Box<T[keyof T]>
+>result : Boxified<T>
+>k : keyof T
+>{ value: obj[k] } : { value: T[keyof T]; }
+>value : T[keyof T]
+>obj[k] : T[keyof T]
+>obj : T
+>k : keyof T
+        }
+        return result;
+>result : Boxified<T>
+    }
+    return <any>obj;
+><any>obj : any
+>obj : never
+}
+
+type A = { a: string };
+>A : A
+>a : string
+
+type B = { b: string };
+>B : B
+>b : string
+
+type C = { c: string };
+>C : C
+>c : string
+
+function f1(x: A | B | C | undefined) {
+>f1 : (x: A | B | C | undefined) => Boxified<A> | Boxified<B> | Boxified<C> | undefined
+>x : A | B | C | undefined
+>A : A
+>B : B
+>C : C
+
+    return boxify(x);
+>boxify(x) : Boxified<A> | Boxified<B> | Boxified<C> | undefined
+>boxify : <T>(obj: T) => Boxified<T>
+>x : A | B | C | undefined
+}
+
+type T00 = Partial<A | B | C>;
+>T00 : Partial<A> | Partial<B> | Partial<C>
+>Partial : Partial<T>
+>A : A
+>B : B
+>C : C
+
+type T01 = Readonly<A | B | C | null | undefined>;
+>T01 : Readonly<A> | Readonly<B> | Readonly<C> | null | undefined
+>Readonly : Readonly<T>
+>A : A
+>B : B
+>C : C
+>null : null
+
+type T02 = Boxified<A | B[] | C | string>
+>T02 : string | Boxified<A> | Boxified<C> | Boxified<B[]>
+>Boxified : Boxified<T>
+>A : A
+>B : B
+>C : C
+
+type T03 = Readonly<string | number | boolean | null | undefined | void>;
+>T03 : string | number | boolean | void | null | undefined
+>Readonly : Readonly<T>
+>null : null
+
+type T04 = Boxified<string | number | boolean | null | undefined | void>;
+>T04 : string | number | boolean | void | null | undefined
+>Boxified : Boxified<T>
+>null : null
+
+type T05 = Partial<"hello" | "world" | 42>;
+>T05 : "hello" | "world" | 42
+>Partial : Partial<T>
+
+type BoxifiedWithSentinel<T, U> = {
+>BoxifiedWithSentinel : BoxifiedWithSentinel<T, U>
+>T : T
+>U : U
+
+    [P in keyof T]: Box<T[P]> | U;
+>P : P
+>T : T
+>Box : Box<T>
+>T : T
+>P : P
+>U : U
+}
+
+type T10 = BoxifiedWithSentinel<A | B | C, null>;
+>T10 : BoxifiedWithSentinel<A, null> | BoxifiedWithSentinel<B, null> | BoxifiedWithSentinel<C, null>
+>BoxifiedWithSentinel : BoxifiedWithSentinel<T, U>
+>A : A
+>B : B
+>C : C
+>null : null
+
+type T11 = BoxifiedWithSentinel<A | B | C, undefined>;
+>T11 : BoxifiedWithSentinel<A, undefined> | BoxifiedWithSentinel<B, undefined> | BoxifiedWithSentinel<C, undefined>
+>BoxifiedWithSentinel : BoxifiedWithSentinel<T, U>
+>A : A
+>B : B
+>C : C
+
+type T12 = BoxifiedWithSentinel<string, undefined>;
+>T12 : string
+>BoxifiedWithSentinel : BoxifiedWithSentinel<T, U>
+
+type DeepReadonly<T> = {
+>DeepReadonly : DeepReadonly<T>
+>T : T
+
+    readonly [P in keyof T]: DeepReadonly<T[P]>;
+>P : P
+>T : T
+>DeepReadonly : DeepReadonly<T>
+>T : T
+>P : P
+
+};
+
+type Foo = {
+>Foo : Foo
+
+    x: number;
+>x : number
+
+    y: { a: string, b: number };
+>y : { a: string; b: number; }
+>a : string
+>b : number
+
+    z: boolean;
+>z : boolean
+
+};
+
+type DeepReadonlyFoo = {
+>DeepReadonlyFoo : DeepReadonlyFoo
+
+    readonly x: number;
+>x : number
+
+    readonly y: { readonly a: string, readonly b: number };
+>y : { readonly a: string; readonly b: number; }
+>a : string
+>b : number
+
+    readonly z: boolean;
+>z : boolean
+
+};
+
+var x1: DeepReadonly<Foo>;
+>x1 : DeepReadonly<Foo>
+>DeepReadonly : DeepReadonly<T>
+>Foo : Foo
+
+var x1: DeepReadonlyFoo;
+>x1 : DeepReadonly<Foo>
+>DeepReadonlyFoo : DeepReadonlyFoo
+

--- a/tests/cases/conformance/types/mapped/mappedTypes1.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypes1.ts
@@ -34,7 +34,9 @@ type T47 = { [P in string | "a" | "b" | "0" | "1"]: void };
 declare function f1<T1>(): { [P in keyof T1]: void };
 declare function f2<T1 extends string>(): { [P in keyof T1]: void };
 declare function f3<T1 extends number>(): { [P in keyof T1]: void };
+declare function f4<T1 extends Number>(): { [P in keyof T1]: void };
 
 let x1 = f1();
 let x2 = f2();
 let x3 = f3();
+let x4 = f4();

--- a/tests/cases/conformance/types/mapped/mappedTypes2.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypes2.ts
@@ -31,25 +31,30 @@ declare function pick<T, K extends keyof T>(obj: T, ...keys: K[]): Pick<T, K>;
 declare function mapObject<K extends string, T, U>(obj: Record<K, T>, f: (x: T) => U): Record<K, U>;
 declare function proxify<T>(obj: T): Proxify<T>;
 
+interface Point {
+    x: number;
+    y: number;
+}
+
 interface Shape {
     name: string;
     width: number;
     height: number;
-    visible: boolean;
+    location: Point;
 }
 
 interface PartialShape {
     name?: string;
     width?: number;
     height?: number;
-    visible?: boolean;
+    location?: Point;
 }
 
 interface ReadonlyShape {
     readonly name: string;
     readonly width: number;
     readonly height: number;
-    readonly visible: boolean;
+    readonly location: Point;
 }
 
 function f0(s1: Shape, s2: Shape) {
@@ -70,7 +75,7 @@ function f2(shape: Shape) {
 }
 
 function f3(shape: Shape) {
-    const x = pick(shape, "name", "visible");  // { name: string, visible: boolean }
+    const x = pick(shape, "name", "location");  // { name: string, location: Point }
 }
 
 function f4() {
@@ -81,11 +86,11 @@ function f4() {
 function f5(shape: Shape) {
     const p = proxify(shape);
     let name = p.name.get();
-    p.visible.set(false);
+    p.width.set(42);
 }
 
 function f6(shape: DeepReadonly<Shape>) {
-    let name = shape.name;  // DeepReadonly<string>
-    let length = name.length;  // DeepReadonly<number>
-    let toString = length.toString;  // DeepReadonly<(radix?: number) => string>
+    let name = shape.name;  // string
+    let location = shape.location;  // DeepReadonly<Point>
+    let x = location.x;  // number
 }

--- a/tests/cases/conformance/types/mapped/mappedTypes4.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypes4.ts
@@ -1,0 +1,62 @@
+// @strictNullChecks: true
+// @declaration: true
+
+type Box<T> = {
+};
+
+type Boxified<T> = {
+    [P in keyof T]: Box<T[P]>;
+};
+
+function boxify<T>(obj: T): Boxified<T> {
+    if (typeof obj === "object") {
+        let result = {} as Boxified<T>;
+        for (let k in obj) {
+            result[k] = { value: obj[k] };
+        }
+        return result;
+    }
+    return <any>obj;
+}
+
+type A = { a: string };
+type B = { b: string };
+type C = { c: string };
+
+function f1(x: A | B | C | undefined) {
+    return boxify(x);
+}
+
+type T00 = Partial<A | B | C>;
+type T01 = Readonly<A | B | C | null | undefined>;
+type T02 = Boxified<A | B[] | C | string>
+type T03 = Readonly<string | number | boolean | null | undefined | void>;
+type T04 = Boxified<string | number | boolean | null | undefined | void>;
+type T05 = Partial<"hello" | "world" | 42>;
+
+type BoxifiedWithSentinel<T, U> = {
+    [P in keyof T]: Box<T[P]> | U;
+}
+
+type T10 = BoxifiedWithSentinel<A | B | C, null>;
+type T11 = BoxifiedWithSentinel<A | B | C, undefined>;
+type T12 = BoxifiedWithSentinel<string, undefined>;
+
+type DeepReadonly<T> = {
+    readonly [P in keyof T]: DeepReadonly<T[P]>;
+};
+
+type Foo = {
+    x: number;
+    y: { a: string, b: number };
+    z: boolean;
+};
+
+type DeepReadonlyFoo = {
+    readonly x: number;
+    readonly y: { readonly a: string, readonly b: number };
+    readonly z: boolean;
+};
+
+var x1: DeepReadonly<Foo>;
+var x1: DeepReadonlyFoo;


### PR DESCRIPTION
A mapped type of the form `{ [P in keyof T]: X }`, where `T` is some type parameter, is said to be an *isomorphic mapped type* because it produces a type with the same shape as `T`. With this PR we make instantiations of isomorphic mapped types distributive over union types. For example, when `{ [P in keyof T]: X }` is instantiated with `A | B` for `T`, we produce `{ [P in keyof A]: X } | { [P in keyof B]: X }`. Furthermore, when a primitive type is substituted for `T` in an isomorphic mapped type, we simply produce that primitive type. For example, when `{ [P in keyof T]: X }` is instantiated with `A | undefined` for `T`, we produce `{ [P in keyof A]: X } | undefined`.

```ts
type A = { a: string };
type B = { b: string };
type C = { c: string };

type T1 = Partial<A | B | C>;  // Partial<A> | Partial<B> | Partial<C>
type T2 = Readonly<A | B | null | undefined>;  // Readonly<A> | Readonly<B> | null | undefined
type T3 = Readonly<A | B[] | string>;  // Readonly<A> | Readonly<B[]> | string
type T4 = Readonly<string>;  // string
type T5 = Readonly<string | number | boolean>;  // string | number | boolean
```

This PR also includes a minor fix that makes any isomorphic mapped type assignable to an empty object type.