### PR TITLE
respect casing when comparing names of config files

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -578,6 +578,35 @@ namespace ts.projectSystem {
             checkWatchedDirectories(host, ["/a/b/c", "/a/b", "/a"]);
         });
 
+        it("can handle tsconfig file name with difference casing", () => {
+            const f1 = {
+                path: "/a/b/app.ts",
+                content: "let x = 1"
+            };
+            const config = {
+                path: "/a/b/tsconfig.json",
+                content: JSON.stringify({
+                    include: []
+                })
+            };
+
+            const host = createServerHost([f1, config], { useCaseSensitiveFileNames: false });
+            const service = createProjectService(host);
+            service.openExternalProject(<protocol.ExternalProject>{
+                projectFileName: "/a/b/project.csproj",
+                rootFiles: toExternalFiles([f1.path, combinePaths(getDirectoryPath(config.path).toUpperCase(), getBaseFileName(config.path))]),
+                options: {}
+            });
+            service.checkNumberOfProjects({ configuredProjects: 1 });
+            checkProjectActualFiles(service.configuredProjects[0], []);
+
+            service.openClientFile(f1.path);
+            service.checkNumberOfProjects({ configuredProjects: 1, inferredProjects: 1 });
+
+            checkProjectActualFiles(service.configuredProjects[0], []);
+            checkProjectActualFiles(service.inferredProjects[0], [f1.path]);
+        })
+
         it("create configured project without file list", () => {
             const configFile: FileOrFolder = {
                 path: "/a/b/tsconfig.json",

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -257,7 +257,7 @@ namespace ts.server {
 
         private changedFiles: ScriptInfo[];
 
-        private toCanonicalFileName: (f: string) => string;
+        readonly toCanonicalFileName: (f: string) => string;
 
         public lastDeletedFile: ScriptInfo;
 
@@ -777,7 +777,13 @@ namespace ts.server {
         }
 
         private findConfiguredProjectByProjectName(configFileName: NormalizedPath) {
-            return findProjectByName(configFileName, this.configuredProjects);
+            // make sure that casing of config file name is consistent
+            configFileName = asNormalizedPath(this.toCanonicalFileName(configFileName));
+            for (const proj of this.configuredProjects) {
+                if (proj.canonicalConfigFilePath === configFileName) {
+                    return proj;
+                }
+            }
         }
 
         private findExternalProjectByProjectName(projectFileName: string) {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -817,6 +817,7 @@ namespace ts.server {
         private directoryWatcher: FileWatcher;
         private directoriesWatchedForWildcards: Map<FileWatcher>;
         private typeRootsWatchers: FileWatcher[];
+        readonly canonicalConfigFilePath: NormalizedPath;
 
         /** Used for configured projects which may have multiple open roots */
         openRefCount = 0;
@@ -830,6 +831,7 @@ namespace ts.server {
             languageServiceEnabled: boolean,
             public compileOnSaveEnabled: boolean) {
             super(configFileName, ProjectKind.Configured, projectService, documentRegistry, hasExplicitListOfFiles, languageServiceEnabled, compilerOptions, compileOnSaveEnabled);
+            this.canonicalConfigFilePath = asNormalizedPath(projectService.toCanonicalFileName(configFileName));
         }
 
         getConfigFilePath() {


### PR DESCRIPTION
// cc @mhegazy, @zhengbli 