### PR TITLE
[release-2.1] Instead of creating clone of the jsxFactory's leaf node, create synthesized node

### DIFF
--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -1677,16 +1677,10 @@ namespace ts {
 
     function createJsxFactoryExpressionFromEntityName(jsxFactory: EntityName, parent: JsxOpeningLikeElement): Expression {
         if (isQualifiedName(jsxFactory)) {
-            return createPropertyAccess(
-                createJsxFactoryExpressionFromEntityName(
-                    jsxFactory.left,
-                    parent
-                ),
-                setEmitFlags(
-                    getMutableClone(jsxFactory.right),
-                    EmitFlags.NoSourceMap
-                )
-            );
+            const left = createJsxFactoryExpressionFromEntityName(jsxFactory.left, parent);
+            const right = <Identifier>createSynthesizedNode(SyntaxKind.Identifier);
+            right.text = jsxFactory.right.text;
+            return createPropertyAccess(left, right);
         }
         else {
             return createReactNamespace(jsxFactory.text, parent);

--- a/tests/baselines/reference/jsxFactoryQualifiedNameWithEs5.js
+++ b/tests/baselines/reference/jsxFactoryQualifiedNameWithEs5.js
@@ -1,0 +1,27 @@
+//// [index.tsx]
+
+import "./jsx";
+
+var skate: any;
+const React = { createElement: skate.h };
+
+class Component {
+    renderCallback() {
+        return <div>test</div>;
+    }
+};
+
+//// [index.js]
+"use strict";
+require("./jsx");
+var skate;
+var React = { createElement: skate.h };
+var Component = (function () {
+    function Component() {
+    }
+    Component.prototype.renderCallback = function () {
+        return skate.h("div", null, "test");
+    };
+    return Component;
+}());
+;

--- a/tests/baselines/reference/jsxFactoryQualifiedNameWithEs5.symbols
+++ b/tests/baselines/reference/jsxFactoryQualifiedNameWithEs5.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/index.tsx ===
+
+import "./jsx";
+
+var skate: any;
+>skate : Symbol(skate, Decl(index.tsx, 3, 3))
+
+const React = { createElement: skate.h };
+>React : Symbol(React, Decl(index.tsx, 4, 5))
+>createElement : Symbol(createElement, Decl(index.tsx, 4, 15))
+>skate : Symbol(skate, Decl(index.tsx, 3, 3))
+
+class Component {
+>Component : Symbol(Component, Decl(index.tsx, 4, 41))
+
+    renderCallback() {
+>renderCallback : Symbol(Component.renderCallback, Decl(index.tsx, 6, 17))
+
+        return <div>test</div>;
+>div : Symbol(unknown)
+>div : Symbol(unknown)
+    }
+};

--- a/tests/baselines/reference/jsxFactoryQualifiedNameWithEs5.types
+++ b/tests/baselines/reference/jsxFactoryQualifiedNameWithEs5.types
@@ -1,0 +1,27 @@
+=== tests/cases/compiler/index.tsx ===
+
+import "./jsx";
+
+var skate: any;
+>skate : any
+
+const React = { createElement: skate.h };
+>React : { createElement: any; }
+>{ createElement: skate.h } : { createElement: any; }
+>createElement : any
+>skate.h : any
+>skate : any
+>h : any
+
+class Component {
+>Component : Component
+
+    renderCallback() {
+>renderCallback : () => any
+
+        return <div>test</div>;
+><div>test</div> : any
+>div : any
+>div : any
+    }
+};

--- a/tests/cases/compiler/jsxFactoryQualifiedNameWithEs5.ts
+++ b/tests/cases/compiler/jsxFactoryQualifiedNameWithEs5.ts
@@ -1,0 +1,17 @@
+//@module: commonjs
+//@target: es5
+//@jsx: react
+//@jsxFactory: skate.h
+//@noEmit: false
+
+// @filename: index.tsx
+import "./jsx";
+
+var skate: any;
+const React = { createElement: skate.h };
+
+class Component {
+    renderCallback() {
+        return <div>test</div>;
+    }
+};


### PR DESCRIPTION
This avoid setting original node which would be something from isolated parsing and hence not valid when resolving expression
Fixes #12467