### PR TITLE
Update keyof tests to reflect #12425

### DIFF
--- a/tests/baselines/reference/keyofAndIndexedAccess.js
+++ b/tests/baselines/reference/keyofAndIndexedAccess.js
@@ -21,11 +21,12 @@ class Options {
 }
 
 type Dictionary<T> = { [x: string]: T };
+type NumericallyIndexed<T> = { [x: number]: T };
 
 const enum E { A, B, C }
 
-type K00 = keyof any;  // string | number
-type K01 = keyof string;  // number | "toString" | "charAt" | ...
+type K00 = keyof any;  // string
+type K01 = keyof string;  // "toString" | "charAt" | ...
 type K02 = keyof number;  // "toString" | "toFixed" | "toExponential" | ...
 type K03 = keyof boolean;  // "valueOf"
 type K04 = keyof void;  // never
@@ -34,19 +35,20 @@ type K06 = keyof null;  // never
 type K07 = keyof never;  // never
 
 type K10 = keyof Shape;  // "name" | "width" | "height" | "visible"
-type K11 = keyof Shape[];  // number | "length" | "toString" | ...
-type K12 = keyof Dictionary<Shape>;  // string | number
+type K11 = keyof Shape[];  // "length" | "toString" | ...
+type K12 = keyof Dictionary<Shape>;  // string
 type K13 = keyof {};  // never
 type K14 = keyof Object;  // "constructor" | "toString" | ...
 type K15 = keyof E;  // "toString" | "toFixed" | "toExponential" | ...
-type K16 = keyof [string, number];  // number | "0" | "1" | "length" | "toString" | ...
+type K16 = keyof [string, number];  // "0" | "1" | "length" | "toString" | ...
 type K17 = keyof (Shape | Item);  // "name"
 type K18 = keyof (Shape & Item);  // "name" | "width" | "height" | "visible" | "price"
+type K19 = keyof NumericallyIndexed<Shape> // never
 
 type KeyOf<T> = keyof T;
 
 type K20 = KeyOf<Shape>;  // "name" | "width" | "height" | "visible"
-type K21 = KeyOf<Dictionary<Shape>>;  // string | number
+type K21 = KeyOf<Dictionary<Shape>>;  // string
 
 type NAME = "name";
 type WIDTH_OR_HEIGHT = "width" | "height";
@@ -249,6 +251,7 @@ class OtherPerson {
     }
 }
 
+
 //// [keyofAndIndexedAccess.js]
 var __extends = (this && this.__extends) || function (d, b) {
     for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
@@ -449,6 +452,9 @@ declare class Options {
 declare type Dictionary<T> = {
     [x: string]: T;
 };
+declare type NumericallyIndexed<T> = {
+    [x: number]: T;
+};
 declare const enum E {
     A = 0,
     B = 1,
@@ -471,6 +477,7 @@ declare type K15 = keyof E;
 declare type K16 = keyof [string, number];
 declare type K17 = keyof (Shape | Item);
 declare type K18 = keyof (Shape & Item);
+declare type K19 = keyof NumericallyIndexed<Shape>;
 declare type KeyOf<T> = keyof T;
 declare type K20 = KeyOf<Shape>;
 declare type K21 = KeyOf<Dictionary<Shape>>;

--- a/tests/baselines/reference/keyofAndIndexedAccess.symbols
+++ b/tests/baselines/reference/keyofAndIndexedAccess.symbols
@@ -47,792 +47,804 @@ type Dictionary<T> = { [x: string]: T };
 >x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 21, 24))
 >T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 21, 16))
 
+type NumericallyIndexed<T> = { [x: number]: T };
+>NumericallyIndexed : Symbol(NumericallyIndexed, Decl(keyofAndIndexedAccess.ts, 21, 40))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 22, 24))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 22, 32))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 22, 24))
+
 const enum E { A, B, C }
->E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 21, 40))
->A : Symbol(E.A, Decl(keyofAndIndexedAccess.ts, 23, 14))
->B : Symbol(E.B, Decl(keyofAndIndexedAccess.ts, 23, 17))
->C : Symbol(E.C, Decl(keyofAndIndexedAccess.ts, 23, 20))
+>E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 22, 48))
+>A : Symbol(E.A, Decl(keyofAndIndexedAccess.ts, 24, 14))
+>B : Symbol(E.B, Decl(keyofAndIndexedAccess.ts, 24, 17))
+>C : Symbol(E.C, Decl(keyofAndIndexedAccess.ts, 24, 20))
 
-type K00 = keyof any;  // string | number
->K00 : Symbol(K00, Decl(keyofAndIndexedAccess.ts, 23, 24))
+type K00 = keyof any;  // string
+>K00 : Symbol(K00, Decl(keyofAndIndexedAccess.ts, 24, 24))
 
-type K01 = keyof string;  // number | "toString" | "charAt" | ...
->K01 : Symbol(K01, Decl(keyofAndIndexedAccess.ts, 25, 21))
+type K01 = keyof string;  // "toString" | "charAt" | ...
+>K01 : Symbol(K01, Decl(keyofAndIndexedAccess.ts, 26, 21))
 
 type K02 = keyof number;  // "toString" | "toFixed" | "toExponential" | ...
->K02 : Symbol(K02, Decl(keyofAndIndexedAccess.ts, 26, 24))
+>K02 : Symbol(K02, Decl(keyofAndIndexedAccess.ts, 27, 24))
 
 type K03 = keyof boolean;  // "valueOf"
->K03 : Symbol(K03, Decl(keyofAndIndexedAccess.ts, 27, 24))
+>K03 : Symbol(K03, Decl(keyofAndIndexedAccess.ts, 28, 24))
 
 type K04 = keyof void;  // never
->K04 : Symbol(K04, Decl(keyofAndIndexedAccess.ts, 28, 25))
+>K04 : Symbol(K04, Decl(keyofAndIndexedAccess.ts, 29, 25))
 
 type K05 = keyof undefined;  // never
->K05 : Symbol(K05, Decl(keyofAndIndexedAccess.ts, 29, 22))
+>K05 : Symbol(K05, Decl(keyofAndIndexedAccess.ts, 30, 22))
 
 type K06 = keyof null;  // never
->K06 : Symbol(K06, Decl(keyofAndIndexedAccess.ts, 30, 27))
+>K06 : Symbol(K06, Decl(keyofAndIndexedAccess.ts, 31, 27))
 
 type K07 = keyof never;  // never
->K07 : Symbol(K07, Decl(keyofAndIndexedAccess.ts, 31, 22))
+>K07 : Symbol(K07, Decl(keyofAndIndexedAccess.ts, 32, 22))
 
 type K10 = keyof Shape;  // "name" | "width" | "height" | "visible"
->K10 : Symbol(K10, Decl(keyofAndIndexedAccess.ts, 32, 23))
+>K10 : Symbol(K10, Decl(keyofAndIndexedAccess.ts, 33, 23))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
-type K11 = keyof Shape[];  // number | "length" | "toString" | ...
->K11 : Symbol(K11, Decl(keyofAndIndexedAccess.ts, 34, 23))
+type K11 = keyof Shape[];  // "length" | "toString" | ...
+>K11 : Symbol(K11, Decl(keyofAndIndexedAccess.ts, 35, 23))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
-type K12 = keyof Dictionary<Shape>;  // string | number
->K12 : Symbol(K12, Decl(keyofAndIndexedAccess.ts, 35, 25))
+type K12 = keyof Dictionary<Shape>;  // string
+>K12 : Symbol(K12, Decl(keyofAndIndexedAccess.ts, 36, 25))
 >Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 19, 1))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type K13 = keyof {};  // never
->K13 : Symbol(K13, Decl(keyofAndIndexedAccess.ts, 36, 35))
+>K13 : Symbol(K13, Decl(keyofAndIndexedAccess.ts, 37, 35))
 
 type K14 = keyof Object;  // "constructor" | "toString" | ...
->K14 : Symbol(K14, Decl(keyofAndIndexedAccess.ts, 37, 20))
+>K14 : Symbol(K14, Decl(keyofAndIndexedAccess.ts, 38, 20))
 >Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 
 type K15 = keyof E;  // "toString" | "toFixed" | "toExponential" | ...
->K15 : Symbol(K15, Decl(keyofAndIndexedAccess.ts, 38, 24))
->E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 21, 40))
+>K15 : Symbol(K15, Decl(keyofAndIndexedAccess.ts, 39, 24))
+>E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 22, 48))
 
-type K16 = keyof [string, number];  // number | "0" | "1" | "length" | "toString" | ...
->K16 : Symbol(K16, Decl(keyofAndIndexedAccess.ts, 39, 19))
+type K16 = keyof [string, number];  // "0" | "1" | "length" | "toString" | ...
+>K16 : Symbol(K16, Decl(keyofAndIndexedAccess.ts, 40, 19))
 
 type K17 = keyof (Shape | Item);  // "name"
->K17 : Symbol(K17, Decl(keyofAndIndexedAccess.ts, 40, 34))
+>K17 : Symbol(K17, Decl(keyofAndIndexedAccess.ts, 41, 34))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 >Item : Symbol(Item, Decl(keyofAndIndexedAccess.ts, 10, 1))
 
 type K18 = keyof (Shape & Item);  // "name" | "width" | "height" | "visible" | "price"
->K18 : Symbol(K18, Decl(keyofAndIndexedAccess.ts, 41, 32))
+>K18 : Symbol(K18, Decl(keyofAndIndexedAccess.ts, 42, 32))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 >Item : Symbol(Item, Decl(keyofAndIndexedAccess.ts, 10, 1))
 
-type KeyOf<T> = keyof T;
->KeyOf : Symbol(KeyOf, Decl(keyofAndIndexedAccess.ts, 42, 32))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 44, 11))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 44, 11))
-
-type K20 = KeyOf<Shape>;  // "name" | "width" | "height" | "visible"
->K20 : Symbol(K20, Decl(keyofAndIndexedAccess.ts, 44, 24))
->KeyOf : Symbol(KeyOf, Decl(keyofAndIndexedAccess.ts, 42, 32))
+type K19 = keyof NumericallyIndexed<Shape> // never
+>K19 : Symbol(K19, Decl(keyofAndIndexedAccess.ts, 43, 32))
+>NumericallyIndexed : Symbol(NumericallyIndexed, Decl(keyofAndIndexedAccess.ts, 21, 40))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
-type K21 = KeyOf<Dictionary<Shape>>;  // string | number
->K21 : Symbol(K21, Decl(keyofAndIndexedAccess.ts, 46, 24))
->KeyOf : Symbol(KeyOf, Decl(keyofAndIndexedAccess.ts, 42, 32))
+type KeyOf<T> = keyof T;
+>KeyOf : Symbol(KeyOf, Decl(keyofAndIndexedAccess.ts, 44, 42))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 46, 11))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 46, 11))
+
+type K20 = KeyOf<Shape>;  // "name" | "width" | "height" | "visible"
+>K20 : Symbol(K20, Decl(keyofAndIndexedAccess.ts, 46, 24))
+>KeyOf : Symbol(KeyOf, Decl(keyofAndIndexedAccess.ts, 44, 42))
+>Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
+
+type K21 = KeyOf<Dictionary<Shape>>;  // string
+>K21 : Symbol(K21, Decl(keyofAndIndexedAccess.ts, 48, 24))
+>KeyOf : Symbol(KeyOf, Decl(keyofAndIndexedAccess.ts, 44, 42))
 >Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 19, 1))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type NAME = "name";
->NAME : Symbol(NAME, Decl(keyofAndIndexedAccess.ts, 47, 36))
+>NAME : Symbol(NAME, Decl(keyofAndIndexedAccess.ts, 49, 36))
 
 type WIDTH_OR_HEIGHT = "width" | "height";
->WIDTH_OR_HEIGHT : Symbol(WIDTH_OR_HEIGHT, Decl(keyofAndIndexedAccess.ts, 49, 19))
+>WIDTH_OR_HEIGHT : Symbol(WIDTH_OR_HEIGHT, Decl(keyofAndIndexedAccess.ts, 51, 19))
 
 type Q10 = Shape["name"];  // string
->Q10 : Symbol(Q10, Decl(keyofAndIndexedAccess.ts, 50, 42))
+>Q10 : Symbol(Q10, Decl(keyofAndIndexedAccess.ts, 52, 42))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type Q11 = Shape["width" | "height"];  // number
->Q11 : Symbol(Q11, Decl(keyofAndIndexedAccess.ts, 52, 25))
+>Q11 : Symbol(Q11, Decl(keyofAndIndexedAccess.ts, 54, 25))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type Q12 = Shape["name" | "visible"];  // string | boolean
->Q12 : Symbol(Q12, Decl(keyofAndIndexedAccess.ts, 53, 37))
+>Q12 : Symbol(Q12, Decl(keyofAndIndexedAccess.ts, 55, 37))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type Q20 = Shape[NAME];  // string
->Q20 : Symbol(Q20, Decl(keyofAndIndexedAccess.ts, 54, 37))
+>Q20 : Symbol(Q20, Decl(keyofAndIndexedAccess.ts, 56, 37))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->NAME : Symbol(NAME, Decl(keyofAndIndexedAccess.ts, 47, 36))
+>NAME : Symbol(NAME, Decl(keyofAndIndexedAccess.ts, 49, 36))
 
 type Q21 = Shape[WIDTH_OR_HEIGHT];  // number
->Q21 : Symbol(Q21, Decl(keyofAndIndexedAccess.ts, 56, 23))
+>Q21 : Symbol(Q21, Decl(keyofAndIndexedAccess.ts, 58, 23))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->WIDTH_OR_HEIGHT : Symbol(WIDTH_OR_HEIGHT, Decl(keyofAndIndexedAccess.ts, 49, 19))
+>WIDTH_OR_HEIGHT : Symbol(WIDTH_OR_HEIGHT, Decl(keyofAndIndexedAccess.ts, 51, 19))
 
 type Q30 = [string, number][0];  // string
->Q30 : Symbol(Q30, Decl(keyofAndIndexedAccess.ts, 57, 34))
+>Q30 : Symbol(Q30, Decl(keyofAndIndexedAccess.ts, 59, 34))
 
 type Q31 = [string, number][1];  // number
->Q31 : Symbol(Q31, Decl(keyofAndIndexedAccess.ts, 59, 31))
+>Q31 : Symbol(Q31, Decl(keyofAndIndexedAccess.ts, 61, 31))
 
 type Q32 = [string, number][2];  // string | number
->Q32 : Symbol(Q32, Decl(keyofAndIndexedAccess.ts, 60, 31))
+>Q32 : Symbol(Q32, Decl(keyofAndIndexedAccess.ts, 62, 31))
 
 type Q33 = [string, number][E.A];  // string
->Q33 : Symbol(Q33, Decl(keyofAndIndexedAccess.ts, 61, 31))
->E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 21, 40))
->A : Symbol(E.A, Decl(keyofAndIndexedAccess.ts, 23, 14))
+>Q33 : Symbol(Q33, Decl(keyofAndIndexedAccess.ts, 63, 31))
+>E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 22, 48))
+>A : Symbol(E.A, Decl(keyofAndIndexedAccess.ts, 24, 14))
 
 type Q34 = [string, number][E.B];  // number
->Q34 : Symbol(Q34, Decl(keyofAndIndexedAccess.ts, 62, 33))
->E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 21, 40))
->B : Symbol(E.B, Decl(keyofAndIndexedAccess.ts, 23, 17))
+>Q34 : Symbol(Q34, Decl(keyofAndIndexedAccess.ts, 64, 33))
+>E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 22, 48))
+>B : Symbol(E.B, Decl(keyofAndIndexedAccess.ts, 24, 17))
 
 type Q35 = [string, number][E.C];  // string | number
->Q35 : Symbol(Q35, Decl(keyofAndIndexedAccess.ts, 63, 33))
->E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 21, 40))
->C : Symbol(E.C, Decl(keyofAndIndexedAccess.ts, 23, 20))
+>Q35 : Symbol(Q35, Decl(keyofAndIndexedAccess.ts, 65, 33))
+>E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 22, 48))
+>C : Symbol(E.C, Decl(keyofAndIndexedAccess.ts, 24, 20))
 
 type Q36 = [string, number]["0"];  // string
->Q36 : Symbol(Q36, Decl(keyofAndIndexedAccess.ts, 64, 33))
+>Q36 : Symbol(Q36, Decl(keyofAndIndexedAccess.ts, 66, 33))
 
 type Q37 = [string, number]["1"];  // string
->Q37 : Symbol(Q37, Decl(keyofAndIndexedAccess.ts, 65, 33))
+>Q37 : Symbol(Q37, Decl(keyofAndIndexedAccess.ts, 67, 33))
 
 type Q40 = (Shape | Options)["visible"];  // boolean | "yes" | "no"
->Q40 : Symbol(Q40, Decl(keyofAndIndexedAccess.ts, 66, 33))
+>Q40 : Symbol(Q40, Decl(keyofAndIndexedAccess.ts, 68, 33))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 >Options : Symbol(Options, Decl(keyofAndIndexedAccess.ts, 15, 1))
 
 type Q41 = (Shape & Options)["visible"];  // true & "yes" | true & "no" | false & "yes" | false & "no"
->Q41 : Symbol(Q41, Decl(keyofAndIndexedAccess.ts, 68, 40))
+>Q41 : Symbol(Q41, Decl(keyofAndIndexedAccess.ts, 70, 40))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 >Options : Symbol(Options, Decl(keyofAndIndexedAccess.ts, 15, 1))
 
 type Q50 = Dictionary<Shape>["howdy"];  // Shape
->Q50 : Symbol(Q50, Decl(keyofAndIndexedAccess.ts, 69, 40))
+>Q50 : Symbol(Q50, Decl(keyofAndIndexedAccess.ts, 71, 40))
 >Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 19, 1))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type Q51 = Dictionary<Shape>[123];  // Shape
->Q51 : Symbol(Q51, Decl(keyofAndIndexedAccess.ts, 71, 38))
+>Q51 : Symbol(Q51, Decl(keyofAndIndexedAccess.ts, 73, 38))
 >Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 19, 1))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
 type Q52 = Dictionary<Shape>[E.B];  // Shape
->Q52 : Symbol(Q52, Decl(keyofAndIndexedAccess.ts, 72, 34))
+>Q52 : Symbol(Q52, Decl(keyofAndIndexedAccess.ts, 74, 34))
 >Dictionary : Symbol(Dictionary, Decl(keyofAndIndexedAccess.ts, 19, 1))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 21, 40))
->B : Symbol(E.B, Decl(keyofAndIndexedAccess.ts, 23, 17))
+>E : Symbol(E, Decl(keyofAndIndexedAccess.ts, 22, 48))
+>B : Symbol(E.B, Decl(keyofAndIndexedAccess.ts, 24, 17))
 
 declare let cond: boolean;
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 77, 11))
 
 function getProperty<T, K extends keyof T>(obj: T, key: K) {
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 77, 21))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 77, 23))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 77, 21))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 77, 43))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 77, 21))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 77, 50))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 77, 23))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 77, 26))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 79, 21))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 79, 23))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 79, 21))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 79, 43))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 79, 21))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 79, 50))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 79, 23))
 
     return obj[key];
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 77, 43))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 77, 50))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 79, 43))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 79, 50))
 }
 
 function setProperty<T, K extends keyof T>(obj: T, key: K, value: T[K]) {
->setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 79, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 81, 21))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 81, 23))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 81, 21))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 81, 43))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 81, 21))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 81, 50))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 81, 23))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 81, 58))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 81, 21))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 81, 23))
+>setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 81, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 83, 21))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 83, 23))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 83, 21))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 83, 43))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 83, 21))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 83, 50))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 83, 23))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 83, 58))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 83, 21))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 83, 23))
 
     obj[key] = value;
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 81, 43))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 81, 50))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 81, 58))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 83, 43))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 83, 50))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 83, 58))
 }
 
 function f10(shape: Shape) {
->f10 : Symbol(f10, Decl(keyofAndIndexedAccess.ts, 83, 1))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 85, 13))
+>f10 : Symbol(f10, Decl(keyofAndIndexedAccess.ts, 85, 1))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 87, 13))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
     let name = getProperty(shape, "name");  // string
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 86, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 85, 13))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 88, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 77, 26))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 87, 13))
 
     let widthOrHeight = getProperty(shape, cond ? "width" : "height");  // number
->widthOrHeight : Symbol(widthOrHeight, Decl(keyofAndIndexedAccess.ts, 87, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 85, 13))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
+>widthOrHeight : Symbol(widthOrHeight, Decl(keyofAndIndexedAccess.ts, 89, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 77, 26))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 87, 13))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 77, 11))
 
     let nameOrVisible = getProperty(shape, cond ? "name" : "visible");  // string | boolean
->nameOrVisible : Symbol(nameOrVisible, Decl(keyofAndIndexedAccess.ts, 88, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 85, 13))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
+>nameOrVisible : Symbol(nameOrVisible, Decl(keyofAndIndexedAccess.ts, 90, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 77, 26))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 87, 13))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 77, 11))
 
     setProperty(shape, "name", "rectangle");
->setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 79, 1))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 85, 13))
+>setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 81, 1))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 87, 13))
 
     setProperty(shape, cond ? "width" : "height", 10);
->setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 79, 1))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 85, 13))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
+>setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 81, 1))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 87, 13))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 77, 11))
 
     setProperty(shape, cond ? "name" : "visible", true);  // Technically not safe
->setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 79, 1))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 85, 13))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
+>setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 81, 1))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 87, 13))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 77, 11))
 }
 
 function f11(a: Shape[]) {
->f11 : Symbol(f11, Decl(keyofAndIndexedAccess.ts, 92, 1))
->a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 94, 13))
+>f11 : Symbol(f11, Decl(keyofAndIndexedAccess.ts, 94, 1))
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 96, 13))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
     let len = getProperty(a, "length");  // number
->len : Symbol(len, Decl(keyofAndIndexedAccess.ts, 95, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 94, 13))
+>len : Symbol(len, Decl(keyofAndIndexedAccess.ts, 97, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 77, 26))
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 96, 13))
 
     setProperty(a, "length", len);
->setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 79, 1))
->a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 94, 13))
->len : Symbol(len, Decl(keyofAndIndexedAccess.ts, 95, 7))
+>setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 81, 1))
+>a : Symbol(a, Decl(keyofAndIndexedAccess.ts, 96, 13))
+>len : Symbol(len, Decl(keyofAndIndexedAccess.ts, 97, 7))
 }
 
 function f12(t: [Shape, boolean]) {
->f12 : Symbol(f12, Decl(keyofAndIndexedAccess.ts, 97, 1))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 99, 13))
+>f12 : Symbol(f12, Decl(keyofAndIndexedAccess.ts, 99, 1))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 101, 13))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
     let len = getProperty(t, "length");
->len : Symbol(len, Decl(keyofAndIndexedAccess.ts, 100, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 99, 13))
+>len : Symbol(len, Decl(keyofAndIndexedAccess.ts, 102, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 77, 26))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 101, 13))
 
     let s2 = getProperty(t, "0");  // Shape
->s2 : Symbol(s2, Decl(keyofAndIndexedAccess.ts, 101, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 99, 13))
+>s2 : Symbol(s2, Decl(keyofAndIndexedAccess.ts, 103, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 77, 26))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 101, 13))
 
     let b2 = getProperty(t, "1");  // boolean
->b2 : Symbol(b2, Decl(keyofAndIndexedAccess.ts, 102, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 99, 13))
+>b2 : Symbol(b2, Decl(keyofAndIndexedAccess.ts, 104, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 77, 26))
+>t : Symbol(t, Decl(keyofAndIndexedAccess.ts, 101, 13))
 }
 
 function f13(foo: any, bar: any) {
->f13 : Symbol(f13, Decl(keyofAndIndexedAccess.ts, 103, 1))
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 105, 13))
->bar : Symbol(bar, Decl(keyofAndIndexedAccess.ts, 105, 22))
+>f13 : Symbol(f13, Decl(keyofAndIndexedAccess.ts, 105, 1))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 107, 13))
+>bar : Symbol(bar, Decl(keyofAndIndexedAccess.ts, 107, 22))
 
     let x = getProperty(foo, "x");  // any
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 106, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 105, 13))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 108, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 77, 26))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 107, 13))
 
     let y = getProperty(foo, "100");  // any
->y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 107, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 105, 13))
+>y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 109, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 77, 26))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 107, 13))
 
     let z = getProperty(foo, bar);  // any
->z : Symbol(z, Decl(keyofAndIndexedAccess.ts, 108, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 105, 13))
->bar : Symbol(bar, Decl(keyofAndIndexedAccess.ts, 105, 22))
+>z : Symbol(z, Decl(keyofAndIndexedAccess.ts, 110, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 77, 26))
+>foo : Symbol(foo, Decl(keyofAndIndexedAccess.ts, 107, 13))
+>bar : Symbol(bar, Decl(keyofAndIndexedAccess.ts, 107, 22))
 }
 
 class Component<PropType> {
->Component : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 109, 1))
->PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 111, 16))
+>Component : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 111, 1))
+>PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 113, 16))
 
     props: PropType;
->props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 111, 27))
->PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 111, 16))
+>props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 113, 27))
+>PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 113, 16))
 
     getProperty<K extends keyof PropType>(key: K) {
->getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 113, 16))
->PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 111, 16))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 113, 42))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 113, 16))
+>getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 114, 20))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 115, 16))
+>PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 113, 16))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 115, 42))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 115, 16))
 
         return this.props[key];
->this.props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 111, 27))
->this : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 109, 1))
->props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 111, 27))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 113, 42))
+>this.props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 113, 27))
+>this : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 111, 1))
+>props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 113, 27))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 115, 42))
     }
     setProperty<K extends keyof PropType>(key: K, value: PropType[K]) {
->setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 116, 16))
->PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 111, 16))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 116, 42))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 116, 16))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 116, 49))
->PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 111, 16))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 116, 16))
+>setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 117, 5))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 118, 16))
+>PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 113, 16))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 118, 42))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 118, 16))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 118, 49))
+>PropType : Symbol(PropType, Decl(keyofAndIndexedAccess.ts, 113, 16))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 118, 16))
 
         this.props[key] = value;
->this.props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 111, 27))
->this : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 109, 1))
->props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 111, 27))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 116, 42))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 116, 49))
+>this.props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 113, 27))
+>this : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 111, 1))
+>props : Symbol(Component.props, Decl(keyofAndIndexedAccess.ts, 113, 27))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 118, 42))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 118, 49))
     }
 }
 
 function f20(component: Component<Shape>) {
->f20 : Symbol(f20, Decl(keyofAndIndexedAccess.ts, 119, 1))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
->Component : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 109, 1))
+>f20 : Symbol(f20, Decl(keyofAndIndexedAccess.ts, 121, 1))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 123, 13))
+>Component : Symbol(Component, Decl(keyofAndIndexedAccess.ts, 111, 1))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
     let name = component.getProperty("name");  // string
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 122, 7))
->component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
->getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 124, 7))
+>component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 114, 20))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 123, 13))
+>getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 114, 20))
 
     let widthOrHeight = component.getProperty(cond ? "width" : "height");  // number
->widthOrHeight : Symbol(widthOrHeight, Decl(keyofAndIndexedAccess.ts, 123, 7))
->component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
->getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
+>widthOrHeight : Symbol(widthOrHeight, Decl(keyofAndIndexedAccess.ts, 125, 7))
+>component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 114, 20))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 123, 13))
+>getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 114, 20))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 77, 11))
 
     let nameOrVisible = component.getProperty(cond ? "name" : "visible");  // string | boolean
->nameOrVisible : Symbol(nameOrVisible, Decl(keyofAndIndexedAccess.ts, 124, 7))
->component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
->getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 112, 20))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
+>nameOrVisible : Symbol(nameOrVisible, Decl(keyofAndIndexedAccess.ts, 126, 7))
+>component.getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 114, 20))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 123, 13))
+>getProperty : Symbol(Component.getProperty, Decl(keyofAndIndexedAccess.ts, 114, 20))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 77, 11))
 
     component.setProperty("name", "rectangle");
->component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
->setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
+>component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 117, 5))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 123, 13))
+>setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 117, 5))
 
     component.setProperty(cond ? "width" : "height", 10)
->component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
->setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
+>component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 117, 5))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 123, 13))
+>setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 117, 5))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 77, 11))
 
     component.setProperty(cond ? "name" : "visible", true);  // Technically not safe
->component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
->component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 121, 13))
->setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 115, 5))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
+>component.setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 117, 5))
+>component : Symbol(component, Decl(keyofAndIndexedAccess.ts, 123, 13))
+>setProperty : Symbol(Component.setProperty, Decl(keyofAndIndexedAccess.ts, 117, 5))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 77, 11))
 }
 
 function pluck<T, K extends keyof T>(array: T[], key: K) {
->pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 128, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 130, 15))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 130, 17))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 130, 15))
->array : Symbol(array, Decl(keyofAndIndexedAccess.ts, 130, 37))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 130, 15))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 130, 48))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 130, 17))
+>pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 130, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 132, 15))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 132, 17))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 132, 15))
+>array : Symbol(array, Decl(keyofAndIndexedAccess.ts, 132, 37))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 132, 15))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 132, 48))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 132, 17))
 
     return array.map(x => x[key]);
 >array.map : Symbol(Array.map, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->array : Symbol(array, Decl(keyofAndIndexedAccess.ts, 130, 37))
+>array : Symbol(array, Decl(keyofAndIndexedAccess.ts, 132, 37))
 >map : Symbol(Array.map, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 131, 21))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 131, 21))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 130, 48))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 133, 21))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 133, 21))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 132, 48))
 }
 
 function f30(shapes: Shape[]) {
->f30 : Symbol(f30, Decl(keyofAndIndexedAccess.ts, 132, 1))
->shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 134, 13))
+>f30 : Symbol(f30, Decl(keyofAndIndexedAccess.ts, 134, 1))
+>shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 136, 13))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
 
     let names = pluck(shapes, "name");    // string[]
->names : Symbol(names, Decl(keyofAndIndexedAccess.ts, 135, 7))
->pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 128, 1))
->shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 134, 13))
+>names : Symbol(names, Decl(keyofAndIndexedAccess.ts, 137, 7))
+>pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 130, 1))
+>shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 136, 13))
 
     let widths = pluck(shapes, "width");  // number[]
->widths : Symbol(widths, Decl(keyofAndIndexedAccess.ts, 136, 7))
->pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 128, 1))
->shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 134, 13))
+>widths : Symbol(widths, Decl(keyofAndIndexedAccess.ts, 138, 7))
+>pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 130, 1))
+>shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 136, 13))
 
     let nameOrVisibles = pluck(shapes, cond ? "name" : "visible");  // (string | boolean)[]
->nameOrVisibles : Symbol(nameOrVisibles, Decl(keyofAndIndexedAccess.ts, 137, 7))
->pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 128, 1))
->shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 134, 13))
->cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 75, 11))
+>nameOrVisibles : Symbol(nameOrVisibles, Decl(keyofAndIndexedAccess.ts, 139, 7))
+>pluck : Symbol(pluck, Decl(keyofAndIndexedAccess.ts, 130, 1))
+>shapes : Symbol(shapes, Decl(keyofAndIndexedAccess.ts, 136, 13))
+>cond : Symbol(cond, Decl(keyofAndIndexedAccess.ts, 77, 11))
 }
 
 function f31<K extends keyof Shape>(key: K) {
->f31 : Symbol(f31, Decl(keyofAndIndexedAccess.ts, 138, 1))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 140, 13))
+>f31 : Symbol(f31, Decl(keyofAndIndexedAccess.ts, 140, 1))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 142, 13))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 140, 36))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 140, 13))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 142, 36))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 142, 13))
 
     const shape: Shape = { name: "foo", width: 5, height: 10, visible: true };
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 141, 9))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 143, 9))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 141, 26))
->width : Symbol(width, Decl(keyofAndIndexedAccess.ts, 141, 39))
->height : Symbol(height, Decl(keyofAndIndexedAccess.ts, 141, 49))
->visible : Symbol(visible, Decl(keyofAndIndexedAccess.ts, 141, 61))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 143, 26))
+>width : Symbol(width, Decl(keyofAndIndexedAccess.ts, 143, 39))
+>height : Symbol(height, Decl(keyofAndIndexedAccess.ts, 143, 49))
+>visible : Symbol(visible, Decl(keyofAndIndexedAccess.ts, 143, 61))
 
     return shape[key];  // Shape[K]
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 141, 9))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 140, 36))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 143, 9))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 142, 36))
 }
 
 function f32<K extends "width" | "height">(key: K) {
->f32 : Symbol(f32, Decl(keyofAndIndexedAccess.ts, 143, 1))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 145, 13))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 145, 43))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 145, 13))
+>f32 : Symbol(f32, Decl(keyofAndIndexedAccess.ts, 145, 1))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 147, 13))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 147, 43))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 147, 13))
 
     const shape: Shape = { name: "foo", width: 5, height: 10, visible: true };
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 146, 9))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 148, 9))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 146, 26))
->width : Symbol(width, Decl(keyofAndIndexedAccess.ts, 146, 39))
->height : Symbol(height, Decl(keyofAndIndexedAccess.ts, 146, 49))
->visible : Symbol(visible, Decl(keyofAndIndexedAccess.ts, 146, 61))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 148, 26))
+>width : Symbol(width, Decl(keyofAndIndexedAccess.ts, 148, 39))
+>height : Symbol(height, Decl(keyofAndIndexedAccess.ts, 148, 49))
+>visible : Symbol(visible, Decl(keyofAndIndexedAccess.ts, 148, 61))
 
     return shape[key];  // Shape[K]
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 146, 9))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 145, 43))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 148, 9))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 147, 43))
 }
 
 function f33<S extends Shape, K extends keyof S>(shape: S, key: K) {
->f33 : Symbol(f33, Decl(keyofAndIndexedAccess.ts, 148, 1))
->S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 150, 13))
+>f33 : Symbol(f33, Decl(keyofAndIndexedAccess.ts, 150, 1))
+>S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 152, 13))
 >Shape : Symbol(Shape, Decl(keyofAndIndexedAccess.ts, 0, 0))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 150, 29))
->S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 150, 13))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 150, 49))
->S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 150, 13))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 150, 58))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 150, 29))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 152, 29))
+>S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 152, 13))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 152, 49))
+>S : Symbol(S, Decl(keyofAndIndexedAccess.ts, 152, 13))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 152, 58))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 152, 29))
 
     let name = getProperty(shape, "name");
->name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 151, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 150, 49))
+>name : Symbol(name, Decl(keyofAndIndexedAccess.ts, 153, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 77, 26))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 152, 49))
 
     let prop = getProperty(shape, key);
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 152, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 150, 49))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 150, 58))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 154, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 77, 26))
+>shape : Symbol(shape, Decl(keyofAndIndexedAccess.ts, 152, 49))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 152, 58))
 
     return prop;
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 152, 7))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 154, 7))
 }
 
 function f34(ts: TaggedShape) {
->f34 : Symbol(f34, Decl(keyofAndIndexedAccess.ts, 154, 1))
->ts : Symbol(ts, Decl(keyofAndIndexedAccess.ts, 156, 13))
+>f34 : Symbol(f34, Decl(keyofAndIndexedAccess.ts, 156, 1))
+>ts : Symbol(ts, Decl(keyofAndIndexedAccess.ts, 158, 13))
 >TaggedShape : Symbol(TaggedShape, Decl(keyofAndIndexedAccess.ts, 6, 1))
 
     let tag1 = f33(ts, "tag");
->tag1 : Symbol(tag1, Decl(keyofAndIndexedAccess.ts, 157, 7))
->f33 : Symbol(f33, Decl(keyofAndIndexedAccess.ts, 148, 1))
->ts : Symbol(ts, Decl(keyofAndIndexedAccess.ts, 156, 13))
+>tag1 : Symbol(tag1, Decl(keyofAndIndexedAccess.ts, 159, 7))
+>f33 : Symbol(f33, Decl(keyofAndIndexedAccess.ts, 150, 1))
+>ts : Symbol(ts, Decl(keyofAndIndexedAccess.ts, 158, 13))
 
     let tag2 = getProperty(ts, "tag");
->tag2 : Symbol(tag2, Decl(keyofAndIndexedAccess.ts, 158, 7))
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->ts : Symbol(ts, Decl(keyofAndIndexedAccess.ts, 156, 13))
+>tag2 : Symbol(tag2, Decl(keyofAndIndexedAccess.ts, 160, 7))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 77, 26))
+>ts : Symbol(ts, Decl(keyofAndIndexedAccess.ts, 158, 13))
 }
 
 class C {
->C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 159, 1))
+>C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 161, 1))
 
     public x: string;
->x : Symbol(C.x, Decl(keyofAndIndexedAccess.ts, 161, 9))
+>x : Symbol(C.x, Decl(keyofAndIndexedAccess.ts, 163, 9))
 
     protected y: string;
->y : Symbol(C.y, Decl(keyofAndIndexedAccess.ts, 162, 21))
+>y : Symbol(C.y, Decl(keyofAndIndexedAccess.ts, 164, 21))
 
     private z: string;
->z : Symbol(C.z, Decl(keyofAndIndexedAccess.ts, 163, 24))
+>z : Symbol(C.z, Decl(keyofAndIndexedAccess.ts, 165, 24))
 }
 
 // Indexed access expressions have always permitted access to private and protected members.
 // For consistency we also permit such access in indexed access types.
 function f40(c: C) {
->f40 : Symbol(f40, Decl(keyofAndIndexedAccess.ts, 165, 1))
->c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 169, 13))
->C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 159, 1))
+>f40 : Symbol(f40, Decl(keyofAndIndexedAccess.ts, 167, 1))
+>c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 171, 13))
+>C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 161, 1))
 
     type X = C["x"];
->X : Symbol(X, Decl(keyofAndIndexedAccess.ts, 169, 20))
->C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 159, 1))
+>X : Symbol(X, Decl(keyofAndIndexedAccess.ts, 171, 20))
+>C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 161, 1))
 
     type Y = C["y"];
->Y : Symbol(Y, Decl(keyofAndIndexedAccess.ts, 170, 20))
->C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 159, 1))
+>Y : Symbol(Y, Decl(keyofAndIndexedAccess.ts, 172, 20))
+>C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 161, 1))
 
     type Z = C["z"];
->Z : Symbol(Z, Decl(keyofAndIndexedAccess.ts, 171, 20))
->C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 159, 1))
+>Z : Symbol(Z, Decl(keyofAndIndexedAccess.ts, 173, 20))
+>C : Symbol(C, Decl(keyofAndIndexedAccess.ts, 161, 1))
 
     let x: X = c["x"];
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 173, 7))
->X : Symbol(X, Decl(keyofAndIndexedAccess.ts, 169, 20))
->c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 169, 13))
->"x" : Symbol(C.x, Decl(keyofAndIndexedAccess.ts, 161, 9))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 175, 7))
+>X : Symbol(X, Decl(keyofAndIndexedAccess.ts, 171, 20))
+>c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 171, 13))
+>"x" : Symbol(C.x, Decl(keyofAndIndexedAccess.ts, 163, 9))
 
     let y: Y = c["y"];
->y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 174, 7))
->Y : Symbol(Y, Decl(keyofAndIndexedAccess.ts, 170, 20))
->c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 169, 13))
->"y" : Symbol(C.y, Decl(keyofAndIndexedAccess.ts, 162, 21))
+>y : Symbol(y, Decl(keyofAndIndexedAccess.ts, 176, 7))
+>Y : Symbol(Y, Decl(keyofAndIndexedAccess.ts, 172, 20))
+>c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 171, 13))
+>"y" : Symbol(C.y, Decl(keyofAndIndexedAccess.ts, 164, 21))
 
     let z: Z = c["z"];
->z : Symbol(z, Decl(keyofAndIndexedAccess.ts, 175, 7))
->Z : Symbol(Z, Decl(keyofAndIndexedAccess.ts, 171, 20))
->c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 169, 13))
->"z" : Symbol(C.z, Decl(keyofAndIndexedAccess.ts, 163, 24))
+>z : Symbol(z, Decl(keyofAndIndexedAccess.ts, 177, 7))
+>Z : Symbol(Z, Decl(keyofAndIndexedAccess.ts, 173, 20))
+>c : Symbol(c, Decl(keyofAndIndexedAccess.ts, 171, 13))
+>"z" : Symbol(C.z, Decl(keyofAndIndexedAccess.ts, 165, 24))
 }
 
 function f50<T>(k: keyof T, s: string) {
->f50 : Symbol(f50, Decl(keyofAndIndexedAccess.ts, 176, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 178, 13))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 178, 16))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 178, 13))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 178, 27))
+>f50 : Symbol(f50, Decl(keyofAndIndexedAccess.ts, 178, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 180, 13))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 180, 16))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 180, 13))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 180, 27))
 
     const x1 = s as keyof T;
->x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 179, 9))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 178, 27))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 178, 13))
+>x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 181, 9))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 180, 27))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 180, 13))
 
     const x2 = k as string;
->x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 180, 9))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 178, 16))
+>x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 182, 9))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 180, 16))
 }
 
 function f51<T, K extends keyof T>(k: K, s: string) {
->f51 : Symbol(f51, Decl(keyofAndIndexedAccess.ts, 181, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 183, 13))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 183, 15))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 183, 13))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 183, 35))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 183, 15))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 183, 40))
+>f51 : Symbol(f51, Decl(keyofAndIndexedAccess.ts, 183, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 185, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 185, 15))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 185, 13))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 185, 35))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 185, 15))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 185, 40))
 
     const x1 = s as keyof T;
->x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 184, 9))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 183, 40))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 183, 13))
+>x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 186, 9))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 185, 40))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 185, 13))
 
     const x2 = k as string;
->x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 185, 9))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 183, 35))
+>x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 187, 9))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 185, 35))
 }
 
 function f52<T>(obj: { [x: string]: boolean }, k: keyof T, s: string, n: number) {
->f52 : Symbol(f52, Decl(keyofAndIndexedAccess.ts, 186, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 188, 13))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 188, 16))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 188, 24))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 188, 46))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 188, 13))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 188, 58))
->n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 188, 69))
+>f52 : Symbol(f52, Decl(keyofAndIndexedAccess.ts, 188, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 190, 13))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 190, 16))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 190, 24))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 190, 46))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 190, 13))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 190, 58))
+>n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 190, 69))
 
     const x1 = obj[s];
->x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 189, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 188, 16))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 188, 58))
+>x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 191, 9))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 190, 16))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 190, 58))
 
     const x2 = obj[n];
->x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 190, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 188, 16))
->n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 188, 69))
+>x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 192, 9))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 190, 16))
+>n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 190, 69))
 
     const x3 = obj[k];
->x3 : Symbol(x3, Decl(keyofAndIndexedAccess.ts, 191, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 188, 16))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 188, 46))
+>x3 : Symbol(x3, Decl(keyofAndIndexedAccess.ts, 193, 9))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 190, 16))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 190, 46))
 }
 
 function f53<T, K extends keyof T>(obj: { [x: string]: boolean }, k: K, s: string, n: number) {
->f53 : Symbol(f53, Decl(keyofAndIndexedAccess.ts, 192, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 194, 13))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 194, 15))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 194, 13))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 194, 35))
->x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 194, 43))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 194, 65))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 194, 15))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 194, 71))
->n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 194, 82))
+>f53 : Symbol(f53, Decl(keyofAndIndexedAccess.ts, 194, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 196, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 196, 15))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 196, 13))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 196, 35))
+>x : Symbol(x, Decl(keyofAndIndexedAccess.ts, 196, 43))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 196, 65))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 196, 15))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 196, 71))
+>n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 196, 82))
 
     const x1 = obj[s];
->x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 195, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 194, 35))
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 194, 71))
+>x1 : Symbol(x1, Decl(keyofAndIndexedAccess.ts, 197, 9))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 196, 35))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 196, 71))
 
     const x2 = obj[n];
->x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 196, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 194, 35))
->n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 194, 82))
+>x2 : Symbol(x2, Decl(keyofAndIndexedAccess.ts, 198, 9))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 196, 35))
+>n : Symbol(n, Decl(keyofAndIndexedAccess.ts, 196, 82))
 
     const x3 = obj[k];
->x3 : Symbol(x3, Decl(keyofAndIndexedAccess.ts, 197, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 194, 35))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 194, 65))
+>x3 : Symbol(x3, Decl(keyofAndIndexedAccess.ts, 199, 9))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 196, 35))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 196, 65))
 }
 
 function f54<T>(obj: T, key: keyof T) {
->f54 : Symbol(f54, Decl(keyofAndIndexedAccess.ts, 198, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 200, 13))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 200, 16))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 200, 13))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 200, 23))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 200, 13))
+>f54 : Symbol(f54, Decl(keyofAndIndexedAccess.ts, 200, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 202, 13))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 202, 16))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 202, 13))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 202, 23))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 202, 13))
 
     for (let s in obj[key]) {
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 201, 12))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 200, 16))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 200, 23))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 203, 12))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 202, 16))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 202, 23))
     }
     const b = "foo" in obj[key];
->b : Symbol(b, Decl(keyofAndIndexedAccess.ts, 203, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 200, 16))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 200, 23))
+>b : Symbol(b, Decl(keyofAndIndexedAccess.ts, 205, 9))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 202, 16))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 202, 23))
 }
 
 function f55<T, K extends keyof T>(obj: T, key: K) {
->f55 : Symbol(f55, Decl(keyofAndIndexedAccess.ts, 204, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 206, 13))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 206, 15))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 206, 13))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 206, 35))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 206, 13))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 206, 42))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 206, 15))
+>f55 : Symbol(f55, Decl(keyofAndIndexedAccess.ts, 206, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 208, 13))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 208, 15))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 208, 13))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 208, 35))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 208, 13))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 208, 42))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 208, 15))
 
     for (let s in obj[key]) {
->s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 207, 12))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 206, 35))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 206, 42))
+>s : Symbol(s, Decl(keyofAndIndexedAccess.ts, 209, 12))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 208, 35))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 208, 42))
     }
     const b = "foo" in obj[key];
->b : Symbol(b, Decl(keyofAndIndexedAccess.ts, 209, 9))
->obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 206, 35))
->key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 206, 42))
+>b : Symbol(b, Decl(keyofAndIndexedAccess.ts, 211, 9))
+>obj : Symbol(obj, Decl(keyofAndIndexedAccess.ts, 208, 35))
+>key : Symbol(key, Decl(keyofAndIndexedAccess.ts, 208, 42))
 }
 
 function f60<T>(source: T, target: T) {
->f60 : Symbol(f60, Decl(keyofAndIndexedAccess.ts, 210, 1))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 212, 13))
->source : Symbol(source, Decl(keyofAndIndexedAccess.ts, 212, 16))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 212, 13))
->target : Symbol(target, Decl(keyofAndIndexedAccess.ts, 212, 26))
->T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 212, 13))
+>f60 : Symbol(f60, Decl(keyofAndIndexedAccess.ts, 212, 1))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 214, 13))
+>source : Symbol(source, Decl(keyofAndIndexedAccess.ts, 214, 16))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 214, 13))
+>target : Symbol(target, Decl(keyofAndIndexedAccess.ts, 214, 26))
+>T : Symbol(T, Decl(keyofAndIndexedAccess.ts, 214, 13))
 
     for (let k in source) {
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 213, 12))
->source : Symbol(source, Decl(keyofAndIndexedAccess.ts, 212, 16))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 215, 12))
+>source : Symbol(source, Decl(keyofAndIndexedAccess.ts, 214, 16))
 
         target[k] = source[k];
->target : Symbol(target, Decl(keyofAndIndexedAccess.ts, 212, 26))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 213, 12))
->source : Symbol(source, Decl(keyofAndIndexedAccess.ts, 212, 16))
->k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 213, 12))
+>target : Symbol(target, Decl(keyofAndIndexedAccess.ts, 214, 26))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 215, 12))
+>source : Symbol(source, Decl(keyofAndIndexedAccess.ts, 214, 16))
+>k : Symbol(k, Decl(keyofAndIndexedAccess.ts, 215, 12))
     }
 }
 
 // Repros from #12011
 
 class Base {
->Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 216, 1))
+>Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 218, 1))
 
     get<K extends keyof this>(prop: K) {
->get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 220, 12))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 221, 8))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 221, 30))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 221, 8))
+>get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 222, 12))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 223, 8))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 223, 30))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 223, 8))
 
         return this[prop];
->this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 216, 1))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 221, 30))
+>this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 218, 1))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 223, 30))
     }
     set<K extends keyof this>(prop: K, value: this[K]) {
->set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 223, 5))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 224, 8))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 224, 30))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 224, 8))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 224, 38))
->K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 224, 8))
+>set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 225, 5))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 226, 8))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 226, 30))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 226, 8))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 226, 38))
+>K : Symbol(K, Decl(keyofAndIndexedAccess.ts, 226, 8))
 
         this[prop] = value;
->this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 216, 1))
->prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 224, 30))
->value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 224, 38))
+>this : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 218, 1))
+>prop : Symbol(prop, Decl(keyofAndIndexedAccess.ts, 226, 30))
+>value : Symbol(value, Decl(keyofAndIndexedAccess.ts, 226, 38))
     }
 }
 
 class Person extends Base {
->Person : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 227, 1))
->Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 216, 1))
+>Person : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 229, 1))
+>Base : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 218, 1))
 
     parts: number;
->parts : Symbol(Person.parts, Decl(keyofAndIndexedAccess.ts, 229, 27))
+>parts : Symbol(Person.parts, Decl(keyofAndIndexedAccess.ts, 231, 27))
 
     constructor(parts: number) {
->parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 231, 16))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 233, 16))
 
         super();
->super : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 216, 1))
+>super : Symbol(Base, Decl(keyofAndIndexedAccess.ts, 218, 1))
 
         this.set("parts", parts);
->this.set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 223, 5))
->this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 227, 1))
->set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 223, 5))
->parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 231, 16))
+>this.set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 225, 5))
+>this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 229, 1))
+>set : Symbol(Base.set, Decl(keyofAndIndexedAccess.ts, 225, 5))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 233, 16))
     }
     getParts() {
->getParts : Symbol(Person.getParts, Decl(keyofAndIndexedAccess.ts, 234, 5))
+>getParts : Symbol(Person.getParts, Decl(keyofAndIndexedAccess.ts, 236, 5))
 
         return this.get("parts")
->this.get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 220, 12))
->this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 227, 1))
->get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 220, 12))
+>this.get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 222, 12))
+>this : Symbol(Person, Decl(keyofAndIndexedAccess.ts, 229, 1))
+>get : Symbol(Base.get, Decl(keyofAndIndexedAccess.ts, 222, 12))
     }
 }
 
 class OtherPerson {
->OtherPerson : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 238, 1))
+>OtherPerson : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 240, 1))
 
     parts: number;
->parts : Symbol(OtherPerson.parts, Decl(keyofAndIndexedAccess.ts, 240, 19))
+>parts : Symbol(OtherPerson.parts, Decl(keyofAndIndexedAccess.ts, 242, 19))
 
     constructor(parts: number) {
->parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 242, 16))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 244, 16))
 
         setProperty(this, "parts", parts);
->setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 79, 1))
->this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 238, 1))
->parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 242, 16))
+>setProperty : Symbol(setProperty, Decl(keyofAndIndexedAccess.ts, 81, 1))
+>this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 240, 1))
+>parts : Symbol(parts, Decl(keyofAndIndexedAccess.ts, 244, 16))
     }
     getParts() {
->getParts : Symbol(OtherPerson.getParts, Decl(keyofAndIndexedAccess.ts, 244, 5))
+>getParts : Symbol(OtherPerson.getParts, Decl(keyofAndIndexedAccess.ts, 246, 5))
 
         return getProperty(this, "parts")
->getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 75, 26))
->this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 238, 1))
+>getProperty : Symbol(getProperty, Decl(keyofAndIndexedAccess.ts, 77, 26))
+>this : Symbol(OtherPerson, Decl(keyofAndIndexedAccess.ts, 240, 1))
     }
 }
+

--- a/tests/baselines/reference/keyofAndIndexedAccess.types
+++ b/tests/baselines/reference/keyofAndIndexedAccess.types
@@ -47,16 +47,22 @@ type Dictionary<T> = { [x: string]: T };
 >x : string
 >T : T
 
+type NumericallyIndexed<T> = { [x: number]: T };
+>NumericallyIndexed : NumericallyIndexed<T>
+>T : T
+>x : number
+>T : T
+
 const enum E { A, B, C }
 >E : E
 >A : E.A
 >B : E.B
 >C : E.C
 
-type K00 = keyof any;  // string | number
+type K00 = keyof any;  // string
 >K00 : string
 
-type K01 = keyof string;  // number | "toString" | "charAt" | ...
+type K01 = keyof string;  // "toString" | "charAt" | ...
 >K01 : "length" | "toString" | "concat" | "slice" | "indexOf" | "lastIndexOf" | "charAt" | "charCodeAt" | "localeCompare" | "match" | "replace" | "search" | "split" | "substring" | "toLowerCase" | "toLocaleLowerCase" | "toUpperCase" | "toLocaleUpperCase" | "trim" | "substr" | "valueOf"
 
 type K02 = keyof number;  // "toString" | "toFixed" | "toExponential" | ...
@@ -82,11 +88,11 @@ type K10 = keyof Shape;  // "name" | "width" | "height" | "visible"
 >K10 : "name" | "width" | "height" | "visible"
 >Shape : Shape
 
-type K11 = keyof Shape[];  // number | "length" | "toString" | ...
+type K11 = keyof Shape[];  // "length" | "toString" | ...
 >K11 : "length" | "toString" | "toLocaleString" | "push" | "pop" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight"
 >Shape : Shape
 
-type K12 = keyof Dictionary<Shape>;  // string | number
+type K12 = keyof Dictionary<Shape>;  // string
 >K12 : string
 >Dictionary : Dictionary<T>
 >Shape : Shape
@@ -102,7 +108,7 @@ type K15 = keyof E;  // "toString" | "toFixed" | "toExponential" | ...
 >K15 : "toString" | "toLocaleString" | "valueOf" | "toFixed" | "toExponential" | "toPrecision"
 >E : E
 
-type K16 = keyof [string, number];  // number | "0" | "1" | "length" | "toString" | ...
+type K16 = keyof [string, number];  // "0" | "1" | "length" | "toString" | ...
 >K16 : "0" | "1" | "length" | "toString" | "toLocaleString" | "push" | "pop" | "concat" | "join" | "reverse" | "shift" | "slice" | "sort" | "splice" | "unshift" | "indexOf" | "lastIndexOf" | "every" | "some" | "forEach" | "map" | "filter" | "reduce" | "reduceRight"
 
 type K17 = keyof (Shape | Item);  // "name"
@@ -115,6 +121,11 @@ type K18 = keyof (Shape & Item);  // "name" | "width" | "height" | "visible" | "
 >Shape : Shape
 >Item : Item
 
+type K19 = keyof NumericallyIndexed<Shape> // never
+>K19 : never
+>NumericallyIndexed : NumericallyIndexed<T>
+>Shape : Shape
+
 type KeyOf<T> = keyof T;
 >KeyOf : keyof T
 >T : T
@@ -125,7 +136,7 @@ type K20 = KeyOf<Shape>;  // "name" | "width" | "height" | "visible"
 >KeyOf : keyof T
 >Shape : Shape
 
-type K21 = KeyOf<Dictionary<Shape>>;  // string | number
+type K21 = KeyOf<Dictionary<Shape>>;  // string
 >K21 : string
 >KeyOf : keyof T
 >Dictionary : Dictionary<T>
@@ -970,3 +981,4 @@ class OtherPerson {
 >"parts" : "parts"
     }
 }
+

--- a/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
+++ b/tests/cases/conformance/types/keyof/keyofAndIndexedAccess.ts
@@ -21,11 +21,12 @@ class Options {
 }
 
 type Dictionary<T> = { [x: string]: T };
+type NumericallyIndexed<T> = { [x: number]: T };
 
 const enum E { A, B, C }
 
-type K00 = keyof any;  // string | number
-type K01 = keyof string;  // number | "toString" | "charAt" | ...
+type K00 = keyof any;  // string
+type K01 = keyof string;  // "toString" | "charAt" | ...
 type K02 = keyof number;  // "toString" | "toFixed" | "toExponential" | ...
 type K03 = keyof boolean;  // "valueOf"
 type K04 = keyof void;  // never
@@ -34,19 +35,20 @@ type K06 = keyof null;  // never
 type K07 = keyof never;  // never
 
 type K10 = keyof Shape;  // "name" | "width" | "height" | "visible"
-type K11 = keyof Shape[];  // number | "length" | "toString" | ...
-type K12 = keyof Dictionary<Shape>;  // string | number
+type K11 = keyof Shape[];  // "length" | "toString" | ...
+type K12 = keyof Dictionary<Shape>;  // string
 type K13 = keyof {};  // never
 type K14 = keyof Object;  // "constructor" | "toString" | ...
 type K15 = keyof E;  // "toString" | "toFixed" | "toExponential" | ...
-type K16 = keyof [string, number];  // number | "0" | "1" | "length" | "toString" | ...
+type K16 = keyof [string, number];  // "0" | "1" | "length" | "toString" | ...
 type K17 = keyof (Shape | Item);  // "name"
 type K18 = keyof (Shape & Item);  // "name" | "width" | "height" | "visible" | "price"
+type K19 = keyof NumericallyIndexed<Shape> // never
 
 type KeyOf<T> = keyof T;
 
 type K20 = KeyOf<Shape>;  // "name" | "width" | "height" | "visible"
-type K21 = KeyOf<Dictionary<Shape>>;  // string | number
+type K21 = KeyOf<Dictionary<Shape>>;  // string
 
 type NAME = "name";
 type WIDTH_OR_HEIGHT = "width" | "height";


### PR DESCRIPTION
#12425 removed number from the union type constituting `keyof T`, but the comments in the test cases still had number as a possible type. This PR changes the comments in the tests so they match the actual behavior.

It also adds a test that numeric index signatures:

```
keyof NumericallyIndexed<Shape> // checks that this is never
type NumericallyIndexed<T> = { [x: number]: T };
```