### PR TITLE
tsserver: get candidates from <K extends keyof Foo> (fix #12536)

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -112,7 +112,8 @@ namespace ts {
                 // we deliberately exclude augmentations
                 // since we are only interested in declarations of the module itself
                 return tryFindAmbientModule(moduleName, /*withAugmentations*/ false);
-            }
+            },
+            getApparentType
         };
 
         const tupleTypes: GenericType[] = [];

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2379,6 +2379,7 @@ namespace ts {
         getAmbientModules(): Symbol[];
 
         tryGetMemberInModuleExports(memberName: string, moduleSymbol: Symbol): Symbol | undefined;
+        getApparentType(type: Type): Type;
 
         /* @internal */ tryFindAmbientModuleWithoutAugmentations(moduleName: string): Symbol;
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -244,6 +244,9 @@ namespace ts.Completions {
         }
 
         function addStringLiteralCompletionsFromType(type: Type, result: CompletionEntry[]): void {
+            if (type && type.flags & TypeFlags.TypeParameter) {
+                type = typeChecker.getApparentType(type);
+            }
             if (!type) {
                 return;
             }

--- a/tests/cases/fourslash/completionForStringLiteral5.ts
+++ b/tests/cases/fourslash/completionForStringLiteral5.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts'/>
+
+////interface Foo {
+////    foo: string;
+////    bar: string;
+////}
+////
+////function f<K extends keyof Foo>(a: K) { };
+////f("/*1*/
+
+goTo.marker('1');
+verify.completionListContains("foo");
+verify.completionListContains("bar");
+verify.memberListCount(2);
+


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #12536
