### PR TITLE
Preserve modifiers in homomorphic mapped types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4497,12 +4497,14 @@ namespace ts {
             // Resolve upfront such that recursive references see an empty object type.
             setStructuredTypeMembers(type, emptySymbols, emptyArray, emptyArray, undefined, undefined);
             // In { [P in K]: T }, we refer to P as the type parameter type, K as the constraint type,
-            // and T as the template type.
+            // and T as the template type. If K is of the form 'keyof S', the mapped type and S are
+            // isomorphic and we copy property modifiers from corresponding properties in S.
             const typeParameter = getTypeParameterFromMappedType(type);
             const constraintType = getConstraintTypeFromMappedType(type);
+            const isomorphicType = getIsomorphicTypeFromMappedType(type);
             const templateType = getTemplateTypeFromMappedType(type);
-            const isReadonly = !!type.declaration.readonlyToken;
-            const isOptional = !!type.declaration.questionToken;
+            const templateReadonly = !!type.declaration.readonlyToken;
+            const templateOptional = !!type.declaration.questionToken;
             // First, if the constraint type is a type parameter, obtain the base constraint. Then,
             // if the key type is a 'keyof X', obtain 'keyof C' where C is the base constraint of X.
             // Finally, iterate over the constituents of the resulting iteration type.
@@ -4515,18 +4517,19 @@ namespace ts {
                 const iterationMapper = createUnaryTypeMapper(typeParameter, t);
                 const templateMapper = type.mapper ? combineTypeMappers(type.mapper, iterationMapper) : iterationMapper;
                 const propType = instantiateType(templateType, templateMapper);
-                // If the current iteration type constituent is a literal type, create a property.
-                // Otherwise, for type string create a string index signature and for type number
-                // create a numeric index signature.
-                if (t.flags & (TypeFlags.StringLiteral | TypeFlags.NumberLiteral | TypeFlags.EnumLiteral)) {
+                // If the current iteration type constituent is a string literal type, create a property.
+                // Otherwise, for type string create a string index signature.
+                if (t.flags & TypeFlags.StringLiteral) {
                     const propName = (<LiteralType>t).text;
+                    const isomorphicProp = isomorphicType && getPropertyOfType(isomorphicType, propName);
+                    const isOptional = templateOptional || !!(isomorphicProp && isomorphicProp.flags & SymbolFlags.Optional);
                     const prop = <TransientSymbol>createSymbol(SymbolFlags.Property | SymbolFlags.Transient | (isOptional ? SymbolFlags.Optional : 0), propName);
                     prop.type = addOptionality(propType, isOptional);
-                    prop.isReadonly = isReadonly;
+                    prop.isReadonly = templateReadonly || isomorphicProp && isReadonlySymbol(isomorphicProp);
                     members[propName] = prop;
                 }
                 else if (t.flags & TypeFlags.String) {
-                    stringIndexInfo = createIndexInfo(propType, isReadonly);
+                    stringIndexInfo = createIndexInfo(propType, templateReadonly);
                 }
             });
             setStructuredTypeMembers(type, members, emptyArray, emptyArray, stringIndexInfo, undefined);
@@ -4547,6 +4550,11 @@ namespace ts {
                 (type.templateType = type.declaration.type ?
                     instantiateType(getTypeFromTypeNode(type.declaration.type), type.mapper || identityMapper) :
                     unknownType);
+        }
+
+        function getIsomorphicTypeFromMappedType(type: MappedType) {
+            const constraint = getConstraintDeclaration(getTypeParameterFromMappedType(type));
+            return constraint.kind === SyntaxKind.TypeOperator ? instantiateType(getTypeFromTypeNode((<TypeOperatorNode>constraint).type), type.mapper || identityMapper) : undefined;
         }
 
         function getErasedTemplateTypeFromMappedType(type: MappedType) {

--- a/tests/baselines/reference/mappedTypeModifiers.js
+++ b/tests/baselines/reference/mappedTypeModifiers.js
@@ -1,0 +1,73 @@
+//// [mappedTypeModifiers.ts]
+
+type T = { a: number, b: string };
+type U = { a: number | undefined, b: string | undefined };
+type P = { a?: number, b?: string };
+type R = { readonly a: number, readonly b: string };
+type PR = { readonly a?: number, readonly b?: string };
+
+// Validate they all have the same keys
+var v00: "a" | "b";
+var v00: keyof T;
+var v00: keyof U;
+var v00: keyof P;
+var v00: keyof R;
+var v00: keyof PR;
+
+// Validate that non-isomorphic mapped types strip modifiers
+var v01: T;
+var v01: Pick<R, keyof T>;
+var v01: Pick<Readonly<T>, keyof T>;
+
+// Validate that non-isomorphic mapped types strip modifiers
+var v02: U;
+var v02: Pick<P, keyof T>;
+var v02: Pick<PR, keyof T>;
+var v02: Pick<Partial<T>, keyof T>;
+var v02: Pick<Partial<Readonly<T>>, keyof T>;
+
+// Validate that isomorphic mapped types preserve optional modifier
+var v03: P;
+var v03: Partial<T>;
+
+// Validate that isomorphic mapped types preserve readonly modifier
+var v04: R;
+var v04: Readonly<T>;
+
+// Validate that isomorphic mapped types preserve both partial and readonly modifiers
+var v05: PR;
+var v05: Partial<R>;
+var v05: Readonly<P>;
+var v05: Partial<Readonly<T>>;
+var v05: Readonly<Partial<T>>;
+
+//// [mappedTypeModifiers.js]
+// Validate they all have the same keys
+var v00;
+var v00;
+var v00;
+var v00;
+var v00;
+var v00;
+// Validate that non-isomorphic mapped types strip modifiers
+var v01;
+var v01;
+var v01;
+// Validate that non-isomorphic mapped types strip modifiers
+var v02;
+var v02;
+var v02;
+var v02;
+var v02;
+// Validate that isomorphic mapped types preserve optional modifier
+var v03;
+var v03;
+// Validate that isomorphic mapped types preserve readonly modifier
+var v04;
+var v04;
+// Validate that isomorphic mapped types preserve both partial and readonly modifiers
+var v05;
+var v05;
+var v05;
+var v05;
+var v05;

--- a/tests/baselines/reference/mappedTypeModifiers.js
+++ b/tests/baselines/reference/mappedTypeModifiers.js
@@ -1,45 +1,88 @@
 //// [mappedTypeModifiers.ts]
 
 type T = { a: number, b: string };
-type U = { a: number | undefined, b: string | undefined };
-type P = { a?: number, b?: string };
-type R = { readonly a: number, readonly b: string };
-type PR = { readonly a?: number, readonly b?: string };
+type TU = { a: number | undefined, b: string | undefined };
+type TP = { a?: number, b?: string };
+type TR = { readonly a: number, readonly b: string };
+type TPR = { readonly a?: number, readonly b?: string };
 
 // Validate they all have the same keys
 var v00: "a" | "b";
 var v00: keyof T;
-var v00: keyof U;
-var v00: keyof P;
-var v00: keyof R;
-var v00: keyof PR;
+var v00: keyof TU;
+var v00: keyof TP;
+var v00: keyof TR;
+var v00: keyof TPR;
 
 // Validate that non-isomorphic mapped types strip modifiers
 var v01: T;
-var v01: Pick<R, keyof T>;
+var v01: Pick<TR, keyof T>;
 var v01: Pick<Readonly<T>, keyof T>;
 
 // Validate that non-isomorphic mapped types strip modifiers
-var v02: U;
-var v02: Pick<P, keyof T>;
-var v02: Pick<PR, keyof T>;
+var v02: TU;
+var v02: Pick<TP, keyof T>;
+var v02: Pick<TPR, keyof T>;
 var v02: Pick<Partial<T>, keyof T>;
 var v02: Pick<Partial<Readonly<T>>, keyof T>;
 
 // Validate that isomorphic mapped types preserve optional modifier
-var v03: P;
+var v03: TP;
 var v03: Partial<T>;
 
 // Validate that isomorphic mapped types preserve readonly modifier
-var v04: R;
+var v04: TR;
 var v04: Readonly<T>;
 
 // Validate that isomorphic mapped types preserve both partial and readonly modifiers
-var v05: PR;
-var v05: Partial<R>;
-var v05: Readonly<P>;
+var v05: TPR;
+var v05: Partial<TR>;
+var v05: Readonly<TP>;
 var v05: Partial<Readonly<T>>;
 var v05: Readonly<Partial<T>>;
+
+type Boxified<T> = { [P in keyof T]: { x: T[P] } };
+
+type B = { a: { x: number }, b: { x: string } };
+type BU = { a: { x: number } | undefined, b: { x: string } | undefined };
+type BP = { a?: { x: number }, b?: { x: string } };
+type BR = { readonly a: { x: number }, readonly b: { x: string } };
+type BPR = { readonly a?: { x: number }, readonly b?: { x: string } };
+
+// Validate they all have the same keys
+var b00: "a" | "b";
+var b00: keyof B;
+var b00: keyof BU;
+var b00: keyof BP;
+var b00: keyof BR;
+var b00: keyof BPR;
+
+// Validate that non-isomorphic mapped types strip modifiers
+var b01: B;
+var b01: Pick<BR, keyof B>;
+var b01: Pick<Readonly<BR>, keyof B>;
+
+// Validate that non-isomorphic mapped types strip modifiers
+var b02: BU;
+var b02: Pick<BP, keyof B>;
+var b02: Pick<BPR, keyof B>;
+var b02: Pick<Partial<B>, keyof B>;
+var b02: Pick<Partial<Readonly<B>>, keyof B>;
+
+// Validate that isomorphic mapped types preserve optional modifier
+var b03: BP;
+var b03: Partial<B>;
+
+// Validate that isomorphic mapped types preserve readonly modifier
+var b04: BR;
+var b04: Readonly<B>;
+
+// Validate that isomorphic mapped types preserve both partial and readonly modifiers
+var b05: BPR;
+var b05: Partial<BR>;
+var b05: Readonly<BP>;
+var b05: Partial<Readonly<B>>;
+var b05: Readonly<Partial<B>>;
 
 //// [mappedTypeModifiers.js]
 // Validate they all have the same keys
@@ -71,3 +114,32 @@ var v05;
 var v05;
 var v05;
 var v05;
+// Validate they all have the same keys
+var b00;
+var b00;
+var b00;
+var b00;
+var b00;
+var b00;
+// Validate that non-isomorphic mapped types strip modifiers
+var b01;
+var b01;
+var b01;
+// Validate that non-isomorphic mapped types strip modifiers
+var b02;
+var b02;
+var b02;
+var b02;
+var b02;
+// Validate that isomorphic mapped types preserve optional modifier
+var b03;
+var b03;
+// Validate that isomorphic mapped types preserve readonly modifier
+var b04;
+var b04;
+// Validate that isomorphic mapped types preserve both partial and readonly modifiers
+var b05;
+var b05;
+var b05;
+var b05;
+var b05;

--- a/tests/baselines/reference/mappedTypeModifiers.symbols
+++ b/tests/baselines/reference/mappedTypeModifiers.symbols
@@ -1,0 +1,148 @@
+=== tests/cases/conformance/types/mapped/mappedTypeModifiers.ts ===
+
+type T = { a: number, b: string };
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 1, 10))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 1, 21))
+
+type U = { a: number | undefined, b: string | undefined };
+>U : Symbol(U, Decl(mappedTypeModifiers.ts, 1, 34))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 2, 10))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 2, 33))
+
+type P = { a?: number, b?: string };
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 2, 58))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 3, 10))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 3, 22))
+
+type R = { readonly a: number, readonly b: string };
+>R : Symbol(R, Decl(mappedTypeModifiers.ts, 3, 36))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 4, 10))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 4, 30))
+
+type PR = { readonly a?: number, readonly b?: string };
+>PR : Symbol(PR, Decl(mappedTypeModifiers.ts, 4, 52))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 5, 11))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 5, 32))
+
+// Validate they all have the same keys
+var v00: "a" | "b";
+>v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
+
+var v00: keyof T;
+>v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+
+var v00: keyof U;
+>v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
+>U : Symbol(U, Decl(mappedTypeModifiers.ts, 1, 34))
+
+var v00: keyof P;
+>v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 2, 58))
+
+var v00: keyof R;
+>v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
+>R : Symbol(R, Decl(mappedTypeModifiers.ts, 3, 36))
+
+var v00: keyof PR;
+>v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
+>PR : Symbol(PR, Decl(mappedTypeModifiers.ts, 4, 52))
+
+// Validate that non-isomorphic mapped types strip modifiers
+var v01: T;
+>v01 : Symbol(v01, Decl(mappedTypeModifiers.ts, 16, 3), Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+
+var v01: Pick<R, keyof T>;
+>v01 : Symbol(v01, Decl(mappedTypeModifiers.ts, 16, 3), Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>R : Symbol(R, Decl(mappedTypeModifiers.ts, 3, 36))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+
+var v01: Pick<Readonly<T>, keyof T>;
+>v01 : Symbol(v01, Decl(mappedTypeModifiers.ts, 16, 3), Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+
+// Validate that non-isomorphic mapped types strip modifiers
+var v02: U;
+>v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 21, 3), Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
+>U : Symbol(U, Decl(mappedTypeModifiers.ts, 1, 34))
+
+var v02: Pick<P, keyof T>;
+>v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 21, 3), Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 2, 58))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+
+var v02: Pick<PR, keyof T>;
+>v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 21, 3), Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>PR : Symbol(PR, Decl(mappedTypeModifiers.ts, 4, 52))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+
+var v02: Pick<Partial<T>, keyof T>;
+>v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 21, 3), Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+
+var v02: Pick<Partial<Readonly<T>>, keyof T>;
+>v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 21, 3), Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+
+// Validate that isomorphic mapped types preserve optional modifier
+var v03: P;
+>v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 2, 58))
+
+var v03: Partial<T>;
+>v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+
+// Validate that isomorphic mapped types preserve readonly modifier
+var v04: R;
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
+>R : Symbol(R, Decl(mappedTypeModifiers.ts, 3, 36))
+
+var v04: Readonly<T>;
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+
+// Validate that isomorphic mapped types preserve both partial and readonly modifiers
+var v05: PR;
+>v05 : Symbol(v05, Decl(mappedTypeModifiers.ts, 36, 3), Decl(mappedTypeModifiers.ts, 37, 3), Decl(mappedTypeModifiers.ts, 38, 3), Decl(mappedTypeModifiers.ts, 39, 3), Decl(mappedTypeModifiers.ts, 40, 3))
+>PR : Symbol(PR, Decl(mappedTypeModifiers.ts, 4, 52))
+
+var v05: Partial<R>;
+>v05 : Symbol(v05, Decl(mappedTypeModifiers.ts, 36, 3), Decl(mappedTypeModifiers.ts, 37, 3), Decl(mappedTypeModifiers.ts, 38, 3), Decl(mappedTypeModifiers.ts, 39, 3), Decl(mappedTypeModifiers.ts, 40, 3))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>R : Symbol(R, Decl(mappedTypeModifiers.ts, 3, 36))
+
+var v05: Readonly<P>;
+>v05 : Symbol(v05, Decl(mappedTypeModifiers.ts, 36, 3), Decl(mappedTypeModifiers.ts, 37, 3), Decl(mappedTypeModifiers.ts, 38, 3), Decl(mappedTypeModifiers.ts, 39, 3), Decl(mappedTypeModifiers.ts, 40, 3))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 2, 58))
+
+var v05: Partial<Readonly<T>>;
+>v05 : Symbol(v05, Decl(mappedTypeModifiers.ts, 36, 3), Decl(mappedTypeModifiers.ts, 37, 3), Decl(mappedTypeModifiers.ts, 38, 3), Decl(mappedTypeModifiers.ts, 39, 3), Decl(mappedTypeModifiers.ts, 40, 3))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+
+var v05: Readonly<Partial<T>>;
+>v05 : Symbol(v05, Decl(mappedTypeModifiers.ts, 36, 3), Decl(mappedTypeModifiers.ts, 37, 3), Decl(mappedTypeModifiers.ts, 38, 3), Decl(mappedTypeModifiers.ts, 39, 3), Decl(mappedTypeModifiers.ts, 40, 3))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+

--- a/tests/baselines/reference/mappedTypeModifiers.symbols
+++ b/tests/baselines/reference/mappedTypeModifiers.symbols
@@ -5,25 +5,25 @@ type T = { a: number, b: string };
 >a : Symbol(a, Decl(mappedTypeModifiers.ts, 1, 10))
 >b : Symbol(b, Decl(mappedTypeModifiers.ts, 1, 21))
 
-type U = { a: number | undefined, b: string | undefined };
->U : Symbol(U, Decl(mappedTypeModifiers.ts, 1, 34))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 2, 10))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 2, 33))
+type TU = { a: number | undefined, b: string | undefined };
+>TU : Symbol(TU, Decl(mappedTypeModifiers.ts, 1, 34))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 2, 11))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 2, 34))
 
-type P = { a?: number, b?: string };
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 2, 58))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 3, 10))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 3, 22))
+type TP = { a?: number, b?: string };
+>TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 2, 59))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 3, 11))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 3, 23))
 
-type R = { readonly a: number, readonly b: string };
->R : Symbol(R, Decl(mappedTypeModifiers.ts, 3, 36))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 4, 10))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 4, 30))
+type TR = { readonly a: number, readonly b: string };
+>TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 3, 37))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 4, 11))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 4, 31))
 
-type PR = { readonly a?: number, readonly b?: string };
->PR : Symbol(PR, Decl(mappedTypeModifiers.ts, 4, 52))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 5, 11))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 5, 32))
+type TPR = { readonly a?: number, readonly b?: string };
+>TPR : Symbol(TPR, Decl(mappedTypeModifiers.ts, 4, 53))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 5, 12))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 5, 33))
 
 // Validate they all have the same keys
 var v00: "a" | "b";
@@ -33,31 +33,31 @@ var v00: keyof T;
 >v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
-var v00: keyof U;
+var v00: keyof TU;
 >v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
->U : Symbol(U, Decl(mappedTypeModifiers.ts, 1, 34))
+>TU : Symbol(TU, Decl(mappedTypeModifiers.ts, 1, 34))
 
-var v00: keyof P;
+var v00: keyof TP;
 >v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 2, 58))
+>TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 2, 59))
 
-var v00: keyof R;
+var v00: keyof TR;
 >v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
->R : Symbol(R, Decl(mappedTypeModifiers.ts, 3, 36))
+>TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 3, 37))
 
-var v00: keyof PR;
+var v00: keyof TPR;
 >v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
->PR : Symbol(PR, Decl(mappedTypeModifiers.ts, 4, 52))
+>TPR : Symbol(TPR, Decl(mappedTypeModifiers.ts, 4, 53))
 
 // Validate that non-isomorphic mapped types strip modifiers
 var v01: T;
 >v01 : Symbol(v01, Decl(mappedTypeModifiers.ts, 16, 3), Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
-var v01: Pick<R, keyof T>;
+var v01: Pick<TR, keyof T>;
 >v01 : Symbol(v01, Decl(mappedTypeModifiers.ts, 16, 3), Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->R : Symbol(R, Decl(mappedTypeModifiers.ts, 3, 36))
+>TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 3, 37))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
 var v01: Pick<Readonly<T>, keyof T>;
@@ -68,20 +68,20 @@ var v01: Pick<Readonly<T>, keyof T>;
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
 // Validate that non-isomorphic mapped types strip modifiers
-var v02: U;
+var v02: TU;
 >v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 21, 3), Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
->U : Symbol(U, Decl(mappedTypeModifiers.ts, 1, 34))
+>TU : Symbol(TU, Decl(mappedTypeModifiers.ts, 1, 34))
 
-var v02: Pick<P, keyof T>;
+var v02: Pick<TP, keyof T>;
 >v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 21, 3), Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 2, 58))
+>TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 2, 59))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
-var v02: Pick<PR, keyof T>;
+var v02: Pick<TPR, keyof T>;
 >v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 21, 3), Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->PR : Symbol(PR, Decl(mappedTypeModifiers.ts, 4, 52))
+>TPR : Symbol(TPR, Decl(mappedTypeModifiers.ts, 4, 53))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
 var v02: Pick<Partial<T>, keyof T>;
@@ -100,9 +100,9 @@ var v02: Pick<Partial<Readonly<T>>, keyof T>;
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
 // Validate that isomorphic mapped types preserve optional modifier
-var v03: P;
+var v03: TP;
 >v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 2, 58))
+>TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 2, 59))
 
 var v03: Partial<T>;
 >v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3))
@@ -110,9 +110,9 @@ var v03: Partial<T>;
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
 // Validate that isomorphic mapped types preserve readonly modifier
-var v04: R;
+var v04: TR;
 >v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
->R : Symbol(R, Decl(mappedTypeModifiers.ts, 3, 36))
+>TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 3, 37))
 
 var v04: Readonly<T>;
 >v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
@@ -120,19 +120,19 @@ var v04: Readonly<T>;
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
 // Validate that isomorphic mapped types preserve both partial and readonly modifiers
-var v05: PR;
+var v05: TPR;
 >v05 : Symbol(v05, Decl(mappedTypeModifiers.ts, 36, 3), Decl(mappedTypeModifiers.ts, 37, 3), Decl(mappedTypeModifiers.ts, 38, 3), Decl(mappedTypeModifiers.ts, 39, 3), Decl(mappedTypeModifiers.ts, 40, 3))
->PR : Symbol(PR, Decl(mappedTypeModifiers.ts, 4, 52))
+>TPR : Symbol(TPR, Decl(mappedTypeModifiers.ts, 4, 53))
 
-var v05: Partial<R>;
+var v05: Partial<TR>;
 >v05 : Symbol(v05, Decl(mappedTypeModifiers.ts, 36, 3), Decl(mappedTypeModifiers.ts, 37, 3), Decl(mappedTypeModifiers.ts, 38, 3), Decl(mappedTypeModifiers.ts, 39, 3), Decl(mappedTypeModifiers.ts, 40, 3))
 >Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->R : Symbol(R, Decl(mappedTypeModifiers.ts, 3, 36))
+>TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 3, 37))
 
-var v05: Readonly<P>;
+var v05: Readonly<TP>;
 >v05 : Symbol(v05, Decl(mappedTypeModifiers.ts, 36, 3), Decl(mappedTypeModifiers.ts, 37, 3), Decl(mappedTypeModifiers.ts, 38, 3), Decl(mappedTypeModifiers.ts, 39, 3), Decl(mappedTypeModifiers.ts, 40, 3))
 >Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 2, 58))
+>TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 2, 59))
 
 var v05: Partial<Readonly<T>>;
 >v05 : Symbol(v05, Decl(mappedTypeModifiers.ts, 36, 3), Decl(mappedTypeModifiers.ts, 37, 3), Decl(mappedTypeModifiers.ts, 38, 3), Decl(mappedTypeModifiers.ts, 39, 3), Decl(mappedTypeModifiers.ts, 40, 3))
@@ -145,4 +145,169 @@ var v05: Readonly<Partial<T>>;
 >Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
 >Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+
+type Boxified<T> = { [P in keyof T]: { x: T[P] } };
+>Boxified : Symbol(Boxified, Decl(mappedTypeModifiers.ts, 40, 30))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 42, 14))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 42, 22))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 42, 14))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 42, 38))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 42, 14))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 42, 22))
+
+type B = { a: { x: number }, b: { x: string } };
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 44, 10))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 44, 15))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 44, 28))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 44, 33))
+
+type BU = { a: { x: number } | undefined, b: { x: string } | undefined };
+>BU : Symbol(BU, Decl(mappedTypeModifiers.ts, 44, 48))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 45, 11))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 45, 16))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 45, 41))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 45, 46))
+
+type BP = { a?: { x: number }, b?: { x: string } };
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 45, 73))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 46, 11))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 46, 17))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 46, 30))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 46, 36))
+
+type BR = { readonly a: { x: number }, readonly b: { x: string } };
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 46, 51))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 47, 11))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 47, 25))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 47, 38))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 47, 52))
+
+type BPR = { readonly a?: { x: number }, readonly b?: { x: string } };
+>BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 47, 67))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 48, 12))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 48, 27))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 48, 40))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 48, 55))
+
+// Validate they all have the same keys
+var b00: "a" | "b";
+>b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 51, 3), Decl(mappedTypeModifiers.ts, 52, 3), Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
+
+var b00: keyof B;
+>b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 51, 3), Decl(mappedTypeModifiers.ts, 52, 3), Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+
+var b00: keyof BU;
+>b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 51, 3), Decl(mappedTypeModifiers.ts, 52, 3), Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
+>BU : Symbol(BU, Decl(mappedTypeModifiers.ts, 44, 48))
+
+var b00: keyof BP;
+>b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 51, 3), Decl(mappedTypeModifiers.ts, 52, 3), Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 45, 73))
+
+var b00: keyof BR;
+>b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 51, 3), Decl(mappedTypeModifiers.ts, 52, 3), Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 46, 51))
+
+var b00: keyof BPR;
+>b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 51, 3), Decl(mappedTypeModifiers.ts, 52, 3), Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
+>BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 47, 67))
+
+// Validate that non-isomorphic mapped types strip modifiers
+var b01: B;
+>b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3), Decl(mappedTypeModifiers.ts, 61, 3))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+
+var b01: Pick<BR, keyof B>;
+>b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3), Decl(mappedTypeModifiers.ts, 61, 3))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 46, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+
+var b01: Pick<Readonly<BR>, keyof B>;
+>b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3), Decl(mappedTypeModifiers.ts, 61, 3))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 46, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+
+// Validate that non-isomorphic mapped types strip modifiers
+var b02: BU;
+>b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3))
+>BU : Symbol(BU, Decl(mappedTypeModifiers.ts, 44, 48))
+
+var b02: Pick<BP, keyof B>;
+>b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 45, 73))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+
+var b02: Pick<BPR, keyof B>;
+>b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 47, 67))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+
+var b02: Pick<Partial<B>, keyof B>;
+>b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+
+var b02: Pick<Partial<Readonly<B>>, keyof B>;
+>b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+
+// Validate that isomorphic mapped types preserve optional modifier
+var b03: BP;
+>b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 71, 3), Decl(mappedTypeModifiers.ts, 72, 3))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 45, 73))
+
+var b03: Partial<B>;
+>b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 71, 3), Decl(mappedTypeModifiers.ts, 72, 3))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+
+// Validate that isomorphic mapped types preserve readonly modifier
+var b04: BR;
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 75, 3), Decl(mappedTypeModifiers.ts, 76, 3))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 46, 51))
+
+var b04: Readonly<B>;
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 75, 3), Decl(mappedTypeModifiers.ts, 76, 3))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+
+// Validate that isomorphic mapped types preserve both partial and readonly modifiers
+var b05: BPR;
+>b05 : Symbol(b05, Decl(mappedTypeModifiers.ts, 79, 3), Decl(mappedTypeModifiers.ts, 80, 3), Decl(mappedTypeModifiers.ts, 81, 3), Decl(mappedTypeModifiers.ts, 82, 3), Decl(mappedTypeModifiers.ts, 83, 3))
+>BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 47, 67))
+
+var b05: Partial<BR>;
+>b05 : Symbol(b05, Decl(mappedTypeModifiers.ts, 79, 3), Decl(mappedTypeModifiers.ts, 80, 3), Decl(mappedTypeModifiers.ts, 81, 3), Decl(mappedTypeModifiers.ts, 82, 3), Decl(mappedTypeModifiers.ts, 83, 3))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 46, 51))
+
+var b05: Readonly<BP>;
+>b05 : Symbol(b05, Decl(mappedTypeModifiers.ts, 79, 3), Decl(mappedTypeModifiers.ts, 80, 3), Decl(mappedTypeModifiers.ts, 81, 3), Decl(mappedTypeModifiers.ts, 82, 3), Decl(mappedTypeModifiers.ts, 83, 3))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 45, 73))
+
+var b05: Partial<Readonly<B>>;
+>b05 : Symbol(b05, Decl(mappedTypeModifiers.ts, 79, 3), Decl(mappedTypeModifiers.ts, 80, 3), Decl(mappedTypeModifiers.ts, 81, 3), Decl(mappedTypeModifiers.ts, 82, 3), Decl(mappedTypeModifiers.ts, 83, 3))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+
+var b05: Readonly<Partial<B>>;
+>b05 : Symbol(b05, Decl(mappedTypeModifiers.ts, 79, 3), Decl(mappedTypeModifiers.ts, 80, 3), Decl(mappedTypeModifiers.ts, 81, 3), Decl(mappedTypeModifiers.ts, 82, 3), Decl(mappedTypeModifiers.ts, 83, 3))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
 

--- a/tests/baselines/reference/mappedTypeModifiers.types
+++ b/tests/baselines/reference/mappedTypeModifiers.types
@@ -1,0 +1,148 @@
+=== tests/cases/conformance/types/mapped/mappedTypeModifiers.ts ===
+
+type T = { a: number, b: string };
+>T : T
+>a : number
+>b : string
+
+type U = { a: number | undefined, b: string | undefined };
+>U : U
+>a : number | undefined
+>b : string | undefined
+
+type P = { a?: number, b?: string };
+>P : P
+>a : number | undefined
+>b : string | undefined
+
+type R = { readonly a: number, readonly b: string };
+>R : R
+>a : number
+>b : string
+
+type PR = { readonly a?: number, readonly b?: string };
+>PR : PR
+>a : number | undefined
+>b : string | undefined
+
+// Validate they all have the same keys
+var v00: "a" | "b";
+>v00 : "a" | "b"
+
+var v00: keyof T;
+>v00 : "a" | "b"
+>T : T
+
+var v00: keyof U;
+>v00 : "a" | "b"
+>U : U
+
+var v00: keyof P;
+>v00 : "a" | "b"
+>P : P
+
+var v00: keyof R;
+>v00 : "a" | "b"
+>R : R
+
+var v00: keyof PR;
+>v00 : "a" | "b"
+>PR : PR
+
+// Validate that non-isomorphic mapped types strip modifiers
+var v01: T;
+>v01 : T
+>T : T
+
+var v01: Pick<R, keyof T>;
+>v01 : T
+>Pick : Pick<T, K>
+>R : R
+>T : T
+
+var v01: Pick<Readonly<T>, keyof T>;
+>v01 : T
+>Pick : Pick<T, K>
+>Readonly : Readonly<T>
+>T : T
+>T : T
+
+// Validate that non-isomorphic mapped types strip modifiers
+var v02: U;
+>v02 : U
+>U : U
+
+var v02: Pick<P, keyof T>;
+>v02 : U
+>Pick : Pick<T, K>
+>P : P
+>T : T
+
+var v02: Pick<PR, keyof T>;
+>v02 : U
+>Pick : Pick<T, K>
+>PR : PR
+>T : T
+
+var v02: Pick<Partial<T>, keyof T>;
+>v02 : U
+>Pick : Pick<T, K>
+>Partial : Partial<T>
+>T : T
+>T : T
+
+var v02: Pick<Partial<Readonly<T>>, keyof T>;
+>v02 : U
+>Pick : Pick<T, K>
+>Partial : Partial<T>
+>Readonly : Readonly<T>
+>T : T
+>T : T
+
+// Validate that isomorphic mapped types preserve optional modifier
+var v03: P;
+>v03 : P
+>P : P
+
+var v03: Partial<T>;
+>v03 : P
+>Partial : Partial<T>
+>T : T
+
+// Validate that isomorphic mapped types preserve readonly modifier
+var v04: R;
+>v04 : R
+>R : R
+
+var v04: Readonly<T>;
+>v04 : R
+>Readonly : Readonly<T>
+>T : T
+
+// Validate that isomorphic mapped types preserve both partial and readonly modifiers
+var v05: PR;
+>v05 : PR
+>PR : PR
+
+var v05: Partial<R>;
+>v05 : PR
+>Partial : Partial<T>
+>R : R
+
+var v05: Readonly<P>;
+>v05 : PR
+>Readonly : Readonly<T>
+>P : P
+
+var v05: Partial<Readonly<T>>;
+>v05 : PR
+>Partial : Partial<T>
+>Readonly : Readonly<T>
+>T : T
+
+var v05: Readonly<Partial<T>>;
+>v05 : PR
+>Readonly : Readonly<T>
+>Partial : Partial<T>
+>T : T
+

--- a/tests/baselines/reference/mappedTypeModifiers.types
+++ b/tests/baselines/reference/mappedTypeModifiers.types
@@ -5,23 +5,23 @@ type T = { a: number, b: string };
 >a : number
 >b : string
 
-type U = { a: number | undefined, b: string | undefined };
->U : U
+type TU = { a: number | undefined, b: string | undefined };
+>TU : TU
 >a : number | undefined
 >b : string | undefined
 
-type P = { a?: number, b?: string };
->P : P
+type TP = { a?: number, b?: string };
+>TP : TP
 >a : number | undefined
 >b : string | undefined
 
-type R = { readonly a: number, readonly b: string };
->R : R
+type TR = { readonly a: number, readonly b: string };
+>TR : TR
 >a : number
 >b : string
 
-type PR = { readonly a?: number, readonly b?: string };
->PR : PR
+type TPR = { readonly a?: number, readonly b?: string };
+>TPR : TPR
 >a : number | undefined
 >b : string | undefined
 
@@ -33,31 +33,31 @@ var v00: keyof T;
 >v00 : "a" | "b"
 >T : T
 
-var v00: keyof U;
+var v00: keyof TU;
 >v00 : "a" | "b"
->U : U
+>TU : TU
 
-var v00: keyof P;
+var v00: keyof TP;
 >v00 : "a" | "b"
->P : P
+>TP : TP
 
-var v00: keyof R;
+var v00: keyof TR;
 >v00 : "a" | "b"
->R : R
+>TR : TR
 
-var v00: keyof PR;
+var v00: keyof TPR;
 >v00 : "a" | "b"
->PR : PR
+>TPR : TPR
 
 // Validate that non-isomorphic mapped types strip modifiers
 var v01: T;
 >v01 : T
 >T : T
 
-var v01: Pick<R, keyof T>;
+var v01: Pick<TR, keyof T>;
 >v01 : T
 >Pick : Pick<T, K>
->R : R
+>TR : TR
 >T : T
 
 var v01: Pick<Readonly<T>, keyof T>;
@@ -68,31 +68,31 @@ var v01: Pick<Readonly<T>, keyof T>;
 >T : T
 
 // Validate that non-isomorphic mapped types strip modifiers
-var v02: U;
->v02 : U
->U : U
+var v02: TU;
+>v02 : TU
+>TU : TU
 
-var v02: Pick<P, keyof T>;
->v02 : U
+var v02: Pick<TP, keyof T>;
+>v02 : TU
 >Pick : Pick<T, K>
->P : P
+>TP : TP
 >T : T
 
-var v02: Pick<PR, keyof T>;
->v02 : U
+var v02: Pick<TPR, keyof T>;
+>v02 : TU
 >Pick : Pick<T, K>
->PR : PR
+>TPR : TPR
 >T : T
 
 var v02: Pick<Partial<T>, keyof T>;
->v02 : U
+>v02 : TU
 >Pick : Pick<T, K>
 >Partial : Partial<T>
 >T : T
 >T : T
 
 var v02: Pick<Partial<Readonly<T>>, keyof T>;
->v02 : U
+>v02 : TU
 >Pick : Pick<T, K>
 >Partial : Partial<T>
 >Readonly : Readonly<T>
@@ -100,49 +100,214 @@ var v02: Pick<Partial<Readonly<T>>, keyof T>;
 >T : T
 
 // Validate that isomorphic mapped types preserve optional modifier
-var v03: P;
->v03 : P
->P : P
+var v03: TP;
+>v03 : TP
+>TP : TP
 
 var v03: Partial<T>;
->v03 : P
+>v03 : TP
 >Partial : Partial<T>
 >T : T
 
 // Validate that isomorphic mapped types preserve readonly modifier
-var v04: R;
->v04 : R
->R : R
+var v04: TR;
+>v04 : TR
+>TR : TR
 
 var v04: Readonly<T>;
->v04 : R
+>v04 : TR
 >Readonly : Readonly<T>
 >T : T
 
 // Validate that isomorphic mapped types preserve both partial and readonly modifiers
-var v05: PR;
->v05 : PR
->PR : PR
+var v05: TPR;
+>v05 : TPR
+>TPR : TPR
 
-var v05: Partial<R>;
->v05 : PR
+var v05: Partial<TR>;
+>v05 : TPR
 >Partial : Partial<T>
->R : R
+>TR : TR
 
-var v05: Readonly<P>;
->v05 : PR
+var v05: Readonly<TP>;
+>v05 : TPR
 >Readonly : Readonly<T>
->P : P
+>TP : TP
 
 var v05: Partial<Readonly<T>>;
->v05 : PR
+>v05 : TPR
 >Partial : Partial<T>
 >Readonly : Readonly<T>
 >T : T
 
 var v05: Readonly<Partial<T>>;
->v05 : PR
+>v05 : TPR
 >Readonly : Readonly<T>
 >Partial : Partial<T>
 >T : T
+
+type Boxified<T> = { [P in keyof T]: { x: T[P] } };
+>Boxified : Boxified<T>
+>T : T
+>P : P
+>T : T
+>x : T[P]
+>T : T
+>P : P
+
+type B = { a: { x: number }, b: { x: string } };
+>B : B
+>a : { x: number; }
+>x : number
+>b : { x: string; }
+>x : string
+
+type BU = { a: { x: number } | undefined, b: { x: string } | undefined };
+>BU : BU
+>a : { x: number; } | undefined
+>x : number
+>b : { x: string; } | undefined
+>x : string
+
+type BP = { a?: { x: number }, b?: { x: string } };
+>BP : BP
+>a : { x: number; } | undefined
+>x : number
+>b : { x: string; } | undefined
+>x : string
+
+type BR = { readonly a: { x: number }, readonly b: { x: string } };
+>BR : BR
+>a : { x: number; }
+>x : number
+>b : { x: string; }
+>x : string
+
+type BPR = { readonly a?: { x: number }, readonly b?: { x: string } };
+>BPR : BPR
+>a : { x: number; } | undefined
+>x : number
+>b : { x: string; } | undefined
+>x : string
+
+// Validate they all have the same keys
+var b00: "a" | "b";
+>b00 : "a" | "b"
+
+var b00: keyof B;
+>b00 : "a" | "b"
+>B : B
+
+var b00: keyof BU;
+>b00 : "a" | "b"
+>BU : BU
+
+var b00: keyof BP;
+>b00 : "a" | "b"
+>BP : BP
+
+var b00: keyof BR;
+>b00 : "a" | "b"
+>BR : BR
+
+var b00: keyof BPR;
+>b00 : "a" | "b"
+>BPR : BPR
+
+// Validate that non-isomorphic mapped types strip modifiers
+var b01: B;
+>b01 : B
+>B : B
+
+var b01: Pick<BR, keyof B>;
+>b01 : B
+>Pick : Pick<T, K>
+>BR : BR
+>B : B
+
+var b01: Pick<Readonly<BR>, keyof B>;
+>b01 : B
+>Pick : Pick<T, K>
+>Readonly : Readonly<T>
+>BR : BR
+>B : B
+
+// Validate that non-isomorphic mapped types strip modifiers
+var b02: BU;
+>b02 : BU
+>BU : BU
+
+var b02: Pick<BP, keyof B>;
+>b02 : BU
+>Pick : Pick<T, K>
+>BP : BP
+>B : B
+
+var b02: Pick<BPR, keyof B>;
+>b02 : BU
+>Pick : Pick<T, K>
+>BPR : BPR
+>B : B
+
+var b02: Pick<Partial<B>, keyof B>;
+>b02 : BU
+>Pick : Pick<T, K>
+>Partial : Partial<T>
+>B : B
+>B : B
+
+var b02: Pick<Partial<Readonly<B>>, keyof B>;
+>b02 : BU
+>Pick : Pick<T, K>
+>Partial : Partial<T>
+>Readonly : Readonly<T>
+>B : B
+>B : B
+
+// Validate that isomorphic mapped types preserve optional modifier
+var b03: BP;
+>b03 : BP
+>BP : BP
+
+var b03: Partial<B>;
+>b03 : BP
+>Partial : Partial<T>
+>B : B
+
+// Validate that isomorphic mapped types preserve readonly modifier
+var b04: BR;
+>b04 : BR
+>BR : BR
+
+var b04: Readonly<B>;
+>b04 : BR
+>Readonly : Readonly<T>
+>B : B
+
+// Validate that isomorphic mapped types preserve both partial and readonly modifiers
+var b05: BPR;
+>b05 : BPR
+>BPR : BPR
+
+var b05: Partial<BR>;
+>b05 : BPR
+>Partial : Partial<T>
+>BR : BR
+
+var b05: Readonly<BP>;
+>b05 : BPR
+>Readonly : Readonly<T>
+>BP : BP
+
+var b05: Partial<Readonly<B>>;
+>b05 : BPR
+>Partial : Partial<T>
+>Readonly : Readonly<T>
+>B : B
+
+var b05: Readonly<Partial<B>>;
+>b05 : BPR
+>Readonly : Readonly<T>
+>Partial : Partial<T>
+>B : B
 

--- a/tests/cases/conformance/types/mapped/mappedTypeModifiers.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypeModifiers.ts
@@ -1,42 +1,85 @@
 // @strictNullChecks: true
 
 type T = { a: number, b: string };
-type U = { a: number | undefined, b: string | undefined };
-type P = { a?: number, b?: string };
-type R = { readonly a: number, readonly b: string };
-type PR = { readonly a?: number, readonly b?: string };
+type TU = { a: number | undefined, b: string | undefined };
+type TP = { a?: number, b?: string };
+type TR = { readonly a: number, readonly b: string };
+type TPR = { readonly a?: number, readonly b?: string };
 
 // Validate they all have the same keys
 var v00: "a" | "b";
 var v00: keyof T;
-var v00: keyof U;
-var v00: keyof P;
-var v00: keyof R;
-var v00: keyof PR;
+var v00: keyof TU;
+var v00: keyof TP;
+var v00: keyof TR;
+var v00: keyof TPR;
 
 // Validate that non-isomorphic mapped types strip modifiers
 var v01: T;
-var v01: Pick<R, keyof T>;
+var v01: Pick<TR, keyof T>;
 var v01: Pick<Readonly<T>, keyof T>;
 
 // Validate that non-isomorphic mapped types strip modifiers
-var v02: U;
-var v02: Pick<P, keyof T>;
-var v02: Pick<PR, keyof T>;
+var v02: TU;
+var v02: Pick<TP, keyof T>;
+var v02: Pick<TPR, keyof T>;
 var v02: Pick<Partial<T>, keyof T>;
 var v02: Pick<Partial<Readonly<T>>, keyof T>;
 
 // Validate that isomorphic mapped types preserve optional modifier
-var v03: P;
+var v03: TP;
 var v03: Partial<T>;
 
 // Validate that isomorphic mapped types preserve readonly modifier
-var v04: R;
+var v04: TR;
 var v04: Readonly<T>;
 
 // Validate that isomorphic mapped types preserve both partial and readonly modifiers
-var v05: PR;
-var v05: Partial<R>;
-var v05: Readonly<P>;
+var v05: TPR;
+var v05: Partial<TR>;
+var v05: Readonly<TP>;
 var v05: Partial<Readonly<T>>;
 var v05: Readonly<Partial<T>>;
+
+type Boxified<T> = { [P in keyof T]: { x: T[P] } };
+
+type B = { a: { x: number }, b: { x: string } };
+type BU = { a: { x: number } | undefined, b: { x: string } | undefined };
+type BP = { a?: { x: number }, b?: { x: string } };
+type BR = { readonly a: { x: number }, readonly b: { x: string } };
+type BPR = { readonly a?: { x: number }, readonly b?: { x: string } };
+
+// Validate they all have the same keys
+var b00: "a" | "b";
+var b00: keyof B;
+var b00: keyof BU;
+var b00: keyof BP;
+var b00: keyof BR;
+var b00: keyof BPR;
+
+// Validate that non-isomorphic mapped types strip modifiers
+var b01: B;
+var b01: Pick<BR, keyof B>;
+var b01: Pick<Readonly<BR>, keyof B>;
+
+// Validate that non-isomorphic mapped types strip modifiers
+var b02: BU;
+var b02: Pick<BP, keyof B>;
+var b02: Pick<BPR, keyof B>;
+var b02: Pick<Partial<B>, keyof B>;
+var b02: Pick<Partial<Readonly<B>>, keyof B>;
+
+// Validate that isomorphic mapped types preserve optional modifier
+var b03: BP;
+var b03: Partial<B>;
+
+// Validate that isomorphic mapped types preserve readonly modifier
+var b04: BR;
+var b04: Readonly<B>;
+
+// Validate that isomorphic mapped types preserve both partial and readonly modifiers
+var b05: BPR;
+var b05: Partial<BR>;
+var b05: Readonly<BP>;
+var b05: Partial<Readonly<B>>;
+var b05: Readonly<Partial<B>>;

--- a/tests/cases/conformance/types/mapped/mappedTypeModifiers.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypeModifiers.ts
@@ -1,0 +1,42 @@
+// @strictNullChecks: true
+
+type T = { a: number, b: string };
+type U = { a: number | undefined, b: string | undefined };
+type P = { a?: number, b?: string };
+type R = { readonly a: number, readonly b: string };
+type PR = { readonly a?: number, readonly b?: string };
+
+// Validate they all have the same keys
+var v00: "a" | "b";
+var v00: keyof T;
+var v00: keyof U;
+var v00: keyof P;
+var v00: keyof R;
+var v00: keyof PR;
+
+// Validate that non-isomorphic mapped types strip modifiers
+var v01: T;
+var v01: Pick<R, keyof T>;
+var v01: Pick<Readonly<T>, keyof T>;
+
+// Validate that non-isomorphic mapped types strip modifiers
+var v02: U;
+var v02: Pick<P, keyof T>;
+var v02: Pick<PR, keyof T>;
+var v02: Pick<Partial<T>, keyof T>;
+var v02: Pick<Partial<Readonly<T>>, keyof T>;
+
+// Validate that isomorphic mapped types preserve optional modifier
+var v03: P;
+var v03: Partial<T>;
+
+// Validate that isomorphic mapped types preserve readonly modifier
+var v04: R;
+var v04: Readonly<T>;
+
+// Validate that isomorphic mapped types preserve both partial and readonly modifiers
+var v05: PR;
+var v05: Partial<R>;
+var v05: Readonly<P>;
+var v05: Partial<Readonly<T>>;
+var v05: Readonly<Partial<T>>;


### PR DESCRIPTION
WIth this PR we preserve property modifiers in isomorphic mapped types. A mapped type of the form `{ [P in keyof T]: X }` is isomorphic with `T` (because it has the same set of properties as `T`) and now preserves the optional and readonly modifiers as they exist on the properties in `T`.

Since the predefined mapped types `Partial<T>` and `Readonly<T>` are isomorphic they now preserve already existing property modifiers. Note, however, that the predefined mapped type `Pick<T, K>` is not isomorphic. For that reason it can be used to strip modifiers. For example, `Pick<T, keyof T>` for some `T` yields a type wherein the property modifiers have been stripped.

```ts
type T1 = { a?: number, b: string };
type T2 = Partial<T1>;  // { a?: number, b?: string }
type T3 = Readonly<T1>;  // { readonly a?: number, readonly b: string }
type T4 = Partial<Readonly<T1>>;  // { readonly a?: number, readonly b?: string }
type T5 = Readonly<Partial<T1>>;  // { readonly a?: number, readonly b?: string }
type T6 = Pick<T5, keyof T5>;  // { a: number, b: string }
```

The types noted in comments above reflect classic type checking mode. In `--strictNullChecks` mode, the type `T6` above is actually `{ a: number | undefined, b: number | undefined }` because the `undefined` that was added as a result of making the properties optional persists even when the modifiers are stripped.

Fixes #12542.