### PR TITLE
Rest of untyped binding pattern is { [s: string]: any }

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3099,6 +3099,15 @@ namespace ts {
                         error(declaration, Diagnostics.Rest_types_may_only_be_created_from_object_types);
                         return unknownType;
                     }
+                    const parent = pattern.parent as VariableLikeDeclaration;
+                        if (parent.kind === SyntaxKind.Parameter &&
+                            !parent.type &&
+                            !parent.initializer &&
+                            !getContextuallyTypedParameterType(parent as ParameterDeclaration)) {
+                            // if this type came from examining the structure of the pattern --
+                            // there was no other information -- then it is not sufficient to determine the rest type, so just return any
+                        return anyType;
+                    }
                     const literalMembers: PropertyName[] = [];
                     for (const element of pattern.elements) {
                         if (!(element as BindingElement).dotDotDotToken) {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3106,6 +3106,12 @@ namespace ts {
                         }
                     }
                     type = getRestType(parentType, literalMembers, declaration.symbol);
+                    if (getPropertiesOfObjectType(type).length === 0 && getIndexTypeOfType(type, IndexKind.String) === anyType) {
+                        if (compilerOptions.noImplicitAny) {
+                            reportImplicitAnyError(declaration, anyType);
+                        }
+                        return anyType;
+                    }
                 }
                 else {
                     // Use explicitly specified property name ({ p: xxx } form), or otherwise the implied name ({ p } form)

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3106,12 +3106,6 @@ namespace ts {
                         }
                     }
                     type = getRestType(parentType, literalMembers, declaration.symbol);
-                    if (getPropertiesOfObjectType(type).length === 0 && getIndexTypeOfType(type, IndexKind.String) === anyType) {
-                        if (compilerOptions.noImplicitAny) {
-                            reportImplicitAnyError(declaration, anyType);
-                        }
-                        return anyType;
-                    }
                 }
                 else {
                     // Use explicitly specified property name ({ p: xxx } form), or otherwise the implied name ({ p } form)

--- a/tests/baselines/reference/objectRest.js
+++ b/tests/baselines/reference/objectRest.js
@@ -37,7 +37,7 @@ let computed2 = 'a';
 var { [computed]: stillNotGreat, [computed2]: soSo,  ...o } = o;
 ({ [computed]: stillNotGreat, [computed2]: soSo, ...o } = o);
 
-var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber;
+var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject.anythingGoes;
 
 
 //// [objectRest.js]
@@ -80,6 +80,6 @@ var _g = computed, stillNotGreat = o[_g], _h = computed2, soSo = o[_h], o = __re
 (_j = computed, stillNotGreat = o[_j], _k = computed2, soSo = o[_k], o = __rest(o, [typeof _j === "symbol" ? _j : _j + "", typeof _k === "symbol" ? _k : _k + ""]));
 var noContextualType = (_a) => {
     var { aNumber = 12 } = _a, notEmptyObject = __rest(_a, ["aNumber"]);
-    return aNumber;
+    return aNumber + notEmptyObject.anythingGoes;
 };
 var _d, _f, _j, _k;

--- a/tests/baselines/reference/objectRest.js
+++ b/tests/baselines/reference/objectRest.js
@@ -37,6 +37,8 @@ let computed2 = 'a';
 var { [computed]: stillNotGreat, [computed2]: soSo,  ...o } = o;
 ({ [computed]: stillNotGreat, [computed2]: soSo, ...o } = o);
 
+var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber;
+
 
 //// [objectRest.js]
 var __rest = (this && this.__rest) || function (s, e) {
@@ -76,4 +78,8 @@ let computed = 'b';
 let computed2 = 'a';
 var _g = computed, stillNotGreat = o[_g], _h = computed2, soSo = o[_h], o = __rest(o, [typeof _g === "symbol" ? _g : _g + "", typeof _h === "symbol" ? _h : _h + ""]);
 (_j = computed, stillNotGreat = o[_j], _k = computed2, soSo = o[_k], o = __rest(o, [typeof _j === "symbol" ? _j : _j + "", typeof _k === "symbol" ? _k : _k + ""]));
+var noContextualType = (_a) => {
+    var { aNumber = 12 } = _a, notEmptyObject = __rest(_a, ["aNumber"]);
+    return aNumber;
+};
 var _d, _f, _j, _k;

--- a/tests/baselines/reference/objectRest.js
+++ b/tests/baselines/reference/objectRest.js
@@ -37,7 +37,7 @@ let computed2 = 'a';
 var { [computed]: stillNotGreat, [computed2]: soSo,  ...o } = o;
 ({ [computed]: stillNotGreat, [computed2]: soSo, ...o } = o);
 
-var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject.anythingGoes;
+var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject['anythingGoes'];
 
 
 //// [objectRest.js]
@@ -80,6 +80,6 @@ var _g = computed, stillNotGreat = o[_g], _h = computed2, soSo = o[_h], o = __re
 (_j = computed, stillNotGreat = o[_j], _k = computed2, soSo = o[_k], o = __rest(o, [typeof _j === "symbol" ? _j : _j + "", typeof _k === "symbol" ? _k : _k + ""]));
 var noContextualType = (_a) => {
     var { aNumber = 12 } = _a, notEmptyObject = __rest(_a, ["aNumber"]);
-    return aNumber + notEmptyObject.anythingGoes;
+    return aNumber + notEmptyObject['anythingGoes'];
 };
 var _d, _f, _j, _k;

--- a/tests/baselines/reference/objectRest.symbols
+++ b/tests/baselines/reference/objectRest.symbols
@@ -169,7 +169,7 @@ var { [computed]: stillNotGreat, [computed2]: soSo,  ...o } = o;
 >o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
 >o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
 
-var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject.anythingGoes;
+var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject['anythingGoes'];
 >noContextualType : Symbol(noContextualType, Decl(objectRest.ts, 38, 3))
 >aNumber : Symbol(aNumber, Decl(objectRest.ts, 38, 25))
 >notEmptyObject : Symbol(notEmptyObject, Decl(objectRest.ts, 38, 39))

--- a/tests/baselines/reference/objectRest.symbols
+++ b/tests/baselines/reference/objectRest.symbols
@@ -169,9 +169,10 @@ var { [computed]: stillNotGreat, [computed2]: soSo,  ...o } = o;
 >o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
 >o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
 
-var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber;
+var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject.anythingGoes;
 >noContextualType : Symbol(noContextualType, Decl(objectRest.ts, 38, 3))
 >aNumber : Symbol(aNumber, Decl(objectRest.ts, 38, 25))
 >notEmptyObject : Symbol(notEmptyObject, Decl(objectRest.ts, 38, 39))
 >aNumber : Symbol(aNumber, Decl(objectRest.ts, 38, 25))
+>notEmptyObject : Symbol(notEmptyObject, Decl(objectRest.ts, 38, 39))
 

--- a/tests/baselines/reference/objectRest.symbols
+++ b/tests/baselines/reference/objectRest.symbols
@@ -169,3 +169,9 @@ var { [computed]: stillNotGreat, [computed2]: soSo,  ...o } = o;
 >o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
 >o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
 
+var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber;
+>noContextualType : Symbol(noContextualType, Decl(objectRest.ts, 38, 3))
+>aNumber : Symbol(aNumber, Decl(objectRest.ts, 38, 25))
+>notEmptyObject : Symbol(notEmptyObject, Decl(objectRest.ts, 38, 39))
+>aNumber : Symbol(aNumber, Decl(objectRest.ts, 38, 25))
+

--- a/tests/baselines/reference/objectRest.types
+++ b/tests/baselines/reference/objectRest.types
@@ -195,15 +195,15 @@ var { [computed]: stillNotGreat, [computed2]: soSo,  ...o } = o;
 >o : { a: number; b: string; }
 >o : { a: number; b: string; }
 
-var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject.anythingGoes;
+var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject['anythingGoes'];
 >noContextualType : ({aNumber, ...notEmptyObject}: { [x: string]: any; aNumber?: number; }) => any
->({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject.anythingGoes : ({aNumber, ...notEmptyObject}: { [x: string]: any; aNumber?: number; }) => any
+>({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject['anythingGoes'] : ({aNumber, ...notEmptyObject}: { [x: string]: any; aNumber?: number; }) => any
 >aNumber : number
 >12 : 12
->notEmptyObject : any
->aNumber + notEmptyObject.anythingGoes : any
+>notEmptyObject : { [x: string]: any; }
+>aNumber + notEmptyObject['anythingGoes'] : any
 >aNumber : number
->notEmptyObject.anythingGoes : any
->notEmptyObject : any
->anythingGoes : any
+>notEmptyObject['anythingGoes'] : any
+>notEmptyObject : { [x: string]: any; }
+>'anythingGoes' : "anythingGoes"
 

--- a/tests/baselines/reference/objectRest.types
+++ b/tests/baselines/reference/objectRest.types
@@ -195,11 +195,15 @@ var { [computed]: stillNotGreat, [computed2]: soSo,  ...o } = o;
 >o : { a: number; b: string; }
 >o : { a: number; b: string; }
 
-var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber;
->noContextualType : ({aNumber, ...notEmptyObject}: { [x: string]: any; aNumber?: number; }) => number
->({ aNumber = 12, ...notEmptyObject }) => aNumber : ({aNumber, ...notEmptyObject}: { [x: string]: any; aNumber?: number; }) => number
+var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject.anythingGoes;
+>noContextualType : ({aNumber, ...notEmptyObject}: { [x: string]: any; aNumber?: number; }) => any
+>({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject.anythingGoes : ({aNumber, ...notEmptyObject}: { [x: string]: any; aNumber?: number; }) => any
 >aNumber : number
 >12 : 12
->notEmptyObject : { [x: string]: any; }
+>notEmptyObject : any
+>aNumber + notEmptyObject.anythingGoes : any
 >aNumber : number
+>notEmptyObject.anythingGoes : any
+>notEmptyObject : any
+>anythingGoes : any
 

--- a/tests/baselines/reference/objectRest.types
+++ b/tests/baselines/reference/objectRest.types
@@ -195,3 +195,11 @@ var { [computed]: stillNotGreat, [computed2]: soSo,  ...o } = o;
 >o : { a: number; b: string; }
 >o : { a: number; b: string; }
 
+var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber;
+>noContextualType : ({aNumber, ...notEmptyObject}: { aNumber?: number; }) => number
+>({ aNumber = 12, ...notEmptyObject }) => aNumber : ({aNumber, ...notEmptyObject}: { aNumber?: number; }) => number
+>aNumber : number
+>12 : 12
+>notEmptyObject : any
+>aNumber : number
+

--- a/tests/baselines/reference/objectRest.types
+++ b/tests/baselines/reference/objectRest.types
@@ -196,10 +196,10 @@ var { [computed]: stillNotGreat, [computed2]: soSo,  ...o } = o;
 >o : { a: number; b: string; }
 
 var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber;
->noContextualType : ({aNumber, ...notEmptyObject}: { aNumber?: number; }) => number
->({ aNumber = 12, ...notEmptyObject }) => aNumber : ({aNumber, ...notEmptyObject}: { aNumber?: number; }) => number
+>noContextualType : ({aNumber, ...notEmptyObject}: { [x: string]: any; aNumber?: number; }) => number
+>({ aNumber = 12, ...notEmptyObject }) => aNumber : ({aNumber, ...notEmptyObject}: { [x: string]: any; aNumber?: number; }) => number
 >aNumber : number
 >12 : 12
->notEmptyObject : any
+>notEmptyObject : { [x: string]: any; }
 >aNumber : number
 

--- a/tests/baselines/reference/objectRestNegative.errors.txt
+++ b/tests/baselines/reference/objectRestNegative.errors.txt
@@ -7,7 +7,7 @@ tests/cases/conformance/types/rest/objectRestNegative.ts(11,30): error TS7008: M
 tests/cases/conformance/types/rest/objectRestNegative.ts(11,33): error TS7008: Member 'y' implicitly has an 'any' type.
 tests/cases/conformance/types/rest/objectRestNegative.ts(12,17): error TS2700: Rest types may only be created from object types.
 tests/cases/conformance/types/rest/objectRestNegative.ts(17,9): error TS2701: The target of an object rest assignment must be a variable or a property access.
-tests/cases/conformance/types/rest/objectRestNegative.ts(19,44): error TS7031: Binding element 'implicitlyAny' implicitly has an 'any' type.
+tests/cases/conformance/types/rest/objectRestNegative.ts(19,90): error TS2339: Property 'anythingGoes' does not exist on type '{ [x: string]: any; }'.
 
 
 ==== tests/cases/conformance/types/rest/objectRestNegative.ts (8 errors) ====
@@ -45,7 +45,7 @@ tests/cases/conformance/types/rest/objectRestNegative.ts(19,44): error TS7031: B
             ~~~~~~~~~~~~~~~
 !!! error TS2701: The target of an object rest assignment must be a variable or a property access.
     
-    var noContextualType = ({ aNumber = 12, ...implicitlyAny }) => aNumber + implicitlyAny.anythingGoes;
-                                               ~~~~~~~~~~~~~
-!!! error TS7031: Binding element 'implicitlyAny' implicitly has an 'any' type.
+    var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject.anythingGoes;
+                                                                                             ~~~~~~~~~~~~
+!!! error TS2339: Property 'anythingGoes' does not exist on type '{ [x: string]: any; }'.
     

--- a/tests/baselines/reference/objectRestNegative.errors.txt
+++ b/tests/baselines/reference/objectRestNegative.errors.txt
@@ -3,11 +3,14 @@ tests/cases/conformance/types/rest/objectRestNegative.ts(6,10): error TS2322: Ty
   Types of property 'a' are incompatible.
     Type 'number' is not assignable to type 'string'.
 tests/cases/conformance/types/rest/objectRestNegative.ts(9,31): error TS2462: A rest element must be last in a destructuring pattern
+tests/cases/conformance/types/rest/objectRestNegative.ts(11,30): error TS7008: Member 'x' implicitly has an 'any' type.
+tests/cases/conformance/types/rest/objectRestNegative.ts(11,33): error TS7008: Member 'y' implicitly has an 'any' type.
 tests/cases/conformance/types/rest/objectRestNegative.ts(12,17): error TS2700: Rest types may only be created from object types.
 tests/cases/conformance/types/rest/objectRestNegative.ts(17,9): error TS2701: The target of an object rest assignment must be a variable or a property access.
+tests/cases/conformance/types/rest/objectRestNegative.ts(19,44): error TS7031: Binding element 'implicitlyAny' implicitly has an 'any' type.
 
 
-==== tests/cases/conformance/types/rest/objectRestNegative.ts (5 errors) ====
+==== tests/cases/conformance/types/rest/objectRestNegative.ts (8 errors) ====
     let o = { a: 1, b: 'no' };
     var { ...mustBeLast, a } = o;
              ~~~~~~~~~~
@@ -27,6 +30,10 @@ tests/cases/conformance/types/rest/objectRestNegative.ts(17,9): error TS2701: Th
 !!! error TS2462: A rest element must be last in a destructuring pattern
     }
     function generic<T extends { x, y }>(t: T) {
+                                 ~~
+!!! error TS7008: Member 'x' implicitly has an 'any' type.
+                                    ~
+!!! error TS7008: Member 'y' implicitly has an 'any' type.
         let { x, ...rest } = t;
                     ~~~~
 !!! error TS2700: Rest types may only be created from object types.
@@ -37,4 +44,8 @@ tests/cases/conformance/types/rest/objectRestNegative.ts(17,9): error TS2701: Th
     ({a, ...rest.b + rest.b} = o);
             ~~~~~~~~~~~~~~~
 !!! error TS2701: The target of an object rest assignment must be a variable or a property access.
+    
+    var noContextualType = ({ aNumber = 12, ...implicitlyAny }) => aNumber + implicitlyAny.anythingGoes;
+                                               ~~~~~~~~~~~~~
+!!! error TS7031: Binding element 'implicitlyAny' implicitly has an 'any' type.
     

--- a/tests/baselines/reference/objectRestNegative.js
+++ b/tests/baselines/reference/objectRestNegative.js
@@ -17,7 +17,7 @@ function generic<T extends { x, y }>(t: T) {
 let rest: { b: string }
 ({a, ...rest.b + rest.b} = o);
 
-var noContextualType = ({ aNumber = 12, ...implicitlyAny }) => aNumber + implicitlyAny.anythingGoes;
+var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject.anythingGoes;
 
 
 //// [objectRestNegative.js]
@@ -45,6 +45,6 @@ function generic(t) {
 var rest;
 (a = o.a, o, rest.b + rest.b = __rest(o, ["a"]));
 var noContextualType = function (_a) {
-    var _b = _a.aNumber, aNumber = _b === void 0 ? 12 : _b, implicitlyAny = __rest(_a, ["aNumber"]);
-    return aNumber + implicitlyAny.anythingGoes;
+    var _b = _a.aNumber, aNumber = _b === void 0 ? 12 : _b, notEmptyObject = __rest(_a, ["aNumber"]);
+    return aNumber + notEmptyObject.anythingGoes;
 };

--- a/tests/baselines/reference/objectRestNegative.js
+++ b/tests/baselines/reference/objectRestNegative.js
@@ -17,6 +17,8 @@ function generic<T extends { x, y }>(t: T) {
 let rest: { b: string }
 ({a, ...rest.b + rest.b} = o);
 
+var noContextualType = ({ aNumber = 12, ...implicitlyAny }) => aNumber + implicitlyAny.anythingGoes;
+
 
 //// [objectRestNegative.js]
 var __rest = (this && this.__rest) || function (s, e) {
@@ -42,3 +44,7 @@ function generic(t) {
 }
 var rest;
 (a = o.a, o, rest.b + rest.b = __rest(o, ["a"]));
+var noContextualType = function (_a) {
+    var _b = _a.aNumber, aNumber = _b === void 0 ? 12 : _b, implicitlyAny = __rest(_a, ["aNumber"]);
+    return aNumber + implicitlyAny.anythingGoes;
+};

--- a/tests/cases/conformance/types/rest/objectRest.ts
+++ b/tests/cases/conformance/types/rest/objectRest.ts
@@ -37,4 +37,4 @@ let computed2 = 'a';
 var { [computed]: stillNotGreat, [computed2]: soSo,  ...o } = o;
 ({ [computed]: stillNotGreat, [computed2]: soSo, ...o } = o);
 
-var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject.anythingGoes;
+var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject['anythingGoes'];

--- a/tests/cases/conformance/types/rest/objectRest.ts
+++ b/tests/cases/conformance/types/rest/objectRest.ts
@@ -37,4 +37,4 @@ let computed2 = 'a';
 var { [computed]: stillNotGreat, [computed2]: soSo,  ...o } = o;
 ({ [computed]: stillNotGreat, [computed2]: soSo, ...o } = o);
 
-var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber;
+var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject.anythingGoes;

--- a/tests/cases/conformance/types/rest/objectRest.ts
+++ b/tests/cases/conformance/types/rest/objectRest.ts
@@ -36,3 +36,5 @@ let computed = 'b';
 let computed2 = 'a';
 var { [computed]: stillNotGreat, [computed2]: soSo,  ...o } = o;
 ({ [computed]: stillNotGreat, [computed2]: soSo, ...o } = o);
+
+var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber;

--- a/tests/cases/conformance/types/rest/objectRestNegative.ts
+++ b/tests/cases/conformance/types/rest/objectRestNegative.ts
@@ -1,3 +1,4 @@
+// @noImplicitAny: true
 let o = { a: 1, b: 'no' };
 var { ...mustBeLast, a } = o;
 
@@ -15,3 +16,5 @@ function generic<T extends { x, y }>(t: T) {
 
 let rest: { b: string }
 ({a, ...rest.b + rest.b} = o);
+
+var noContextualType = ({ aNumber = 12, ...implicitlyAny }) => aNumber + implicitlyAny.anythingGoes;

--- a/tests/cases/conformance/types/rest/objectRestNegative.ts
+++ b/tests/cases/conformance/types/rest/objectRestNegative.ts
@@ -17,4 +17,4 @@ function generic<T extends { x, y }>(t: T) {
 let rest: { b: string }
 ({a, ...rest.b + rest.b} = o);
 
-var noContextualType = ({ aNumber = 12, ...implicitlyAny }) => aNumber + implicitlyAny.anythingGoes;
+var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject.anythingGoes;


### PR DESCRIPTION
Fixes #12519 

Edit:
@mhegazy pointed out that (1) rest of an untyped binding pattern isn't really any since it's definitely not a function (2) adding an index signature results in a more straightforward fix. So the current version adds an index signature to the structurally inferred type of an untyped binding pattern.