### PR TITLE
Reset the noEmitForJsFiles option when updating compiler options

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -2738,7 +2738,7 @@ namespace ts.projectSystem {
             const diagsAfterUpdate = session.executeCommand(<server.protocol.CompilerOptionsDiagnosticsRequest>{
                 type: "request",
                 command: server.CommandNames.CompilerOptionsDiagnosticsFull,
-                seq: 3,
+                seq: 4,
                 arguments: { projectFileName: projectName }
             }).response;
             assert.isTrue(diagsAfterUpdate.length === 0);
@@ -2783,7 +2783,7 @@ namespace ts.projectSystem {
             const diagsAfterUpdate = session.executeCommand(<server.protocol.CompilerOptionsDiagnosticsRequest>{
                 type: "request",
                 command: server.CommandNames.CompilerOptionsDiagnosticsFull,
-                seq: 3,
+                seq: 4,
                 arguments: { projectFileName }
             }).response;
             assert.isTrue(diagsAfterUpdate.length === 0);

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -2728,6 +2728,65 @@ namespace ts.projectSystem {
                 arguments: { projectFileName: projectName }
             }).response;
             assert.isTrue(diags.length === 0);
+
+            session.executeCommand(<server.protocol.SetCompilerOptionsForInferredProjectsRequest>{
+                type: "request",
+                command: server.CommandNames.CompilerOptionsForInferredProjects,
+                seq: 3,
+                arguments: { options: { module: ModuleKind.CommonJS } }
+            });
+            const diagsAfterUpdate = session.executeCommand(<server.protocol.CompilerOptionsDiagnosticsRequest>{
+                type: "request",
+                command: server.CommandNames.CompilerOptionsDiagnosticsFull,
+                seq: 3,
+                arguments: { projectFileName: projectName }
+            }).response;
+            assert.isTrue(diagsAfterUpdate.length === 0);
+        });
+
+        it("for external project", () => {
+            const f1 = {
+                path: "/a/b/f1.js",
+                content: "function test1() { }"
+            };
+            const host = createServerHost([f1, libFile]);
+            const session = createSession(host);
+            const projectService = session.getProjectService();
+            const projectFileName = "/a/b/project.csproj";
+            const externalFiles = toExternalFiles([f1.path]);
+            projectService.openExternalProject(<protocol.ExternalProject>{
+                projectFileName,
+                rootFiles: externalFiles,
+                options: {}
+            });
+
+            checkNumberOfProjects(projectService, { externalProjects: 1 });
+
+            const diags = session.executeCommand(<server.protocol.CompilerOptionsDiagnosticsRequest>{
+                type: "request",
+                command: server.CommandNames.CompilerOptionsDiagnosticsFull,
+                seq: 2,
+                arguments: { projectFileName }
+            }).response;
+            assert.isTrue(diags.length === 0);
+
+            session.executeCommand(<server.protocol.OpenExternalProjectRequest>{
+                type: "request",
+                command: server.CommandNames.OpenExternalProject,
+                seq: 3,
+                arguments: {
+                    projectFileName,
+                    rootFiles: externalFiles,
+                    options: { module: ModuleKind.CommonJS }
+                }
+            });
+            const diagsAfterUpdate = session.executeCommand(<server.protocol.CompilerOptionsDiagnosticsRequest>{
+                type: "request",
+                command: server.CommandNames.CompilerOptionsDiagnosticsFull,
+                seq: 3,
+                arguments: { projectFileName }
+            }).response;
+            assert.isTrue(diagsAfterUpdate.length === 0);
         });
     });
 

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -248,9 +248,7 @@ namespace ts.server {
                 this.compilerOptions.allowNonTsExtensions = true;
             }
 
-            if (this.projectKind === ProjectKind.Inferred || this.projectKind === ProjectKind.External) {
-                this.compilerOptions.noEmitForJsFiles = true;
-            }
+            this.setInternalCompilerOptionsForEmittingJsFiles();
 
             this.lsHost = new LSHost(this.projectService.host, this, this.projectService.cancellationToken);
             this.lsHost.setCompilationSettings(this.compilerOptions);
@@ -264,6 +262,12 @@ namespace ts.server {
 
             this.builder = createBuilder(this);
             this.markAsDirty();
+        }
+
+        setInternalCompilerOptionsForEmittingJsFiles() {
+            if (this.projectKind === ProjectKind.Inferred || this.projectKind === ProjectKind.External) {
+                this.compilerOptions.noEmitForJsFiles = true;
+            }
         }
 
         getProjectErrors() {
@@ -636,10 +640,8 @@ namespace ts.server {
                     this.cachedUnresolvedImportsPerFile.clear();
                     this.lastCachedUnresolvedImportsList = undefined;
                 }
-                if (this.projectKind === ProjectKind.Inferred || this.projectKind === ProjectKind.Configured) {
-                    compilerOptions.noEmitForJsFiles = true;
-                }
                 this.compilerOptions = compilerOptions;
+                this.setInternalCompilerOptionsForEmittingJsFiles();
                 this.lsHost.setCompilationSettings(compilerOptions);
 
                 this.markAsDirty();

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -636,6 +636,9 @@ namespace ts.server {
                     this.cachedUnresolvedImportsPerFile.clear();
                     this.lastCachedUnresolvedImportsList = undefined;
                 }
+                if (this.projectKind === ProjectKind.Inferred || this.projectKind === ProjectKind.Configured) {
+                    compilerOptions.noEmitForJsFiles = true;
+                }
                 this.compilerOptions = compilerOptions;
                 this.lsHost.setCompilationSettings(compilerOptions);
 

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -264,7 +264,7 @@ namespace ts.server {
             this.markAsDirty();
         }
 
-        setInternalCompilerOptionsForEmittingJsFiles() {
+        private setInternalCompilerOptionsForEmittingJsFiles() {
             if (this.projectKind === ProjectKind.Inferred || this.projectKind === ProjectKind.External) {
                 this.compilerOptions.noEmitForJsFiles = true;
             }


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->


