### PR TITLE
Fix the incorrectly emitted method name in decorator expression when it starts with underscore

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -1905,7 +1905,7 @@ namespace ts {
                     : (<ComputedPropertyName>name).expression;
             }
             else if (isIdentifier(name)) {
-                return createLiteral(name.text);
+                return createLiteral(unescapeIdentifier(name.text));
             }
             else {
                 return getSynthesizedClone(name);

--- a/tests/baselines/reference/decoratorWithUnderscoreMethod.js
+++ b/tests/baselines/reference/decoratorWithUnderscoreMethod.js
@@ -1,0 +1,37 @@
+//// [decoratorWithUnderscoreMethod.ts]
+
+declare var console : { log(arg: string): void };
+function dec(): Function {
+    return function (target: any, propKey: string, descr: PropertyDescriptor): void {
+        console.log(target[propKey]);
+        //logs undefined
+        //propKey has three underscores as prefix, but the method has only two underscores
+    };
+}
+
+class A {
+    @dec()
+    private __foo(bar: string): void {
+        // do something with bar
+    }
+}
+
+//// [decoratorWithUnderscoreMethod.js]
+function dec() {
+    return function (target, propKey, descr) {
+        console.log(target[propKey]);
+        //logs undefined
+        //propKey has three underscores as prefix, but the method has only two underscores
+    };
+}
+var A = (function () {
+    function A() {
+    }
+    A.prototype.__foo = function (bar) {
+        // do something with bar
+    };
+    return A;
+}());
+__decorate([
+    dec()
+], A.prototype, "___foo");

--- a/tests/baselines/reference/decoratorWithUnderscoreMethod.js
+++ b/tests/baselines/reference/decoratorWithUnderscoreMethod.js
@@ -34,4 +34,4 @@ var A = (function () {
 }());
 __decorate([
     dec()
-], A.prototype, "___foo");
+], A.prototype, "__foo");

--- a/tests/baselines/reference/decoratorWithUnderscoreMethod.symbols
+++ b/tests/baselines/reference/decoratorWithUnderscoreMethod.symbols
@@ -1,0 +1,42 @@
+=== tests/cases/compiler/decoratorWithUnderscoreMethod.ts ===
+
+declare var console : { log(arg: string): void };
+>console : Symbol(console, Decl(decoratorWithUnderscoreMethod.ts, 1, 11))
+>log : Symbol(log, Decl(decoratorWithUnderscoreMethod.ts, 1, 23))
+>arg : Symbol(arg, Decl(decoratorWithUnderscoreMethod.ts, 1, 28))
+
+function dec(): Function {
+>dec : Symbol(dec, Decl(decoratorWithUnderscoreMethod.ts, 1, 49))
+>Function : Symbol(Function, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+    return function (target: any, propKey: string, descr: PropertyDescriptor): void {
+>target : Symbol(target, Decl(decoratorWithUnderscoreMethod.ts, 3, 21))
+>propKey : Symbol(propKey, Decl(decoratorWithUnderscoreMethod.ts, 3, 33))
+>descr : Symbol(descr, Decl(decoratorWithUnderscoreMethod.ts, 3, 50))
+>PropertyDescriptor : Symbol(PropertyDescriptor, Decl(lib.d.ts, --, --))
+
+        console.log(target[propKey]);
+>console.log : Symbol(log, Decl(decoratorWithUnderscoreMethod.ts, 1, 23))
+>console : Symbol(console, Decl(decoratorWithUnderscoreMethod.ts, 1, 11))
+>log : Symbol(log, Decl(decoratorWithUnderscoreMethod.ts, 1, 23))
+>target : Symbol(target, Decl(decoratorWithUnderscoreMethod.ts, 3, 21))
+>propKey : Symbol(propKey, Decl(decoratorWithUnderscoreMethod.ts, 3, 33))
+
+        //logs undefined
+        //propKey has three underscores as prefix, but the method has only two underscores
+    };
+}
+
+class A {
+>A : Symbol(A, Decl(decoratorWithUnderscoreMethod.ts, 8, 1))
+
+    @dec()
+>dec : Symbol(dec, Decl(decoratorWithUnderscoreMethod.ts, 1, 49))
+
+    private __foo(bar: string): void {
+>__foo : Symbol(A.__foo, Decl(decoratorWithUnderscoreMethod.ts, 10, 9))
+>bar : Symbol(bar, Decl(decoratorWithUnderscoreMethod.ts, 12, 18))
+
+        // do something with bar
+    }
+}

--- a/tests/baselines/reference/decoratorWithUnderscoreMethod.types
+++ b/tests/baselines/reference/decoratorWithUnderscoreMethod.types
@@ -1,0 +1,46 @@
+=== tests/cases/compiler/decoratorWithUnderscoreMethod.ts ===
+
+declare var console : { log(arg: string): void };
+>console : { log(arg: string): void; }
+>log : (arg: string) => void
+>arg : string
+
+function dec(): Function {
+>dec : () => Function
+>Function : Function
+
+    return function (target: any, propKey: string, descr: PropertyDescriptor): void {
+>function (target: any, propKey: string, descr: PropertyDescriptor): void {        console.log(target[propKey]);        //logs undefined        //propKey has three underscores as prefix, but the method has only two underscores    } : (target: any, propKey: string, descr: PropertyDescriptor) => void
+>target : any
+>propKey : string
+>descr : PropertyDescriptor
+>PropertyDescriptor : PropertyDescriptor
+
+        console.log(target[propKey]);
+>console.log(target[propKey]) : void
+>console.log : (arg: string) => void
+>console : { log(arg: string): void; }
+>log : (arg: string) => void
+>target[propKey] : any
+>target : any
+>propKey : string
+
+        //logs undefined
+        //propKey has three underscores as prefix, but the method has only two underscores
+    };
+}
+
+class A {
+>A : A
+
+    @dec()
+>dec() : Function
+>dec : () => Function
+
+    private __foo(bar: string): void {
+>__foo : (bar: string) => void
+>bar : string
+
+        // do something with bar
+    }
+}

--- a/tests/cases/compiler/decoratorWithUnderscoreMethod.ts
+++ b/tests/cases/compiler/decoratorWithUnderscoreMethod.ts
@@ -1,0 +1,18 @@
+// @noemithelpers: true
+// @experimentaldecorators: true
+
+declare var console : { log(arg: string): void };
+function dec(): Function {
+    return function (target: any, propKey: string, descr: PropertyDescriptor): void {
+        console.log(target[propKey]);
+        //logs undefined
+        //propKey has three underscores as prefix, but the method has only two underscores
+    };
+}
+
+class A {
+    @dec()
+    private __foo(bar: string): void {
+        // do something with bar
+    }
+}


### PR DESCRIPTION
Fixes #12562
