### PR TITLE
Add node6 to ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 
 node_js:
   - 'stable'
+  - '6'
   - '4'
 
 sudo: false

--- a/netci.groovy
+++ b/netci.groovy
@@ -5,7 +5,7 @@ import jobs.generation.Utilities;
 def project = GithubProject
 def branch = GithubBranchName
 
-def nodeVersions = ['stable', '4']
+def nodeVersions = ['stable', '6', '4']
 
 nodeVersions.each { nodeVer ->
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "tsserver": "./bin/tsserver"
     },
     "engines": {
-        "node": ">=0.8.0"
+        "node": ">=4.2.0"
     },
     "devDependencies": {
         "@types/browserify": "latest",


### PR DESCRIPTION
- Add Node.js 6 LTS to CI
- Drop unmaintained versions of Node.js from package.json