### PR TITLE
Fix elided syntax kinds falling through to visitConstructor in TypeScript transformer

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -345,6 +345,7 @@ namespace ts {
 
                 case SyntaxKind.PropertyDeclaration:
                     // TypeScript property declarations are elided.
+                    return undefined;
 
                 case SyntaxKind.Constructor:
                     return visitConstructor(<ConstructorDeclaration>node);


### PR DESCRIPTION
The TypeScript transformer elides a bunch of syntax kinds that should not appear in the emitted JavaScript code (e.g. access modifiers, types,...). Normally, this elision would be done by returning `undefined` from the visitor.

[This commit](https://github.com/Microsoft/TypeScript/commit/980a8947875fdf78231ea546767dee47393fabfa#diff-c0d0e8b1528663b6cff3bb893150cec3R290) changed the handling for `SyntaxKind.Constructor`: previously constructors were elided, but now `visitConstructor` handles them. However, the commit forgot to stop the cases above the `SyntaxKind.Constructor` case falling through, so now all cases that should just have `return undefined` actually call `visitConstructor` instead. Luckily, `visitConstructor` returns `undefined` when its argument is not a function-like declaration, which is why the code works and passes the tests... although it works for the wrong reason. 😛 

This change re-introduces the missing `return undefined` statement, so the elided cases no longer fall through to `visitConstructor`.