### PR TITLE
Normalize 'basePath' in 'parseJsonConfigFileContent'

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -850,6 +850,7 @@ namespace ts {
       */
     export function parseJsonConfigFileContent(json: any, host: ParseConfigHost, basePath: string, existingOptions: CompilerOptions = {}, configFileName?: string, resolutionStack: Path[] = []): ParsedCommandLine {
         const errors: Diagnostic[] = [];
+        basePath = normalizeSlashes(basePath);
         const getCanonicalFileName = createGetCanonicalFileName(host.useCaseSensitiveFileNames);
         const resolvedPath = toPath(configFileName || "", basePath, getCanonicalFileName);
         if (resolutionStack.indexOf(resolvedPath) >= 0) {


### PR DESCRIPTION
Fixes #9123

like https://github.com/otbe/TypeScript/blob/1f43720026c824151217e6ea9991b19e449c85cc/src/compiler/commandLineParser.ts but without removing the open-curly of the function