### PR TITLE
Write property name of destructuring pattern explicitly when writing symbol display for binding element

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2673,7 +2673,7 @@ namespace ts {
                 }
                 Debug.assert(bindingElement.kind === SyntaxKind.BindingElement);
                 if (bindingElement.propertyName) {
-                    writer.writeSymbol(getTextOfNode(bindingElement.propertyName), bindingElement.symbol);
+                    writer.writeProperty(getTextOfNode(bindingElement.propertyName));
                     writePunctuation(writer, SyntaxKind.ColonToken);
                     writeSpace(writer);
                 }

--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -194,6 +194,7 @@ namespace ts {
             writer.writeSpace = writer.write;
             writer.writeStringLiteral = writer.writeLiteral;
             writer.writeParameter = writer.write;
+            writer.writeProperty = writer.write;
             writer.writeSymbol = writer.write;
             setWriter(writer);
         }

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2407,6 +2407,7 @@ namespace ts {
         writeSpace(text: string): void;
         writeStringLiteral(text: string): void;
         writeParameter(text: string): void;
+        writeProperty(text: string): void;
         writeSymbol(text: string, symbol: Symbol): void;
         writeLine(): void;
         increaseIndent(): void;

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -43,6 +43,7 @@ namespace ts {
                 writeSpace: writeText,
                 writeStringLiteral: writeText,
                 writeParameter: writeText,
+                writeProperty: writeText,
                 writeSymbol: writeText,
 
                 // Completely ignore indentation for string writers.  And map newlines to

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1137,6 +1137,7 @@ namespace ts {
             writeSpace: text => writeKind(text, SymbolDisplayPartKind.space),
             writeStringLiteral: text => writeKind(text, SymbolDisplayPartKind.stringLiteral),
             writeParameter: text => writeKind(text, SymbolDisplayPartKind.parameterName),
+            writeProperty: text => writeKind(text, SymbolDisplayPartKind.propertyName),
             writeSymbol,
             writeLine,
             increaseIndent: () => { indent++; },

--- a/tests/cases/fourslash/quickInfoWithNestedDestructuredParameterInLambda.ts
+++ b/tests/cases/fourslash/quickInfoWithNestedDestructuredParameterInLambda.ts
@@ -1,0 +1,15 @@
+/// <reference path='fourslash.ts' />
+
+// @filename: a.tsx
+////import * as React from 'react';
+////interface SomeInterface {
+////    someBoolean: boolean,
+////    someString: string;
+////}
+////interface SomeProps {
+////    someProp: SomeInterface;
+////}
+////export const /*1*/SomeStatelessComponent = ({someProp: { someBoolean, someString}}: SomeProps) => (<div>{`${someBoolean}${someString}`});
+
+goTo.marker("1");
+verify.quickInfoExists();


### PR DESCRIPTION
There wont be any symbol for the property name but we already know it is a property name
Fixes #12166