### PR TITLE
Fix decorator emit for accessors

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -1223,11 +1223,12 @@ namespace ts {
             }
 
             const { firstAccessor, secondAccessor, setAccessor } = getAllAccessorDeclarations(node.members, accessor);
-            if (accessor !== firstAccessor) {
+            const firstAccessorWithDecorators = firstAccessor.decorators ? firstAccessor : secondAccessor && secondAccessor.decorators ? secondAccessor : undefined;
+            if (!firstAccessorWithDecorators || accessor !== firstAccessorWithDecorators) {
                 return undefined;
             }
 
-            const decorators = firstAccessor.decorators || (secondAccessor && secondAccessor.decorators);
+            const decorators = firstAccessorWithDecorators.decorators;
             const parameters = getDecoratorsOfParameters(setAccessor);
             if (!decorators && !parameters) {
                 return undefined;

--- a/tests/baselines/reference/decoratorOnClassAccessor7.errors.txt
+++ b/tests/baselines/reference/decoratorOnClassAccessor7.errors.txt
@@ -1,0 +1,41 @@
+tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor7.ts(26,5): error TS1207: Decorators cannot be applied to multiple get/set accessors of the same name.
+tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor7.ts(31,5): error TS1207: Decorators cannot be applied to multiple get/set accessors of the same name.
+
+
+==== tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor7.ts (2 errors) ====
+    declare function dec1<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+    declare function dec2<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+    
+    class A {
+        @dec1 get x() { return 0; }
+        set x(value: number) { }
+    }
+    
+    class B {
+        get x() { return 0; }
+        @dec2 set x(value: number) { }
+    }
+    
+    class C {
+        @dec1 set x(value: number) { }
+        get x() { return 0; }
+    }
+    
+    class D {
+        set x(value: number) { }
+        @dec2 get x() { return 0; }
+    }
+    
+    class E {
+        @dec1 get x() { return 0; }
+        @dec2 set x(value: number) { }
+        ~
+!!! error TS1207: Decorators cannot be applied to multiple get/set accessors of the same name.
+    }
+    
+    class F {
+        @dec1 set x(value: number) { }
+        @dec2 get x() { return 0; }
+        ~
+!!! error TS1207: Decorators cannot be applied to multiple get/set accessors of the same name.
+    }

--- a/tests/baselines/reference/decoratorOnClassAccessor7.js
+++ b/tests/baselines/reference/decoratorOnClassAccessor7.js
@@ -1,0 +1,125 @@
+//// [decoratorOnClassAccessor7.ts]
+declare function dec1<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+declare function dec2<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class A {
+    @dec1 get x() { return 0; }
+    set x(value: number) { }
+}
+
+class B {
+    get x() { return 0; }
+    @dec2 set x(value: number) { }
+}
+
+class C {
+    @dec1 set x(value: number) { }
+    get x() { return 0; }
+}
+
+class D {
+    set x(value: number) { }
+    @dec2 get x() { return 0; }
+}
+
+class E {
+    @dec1 get x() { return 0; }
+    @dec2 set x(value: number) { }
+}
+
+class F {
+    @dec1 set x(value: number) { }
+    @dec2 get x() { return 0; }
+}
+
+//// [decoratorOnClassAccessor7.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var A = (function () {
+    function A() {
+    }
+    Object.defineProperty(A.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
+    return A;
+}());
+__decorate([
+    dec1
+], A.prototype, "x", null);
+var B = (function () {
+    function B() {
+    }
+    Object.defineProperty(B.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
+    return B;
+}());
+__decorate([
+    dec2
+], B.prototype, "x", null);
+var C = (function () {
+    function C() {
+    }
+    Object.defineProperty(C.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
+    return C;
+}());
+__decorate([
+    dec1
+], C.prototype, "x", null);
+var D = (function () {
+    function D() {
+    }
+    Object.defineProperty(D.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
+    return D;
+}());
+__decorate([
+    dec2
+], D.prototype, "x", null);
+var E = (function () {
+    function E() {
+    }
+    Object.defineProperty(E.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
+    return E;
+}());
+__decorate([
+    dec1
+], E.prototype, "x", null);
+var F = (function () {
+    function F() {
+    }
+    Object.defineProperty(F.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
+    return F;
+}());
+__decorate([
+    dec1
+], F.prototype, "x", null);

--- a/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor7.ts
+++ b/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor7.ts
@@ -1,0 +1,34 @@
+// @target:es5
+// @experimentaldecorators: true
+declare function dec1<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+declare function dec2<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class A {
+    @dec1 get x() { return 0; }
+    set x(value: number) { }
+}
+
+class B {
+    get x() { return 0; }
+    @dec2 set x(value: number) { }
+}
+
+class C {
+    @dec1 set x(value: number) { }
+    get x() { return 0; }
+}
+
+class D {
+    set x(value: number) { }
+    @dec2 get x() { return 0; }
+}
+
+class E {
+    @dec1 get x() { return 0; }
+    @dec2 set x(value: number) { }
+}
+
+class F {
+    @dec1 set x(value: number) { }
+    @dec2 get x() { return 0; }
+}


### PR DESCRIPTION
This fixes an issue where the new emitter was not emitting decorators for accessor pairs where only the second accessor was decorated:

```ts
declare var dec: any;
class A {
    @dec() set value(value: string) { } // emits fine
    get value() { return ""; }
}
class B {
    set value(value: string) { }
    @dec() get value() { return ""; } // not emitted
}
```

Fixes #12727

//cc: @mhegazy 

