### PR TITLE
Fix await for inherited promise

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -16207,7 +16207,7 @@ namespace ts {
                 return undefined;
             }
 
-            const onfulfilledParameterType = getTypeWithFacts(getUnionType(map(thenSignatures, getTypeOfFirstParameterOfSignature)), TypeFacts.NEUndefined);
+            const onfulfilledParameterType = getTypeWithFacts(getUnionType(map(thenSignatures, getTypeOfFirstParameterOfSignature)), TypeFacts.NEUndefinedOrNull);
             if (isTypeAny(onfulfilledParameterType)) {
                 return undefined;
             }

--- a/tests/baselines/reference/awaitInheritedPromise_es2017.js
+++ b/tests/baselines/reference/awaitInheritedPromise_es2017.js
@@ -1,0 +1,11 @@
+//// [awaitInheritedPromise_es2017.ts]
+interface A extends Promise<string> {}
+declare var a: A;
+async function f() {
+    await a;
+}
+
+//// [awaitInheritedPromise_es2017.js]
+async function f() {
+    await a;
+}

--- a/tests/baselines/reference/awaitInheritedPromise_es2017.symbols
+++ b/tests/baselines/reference/awaitInheritedPromise_es2017.symbols
@@ -1,0 +1,15 @@
+=== tests/cases/conformance/async/es2017/awaitInheritedPromise_es2017.ts ===
+interface A extends Promise<string> {}
+>A : Symbol(A, Decl(awaitInheritedPromise_es2017.ts, 0, 0))
+>Promise : Symbol(Promise, Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+
+declare var a: A;
+>a : Symbol(a, Decl(awaitInheritedPromise_es2017.ts, 1, 11))
+>A : Symbol(A, Decl(awaitInheritedPromise_es2017.ts, 0, 0))
+
+async function f() {
+>f : Symbol(f, Decl(awaitInheritedPromise_es2017.ts, 1, 17))
+
+    await a;
+>a : Symbol(a, Decl(awaitInheritedPromise_es2017.ts, 1, 11))
+}

--- a/tests/baselines/reference/awaitInheritedPromise_es2017.types
+++ b/tests/baselines/reference/awaitInheritedPromise_es2017.types
@@ -1,0 +1,16 @@
+=== tests/cases/conformance/async/es2017/awaitInheritedPromise_es2017.ts ===
+interface A extends Promise<string> {}
+>A : A
+>Promise : Promise<T>
+
+declare var a: A;
+>a : A
+>A : A
+
+async function f() {
+>f : () => Promise<void>
+
+    await a;
+>await a : string
+>a : A
+}

--- a/tests/cases/conformance/async/es2017/awaitInheritedPromise_es2017.ts
+++ b/tests/cases/conformance/async/es2017/awaitInheritedPromise_es2017.ts
@@ -1,0 +1,7 @@
+// @target: es2017
+// @strictNullChecks: true
+interface A extends Promise<string> {}
+declare var a: A;
+async function f() {
+    await a;
+}


### PR DESCRIPTION
Fixes errors reported with `--strictNullChecks` when awaiting a value whose type inherits from `Promise<T>`.

Fixes #12737

//cc: @mhegazy 