### PR TITLE
Include known properties in index type even if there is a string indexer 

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5783,7 +5783,7 @@ namespace ts {
         // expression constructs such as array literals and the || and ?: operators). Named types can
         // circularly reference themselves and therefore cannot be subtype reduced during their declaration.
         // For example, "type Item = string | (() => Item" is a named type that circularly references itself.
-        function getUnionType(types: Type[], subtypeReduction?: boolean, aliasSymbol?: Symbol, aliasTypeArguments?: Type[], keepLiteralTypes?:boolean): Type {
+        function getUnionType(types: Type[], subtypeReduction?: boolean, aliasSymbol?: Symbol, aliasTypeArguments?: Type[], keepLiteralTypes?: boolean): Type {
             if (types.length === 0) {
                 return neverType;
             }
@@ -5934,7 +5934,7 @@ namespace ts {
             return maybeTypeOfKind(type, TypeFlags.TypeVariable) ? getIndexTypeForGenericType(<TypeVariable | UnionOrIntersectionType>type) :
                 getObjectFlags(type) & ObjectFlags.Mapped ? getConstraintTypeFromMappedType(<MappedType>type) :
                 type.flags & TypeFlags.Any ? stringType :
-                getIndexInfoOfType(type, IndexKind.String) ? getUnionType([stringType, getLiteralTypeFromPropertyNames(type)], /*subtypeReduction*/ false, undefined, undefined, true) :
+                getIndexInfoOfType(type, IndexKind.String) ? getUnionType([stringType, getLiteralTypeFromPropertyNames(type)], /*subtypeReduction*/ false, undefined, undefined, /*keepLiteralTypes*/ true) :
                 getLiteralTypeFromPropertyNames(type);
         }
 

--- a/tests/baselines/reference/keyofKnownPropertiesWithIndexSignature.js
+++ b/tests/baselines/reference/keyofKnownPropertiesWithIndexSignature.js
@@ -1,0 +1,29 @@
+//// [keyofKnownPropertiesWithIndexSignature.ts]
+
+interface Foo {
+    prop: number;
+    [x: string]: number;
+}
+
+type t = keyof Foo; // string | "prop"
+
+var x: Partial<Foo>;
+x.prop; // ok
+x["other"].toFixed();
+
+var y: Pick<Foo, keyof Foo>;
+y.prop; // ok
+y["other"].toFixed();
+
+
+
+
+
+
+//// [keyofKnownPropertiesWithIndexSignature.js]
+var x;
+x.prop; // ok
+x["other"].toFixed();
+var y;
+y.prop; // ok
+y["other"].toFixed();

--- a/tests/baselines/reference/keyofKnownPropertiesWithIndexSignature.symbols
+++ b/tests/baselines/reference/keyofKnownPropertiesWithIndexSignature.symbols
@@ -1,0 +1,51 @@
+=== tests/cases/conformance/types/keyof/keyofKnownPropertiesWithIndexSignature.ts ===
+
+interface Foo {
+>Foo : Symbol(Foo, Decl(keyofKnownPropertiesWithIndexSignature.ts, 0, 0))
+
+    prop: number;
+>prop : Symbol(Foo.prop, Decl(keyofKnownPropertiesWithIndexSignature.ts, 1, 15))
+
+    [x: string]: number;
+>x : Symbol(x, Decl(keyofKnownPropertiesWithIndexSignature.ts, 3, 5))
+}
+
+type t = keyof Foo; // string | "prop"
+>t : Symbol(t, Decl(keyofKnownPropertiesWithIndexSignature.ts, 4, 1))
+>Foo : Symbol(Foo, Decl(keyofKnownPropertiesWithIndexSignature.ts, 0, 0))
+
+var x: Partial<Foo>;
+>x : Symbol(x, Decl(keyofKnownPropertiesWithIndexSignature.ts, 8, 3))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>Foo : Symbol(Foo, Decl(keyofKnownPropertiesWithIndexSignature.ts, 0, 0))
+
+x.prop; // ok
+>x.prop : Symbol(prop)
+>x : Symbol(x, Decl(keyofKnownPropertiesWithIndexSignature.ts, 8, 3))
+>prop : Symbol(prop)
+
+x["other"].toFixed();
+>x["other"].toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(keyofKnownPropertiesWithIndexSignature.ts, 8, 3))
+>toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+
+var y: Pick<Foo, keyof Foo>;
+>y : Symbol(y, Decl(keyofKnownPropertiesWithIndexSignature.ts, 12, 3))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>Foo : Symbol(Foo, Decl(keyofKnownPropertiesWithIndexSignature.ts, 0, 0))
+>Foo : Symbol(Foo, Decl(keyofKnownPropertiesWithIndexSignature.ts, 0, 0))
+
+y.prop; // ok
+>y.prop : Symbol(prop)
+>y : Symbol(y, Decl(keyofKnownPropertiesWithIndexSignature.ts, 12, 3))
+>prop : Symbol(prop)
+
+y["other"].toFixed();
+>y["other"].toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+>y : Symbol(y, Decl(keyofKnownPropertiesWithIndexSignature.ts, 12, 3))
+>toFixed : Symbol(Number.toFixed, Decl(lib.d.ts, --, --))
+
+
+
+
+

--- a/tests/baselines/reference/keyofKnownPropertiesWithIndexSignature.types
+++ b/tests/baselines/reference/keyofKnownPropertiesWithIndexSignature.types
@@ -1,0 +1,57 @@
+=== tests/cases/conformance/types/keyof/keyofKnownPropertiesWithIndexSignature.ts ===
+
+interface Foo {
+>Foo : Foo
+
+    prop: number;
+>prop : number
+
+    [x: string]: number;
+>x : string
+}
+
+type t = keyof Foo; // string | "prop"
+>t : string | "prop"
+>Foo : Foo
+
+var x: Partial<Foo>;
+>x : Partial<Foo>
+>Partial : Partial<T>
+>Foo : Foo
+
+x.prop; // ok
+>x.prop : number
+>x : Partial<Foo>
+>prop : number
+
+x["other"].toFixed();
+>x["other"].toFixed() : string
+>x["other"].toFixed : (fractionDigits?: number) => string
+>x["other"] : number
+>x : Partial<Foo>
+>"other" : "other"
+>toFixed : (fractionDigits?: number) => string
+
+var y: Pick<Foo, keyof Foo>;
+>y : Pick<Foo, string | "prop">
+>Pick : Pick<T, K>
+>Foo : Foo
+>Foo : Foo
+
+y.prop; // ok
+>y.prop : number
+>y : Pick<Foo, string | "prop">
+>prop : number
+
+y["other"].toFixed();
+>y["other"].toFixed() : string
+>y["other"].toFixed : (fractionDigits?: number) => string
+>y["other"] : number
+>y : Pick<Foo, string | "prop">
+>"other" : "other"
+>toFixed : (fractionDigits?: number) => string
+
+
+
+
+

--- a/tests/baselines/reference/keyofKnownPropertiesWithIndexSignatureErrors.errors.txt
+++ b/tests/baselines/reference/keyofKnownPropertiesWithIndexSignatureErrors.errors.txt
@@ -1,0 +1,49 @@
+tests/cases/conformance/types/keyof/keyofKnownPropertiesWithIndexSignatureErrors.ts(8,3): error TS2339: Property 'other' does not exist on type 'Partial<Foo>'.
+tests/cases/conformance/types/keyof/keyofKnownPropertiesWithIndexSignatureErrors.ts(12,3): error TS2339: Property 'other' does not exist on type 'Pick<Foo, string | "prop">'.
+tests/cases/conformance/types/keyof/keyofKnownPropertiesWithIndexSignatureErrors.ts(17,5): error TS2322: Type '{ a: string; }' is not assignable to type 'T2'.
+  Types of property 'a' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/types/keyof/keyofKnownPropertiesWithIndexSignatureErrors.ts(18,5): error TS2322: Type '{ a: string; }' is not assignable to type 'Partial<T2>'.
+  Types of property 'a' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/types/keyof/keyofKnownPropertiesWithIndexSignatureErrors.ts(19,5): error TS2322: Type '{ a: string; }' is not assignable to type '{ [x: string]: any; a?: number; }'.
+  Types of property 'a' are incompatible.
+    Type 'string' is not assignable to type 'number'.
+
+
+==== tests/cases/conformance/types/keyof/keyofKnownPropertiesWithIndexSignatureErrors.ts (5 errors) ====
+    interface Foo {
+        prop: number;
+        [x: string]: number;
+    }
+    
+    var x: Partial<Foo>;
+    x.prop; // ok
+    x.other; // Error unknown property other
+      ~~~~~
+!!! error TS2339: Property 'other' does not exist on type 'Partial<Foo>'.
+    
+    var y: Pick<Foo, keyof Foo>;
+    y.prop; // ok
+    y.other; // Error unknown property other
+      ~~~~~
+!!! error TS2339: Property 'other' does not exist on type 'Pick<Foo, string | "prop">'.
+    
+    
+    type T2 = { a?: number, [key: string]: any };
+    
+    let o2: T2 = { a: 'no' }; // error: Type '{ a: string; }' is not assignable to type 'T2'
+        ~~
+!!! error TS2322: Type '{ a: string; }' is not assignable to type 'T2'.
+!!! error TS2322:   Types of property 'a' are incompatible.
+!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+    let p2: Partial<T2> = { a: 'no' }; // error
+        ~~
+!!! error TS2322: Type '{ a: string; }' is not assignable to type 'Partial<T2>'.
+!!! error TS2322:   Types of property 'a' are incompatible.
+!!! error TS2322:     Type 'string' is not assignable to type 'number'.
+    let p3: { [P in keyof T2]: T2[P]} = { a: 'no' }; // error
+        ~~
+!!! error TS2322: Type '{ a: string; }' is not assignable to type '{ [x: string]: any; a?: number; }'.
+!!! error TS2322:   Types of property 'a' are incompatible.
+!!! error TS2322:     Type 'string' is not assignable to type 'number'.

--- a/tests/baselines/reference/keyofKnownPropertiesWithIndexSignatureErrors.js
+++ b/tests/baselines/reference/keyofKnownPropertiesWithIndexSignatureErrors.js
@@ -1,0 +1,31 @@
+//// [keyofKnownPropertiesWithIndexSignatureErrors.ts]
+interface Foo {
+    prop: number;
+    [x: string]: number;
+}
+
+var x: Partial<Foo>;
+x.prop; // ok
+x.other; // Error unknown property other
+
+var y: Pick<Foo, keyof Foo>;
+y.prop; // ok
+y.other; // Error unknown property other
+
+
+type T2 = { a?: number, [key: string]: any };
+
+let o2: T2 = { a: 'no' }; // error: Type '{ a: string; }' is not assignable to type 'T2'
+let p2: Partial<T2> = { a: 'no' }; // error
+let p3: { [P in keyof T2]: T2[P]} = { a: 'no' }; // error
+
+//// [keyofKnownPropertiesWithIndexSignatureErrors.js]
+var x;
+x.prop; // ok
+x.other; // Error unknown property other
+var y;
+y.prop; // ok
+y.other; // Error unknown property other
+var o2 = { a: 'no' }; // error: Type '{ a: string; }' is not assignable to type 'T2'
+var p2 = { a: 'no' }; // error
+var p3 = { a: 'no' }; // error

--- a/tests/cases/conformance/types/keyof/keyofKnownPropertiesWithIndexSignature.ts
+++ b/tests/cases/conformance/types/keyof/keyofKnownPropertiesWithIndexSignature.ts
@@ -1,0 +1,20 @@
+// @noImplicitAny: true
+
+interface Foo {
+    prop: number;
+    [x: string]: number;
+}
+
+type t = keyof Foo; // string | "prop"
+
+var x: Partial<Foo>;
+x.prop; // ok
+x["other"].toFixed();
+
+var y: Pick<Foo, keyof Foo>;
+y.prop; // ok
+y["other"].toFixed();
+
+
+
+

--- a/tests/cases/conformance/types/keyof/keyofKnownPropertiesWithIndexSignatureErrors.ts
+++ b/tests/cases/conformance/types/keyof/keyofKnownPropertiesWithIndexSignatureErrors.ts
@@ -1,0 +1,19 @@
+interface Foo {
+    prop: number;
+    [x: string]: number;
+}
+
+var x: Partial<Foo>;
+x.prop; // ok
+x.other; // Error unknown property other
+
+var y: Pick<Foo, keyof Foo>;
+y.prop; // ok
+y.other; // Error unknown property other
+
+
+type T2 = { a?: number, [key: string]: any };
+
+let o2: T2 = { a: 'no' }; // error: Type '{ a: string; }' is not assignable to type 'T2'
+let p2: Partial<T2> = { a: 'no' }; // error
+let p3: { [P in keyof T2]: T2[P]} = { a: 'no' }; // error


### PR DESCRIPTION

Fixes #12665
Fixes #12712

// CC @ahejlsberg 