### PR TITLE
Fix error on extends in declaration file with importHelpers

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -17999,7 +17999,7 @@ namespace ts {
 
             const baseTypeNode = getClassExtendsHeritageClauseElement(node);
             if (baseTypeNode) {
-                if (languageVersion < ScriptTarget.ES2015) {
+                if (languageVersion < ScriptTarget.ES2015 && !isInAmbientContext(node)) {
                     checkExternalEmitHelpers(baseTypeNode.parent, ExternalEmitHelpers.Extends);
                 }
 

--- a/tests/baselines/reference/importHelpersDeclarations.symbols
+++ b/tests/baselines/reference/importHelpersDeclarations.symbols
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/declaration.d.ts ===
+export declare class D {
+>D : Symbol(D, Decl(declaration.d.ts, 0, 0))
+}
+export declare class E extends D {
+>E : Symbol(E, Decl(declaration.d.ts, 1, 1))
+>D : Symbol(D, Decl(declaration.d.ts, 0, 0))
+}

--- a/tests/baselines/reference/importHelpersDeclarations.types
+++ b/tests/baselines/reference/importHelpersDeclarations.types
@@ -1,0 +1,8 @@
+=== tests/cases/compiler/declaration.d.ts ===
+export declare class D {
+>D : D
+}
+export declare class E extends D {
+>E : E
+>D : D
+}

--- a/tests/cases/compiler/importHelpersDeclarations.ts
+++ b/tests/cases/compiler/importHelpersDeclarations.ts
@@ -1,0 +1,9 @@
+// @importHelpers: true
+// @target: es5
+// @module: commonjs
+// @moduleResolution: classic
+// @filename: declaration.d.ts
+export declare class D {
+}
+export declare class E extends D {
+}


### PR DESCRIPTION
The call to `checkExternalEmitHelpers` for the `__extends` helper was incorrectly reporting an error when `extends` was used in a declaration file with `--importHelpers` and a missing `tslib.d.ts` file.

Fixes #12724

