### PR TITLE
do not use ScriptVersionCache for closed files

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -250,6 +250,7 @@ var harnessSources = harnessCoreSources.concat([
     "convertToBase64.ts",
     "transpile.ts",
     "reuseProgramStructure.ts",
+    "textStorage.ts",
     "cachingInServerLSHost.ts",
     "moduleResolution.ts",
     "tsconfigParsing.ts",

--- a/src/harness/unittests/textStorage.ts
+++ b/src/harness/unittests/textStorage.ts
@@ -1,0 +1,71 @@
+/// <reference path="../harness.ts" />
+/// <reference path="../../server/scriptVersionCache.ts"/>
+/// <reference path="./tsserverProjectSystem.ts" />
+
+namespace ts.textStorage {
+    describe("Text storage", () => {
+        const f = {
+            path: "/a/app.ts",
+            content: `
+                let x = 1;
+                let y = 2;
+                function bar(a: number) {
+                    return a + 1;
+                }`
+        };
+
+        it("text based storage should be have exactly the same as script version cache", () => {
+
+            debugger
+            const host = ts.projectSystem.createServerHost([f]);
+
+            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path));
+            const ts2 = new server.TextStorage(host, server.asNormalizedPath(f.path));
+
+            ts1.useScriptVersionCache();
+            ts2.useText();
+
+            const lineMap = computeLineStarts(f.content);
+
+            for (let line = 0; line < lineMap.length; line++) {
+                const start = lineMap[line];
+                const end = line === lineMap.length - 1 ? f.path.length : lineMap[line + 1];
+
+                for (let offset = 0; offset < end - start; offset++) {
+                    const pos1 = ts1.lineOffsetToPosition(line + 1, offset + 1);
+                    const pos2 = ts2.lineOffsetToPosition(line + 1, offset + 1);
+                    assert.isTrue(pos1 === pos2, `lineOffsetToPosition ${line + 1}-${offset + 1}: expected ${pos1} to equal ${pos2}`);
+                }
+
+                const {start: start1, length: length1 } = ts1.lineToTextSpan(line);
+                const {start: start2, length: length2 } = ts2.lineToTextSpan(line);
+                assert.isTrue(start1 === start2, `lineToTextSpan ${line}::start:: expected ${start1} to equal ${start2}`);
+                assert.isTrue(length1 === length2, `lineToTextSpan ${line}::length:: expected ${length1} to equal ${length2}`);
+            }
+
+            for (let pos = 0; pos < f.content.length; pos++) {
+                const { line: line1, offset: offset1 } = ts1.positionToLineOffset(pos);
+                const { line: line2, offset: offset2 } = ts2.positionToLineOffset(pos);
+                assert.isTrue(line1 === line2, `positionToLineOffset ${pos}::line:: expected ${line1} to equal ${line2}`);
+                assert.isTrue(offset1 === offset2, `positionToLineOffset ${pos}::offset:: expected ${offset1} to equal ${offset2}`);
+            }
+        });
+
+        it("should switch to script version cache if necessary", () => {
+            const host = ts.projectSystem.createServerHost([f]);
+            const ts1 = new server.TextStorage(host, server.asNormalizedPath(f.path));
+
+            ts1.getSnapshot();
+            assert.isTrue(!ts1.hasScriptVersionCache(), "should not have script version cache - 1");
+
+            ts1.edit(0, 5, "   ");
+            assert.isTrue(ts1.hasScriptVersionCache(), "have script version cache - 1");
+
+            ts1.useText();
+            assert.isTrue(!ts1.hasScriptVersionCache(), "should not have script version cache - 2");
+
+            ts1.getLineInfo(0);
+            assert.isTrue(ts1.hasScriptVersionCache(), "have script version cache - 2");
+        })
+    });
+}

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -1574,7 +1574,7 @@ namespace ts.projectSystem {
             const project = projectService.externalProjects[0];
 
             const scriptInfo = project.getScriptInfo(file1.path);
-            const snap = scriptInfo.snap();
+            const snap = scriptInfo.getSnapshot();
             const actualText = snap.getText(0, snap.getLength());
             assert.equal(actualText, "", `expected content to be empty string, got "${actualText}"`);
 
@@ -1587,7 +1587,7 @@ namespace ts.projectSystem {
             projectService.closeClientFile(file1.path);
 
             const scriptInfo2 = project.getScriptInfo(file1.path);
-            const snap2 = scriptInfo2.snap();
+            const snap2 = scriptInfo2.getSnapshot();
             const actualText2 = snap2.getText(0, snap.getLength());
             assert.equal(actualText2, "", `expected content to be empty string, got "${actualText2}"`);
         });
@@ -2285,13 +2285,13 @@ namespace ts.projectSystem {
             p.updateGraph();
 
             const scriptInfo = p.getScriptInfo(f.path);
-            checkSnapLength(scriptInfo.snap(), f.content.length);
+            checkSnapLength(scriptInfo.getSnapshot(), f.content.length);
 
             // open project and replace its content with empty string
             projectService.openClientFile(f.path, "");
-            checkSnapLength(scriptInfo.snap(), 0);
+            checkSnapLength(scriptInfo.getSnapshot(), 0);
         });
-        function checkSnapLength(snap: server.LineIndexSnapshot, expectedLength: number) {
+        function checkSnapLength(snap: IScriptSnapshot, expectedLength: number) {
             assert.equal(snap.getLength(), expectedLength, "Incorrect snapshot size");
         }
     });
@@ -2444,7 +2444,6 @@ namespace ts.projectSystem {
             const cwd = {
                 path: "/a/c"
             };
-            debugger;
             const host = createServerHost([f1, config, node, cwd], { currentDirectory: cwd.path });
             const projectService = createProjectService(host);
             projectService.openClientFile(f1.path);
@@ -2715,7 +2714,7 @@ namespace ts.projectSystem {
 
             // verify content
             const projectServiice = session.getProjectService();
-            const snap1 = projectServiice.getScriptInfo(f1.path).snap();
+            const snap1 = projectServiice.getScriptInfo(f1.path).getSnapshot();
             assert.equal(snap1.getText(0, snap1.getLength()), tmp.content, "content should be equal to the content of temp file");
 
             // reload from original file file
@@ -2727,7 +2726,7 @@ namespace ts.projectSystem {
             });
 
             // verify content
-            const snap2 = projectServiice.getScriptInfo(f1.path).snap();
+            const snap2 = projectServiice.getScriptInfo(f1.path).getSnapshot();
             assert.equal(snap2.getText(0, snap2.getLength()), f1.content, "content should be equal to the content of original file");
 
         });

--- a/src/server/lsHost.ts
+++ b/src/server/lsHost.ts
@@ -169,7 +169,7 @@ namespace ts.server {
         getScriptSnapshot(filename: string): ts.IScriptSnapshot {
             const scriptInfo = this.project.getScriptInfoLSHost(filename);
             if (scriptInfo) {
-                return scriptInfo.snap();
+                return scriptInfo.getSnapshot();
             }
         }
 

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -448,7 +448,7 @@ namespace ts.server {
 
         containsFile(filename: NormalizedPath, requireOpen?: boolean) {
             const info = this.projectService.getScriptInfoForNormalizedPath(filename);
-            if (info && (info.isOpen || !requireOpen)) {
+            if (info && (info.isScriptOpen() || !requireOpen)) {
                 return this.containsScriptInfo(info);
             }
         }

--- a/src/server/scriptInfo.ts
+++ b/src/server/scriptInfo.ts
@@ -2,6 +2,161 @@
 
 namespace ts.server {
 
+    /* @internal */
+    export class TextStorage {
+        private svc: ScriptVersionCache | undefined;
+        private svcVersion = 0;
+
+        private text: string;
+        private lineMap: number[];
+        private textVersion = 0;
+
+        constructor(private readonly host: ServerHost, private readonly fileName: NormalizedPath) {
+        }
+
+        public getVersion() {
+            return this.svc
+                ? `SVC-${this.svcVersion}-${this.svc.getSnapshot().version}`
+                : `Text-${this.textVersion}`;
+        }
+
+        public hasScriptVersionCache() {
+            return this.svc !== undefined;
+        }
+
+        public useScriptVersionCache(newText?: string) {
+            this.switchToScriptVersionCache(newText);
+        }
+
+        public useText() {
+            this.svc = undefined;
+            this.reloadFromFile();
+        }
+
+        public edit(start: number, end: number, newText: string) {
+            this.switchToScriptVersionCache().edit(start, end - start, newText);
+        }
+
+        public reload(text: string) {
+            if (this.svc) {
+                this.svc.reload(text);
+            }
+            else {
+                this.setText(text);
+            }
+        }
+
+        public reloadFromFile(tempFileName?: string) {
+            if (this.svc || (tempFileName !== this.fileName)) {
+                this.reload(this.getFileText(tempFileName))
+            }
+            else {
+                this.setText(undefined);
+            }
+        }
+
+        public getSnapshot(): IScriptSnapshot {
+            return this.svc
+                ? this.svc.getSnapshot()
+                : ScriptSnapshot.fromString(this.getOrLoadText());
+        }
+
+        public getLineInfo(line: number) {
+            return this.switchToScriptVersionCache().getSnapshot().index.lineNumberToInfo(line);
+        }
+        /**
+         *  @param line 0 based index
+         */
+        lineToTextSpan(line: number) {
+            if (!this.svc) {
+                const lineMap = this.getLineMap();
+                const start = lineMap[line]; // -1 since line is 1-based
+                const end = line + 1 < lineMap.length ? lineMap[line + 1] : this.text.length;
+                return ts.createTextSpanFromBounds(start, end);
+            }
+            const index = this.svc.getSnapshot().index;
+            const lineInfo = index.lineNumberToInfo(line + 1);
+            let len: number;
+            if (lineInfo.leaf) {
+                len = lineInfo.leaf.text.length;
+            }
+            else {
+                const nextLineInfo = index.lineNumberToInfo(line + 2);
+                len = nextLineInfo.offset - lineInfo.offset;
+            }
+            return ts.createTextSpan(lineInfo.offset, len);
+        }
+
+        /**
+         * @param line 1 based index
+         * @param offset 1 based index
+         */
+        lineOffsetToPosition(line: number, offset: number): number {
+            if (!this.svc) {
+                return computePositionOfLineAndCharacter(this.getLineMap(), line - 1, offset - 1);
+            }
+            const index = this.svc.getSnapshot().index;
+
+            const lineInfo = index.lineNumberToInfo(line);
+            // TODO: assert this offset is actually on the line
+            return (lineInfo.offset + offset - 1);
+        }
+
+        /**
+         * @param line 1-based index
+         * @param offset 1-based index
+         */
+        positionToLineOffset(position: number): ILineInfo {
+            if (!this.svc) {
+                const { line, character } = computeLineAndCharacterOfPosition(this.getLineMap(), position);
+                return { line: line + 1, offset: character + 1 };
+            }
+            const index = this.svc.getSnapshot().index;
+            const lineOffset = index.charOffsetToLineNumberAndPos(position);
+            return { line: lineOffset.line, offset: lineOffset.offset + 1 };
+        }
+
+        private getFileText(tempFileName?: string) {
+            return this.host.readFile(tempFileName || this.fileName) || "";
+        }
+
+        private ensureNoScriptVersionCache() {
+            Debug.assert(!this.svc, "ScriptVersionCache should not be set");
+        }
+
+        private switchToScriptVersionCache(newText?: string): ScriptVersionCache {
+            if (!this.svc) {
+                this.svc = ScriptVersionCache.fromString(this.host, newText !== undefined ? newText : this.getOrLoadText());
+                this.svcVersion++;
+                this.text = undefined;
+            }
+            return this.svc;
+        }
+
+        private getOrLoadText() {
+            this.ensureNoScriptVersionCache();
+            if (this.text === undefined) {
+                this.setText(this.getFileText());
+            }
+            return this.text;
+        }
+
+        private getLineMap() {
+            this.ensureNoScriptVersionCache();
+            return this.lineMap || (this.lineMap = computeLineStarts(this.getOrLoadText()));
+        }
+
+        private setText(newText: string) {
+            this.ensureNoScriptVersionCache();
+            if (newText === undefined || this.text !== newText) {
+                this.text = newText;
+                this.lineMap = undefined;
+                this.textVersion++;
+            }
+        }
+    }
+
+
     export class ScriptInfo {
         /**
          * All projects that include this file
@@ -11,22 +166,44 @@ namespace ts.server {
         readonly path: Path;
 
         private fileWatcher: FileWatcher;
-        private svc: ScriptVersionCache;
+        private textStorage: TextStorage;
+
+        private isOpen: boolean;
 
         // TODO: allow to update hasMixedContent from the outside
         constructor(
             private readonly host: ServerHost,
             readonly fileName: NormalizedPath,
-            content: string,
             readonly scriptKind: ScriptKind,
-            public isOpen = false,
             public hasMixedContent = false) {
 
             this.path = toPath(fileName, host.getCurrentDirectory(), createGetCanonicalFileName(host.useCaseSensitiveFileNames));
-            this.svc = ScriptVersionCache.fromString(host, content);
+            this.textStorage = new TextStorage(host, fileName);
+            if (hasMixedContent) {
+                this.textStorage.reload("");
+            }
             this.scriptKind = scriptKind
                 ? scriptKind
                 : getScriptKindFromFileName(fileName);
+        }
+
+        public isScriptOpen() {
+            return this.isOpen;
+        }
+
+        public open(newText: string) {
+            this.isOpen = true;
+            this.textStorage.useScriptVersionCache(newText);
+            this.markContainingProjectsAsDirty();
+        }
+
+        public close() {
+            this.isOpen = false;
+            this.textStorage.useText();
+        }
+
+        public getSnapshot() {
+            return this.textStorage.getSnapshot();
         }
 
         getFormatCodeSettings() {
@@ -112,16 +289,16 @@ namespace ts.server {
         }
 
         getLatestVersion() {
-            return this.svc.latestVersion().toString();
+            return this.textStorage.getVersion();
         }
 
         reload(script: string) {
-            this.svc.reload(script);
+            this.textStorage.reload(script);
             this.markContainingProjectsAsDirty();
         }
 
         saveTo(fileName: string) {
-            const snap = this.snap();
+            const snap = this.textStorage.getSnapshot();
             this.host.writeFile(fileName, snap.getText(0, snap.getLength()));
         }
 
@@ -130,22 +307,17 @@ namespace ts.server {
                 this.reload("");
             }
             else {
-                this.svc.reloadFromFile(tempFileName || this.fileName);
+                this.textStorage.reloadFromFile(tempFileName);
                 this.markContainingProjectsAsDirty();
             }
         }
 
-        snap() {
-            return this.svc.getSnapshot();
-        }
-
         getLineInfo(line: number) {
-            const snap = this.snap();
-            return snap.index.lineNumberToInfo(line);
+            return this.textStorage.getLineInfo(line);
         }
 
         editContent(start: number, end: number, newText: string): void {
-            this.svc.edit(start, end - start, newText);
+            this.textStorage.edit(start, end, newText);
             this.markContainingProjectsAsDirty();
         }
 
@@ -159,17 +331,7 @@ namespace ts.server {
          *  @param line 1 based index
          */
         lineToTextSpan(line: number) {
-            const index = this.snap().index;
-            const lineInfo = index.lineNumberToInfo(line + 1);
-            let len: number;
-            if (lineInfo.leaf) {
-                len = lineInfo.leaf.text.length;
-            }
-            else {
-                const nextLineInfo = index.lineNumberToInfo(line + 2);
-                len = nextLineInfo.offset - lineInfo.offset;
-            }
-            return ts.createTextSpan(lineInfo.offset, len);
+            return this.textStorage.lineToTextSpan(line);
         }
 
         /**
@@ -177,11 +339,7 @@ namespace ts.server {
          * @param offset 1 based index
          */
         lineOffsetToPosition(line: number, offset: number): number {
-            const index = this.snap().index;
-
-            const lineInfo = index.lineNumberToInfo(line);
-            // TODO: assert this offset is actually on the line
-            return (lineInfo.offset + offset - 1);
+            return this.textStorage.lineOffsetToPosition(line, offset);
         }
 
         /**
@@ -189,9 +347,7 @@ namespace ts.server {
          * @param offset 1-based index
          */
         positionToLineOffset(position: number): ILineInfo {
-            const index = this.snap().index;
-            const lineOffset = index.charOffsetToLineNumberAndPos(position);
-            return { line: lineOffset.line, offset: lineOffset.offset + 1 };
+            return this.textStorage.positionToLineOffset(position);
         }
     }
 }

--- a/src/server/scriptVersionCache.ts
+++ b/src/server/scriptVersionCache.ts
@@ -438,8 +438,9 @@ namespace ts.server {
             }
         }
         getChangeRange(oldSnapshot: ts.IScriptSnapshot): ts.TextChangeRange {
-            const oldSnap = <LineIndexSnapshot>oldSnapshot;
-            return this.getTextChangeRangeSinceVersion(oldSnap.version);
+            if (oldSnapshot instanceof LineIndexSnapshot) {
+                return this.getTextChangeRangeSinceVersion(oldSnapshot.version);
+            }
         }
     }
 

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -709,7 +709,7 @@ namespace ts.server {
                 const displayString = ts.displayPartsToString(nameInfo.displayParts);
                 const nameSpan = nameInfo.textSpan;
                 const nameColStart = scriptInfo.positionToLineOffset(nameSpan.start).offset;
-                const nameText = scriptInfo.snap().getText(nameSpan.start, ts.textSpanEnd(nameSpan));
+                const nameText = scriptInfo.getSnapshot().getText(nameSpan.start, ts.textSpanEnd(nameSpan));
                 const refs = combineProjectOutput<protocol.ReferencesResponseItem>(
                     projects,
                     (project: Project) => {
@@ -722,7 +722,7 @@ namespace ts.server {
                             const refScriptInfo = project.getScriptInfo(ref.fileName);
                             const start = refScriptInfo.positionToLineOffset(ref.textSpan.start);
                             const refLineSpan = refScriptInfo.lineToTextSpan(start.line - 1);
-                            const lineText = refScriptInfo.snap().getText(refLineSpan.start, ts.textSpanEnd(refLineSpan)).replace(/\r|\n/g, "");
+                            const lineText = refScriptInfo.getSnapshot().getText(refLineSpan.start, ts.textSpanEnd(refLineSpan)).replace(/\r|\n/g, "");
                             return {
                                 file: ref.fileName,
                                 start: start,
@@ -1326,7 +1326,7 @@ namespace ts.server {
                     highPriorityFiles.push(fileNameInProject);
                 else {
                     const info = this.projectService.getScriptInfo(fileNameInProject);
-                    if (!info.isOpen) {
+                    if (!info.isScriptOpen()) {
                         if (fileNameInProject.indexOf(".d.ts") > 0)
                             veryLowPriorityFiles.push(fileNameInProject);
                         else

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -91,7 +91,9 @@ namespace ts {
             }
 
             public getText(start: number, end: number): string {
-                return this.text.substring(start, end);
+                return start === 0 && end === this.text.length
+                    ? this.text
+                    : this.text.substring(start, end);
             }
 
             public getLength(): number {


### PR DESCRIPTION
`ScriptVersionCache` internally stores text in tree-like form which is very efficient for editing purposes and at the same time pretty expensive to be used as a generic storage. Size of the tree is proportional to the size of the file and varies from 1.5 x (size of text) for small files through to 3x up to 10x in a degenerate cases (like 40 MB files).  As an example  `android.d.ts` is ~13 MB file and its tree representation is  takes roughly 40 MB.

To avoid paying this cost I've introduced `TextStorage` abstraction that internally can either store text as is or use `ScriptVersionCache`. `ScriptVersionCache` is used for open files or for some operations that cannot be efficiently used on plain text (like editing). For all other cases it uses plain text deferring its loading (which is useful for scenarios when language service is disabled).

// cc @mhegazy 