### PR TITLE
Fix paramtypes metadata emit

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -1277,7 +1277,7 @@ namespace ts {
          * @param node The declaration node.
          * @param allDecorators An object containing all of the decorators for the declaration.
          */
-        function transformAllDecoratorsOfDeclaration(node: Declaration, allDecorators: AllDecorators) {
+        function transformAllDecoratorsOfDeclaration(node: Declaration, container: ClassLikeDeclaration, allDecorators: AllDecorators) {
             if (!allDecorators) {
                 return undefined;
             }
@@ -1285,7 +1285,7 @@ namespace ts {
             const decoratorExpressions: Expression[] = [];
             addRange(decoratorExpressions, map(allDecorators.decorators, transformDecorator));
             addRange(decoratorExpressions, flatMap(allDecorators.parameters, transformDecoratorsOfParameter));
-            addTypeMetadata(node, decoratorExpressions);
+            addTypeMetadata(node, container, decoratorExpressions);
             return decoratorExpressions;
         }
 
@@ -1334,7 +1334,7 @@ namespace ts {
          */
         function generateClassElementDecorationExpression(node: ClassExpression | ClassDeclaration, member: ClassElement) {
             const allDecorators = getAllDecoratorsOfClassElement(node, member);
-            const decoratorExpressions = transformAllDecoratorsOfDeclaration(member, allDecorators);
+            const decoratorExpressions = transformAllDecoratorsOfDeclaration(member, node, allDecorators);
             if (!decoratorExpressions) {
                 return undefined;
             }
@@ -1415,7 +1415,7 @@ namespace ts {
          */
         function generateConstructorDecorationExpression(node: ClassExpression | ClassDeclaration) {
             const allDecorators = getAllDecoratorsOfConstructor(node);
-            const decoratorExpressions = transformAllDecoratorsOfDeclaration(node, allDecorators);
+            const decoratorExpressions = transformAllDecoratorsOfDeclaration(node, node, allDecorators);
             if (!decoratorExpressions) {
                 return undefined;
             }
@@ -1468,22 +1468,22 @@ namespace ts {
          * @param node The declaration node.
          * @param decoratorExpressions The destination array to which to add new decorator expressions.
          */
-        function addTypeMetadata(node: Declaration, decoratorExpressions: Expression[]) {
+        function addTypeMetadata(node: Declaration, container: ClassLikeDeclaration, decoratorExpressions: Expression[]) {
             if (USE_NEW_TYPE_METADATA_FORMAT) {
-                addNewTypeMetadata(node, decoratorExpressions);
+                addNewTypeMetadata(node, container, decoratorExpressions);
             }
             else {
-                addOldTypeMetadata(node, decoratorExpressions);
+                addOldTypeMetadata(node, container, decoratorExpressions);
             }
         }
 
-        function addOldTypeMetadata(node: Declaration, decoratorExpressions: Expression[]) {
+        function addOldTypeMetadata(node: Declaration, container: ClassLikeDeclaration, decoratorExpressions: Expression[]) {
             if (compilerOptions.emitDecoratorMetadata) {
                 if (shouldAddTypeMetadata(node)) {
                     decoratorExpressions.push(createMetadataHelper(context, "design:type", serializeTypeOfNode(node)));
                 }
                 if (shouldAddParamTypesMetadata(node)) {
-                    decoratorExpressions.push(createMetadataHelper(context, "design:paramtypes", serializeParameterTypesOfNode(node)));
+                    decoratorExpressions.push(createMetadataHelper(context, "design:paramtypes", serializeParameterTypesOfNode(node, container)));
                 }
                 if (shouldAddReturnTypeMetadata(node)) {
                     decoratorExpressions.push(createMetadataHelper(context, "design:returntype", serializeReturnTypeOfNode(node)));
@@ -1491,14 +1491,14 @@ namespace ts {
             }
         }
 
-        function addNewTypeMetadata(node: Declaration, decoratorExpressions: Expression[]) {
+        function addNewTypeMetadata(node: Declaration, container: ClassLikeDeclaration, decoratorExpressions: Expression[]) {
             if (compilerOptions.emitDecoratorMetadata) {
                 let properties: ObjectLiteralElementLike[];
                 if (shouldAddTypeMetadata(node)) {
                     (properties || (properties = [])).push(createPropertyAssignment("type", createArrowFunction(/*modifiers*/ undefined, /*typeParameters*/ undefined, [], /*type*/ undefined, createToken(SyntaxKind.EqualsGreaterThanToken), serializeTypeOfNode(node))));
                 }
                 if (shouldAddParamTypesMetadata(node)) {
-                    (properties || (properties = [])).push(createPropertyAssignment("paramTypes", createArrowFunction(/*modifiers*/ undefined, /*typeParameters*/ undefined, [], /*type*/ undefined, createToken(SyntaxKind.EqualsGreaterThanToken), serializeParameterTypesOfNode(node))));
+                    (properties || (properties = [])).push(createPropertyAssignment("paramTypes", createArrowFunction(/*modifiers*/ undefined, /*typeParameters*/ undefined, [], /*type*/ undefined, createToken(SyntaxKind.EqualsGreaterThanToken), serializeParameterTypesOfNode(node, container))));
                 }
                 if (shouldAddReturnTypeMetadata(node)) {
                     (properties || (properties = [])).push(createPropertyAssignment("returnType", createArrowFunction(/*modifiers*/ undefined, /*typeParameters*/ undefined, [], /*type*/ undefined, createToken(SyntaxKind.EqualsGreaterThanToken), serializeReturnTypeOfNode(node))));
@@ -1543,12 +1543,16 @@ namespace ts {
          * @param node The node to test.
          */
         function shouldAddParamTypesMetadata(node: Declaration): boolean {
-            const kind = node.kind;
-            return kind === SyntaxKind.ClassDeclaration
-                || kind === SyntaxKind.ClassExpression
-                || kind === SyntaxKind.MethodDeclaration
-                || kind === SyntaxKind.GetAccessor
-                || kind === SyntaxKind.SetAccessor;
+            switch (node.kind) {
+                case SyntaxKind.ClassDeclaration:
+                case SyntaxKind.ClassExpression:
+                    return getFirstConstructorWithBody(<ClassLikeDeclaration>node) !== undefined;
+                case SyntaxKind.MethodDeclaration:
+                case SyntaxKind.GetAccessor:
+                case SyntaxKind.SetAccessor:
+                    return true;
+            }
+            return false;
         }
 
         /**
@@ -1596,7 +1600,7 @@ namespace ts {
          *
          * @param node The node that should have its parameter types serialized.
          */
-        function serializeParameterTypesOfNode(node: Node): Expression {
+        function serializeParameterTypesOfNode(node: Node, container: ClassLikeDeclaration): Expression {
             const valueDeclaration =
                 isClassLike(node)
                     ? getFirstConstructorWithBody(node)
@@ -1606,7 +1610,7 @@ namespace ts {
 
             const expressions: Expression[] = [];
             if (valueDeclaration) {
-                const parameters = valueDeclaration.parameters;
+                const parameters = getParametersOfDecoratedDeclaration(valueDeclaration, container);
                 const numParameters = parameters.length;
                 for (let i = 0; i < numParameters; i++) {
                     const parameter = parameters[i];
@@ -1623,6 +1627,16 @@ namespace ts {
             }
 
             return createArrayLiteral(expressions);
+        }
+
+        function getParametersOfDecoratedDeclaration(node: FunctionLikeDeclaration, container: ClassLikeDeclaration) {
+            if (container && node.kind === SyntaxKind.GetAccessor) {
+                const { setAccessor } = getAllAccessorDeclarations(container.members, <AccessorDeclaration>node);
+                if (setAccessor) {
+                    return setAccessor.parameters;
+                }
+            }
+            return node.parameters;
         }
 
         /**

--- a/tests/baselines/reference/decoratedClassExportsCommonJS1.js
+++ b/tests/baselines/reference/decoratedClassExportsCommonJS1.js
@@ -14,15 +14,11 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-var __metadata = (this && this.__metadata) || function (k, v) {
-    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
-};
 let Testing123 = Testing123_1 = class Testing123 {
 };
 Testing123.prop1 = Testing123_1.prop0;
 Testing123 = Testing123_1 = __decorate([
-    Something({ v: () => Testing123_1 }),
-    __metadata("design:paramtypes", [])
+    Something({ v: () => Testing123_1 })
 ], Testing123);
 exports.Testing123 = Testing123;
 var Testing123_1;

--- a/tests/baselines/reference/decoratedClassExportsCommonJS2.js
+++ b/tests/baselines/reference/decoratedClassExportsCommonJS2.js
@@ -13,14 +13,10 @@ var __decorate = (this && this.__decorate) || function (decorators, target, key,
     else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
     return c > 3 && r && Object.defineProperty(target, key, r), r;
 };
-var __metadata = (this && this.__metadata) || function (k, v) {
-    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
-};
 let Testing123 = Testing123_1 = class Testing123 {
 };
 Testing123 = Testing123_1 = __decorate([
-    Something({ v: () => Testing123_1 }),
-    __metadata("design:paramtypes", [])
+    Something({ v: () => Testing123_1 })
 ], Testing123);
 exports.Testing123 = Testing123;
 var Testing123_1;

--- a/tests/baselines/reference/decoratedClassExportsSystem1.js
+++ b/tests/baselines/reference/decoratedClassExportsSystem1.js
@@ -17,9 +17,6 @@ System.register([], function (exports_1, context_1) {
         else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
         return c > 3 && r && Object.defineProperty(target, key, r), r;
     };
-    var __metadata = (this && this.__metadata) || function (k, v) {
-        if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
-    };
     var __moduleName = context_1 && context_1.id;
     var Testing123, Testing123_1;
     return {
@@ -29,8 +26,7 @@ System.register([], function (exports_1, context_1) {
             };
             Testing123.prop1 = Testing123_1.prop0;
             Testing123 = Testing123_1 = __decorate([
-                Something({ v: () => Testing123_1 }),
-                __metadata("design:paramtypes", [])
+                Something({ v: () => Testing123_1 })
             ], Testing123);
             exports_1("Testing123", Testing123);
         }

--- a/tests/baselines/reference/decoratedClassExportsSystem2.js
+++ b/tests/baselines/reference/decoratedClassExportsSystem2.js
@@ -14,9 +14,6 @@ System.register([], function (exports_1, context_1) {
         else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
         return c > 3 && r && Object.defineProperty(target, key, r), r;
     };
-    var __metadata = (this && this.__metadata) || function (k, v) {
-        if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
-    };
     var __moduleName = context_1 && context_1.id;
     var Testing123, Testing123_1;
     return {
@@ -25,8 +22,7 @@ System.register([], function (exports_1, context_1) {
             Testing123 = Testing123_1 = class Testing123 {
             };
             Testing123 = Testing123_1 = __decorate([
-                Something({ v: () => Testing123_1 }),
-                __metadata("design:paramtypes", [])
+                Something({ v: () => Testing123_1 })
             ], Testing123);
             exports_1("Testing123", Testing123);
         }

--- a/tests/baselines/reference/decoratorOnClassAccessor8.js
+++ b/tests/baselines/reference/decoratorOnClassAccessor8.js
@@ -1,0 +1,135 @@
+//// [decoratorOnClassAccessor8.ts]
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class A {
+    @dec get x() { return 0; }
+    set x(value: number) { }
+}
+
+class B {
+    get x() { return 0; }
+    @dec set x(value: number) { }
+}
+
+class C {
+    @dec set x(value: number) { }
+    get x() { return 0; }
+}
+
+class D {
+    set x(value: number) { }
+    @dec get x() { return 0; }
+}
+
+class E {
+    @dec get x() { return 0; }
+}
+
+class F {
+    @dec set x(value: number) { }
+}
+
+//// [decoratorOnClassAccessor8.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var A = (function () {
+    function A() {
+    }
+    Object.defineProperty(A.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
+    return A;
+}());
+__decorate([
+    dec,
+    __metadata("design:type", Object),
+    __metadata("design:paramtypes", [Number])
+], A.prototype, "x", null);
+var B = (function () {
+    function B() {
+    }
+    Object.defineProperty(B.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
+    return B;
+}());
+__decorate([
+    dec,
+    __metadata("design:type", Number),
+    __metadata("design:paramtypes", [Number])
+], B.prototype, "x", null);
+var C = (function () {
+    function C() {
+    }
+    Object.defineProperty(C.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
+    return C;
+}());
+__decorate([
+    dec,
+    __metadata("design:type", Number),
+    __metadata("design:paramtypes", [Number])
+], C.prototype, "x", null);
+var D = (function () {
+    function D() {
+    }
+    Object.defineProperty(D.prototype, "x", {
+        get: function () { return 0; },
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
+    return D;
+}());
+__decorate([
+    dec,
+    __metadata("design:type", Object),
+    __metadata("design:paramtypes", [Number])
+], D.prototype, "x", null);
+var E = (function () {
+    function E() {
+    }
+    Object.defineProperty(E.prototype, "x", {
+        get: function () { return 0; },
+        enumerable: true,
+        configurable: true
+    });
+    return E;
+}());
+__decorate([
+    dec,
+    __metadata("design:type", Object),
+    __metadata("design:paramtypes", [])
+], E.prototype, "x", null);
+var F = (function () {
+    function F() {
+    }
+    Object.defineProperty(F.prototype, "x", {
+        set: function (value) { },
+        enumerable: true,
+        configurable: true
+    });
+    return F;
+}());
+__decorate([
+    dec,
+    __metadata("design:type", Number),
+    __metadata("design:paramtypes", [Number])
+], F.prototype, "x", null);

--- a/tests/baselines/reference/decoratorOnClassAccessor8.symbols
+++ b/tests/baselines/reference/decoratorOnClassAccessor8.symbols
@@ -1,0 +1,76 @@
+=== tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor8.ts ===
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor8.ts, 0, 0))
+>T : Symbol(T, Decl(decoratorOnClassAccessor8.ts, 0, 21))
+>target : Symbol(target, Decl(decoratorOnClassAccessor8.ts, 0, 24))
+>propertyKey : Symbol(propertyKey, Decl(decoratorOnClassAccessor8.ts, 0, 36))
+>descriptor : Symbol(descriptor, Decl(decoratorOnClassAccessor8.ts, 0, 57))
+>TypedPropertyDescriptor : Symbol(TypedPropertyDescriptor, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(decoratorOnClassAccessor8.ts, 0, 21))
+>TypedPropertyDescriptor : Symbol(TypedPropertyDescriptor, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(decoratorOnClassAccessor8.ts, 0, 21))
+
+class A {
+>A : Symbol(A, Decl(decoratorOnClassAccessor8.ts, 0, 126))
+
+    @dec get x() { return 0; }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor8.ts, 0, 0))
+>x : Symbol(A.x, Decl(decoratorOnClassAccessor8.ts, 2, 9), Decl(decoratorOnClassAccessor8.ts, 3, 30))
+
+    set x(value: number) { }
+>x : Symbol(A.x, Decl(decoratorOnClassAccessor8.ts, 2, 9), Decl(decoratorOnClassAccessor8.ts, 3, 30))
+>value : Symbol(value, Decl(decoratorOnClassAccessor8.ts, 4, 10))
+}
+
+class B {
+>B : Symbol(B, Decl(decoratorOnClassAccessor8.ts, 5, 1))
+
+    get x() { return 0; }
+>x : Symbol(B.x, Decl(decoratorOnClassAccessor8.ts, 7, 9), Decl(decoratorOnClassAccessor8.ts, 8, 25))
+
+    @dec set x(value: number) { }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor8.ts, 0, 0))
+>x : Symbol(B.x, Decl(decoratorOnClassAccessor8.ts, 7, 9), Decl(decoratorOnClassAccessor8.ts, 8, 25))
+>value : Symbol(value, Decl(decoratorOnClassAccessor8.ts, 9, 15))
+}
+
+class C {
+>C : Symbol(C, Decl(decoratorOnClassAccessor8.ts, 10, 1))
+
+    @dec set x(value: number) { }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor8.ts, 0, 0))
+>x : Symbol(C.x, Decl(decoratorOnClassAccessor8.ts, 12, 9), Decl(decoratorOnClassAccessor8.ts, 13, 33))
+>value : Symbol(value, Decl(decoratorOnClassAccessor8.ts, 13, 15))
+
+    get x() { return 0; }
+>x : Symbol(C.x, Decl(decoratorOnClassAccessor8.ts, 12, 9), Decl(decoratorOnClassAccessor8.ts, 13, 33))
+}
+
+class D {
+>D : Symbol(D, Decl(decoratorOnClassAccessor8.ts, 15, 1))
+
+    set x(value: number) { }
+>x : Symbol(D.x, Decl(decoratorOnClassAccessor8.ts, 17, 9), Decl(decoratorOnClassAccessor8.ts, 18, 28))
+>value : Symbol(value, Decl(decoratorOnClassAccessor8.ts, 18, 10))
+
+    @dec get x() { return 0; }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor8.ts, 0, 0))
+>x : Symbol(D.x, Decl(decoratorOnClassAccessor8.ts, 17, 9), Decl(decoratorOnClassAccessor8.ts, 18, 28))
+}
+
+class E {
+>E : Symbol(E, Decl(decoratorOnClassAccessor8.ts, 20, 1))
+
+    @dec get x() { return 0; }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor8.ts, 0, 0))
+>x : Symbol(E.x, Decl(decoratorOnClassAccessor8.ts, 22, 9))
+}
+
+class F {
+>F : Symbol(F, Decl(decoratorOnClassAccessor8.ts, 24, 1))
+
+    @dec set x(value: number) { }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor8.ts, 0, 0))
+>x : Symbol(F.x, Decl(decoratorOnClassAccessor8.ts, 26, 9))
+>value : Symbol(value, Decl(decoratorOnClassAccessor8.ts, 27, 15))
+}

--- a/tests/baselines/reference/decoratorOnClassAccessor8.types
+++ b/tests/baselines/reference/decoratorOnClassAccessor8.types
@@ -1,0 +1,81 @@
+=== tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor8.ts ===
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>T : T
+>target : any
+>propertyKey : string
+>descriptor : TypedPropertyDescriptor<T>
+>TypedPropertyDescriptor : TypedPropertyDescriptor<T>
+>T : T
+>TypedPropertyDescriptor : TypedPropertyDescriptor<T>
+>T : T
+
+class A {
+>A : A
+
+    @dec get x() { return 0; }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>0 : 0
+
+    set x(value: number) { }
+>x : number
+>value : number
+}
+
+class B {
+>B : B
+
+    get x() { return 0; }
+>x : number
+>0 : 0
+
+    @dec set x(value: number) { }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>value : number
+}
+
+class C {
+>C : C
+
+    @dec set x(value: number) { }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>value : number
+
+    get x() { return 0; }
+>x : number
+>0 : 0
+}
+
+class D {
+>D : D
+
+    set x(value: number) { }
+>x : number
+>value : number
+
+    @dec get x() { return 0; }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>0 : 0
+}
+
+class E {
+>E : E
+
+    @dec get x() { return 0; }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>0 : 0
+}
+
+class F {
+>F : F
+
+    @dec set x(value: number) { }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>x : number
+>value : number
+}

--- a/tests/baselines/reference/decoratorOnClassConstructor4.js
+++ b/tests/baselines/reference/decoratorOnClassConstructor4.js
@@ -1,0 +1,58 @@
+//// [decoratorOnClassConstructor4.ts]
+declare var dec: any;
+
+@dec
+class A {
+}
+
+@dec
+class B {
+    constructor(x: number) {}
+}
+
+@dec
+class C extends A {
+}
+
+//// [decoratorOnClassConstructor4.js]
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var A = (function () {
+    function A() {
+    }
+    return A;
+}());
+A = __decorate([
+    dec
+], A);
+var B = (function () {
+    function B(x) {
+    }
+    return B;
+}());
+B = __decorate([
+    dec,
+    __metadata("design:paramtypes", [Number])
+], B);
+var C = (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super.apply(this, arguments) || this;
+    }
+    return C;
+}(A));
+C = __decorate([
+    dec
+], C);

--- a/tests/baselines/reference/decoratorOnClassConstructor4.symbols
+++ b/tests/baselines/reference/decoratorOnClassConstructor4.symbols
@@ -1,0 +1,28 @@
+=== tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor4.ts ===
+declare var dec: any;
+>dec : Symbol(dec, Decl(decoratorOnClassConstructor4.ts, 0, 11))
+
+@dec
+>dec : Symbol(dec, Decl(decoratorOnClassConstructor4.ts, 0, 11))
+
+class A {
+>A : Symbol(A, Decl(decoratorOnClassConstructor4.ts, 0, 21))
+}
+
+@dec
+>dec : Symbol(dec, Decl(decoratorOnClassConstructor4.ts, 0, 11))
+
+class B {
+>B : Symbol(B, Decl(decoratorOnClassConstructor4.ts, 4, 1))
+
+    constructor(x: number) {}
+>x : Symbol(x, Decl(decoratorOnClassConstructor4.ts, 8, 16))
+}
+
+@dec
+>dec : Symbol(dec, Decl(decoratorOnClassConstructor4.ts, 0, 11))
+
+class C extends A {
+>C : Symbol(C, Decl(decoratorOnClassConstructor4.ts, 9, 1))
+>A : Symbol(A, Decl(decoratorOnClassConstructor4.ts, 0, 21))
+}

--- a/tests/baselines/reference/decoratorOnClassConstructor4.types
+++ b/tests/baselines/reference/decoratorOnClassConstructor4.types
@@ -1,0 +1,28 @@
+=== tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor4.ts ===
+declare var dec: any;
+>dec : any
+
+@dec
+>dec : any
+
+class A {
+>A : A
+}
+
+@dec
+>dec : any
+
+class B {
+>B : B
+
+    constructor(x: number) {}
+>x : number
+}
+
+@dec
+>dec : any
+
+class C extends A {
+>C : C
+>A : A
+}

--- a/tests/baselines/reference/importHelpers.js
+++ b/tests/baselines/reference/importHelpers.js
@@ -64,8 +64,7 @@ tslib_1.__decorate([
     tslib_1.__metadata("design:returntype", void 0)
 ], C.prototype, "method", null);
 C = tslib_1.__decorate([
-    dec,
-    tslib_1.__metadata("design:paramtypes", [])
+    dec
 ], C);
 //// [script.js]
 var __extends = (this && this.__extends) || function (d, b) {
@@ -111,6 +110,5 @@ __decorate([
     __metadata("design:returntype", void 0)
 ], C.prototype, "method", null);
 C = __decorate([
-    dec,
-    __metadata("design:paramtypes", [])
+    dec
 ], C);

--- a/tests/baselines/reference/importHelpersInIsolatedModules.js
+++ b/tests/baselines/reference/importHelpersInIsolatedModules.js
@@ -64,8 +64,7 @@ tslib_1.__decorate([
     tslib_1.__metadata("design:returntype", void 0)
 ], C.prototype, "method", null);
 C = tslib_1.__decorate([
-    dec,
-    tslib_1.__metadata("design:paramtypes", [])
+    dec
 ], C);
 //// [script.js]
 "use strict";
@@ -96,6 +95,5 @@ tslib_1.__decorate([
     tslib_1.__metadata("design:returntype", void 0)
 ], C.prototype, "method", null);
 C = tslib_1.__decorate([
-    dec,
-    tslib_1.__metadata("design:paramtypes", [])
+    dec
 ], C);

--- a/tests/baselines/reference/importHelpersNoHelpers.js
+++ b/tests/baselines/reference/importHelpersNoHelpers.js
@@ -63,8 +63,7 @@ tslib_1.__decorate([
     tslib_1.__metadata("design:returntype", void 0)
 ], C.prototype, "method", null);
 C = tslib_1.__decorate([
-    dec,
-    tslib_1.__metadata("design:paramtypes", [])
+    dec
 ], C);
 var o = { a: 1 };
 var y = tslib_1.__assign({}, o);
@@ -113,6 +112,5 @@ __decorate([
     __metadata("design:returntype", void 0)
 ], C.prototype, "method", null);
 C = __decorate([
-    dec,
-    __metadata("design:paramtypes", [])
+    dec
 ], C);

--- a/tests/baselines/reference/importHelpersNoModule.js
+++ b/tests/baselines/reference/importHelpersNoModule.js
@@ -56,8 +56,7 @@ tslib_1.__decorate([
     tslib_1.__metadata("design:returntype", void 0)
 ], C.prototype, "method", null);
 C = tslib_1.__decorate([
-    dec,
-    tslib_1.__metadata("design:paramtypes", [])
+    dec
 ], C);
 //// [script.js]
 var __extends = (this && this.__extends) || function (d, b) {
@@ -103,6 +102,5 @@ __decorate([
     __metadata("design:returntype", void 0)
 ], C.prototype, "method", null);
 C = __decorate([
-    dec,
-    __metadata("design:paramtypes", [])
+    dec
 ], C);

--- a/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor8.ts
+++ b/tests/cases/conformance/decorators/class/accessor/decoratorOnClassAccessor8.ts
@@ -1,0 +1,32 @@
+// @target:es5
+// @experimentaldecorators: true
+// @emitdecoratormetadata: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+class A {
+    @dec get x() { return 0; }
+    set x(value: number) { }
+}
+
+class B {
+    get x() { return 0; }
+    @dec set x(value: number) { }
+}
+
+class C {
+    @dec set x(value: number) { }
+    get x() { return 0; }
+}
+
+class D {
+    set x(value: number) { }
+    @dec get x() { return 0; }
+}
+
+class E {
+    @dec get x() { return 0; }
+}
+
+class F {
+    @dec set x(value: number) { }
+}

--- a/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor4.ts
+++ b/tests/cases/conformance/decorators/class/constructor/decoratorOnClassConstructor4.ts
@@ -1,0 +1,18 @@
+﻿// @target: es5
+// @module: commonjs
+// @experimentaldecorators: true
+// @emitdecoratormetadata: true
+declare var dec: any;
+
+@dec
+class A {
+}
+
+@dec
+class B {
+    constructor(x: number) {}
+}
+
+@dec
+class C extends A {
+}


### PR DESCRIPTION
This change fixes two issues with `design:paramtypes` decorator metadata emit:

* #12439 - Incorrect emit of `__metadata('design:paramtypes', [])` when using `emitDecoratorMetadata` and inheritance
* Inconsistent emit for `design:paramtypes` on accessors, as mentioned in [this comment](https://github.com/Microsoft/TypeScript/issues/12727#issuecomment-265904061).

Fixes #12439

