### PR TITLE
Self-referencing spread recursive loop

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11252,13 +11252,7 @@ namespace ts {
         }
 
         function checkSpreadExpression(node: SpreadElement, contextualMapper?: TypeMapper): Type {
-            // It is usually not safe to call checkExpressionCached if we can be contextually typing.
-            // You can tell that we are contextually typing because of the contextualMapper parameter.
-            // While it is true that a spread element can have a contextual type, it does not do anything
-            // with this type. It is neither affected by it, nor does it propagate it to its operand.
-            // So the fact that contextualMapper is passed is not important, because the operand of a spread
-            // element is not contextually typed.
-            const arrayOrIterableType = checkExpressionCached(node.expression, contextualMapper);
+            const arrayOrIterableType = checkExpression(node.expression, contextualMapper);
             return checkIteratedTypeOrElementType(arrayOrIterableType, node.expression, /*allowStringInput*/ false);
         }
 

--- a/tests/baselines/reference/selfReferencingSpreadInLoop.errors.txt
+++ b/tests/baselines/reference/selfReferencingSpreadInLoop.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/selfReferencingSpreadInLoop.ts(1,5): error TS7034: Variable 'additional' implicitly has type 'any[]' in some locations where its type cannot be determined.
+tests/cases/compiler/selfReferencingSpreadInLoop.ts(3,22): error TS7005: Variable 'additional' implicitly has an 'any[]' type.
+
+
+==== tests/cases/compiler/selfReferencingSpreadInLoop.ts (2 errors) ====
+    let additional = [];
+        ~~~~~~~~~~
+!!! error TS7034: Variable 'additional' implicitly has type 'any[]' in some locations where its type cannot be determined.
+    for (const subcomponent of [1, 2, 3]) {
+        additional = [...additional, subcomponent];
+                         ~~~~~~~~~~
+!!! error TS7005: Variable 'additional' implicitly has an 'any[]' type.
+    }
+    

--- a/tests/baselines/reference/selfReferencingSpreadInLoop.js
+++ b/tests/baselines/reference/selfReferencingSpreadInLoop.js
@@ -1,0 +1,13 @@
+//// [selfReferencingSpreadInLoop.ts]
+let additional = [];
+for (const subcomponent of [1, 2, 3]) {
+    additional = [...additional, subcomponent];
+}
+
+
+//// [selfReferencingSpreadInLoop.js]
+var additional = [];
+for (var _i = 0, _a = [1, 2, 3]; _i < _a.length; _i++) {
+    var subcomponent = _a[_i];
+    additional = additional.concat([subcomponent]);
+}

--- a/tests/cases/compiler/selfReferencingSpreadInLoop.ts
+++ b/tests/cases/compiler/selfReferencingSpreadInLoop.ts
@@ -1,0 +1,5 @@
+// @noImplicitAny: true
+let additional = [];
+for (const subcomponent of [1, 2, 3]) {
+    additional = [...additional, subcomponent];
+}


### PR DESCRIPTION
Fixes #12735 

Use `checkExpression` in `checkSpreadExpression`, not `checkExpressionCached`. `checkExpressionCached` ignores ongoing control flow analysis, which causes the following loop to make the compiler recur infinitely:

```ts
// @noImplicitAny: true
let a = []
for (const x of []) {
    a = [...a]
}
```

An alternate fix would make `checkExpressionCached` not ignore control flow analysis in some situations, but that's a much more complicated fix, I think. @ahejlsberg, do you have an opinion on whether that or some other fix is feasible?