### PR TITLE
Improve propagation of modifiers in mapped types

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2933,6 +2933,7 @@ namespace ts {
         typeParameter?: TypeParameter;
         constraintType?: Type;
         templateType?: Type;
+        modifiersType?: Type;
         mapper?: TypeMapper;  // Instantiation mapper
     }
 

--- a/tests/baselines/reference/mappedTypeErrors.errors.txt
+++ b/tests/baselines/reference/mappedTypeErrors.errors.txt
@@ -26,9 +26,19 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(78,59): error TS2345: A
   Object literal may only specify known properties, and 'z' does not exist in type 'Readonly<{ x: number; y: number; }>'.
 tests/cases/conformance/types/mapped/mappedTypeErrors.ts(84,58): error TS2345: Argument of type '{ x: number; y: number; z: number; }' is not assignable to parameter of type 'Partial<{ x: number; y: number; }>'.
   Object literal may only specify known properties, and 'z' does not exist in type 'Partial<{ x: number; y: number; }>'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(106,15): error TS2345: Argument of type '{ a: undefined; }' is not assignable to parameter of type 'Pick<Foo, "a">'.
+  Types of property 'a' are incompatible.
+    Type 'undefined' is not assignable to type 'string'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(107,17): error TS2345: Argument of type '{ c: boolean; }' is not assignable to parameter of type 'Pick<Foo, "a" | "b">'.
+  Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, "a" | "b">'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(124,12): error TS2345: Argument of type '{ a: undefined; }' is not assignable to parameter of type 'Pick<Foo, "a">'.
+  Types of property 'a' are incompatible.
+    Type 'undefined' is not assignable to type 'string'.
+tests/cases/conformance/types/mapped/mappedTypeErrors.ts(125,14): error TS2345: Argument of type '{ c: boolean; }' is not assignable to parameter of type 'Pick<Foo, "a" | "b">'.
+  Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, "a" | "b">'.
 
 
-==== tests/cases/conformance/types/mapped/mappedTypeErrors.ts (17 errors) ====
+==== tests/cases/conformance/types/mapped/mappedTypeErrors.ts (21 errors) ====
     
     interface Shape {
         name: string;
@@ -159,3 +169,58 @@ tests/cases/conformance/types/mapped/mappedTypeErrors.ts(84,58): error TS2345: A
 !!! error TS2345: Argument of type '{ x: number; y: number; z: number; }' is not assignable to parameter of type 'Partial<{ x: number; y: number; }>'.
 !!! error TS2345:   Object literal may only specify known properties, and 'z' does not exist in type 'Partial<{ x: number; y: number; }>'.
     }
+    
+    // Verify use of Pick<T, K> for setState functions (#12793)
+    
+    interface Foo {
+        a: string;
+        b?: number;
+    }
+    
+    function setState<T, K extends keyof T>(obj: T, props: Pick<T, K>) {
+        for (let k in props) {
+            obj[k] = props[k];
+        }
+    }
+    
+    let foo: Foo = { a: "hello", b: 42 };
+    setState(foo, { a: "test", b: 43 })
+    setState(foo, { a: "hi" });
+    setState(foo, { b: undefined });
+    setState(foo, { });
+    setState(foo, foo);
+    setState(foo, { a: undefined });  // Error
+                  ~~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ a: undefined; }' is not assignable to parameter of type 'Pick<Foo, "a">'.
+!!! error TS2345:   Types of property 'a' are incompatible.
+!!! error TS2345:     Type 'undefined' is not assignable to type 'string'.
+    setState(foo, { c: true });  // Error
+                    ~~~~~~~
+!!! error TS2345: Argument of type '{ c: boolean; }' is not assignable to parameter of type 'Pick<Foo, "a" | "b">'.
+!!! error TS2345:   Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, "a" | "b">'.
+    
+    class C<T> {
+        state: T;
+        setState<K extends keyof T>(props: Pick<T, K>) {
+            for (let k in props) {
+                this.state[k] = props[k];
+            }
+        }
+    }
+    
+    let c = new C<Foo>();
+    c.setState({ a: "test", b: 43 });
+    c.setState({ a: "hi" });
+    c.setState({ b: undefined });
+    c.setState({ });
+    c.setState(foo);
+    c.setState({ a: undefined });  // Error
+               ~~~~~~~~~~~~~~~~
+!!! error TS2345: Argument of type '{ a: undefined; }' is not assignable to parameter of type 'Pick<Foo, "a">'.
+!!! error TS2345:   Types of property 'a' are incompatible.
+!!! error TS2345:     Type 'undefined' is not assignable to type 'string'.
+    c.setState({ c: true });  // Error
+                 ~~~~~~~
+!!! error TS2345: Argument of type '{ c: boolean; }' is not assignable to parameter of type 'Pick<Foo, "a" | "b">'.
+!!! error TS2345:   Object literal may only specify known properties, and 'c' does not exist in type 'Pick<Foo, "a" | "b">'.
+    

--- a/tests/baselines/reference/mappedTypeModifiers.js
+++ b/tests/baselines/reference/mappedTypeModifiers.js
@@ -1,145 +1,121 @@
 //// [mappedTypeModifiers.ts]
 
 type T = { a: number, b: string };
-type TU = { a: number | undefined, b: string | undefined };
 type TP = { a?: number, b?: string };
 type TR = { readonly a: number, readonly b: string };
 type TPR = { readonly a?: number, readonly b?: string };
 
-// Validate they all have the same keys
 var v00: "a" | "b";
 var v00: keyof T;
-var v00: keyof TU;
 var v00: keyof TP;
 var v00: keyof TR;
 var v00: keyof TPR;
 
-// Validate that non-isomorphic mapped types strip modifiers
 var v01: T;
-var v01: Pick<TR, keyof T>;
-var v01: Pick<Readonly<T>, keyof T>;
+var v01: { [P in keyof T]: T[P] };
+var v01: Pick<T, keyof T>;
+var v01: Pick<Pick<T, keyof T>, keyof T>;
 
-// Validate that non-isomorphic mapped types strip modifiers
-var v02: TU;
+var v02: TP;
+var v02: { [P in keyof T]?: T[P] };
+var v02: Partial<T>;
 var v02: Pick<TP, keyof T>;
-var v02: Pick<TPR, keyof T>;
-var v02: Pick<Partial<T>, keyof T>;
-var v02: Pick<Partial<Readonly<T>>, keyof T>;
 
-// Validate that isomorphic mapped types preserve optional modifier
-var v03: TP;
-var v03: Partial<T>;
+var v03: TR;
+var v03: { readonly [P in keyof T]: T[P] };
+var v03: Readonly<T>;
+var v03: Pick<TR, keyof T>;
 
-// Validate that isomorphic mapped types preserve readonly modifier
-var v04: TR;
-var v04: Readonly<T>;
-
-// Validate that isomorphic mapped types preserve both partial and readonly modifiers
-var v05: TPR;
-var v05: Partial<TR>;
-var v05: Readonly<TP>;
-var v05: Partial<Readonly<T>>;
-var v05: Readonly<Partial<T>>;
+var v04: TPR;
+var v04: { readonly [P in keyof T]?: T[P] };
+var v04: Partial<TR>;
+var v04: Readonly<TP>;
+var v04: Partial<Readonly<T>>;
+var v04: Readonly<Partial<T>>;
+var v04: Pick<TPR, keyof T>;
 
 type Boxified<T> = { [P in keyof T]: { x: T[P] } };
 
 type B = { a: { x: number }, b: { x: string } };
-type BU = { a: { x: number } | undefined, b: { x: string } | undefined };
 type BP = { a?: { x: number }, b?: { x: string } };
 type BR = { readonly a: { x: number }, readonly b: { x: string } };
 type BPR = { readonly a?: { x: number }, readonly b?: { x: string } };
 
-// Validate they all have the same keys
 var b00: "a" | "b";
 var b00: keyof B;
-var b00: keyof BU;
 var b00: keyof BP;
 var b00: keyof BR;
 var b00: keyof BPR;
 
-// Validate that non-isomorphic mapped types strip modifiers
 var b01: B;
-var b01: Pick<BR, keyof B>;
-var b01: Pick<Readonly<BR>, keyof B>;
+var b01: { [P in keyof B]: B[P] };
+var b01: Pick<B, keyof B>;
+var b01: Pick<Pick<B, keyof B>, keyof B>;
 
-// Validate that non-isomorphic mapped types strip modifiers
-var b02: BU;
+var b02: BP;
+var b02: { [P in keyof B]?: B[P] };
+var b02: Partial<B>;
 var b02: Pick<BP, keyof B>;
-var b02: Pick<BPR, keyof B>;
-var b02: Pick<Partial<B>, keyof B>;
-var b02: Pick<Partial<Readonly<B>>, keyof B>;
 
-// Validate that isomorphic mapped types preserve optional modifier
-var b03: BP;
-var b03: Partial<B>;
+var b03: BR;
+var b03: { readonly [P in keyof B]: B[P] };
+var b03: Readonly<B>;
+var b03: Pick<BR, keyof B>;
 
-// Validate that isomorphic mapped types preserve readonly modifier
-var b04: BR;
-var b04: Readonly<B>;
-
-// Validate that isomorphic mapped types preserve both partial and readonly modifiers
-var b05: BPR;
-var b05: Partial<BR>;
-var b05: Readonly<BP>;
-var b05: Partial<Readonly<B>>;
-var b05: Readonly<Partial<B>>;
+var b04: BPR;
+var b04: { readonly [P in keyof B]?: B[P] };
+var b04: Partial<BR>;
+var b04: Readonly<BP>;
+var b04: Partial<Readonly<B>>;
+var b04: Readonly<Partial<B>>;
+var b04: Pick<BPR, keyof B>;
 
 //// [mappedTypeModifiers.js]
-// Validate they all have the same keys
 var v00;
 var v00;
 var v00;
 var v00;
 var v00;
-var v00;
-// Validate that non-isomorphic mapped types strip modifiers
 var v01;
 var v01;
 var v01;
-// Validate that non-isomorphic mapped types strip modifiers
+var v01;
 var v02;
 var v02;
 var v02;
 var v02;
-var v02;
-// Validate that isomorphic mapped types preserve optional modifier
 var v03;
 var v03;
-// Validate that isomorphic mapped types preserve readonly modifier
+var v03;
+var v03;
 var v04;
 var v04;
-// Validate that isomorphic mapped types preserve both partial and readonly modifiers
-var v05;
-var v05;
-var v05;
-var v05;
-var v05;
-// Validate they all have the same keys
+var v04;
+var v04;
+var v04;
+var v04;
+var v04;
 var b00;
 var b00;
 var b00;
 var b00;
 var b00;
-var b00;
-// Validate that non-isomorphic mapped types strip modifiers
 var b01;
 var b01;
 var b01;
-// Validate that non-isomorphic mapped types strip modifiers
+var b01;
 var b02;
 var b02;
 var b02;
 var b02;
-var b02;
-// Validate that isomorphic mapped types preserve optional modifier
 var b03;
 var b03;
-// Validate that isomorphic mapped types preserve readonly modifier
+var b03;
+var b03;
 var b04;
 var b04;
-// Validate that isomorphic mapped types preserve both partial and readonly modifiers
-var b05;
-var b05;
-var b05;
-var b05;
-var b05;
+var b04;
+var b04;
+var b04;
+var b04;
+var b04;

--- a/tests/baselines/reference/mappedTypeModifiers.symbols
+++ b/tests/baselines/reference/mappedTypeModifiers.symbols
@@ -5,309 +5,309 @@ type T = { a: number, b: string };
 >a : Symbol(a, Decl(mappedTypeModifiers.ts, 1, 10))
 >b : Symbol(b, Decl(mappedTypeModifiers.ts, 1, 21))
 
-type TU = { a: number | undefined, b: string | undefined };
->TU : Symbol(TU, Decl(mappedTypeModifiers.ts, 1, 34))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 2, 11))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 2, 34))
-
 type TP = { a?: number, b?: string };
->TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 2, 59))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 3, 11))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 3, 23))
+>TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 1, 34))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 2, 11))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 2, 23))
 
 type TR = { readonly a: number, readonly b: string };
->TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 3, 37))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 4, 11))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 4, 31))
+>TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 2, 37))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 3, 11))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 3, 31))
 
 type TPR = { readonly a?: number, readonly b?: string };
->TPR : Symbol(TPR, Decl(mappedTypeModifiers.ts, 4, 53))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 5, 12))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 5, 33))
+>TPR : Symbol(TPR, Decl(mappedTypeModifiers.ts, 3, 53))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 4, 12))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 4, 33))
 
-// Validate they all have the same keys
 var v00: "a" | "b";
->v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
+>v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 6, 3), Decl(mappedTypeModifiers.ts, 7, 3), Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3))
 
 var v00: keyof T;
->v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
+>v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 6, 3), Decl(mappedTypeModifiers.ts, 7, 3), Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
-
-var v00: keyof TU;
->v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
->TU : Symbol(TU, Decl(mappedTypeModifiers.ts, 1, 34))
 
 var v00: keyof TP;
->v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
->TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 2, 59))
+>v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 6, 3), Decl(mappedTypeModifiers.ts, 7, 3), Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3))
+>TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 1, 34))
 
 var v00: keyof TR;
->v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
->TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 3, 37))
+>v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 6, 3), Decl(mappedTypeModifiers.ts, 7, 3), Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3))
+>TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 2, 37))
 
 var v00: keyof TPR;
->v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3), Decl(mappedTypeModifiers.ts, 11, 3), Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3))
->TPR : Symbol(TPR, Decl(mappedTypeModifiers.ts, 4, 53))
+>v00 : Symbol(v00, Decl(mappedTypeModifiers.ts, 6, 3), Decl(mappedTypeModifiers.ts, 7, 3), Decl(mappedTypeModifiers.ts, 8, 3), Decl(mappedTypeModifiers.ts, 9, 3), Decl(mappedTypeModifiers.ts, 10, 3))
+>TPR : Symbol(TPR, Decl(mappedTypeModifiers.ts, 3, 53))
 
-// Validate that non-isomorphic mapped types strip modifiers
 var v01: T;
->v01 : Symbol(v01, Decl(mappedTypeModifiers.ts, 16, 3), Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3))
+>v01 : Symbol(v01, Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3), Decl(mappedTypeModifiers.ts, 14, 3), Decl(mappedTypeModifiers.ts, 15, 3))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
-var v01: Pick<TR, keyof T>;
->v01 : Symbol(v01, Decl(mappedTypeModifiers.ts, 16, 3), Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3))
+var v01: { [P in keyof T]: T[P] };
+>v01 : Symbol(v01, Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3), Decl(mappedTypeModifiers.ts, 14, 3), Decl(mappedTypeModifiers.ts, 15, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 13, 12))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 13, 12))
+
+var v01: Pick<T, keyof T>;
+>v01 : Symbol(v01, Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3), Decl(mappedTypeModifiers.ts, 14, 3), Decl(mappedTypeModifiers.ts, 15, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 3, 37))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
-var v01: Pick<Readonly<T>, keyof T>;
->v01 : Symbol(v01, Decl(mappedTypeModifiers.ts, 16, 3), Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3))
+var v01: Pick<Pick<T, keyof T>, keyof T>;
+>v01 : Symbol(v01, Decl(mappedTypeModifiers.ts, 12, 3), Decl(mappedTypeModifiers.ts, 13, 3), Decl(mappedTypeModifiers.ts, 14, 3), Decl(mappedTypeModifiers.ts, 15, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
-// Validate that non-isomorphic mapped types strip modifiers
-var v02: TU;
->v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 21, 3), Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
->TU : Symbol(TU, Decl(mappedTypeModifiers.ts, 1, 34))
+var v02: TP;
+>v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3), Decl(mappedTypeModifiers.ts, 19, 3), Decl(mappedTypeModifiers.ts, 20, 3))
+>TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 1, 34))
+
+var v02: { [P in keyof T]?: T[P] };
+>v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3), Decl(mappedTypeModifiers.ts, 19, 3), Decl(mappedTypeModifiers.ts, 20, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 18, 12))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 18, 12))
+
+var v02: Partial<T>;
+>v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3), Decl(mappedTypeModifiers.ts, 19, 3), Decl(mappedTypeModifiers.ts, 20, 3))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
 var v02: Pick<TP, keyof T>;
->v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 21, 3), Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
+>v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3), Decl(mappedTypeModifiers.ts, 19, 3), Decl(mappedTypeModifiers.ts, 20, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 2, 59))
+>TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 1, 34))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
-var v02: Pick<TPR, keyof T>;
->v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 21, 3), Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
+var v03: TR;
+>v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
+>TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 2, 37))
+
+var v03: { readonly [P in keyof T]: T[P] };
+>v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 23, 21))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 23, 21))
+
+var v03: Readonly<T>;
+>v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+
+var v03: Pick<TR, keyof T>;
+>v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->TPR : Symbol(TPR, Decl(mappedTypeModifiers.ts, 4, 53))
+>TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 2, 37))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
-var v02: Pick<Partial<T>, keyof T>;
->v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 21, 3), Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
+var v04: TPR;
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 27, 3), Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
+>TPR : Symbol(TPR, Decl(mappedTypeModifiers.ts, 3, 53))
+
+var v04: { readonly [P in keyof T]?: T[P] };
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 27, 3), Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 28, 21))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 28, 21))
+
+var v04: Partial<TR>;
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 27, 3), Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 2, 37))
+
+var v04: Readonly<TP>;
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 27, 3), Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 1, 34))
+
+var v04: Partial<Readonly<T>>;
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 27, 3), Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+
+var v04: Readonly<Partial<T>>;
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 27, 3), Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+
+var v04: Pick<TPR, keyof T>;
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 27, 3), Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
->T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
-
-var v02: Pick<Partial<Readonly<T>>, keyof T>;
->v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 21, 3), Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
->Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
->T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
-
-// Validate that isomorphic mapped types preserve optional modifier
-var v03: TP;
->v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3))
->TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 2, 59))
-
-var v03: Partial<T>;
->v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3))
->Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
-
-// Validate that isomorphic mapped types preserve readonly modifier
-var v04: TR;
->v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
->TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 3, 37))
-
-var v04: Readonly<T>;
->v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
->Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
-
-// Validate that isomorphic mapped types preserve both partial and readonly modifiers
-var v05: TPR;
->v05 : Symbol(v05, Decl(mappedTypeModifiers.ts, 36, 3), Decl(mappedTypeModifiers.ts, 37, 3), Decl(mappedTypeModifiers.ts, 38, 3), Decl(mappedTypeModifiers.ts, 39, 3), Decl(mappedTypeModifiers.ts, 40, 3))
->TPR : Symbol(TPR, Decl(mappedTypeModifiers.ts, 4, 53))
-
-var v05: Partial<TR>;
->v05 : Symbol(v05, Decl(mappedTypeModifiers.ts, 36, 3), Decl(mappedTypeModifiers.ts, 37, 3), Decl(mappedTypeModifiers.ts, 38, 3), Decl(mappedTypeModifiers.ts, 39, 3), Decl(mappedTypeModifiers.ts, 40, 3))
->Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 3, 37))
-
-var v05: Readonly<TP>;
->v05 : Symbol(v05, Decl(mappedTypeModifiers.ts, 36, 3), Decl(mappedTypeModifiers.ts, 37, 3), Decl(mappedTypeModifiers.ts, 38, 3), Decl(mappedTypeModifiers.ts, 39, 3), Decl(mappedTypeModifiers.ts, 40, 3))
->Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 2, 59))
-
-var v05: Partial<Readonly<T>>;
->v05 : Symbol(v05, Decl(mappedTypeModifiers.ts, 36, 3), Decl(mappedTypeModifiers.ts, 37, 3), Decl(mappedTypeModifiers.ts, 38, 3), Decl(mappedTypeModifiers.ts, 39, 3), Decl(mappedTypeModifiers.ts, 40, 3))
->Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
-
-var v05: Readonly<Partial<T>>;
->v05 : Symbol(v05, Decl(mappedTypeModifiers.ts, 36, 3), Decl(mappedTypeModifiers.ts, 37, 3), Decl(mappedTypeModifiers.ts, 38, 3), Decl(mappedTypeModifiers.ts, 39, 3), Decl(mappedTypeModifiers.ts, 40, 3))
->Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>TPR : Symbol(TPR, Decl(mappedTypeModifiers.ts, 3, 53))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
 type Boxified<T> = { [P in keyof T]: { x: T[P] } };
->Boxified : Symbol(Boxified, Decl(mappedTypeModifiers.ts, 40, 30))
->T : Symbol(T, Decl(mappedTypeModifiers.ts, 42, 14))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 42, 22))
->T : Symbol(T, Decl(mappedTypeModifiers.ts, 42, 14))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 42, 38))
->T : Symbol(T, Decl(mappedTypeModifiers.ts, 42, 14))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 42, 22))
+>Boxified : Symbol(Boxified, Decl(mappedTypeModifiers.ts, 33, 28))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 35, 14))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 35, 22))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 35, 14))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 35, 38))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 35, 14))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 35, 22))
 
 type B = { a: { x: number }, b: { x: string } };
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 44, 10))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 44, 15))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 44, 28))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 44, 33))
-
-type BU = { a: { x: number } | undefined, b: { x: string } | undefined };
->BU : Symbol(BU, Decl(mappedTypeModifiers.ts, 44, 48))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 45, 11))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 45, 16))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 45, 41))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 45, 46))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 37, 10))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 37, 15))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 37, 28))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 37, 33))
 
 type BP = { a?: { x: number }, b?: { x: string } };
->BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 45, 73))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 46, 11))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 46, 17))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 46, 30))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 46, 36))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 37, 48))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 38, 11))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 38, 17))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 38, 30))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 38, 36))
 
 type BR = { readonly a: { x: number }, readonly b: { x: string } };
->BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 46, 51))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 47, 11))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 47, 25))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 47, 38))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 47, 52))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 38, 51))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 39, 11))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 39, 25))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 39, 38))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 39, 52))
 
 type BPR = { readonly a?: { x: number }, readonly b?: { x: string } };
->BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 47, 67))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 48, 12))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 48, 27))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 48, 40))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 48, 55))
+>BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 39, 67))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 40, 12))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 40, 27))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 40, 40))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 40, 55))
 
-// Validate they all have the same keys
 var b00: "a" | "b";
->b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 51, 3), Decl(mappedTypeModifiers.ts, 52, 3), Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
+>b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 42, 3), Decl(mappedTypeModifiers.ts, 43, 3), Decl(mappedTypeModifiers.ts, 44, 3), Decl(mappedTypeModifiers.ts, 45, 3), Decl(mappedTypeModifiers.ts, 46, 3))
 
 var b00: keyof B;
->b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 51, 3), Decl(mappedTypeModifiers.ts, 52, 3), Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
-
-var b00: keyof BU;
->b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 51, 3), Decl(mappedTypeModifiers.ts, 52, 3), Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
->BU : Symbol(BU, Decl(mappedTypeModifiers.ts, 44, 48))
+>b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 42, 3), Decl(mappedTypeModifiers.ts, 43, 3), Decl(mappedTypeModifiers.ts, 44, 3), Decl(mappedTypeModifiers.ts, 45, 3), Decl(mappedTypeModifiers.ts, 46, 3))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
 
 var b00: keyof BP;
->b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 51, 3), Decl(mappedTypeModifiers.ts, 52, 3), Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
->BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 45, 73))
+>b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 42, 3), Decl(mappedTypeModifiers.ts, 43, 3), Decl(mappedTypeModifiers.ts, 44, 3), Decl(mappedTypeModifiers.ts, 45, 3), Decl(mappedTypeModifiers.ts, 46, 3))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 37, 48))
 
 var b00: keyof BR;
->b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 51, 3), Decl(mappedTypeModifiers.ts, 52, 3), Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
->BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 46, 51))
+>b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 42, 3), Decl(mappedTypeModifiers.ts, 43, 3), Decl(mappedTypeModifiers.ts, 44, 3), Decl(mappedTypeModifiers.ts, 45, 3), Decl(mappedTypeModifiers.ts, 46, 3))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 38, 51))
 
 var b00: keyof BPR;
->b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 51, 3), Decl(mappedTypeModifiers.ts, 52, 3), Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
->BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 47, 67))
+>b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 42, 3), Decl(mappedTypeModifiers.ts, 43, 3), Decl(mappedTypeModifiers.ts, 44, 3), Decl(mappedTypeModifiers.ts, 45, 3), Decl(mappedTypeModifiers.ts, 46, 3))
+>BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 39, 67))
 
-// Validate that non-isomorphic mapped types strip modifiers
 var b01: B;
->b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3), Decl(mappedTypeModifiers.ts, 61, 3))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+>b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 48, 3), Decl(mappedTypeModifiers.ts, 49, 3), Decl(mappedTypeModifiers.ts, 50, 3), Decl(mappedTypeModifiers.ts, 51, 3))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
 
-var b01: Pick<BR, keyof B>;
->b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3), Decl(mappedTypeModifiers.ts, 61, 3))
+var b01: { [P in keyof B]: B[P] };
+>b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 48, 3), Decl(mappedTypeModifiers.ts, 49, 3), Decl(mappedTypeModifiers.ts, 50, 3), Decl(mappedTypeModifiers.ts, 51, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 49, 12))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 49, 12))
+
+var b01: Pick<B, keyof B>;
+>b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 48, 3), Decl(mappedTypeModifiers.ts, 49, 3), Decl(mappedTypeModifiers.ts, 50, 3), Decl(mappedTypeModifiers.ts, 51, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 46, 51))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
 
-var b01: Pick<Readonly<BR>, keyof B>;
->b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3), Decl(mappedTypeModifiers.ts, 61, 3))
+var b01: Pick<Pick<B, keyof B>, keyof B>;
+>b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 48, 3), Decl(mappedTypeModifiers.ts, 49, 3), Decl(mappedTypeModifiers.ts, 50, 3), Decl(mappedTypeModifiers.ts, 51, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 46, 51))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+>Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
 
-// Validate that non-isomorphic mapped types strip modifiers
-var b02: BU;
->b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3))
->BU : Symbol(BU, Decl(mappedTypeModifiers.ts, 44, 48))
+var b02: BP;
+>b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 37, 48))
+
+var b02: { [P in keyof B]?: B[P] };
+>b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 54, 12))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 54, 12))
+
+var b02: Partial<B>;
+>b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
 
 var b02: Pick<BP, keyof B>;
->b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3))
+>b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 45, 73))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 37, 48))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
 
-var b02: Pick<BPR, keyof B>;
->b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3))
+var b03: BR;
+>b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 58, 3), Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3), Decl(mappedTypeModifiers.ts, 61, 3))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 38, 51))
+
+var b03: { readonly [P in keyof B]: B[P] };
+>b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 58, 3), Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3), Decl(mappedTypeModifiers.ts, 61, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 59, 21))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 59, 21))
+
+var b03: Readonly<B>;
+>b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 58, 3), Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3), Decl(mappedTypeModifiers.ts, 61, 3))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+
+var b03: Pick<BR, keyof B>;
+>b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 58, 3), Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3), Decl(mappedTypeModifiers.ts, 61, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 47, 67))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 38, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
 
-var b02: Pick<Partial<B>, keyof B>;
->b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3))
+var b04: BPR;
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3))
+>BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 39, 67))
+
+var b04: { readonly [P in keyof B]?: B[P] };
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 64, 21))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 64, 21))
+
+var b04: Partial<BR>;
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 38, 51))
+
+var b04: Readonly<BP>;
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 37, 48))
+
+var b04: Partial<Readonly<B>>;
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+
+var b04: Readonly<Partial<B>>;
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3))
+>Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+
+var b04: Pick<BPR, keyof B>;
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
-
-var b02: Pick<Partial<Readonly<B>>, keyof B>;
->b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3))
->Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
-
-// Validate that isomorphic mapped types preserve optional modifier
-var b03: BP;
->b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 71, 3), Decl(mappedTypeModifiers.ts, 72, 3))
->BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 45, 73))
-
-var b03: Partial<B>;
->b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 71, 3), Decl(mappedTypeModifiers.ts, 72, 3))
->Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
-
-// Validate that isomorphic mapped types preserve readonly modifier
-var b04: BR;
->b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 75, 3), Decl(mappedTypeModifiers.ts, 76, 3))
->BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 46, 51))
-
-var b04: Readonly<B>;
->b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 75, 3), Decl(mappedTypeModifiers.ts, 76, 3))
->Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
-
-// Validate that isomorphic mapped types preserve both partial and readonly modifiers
-var b05: BPR;
->b05 : Symbol(b05, Decl(mappedTypeModifiers.ts, 79, 3), Decl(mappedTypeModifiers.ts, 80, 3), Decl(mappedTypeModifiers.ts, 81, 3), Decl(mappedTypeModifiers.ts, 82, 3), Decl(mappedTypeModifiers.ts, 83, 3))
->BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 47, 67))
-
-var b05: Partial<BR>;
->b05 : Symbol(b05, Decl(mappedTypeModifiers.ts, 79, 3), Decl(mappedTypeModifiers.ts, 80, 3), Decl(mappedTypeModifiers.ts, 81, 3), Decl(mappedTypeModifiers.ts, 82, 3), Decl(mappedTypeModifiers.ts, 83, 3))
->Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 46, 51))
-
-var b05: Readonly<BP>;
->b05 : Symbol(b05, Decl(mappedTypeModifiers.ts, 79, 3), Decl(mappedTypeModifiers.ts, 80, 3), Decl(mappedTypeModifiers.ts, 81, 3), Decl(mappedTypeModifiers.ts, 82, 3), Decl(mappedTypeModifiers.ts, 83, 3))
->Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 45, 73))
-
-var b05: Partial<Readonly<B>>;
->b05 : Symbol(b05, Decl(mappedTypeModifiers.ts, 79, 3), Decl(mappedTypeModifiers.ts, 80, 3), Decl(mappedTypeModifiers.ts, 81, 3), Decl(mappedTypeModifiers.ts, 82, 3), Decl(mappedTypeModifiers.ts, 83, 3))
->Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
-
-var b05: Readonly<Partial<B>>;
->b05 : Symbol(b05, Decl(mappedTypeModifiers.ts, 79, 3), Decl(mappedTypeModifiers.ts, 80, 3), Decl(mappedTypeModifiers.ts, 81, 3), Decl(mappedTypeModifiers.ts, 82, 3), Decl(mappedTypeModifiers.ts, 83, 3))
->Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 42, 51))
+>BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 39, 67))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
 

--- a/tests/baselines/reference/mappedTypeModifiers.types
+++ b/tests/baselines/reference/mappedTypeModifiers.types
@@ -5,11 +5,6 @@ type T = { a: number, b: string };
 >a : number
 >b : string
 
-type TU = { a: number | undefined, b: string | undefined };
->TU : TU
->a : number | undefined
->b : string | undefined
-
 type TP = { a?: number, b?: string };
 >TP : TP
 >a : number | undefined
@@ -25,17 +20,12 @@ type TPR = { readonly a?: number, readonly b?: string };
 >a : number | undefined
 >b : string | undefined
 
-// Validate they all have the same keys
 var v00: "a" | "b";
 >v00 : "a" | "b"
 
 var v00: keyof T;
 >v00 : "a" | "b"
 >T : T
-
-var v00: keyof TU;
->v00 : "a" | "b"
->TU : TU
 
 var v00: keyof TP;
 >v00 : "a" | "b"
@@ -49,101 +39,112 @@ var v00: keyof TPR;
 >v00 : "a" | "b"
 >TPR : TPR
 
-// Validate that non-isomorphic mapped types strip modifiers
 var v01: T;
 >v01 : T
 >T : T
 
-var v01: Pick<TR, keyof T>;
+var v01: { [P in keyof T]: T[P] };
+>v01 : T
+>P : P
+>T : T
+>T : T
+>P : P
+
+var v01: Pick<T, keyof T>;
 >v01 : T
 >Pick : Pick<T, K>
->TR : TR
+>T : T
 >T : T
 
-var v01: Pick<Readonly<T>, keyof T>;
+var v01: Pick<Pick<T, keyof T>, keyof T>;
 >v01 : T
 >Pick : Pick<T, K>
->Readonly : Readonly<T>
+>Pick : Pick<T, K>
+>T : T
 >T : T
 >T : T
 
-// Validate that non-isomorphic mapped types strip modifiers
-var v02: TU;
->v02 : TU
->TU : TU
+var v02: TP;
+>v02 : TP
+>TP : TP
+
+var v02: { [P in keyof T]?: T[P] };
+>v02 : TP
+>P : P
+>T : T
+>T : T
+>P : P
+
+var v02: Partial<T>;
+>v02 : TP
+>Partial : Partial<T>
+>T : T
 
 var v02: Pick<TP, keyof T>;
->v02 : TU
+>v02 : TP
 >Pick : Pick<T, K>
 >TP : TP
 >T : T
 
-var v02: Pick<TPR, keyof T>;
->v02 : TU
->Pick : Pick<T, K>
->TPR : TPR
->T : T
-
-var v02: Pick<Partial<T>, keyof T>;
->v02 : TU
->Pick : Pick<T, K>
->Partial : Partial<T>
->T : T
->T : T
-
-var v02: Pick<Partial<Readonly<T>>, keyof T>;
->v02 : TU
->Pick : Pick<T, K>
->Partial : Partial<T>
->Readonly : Readonly<T>
->T : T
->T : T
-
-// Validate that isomorphic mapped types preserve optional modifier
-var v03: TP;
->v03 : TP
->TP : TP
-
-var v03: Partial<T>;
->v03 : TP
->Partial : Partial<T>
->T : T
-
-// Validate that isomorphic mapped types preserve readonly modifier
-var v04: TR;
->v04 : TR
+var v03: TR;
+>v03 : TR
 >TR : TR
 
-var v04: Readonly<T>;
->v04 : TR
+var v03: { readonly [P in keyof T]: T[P] };
+>v03 : TR
+>P : P
+>T : T
+>T : T
+>P : P
+
+var v03: Readonly<T>;
+>v03 : TR
 >Readonly : Readonly<T>
 >T : T
 
-// Validate that isomorphic mapped types preserve both partial and readonly modifiers
-var v05: TPR;
->v05 : TPR
+var v03: Pick<TR, keyof T>;
+>v03 : TR
+>Pick : Pick<T, K>
+>TR : TR
+>T : T
+
+var v04: TPR;
+>v04 : TPR
 >TPR : TPR
 
-var v05: Partial<TR>;
->v05 : TPR
+var v04: { readonly [P in keyof T]?: T[P] };
+>v04 : TPR
+>P : P
+>T : T
+>T : T
+>P : P
+
+var v04: Partial<TR>;
+>v04 : TPR
 >Partial : Partial<T>
 >TR : TR
 
-var v05: Readonly<TP>;
->v05 : TPR
+var v04: Readonly<TP>;
+>v04 : TPR
 >Readonly : Readonly<T>
 >TP : TP
 
-var v05: Partial<Readonly<T>>;
->v05 : TPR
+var v04: Partial<Readonly<T>>;
+>v04 : TPR
 >Partial : Partial<T>
 >Readonly : Readonly<T>
 >T : T
 
-var v05: Readonly<Partial<T>>;
->v05 : TPR
+var v04: Readonly<Partial<T>>;
+>v04 : TPR
 >Readonly : Readonly<T>
 >Partial : Partial<T>
+>T : T
+
+var v04: Pick<TPR, keyof T>;
+>v04 : TPR
+>Pick : Pick<T, K>
+>TPR : TPR
 >T : T
 
 type Boxified<T> = { [P in keyof T]: { x: T[P] } };
@@ -160,13 +161,6 @@ type B = { a: { x: number }, b: { x: string } };
 >a : { x: number; }
 >x : number
 >b : { x: string; }
->x : string
-
-type BU = { a: { x: number } | undefined, b: { x: string } | undefined };
->BU : BU
->a : { x: number; } | undefined
->x : number
->b : { x: string; } | undefined
 >x : string
 
 type BP = { a?: { x: number }, b?: { x: string } };
@@ -190,17 +184,12 @@ type BPR = { readonly a?: { x: number }, readonly b?: { x: string } };
 >b : { x: string; } | undefined
 >x : string
 
-// Validate they all have the same keys
 var b00: "a" | "b";
 >b00 : "a" | "b"
 
 var b00: keyof B;
 >b00 : "a" | "b"
 >B : B
-
-var b00: keyof BU;
->b00 : "a" | "b"
->BU : BU
 
 var b00: keyof BP;
 >b00 : "a" | "b"
@@ -214,100 +203,111 @@ var b00: keyof BPR;
 >b00 : "a" | "b"
 >BPR : BPR
 
-// Validate that non-isomorphic mapped types strip modifiers
 var b01: B;
 >b01 : B
 >B : B
 
-var b01: Pick<BR, keyof B>;
+var b01: { [P in keyof B]: B[P] };
+>b01 : B
+>P : P
+>B : B
+>B : B
+>P : P
+
+var b01: Pick<B, keyof B>;
 >b01 : B
 >Pick : Pick<T, K>
->BR : BR
+>B : B
 >B : B
 
-var b01: Pick<Readonly<BR>, keyof B>;
+var b01: Pick<Pick<B, keyof B>, keyof B>;
 >b01 : B
 >Pick : Pick<T, K>
->Readonly : Readonly<T>
->BR : BR
+>Pick : Pick<T, K>
+>B : B
+>B : B
 >B : B
 
-// Validate that non-isomorphic mapped types strip modifiers
-var b02: BU;
->b02 : BU
->BU : BU
+var b02: BP;
+>b02 : BP
+>BP : BP
+
+var b02: { [P in keyof B]?: B[P] };
+>b02 : BP
+>P : P
+>B : B
+>B : B
+>P : P
+
+var b02: Partial<B>;
+>b02 : BP
+>Partial : Partial<T>
+>B : B
 
 var b02: Pick<BP, keyof B>;
->b02 : BU
+>b02 : BP
 >Pick : Pick<T, K>
 >BP : BP
 >B : B
 
-var b02: Pick<BPR, keyof B>;
->b02 : BU
->Pick : Pick<T, K>
->BPR : BPR
->B : B
-
-var b02: Pick<Partial<B>, keyof B>;
->b02 : BU
->Pick : Pick<T, K>
->Partial : Partial<T>
->B : B
->B : B
-
-var b02: Pick<Partial<Readonly<B>>, keyof B>;
->b02 : BU
->Pick : Pick<T, K>
->Partial : Partial<T>
->Readonly : Readonly<T>
->B : B
->B : B
-
-// Validate that isomorphic mapped types preserve optional modifier
-var b03: BP;
->b03 : BP
->BP : BP
-
-var b03: Partial<B>;
->b03 : BP
->Partial : Partial<T>
->B : B
-
-// Validate that isomorphic mapped types preserve readonly modifier
-var b04: BR;
->b04 : BR
+var b03: BR;
+>b03 : BR
 >BR : BR
 
-var b04: Readonly<B>;
->b04 : BR
+var b03: { readonly [P in keyof B]: B[P] };
+>b03 : BR
+>P : P
+>B : B
+>B : B
+>P : P
+
+var b03: Readonly<B>;
+>b03 : BR
 >Readonly : Readonly<T>
 >B : B
 
-// Validate that isomorphic mapped types preserve both partial and readonly modifiers
-var b05: BPR;
->b05 : BPR
+var b03: Pick<BR, keyof B>;
+>b03 : BR
+>Pick : Pick<T, K>
+>BR : BR
+>B : B
+
+var b04: BPR;
+>b04 : BPR
 >BPR : BPR
 
-var b05: Partial<BR>;
->b05 : BPR
+var b04: { readonly [P in keyof B]?: B[P] };
+>b04 : BPR
+>P : P
+>B : B
+>B : B
+>P : P
+
+var b04: Partial<BR>;
+>b04 : BPR
 >Partial : Partial<T>
 >BR : BR
 
-var b05: Readonly<BP>;
->b05 : BPR
+var b04: Readonly<BP>;
+>b04 : BPR
 >Readonly : Readonly<T>
 >BP : BP
 
-var b05: Partial<Readonly<B>>;
->b05 : BPR
+var b04: Partial<Readonly<B>>;
+>b04 : BPR
 >Partial : Partial<T>
 >Readonly : Readonly<T>
 >B : B
 
-var b05: Readonly<Partial<B>>;
->b05 : BPR
+var b04: Readonly<Partial<B>>;
+>b04 : BPR
 >Readonly : Readonly<T>
 >Partial : Partial<T>
+>B : B
+
+var b04: Pick<BPR, keyof B>;
+>b04 : BPR
+>Pick : Pick<T, K>
+>BPR : BPR
 >B : B
 

--- a/tests/cases/conformance/types/mapped/mappedTypeErrors.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypeErrors.ts
@@ -85,3 +85,43 @@ function f21() {
     let x2 = objAndPartial({ x: 0, y: 0 }, { x: 1, y: 1 });
     let x3 = objAndPartial({ x: 0, y: 0 }, { x: 1, y: 1, z: 1 });  // Error
 }
+
+// Verify use of Pick<T, K> for setState functions (#12793)
+
+interface Foo {
+    a: string;
+    b?: number;
+}
+
+function setState<T, K extends keyof T>(obj: T, props: Pick<T, K>) {
+    for (let k in props) {
+        obj[k] = props[k];
+    }
+}
+
+let foo: Foo = { a: "hello", b: 42 };
+setState(foo, { a: "test", b: 43 })
+setState(foo, { a: "hi" });
+setState(foo, { b: undefined });
+setState(foo, { });
+setState(foo, foo);
+setState(foo, { a: undefined });  // Error
+setState(foo, { c: true });  // Error
+
+class C<T> {
+    state: T;
+    setState<K extends keyof T>(props: Pick<T, K>) {
+        for (let k in props) {
+            this.state[k] = props[k];
+        }
+    }
+}
+
+let c = new C<Foo>();
+c.setState({ a: "test", b: 43 });
+c.setState({ a: "hi" });
+c.setState({ b: undefined });
+c.setState({ });
+c.setState(foo);
+c.setState({ a: undefined });  // Error
+c.setState({ c: true });  // Error

--- a/tests/cases/conformance/types/mapped/mappedTypeModifiers.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypeModifiers.ts
@@ -1,85 +1,71 @@
 // @strictNullChecks: true
 
 type T = { a: number, b: string };
-type TU = { a: number | undefined, b: string | undefined };
 type TP = { a?: number, b?: string };
 type TR = { readonly a: number, readonly b: string };
 type TPR = { readonly a?: number, readonly b?: string };
 
-// Validate they all have the same keys
 var v00: "a" | "b";
 var v00: keyof T;
-var v00: keyof TU;
 var v00: keyof TP;
 var v00: keyof TR;
 var v00: keyof TPR;
 
-// Validate that non-isomorphic mapped types strip modifiers
 var v01: T;
-var v01: Pick<TR, keyof T>;
-var v01: Pick<Readonly<T>, keyof T>;
+var v01: { [P in keyof T]: T[P] };
+var v01: Pick<T, keyof T>;
+var v01: Pick<Pick<T, keyof T>, keyof T>;
 
-// Validate that non-isomorphic mapped types strip modifiers
-var v02: TU;
+var v02: TP;
+var v02: { [P in keyof T]?: T[P] };
+var v02: Partial<T>;
 var v02: Pick<TP, keyof T>;
-var v02: Pick<TPR, keyof T>;
-var v02: Pick<Partial<T>, keyof T>;
-var v02: Pick<Partial<Readonly<T>>, keyof T>;
 
-// Validate that isomorphic mapped types preserve optional modifier
-var v03: TP;
-var v03: Partial<T>;
+var v03: TR;
+var v03: { readonly [P in keyof T]: T[P] };
+var v03: Readonly<T>;
+var v03: Pick<TR, keyof T>;
 
-// Validate that isomorphic mapped types preserve readonly modifier
-var v04: TR;
-var v04: Readonly<T>;
-
-// Validate that isomorphic mapped types preserve both partial and readonly modifiers
-var v05: TPR;
-var v05: Partial<TR>;
-var v05: Readonly<TP>;
-var v05: Partial<Readonly<T>>;
-var v05: Readonly<Partial<T>>;
+var v04: TPR;
+var v04: { readonly [P in keyof T]?: T[P] };
+var v04: Partial<TR>;
+var v04: Readonly<TP>;
+var v04: Partial<Readonly<T>>;
+var v04: Readonly<Partial<T>>;
+var v04: Pick<TPR, keyof T>;
 
 type Boxified<T> = { [P in keyof T]: { x: T[P] } };
 
 type B = { a: { x: number }, b: { x: string } };
-type BU = { a: { x: number } | undefined, b: { x: string } | undefined };
 type BP = { a?: { x: number }, b?: { x: string } };
 type BR = { readonly a: { x: number }, readonly b: { x: string } };
 type BPR = { readonly a?: { x: number }, readonly b?: { x: string } };
 
-// Validate they all have the same keys
 var b00: "a" | "b";
 var b00: keyof B;
-var b00: keyof BU;
 var b00: keyof BP;
 var b00: keyof BR;
 var b00: keyof BPR;
 
-// Validate that non-isomorphic mapped types strip modifiers
 var b01: B;
-var b01: Pick<BR, keyof B>;
-var b01: Pick<Readonly<BR>, keyof B>;
+var b01: { [P in keyof B]: B[P] };
+var b01: Pick<B, keyof B>;
+var b01: Pick<Pick<B, keyof B>, keyof B>;
 
-// Validate that non-isomorphic mapped types strip modifiers
-var b02: BU;
+var b02: BP;
+var b02: { [P in keyof B]?: B[P] };
+var b02: Partial<B>;
 var b02: Pick<BP, keyof B>;
-var b02: Pick<BPR, keyof B>;
-var b02: Pick<Partial<B>, keyof B>;
-var b02: Pick<Partial<Readonly<B>>, keyof B>;
 
-// Validate that isomorphic mapped types preserve optional modifier
-var b03: BP;
-var b03: Partial<B>;
+var b03: BR;
+var b03: { readonly [P in keyof B]: B[P] };
+var b03: Readonly<B>;
+var b03: Pick<BR, keyof B>;
 
-// Validate that isomorphic mapped types preserve readonly modifier
-var b04: BR;
-var b04: Readonly<B>;
-
-// Validate that isomorphic mapped types preserve both partial and readonly modifiers
-var b05: BPR;
-var b05: Partial<BR>;
-var b05: Readonly<BP>;
-var b05: Partial<Readonly<B>>;
-var b05: Readonly<Partial<B>>;
+var b04: BPR;
+var b04: { readonly [P in keyof B]?: B[P] };
+var b04: Partial<BR>;
+var b04: Readonly<BP>;
+var b04: Partial<Readonly<B>>;
+var b04: Readonly<Partial<B>>;
+var b04: Pick<BPR, keyof B>;


### PR DESCRIPTION
With this PR we more consistently propagate property modifiers in mapped types. For a given type parameter `T`, mapped types declared as `{ [P in keyof T]: X }` or `{ [P in K]: X}`, where `K` is a type parameter `K extends keyof T`, now propagate property modifiers from `T`. This in particular means that the predefined type `Pick<T, K>` now propagates property modifiers from `T`.

The intuitive way to think of this is that when a mapped type is known to operate on property names from a particular type (i.e. `T` in `keyof T`) or a subset of the property names of a particular type, then we propagate the property modifiers from that type.

```ts
interface Foo {
    a: string;
    b?: number;
}

function setState<T, K extends keyof T>(obj: T, props: Pick<T, K>) {
    for (let k in props) {
        obj[k] = props[k];
    }
}

let foo: Foo = { a: "hello", b: 42 };
setState(foo, { a: "test", b: 43 })
setState(foo, { a: "hi" });
setState(foo, { b: undefined });
setState(foo, { });
setState(foo, foo);
setState(foo, { a: undefined });  // Error
setState(foo, { c: true });  // Error

class C<T> {
    state: T;
    setState<K extends keyof T>(props: Pick<T, K>) {
        for (let k in props) {
            this.state[k] = props[k];
        }
    }
}

let c = new C<Foo>();
c.setState({ a: "test", b: 43 });
c.setState({ a: "hi" });
c.setState({ b: undefined });
c.setState({ });
c.setState(foo);
c.setState({ a: undefined });  // Error
c.setState({ c: true });  // Error
```

Note that because `Pick<T, K>` now propagates modifiers, it can no longer be used to "strip" modifiers.

Fixes #12793.