### PR TITLE
Additional tweak to mapped type property modifier propagation

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4577,12 +4577,22 @@ namespace ts {
 
         function getModifiersTypeFromMappedType(type: MappedType) {
             if (!type.modifiersType) {
-                // If the mapped type was declared as { [P in keyof T]: X } or as { [P in K]: X }, where
-                // K is constrained to 'K extends keyof T', then we will copy property modifiers from T.
-                const declaredType = <MappedType>getTypeFromMappedTypeNode(type.declaration);
-                const constraint = getConstraintTypeFromMappedType(declaredType);
-                const extendedConstraint = constraint.flags & TypeFlags.TypeParameter ? getConstraintOfTypeParameter(<TypeParameter>constraint) : constraint;
-                type.modifiersType = extendedConstraint.flags & TypeFlags.Index ? instantiateType((<IndexType>extendedConstraint).type, type.mapper || identityMapper) : emptyObjectType;
+                const constraintDeclaration = type.declaration.typeParameter.constraint;
+                if (constraintDeclaration.kind === SyntaxKind.TypeOperator) {
+                    // If the constraint declaration is a 'keyof T' node, the modifiers type is T. We check
+                    // AST nodes here because, when T is a non-generic type, the logic below eagerly resolves
+                    // 'keyof T' to a literal union type and we can't recover T from that type.
+                    type.modifiersType = instantiateType(getTypeFromTypeNode((<TypeOperatorNode>constraintDeclaration).type), type.mapper || identityMapper);
+                }
+                else {
+                    // Otherwise, get the declared constraint type, and if the constraint type is a type parameter,
+                    // get the constraint of that type parameter. If the resulting type is an indexed type 'keyof T',
+                    // the modifiers type is T. Otherwise, the modifiers type is {}.
+                    const declaredType = <MappedType>getTypeFromMappedTypeNode(type.declaration);
+                    const constraint = getConstraintTypeFromMappedType(declaredType);
+                    const extendedConstraint = constraint.flags & TypeFlags.TypeParameter ? getConstraintOfTypeParameter(<TypeParameter>constraint) : constraint;
+                    type.modifiersType = extendedConstraint.flags & TypeFlags.Index ? instantiateType((<IndexType>extendedConstraint).type, type.mapper || identityMapper) : emptyObjectType;
+                }
             }
             return type.modifiersType;
         }

--- a/tests/baselines/reference/mappedTypeModifiers.js
+++ b/tests/baselines/reference/mappedTypeModifiers.js
@@ -19,12 +19,14 @@ var v01: Pick<Pick<T, keyof T>, keyof T>;
 var v02: TP;
 var v02: { [P in keyof T]?: T[P] };
 var v02: Partial<T>;
-var v02: Pick<TP, keyof T>;
+var v02: { [P in keyof TP]: TP[P] }
+var v02: Pick<TP, keyof TP>;
 
 var v03: TR;
 var v03: { readonly [P in keyof T]: T[P] };
 var v03: Readonly<T>;
-var v03: Pick<TR, keyof T>;
+var v03: { [P in keyof TR]: TR[P] }
+var v03: Pick<TR, keyof TR>;
 
 var v04: TPR;
 var v04: { readonly [P in keyof T]?: T[P] };
@@ -32,6 +34,7 @@ var v04: Partial<TR>;
 var v04: Readonly<TP>;
 var v04: Partial<Readonly<T>>;
 var v04: Readonly<Partial<T>>;
+var v04: { [P in keyof TPR]: TPR[P] }
 var v04: Pick<TPR, keyof T>;
 
 type Boxified<T> = { [P in keyof T]: { x: T[P] } };
@@ -55,12 +58,14 @@ var b01: Pick<Pick<B, keyof B>, keyof B>;
 var b02: BP;
 var b02: { [P in keyof B]?: B[P] };
 var b02: Partial<B>;
-var b02: Pick<BP, keyof B>;
+var b02: { [P in keyof BP]: BP[P] }
+var b02: Pick<BP, keyof BP>;
 
 var b03: BR;
 var b03: { readonly [P in keyof B]: B[P] };
 var b03: Readonly<B>;
-var b03: Pick<BR, keyof B>;
+var b03: { [P in keyof BR]: BR[P] }
+var b03: Pick<BR, keyof BR>;
 
 var b04: BPR;
 var b04: { readonly [P in keyof B]?: B[P] };
@@ -68,7 +73,8 @@ var b04: Partial<BR>;
 var b04: Readonly<BP>;
 var b04: Partial<Readonly<B>>;
 var b04: Readonly<Partial<B>>;
-var b04: Pick<BPR, keyof B>;
+var b04: { [P in keyof BPR]: BPR[P] }
+var b04: Pick<BPR, keyof BPR>;
 
 //// [mappedTypeModifiers.js]
 var v00;
@@ -84,10 +90,13 @@ var v02;
 var v02;
 var v02;
 var v02;
+var v02;
 var v03;
 var v03;
 var v03;
 var v03;
+var v03;
+var v04;
 var v04;
 var v04;
 var v04;
@@ -108,10 +117,13 @@ var b02;
 var b02;
 var b02;
 var b02;
+var b02;
 var b03;
 var b03;
 var b03;
 var b03;
+var b03;
+var b04;
 var b04;
 var b04;
 var b04;

--- a/tests/baselines/reference/mappedTypeModifiers.symbols
+++ b/tests/baselines/reference/mappedTypeModifiers.symbols
@@ -65,249 +65,291 @@ var v01: Pick<Pick<T, keyof T>, keyof T>;
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
 var v02: TP;
->v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3), Decl(mappedTypeModifiers.ts, 19, 3), Decl(mappedTypeModifiers.ts, 20, 3))
+>v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3), Decl(mappedTypeModifiers.ts, 19, 3), Decl(mappedTypeModifiers.ts, 20, 3), Decl(mappedTypeModifiers.ts, 21, 3))
 >TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 1, 34))
 
 var v02: { [P in keyof T]?: T[P] };
->v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3), Decl(mappedTypeModifiers.ts, 19, 3), Decl(mappedTypeModifiers.ts, 20, 3))
+>v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3), Decl(mappedTypeModifiers.ts, 19, 3), Decl(mappedTypeModifiers.ts, 20, 3), Decl(mappedTypeModifiers.ts, 21, 3))
 >P : Symbol(P, Decl(mappedTypeModifiers.ts, 18, 12))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 >P : Symbol(P, Decl(mappedTypeModifiers.ts, 18, 12))
 
 var v02: Partial<T>;
->v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3), Decl(mappedTypeModifiers.ts, 19, 3), Decl(mappedTypeModifiers.ts, 20, 3))
+>v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3), Decl(mappedTypeModifiers.ts, 19, 3), Decl(mappedTypeModifiers.ts, 20, 3), Decl(mappedTypeModifiers.ts, 21, 3))
 >Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
-var v02: Pick<TP, keyof T>;
->v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3), Decl(mappedTypeModifiers.ts, 19, 3), Decl(mappedTypeModifiers.ts, 20, 3))
+var v02: { [P in keyof TP]: TP[P] }
+>v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3), Decl(mappedTypeModifiers.ts, 19, 3), Decl(mappedTypeModifiers.ts, 20, 3), Decl(mappedTypeModifiers.ts, 21, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 20, 12))
+>TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 1, 34))
+>TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 1, 34))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 20, 12))
+
+var v02: Pick<TP, keyof TP>;
+>v02 : Symbol(v02, Decl(mappedTypeModifiers.ts, 17, 3), Decl(mappedTypeModifiers.ts, 18, 3), Decl(mappedTypeModifiers.ts, 19, 3), Decl(mappedTypeModifiers.ts, 20, 3), Decl(mappedTypeModifiers.ts, 21, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
 >TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 1, 34))
->T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+>TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 1, 34))
 
 var v03: TR;
->v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
+>v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3), Decl(mappedTypeModifiers.ts, 26, 3), Decl(mappedTypeModifiers.ts, 27, 3))
 >TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 2, 37))
 
 var v03: { readonly [P in keyof T]: T[P] };
->v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 23, 21))
+>v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3), Decl(mappedTypeModifiers.ts, 26, 3), Decl(mappedTypeModifiers.ts, 27, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 24, 21))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 23, 21))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 24, 21))
 
 var v03: Readonly<T>;
->v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
+>v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3), Decl(mappedTypeModifiers.ts, 26, 3), Decl(mappedTypeModifiers.ts, 27, 3))
 >Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
-var v03: Pick<TR, keyof T>;
->v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 22, 3), Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3))
+var v03: { [P in keyof TR]: TR[P] }
+>v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3), Decl(mappedTypeModifiers.ts, 26, 3), Decl(mappedTypeModifiers.ts, 27, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 26, 12))
+>TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 2, 37))
+>TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 2, 37))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 26, 12))
+
+var v03: Pick<TR, keyof TR>;
+>v03 : Symbol(v03, Decl(mappedTypeModifiers.ts, 23, 3), Decl(mappedTypeModifiers.ts, 24, 3), Decl(mappedTypeModifiers.ts, 25, 3), Decl(mappedTypeModifiers.ts, 26, 3), Decl(mappedTypeModifiers.ts, 27, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
 >TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 2, 37))
->T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
+>TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 2, 37))
 
 var v04: TPR;
->v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 27, 3), Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3), Decl(mappedTypeModifiers.ts, 34, 3), Decl(mappedTypeModifiers.ts, 35, 3), Decl(mappedTypeModifiers.ts, 36, 3))
 >TPR : Symbol(TPR, Decl(mappedTypeModifiers.ts, 3, 53))
 
 var v04: { readonly [P in keyof T]?: T[P] };
->v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 27, 3), Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 28, 21))
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3), Decl(mappedTypeModifiers.ts, 34, 3), Decl(mappedTypeModifiers.ts, 35, 3), Decl(mappedTypeModifiers.ts, 36, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 30, 21))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 28, 21))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 30, 21))
 
 var v04: Partial<TR>;
->v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 27, 3), Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3), Decl(mappedTypeModifiers.ts, 34, 3), Decl(mappedTypeModifiers.ts, 35, 3), Decl(mappedTypeModifiers.ts, 36, 3))
 >Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
 >TR : Symbol(TR, Decl(mappedTypeModifiers.ts, 2, 37))
 
 var v04: Readonly<TP>;
->v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 27, 3), Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3), Decl(mappedTypeModifiers.ts, 34, 3), Decl(mappedTypeModifiers.ts, 35, 3), Decl(mappedTypeModifiers.ts, 36, 3))
 >Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
 >TP : Symbol(TP, Decl(mappedTypeModifiers.ts, 1, 34))
 
 var v04: Partial<Readonly<T>>;
->v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 27, 3), Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3), Decl(mappedTypeModifiers.ts, 34, 3), Decl(mappedTypeModifiers.ts, 35, 3), Decl(mappedTypeModifiers.ts, 36, 3))
 >Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
 >Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
 var v04: Readonly<Partial<T>>;
->v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 27, 3), Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3), Decl(mappedTypeModifiers.ts, 34, 3), Decl(mappedTypeModifiers.ts, 35, 3), Decl(mappedTypeModifiers.ts, 36, 3))
 >Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
 >Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
+var v04: { [P in keyof TPR]: TPR[P] }
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3), Decl(mappedTypeModifiers.ts, 34, 3), Decl(mappedTypeModifiers.ts, 35, 3), Decl(mappedTypeModifiers.ts, 36, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 35, 12))
+>TPR : Symbol(TPR, Decl(mappedTypeModifiers.ts, 3, 53))
+>TPR : Symbol(TPR, Decl(mappedTypeModifiers.ts, 3, 53))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 35, 12))
+
 var v04: Pick<TPR, keyof T>;
->v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 27, 3), Decl(mappedTypeModifiers.ts, 28, 3), Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3))
+>v04 : Symbol(v04, Decl(mappedTypeModifiers.ts, 29, 3), Decl(mappedTypeModifiers.ts, 30, 3), Decl(mappedTypeModifiers.ts, 31, 3), Decl(mappedTypeModifiers.ts, 32, 3), Decl(mappedTypeModifiers.ts, 33, 3), Decl(mappedTypeModifiers.ts, 34, 3), Decl(mappedTypeModifiers.ts, 35, 3), Decl(mappedTypeModifiers.ts, 36, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
 >TPR : Symbol(TPR, Decl(mappedTypeModifiers.ts, 3, 53))
 >T : Symbol(T, Decl(mappedTypeModifiers.ts, 0, 0))
 
 type Boxified<T> = { [P in keyof T]: { x: T[P] } };
->Boxified : Symbol(Boxified, Decl(mappedTypeModifiers.ts, 33, 28))
->T : Symbol(T, Decl(mappedTypeModifiers.ts, 35, 14))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 35, 22))
->T : Symbol(T, Decl(mappedTypeModifiers.ts, 35, 14))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 35, 38))
->T : Symbol(T, Decl(mappedTypeModifiers.ts, 35, 14))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 35, 22))
+>Boxified : Symbol(Boxified, Decl(mappedTypeModifiers.ts, 36, 28))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 38, 14))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 38, 22))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 38, 14))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 38, 38))
+>T : Symbol(T, Decl(mappedTypeModifiers.ts, 38, 14))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 38, 22))
 
 type B = { a: { x: number }, b: { x: string } };
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 37, 10))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 37, 15))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 37, 28))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 37, 33))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 40, 10))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 40, 15))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 40, 28))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 40, 33))
 
 type BP = { a?: { x: number }, b?: { x: string } };
->BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 37, 48))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 38, 11))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 38, 17))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 38, 30))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 38, 36))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 40, 48))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 41, 11))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 41, 17))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 41, 30))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 41, 36))
 
 type BR = { readonly a: { x: number }, readonly b: { x: string } };
->BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 38, 51))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 39, 11))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 39, 25))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 39, 38))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 39, 52))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 41, 51))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 42, 11))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 42, 25))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 42, 38))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 42, 52))
 
 type BPR = { readonly a?: { x: number }, readonly b?: { x: string } };
->BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 39, 67))
->a : Symbol(a, Decl(mappedTypeModifiers.ts, 40, 12))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 40, 27))
->b : Symbol(b, Decl(mappedTypeModifiers.ts, 40, 40))
->x : Symbol(x, Decl(mappedTypeModifiers.ts, 40, 55))
+>BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 42, 67))
+>a : Symbol(a, Decl(mappedTypeModifiers.ts, 43, 12))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 43, 27))
+>b : Symbol(b, Decl(mappedTypeModifiers.ts, 43, 40))
+>x : Symbol(x, Decl(mappedTypeModifiers.ts, 43, 55))
 
 var b00: "a" | "b";
->b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 42, 3), Decl(mappedTypeModifiers.ts, 43, 3), Decl(mappedTypeModifiers.ts, 44, 3), Decl(mappedTypeModifiers.ts, 45, 3), Decl(mappedTypeModifiers.ts, 46, 3))
+>b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 45, 3), Decl(mappedTypeModifiers.ts, 46, 3), Decl(mappedTypeModifiers.ts, 47, 3), Decl(mappedTypeModifiers.ts, 48, 3), Decl(mappedTypeModifiers.ts, 49, 3))
 
 var b00: keyof B;
->b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 42, 3), Decl(mappedTypeModifiers.ts, 43, 3), Decl(mappedTypeModifiers.ts, 44, 3), Decl(mappedTypeModifiers.ts, 45, 3), Decl(mappedTypeModifiers.ts, 46, 3))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 45, 3), Decl(mappedTypeModifiers.ts, 46, 3), Decl(mappedTypeModifiers.ts, 47, 3), Decl(mappedTypeModifiers.ts, 48, 3), Decl(mappedTypeModifiers.ts, 49, 3))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
 
 var b00: keyof BP;
->b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 42, 3), Decl(mappedTypeModifiers.ts, 43, 3), Decl(mappedTypeModifiers.ts, 44, 3), Decl(mappedTypeModifiers.ts, 45, 3), Decl(mappedTypeModifiers.ts, 46, 3))
->BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 37, 48))
+>b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 45, 3), Decl(mappedTypeModifiers.ts, 46, 3), Decl(mappedTypeModifiers.ts, 47, 3), Decl(mappedTypeModifiers.ts, 48, 3), Decl(mappedTypeModifiers.ts, 49, 3))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 40, 48))
 
 var b00: keyof BR;
->b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 42, 3), Decl(mappedTypeModifiers.ts, 43, 3), Decl(mappedTypeModifiers.ts, 44, 3), Decl(mappedTypeModifiers.ts, 45, 3), Decl(mappedTypeModifiers.ts, 46, 3))
->BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 38, 51))
+>b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 45, 3), Decl(mappedTypeModifiers.ts, 46, 3), Decl(mappedTypeModifiers.ts, 47, 3), Decl(mappedTypeModifiers.ts, 48, 3), Decl(mappedTypeModifiers.ts, 49, 3))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 41, 51))
 
 var b00: keyof BPR;
->b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 42, 3), Decl(mappedTypeModifiers.ts, 43, 3), Decl(mappedTypeModifiers.ts, 44, 3), Decl(mappedTypeModifiers.ts, 45, 3), Decl(mappedTypeModifiers.ts, 46, 3))
->BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 39, 67))
+>b00 : Symbol(b00, Decl(mappedTypeModifiers.ts, 45, 3), Decl(mappedTypeModifiers.ts, 46, 3), Decl(mappedTypeModifiers.ts, 47, 3), Decl(mappedTypeModifiers.ts, 48, 3), Decl(mappedTypeModifiers.ts, 49, 3))
+>BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 42, 67))
 
 var b01: B;
->b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 48, 3), Decl(mappedTypeModifiers.ts, 49, 3), Decl(mappedTypeModifiers.ts, 50, 3), Decl(mappedTypeModifiers.ts, 51, 3))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 51, 3), Decl(mappedTypeModifiers.ts, 52, 3), Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
 
 var b01: { [P in keyof B]: B[P] };
->b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 48, 3), Decl(mappedTypeModifiers.ts, 49, 3), Decl(mappedTypeModifiers.ts, 50, 3), Decl(mappedTypeModifiers.ts, 51, 3))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 49, 12))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 49, 12))
+>b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 51, 3), Decl(mappedTypeModifiers.ts, 52, 3), Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 52, 12))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 52, 12))
 
 var b01: Pick<B, keyof B>;
->b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 48, 3), Decl(mappedTypeModifiers.ts, 49, 3), Decl(mappedTypeModifiers.ts, 50, 3), Decl(mappedTypeModifiers.ts, 51, 3))
+>b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 51, 3), Decl(mappedTypeModifiers.ts, 52, 3), Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
 
 var b01: Pick<Pick<B, keyof B>, keyof B>;
->b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 48, 3), Decl(mappedTypeModifiers.ts, 49, 3), Decl(mappedTypeModifiers.ts, 50, 3), Decl(mappedTypeModifiers.ts, 51, 3))
+>b01 : Symbol(b01, Decl(mappedTypeModifiers.ts, 51, 3), Decl(mappedTypeModifiers.ts, 52, 3), Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
 
 var b02: BP;
->b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
->BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 37, 48))
+>b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 56, 3), Decl(mappedTypeModifiers.ts, 57, 3), Decl(mappedTypeModifiers.ts, 58, 3), Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 40, 48))
 
 var b02: { [P in keyof B]?: B[P] };
->b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 54, 12))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 54, 12))
+>b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 56, 3), Decl(mappedTypeModifiers.ts, 57, 3), Decl(mappedTypeModifiers.ts, 58, 3), Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 57, 12))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 57, 12))
 
 var b02: Partial<B>;
->b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
+>b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 56, 3), Decl(mappedTypeModifiers.ts, 57, 3), Decl(mappedTypeModifiers.ts, 58, 3), Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3))
 >Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
 
-var b02: Pick<BP, keyof B>;
->b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 53, 3), Decl(mappedTypeModifiers.ts, 54, 3), Decl(mappedTypeModifiers.ts, 55, 3), Decl(mappedTypeModifiers.ts, 56, 3))
+var b02: { [P in keyof BP]: BP[P] }
+>b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 56, 3), Decl(mappedTypeModifiers.ts, 57, 3), Decl(mappedTypeModifiers.ts, 58, 3), Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 59, 12))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 40, 48))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 40, 48))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 59, 12))
+
+var b02: Pick<BP, keyof BP>;
+>b02 : Symbol(b02, Decl(mappedTypeModifiers.ts, 56, 3), Decl(mappedTypeModifiers.ts, 57, 3), Decl(mappedTypeModifiers.ts, 58, 3), Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 37, 48))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 40, 48))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 40, 48))
 
 var b03: BR;
->b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 58, 3), Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3), Decl(mappedTypeModifiers.ts, 61, 3))
->BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 38, 51))
+>b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 62, 3), Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 41, 51))
 
 var b03: { readonly [P in keyof B]: B[P] };
->b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 58, 3), Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3), Decl(mappedTypeModifiers.ts, 61, 3))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 59, 21))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 59, 21))
+>b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 62, 3), Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 63, 21))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 63, 21))
 
 var b03: Readonly<B>;
->b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 58, 3), Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3), Decl(mappedTypeModifiers.ts, 61, 3))
+>b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 62, 3), Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3))
 >Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
 
-var b03: Pick<BR, keyof B>;
->b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 58, 3), Decl(mappedTypeModifiers.ts, 59, 3), Decl(mappedTypeModifiers.ts, 60, 3), Decl(mappedTypeModifiers.ts, 61, 3))
+var b03: { [P in keyof BR]: BR[P] }
+>b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 62, 3), Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 65, 12))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 41, 51))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 41, 51))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 65, 12))
+
+var b03: Pick<BR, keyof BR>;
+>b03 : Symbol(b03, Decl(mappedTypeModifiers.ts, 62, 3), Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 38, 51))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 41, 51))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 41, 51))
 
 var b04: BPR;
->b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3))
->BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 39, 67))
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3), Decl(mappedTypeModifiers.ts, 70, 3), Decl(mappedTypeModifiers.ts, 71, 3), Decl(mappedTypeModifiers.ts, 72, 3), Decl(mappedTypeModifiers.ts, 73, 3), Decl(mappedTypeModifiers.ts, 74, 3), Decl(mappedTypeModifiers.ts, 75, 3))
+>BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 42, 67))
 
 var b04: { readonly [P in keyof B]?: B[P] };
->b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 64, 21))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
->P : Symbol(P, Decl(mappedTypeModifiers.ts, 64, 21))
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3), Decl(mappedTypeModifiers.ts, 70, 3), Decl(mappedTypeModifiers.ts, 71, 3), Decl(mappedTypeModifiers.ts, 72, 3), Decl(mappedTypeModifiers.ts, 73, 3), Decl(mappedTypeModifiers.ts, 74, 3), Decl(mappedTypeModifiers.ts, 75, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 69, 21))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 69, 21))
 
 var b04: Partial<BR>;
->b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3))
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3), Decl(mappedTypeModifiers.ts, 70, 3), Decl(mappedTypeModifiers.ts, 71, 3), Decl(mappedTypeModifiers.ts, 72, 3), Decl(mappedTypeModifiers.ts, 73, 3), Decl(mappedTypeModifiers.ts, 74, 3), Decl(mappedTypeModifiers.ts, 75, 3))
 >Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 38, 51))
+>BR : Symbol(BR, Decl(mappedTypeModifiers.ts, 41, 51))
 
 var b04: Readonly<BP>;
->b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3))
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3), Decl(mappedTypeModifiers.ts, 70, 3), Decl(mappedTypeModifiers.ts, 71, 3), Decl(mappedTypeModifiers.ts, 72, 3), Decl(mappedTypeModifiers.ts, 73, 3), Decl(mappedTypeModifiers.ts, 74, 3), Decl(mappedTypeModifiers.ts, 75, 3))
 >Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 37, 48))
+>BP : Symbol(BP, Decl(mappedTypeModifiers.ts, 40, 48))
 
 var b04: Partial<Readonly<B>>;
->b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3))
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3), Decl(mappedTypeModifiers.ts, 70, 3), Decl(mappedTypeModifiers.ts, 71, 3), Decl(mappedTypeModifiers.ts, 72, 3), Decl(mappedTypeModifiers.ts, 73, 3), Decl(mappedTypeModifiers.ts, 74, 3), Decl(mappedTypeModifiers.ts, 75, 3))
 >Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
 >Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
 
 var b04: Readonly<Partial<B>>;
->b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3))
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3), Decl(mappedTypeModifiers.ts, 70, 3), Decl(mappedTypeModifiers.ts, 71, 3), Decl(mappedTypeModifiers.ts, 72, 3), Decl(mappedTypeModifiers.ts, 73, 3), Decl(mappedTypeModifiers.ts, 74, 3), Decl(mappedTypeModifiers.ts, 75, 3))
 >Readonly : Symbol(Readonly, Decl(lib.d.ts, --, --))
 >Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>B : Symbol(B, Decl(mappedTypeModifiers.ts, 38, 51))
 
-var b04: Pick<BPR, keyof B>;
->b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 63, 3), Decl(mappedTypeModifiers.ts, 64, 3), Decl(mappedTypeModifiers.ts, 65, 3), Decl(mappedTypeModifiers.ts, 66, 3), Decl(mappedTypeModifiers.ts, 67, 3), Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3))
+var b04: { [P in keyof BPR]: BPR[P] }
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3), Decl(mappedTypeModifiers.ts, 70, 3), Decl(mappedTypeModifiers.ts, 71, 3), Decl(mappedTypeModifiers.ts, 72, 3), Decl(mappedTypeModifiers.ts, 73, 3), Decl(mappedTypeModifiers.ts, 74, 3), Decl(mappedTypeModifiers.ts, 75, 3))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 74, 12))
+>BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 42, 67))
+>BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 42, 67))
+>P : Symbol(P, Decl(mappedTypeModifiers.ts, 74, 12))
+
+var b04: Pick<BPR, keyof BPR>;
+>b04 : Symbol(b04, Decl(mappedTypeModifiers.ts, 68, 3), Decl(mappedTypeModifiers.ts, 69, 3), Decl(mappedTypeModifiers.ts, 70, 3), Decl(mappedTypeModifiers.ts, 71, 3), Decl(mappedTypeModifiers.ts, 72, 3), Decl(mappedTypeModifiers.ts, 73, 3), Decl(mappedTypeModifiers.ts, 74, 3), Decl(mappedTypeModifiers.ts, 75, 3))
 >Pick : Symbol(Pick, Decl(lib.d.ts, --, --))
->BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 39, 67))
->B : Symbol(B, Decl(mappedTypeModifiers.ts, 35, 51))
+>BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 42, 67))
+>BPR : Symbol(BPR, Decl(mappedTypeModifiers.ts, 42, 67))
 

--- a/tests/baselines/reference/mappedTypeModifiers.types
+++ b/tests/baselines/reference/mappedTypeModifiers.types
@@ -80,11 +80,18 @@ var v02: Partial<T>;
 >Partial : Partial<T>
 >T : T
 
-var v02: Pick<TP, keyof T>;
+var v02: { [P in keyof TP]: TP[P] }
+>v02 : TP
+>P : P
+>TP : TP
+>TP : TP
+>P : P
+
+var v02: Pick<TP, keyof TP>;
 >v02 : TP
 >Pick : Pick<T, K>
 >TP : TP
->T : T
+>TP : TP
 
 var v03: TR;
 >v03 : TR
@@ -102,11 +109,18 @@ var v03: Readonly<T>;
 >Readonly : Readonly<T>
 >T : T
 
-var v03: Pick<TR, keyof T>;
+var v03: { [P in keyof TR]: TR[P] }
+>v03 : TR
+>P : P
+>TR : TR
+>TR : TR
+>P : P
+
+var v03: Pick<TR, keyof TR>;
 >v03 : TR
 >Pick : Pick<T, K>
 >TR : TR
->T : T
+>TR : TR
 
 var v04: TPR;
 >v04 : TPR
@@ -140,6 +154,13 @@ var v04: Readonly<Partial<T>>;
 >Readonly : Readonly<T>
 >Partial : Partial<T>
 >T : T
+
+var v04: { [P in keyof TPR]: TPR[P] }
+>v04 : TPR
+>P : P
+>TPR : TPR
+>TPR : TPR
+>P : P
 
 var v04: Pick<TPR, keyof T>;
 >v04 : TPR
@@ -244,11 +265,18 @@ var b02: Partial<B>;
 >Partial : Partial<T>
 >B : B
 
-var b02: Pick<BP, keyof B>;
+var b02: { [P in keyof BP]: BP[P] }
+>b02 : BP
+>P : P
+>BP : BP
+>BP : BP
+>P : P
+
+var b02: Pick<BP, keyof BP>;
 >b02 : BP
 >Pick : Pick<T, K>
 >BP : BP
->B : B
+>BP : BP
 
 var b03: BR;
 >b03 : BR
@@ -266,11 +294,18 @@ var b03: Readonly<B>;
 >Readonly : Readonly<T>
 >B : B
 
-var b03: Pick<BR, keyof B>;
+var b03: { [P in keyof BR]: BR[P] }
+>b03 : BR
+>P : P
+>BR : BR
+>BR : BR
+>P : P
+
+var b03: Pick<BR, keyof BR>;
 >b03 : BR
 >Pick : Pick<T, K>
 >BR : BR
->B : B
+>BR : BR
 
 var b04: BPR;
 >b04 : BPR
@@ -305,9 +340,16 @@ var b04: Readonly<Partial<B>>;
 >Partial : Partial<T>
 >B : B
 
-var b04: Pick<BPR, keyof B>;
+var b04: { [P in keyof BPR]: BPR[P] }
+>b04 : BPR
+>P : P
+>BPR : BPR
+>BPR : BPR
+>P : P
+
+var b04: Pick<BPR, keyof BPR>;
 >b04 : BPR
 >Pick : Pick<T, K>
 >BPR : BPR
->B : B
+>BPR : BPR
 

--- a/tests/cases/conformance/types/mapped/mappedTypeModifiers.ts
+++ b/tests/cases/conformance/types/mapped/mappedTypeModifiers.ts
@@ -19,12 +19,14 @@ var v01: Pick<Pick<T, keyof T>, keyof T>;
 var v02: TP;
 var v02: { [P in keyof T]?: T[P] };
 var v02: Partial<T>;
-var v02: Pick<TP, keyof T>;
+var v02: { [P in keyof TP]: TP[P] }
+var v02: Pick<TP, keyof TP>;
 
 var v03: TR;
 var v03: { readonly [P in keyof T]: T[P] };
 var v03: Readonly<T>;
-var v03: Pick<TR, keyof T>;
+var v03: { [P in keyof TR]: TR[P] }
+var v03: Pick<TR, keyof TR>;
 
 var v04: TPR;
 var v04: { readonly [P in keyof T]?: T[P] };
@@ -32,6 +34,7 @@ var v04: Partial<TR>;
 var v04: Readonly<TP>;
 var v04: Partial<Readonly<T>>;
 var v04: Readonly<Partial<T>>;
+var v04: { [P in keyof TPR]: TPR[P] }
 var v04: Pick<TPR, keyof T>;
 
 type Boxified<T> = { [P in keyof T]: { x: T[P] } };
@@ -55,12 +58,14 @@ var b01: Pick<Pick<B, keyof B>, keyof B>;
 var b02: BP;
 var b02: { [P in keyof B]?: B[P] };
 var b02: Partial<B>;
-var b02: Pick<BP, keyof B>;
+var b02: { [P in keyof BP]: BP[P] }
+var b02: Pick<BP, keyof BP>;
 
 var b03: BR;
 var b03: { readonly [P in keyof B]: B[P] };
 var b03: Readonly<B>;
-var b03: Pick<BR, keyof B>;
+var b03: { [P in keyof BR]: BR[P] }
+var b03: Pick<BR, keyof BR>;
 
 var b04: BPR;
 var b04: { readonly [P in keyof B]?: B[P] };
@@ -68,4 +73,5 @@ var b04: Partial<BR>;
 var b04: Readonly<BP>;
 var b04: Partial<Readonly<B>>;
 var b04: Readonly<Partial<B>>;
-var b04: Pick<BPR, keyof B>;
+var b04: { [P in keyof BPR]: BPR[P] }
+var b04: Pick<BPR, keyof BPR>;


### PR DESCRIPTION
This PR adds a bit of functionality that was lost with #12826. Specifically, with #12826 we don't propagate property modifiers in a mapped type `{ [P in keyof T]: X }` if `T` is written as a non-generic type. This PR fixes that.

Fixes #12842.

cc: @mhegazy 