### PR TITLE
Produce an error for an augmentation of an untyped module even if `moduleNotFoundError` is not defined

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1439,9 +1439,8 @@ namespace ts {
              // May be an untyped module. If so, ignore resolutionDiagnostic.
             if (!isRelative && resolvedModule && !extensionIsTypeScript(resolvedModule.extension)) {
                 if (isForAugmentation) {
-                    Debug.assert(!!moduleNotFoundError);
                     const diag = Diagnostics.Invalid_module_name_in_augmentation_Module_0_resolves_to_an_untyped_module_at_1_which_cannot_be_augmented;
-                    error(errorNode, diag, moduleName, resolvedModule.resolvedFileName);
+                    error(errorNode, diag, moduleReference, resolvedModule.resolvedFileName);
                 }
                 else if (compilerOptions.noImplicitAny && moduleNotFoundError) {
                     error(errorNode,

--- a/tests/baselines/reference/untypedModuleImport_withAugmentation2.errors.txt
+++ b/tests/baselines/reference/untypedModuleImport_withAugmentation2.errors.txt
@@ -1,0 +1,19 @@
+/node_modules/augmenter/index.d.ts(3,16): error TS2665: Invalid module name in augmentation. Module 'js' resolves to an untyped module at '/node_modules/js/index.js', which cannot be augmented.
+
+
+==== /a.ts (0 errors) ====
+    import { } from "augmenter";
+    
+==== /node_modules/augmenter/index.d.ts (1 errors) ====
+    // This tests that augmenting an untyped module is forbidden even in an ambient context. Contrast with `moduleAugmentationInDependency.ts`.
+    
+    declare module "js" {
+                   ~~~~
+!!! error TS2665: Invalid module name in augmentation. Module 'js' resolves to an untyped module at '/node_modules/js/index.js', which cannot be augmented.
+        export const j: number;
+    }
+    export {};
+    
+==== /node_modules/js/index.js (0 errors) ====
+    This file is not processed.
+    

--- a/tests/baselines/reference/untypedModuleImport_withAugmentation2.js
+++ b/tests/baselines/reference/untypedModuleImport_withAugmentation2.js
@@ -1,0 +1,19 @@
+//// [tests/cases/compiler/untypedModuleImport_withAugmentation2.ts] ////
+
+//// [index.d.ts]
+// This tests that augmenting an untyped module is forbidden even in an ambient context. Contrast with `moduleAugmentationInDependency.ts`.
+
+declare module "js" {
+    export const j: number;
+}
+export {};
+
+//// [index.js]
+This file is not processed.
+
+//// [a.ts]
+import { } from "augmenter";
+
+
+//// [a.js]
+"use strict";

--- a/tests/cases/compiler/untypedModuleImport_withAugmentation2.ts
+++ b/tests/cases/compiler/untypedModuleImport_withAugmentation2.ts
@@ -1,0 +1,14 @@
+// @noImplicitReferences: true
+// This tests that augmenting an untyped module is forbidden even in an ambient context. Contrast with `moduleAugmentationInDependency.ts`.
+
+// @Filename: /node_modules/augmenter/index.d.ts
+declare module "js" {
+    export const j: number;
+}
+export {};
+
+// @Filename: /node_modules/js/index.js
+This file is not processed.
+
+// @Filename: /a.ts
+import { } from "augmenter";


### PR DESCRIPTION
Fixes #12827

The fix in #11962 asserted that `moduleNotFoundError` would be defined for any module augmentations.
However, if the augmentation is in a declaration file, this is undefined, because we don't validate names of augmentations that are defined in ambient context. See #8200. The reason @vladima mentioned was (https://github.com/Microsoft/TypeScript/issues/8113#issuecomment-211058891):

> it is quite possible that some 3rd party module A that was imported in application also defines an augmentation for some another module B but application itself does not use B and as a consequence does not have dependency on it so resolution for B always will fail and user will always see some errors that he cannot get rid of.

However, if we have an untyped import, that means that we *are* using the library, but don't have typings for it. The problem is that you can't augment typings that don't exist.
We could elide the error, but the augmentation would then have no effect -- you would still get `any` when trying to use functions defined by the augmentation.
