### PR TITLE
Expose JSDoc tags through the language service

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -6468,7 +6468,7 @@ namespace ts {
 
                 function parseTagComments(indent: number) {
                     const comments: string[] = [];
-                    let state = JSDocState.SawAsterisk;
+                    let state = JSDocState.BeginningOfLine;
                     let margin: number | undefined;
                     function pushComment(text: string) {
                         if (!margin) {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1442,7 +1442,7 @@ namespace ts {
         return node && firstOrUndefined(getJSDocTags(node, kind));
     }
 
-   function getJSDocs(node: Node): (JSDoc | JSDocTag)[] {
+   export function getJSDocs(node: Node): (JSDoc | JSDocTag)[] {
         let cache: (JSDoc | JSDocTag)[] = node.jsDocCache;
         if (!cache) {
             getJSDocsWorker(node);

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -961,7 +961,9 @@ namespace FourSlash {
 
         public verifyQuickInfoDisplayParts(kind: string, kindModifiers: string, textSpan: { start: number; length: number; },
             displayParts: ts.SymbolDisplayPart[],
-            documentation: ts.SymbolDisplayPart[]) {
+            documentation: ts.SymbolDisplayPart[],
+            tags: ts.JSDocTagInfo[]
+            ) {
 
             const actualQuickInfo = this.languageService.getQuickInfoAtPosition(this.activeFile.fileName, this.currentCaretPosition);
             assert.equal(actualQuickInfo.kind, kind, this.messageAtLastKnownMarker("QuickInfo kind"));
@@ -969,6 +971,11 @@ namespace FourSlash {
             assert.equal(JSON.stringify(actualQuickInfo.textSpan), JSON.stringify(textSpan), this.messageAtLastKnownMarker("QuickInfo textSpan"));
             assert.equal(TestState.getDisplayPartsJson(actualQuickInfo.displayParts), TestState.getDisplayPartsJson(displayParts), this.messageAtLastKnownMarker("QuickInfo displayParts"));
             assert.equal(TestState.getDisplayPartsJson(actualQuickInfo.documentation), TestState.getDisplayPartsJson(documentation), this.messageAtLastKnownMarker("QuickInfo documentation"));
+            assert.equal(actualQuickInfo.tags.length, tags.length, this.messageAtLastKnownMarker("QuickInfo tags"));
+            ts.zipWith(tags, actualQuickInfo.tags, (expectedTag, actualTag) => {
+                assert.equal(expectedTag.name, actualTag.name);
+                assert.equal(expectedTag.text, actualTag.text, this.messageAtLastKnownMarker("QuickInfo tag " + actualTag.name));
+            });
         }
 
         public verifyRenameLocations(findInStrings: boolean, findInComments: boolean, ranges?: Range[]) {
@@ -3414,8 +3421,8 @@ namespace FourSlashInterface {
         }
 
         public verifyQuickInfoDisplayParts(kind: string, kindModifiers: string, textSpan: { start: number; length: number; },
-            displayParts: ts.SymbolDisplayPart[], documentation: ts.SymbolDisplayPart[]) {
-            this.state.verifyQuickInfoDisplayParts(kind, kindModifiers, textSpan, displayParts, documentation);
+            displayParts: ts.SymbolDisplayPart[], documentation: ts.SymbolDisplayPart[], tags: ts.JSDocTagInfo[]) {
+            this.state.verifyQuickInfoDisplayParts(kind, kindModifiers, textSpan, displayParts, documentation, tags);
         }
 
         public getSyntacticDiagnostics(expected: string) {

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -801,7 +801,7 @@ namespace FourSlash {
             }
         }
 
-        public verifyCompletionEntryDetails(entryName: string, expectedText: string, expectedDocumentation?: string, kind?: string) {
+        public verifyCompletionEntryDetails(entryName: string, expectedText: string, expectedDocumentation?: string, kind?: string, tags?: ts.JSDocTagInfo[]) {
             const details = this.getCompletionEntryDetails(entryName);
 
             assert(details, "no completion entry available");
@@ -814,6 +814,14 @@ namespace FourSlash {
 
             if (kind !== undefined) {
                 assert.equal(details.kind, kind, this.assertionMessageAtLastKnownMarker("completion entry kind"));
+            }
+
+            if (tags !== undefined) {
+                assert.equal(details.tags.length, tags.length, this.messageAtLastKnownMarker("QuickInfo tags"));
+                ts.zipWith(tags, details.tags, (expectedTag, actualTag) => {
+                    assert.equal(expectedTag.name, actualTag.name);
+                    assert.equal(expectedTag.text, actualTag.text, this.messageAtLastKnownMarker("QuickInfo tag " + actualTag.name));
+                });
             }
         }
 
@@ -3404,8 +3412,8 @@ namespace FourSlashInterface {
             this.state.verifyDocumentHighlightsAtPositionListCount(expectedCount, fileNamesToSearch);
         }
 
-        public completionEntryDetailIs(entryName: string, text: string, documentation?: string, kind?: string) {
-            this.state.verifyCompletionEntryDetails(entryName, text, documentation, kind);
+        public completionEntryDetailIs(entryName: string, text: string, documentation?: string, kind?: string, tags?: ts.JSDocTagInfo[]) {
+            this.state.verifyCompletionEntryDetails(entryName, text, documentation, kind, tags);
         }
 
         /**

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1069,6 +1069,16 @@ namespace FourSlash {
             assert.equal(ts.displayPartsToString(actualDocComment), docComment, this.assertionMessageAtLastKnownMarker("current signature help doc comment"));
         }
 
+        public verifyCurrentSignatureHelpTags(tags: ts.JSDocTagInfo[]) {
+            const actualTags = this.getActiveSignatureHelpItem().tags;
+
+            assert.equal(actualTags.length, tags.length, this.assertionMessageAtLastKnownMarker("signature help tags"));
+            ts.zipWith(tags, actualTags, (expectedTag, actualTag) => {
+                assert.equal(expectedTag.name, actualTag.name);
+                assert.equal(expectedTag.text, actualTag.text, this.assertionMessageAtLastKnownMarker("signature help tag " + actualTag.name));
+            });
+        }
+
         public verifySignatureHelpCount(expected: number) {
             const help = this.languageService.getSignatureHelpItems(this.activeFile.fileName, this.currentCaretPosition);
             const actual = help && help.items ? help.items.length : 0;
@@ -3268,6 +3278,10 @@ namespace FourSlashInterface {
 
         public currentSignatureHelpDocCommentIs(docComment: string) {
             this.state.verifyCurrentSignatureHelpDocComment(docComment);
+        }
+
+        public currentSignatureHelpTagsAre(tags: ts.JSDocTagInfo[]) {
+            this.state.verifyCurrentSignatureHelpTags(tags);
         }
 
         public signatureHelpCountIs(expected: number) {

--- a/src/server/client.ts
+++ b/src/server/client.ts
@@ -176,7 +176,8 @@ namespace ts.server {
                 kindModifiers: response.body.kindModifiers,
                 textSpan: ts.createTextSpanFromBounds(start, end),
                 displayParts: [{ kind: "text", text: response.body.displayString }],
-                documentation: [{ kind: "text", text: response.body.documentation }]
+                documentation: [{ kind: "text", text: response.body.documentation }],
+                tags: response.body.tags
             };
         }
 

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1600,6 +1600,11 @@ namespace ts.server.protocol {
          * The signature's documentation
          */
         documentation: SymbolDisplayPart[];
+
+        /**
+         * The signature's JSDoc tags
+         */
+        tags: JSDocTagInfo[];
     }
 
     /**

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1530,6 +1530,11 @@ namespace ts.server.protocol {
           * Documentation strings for the symbol.
           */
         documentation: SymbolDisplayPart[];
+
+        /**
+          * JSDoc tags for the symbol.
+          */
+        tags: JSDocTagInfo[];
     }
 
     export interface CompletionsResponse extends Response {

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1295,6 +1295,11 @@ namespace ts.server.protocol {
           * Documentation associated with symbol.
           */
         documentation: string;
+
+        /**
+         * JSDoc tags associated with symbol.
+         */
+        tags: JSDocTagInfo[]
     }
 
     /**

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -853,7 +853,7 @@ namespace ts.server {
             if (simplifiedResult) {
                 const displayString = ts.displayPartsToString(quickInfo.displayParts);
                 const docString = ts.displayPartsToString(quickInfo.documentation);
-                
+
                 return {
                     kind: quickInfo.kind,
                     kindModifiers: quickInfo.kindModifiers,

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -853,11 +853,7 @@ namespace ts.server {
             if (simplifiedResult) {
                 const displayString = ts.displayPartsToString(quickInfo.displayParts);
                 const docString = ts.displayPartsToString(quickInfo.documentation);
-                let tags: ts.JSDocTagInfo[] = [];
-                if (quickInfo.tags) {
-                    tags = quickInfo.tags;
-                }
-
+                
                 return {
                     kind: quickInfo.kind,
                     kindModifiers: quickInfo.kindModifiers,
@@ -865,7 +861,7 @@ namespace ts.server {
                     end: scriptInfo.positionToLineOffset(ts.textSpanEnd(quickInfo.textSpan)),
                     displayString: displayString,
                     documentation: docString,
-                    tags: tags
+                    tags: quickInfo.tags || []
                 };
             }
             else {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -853,6 +853,11 @@ namespace ts.server {
             if (simplifiedResult) {
                 const displayString = ts.displayPartsToString(quickInfo.displayParts);
                 const docString = ts.displayPartsToString(quickInfo.documentation);
+                let tags: ts.JSDocTagInfo[] = [];
+                if (quickInfo.tags) {
+                    tags = quickInfo.tags;
+                }
+
                 return {
                     kind: quickInfo.kind,
                     kindModifiers: quickInfo.kindModifiers,
@@ -860,6 +865,7 @@ namespace ts.server {
                     end: scriptInfo.positionToLineOffset(ts.textSpanEnd(quickInfo.textSpan)),
                     displayString: displayString,
                     documentation: docString,
+                    tags: tags
                 };
             }
             else {

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -759,14 +759,14 @@ namespace ts.Completions {
             const symbol = forEach(symbols, s => getCompletionEntryDisplayNameForSymbol(typeChecker, s, compilerOptions.target, /*performCharacterChecks*/ false, location) === entryName ? s : undefined);
 
             if (symbol) {
-                const { displayParts, documentation, symbolKind, jsDocTags } = SymbolDisplay.getSymbolDisplayPartsDocumentationAndSymbolKind(typeChecker, symbol, sourceFile, location, location, SemanticMeaning.All);
+                const { displayParts, documentation, symbolKind, tags } = SymbolDisplay.getSymbolDisplayPartsDocumentationAndSymbolKind(typeChecker, symbol, sourceFile, location, location, SemanticMeaning.All);
                 return {
                     name: entryName,
                     kindModifiers: SymbolDisplay.getSymbolModifiers(symbol),
                     kind: symbolKind,
                     displayParts,
                     documentation,
-                    tags: jsDocTags
+                    tags
                 };
             }
         }

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -759,13 +759,14 @@ namespace ts.Completions {
             const symbol = forEach(symbols, s => getCompletionEntryDisplayNameForSymbol(typeChecker, s, compilerOptions.target, /*performCharacterChecks*/ false, location) === entryName ? s : undefined);
 
             if (symbol) {
-                const { displayParts, documentation, symbolKind } = SymbolDisplay.getSymbolDisplayPartsDocumentationAndSymbolKind(typeChecker, symbol, sourceFile, location, location, SemanticMeaning.All);
+                const { displayParts, documentation, symbolKind, jsDocTags } = SymbolDisplay.getSymbolDisplayPartsDocumentationAndSymbolKind(typeChecker, symbol, sourceFile, location, location, SemanticMeaning.All);
                 return {
                     name: entryName,
                     kindModifiers: SymbolDisplay.getSymbolModifiers(symbol),
                     kind: symbolKind,
                     displayParts,
-                    documentation
+                    documentation,
+                    tags: jsDocTags
                 };
             }
         }
@@ -778,7 +779,8 @@ namespace ts.Completions {
                 kind: ScriptElementKind.keyword,
                 kindModifiers: ScriptElementKindModifier.none,
                 displayParts: [displayPart(entryName, SymbolDisplayPartKind.keyword)],
-                documentation: undefined
+                documentation: undefined,
+                tags: undefined
             };
         }
 

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -76,19 +76,14 @@ namespace ts.JsDoc {
             if (!jsDocs) {
                 return;
             }
-            const jsDocTags: JSDocTag[] = [];
-            jsDocs.forEach(doc => {
+            for (const doc of jsDocs) {
                 const tagsForDoc = (doc as JSDoc).tags;
                 if (tagsForDoc) {
-                    jsDocTags.push(...tagsForDoc.filter(tag => tag.kind === SyntaxKind.JSDocTag));
-                }
-            });
-            if (!jsDocTags) {
-                return;
-            }
-            for (const tag of jsDocTags) {
-                if (tag) {
-                    tags.push({ name: tag.tagName.text, text: tag.comment });
+                    tags.push(...tagsForDoc.filter(tag => tag.kind === SyntaxKind.JSDocTag).map(jsDocTag => { 
+                        return { 
+                            name: jsDocTag.tagName.text, 
+                            text: jsDocTag.comment 
+                        } }));
                 }
             }
         });

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -79,10 +79,10 @@ namespace ts.JsDoc {
             for (const doc of jsDocs) {
                 const tagsForDoc = (doc as JSDoc).tags;
                 if (tagsForDoc) {
-                    tags.push(...tagsForDoc.filter(tag => tag.kind === SyntaxKind.JSDocTag).map(jsDocTag => { 
-                        return { 
-                            name: jsDocTag.tagName.text, 
-                            text: jsDocTag.comment 
+                    tags.push(...tagsForDoc.filter(tag => tag.kind === SyntaxKind.JSDocTag).map(jsDocTag => {
+                        return {
+                            name: jsDocTag.tagName.text,
+                            text: jsDocTag.comment
                         } }));
                 }
             }

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -68,6 +68,33 @@ namespace ts.JsDoc {
         return documentationComment;
     }
 
+    export function getJsDocTagsFromDeclarations(declarations: Declaration[]) {
+        // Only collect doc comments from duplicate declarations once.
+        const tags: JSDocTagInfo[] = [];
+        forEachUnique(declarations, declaration => {
+            const jsDocs = getJSDocs(declaration);
+            if (!jsDocs) {
+                return;
+            }
+            const jsDocTags: JSDocTag[] = [];
+            jsDocs.forEach(doc => {
+                const tagsForDoc = (doc as JSDoc).tags;
+                if (tagsForDoc) {
+                    jsDocTags.push(...tagsForDoc.filter(tag => tag.kind === SyntaxKind.JSDocTag));
+                }
+            });
+            if (!jsDocTags) {
+                return;
+            }
+            for (const tag of jsDocTags) {
+                if (tag) {
+                    tags.push({ name: tag.tagName.text, text: tag.comment });
+                }
+            }
+        });
+        return tags;
+    }
+
     /**
      * Iterates through 'array' by index and performs the callback on each element of array until the callback
      * returns a truthy value, then returns that value.

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1355,7 +1355,7 @@ namespace ts {
                 textSpan: createTextSpan(node.getStart(), node.getWidth()),
                 displayParts: displayPartsDocumentationsAndKind.displayParts,
                 documentation: displayPartsDocumentationsAndKind.documentation,
-                tags: displayPartsDocumentationsAndKind.jsDocTags
+                tags: displayPartsDocumentationsAndKind.tags
             };
         }
 

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -292,6 +292,10 @@ namespace ts {
         // symbol has no doc comment, then the empty string will be returned.
         documentationComment: SymbolDisplayPart[];
 
+        // Undefined is used to indicate the value has not been computed. If, after computing, the
+        // symbol has no JSDoc tags, then the empty array will be returned.
+        tags: JSDocTagInfo[];
+
         constructor(flags: SymbolFlags, name: string) {
             this.flags = flags;
             this.name = name;
@@ -315,6 +319,14 @@ namespace ts {
             }
 
             return this.documentationComment;
+        }
+
+        getJsDocTags(): JSDocTagInfo[] {
+            if (this.tags === undefined) {
+                this.tags = JsDoc.getJsDocTagsFromDeclarations(this.declarations);
+            }
+
+            return this.tags;
         }
     }
 
@@ -404,6 +416,10 @@ namespace ts {
         // symbol has no doc comment, then the empty string will be returned.
         documentationComment: SymbolDisplayPart[];
 
+        // Undefined is used to indicate the value has not been computed. If, after computing, the
+        // symbol has no doc comment, then the empty array will be returned.
+        jsDocTags: JSDocTagInfo[];
+
         constructor(checker: TypeChecker) {
             this.checker = checker;
         }
@@ -426,6 +442,14 @@ namespace ts {
             }
 
             return this.documentationComment;
+        }
+
+        getJsDocTags(): JSDocTagInfo[] {
+            if (this.jsDocTags === undefined) {
+                this.jsDocTags = this.declaration ? JsDoc.getJsDocTagsFromDeclarations([this.declaration]) : [];
+            }
+
+            return this.jsDocTags;
         }
     }
 
@@ -1315,7 +1339,8 @@ namespace ts {
                                 kindModifiers: ScriptElementKindModifier.none,
                                 textSpan: createTextSpan(node.getStart(), node.getWidth()),
                                 displayParts: typeToDisplayParts(typeChecker, type, getContainerNode(node)),
-                                documentation: type.symbol ? type.symbol.getDocumentationComment() : undefined
+                                documentation: type.symbol ? type.symbol.getDocumentationComment() : undefined,
+                                tags: type.symbol ? type.symbol.getJsDocTags() : undefined
                             };
                         }
                 }
@@ -1329,7 +1354,8 @@ namespace ts {
                 kindModifiers: SymbolDisplay.getSymbolModifiers(symbol),
                 textSpan: createTextSpan(node.getStart(), node.getWidth()),
                 displayParts: displayPartsDocumentationsAndKind.displayParts,
-                documentation: displayPartsDocumentationsAndKind.documentation
+                documentation: displayPartsDocumentationsAndKind.documentation,
+                tags: displayPartsDocumentationsAndKind.jsDocTags
             };
         }
 

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -590,7 +590,8 @@ namespace ts.SignatureHelp {
                 suffixDisplayParts,
                 separatorDisplayParts: [punctuationPart(SyntaxKind.CommaToken), spacePart()],
                 parameters: signatureHelpParameters,
-                documentation: candidateSignature.getDocumentationComment()
+                documentation: candidateSignature.getDocumentationComment(),
+                tags: candidateSignature.getJsDocTags()
             };
         });
 

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -89,6 +89,7 @@ namespace ts.SymbolDisplay {
 
         const displayParts: SymbolDisplayPart[] = [];
         let documentation: SymbolDisplayPart[];
+        let jsDocTags: JSDocTagInfo[];
         const symbolFlags = symbol.flags;
         let symbolKind = getSymbolKindOfConstructorPropertyMethodAccessorFunctionOrVar(typeChecker, symbol, symbolFlags, location);
         let hasAddedSymbolInfo: boolean;
@@ -407,6 +408,7 @@ namespace ts.SymbolDisplay {
 
         if (!documentation) {
             documentation = symbol.getDocumentationComment();
+            jsDocTags = symbol.getJsDocTags();
             if (documentation.length === 0 && symbol.flags & SymbolFlags.Property) {
                 // For some special property access expressions like `experts.foo = foo` or `module.exports.foo = foo`
                 // there documentation comments might be attached to the right hand side symbol of their declarations.
@@ -423,6 +425,7 @@ namespace ts.SymbolDisplay {
                         }
 
                         documentation = rhsSymbol.getDocumentationComment();
+                        jsDocTags = rhsSymbol.getJsDocTags();
                         if (documentation.length > 0) {
                             break;
                         }
@@ -431,7 +434,7 @@ namespace ts.SymbolDisplay {
             }
         }
 
-        return { displayParts, documentation, symbolKind };
+        return { displayParts, documentation, symbolKind, jsDocTags };
 
         function addNewLineIfDisplayPartsExist() {
             if (displayParts.length) {
@@ -489,6 +492,7 @@ namespace ts.SymbolDisplay {
                 displayParts.push(punctuationPart(SyntaxKind.CloseParenToken));
             }
             documentation = signature.getDocumentationComment();
+            jsDocTags = signature.getJsDocTags();
         }
 
         function writeTypeParametersOfSymbol(symbol: Symbol, enclosingDeclaration: Node) {

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -89,7 +89,7 @@ namespace ts.SymbolDisplay {
 
         const displayParts: SymbolDisplayPart[] = [];
         let documentation: SymbolDisplayPart[];
-        let jsDocTags: JSDocTagInfo[];
+        let tags: JSDocTagInfo[];
         const symbolFlags = symbol.flags;
         let symbolKind = getSymbolKindOfConstructorPropertyMethodAccessorFunctionOrVar(typeChecker, symbol, symbolFlags, location);
         let hasAddedSymbolInfo: boolean;
@@ -408,7 +408,7 @@ namespace ts.SymbolDisplay {
 
         if (!documentation) {
             documentation = symbol.getDocumentationComment();
-            jsDocTags = symbol.getJsDocTags();
+            tags = symbol.getJsDocTags();
             if (documentation.length === 0 && symbol.flags & SymbolFlags.Property) {
                 // For some special property access expressions like `experts.foo = foo` or `module.exports.foo = foo`
                 // there documentation comments might be attached to the right hand side symbol of their declarations.
@@ -425,7 +425,7 @@ namespace ts.SymbolDisplay {
                         }
 
                         documentation = rhsSymbol.getDocumentationComment();
-                        jsDocTags = rhsSymbol.getJsDocTags();
+                        tags = rhsSymbol.getJsDocTags();
                         if (documentation.length > 0) {
                             break;
                         }
@@ -434,7 +434,7 @@ namespace ts.SymbolDisplay {
             }
         }
 
-        return { displayParts, documentation, symbolKind, jsDocTags };
+        return { displayParts, documentation, symbolKind, tags };
 
         function addNewLineIfDisplayPartsExist() {
             if (displayParts.length) {
@@ -492,7 +492,7 @@ namespace ts.SymbolDisplay {
                 displayParts.push(punctuationPart(SyntaxKind.CloseParenToken));
             }
             documentation = signature.getDocumentationComment();
-            jsDocTags = signature.getJsDocTags();
+            tags = signature.getJsDocTags();
         }
 
         function writeTypeParametersOfSymbol(symbol: Symbol, enclosingDeclaration: Node) {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -21,6 +21,7 @@ namespace ts {
         getName(): string;
         getDeclarations(): Declaration[];
         getDocumentationComment(): SymbolDisplayPart[];
+        getJsDocTags(): JSDocTagInfo[];
     }
 
     export interface Type {
@@ -43,6 +44,7 @@ namespace ts {
         getParameters(): Symbol[];
         getReturnType(): Type;
         getDocumentationComment(): SymbolDisplayPart[];
+        getJsDocTags(): JSDocTagInfo[];
     }
 
     export interface SourceFile {
@@ -492,12 +494,18 @@ namespace ts {
         kind: string;
     }
 
+    export interface JSDocTagInfo {
+        name: string;
+        text?: string;
+    }
+
     export interface QuickInfo {
         kind: string;
         kindModifiers: string;
         textSpan: TextSpan;
         displayParts: SymbolDisplayPart[];
         documentation: SymbolDisplayPart[];
+        tags: JSDocTagInfo[];
     }
 
     export interface RenameInfo {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -583,6 +583,7 @@ namespace ts {
         kindModifiers: string;   // see ScriptElementKindModifier, comma separated
         displayParts: SymbolDisplayPart[];
         documentation: SymbolDisplayPart[];
+        tags: JSDocTagInfo[];
     }
 
     export interface OutliningSpan {

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -539,6 +539,7 @@ namespace ts {
         separatorDisplayParts: SymbolDisplayPart[];
         parameters: SignatureHelpParameter[];
         documentation: SymbolDisplayPart[];
+        tags: JSDocTagInfo[];
     }
 
     /**

--- a/tests/baselines/reference/jsDocTags.baseline
+++ b/tests/baselines/reference/jsDocTags.baseline
@@ -78,6 +78,12 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/jsDocTags.ts",
+      "position": 902
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsDocTags.ts",
       "position": 906
     },
     "quickInfo": {
@@ -194,6 +200,12 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/jsDocTags.ts",
+      "position": 918
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsDocTags.ts",
       "position": 925
     },
     "quickInfo": {
@@ -265,6 +277,12 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/jsDocTags.ts",
+      "position": 933
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsDocTags.ts",
       "position": 940
     },
     "quickInfo": {
@@ -326,6 +344,12 @@
       ],
       "documentation": [],
       "tags": []
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsDocTags.ts",
+      "position": 948
     }
   },
   {

--- a/tests/baselines/reference/jsDocTags.baseline
+++ b/tests/baselines/reference/jsDocTags.baseline
@@ -2,13 +2,13 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/jsDocTags.ts",
-      "position": 898
+      "position": 981
     },
     "quickInfo": {
       "kind": "constructor",
       "kindModifiers": "",
       "textSpan": {
-        "start": 898,
+        "start": 981,
         "length": 3
       },
       "displayParts": [
@@ -78,19 +78,19 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/jsDocTags.ts",
-      "position": 902
+      "position": 985
     }
   },
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/jsDocTags.ts",
-      "position": 906
+      "position": 989
     },
     "quickInfo": {
       "kind": "class",
       "kindModifiers": "",
       "textSpan": {
-        "start": 906,
+        "start": 989,
         "length": 3
       },
       "displayParts": [
@@ -124,13 +124,13 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/jsDocTags.ts",
-      "position": 910
+      "position": 993
     },
     "quickInfo": {
       "kind": "method",
       "kindModifiers": "static",
       "textSpan": {
-        "start": 910,
+        "start": 993,
         "length": 7
       },
       "displayParts": [
@@ -200,19 +200,19 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/jsDocTags.ts",
-      "position": 918
+      "position": 1001
     }
   },
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/jsDocTags.ts",
-      "position": 925
+      "position": 1008
     },
     "quickInfo": {
       "kind": "method",
       "kindModifiers": "",
       "textSpan": {
-        "start": 925,
+        "start": 1008,
         "length": 7
       },
       "displayParts": [
@@ -277,19 +277,19 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/jsDocTags.ts",
-      "position": 933
+      "position": 1016
     }
   },
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/jsDocTags.ts",
-      "position": 940
+      "position": 1023
     },
     "quickInfo": {
       "kind": "method",
       "kindModifiers": "",
       "textSpan": {
-        "start": 940,
+        "start": 1023,
         "length": 7
       },
       "displayParts": [
@@ -349,19 +349,19 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/jsDocTags.ts",
-      "position": 948
+      "position": 1031
     }
   },
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/jsDocTags.ts",
-      "position": 955
+      "position": 1038
     },
     "quickInfo": {
       "kind": "method",
       "kindModifiers": "",
       "textSpan": {
-        "start": 955,
+        "start": 1038,
         "length": 7
       },
       "displayParts": [
@@ -442,13 +442,13 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/jsDocTags.ts",
-      "position": 970
+      "position": 1053
     },
     "quickInfo": {
       "kind": "property",
       "kindModifiers": "",
       "textSpan": {
-        "start": 970,
+        "start": 1053,
         "length": 9
       },
       "displayParts": [
@@ -505,13 +505,13 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/jsDocTags.ts",
-      "position": 985
+      "position": 1068
     },
     "quickInfo": {
       "kind": "property",
       "kindModifiers": "",
       "textSpan": {
-        "start": 985,
+        "start": 1068,
         "length": 9
       },
       "displayParts": [
@@ -580,13 +580,13 @@
   {
     "marker": {
       "fileName": "/tests/cases/fourslash/jsDocTags.ts",
-      "position": 1000
+      "position": 1083
     },
     "quickInfo": {
       "kind": "method",
       "kindModifiers": "",
       "textSpan": {
-        "start": 1000,
+        "start": 1083,
         "length": 7
       },
       "displayParts": [
@@ -644,6 +644,26 @@
         {
           "name": "mytag",
           "text": ""
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsDocTags.ts",
+      "position": 1104
+    },
+    "quickInfo": {
+      "kind": "",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 1098,
+        "length": 6
+      },
+      "displayParts": [
+        {
+          "text": "any",
+          "kind": "keyword"
         }
       ]
     }

--- a/tests/baselines/reference/jsDocTags.baseline
+++ b/tests/baselines/reference/jsDocTags.baseline
@@ -1,163 +1,39 @@
 [
   {
     "marker": {
-      "fileName": "/tests/cases/fourslash/quickInfoDisplayPartsLiteralLikeNames01.ts",
-      "position": 21
+      "fileName": "/tests/cases/fourslash/jsDocTags.ts",
+      "position": 898
     },
     "quickInfo": {
-      "kind": "method",
-      "kindModifiers": "public",
+      "kind": "constructor",
+      "kindModifiers": "",
       "textSpan": {
-        "start": 21,
-        "length": 1
-      },
-      "displayParts": [
-        {
-          "text": "(",
-          "kind": "punctuation"
-        },
-        {
-          "text": "method",
-          "kind": "text"
-        },
-        {
-          "text": ")",
-          "kind": "punctuation"
-        },
-        {
-          "text": " ",
-          "kind": "space"
-        },
-        {
-          "text": "C",
-          "kind": "className"
-        },
-        {
-          "text": "[",
-          "kind": "punctuation"
-        },
-        {
-          "text": "1",
-          "kind": "methodName"
-        },
-        {
-          "text": "]",
-          "kind": "punctuation"
-        },
-        {
-          "text": "(",
-          "kind": "punctuation"
-        },
-        {
-          "text": ")",
-          "kind": "punctuation"
-        },
-        {
-          "text": ":",
-          "kind": "punctuation"
-        },
-        {
-          "text": " ",
-          "kind": "space"
-        },
-        {
-          "text": "void",
-          "kind": "keyword"
-        }
-      ],
-      "documentation": [],
-      "tags": []
-    }
-  },
-  {
-    "marker": {
-      "fileName": "/tests/cases/fourslash/quickInfoDisplayPartsLiteralLikeNames01.ts",
-      "position": 41
-    },
-    "quickInfo": {
-      "kind": "method",
-      "kindModifiers": "private",
-      "textSpan": {
-        "start": 41,
-        "length": 8
-      },
-      "displayParts": [
-        {
-          "text": "(",
-          "kind": "punctuation"
-        },
-        {
-          "text": "method",
-          "kind": "text"
-        },
-        {
-          "text": ")",
-          "kind": "punctuation"
-        },
-        {
-          "text": " ",
-          "kind": "space"
-        },
-        {
-          "text": "C",
-          "kind": "className"
-        },
-        {
-          "text": ".",
-          "kind": "punctuation"
-        },
-        {
-          "text": "Infinity",
-          "kind": "methodName"
-        },
-        {
-          "text": "(",
-          "kind": "punctuation"
-        },
-        {
-          "text": ")",
-          "kind": "punctuation"
-        },
-        {
-          "text": ":",
-          "kind": "punctuation"
-        },
-        {
-          "text": " ",
-          "kind": "space"
-        },
-        {
-          "text": "void",
-          "kind": "keyword"
-        }
-      ],
-      "documentation": [],
-      "tags": []
-    }
-  },
-  {
-    "marker": {
-      "fileName": "/tests/cases/fourslash/quickInfoDisplayPartsLiteralLikeNames01.ts",
-      "position": 70
-    },
-    "quickInfo": {
-      "kind": "method",
-      "kindModifiers": "protected",
-      "textSpan": {
-        "start": 70,
+        "start": 898,
         "length": 3
       },
       "displayParts": [
         {
+          "text": "constructor",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Foo",
+          "kind": "className"
+        },
+        {
           "text": "(",
           "kind": "punctuation"
         },
         {
-          "text": "method",
-          "kind": "text"
+          "text": "value",
+          "kind": "parameterName"
         },
         {
-          "text": ")",
+          "text": ":",
           "kind": "punctuation"
         },
         {
@@ -165,20 +41,8 @@
           "kind": "space"
         },
         {
-          "text": "C",
-          "kind": "className"
-        },
-        {
-          "text": ".",
-          "kind": "punctuation"
-        },
-        {
-          "text": "NaN",
-          "kind": "methodName"
-        },
-        {
-          "text": "(",
-          "kind": "punctuation"
+          "text": "number",
+          "kind": "keyword"
         },
         {
           "text": ")",
@@ -193,25 +57,75 @@
           "kind": "space"
         },
         {
-          "text": "void",
-          "kind": "keyword"
+          "text": "Foo",
+          "kind": "className"
         }
       ],
-      "documentation": [],
-      "tags": []
+      "documentation": [
+        {
+          "text": "This is the constructor.",
+          "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "myjsdoctag",
+          "text": "this is a comment"
+        }
+      ]
     }
   },
   {
     "marker": {
-      "fileName": "/tests/cases/fourslash/quickInfoDisplayPartsLiteralLikeNames01.ts",
-      "position": 91
+      "fileName": "/tests/cases/fourslash/jsDocTags.ts",
+      "position": 906
+    },
+    "quickInfo": {
+      "kind": "class",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 906,
+        "length": 3
+      },
+      "displayParts": [
+        {
+          "text": "class",
+          "kind": "keyword"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Foo",
+          "kind": "className"
+        }
+      ],
+      "documentation": [
+        {
+          "text": "This is class Foo.",
+          "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "mytag",
+          "text": "comment1 comment2"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsDocTags.ts",
+      "position": 910
     },
     "quickInfo": {
       "kind": "method",
       "kindModifiers": "static",
       "textSpan": {
-        "start": 91,
-        "length": 19
+        "start": 910,
+        "length": 7
       },
       "displayParts": [
         {
@@ -231,217 +145,7 @@
           "kind": "space"
         },
         {
-          "text": "C",
-          "kind": "className"
-        },
-        {
-          "text": "[",
-          "kind": "punctuation"
-        },
-        {
-          "text": "\"stringLiteralName\"",
-          "kind": "stringLiteral"
-        },
-        {
-          "text": "]",
-          "kind": "punctuation"
-        },
-        {
-          "text": "(",
-          "kind": "punctuation"
-        },
-        {
-          "text": ")",
-          "kind": "punctuation"
-        },
-        {
-          "text": ":",
-          "kind": "punctuation"
-        },
-        {
-          "text": " ",
-          "kind": "space"
-        },
-        {
-          "text": "void",
-          "kind": "keyword"
-        }
-      ],
-      "documentation": [],
-      "tags": []
-    }
-  },
-  {
-    "marker": {
-      "fileName": "/tests/cases/fourslash/quickInfoDisplayPartsLiteralLikeNames01.ts",
-      "position": 145
-    },
-    "quickInfo": {
-      "kind": "method",
-      "kindModifiers": "public",
-      "textSpan": {
-        "start": 145,
-        "length": 1
-      },
-      "displayParts": [
-        {
-          "text": "(",
-          "kind": "punctuation"
-        },
-        {
-          "text": "method",
-          "kind": "text"
-        },
-        {
-          "text": ")",
-          "kind": "punctuation"
-        },
-        {
-          "text": " ",
-          "kind": "space"
-        },
-        {
-          "text": "C",
-          "kind": "className"
-        },
-        {
-          "text": "[",
-          "kind": "punctuation"
-        },
-        {
-          "text": "1",
-          "kind": "methodName"
-        },
-        {
-          "text": "]",
-          "kind": "punctuation"
-        },
-        {
-          "text": "(",
-          "kind": "punctuation"
-        },
-        {
-          "text": ")",
-          "kind": "punctuation"
-        },
-        {
-          "text": ":",
-          "kind": "punctuation"
-        },
-        {
-          "text": " ",
-          "kind": "space"
-        },
-        {
-          "text": "void",
-          "kind": "keyword"
-        }
-      ],
-      "documentation": [],
-      "tags": []
-    }
-  },
-  {
-    "marker": {
-      "fileName": "/tests/cases/fourslash/quickInfoDisplayPartsLiteralLikeNames01.ts",
-      "position": 164
-    },
-    "quickInfo": {
-      "kind": "method",
-      "kindModifiers": "public",
-      "textSpan": {
-        "start": 164,
-        "length": 3
-      },
-      "displayParts": [
-        {
-          "text": "(",
-          "kind": "punctuation"
-        },
-        {
-          "text": "method",
-          "kind": "text"
-        },
-        {
-          "text": ")",
-          "kind": "punctuation"
-        },
-        {
-          "text": " ",
-          "kind": "space"
-        },
-        {
-          "text": "C",
-          "kind": "className"
-        },
-        {
-          "text": "[",
-          "kind": "punctuation"
-        },
-        {
-          "text": "1",
-          "kind": "methodName"
-        },
-        {
-          "text": "]",
-          "kind": "punctuation"
-        },
-        {
-          "text": "(",
-          "kind": "punctuation"
-        },
-        {
-          "text": ")",
-          "kind": "punctuation"
-        },
-        {
-          "text": ":",
-          "kind": "punctuation"
-        },
-        {
-          "text": " ",
-          "kind": "space"
-        },
-        {
-          "text": "void",
-          "kind": "keyword"
-        }
-      ],
-      "documentation": [],
-      "tags": []
-    }
-  },
-  {
-    "marker": {
-      "fileName": "/tests/cases/fourslash/quickInfoDisplayPartsLiteralLikeNames01.ts",
-      "position": 185
-    },
-    "quickInfo": {
-      "kind": "method",
-      "kindModifiers": "private",
-      "textSpan": {
-        "start": 185,
-        "length": 8
-      },
-      "displayParts": [
-        {
-          "text": "(",
-          "kind": "punctuation"
-        },
-        {
-          "text": "method",
-          "kind": "text"
-        },
-        {
-          "text": ")",
-          "kind": "punctuation"
-        },
-        {
-          "text": " ",
-          "kind": "space"
-        },
-        {
-          "text": "C",
+          "text": "Foo",
           "kind": "className"
         },
         {
@@ -449,7 +153,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "Infinity",
+          "text": "method1",
           "kind": "methodName"
         },
         {
@@ -473,21 +177,31 @@
           "kind": "keyword"
         }
       ],
-      "documentation": [],
-      "tags": []
+      "documentation": [
+        {
+          "text": "method1 documentation",
+          "kind": "text"
+        }
+      ],
+      "tags": [
+        {
+          "name": "mytag",
+          "text": "comment1 comment2"
+        }
+      ]
     }
   },
   {
     "marker": {
-      "fileName": "/tests/cases/fourslash/quickInfoDisplayPartsLiteralLikeNames01.ts",
-      "position": 210
+      "fileName": "/tests/cases/fourslash/jsDocTags.ts",
+      "position": 925
     },
     "quickInfo": {
       "kind": "method",
-      "kindModifiers": "private",
+      "kindModifiers": "",
       "textSpan": {
-        "start": 210,
-        "length": 10
+        "start": 925,
+        "length": 7
       },
       "displayParts": [
         {
@@ -507,7 +221,7 @@
           "kind": "space"
         },
         {
-          "text": "C",
+          "text": "Foo",
           "kind": "className"
         },
         {
@@ -515,7 +229,7 @@
           "kind": "punctuation"
         },
         {
-          "text": "Infinity",
+          "text": "method2",
           "kind": "methodName"
         },
         {
@@ -540,20 +254,25 @@
         }
       ],
       "documentation": [],
-      "tags": []
+      "tags": [
+        {
+          "name": "mytag",
+          "text": ""
+        }
+      ]
     }
   },
   {
     "marker": {
-      "fileName": "/tests/cases/fourslash/quickInfoDisplayPartsLiteralLikeNames01.ts",
-      "position": 238
+      "fileName": "/tests/cases/fourslash/jsDocTags.ts",
+      "position": 940
     },
     "quickInfo": {
       "kind": "method",
-      "kindModifiers": "protected",
+      "kindModifiers": "",
       "textSpan": {
-        "start": 238,
-        "length": 3
+        "start": 940,
+        "length": 7
       },
       "displayParts": [
         {
@@ -573,7 +292,7 @@
           "kind": "space"
         },
         {
-          "text": "C",
+          "text": "Foo",
           "kind": "className"
         },
         {
@@ -581,7 +300,298 @@
           "kind": "punctuation"
         },
         {
-          "text": "NaN",
+          "text": "method3",
+          "kind": "methodName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": []
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsDocTags.ts",
+      "position": 955
+    },
+    "quickInfo": {
+      "kind": "method",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 955,
+        "length": 7
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "method",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Foo",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "method4",
+          "kind": "methodName"
+        },
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "foo",
+          "kind": "parameterName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "mytag",
+          "text": ""
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsDocTags.ts",
+      "position": 970
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 970,
+        "length": 9
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Foo",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property1",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "string",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "mytag",
+          "text": "comment1 comment2"
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsDocTags.ts",
+      "position": 985
+    },
+    "quickInfo": {
+      "kind": "property",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 985,
+        "length": 9
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Foo",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "property2",
+          "kind": "propertyName"
+        },
+        {
+          "text": ":",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "number",
+          "kind": "keyword"
+        }
+      ],
+      "documentation": [],
+      "tags": [
+        {
+          "name": "mytag1",
+          "text": "some comments\nsome more comments about mytag1"
+        },
+        {
+          "name": "mytag2",
+          "text": "here all the comments are on a new line"
+        },
+        {
+          "name": "mytag3",
+          "text": ""
+        },
+        {
+          "name": "mytag",
+          "text": ""
+        }
+      ]
+    }
+  },
+  {
+    "marker": {
+      "fileName": "/tests/cases/fourslash/jsDocTags.ts",
+      "position": 1000
+    },
+    "quickInfo": {
+      "kind": "method",
+      "kindModifiers": "",
+      "textSpan": {
+        "start": 1000,
+        "length": 7
+      },
+      "displayParts": [
+        {
+          "text": "(",
+          "kind": "punctuation"
+        },
+        {
+          "text": "method",
+          "kind": "text"
+        },
+        {
+          "text": ")",
+          "kind": "punctuation"
+        },
+        {
+          "text": " ",
+          "kind": "space"
+        },
+        {
+          "text": "Foo",
+          "kind": "className"
+        },
+        {
+          "text": ".",
+          "kind": "punctuation"
+        },
+        {
+          "text": "method5",
           "kind": "methodName"
         },
         {
@@ -606,77 +616,12 @@
         }
       ],
       "documentation": [],
-      "tags": []
-    }
-  },
-  {
-    "marker": {
-      "fileName": "/tests/cases/fourslash/quickInfoDisplayPartsLiteralLikeNames01.ts",
-      "position": 255
-    },
-    "quickInfo": {
-      "kind": "method",
-      "kindModifiers": "static",
-      "textSpan": {
-        "start": 255,
-        "length": 17
-      },
-      "displayParts": [
+      "tags": [
         {
-          "text": "(",
-          "kind": "punctuation"
-        },
-        {
-          "text": "method",
-          "kind": "text"
-        },
-        {
-          "text": ")",
-          "kind": "punctuation"
-        },
-        {
-          "text": " ",
-          "kind": "space"
-        },
-        {
-          "text": "C",
-          "kind": "className"
-        },
-        {
-          "text": "[",
-          "kind": "punctuation"
-        },
-        {
-          "text": "\"stringLiteralName\"",
-          "kind": "stringLiteral"
-        },
-        {
-          "text": "]",
-          "kind": "punctuation"
-        },
-        {
-          "text": "(",
-          "kind": "punctuation"
-        },
-        {
-          "text": ")",
-          "kind": "punctuation"
-        },
-        {
-          "text": ":",
-          "kind": "punctuation"
-        },
-        {
-          "text": " ",
-          "kind": "space"
-        },
-        {
-          "text": "void",
-          "kind": "keyword"
+          "name": "mytag",
+          "text": ""
         }
-      ],
-      "documentation": [],
-      "tags": []
+      ]
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsArrowFunctionExpression.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsArrowFunctionExpression.baseline
@@ -73,7 +73,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -122,7 +123,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -223,7 +225,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -272,7 +275,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -321,7 +325,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -398,7 +403,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -447,7 +453,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -508,7 +515,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsClass.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsClass.baseline
@@ -25,7 +25,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -66,7 +67,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -115,7 +117,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -164,7 +167,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -193,7 +197,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsClassAccessors.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsClassAccessors.baseline
@@ -53,7 +53,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -110,7 +111,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -167,7 +169,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -224,7 +227,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -281,7 +285,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -338,7 +343,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -395,7 +401,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -452,7 +459,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -509,7 +517,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -566,7 +575,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -623,7 +633,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -680,7 +691,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -737,7 +749,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -794,7 +807,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -851,7 +865,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -908,7 +923,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -965,7 +981,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1022,7 +1039,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1079,7 +1097,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1136,7 +1155,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1193,7 +1213,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1250,7 +1271,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1307,7 +1329,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1364,7 +1387,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1405,7 +1429,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1462,7 +1487,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1491,7 +1517,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1548,7 +1575,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1589,7 +1617,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1646,7 +1675,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1675,7 +1705,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1732,7 +1763,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsClassConstructor.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsClassConstructor.baseline
@@ -45,7 +45,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -86,7 +87,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -135,7 +137,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -184,7 +187,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -213,7 +217,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -306,7 +311,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -399,7 +405,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -492,7 +499,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -533,7 +541,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -626,7 +635,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -667,7 +677,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -760,7 +771,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -809,7 +821,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -838,7 +851,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -931,7 +945,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1024,7 +1039,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1117,7 +1133,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1210,7 +1227,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1251,7 +1269,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1344,7 +1363,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1385,7 +1405,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1478,7 +1499,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1519,7 +1541,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1612,7 +1635,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1661,7 +1685,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1690,7 +1715,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsClassMethod.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsClassMethod.baseline
@@ -61,7 +61,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -126,7 +127,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -191,7 +193,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -256,7 +259,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -321,7 +325,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -386,7 +391,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -451,7 +457,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -516,7 +523,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -581,7 +589,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -646,7 +655,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -711,7 +721,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -776,7 +787,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -817,7 +829,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -882,7 +895,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -911,7 +925,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -976,7 +991,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsClassProperty.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsClassProperty.baseline
@@ -53,7 +53,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -110,7 +111,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -167,7 +169,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -224,7 +227,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -281,7 +285,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -338,7 +343,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -395,7 +401,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -452,7 +459,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -509,7 +517,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -566,7 +575,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -623,7 +633,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -680,7 +691,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -721,7 +733,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -778,7 +791,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -807,7 +821,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -864,7 +879,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsConst.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsConst.baseline
@@ -37,7 +37,8 @@
           "kind": "stringLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -78,7 +79,8 @@
           "kind": "stringLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -119,7 +121,8 @@
           "kind": "stringLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -160,7 +163,8 @@
           "kind": "stringLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -201,7 +205,8 @@
           "kind": "stringLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -250,7 +255,8 @@
           "kind": "stringLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -291,7 +297,8 @@
           "kind": "stringLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -352,7 +359,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -413,7 +421,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -474,7 +483,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -535,7 +545,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -680,7 +691,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -825,7 +837,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -970,7 +983,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1075,7 +1089,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1180,7 +1195,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsEnum1.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsEnum1.baseline
@@ -25,7 +25,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -86,7 +87,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -147,7 +149,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -208,7 +211,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -249,7 +253,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -278,7 +283,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -319,7 +325,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -348,7 +355,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -409,7 +417,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -450,7 +459,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -479,7 +489,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -540,7 +551,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -581,7 +593,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -610,7 +623,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -671,7 +685,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -708,7 +723,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -769,7 +785,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -830,7 +847,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -891,7 +909,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -932,7 +951,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -969,7 +989,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1010,7 +1031,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1047,7 +1069,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1108,7 +1131,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1149,7 +1173,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1186,7 +1211,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1247,7 +1273,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1288,7 +1315,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1325,7 +1353,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1386,7 +1415,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsEnum2.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsEnum2.baseline
@@ -25,7 +25,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -90,7 +91,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -155,7 +157,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -220,7 +223,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -261,7 +265,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -290,7 +295,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -331,7 +337,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -360,7 +367,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -425,7 +433,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -466,7 +475,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -495,7 +505,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -560,7 +571,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -601,7 +613,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -630,7 +643,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -695,7 +709,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -732,7 +747,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -797,7 +813,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -862,7 +879,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -927,7 +945,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -968,7 +987,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1005,7 +1025,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1046,7 +1067,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1083,7 +1105,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1148,7 +1171,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1189,7 +1213,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1226,7 +1251,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1291,7 +1317,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1332,7 +1359,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1369,7 +1397,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1434,7 +1463,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsEnum3.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsEnum3.baseline
@@ -25,7 +25,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -90,7 +91,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -155,7 +157,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -220,7 +223,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -261,7 +265,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -290,7 +295,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -331,7 +337,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -360,7 +367,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -425,7 +433,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -466,7 +475,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -495,7 +505,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -560,7 +571,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -601,7 +613,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -630,7 +643,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -695,7 +709,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -732,7 +747,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -797,7 +813,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -862,7 +879,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -927,7 +945,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -968,7 +987,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1005,7 +1025,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1046,7 +1067,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1083,7 +1105,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1148,7 +1171,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1189,7 +1213,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1226,7 +1251,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1291,7 +1317,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1332,7 +1359,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1369,7 +1397,8 @@
           "kind": "enumName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1434,7 +1463,8 @@
           "kind": "numericLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsExternalModuleAlias_file0.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsExternalModuleAlias_file0.baseline
@@ -53,7 +53,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -82,7 +83,8 @@
           "kind": "aliasName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -139,7 +141,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -196,7 +199,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -225,7 +229,8 @@
           "kind": "aliasName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -282,7 +287,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsExternalModules.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsExternalModules.baseline
@@ -25,7 +25,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -66,7 +67,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -115,7 +117,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -164,7 +167,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -193,7 +197,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -242,7 +247,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -271,7 +277,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -300,7 +307,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -337,7 +345,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -378,7 +387,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -435,7 +445,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -492,7 +503,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -521,7 +533,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -558,7 +571,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -615,7 +629,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -644,7 +659,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -681,7 +697,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsFunction.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsFunction.baseline
@@ -153,7 +153,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -246,7 +247,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -339,7 +341,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -432,7 +435,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -525,7 +529,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -618,7 +623,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -711,7 +717,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -804,7 +811,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -961,7 +969,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1054,7 +1063,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1147,7 +1157,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1240,7 +1251,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1333,7 +1345,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1426,7 +1439,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsFunctionExpression.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsFunctionExpression.baseline
@@ -57,7 +57,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -114,7 +115,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -171,7 +173,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -232,7 +235,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -289,7 +293,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -346,7 +351,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsInterface.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsInterface.baseline
@@ -25,7 +25,8 @@
           "kind": "interfaceName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -66,7 +67,8 @@
           "kind": "interfaceName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -95,7 +97,8 @@
           "kind": "interfaceName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsInterfaceMembers.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsInterfaceMembers.baseline
@@ -53,7 +53,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -118,7 +119,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -159,7 +161,8 @@
           "kind": "interfaceName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -216,7 +219,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -257,7 +261,8 @@
           "kind": "interfaceName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -322,7 +327,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -387,7 +393,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -428,7 +435,8 @@
           "kind": "interfaceName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -501,7 +509,8 @@
           "kind": "interfaceName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsLet.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsLet.baseline
@@ -37,7 +37,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -78,7 +79,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -119,7 +121,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -160,7 +163,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -201,7 +205,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -250,7 +255,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -291,7 +297,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -352,7 +359,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -413,7 +421,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -474,7 +483,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -535,7 +545,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -680,7 +691,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -825,7 +837,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -970,7 +983,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1075,7 +1089,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1180,7 +1195,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsLocalFunction.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsLocalFunction.baseline
@@ -45,7 +45,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -210,7 +211,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -311,7 +313,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -412,7 +415,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -513,7 +517,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -614,7 +619,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -715,7 +721,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -816,7 +823,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -917,7 +925,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1082,7 +1091,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1183,7 +1193,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1284,7 +1295,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1385,7 +1397,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1486,7 +1499,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1587,7 +1601,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1636,7 +1651,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsModules.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsModules.baseline
@@ -25,7 +25,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -66,7 +67,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -115,7 +117,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -164,7 +167,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -193,7 +197,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -242,7 +247,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -271,7 +277,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -300,7 +307,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -337,7 +345,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -378,7 +387,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -435,7 +445,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -492,7 +503,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -521,7 +533,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -558,7 +571,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -615,7 +629,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -644,7 +659,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -681,7 +697,8 @@
           "kind": "moduleName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsParameters.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsParameters.baseline
@@ -153,7 +153,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -202,7 +203,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -251,7 +253,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -300,7 +303,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -357,7 +361,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -406,7 +411,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -455,7 +461,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -504,7 +511,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -561,7 +569,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsTypeAlias.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsTypeAlias.baseline
@@ -25,7 +25,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -70,7 +71,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -99,7 +101,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -140,7 +143,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -185,7 +189,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -234,7 +239,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsTypeParameterInClass.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsTypeParameterInClass.baseline
@@ -37,7 +37,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -102,7 +103,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -191,7 +193,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -240,7 +243,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -305,7 +309,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -434,7 +439,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -579,7 +585,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -628,7 +635,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -773,7 +781,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -822,7 +831,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -887,7 +897,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -936,7 +947,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -989,7 +1001,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1078,7 +1091,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1127,7 +1141,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1168,7 +1183,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1221,7 +1237,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1350,7 +1367,8 @@
           "kind": "stringLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1419,7 +1437,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1512,7 +1531,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1553,7 +1573,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1670,7 +1691,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1747,7 +1769,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1840,7 +1863,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2025,7 +2049,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2226,7 +2251,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2267,7 +2293,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2344,7 +2371,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2545,7 +2573,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2622,7 +2651,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2715,7 +2745,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2792,7 +2823,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2857,7 +2889,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2982,7 +3015,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3035,7 +3069,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3084,7 +3119,8 @@
           "kind": "className"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3153,7 +3189,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3218,7 +3255,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3407,7 +3445,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3460,7 +3499,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3513,7 +3553,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsTypeParameterInFunction.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsTypeParameterInFunction.baseline
@@ -73,7 +73,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -174,7 +175,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -223,7 +225,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -324,7 +327,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -373,7 +377,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -450,7 +455,8 @@
           "kind": "stringLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -543,7 +549,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -660,7 +667,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -725,7 +733,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -842,7 +851,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -907,7 +917,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -984,7 +995,8 @@
           "kind": "stringLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsTypeParameterInFunctionLikeInTypeAlias.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsTypeParameterInFunctionLikeInTypeAlias.baseline
@@ -69,7 +69,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -142,7 +143,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -215,7 +217,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsTypeParameterInInterface.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsTypeParameterInInterface.baseline
@@ -37,7 +37,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -102,7 +103,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -231,7 +233,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -280,7 +283,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -409,7 +413,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -458,7 +463,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -523,7 +529,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -652,7 +659,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -773,7 +781,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -822,7 +831,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -943,7 +953,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -992,7 +1003,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1057,7 +1069,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1178,7 +1191,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1307,7 +1321,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1452,7 +1467,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1501,7 +1517,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1646,7 +1663,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1695,7 +1713,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1760,7 +1779,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1905,7 +1925,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1958,7 +1979,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1999,7 +2021,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2124,7 +2147,8 @@
           "kind": "stringLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2241,7 +2265,8 @@
           "kind": "stringLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2294,7 +2319,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2423,7 +2449,8 @@
           "kind": "stringLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2492,7 +2519,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2585,7 +2613,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2626,7 +2655,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2783,7 +2813,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2824,7 +2855,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -2901,7 +2933,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3058,7 +3091,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3135,7 +3169,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3228,7 +3263,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3385,7 +3421,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3534,7 +3571,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3575,7 +3613,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3652,7 +3691,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3801,7 +3841,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3878,7 +3919,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -3971,7 +4013,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -4120,7 +4163,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -4305,7 +4349,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -4506,7 +4551,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -4547,7 +4593,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -4624,7 +4671,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -4825,7 +4873,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -4902,7 +4951,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -4995,7 +5045,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -5196,7 +5247,8 @@
           "kind": "typeParameterName"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -5261,7 +5313,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -5330,7 +5383,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -5371,7 +5425,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -5544,7 +5599,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -5597,7 +5653,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -5650,7 +5707,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -5815,7 +5873,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -5868,7 +5927,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -5921,7 +5981,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -5986,7 +6047,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -6175,7 +6237,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -6228,7 +6291,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -6281,7 +6345,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsTypeParameterInTypeAlias.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsTypeParameterInTypeAlias.baseline
@@ -61,7 +61,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -134,7 +135,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -207,7 +209,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -288,7 +291,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -377,7 +381,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -466,7 +471,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsVar.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsVar.baseline
@@ -37,7 +37,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -86,7 +87,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -127,7 +129,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -168,7 +171,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -217,7 +221,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -278,7 +283,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -339,7 +345,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -400,7 +407,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -461,7 +469,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -606,7 +615,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -751,7 +761,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -896,7 +907,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1001,7 +1013,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1106,7 +1119,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsVar.shims-pp.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsVar.shims-pp.baseline
@@ -37,7 +37,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -86,7 +87,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -127,7 +129,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -168,7 +171,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -217,7 +221,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -278,7 +283,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -339,7 +345,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -400,7 +407,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -461,7 +469,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -606,7 +615,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -751,7 +761,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -896,7 +907,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1001,7 +1013,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1106,7 +1119,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsVar.shims.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsVar.shims.baseline
@@ -37,7 +37,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -86,7 +87,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -127,7 +129,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -168,7 +171,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -217,7 +221,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -278,7 +283,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -339,7 +345,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -400,7 +407,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -461,7 +469,8 @@
           "kind": "keyword"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -606,7 +615,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -751,7 +761,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -896,7 +907,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1001,7 +1013,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -1106,7 +1119,8 @@
           "kind": "punctuation"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/baselines/reference/quickInfoDisplayPartsVarWithStringTypes01.baseline
+++ b/tests/baselines/reference/quickInfoDisplayPartsVarWithStringTypes01.baseline
@@ -37,7 +37,8 @@
           "kind": "stringLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -78,7 +79,8 @@
           "kind": "stringLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   },
   {
@@ -135,7 +137,8 @@
           "kind": "stringLiteral"
         }
       ],
-      "documentation": []
+      "documentation": [],
+      "tags": []
     }
   }
 ]

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -253,7 +253,7 @@ declare namespace FourSlashInterface {
         verifyQuickInfoDisplayParts(kind: string, kindModifiers: string, textSpan: {
             start: number;
             length: number;
-        }, displayParts: ts.SymbolDisplayPart[], documentation: ts.SymbolDisplayPart[]): void;
+        }, displayParts: ts.SymbolDisplayPart[], documentation: ts.SymbolDisplayPart[], tags: ts.JSDocTagInfo[]): void;
         getSyntacticDiagnostics(expected: string): void;
         getSemanticDiagnostics(expected: string): void;
         ProjectInfo(expected: string[]): void;

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -192,6 +192,7 @@ declare namespace FourSlashInterface {
         currentParameterSpanIs(parameter: string): void;
         currentParameterHelpArgumentDocCommentIs(docComment: string): void;
         currentSignatureHelpDocCommentIs(docComment: string): void;
+        currentSignatureHelpTagsAre(tags: ts.JSDocTagInfo[]): void;
         signatureHelpCountIs(expected: number): void;
         signatureHelpArgumentCountIs(expected: number): void;
         signatureHelpCurrentArgumentListIsVariadic(expected: boolean);

--- a/tests/cases/fourslash/jsDocFunctionSignatures9.ts
+++ b/tests/cases/fourslash/jsDocFunctionSignatures9.ts
@@ -19,4 +19,5 @@ verify.verifyQuickInfoDisplayParts('function',
                                     {"text": " ", "kind": "space"},
                                     {"text": "void", "kind": "keyword"}
                                    ],
-                                   [{"text": "first line of the comment\n\nthird line ", "kind": "text"}]);
+                                   [{"text": "first line of the comment\n\nthird line ", "kind": "text"}],
+                                   []);

--- a/tests/cases/fourslash/jsDocTags.ts
+++ b/tests/cases/fourslash/jsDocTags.ts
@@ -44,6 +44,10 @@
 ////     method4(foo: string): number { return 3; }
 ////     /** @mytag */
 ////     method5() {}
+////     /** method documentation
+////      *  @mytag a JSDoc tag
+////      */
+////     newMethod() {}
 //// }
 //// var foo = new /*1*/Foo(/*10*/4);
 //// /*2*/Foo./*3*/method1(/*11*/);
@@ -53,6 +57,7 @@
 //// foo./*7*/property1;
 //// foo./*8*/property2;
 //// foo./*9*/method5();
+//// foo.newMet/*14*/
 
 verify.baselineQuickInfo();
 
@@ -65,3 +70,6 @@ goTo.marker("12");
 verify.currentSignatureHelpTagsAre([{name: "mytag", text:""}])
 goTo.marker("13");
 verify.currentSignatureHelpTagsAre([])
+
+goTo.marker('14');
+verify.completionEntryDetailIs("newMethod", "(method) Foo.newMethod(): void", "method documentation", "method", [{name: "mytag", text: "a JSDoc tag"}]);

--- a/tests/cases/fourslash/jsDocTags.ts
+++ b/tests/cases/fourslash/jsDocTags.ts
@@ -45,42 +45,23 @@
 ////     /** @mytag */
 ////     method5() {}
 //// }
-//// var foo = new /*1*/Foo(4);
-//// /*2*/Foo./*3*/method1();
-//// foo./*4*/method2();
-//// foo./*5*/method3();
+//// var foo = new /*1*/Foo(/*10*/4);
+//// /*2*/Foo./*3*/method1(/*11*/);
+//// foo./*4*/method2(/*12*/);
+//// foo./*5*/method3(/*13*/);
 //// foo./*6*/method4();
 //// foo./*7*/property1;
 //// foo./*8*/property2;
 //// foo./*9*/method5();
 
-goTo.marker("1");
-verify.baselineQuickInfo();
-goTo.marker("2");
-verify.baselineQuickInfo();
-goTo.marker("3");
-verify.baselineQuickInfo();
-goTo.marker("4");
-verify.baselineQuickInfo();
-goTo.marker("5");
-verify.baselineQuickInfo();
-goTo.marker("6");
-verify.baselineQuickInfo();
-goTo.marker("7");
-verify.baselineQuickInfo();
-goTo.marker("8");
-verify.baselineQuickInfo();
-goTo.marker("9");
 verify.baselineQuickInfo();
 
-// /** 
-//  * @param foo
-//  * Does 
-//  * stuff!
-//  * @returns void
-//  */
-// function example(foo) {
 
-// }
-
-// example("asdf");
+goTo.marker("10");
+verify.currentSignatureHelpTagsAre([{name: "myjsdoctag", text:"this is a comment"}])
+goTo.marker("11");
+verify.currentSignatureHelpTagsAre([{name: "mytag", text:"comment1 comment2"}])
+goTo.marker("12");
+verify.currentSignatureHelpTagsAre([{name: "mytag", text:""}])
+goTo.marker("13");
+verify.currentSignatureHelpTagsAre([])

--- a/tests/cases/fourslash/jsDocTags.ts
+++ b/tests/cases/fourslash/jsDocTags.ts
@@ -1,0 +1,86 @@
+///<reference path="fourslash.ts" />
+
+//// /**
+////  * This is class Foo.
+////  * @mytag comment1 comment2
+////  */
+//// class Foo {
+////     /**
+////      * This is the constructor.
+////      * @myjsdoctag this is a comment
+////      */
+////     constructor(value: number) {}
+////     /**
+////      * method1 documentation
+////      * @mytag comment1 comment2
+////      */
+////     static method1() {}
+////     /**
+////      * @mytag
+////      */
+////     method2() {}
+////     /**
+////      * @mytag comment1 comment2
+////      */
+////     property1: string;
+////     /**
+////      * @mytag1 some comments
+////      * some more comments about mytag1
+////      * @mytag2 
+////      * here all the comments are on a new line
+////      * @mytag3 
+////      * @mytag
+////      */
+////     property2: number;
+////     /** 
+////      * @returns {number} a value
+////      */
+////     method3(): number { return 3; }
+////     /**
+////      * @param {string} foo A value.
+////      * @returns {number} Another value
+////      * @mytag 
+////      */
+////     method4(foo: string): number { return 3; }
+////     /** @mytag */
+////     method5() {}
+//// }
+//// var foo = new /*1*/Foo(4);
+//// /*2*/Foo./*3*/method1();
+//// foo./*4*/method2();
+//// foo./*5*/method3();
+//// foo./*6*/method4();
+//// foo./*7*/property1;
+//// foo./*8*/property2;
+//// foo./*9*/method5();
+
+goTo.marker("1");
+verify.baselineQuickInfo();
+goTo.marker("2");
+verify.baselineQuickInfo();
+goTo.marker("3");
+verify.baselineQuickInfo();
+goTo.marker("4");
+verify.baselineQuickInfo();
+goTo.marker("5");
+verify.baselineQuickInfo();
+goTo.marker("6");
+verify.baselineQuickInfo();
+goTo.marker("7");
+verify.baselineQuickInfo();
+goTo.marker("8");
+verify.baselineQuickInfo();
+goTo.marker("9");
+verify.baselineQuickInfo();
+
+// /** 
+//  * @param foo
+//  * Does 
+//  * stuff!
+//  * @returns void
+//  */
+// function example(foo) {
+
+// }
+
+// example("asdf");

--- a/tests/cases/fourslash/quickInfoDisplayPartsInternalModuleAlias.ts
+++ b/tests/cases/fourslash/quickInfoDisplayPartsInternalModuleAlias.ts
@@ -30,7 +30,7 @@ function verifyImport(name: string, assigningDisplay:ts.SymbolDisplayPart[], opt
     verify.verifyQuickInfoDisplayParts("alias", optionalParentName ? "export" : "", { start: test.markerByName(marker.toString()).position, length: name.length },
         [{ text: "import", kind: "keyword" }, { text: " ", kind: "space" }].concat(moduleNameDisplay).concat(
             { text: " ", kind: "space" }, { text: "=", kind: "operator" }, { text: " ", kind: "space" }).concat(assigningDisplay),
-        []);
+        [], []);
 }
 
 var moduleMDisplay = [{ text: "m", kind: "moduleName" }];


### PR DESCRIPTION
Expose JSDoc tags through the language service

The main motivation behind this PR is to fix UWP API documentation behavior in Dev15, which relies on a custom JSDoc tag (`@xmldoc`), and was broken between 2.0 and 2.1.

The behavior of getDocumentationComment() was changed by https://github.com/Microsoft/TypeScript/pull/10671  to not include JSDoc tags anymore. I added them back as a new property.

Note the "tags" property I added to these calls will only expose the unknown tags (i.e. things that are not specially handled like `@returns,` `@param` etc) ... I couldn't think of a justification to expose the known tags too (well, also I wouldn't have been able to do so without making more significant changes to the parser which I want to avoid at the moment).

Fixes #11956 

You might be interested @sandersn  @vladima 