### PR TITLE
[release-2.1] Produce an error for an augmentation of an untyped module even if `moduleNotFoundError` is not defined

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1439,9 +1439,8 @@ namespace ts {
              // May be an untyped module. If so, ignore resolutionDiagnostic.
             if (!isRelative && resolvedModule && !extensionIsTypeScript(resolvedModule.extension)) {
                 if (isForAugmentation) {
-                    Debug.assert(!!moduleNotFoundError);
                     const diag = Diagnostics.Invalid_module_name_in_augmentation_Module_0_resolves_to_an_untyped_module_at_1_which_cannot_be_augmented;
-                    error(errorNode, diag, moduleName, resolvedModule.resolvedFileName);
+                    error(errorNode, diag, moduleReference, resolvedModule.resolvedFileName);
                 }
                 else if (compilerOptions.noImplicitAny && moduleNotFoundError) {
                     error(errorNode,

--- a/tests/baselines/reference/untypedModuleImport_withAugmentation2.errors.txt
+++ b/tests/baselines/reference/untypedModuleImport_withAugmentation2.errors.txt
@@ -1,0 +1,19 @@
+/node_modules/augmenter/index.d.ts(3,16): error TS2665: Invalid module name in augmentation. Module 'js' resolves to an untyped module at '/node_modules/js/index.js', which cannot be augmented.
+
+
+==== /a.ts (0 errors) ====
+    import { } from "augmenter";
+    
+==== /node_modules/augmenter/index.d.ts (1 errors) ====
+    // This tests that augmenting an untyped module is forbidden even in an ambient context. Contrast with `moduleAugmentationInDependency.ts`.
+    
+    declare module "js" {
+                   ~~~~
+!!! error TS2665: Invalid module name in augmentation. Module 'js' resolves to an untyped module at '/node_modules/js/index.js', which cannot be augmented.
+        export const j: number;
+    }
+    export {};
+    
+==== /node_modules/js/index.js (0 errors) ====
+    This file is not processed.
+    

--- a/tests/baselines/reference/untypedModuleImport_withAugmentation2.js
+++ b/tests/baselines/reference/untypedModuleImport_withAugmentation2.js
@@ -1,0 +1,19 @@
+//// [tests/cases/compiler/untypedModuleImport_withAugmentation2.ts] ////
+
+//// [index.d.ts]
+// This tests that augmenting an untyped module is forbidden even in an ambient context. Contrast with `moduleAugmentationInDependency.ts`.
+
+declare module "js" {
+    export const j: number;
+}
+export {};
+
+//// [index.js]
+This file is not processed.
+
+//// [a.ts]
+import { } from "augmenter";
+
+
+//// [a.js]
+"use strict";

--- a/tests/cases/compiler/untypedModuleImport_withAugmentation2.ts
+++ b/tests/cases/compiler/untypedModuleImport_withAugmentation2.ts
@@ -1,0 +1,14 @@
+// @noImplicitReferences: true
+// This tests that augmenting an untyped module is forbidden even in an ambient context. Contrast with `moduleAugmentationInDependency.ts`.
+
+// @Filename: /node_modules/augmenter/index.d.ts
+declare module "js" {
+    export const j: number;
+}
+export {};
+
+// @Filename: /node_modules/js/index.js
+This file is not processed.
+
+// @Filename: /a.ts
+import { } from "augmenter";


### PR DESCRIPTION
Port of #12852