### PR TITLE
Set symbol/flags only on (fresh) object spreads

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11638,8 +11638,11 @@ namespace ts {
                 if (propertiesArray.length > 0) {
                     spread = getSpreadType(spread, createObjectLiteralType(), /*isFromObjectLiteral*/ true);
                 }
-                spread.flags |= propagatedFlags;
-                spread.symbol = node.symbol;
+                if (spread.flags & TypeFlags.Object) {
+                    // only set the symbol and flags if this is a (fresh) object type
+                    spread.flags |= propagatedFlags;
+                    spread.symbol = node.symbol;
+                }
                 return spread;
             }
 

--- a/tests/baselines/reference/explicitAnyAfterSpreadNoImplicitAnyError.js
+++ b/tests/baselines/reference/explicitAnyAfterSpreadNoImplicitAnyError.js
@@ -1,0 +1,16 @@
+//// [explicitAnyAfterSpreadNoImplicitAnyError.ts]
+({ a: [], ...(null as any) });
+let x: any;
+
+
+//// [explicitAnyAfterSpreadNoImplicitAnyError.js]
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
+    }
+    return t;
+};
+(__assign({ a: [] }, null));
+var x;

--- a/tests/baselines/reference/explicitAnyAfterSpreadNoImplicitAnyError.symbols
+++ b/tests/baselines/reference/explicitAnyAfterSpreadNoImplicitAnyError.symbols
@@ -1,0 +1,7 @@
+=== tests/cases/compiler/explicitAnyAfterSpreadNoImplicitAnyError.ts ===
+({ a: [], ...(null as any) });
+>a : Symbol(a, Decl(explicitAnyAfterSpreadNoImplicitAnyError.ts, 0, 2))
+
+let x: any;
+>x : Symbol(x, Decl(explicitAnyAfterSpreadNoImplicitAnyError.ts, 1, 3))
+

--- a/tests/baselines/reference/explicitAnyAfterSpreadNoImplicitAnyError.types
+++ b/tests/baselines/reference/explicitAnyAfterSpreadNoImplicitAnyError.types
@@ -1,0 +1,13 @@
+=== tests/cases/compiler/explicitAnyAfterSpreadNoImplicitAnyError.ts ===
+({ a: [], ...(null as any) });
+>({ a: [], ...(null as any) }) : any
+>{ a: [], ...(null as any) } : any
+>a : undefined[]
+>[] : undefined[]
+>(null as any) : any
+>null as any : any
+>null : null
+
+let x: any;
+>x : any
+

--- a/tests/baselines/reference/objectSpread.symbols
+++ b/tests/baselines/reference/objectSpread.symbols
@@ -200,7 +200,6 @@ let cplus: { p: number, plus(): void } = { ...c, plus() { return this.p + 1; } }
 >plus : Symbol(plus, Decl(objectSpread.ts, 49, 23))
 >c : Symbol(c, Decl(objectSpread.ts, 45, 3))
 >plus : Symbol(plus, Decl(objectSpread.ts, 49, 48))
->this : Symbol(__object, Decl(objectSpread.ts, 41, 15))
 
 cplus.plus();
 >cplus.plus : Symbol(plus, Decl(objectSpread.ts, 49, 23))

--- a/tests/cases/compiler/explicitAnyAfterSpreadNoImplicitAnyError.ts
+++ b/tests/cases/compiler/explicitAnyAfterSpreadNoImplicitAnyError.ts
@@ -1,0 +1,3 @@
+// @noImplicitAny: true
+({ a: [], ...(null as any) });
+let x: any;


### PR DESCRIPTION
Set symbol/flags only on (fresh) object spreads. If you spread any into an object, the type is any, which should not be changed.

Previously, `checkObjectLiteral` assumed that the return value of `getSpreadType` was a fresh object type, but this is not true when spreading an expression of type `any`. So it incorrectly added flags to `any` that it inherits from the rest of the object literal. 

In the test case, `[]` contributes a ContainsWideningType flag, which previously made all uses of `any` trigger an implicit any error.