### PR TITLE
NavigateTo is not working correctly for declarations in IIFEs

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -592,9 +592,8 @@ namespace ts {
                             else {
                                 declarations.push(functionDeclaration);
                             }
-
-                            forEachChild(node, visit);
                         }
+                        forEachChild(node, visit);
                         break;
 
                     case SyntaxKind.ClassDeclaration:

--- a/tests/cases/fourslash/navigateToIIFE.ts
+++ b/tests/cases/fourslash/navigateToIIFE.ts
@@ -1,0 +1,19 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: file1.ts
+/////*1*/(function () {
+////    "use strict";
+////    function onResume() {
+////    };
+////} )();
+// @Filename: file2.ts
+/////*2*/class EventManager {
+////    public onResume(name: string) { }
+////}
+////class MyOtherEventManager {
+////    public onResume(name: string) { }
+////}
+verify.navigationItemsListCount(3, "onResume");
+verify.navigationItemsListCount(1, "onResume", undefined, test.marker("1").fileName);
+verify.navigationItemsListContains("onResume", "function", "onResume", "exact", test.marker("1").fileName);
+verify.navigationItemsListCount(2, "onResume", undefined, test.marker("2").fileName);


### PR DESCRIPTION
NavigateTo is not working correctly for declarations in IIFEs

Fix: visit the node's children even when the function declaration name is undefined
