### PR TITLE
Add more files to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,11 @@
 built
 doc
+Gulpfile.ts
 internal
 issue_template.md
+jenkins.sh
 lib/README.md
+netci.groovy
 pull_request_template.md
 scripts
 src


### PR DESCRIPTION
We probably forgot to add these files to `.npmignore` when creating them.