### PR TITLE
For imports via 'main' entry also try appending .js/.jsx

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -684,12 +684,17 @@ namespace ts {
                 // A package.json "typings" may specify an exact filename, or may choose to omit an extension.
                 const fromFile = tryFile(typesFile, failedLookupLocations, onlyRecordFailures, state);
                 if (fromFile) {
-                    // Note: this would allow a package.json to specify a ".js" file as typings. Maybe that should be forbidden.
                     return resolvedFromAnyFile(fromFile);
                 }
-                const x = tryAddingExtensions(typesFile, Extensions.TypeScript, failedLookupLocations, onlyRecordFailures, state);
-                if (x) {
-                    return x;
+                // Attempt with ts extension
+                const xTs = tryAddingExtensions(typesFile, Extensions.TypeScript, failedLookupLocations, onlyRecordFailures, state);
+                if (xTs) {
+                    return xTs;
+                }
+                // Attempt with js extension
+                const xJs = tryAddingExtensions(typesFile, Extensions.JavaScript, failedLookupLocations, onlyRecordFailures, state);
+                if (xJs) {
+                    return xJs;
                 }
             }
             else {

--- a/src/harness/unittests/moduleResolution.ts
+++ b/src/harness/unittests/moduleResolution.ts
@@ -158,6 +158,7 @@ namespace ts {
             /* tslint:enable no-null-keyword */
             testTypingsIgnored(undefined);
         });
+
         it("module name as directory - load index.d.ts", () => {
             test(/*hasDirectoryExists*/ false);
             test(/*hasDirectoryExists*/ true);
@@ -176,6 +177,33 @@ namespace ts {
                 ]);
             }
         });
+
+        it("module name as directory - load js from 'main'", () => {
+            test(/*hasDirectoryExists*/ false);
+            test(/*hasDirectoryExists*/ true);
+
+            function test(hasDirectoryExists: boolean) {
+                const containingFile = { name: "/a/b.ts" };
+                const packageJson = { name: "/a/c/package.json", content: JSON.stringify({ main: "d/e" }) };
+                const indexFile = { name: "/a/c/d/e.js" };
+                const resolution = nodeModuleNameResolver("./c", containingFile.name, {}, createModuleResolutionHost(hasDirectoryExists, containingFile, packageJson, indexFile));
+                checkResolvedModuleWithFailedLookupLocations(resolution, createResolvedModule(indexFile.name), [
+                       "/a/c.ts",
+                       "/a/c.tsx",
+                       "/a/c.d.ts",
+                       "/a/c/index.ts",
+                       "/a/c/index.tsx",
+                       "/a/c/index.d.ts",
+                       "/a/c.js",
+                       "/a/c.jsx",
+                       "/a/c/d/e",
+                       "/a/c/d/e.ts",
+                       "/a/c/d/e.tsx",
+                       "/a/c/d/e.d.ts",
+                ]);
+            }
+        });
+
     });
 
     describe("Node module resolution - non-relative paths", () => {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #12748 #12921

It is common for npm modules to refer their entry script in `package.json`'s `main` property as `build/index` instead of specifying the whole path (i.e. `build/index.js`). 

An example of such a npm package would be`xmlbuilder`. Doing this is covered by the spec: https://docs.npmjs.com/files/package.json#main, the referencing behaviour is similar to node `require` statements.

Extension padding is performed for typescript files, but not for javascript. As of v2.1.0 javascript node imports should work seamlessly, thus this PR aligns the behaviour for Js imports and also attempts to find a `.js`-padded file.

Note: Some packages also do not add a truncated file path to the `main` but only a folder in which an `index.js` file is sitting. This is not covered by this PR, but this wouldn't work for typescript imports either right now. 