### PR TITLE
JSDoc functions are now in scope for instantiation

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6634,7 +6634,7 @@ namespace ts {
             // Starting with the parent of the symbol's declaration, check if the mapper maps any of
             // the type parameters introduced by enclosing declarations. We just pick the first
             // declaration since multiple declarations will all have the same parent anyway.
-            let node = symbol.declarations[0].parent;
+            let node: Node = symbol.declarations[0];
             while (node) {
                 switch (node.kind) {
                     case SyntaxKind.FunctionType:
@@ -6654,7 +6654,7 @@ namespace ts {
                     case SyntaxKind.ClassExpression:
                     case SyntaxKind.InterfaceDeclaration:
                     case SyntaxKind.TypeAliasDeclaration:
-                        const declaration = <DeclarationWithTypeParameters>node;
+                        const declaration = node as DeclarationWithTypeParameters;
                         if (declaration.typeParameters) {
                             for (const d of declaration.typeParameters) {
                                 if (contains(mappedTypes, getDeclaredTypeOfTypeParameter(getSymbolOfNode(d)))) {
@@ -6665,6 +6665,14 @@ namespace ts {
                         if (isClassLike(node) || node.kind === SyntaxKind.InterfaceDeclaration) {
                             const thisType = getDeclaredTypeOfClassOrInterface(getSymbolOfNode(node)).thisType;
                             if (thisType && contains(mappedTypes, thisType)) {
+                                return true;
+                            }
+                        }
+                        break;
+                    case SyntaxKind.JSDocFunctionType:
+                        const func = node as JSDocFunctionType;
+                        for (const p of func.parameters) {
+                            if (contains(mappedTypes, getTypeOfNode(p))) {
                                 return true;
                             }
                         }

--- a/tests/cases/fourslash/jsDocGenerics2.ts
+++ b/tests/cases/fourslash/jsDocGenerics2.ts
@@ -1,0 +1,19 @@
+///<reference path="fourslash.ts" />
+// @allowNonTsExtensions: true
+// @Filename: Foo.js
+
+/////**
+//// * @param {T[]} arr
+//// * @param {(function(T):T)} valuator
+//// * @template T
+//// */
+////function SortFilter(arr,valuator)
+////{
+////    return arr;
+////}
+////var a/*1*/ = SortFilter([0, 1, 2], q/*2*/ => q);
+////var b/*3*/ = SortFilter([0, 1, 2], undefined);
+
+verify.quickInfoAt('1', "var a: number[]");
+verify.quickInfoAt('2', '(parameter) q: number');
+verify.quickInfoAt('3', "var b: number[]");


### PR DESCRIPTION
Fixes #11724

Previously, `isSymbolInScopeOfMappedTypeParameter` did not understand JSDoc, so it would cause generic function declarations in JSDoc not to be instantiated.