### PR TITLE
Fix tslint version. 4.1.0-dev.0 introduced some bugs, so we must wait on #13006 to upgrade.

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "through2": "latest",
         "travis-fold": "latest",
         "ts-node": "latest",
-        "tslint": "next",
+        "tslint": "4.0.2",
         "typescript": "next"
     },
     "scripts": {


### PR DESCRIPTION
Fixes linting for now. We should upgrade with #13006.