### PR TITLE
space-before-function-paren

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -341,6 +341,7 @@ namespace FourSlash {
                 insertSpaceAfterCommaDelimiter: true,
                 insertSpaceAfterSemicolonInForStatements: true,
                 insertSpaceBeforeAndAfterBinaryOperators: true,
+                insertSpaceAfterConstructor: false,
                 insertSpaceAfterKeywordsInControlFlowStatements: true,
                 insertSpaceAfterFunctionKeywordForAnonymousFunctions: false,
                 insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: false,

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2194,6 +2194,7 @@ namespace ts.server.protocol {
         insertSpaceAfterCommaDelimiter?: boolean;
         insertSpaceAfterSemicolonInForStatements?: boolean;
         insertSpaceBeforeAndAfterBinaryOperators?: boolean;
+        insertSpaceAfterConstructor?: boolean;
         insertSpaceAfterKeywordsInControlFlowStatements?: boolean;
         insertSpaceAfterFunctionKeywordForAnonymousFunctions?: boolean;
         insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis?: boolean;

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2200,6 +2200,7 @@ namespace ts.server.protocol {
         insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets?: boolean;
         insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces?: boolean;
         insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces?: boolean;
+        insertSpaceBeforeFunctionParenthesis?: boolean;
         placeOpenBraceOnNewLineForFunctions?: boolean;
         placeOpenBraceOnNewLineForControlBlocks?: boolean;
     }

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -87,6 +87,7 @@ namespace ts.server {
             insertSpaceAfterOpeningAndBeforeClosingNonemptyBrackets: false,
             insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: false,
             insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces: false,
+            insertSpaceBeforeFunctionParenthesis: false,
             placeOpenBraceOnNewLineForFunctions: false,
             placeOpenBraceOnNewLineForControlBlocks: false,
         };

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -78,6 +78,7 @@ namespace ts.server {
             newLineCharacter: host.newLine || "\n",
             convertTabsToSpaces: true,
             indentStyle: ts.IndentStyle.Smart,
+            insertSpaceAfterConstructor: false,
             insertSpaceAfterCommaDelimiter: true,
             insertSpaceAfterSemicolonInForStatements: true,
             insertSpaceBeforeAndAfterBinaryOperators: true,

--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -113,6 +113,7 @@ namespace ts.formatting {
         // TypeScript-specific rules
 
         // Treat constructor as an identifier in a function declaration, and remove spaces between constructor and following left parentheses
+        public SpaceAfterConstructor: Rule;
         public NoSpaceAfterConstructor: Rule;
 
         // Use of module as a function call. e.g.: import m2 = module("m2");
@@ -354,6 +355,7 @@ namespace ts.formatting {
             // TypeScript-specific higher priority rules
 
             // Treat constructor as an identifier in a function declaration, and remove spaces between constructor and following left parentheses
+            this.SpaceAfterConstructor = new Rule(RuleDescriptor.create1(SyntaxKind.ConstructorKeyword, SyntaxKind.OpenParenToken), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext), RuleAction.Space));
             this.NoSpaceAfterConstructor = new Rule(RuleDescriptor.create1(SyntaxKind.ConstructorKeyword, SyntaxKind.OpenParenToken), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext), RuleAction.Delete));
 
             // Use of module as a function call. e.g.: import m2 = module("m2");
@@ -439,7 +441,7 @@ namespace ts.formatting {
                 this.NoSpaceBeforeEqualInJsxAttribute, this.NoSpaceAfterEqualInJsxAttribute,
 
                 // TypeScript-specific rules
-                this.NoSpaceAfterConstructor, this.NoSpaceAfterModuleImport,
+                this.NoSpaceAfterModuleImport,
                 this.SpaceAfterCertainTypeScriptKeywords, this.SpaceBeforeCertainTypeScriptKeywords,
                 this.SpaceAfterModuleName,
                 this.SpaceBeforeArrow, this.SpaceAfterArrow,

--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -87,6 +87,7 @@ namespace ts.formatting {
         public SpaceAfterLetConstInVariableDeclaration: Rule;
         public NoSpaceBeforeOpenParenInFuncCall: Rule;
         public SpaceAfterFunctionInFuncDecl: Rule;
+        public SpaceBeforeOpenParenInFuncDecl: Rule;
         public NoSpaceBeforeOpenParenInFuncDecl: Rule;
         public SpaceAfterVoidOperator: Rule;
 
@@ -329,6 +330,7 @@ namespace ts.formatting {
             this.SpaceAfterLetConstInVariableDeclaration = new Rule(RuleDescriptor.create4(Shared.TokenRange.FromTokens([SyntaxKind.LetKeyword, SyntaxKind.ConstKeyword]), Shared.TokenRange.Any), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext, Rules.IsStartOfVariableDeclarationList), RuleAction.Space));
             this.NoSpaceBeforeOpenParenInFuncCall = new Rule(RuleDescriptor.create2(Shared.TokenRange.Any, SyntaxKind.OpenParenToken), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext, Rules.IsFunctionCallOrNewContext, Rules.IsPreviousTokenNotComma), RuleAction.Delete));
             this.SpaceAfterFunctionInFuncDecl = new Rule(RuleDescriptor.create3(SyntaxKind.FunctionKeyword, Shared.TokenRange.Any), RuleOperation.create2(new RuleOperationContext(Rules.IsFunctionDeclContext), RuleAction.Space));
+            this.SpaceBeforeOpenParenInFuncDecl = new Rule(RuleDescriptor.create2(Shared.TokenRange.Any, SyntaxKind.OpenParenToken), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext, Rules.IsFunctionDeclContext), RuleAction.Space));
             this.NoSpaceBeforeOpenParenInFuncDecl = new Rule(RuleDescriptor.create2(Shared.TokenRange.Any, SyntaxKind.OpenParenToken), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext, Rules.IsFunctionDeclContext), RuleAction.Delete));
             this.SpaceAfterVoidOperator = new Rule(RuleDescriptor.create3(SyntaxKind.VoidKeyword, Shared.TokenRange.Any), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext, Rules.IsVoidOpContext), RuleAction.Space));
 
@@ -462,7 +464,6 @@ namespace ts.formatting {
                 this.NoSpaceBeforeOpenBracket,
                 this.NoSpaceAfterCloseBracket,
                 this.SpaceAfterSemicolon,
-                this.NoSpaceBeforeOpenParenInFuncDecl,
                 this.SpaceBetweenStatements, this.SpaceAfterTryFinally
             ];
 

--- a/src/services/formatting/rulesProvider.ts
+++ b/src/services/formatting/rulesProvider.ts
@@ -128,6 +128,13 @@ namespace ts.formatting {
                 rules.push(this.globalRules.NoSpaceAfterBinaryOperator);
             }
 
+            if (options.insertSpaceBeforeFunctionParenthesis) {
+                rules.push(this.globalRules.SpaceBeforeOpenParenInFuncDecl);
+            }
+            else {
+                rules.push(this.globalRules.NoSpaceBeforeOpenParenInFuncDecl);
+            }
+
             if (options.placeOpenBraceOnNewLineForControlBlocks) {
                 rules.push(this.globalRules.NewLineBeforeOpenBraceInControl);
             }

--- a/src/services/formatting/rulesProvider.ts
+++ b/src/services/formatting/rulesProvider.ts
@@ -38,6 +38,13 @@ namespace ts.formatting {
         private createActiveRules(options: ts.FormatCodeSettings): Rule[] {
             let rules = this.globalRules.HighPriorityCommonRules.slice(0);
 
+            if (options.insertSpaceAfterConstructor) {
+                rules.push(this.globalRules.SpaceAfterConstructor);
+            }
+            else {
+                rules.push(this.globalRules.NoSpaceAfterConstructor);
+            }
+
             if (options.insertSpaceAfterCommaDelimiter) {
                 rules.push(this.globalRules.SpaceAfterComma);
             }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -426,6 +426,7 @@ namespace ts {
         InsertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces: boolean;
         InsertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces?: boolean;
         InsertSpaceAfterTypeAssertion?: boolean;
+        InsertSpaceBeforeFunctionParenthesis?: boolean;
         PlaceOpenBraceOnNewLineForFunctions: boolean;
         PlaceOpenBraceOnNewLineForControlBlocks: boolean;
     }
@@ -442,6 +443,7 @@ namespace ts {
         insertSpaceAfterOpeningAndBeforeClosingTemplateStringBraces?: boolean;
         insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces?: boolean;
         insertSpaceAfterTypeAssertion?: boolean;
+        insertSpaceBeforeFunctionParenthesis?: boolean;
         placeOpenBraceOnNewLineForFunctions?: boolean;
         placeOpenBraceOnNewLineForControlBlocks?: boolean;
     }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -418,6 +418,7 @@ namespace ts {
         InsertSpaceAfterCommaDelimiter: boolean;
         InsertSpaceAfterSemicolonInForStatements: boolean;
         InsertSpaceBeforeAndAfterBinaryOperators: boolean;
+        InsertSpaceAfterConstructor?: boolean;
         InsertSpaceAfterKeywordsInControlFlowStatements: boolean;
         InsertSpaceAfterFunctionKeywordForAnonymousFunctions: boolean;
         InsertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis: boolean;
@@ -435,6 +436,7 @@ namespace ts {
         insertSpaceAfterCommaDelimiter?: boolean;
         insertSpaceAfterSemicolonInForStatements?: boolean;
         insertSpaceBeforeAndAfterBinaryOperators?: boolean;
+        insertSpaceAfterConstructor?: boolean;
         insertSpaceAfterKeywordsInControlFlowStatements?: boolean;
         insertSpaceAfterFunctionKeywordForAnonymousFunctions?: boolean;
         insertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis?: boolean;

--- a/tests/cases/fourslash/formattingSpaceBeforeFunctionParen.ts
+++ b/tests/cases/fourslash/formattingSpaceBeforeFunctionParen.ts
@@ -1,0 +1,13 @@
+/// <reference path='fourslash.ts' />
+
+/////*1*/function foo() { }
+/////*2*/function boo  () { }
+
+format.setOption("InsertSpaceBeforeFunctionParenthesis", true);
+
+format.document();
+
+goTo.marker('1');
+verify.currentLineContentIs('function foo () { }');
+goTo.marker('2');
+verify.currentLineContentIs('function boo () { }');

--- a/tests/cases/fourslash/formattingSpaceBeforeFunctionParen.ts
+++ b/tests/cases/fourslash/formattingSpaceBeforeFunctionParen.ts
@@ -2,6 +2,8 @@
 
 /////*1*/function foo() { }
 /////*2*/function boo  () { }
+/////*3*/var bar = function foo() { };
+/////*4*/var foo = { bar() { } };
 
 format.setOption("InsertSpaceBeforeFunctionParenthesis", true);
 
@@ -11,3 +13,7 @@ goTo.marker('1');
 verify.currentLineContentIs('function foo () { }');
 goTo.marker('2');
 verify.currentLineContentIs('function boo () { }');
+goTo.marker('3');
+verify.currentLineContentIs('var bar = function foo () { };');
+goTo.marker('4');
+verify.currentLineContentIs('var foo = { bar () { } };');

--- a/tests/cases/fourslash/formattingSpacesAfterConstructor.ts
+++ b/tests/cases/fourslash/formattingSpacesAfterConstructor.ts
@@ -4,3 +4,10 @@
 format.document();
 goTo.marker("1");
 verify.currentLineContentIs("class test { constructor() { } }");
+
+/////*2*/class test { constructor                   () { } }
+format.setOption("InsertSpaceAfterConstructor", true);
+
+format.document();
+goTo.marker("2");
+verify.currentLineContentIs("class test { constructor () { } }");


### PR DESCRIPTION
Adding option InsertSpaceBeforeFunctionParenthesis
Should be optional
Typically used to support http://eslint.org/docs/rules/space-before-function-paren

Fixes #12234

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[X ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ X] Code is up-to-date with the `master` branch
[X ] You've successfully run `jake runtests` locally
[ X] You've signed the CLA
[X ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
