### PR TITLE
fix issue #13114

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -264,12 +264,12 @@ namespace ts.formatting {
             this.SpaceAfterSemicolon = new Rule(RuleDescriptor.create3(SyntaxKind.SemicolonToken, Shared.TokenRange.Any), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext), RuleAction.Space));
 
             // Space after }.
-            this.SpaceAfterCloseBrace = new Rule(RuleDescriptor.create3(SyntaxKind.CloseBraceToken, Shared.TokenRange.Any), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext, Rules.IsAfterCodeBlockContext), RuleAction.Space));
+            this.SpaceAfterCloseBrace = new Rule(RuleDescriptor.create3(SyntaxKind.CloseBraceToken, Shared.TokenRange.FromRange(SyntaxKind.FirstToken, SyntaxKind.LastToken, [SyntaxKind.CloseParenToken])), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext, Rules.IsAfterCodeBlockContext), RuleAction.Space));
 
             // Special case for (}, else) and (}, while) since else & while tokens are not part of the tree which makes SpaceAfterCloseBrace rule not applied
             this.SpaceBetweenCloseBraceAndElse = new Rule(RuleDescriptor.create1(SyntaxKind.CloseBraceToken, SyntaxKind.ElseKeyword), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext), RuleAction.Space));
             this.SpaceBetweenCloseBraceAndWhile = new Rule(RuleDescriptor.create1(SyntaxKind.CloseBraceToken, SyntaxKind.WhileKeyword), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext), RuleAction.Space));
-            this.NoSpaceAfterCloseBrace = new Rule(RuleDescriptor.create3(SyntaxKind.CloseBraceToken, Shared.TokenRange.FromTokens([SyntaxKind.CloseParenToken, SyntaxKind.CloseBracketToken, SyntaxKind.CommaToken, SyntaxKind.SemicolonToken])), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext), RuleAction.Delete));
+            this.NoSpaceAfterCloseBrace = new Rule(RuleDescriptor.create3(SyntaxKind.CloseBraceToken, Shared.TokenRange.FromTokens([SyntaxKind.CloseBracketToken, SyntaxKind.CommaToken, SyntaxKind.SemicolonToken])), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext), RuleAction.Delete));
 
             // No space for dot
             this.NoSpaceBeforeDot = new Rule(RuleDescriptor.create2(Shared.TokenRange.Any, SyntaxKind.DotToken), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext), RuleAction.Delete));

--- a/tests/cases/fourslash/formattingSpaceBeforeCloseParen.ts
+++ b/tests/cases/fourslash/formattingSpaceBeforeCloseParen.ts
@@ -1,0 +1,33 @@
+/// <reference path='fourslash.ts' />
+
+/////*1*/({});
+/////*2*/(  {});
+/////*3*/({foo:42});
+/////*4*/(  {foo:42}  );
+/////*5*/var bar = (function (a) { });
+
+format.setOption("InsertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis", true);
+format.document();
+goTo.marker('1');
+verify.currentLineContentIs('( {} );');
+goTo.marker('2');
+verify.currentLineContentIs('( {} );');
+goTo.marker('3');
+verify.currentLineContentIs('( { foo: 42 } );');
+goTo.marker('4');
+verify.currentLineContentIs('( { foo: 42 } );');
+goTo.marker('5');
+verify.currentLineContentIs('var bar = ( function( a ) { } );');
+
+format.setOption("InsertSpaceAfterOpeningAndBeforeClosingNonemptyParenthesis", false);
+format.document();
+goTo.marker('1');
+verify.currentLineContentIs('({});');
+goTo.marker('2');
+verify.currentLineContentIs('({});');
+goTo.marker('3');
+verify.currentLineContentIs('({ foo: 42 });');
+goTo.marker('4');
+verify.currentLineContentIs('({ foo: 42 });');
+goTo.marker('5');
+verify.currentLineContentIs('var bar = (function(a) { });');


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[x] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `jake runtests` locally
[x] You've signed the CLA
[x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #13114 

Move the responsibility for managing space between `}` and `)`, from `(No)SpaceAfterCloseBrace` to the user-defined rule `(No)SpaceBeforeCloseParen`.
