### PR TITLE
mark 'failedLookupLocations' as internal

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3544,6 +3544,7 @@ namespace ts {
 
     export interface ResolvedModuleWithFailedLookupLocations {
         resolvedModule: ResolvedModuleFull | undefined;
+        /* @internal */
         failedLookupLocations: string[];
     }
 


### PR DESCRIPTION
// cc @mhegazy 

Removing this field will simplify the implementation of module resolution. This PR hides it from the API surface to determine if somebody outside is using it.