### PR TITLE
Fix formatting with non-null assertion operator

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -245,6 +245,9 @@ namespace ts.formatting {
         public NoSpaceAfterTypeAssertion: Rule;
         public SpaceAfterTypeAssertion: Rule;
 
+        // No space before non-null assertion operator
+        public NoSpaceBeforeNonNullAssertionOperator: Rule;
+
         constructor() {
             ///
             /// Common Rules
@@ -410,6 +413,9 @@ namespace ts.formatting {
             this.NoSpaceBeforeEqualInJsxAttribute = new Rule(RuleDescriptor.create2(Shared.TokenRange.Any, SyntaxKind.EqualsToken), RuleOperation.create2(new RuleOperationContext(Rules.IsJsxAttributeContext, Rules.IsNonJsxSameLineTokenContext), RuleAction.Delete));
             this.NoSpaceAfterEqualInJsxAttribute = new Rule(RuleDescriptor.create3(SyntaxKind.EqualsToken, Shared.TokenRange.Any), RuleOperation.create2(new RuleOperationContext(Rules.IsJsxAttributeContext, Rules.IsNonJsxSameLineTokenContext), RuleAction.Delete));
 
+            // No space before non-null assertion operator
+            this.NoSpaceBeforeNonNullAssertionOperator = new Rule(RuleDescriptor.create2(Shared.TokenRange.Any, SyntaxKind.ExclamationToken), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext, Rules.IsNonNullAssertionContext), RuleAction.Delete));
+
             // These rules are higher in priority than user-configurable rules.
             this.HighPriorityCommonRules = [
                 this.IgnoreBeforeComment, this.IgnoreAfterLineComment,
@@ -456,6 +462,7 @@ namespace ts.formatting {
                 this.SpaceBeforeAt,
                 this.NoSpaceAfterAt,
                 this.SpaceAfterDecorator,
+                this.NoSpaceBeforeNonNullAssertionOperator
             ];
 
             // These rules are lower in priority than user-configurable rules.
@@ -881,6 +888,10 @@ namespace ts.formatting {
 
         static IsYieldOrYieldStarWithOperand(context: FormattingContext): boolean {
             return context.contextNode.kind === SyntaxKind.YieldExpression && (<YieldExpression>context.contextNode).expression !== undefined;
+        }
+
+        static IsNonNullAssertionContext(context: FormattingContext): boolean {
+            return context.contextNode.kind === SyntaxKind.NonNullExpression;
         }
     }
 }

--- a/tests/cases/fourslash/formattingNonNullAssertionOperator.ts
+++ b/tests/cases/fourslash/formattingNonNullAssertionOperator.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts' />
+
+/////*1*/'bar'!;
+/////*2*/('bar')!;
+/////*3*/'bar'[1]!;
+/////*4*/var bar = 'bar'.foo!;
+/////*5*/var foo = bar!;
+
+format.document();
+goTo.marker('1');
+verify.currentLineContentIs("'bar'!;");
+goTo.marker('2');
+verify.currentLineContentIs("('bar')!;");
+goTo.marker('3');
+verify.currentLineContentIs("'bar'[1]!;");
+goTo.marker('4');
+verify.currentLineContentIs("var bar = 'bar'.foo!;");
+goTo.marker('5');
+verify.currentLineContentIs("var foo = bar!;");

--- a/tests/cases/fourslash/formattingNonNullAssertionOperator.ts
+++ b/tests/cases/fourslash/formattingNonNullAssertionOperator.ts
@@ -7,13 +7,13 @@
 /////*5*/var foo = bar!;
 
 format.document();
-goTo.marker('1');
+goTo.marker("1");
 verify.currentLineContentIs("'bar'!;");
-goTo.marker('2');
+goTo.marker("2");
 verify.currentLineContentIs("('bar')!;");
-goTo.marker('3');
+goTo.marker("3");
 verify.currentLineContentIs("'bar'[1]!;");
-goTo.marker('4');
+goTo.marker("4");
 verify.currentLineContentIs("var bar = 'bar'.foo!;");
-goTo.marker('5');
+goTo.marker("5");
 verify.currentLineContentIs("var foo = bar!;");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[x] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `jake runtests` locally
[x] You've signed the CLA
[x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #11676

Add a new rule `NoSpaceBeforeNonNullAssertionOperator`.

It seems like the rule `SpaceBetweenStatements` causes this bug. At first I tried to remove exclamation mark from RightTokenRange, but it changed the inserting order of rule and broke many tests.
