### PR TITLE
Aggregate transform flags for ExpressionWithTypeArguments

### DIFF
--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -1328,7 +1328,7 @@ namespace ts {
     function aggregateTransformFlagsForSubtree(node: Node): TransformFlags {
         // We do not transform ambient declarations or types, so there is no need to
         // recursively aggregate transform flags.
-        if (hasModifier(node, ModifierFlags.Ambient) || isTypeNode(node)) {
+        if (hasModifier(node, ModifierFlags.Ambient) || (isTypeNode(node) && node.kind !== SyntaxKind.ExpressionWithTypeArguments)) {
             return TransformFlags.None;
         }
 

--- a/tests/baselines/reference/jsxInExtendsClause.js
+++ b/tests/baselines/reference/jsxInExtendsClause.js
@@ -1,0 +1,35 @@
+//// [jsxInExtendsClause.tsx]
+// https://github.com/Microsoft/TypeScript/issues/13157
+declare namespace React {
+  interface ComponentClass<P> { new (): Component<P, {}>; }
+  class Component<A, B> {}
+}
+declare function createComponentClass<P>(factory: () => React.ComponentClass<P>): React.ComponentClass<P>;
+class Foo extends createComponentClass(() => class extends React.Component<{}, {}> {
+  render() {
+    return <span>Hello, world!</span>;
+  }
+}) {}
+
+//// [jsxInExtendsClause.js]
+var __extends = (this && this.__extends) || function (d, b) {
+    for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+    function __() { this.constructor = d; }
+    d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+};
+var Foo = (function (_super) {
+    __extends(Foo, _super);
+    function Foo() {
+        return _super.apply(this, arguments) || this;
+    }
+    return Foo;
+}(createComponentClass(function () { return (function (_super) {
+    __extends(class_1, _super);
+    function class_1() {
+        return _super.apply(this, arguments) || this;
+    }
+    class_1.prototype.render = function () {
+        return React.createElement("span", null, "Hello, world!");
+    };
+    return class_1;
+}(React.Component)); })));

--- a/tests/baselines/reference/jsxInExtendsClause.symbols
+++ b/tests/baselines/reference/jsxInExtendsClause.symbols
@@ -1,0 +1,42 @@
+=== tests/cases/compiler/jsxInExtendsClause.tsx ===
+// https://github.com/Microsoft/TypeScript/issues/13157
+declare namespace React {
+>React : Symbol(React, Decl(jsxInExtendsClause.tsx, 0, 0))
+
+  interface ComponentClass<P> { new (): Component<P, {}>; }
+>ComponentClass : Symbol(ComponentClass, Decl(jsxInExtendsClause.tsx, 1, 25))
+>P : Symbol(P, Decl(jsxInExtendsClause.tsx, 2, 27))
+>Component : Symbol(Component, Decl(jsxInExtendsClause.tsx, 2, 59))
+>P : Symbol(P, Decl(jsxInExtendsClause.tsx, 2, 27))
+
+  class Component<A, B> {}
+>Component : Symbol(Component, Decl(jsxInExtendsClause.tsx, 2, 59))
+>A : Symbol(A, Decl(jsxInExtendsClause.tsx, 3, 18))
+>B : Symbol(B, Decl(jsxInExtendsClause.tsx, 3, 20))
+}
+declare function createComponentClass<P>(factory: () => React.ComponentClass<P>): React.ComponentClass<P>;
+>createComponentClass : Symbol(createComponentClass, Decl(jsxInExtendsClause.tsx, 4, 1))
+>P : Symbol(P, Decl(jsxInExtendsClause.tsx, 5, 38))
+>factory : Symbol(factory, Decl(jsxInExtendsClause.tsx, 5, 41))
+>React : Symbol(React, Decl(jsxInExtendsClause.tsx, 0, 0))
+>ComponentClass : Symbol(React.ComponentClass, Decl(jsxInExtendsClause.tsx, 1, 25))
+>P : Symbol(P, Decl(jsxInExtendsClause.tsx, 5, 38))
+>React : Symbol(React, Decl(jsxInExtendsClause.tsx, 0, 0))
+>ComponentClass : Symbol(React.ComponentClass, Decl(jsxInExtendsClause.tsx, 1, 25))
+>P : Symbol(P, Decl(jsxInExtendsClause.tsx, 5, 38))
+
+class Foo extends createComponentClass(() => class extends React.Component<{}, {}> {
+>Foo : Symbol(Foo, Decl(jsxInExtendsClause.tsx, 5, 106))
+>createComponentClass : Symbol(createComponentClass, Decl(jsxInExtendsClause.tsx, 4, 1))
+>React.Component : Symbol(React.Component, Decl(jsxInExtendsClause.tsx, 2, 59))
+>React : Symbol(React, Decl(jsxInExtendsClause.tsx, 0, 0))
+>Component : Symbol(React.Component, Decl(jsxInExtendsClause.tsx, 2, 59))
+
+  render() {
+>render : Symbol((Anonymous class).render, Decl(jsxInExtendsClause.tsx, 6, 84))
+
+    return <span>Hello, world!</span>;
+>span : Symbol(unknown)
+>span : Symbol(unknown)
+  }
+}) {}

--- a/tests/baselines/reference/jsxInExtendsClause.types
+++ b/tests/baselines/reference/jsxInExtendsClause.types
@@ -1,0 +1,46 @@
+=== tests/cases/compiler/jsxInExtendsClause.tsx ===
+// https://github.com/Microsoft/TypeScript/issues/13157
+declare namespace React {
+>React : typeof React
+
+  interface ComponentClass<P> { new (): Component<P, {}>; }
+>ComponentClass : ComponentClass<P>
+>P : P
+>Component : Component<A, B>
+>P : P
+
+  class Component<A, B> {}
+>Component : Component<A, B>
+>A : A
+>B : B
+}
+declare function createComponentClass<P>(factory: () => React.ComponentClass<P>): React.ComponentClass<P>;
+>createComponentClass : <P>(factory: () => React.ComponentClass<P>) => React.ComponentClass<P>
+>P : P
+>factory : () => React.ComponentClass<P>
+>React : any
+>ComponentClass : React.ComponentClass<P>
+>P : P
+>React : any
+>ComponentClass : React.ComponentClass<P>
+>P : P
+
+class Foo extends createComponentClass(() => class extends React.Component<{}, {}> {
+>Foo : Foo
+>createComponentClass(() => class extends React.Component<{}, {}> {  render() {    return <span>Hello, world!</span>;  }}) : React.Component<{}, {}>
+>createComponentClass : <P>(factory: () => React.ComponentClass<P>) => React.ComponentClass<P>
+>() => class extends React.Component<{}, {}> {  render() {    return <span>Hello, world!</span>;  }} : () => typeof (Anonymous class)
+>class extends React.Component<{}, {}> {  render() {    return <span>Hello, world!</span>;  }} : typeof (Anonymous class)
+>React.Component : React.Component<{}, {}>
+>React : typeof React
+>Component : typeof React.Component
+
+  render() {
+>render : () => any
+
+    return <span>Hello, world!</span>;
+><span>Hello, world!</span> : any
+>span : any
+>span : any
+  }
+}) {}

--- a/tests/cases/compiler/jsxInExtendsClause.tsx
+++ b/tests/cases/compiler/jsxInExtendsClause.tsx
@@ -1,0 +1,12 @@
+// @jsx: react
+// https://github.com/Microsoft/TypeScript/issues/13157
+declare namespace React {
+  interface ComponentClass<P> { new (): Component<P, {}>; }
+  class Component<A, B> {}
+}
+declare function createComponentClass<P>(factory: () => React.ComponentClass<P>): React.ComponentClass<P>;
+class Foo extends createComponentClass(() => class extends React.Component<{}, {}> {
+  render() {
+    return <span>Hello, world!</span>;
+  }
+}) {}


### PR DESCRIPTION
We were failing to aggregate the transform flags for an `ExpressionWithTypeArguments` on subsequent transformation passes as `ExpressionWithTypeArguments` is considered to be a type.

Fixes #13157
