### PR TITLE
For `path` ending with `index`, use the `path` pattern for the import quick fix

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -443,6 +443,7 @@ namespace ts.codefix {
                                 return undefined;
                             }
 
+                            const relativeNameWithIndex = removeFileExtension(relativeName);
                             relativeName = removeExtensionAndIndexPostFix(relativeName);
 
                             if (options.paths) {
@@ -462,7 +463,7 @@ namespace ts.codefix {
                                                 return key.replace("\*", matchedStar);
                                             }
                                         }
-                                        else if (pattern === relativeName) {
+                                        else if (pattern === relativeName || pattern === relativeNameWithIndex) {
                                             return key;
                                         }
                                     }

--- a/tests/cases/fourslash/importNameCodeFixNewImportPaths2.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportPaths2.ts
@@ -1,0 +1,28 @@
+/// <reference path="fourslash.ts" />
+
+//// [|foo/*0*/();|]
+
+// @Filename: folder_b/index.ts
+//// export function foo() {};
+
+// @Filename: tsconfig.path.json
+//// {
+////     "compilerOptions": {
+////         "baseUrl": ".",
+////         "paths": {
+////             "b": [ "folder_b/index" ]
+////         }
+////     }
+//// }
+
+// @Filename: tsconfig.json
+//// {
+////     "extends": "./tsconfig.path",
+////     "compilerOptions": { }
+//// }
+
+verify.importFixAtPosition([
+`import { foo } from "b";
+
+foo();`
+]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #13172

For `path` with a pattern that includes `index` at the end, we should also use the pattern not the full path for the import quick fix.
