### PR TITLE
update declaration file to use intrinsic object type

### DIFF
--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -22,7 +22,7 @@ interface ReadonlyMap<K, V> {
     readonly size: number;
 }
 
-interface WeakMap<K, V> {
+interface WeakMap<K extends object, V> {
     delete(key: K): boolean;
     get(key: K): V | undefined;
     has(key: K): boolean;
@@ -31,7 +31,7 @@ interface WeakMap<K, V> {
 
 interface WeakMapConstructor {
     new (): WeakMap<any, any>;
-    new <K, V>(entries?: [K, V][]): WeakMap<K, V>;
+    new <K extends object, V>(entries?: [K, V][]): WeakMap<K, V>;
     readonly prototype: WeakMap<any, any>;
 }
 declare var WeakMap: WeakMapConstructor;

--- a/src/lib/es2015.core.d.ts
+++ b/src/lib/es2015.core.d.ts
@@ -325,7 +325,7 @@ interface ObjectConstructor {
       * @param o The object to change its prototype.
       * @param proto The value of the new prototype or null.
       */
-    setPrototypeOf(o: any, proto: any): any;
+    setPrototypeOf(o: any, proto: object | null): any;
 
     /**
       * Gets the own property descriptor of the specified object.

--- a/src/lib/es2015.iterable.d.ts
+++ b/src/lib/es2015.iterable.d.ts
@@ -99,10 +99,10 @@ interface MapConstructor {
     new <K, V>(iterable: Iterable<[K, V]>): Map<K, V>;
 }
 
-interface WeakMap<K, V> { }
+interface WeakMap<K extends object, V> { }
 
 interface WeakMapConstructor {
-    new <K, V>(iterable: Iterable<[K, V]>): WeakMap<K, V>;
+    new <K extends object, V>(iterable: Iterable<[K, V]>): WeakMap<K, V>;
 }
 
 interface Set<T> {

--- a/src/lib/es2015.proxy.d.ts
+++ b/src/lib/es2015.proxy.d.ts
@@ -1,5 +1,5 @@
 interface ProxyHandler<T> {
-    getPrototypeOf? (target: T): {} | null;
+    getPrototypeOf? (target: T): object | null;
     setPrototypeOf? (target: T, v: any): boolean;
     isExtensible? (target: T): boolean;
     preventExtensions? (target: T): boolean;
@@ -12,7 +12,7 @@ interface ProxyHandler<T> {
     enumerate? (target: T): PropertyKey[];
     ownKeys? (target: T): PropertyKey[];
     apply? (target: T, thisArg: any, argArray?: any): any;
-    construct? (target: T, argArray: any, newTarget?: any): {};
+    construct? (target: T, argArray: any, newTarget?: any): object
 }
 
 interface ProxyConstructor {

--- a/src/lib/es2015.symbol.wellknown.d.ts
+++ b/src/lib/es2015.symbol.wellknown.d.ts
@@ -110,7 +110,7 @@ interface Map<K, V> {
     readonly [Symbol.toStringTag]: "Map";
 }
 
-interface WeakMap<K, V>{
+interface WeakMap<K extends object, V>{
     readonly [Symbol.toStringTag]: "WeakMap";
 }
 

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -146,14 +146,14 @@ interface ObjectConstructor {
       * Creates an object that has the specified prototype, and that optionally contains specified properties.
       * @param o Object to use as a prototype. May be null
       */
-    create<T>(o: T): T;
+    create<T extends object>(o: T): T;
 
     /**
       * Creates an object that has the specified prototype, and that optionally contains specified properties.
       * @param o Object to use as a prototype. May be null
       * @param properties JavaScript object that contains one or more property descriptors.
       */
-    create(o: any, properties: PropertyDescriptorMap): any;
+    create(o: object | null, properties: PropertyDescriptorMap): any;
 
     /**
       * Adds a property to an object, or modifies attributes of an existing property.


### PR DESCRIPTION
Follow #12501, update declaration files to use intrinsic object type.

Only methods unconditionally throwing runtime `TypeError` are patched. For example, `Object.keys` invoked with primitive type will only throw TypeError in ES5. If we patch such methods, we will break partially ES6 compatible client.
