### PR TITLE
Omit only class methods from object spreads

### DIFF
--- a/tests/baselines/reference/spreadMethods.errors.txt
+++ b/tests/baselines/reference/spreadMethods.errors.txt
@@ -1,0 +1,33 @@
+tests/cases/conformance/types/spread/spreadMethods.ts(7,4): error TS2339: Property 'm' does not exist on type '{ p: number; }'.
+tests/cases/conformance/types/spread/spreadMethods.ts(9,5): error TS2339: Property 'm' does not exist on type '{ p: number; }'.
+
+
+==== tests/cases/conformance/types/spread/spreadMethods.ts (2 errors) ====
+    class K { p = 12; m() { } }
+    interface I { p: number, m(): void }
+    let k = new K()
+    let sk = { ...k };
+    let ssk = { ...k, ...k };
+    sk.p;
+    sk.m(); // error
+       ~
+!!! error TS2339: Property 'm' does not exist on type '{ p: number; }'.
+    ssk.p;
+    ssk.m(); // error
+        ~
+!!! error TS2339: Property 'm' does not exist on type '{ p: number; }'.
+    let i: I = { p: 12, m() { } };
+    let si = { ...i };
+    let ssi = { ...i, ...i };
+    si.p;
+    si.m(); // ok
+    ssi.p;
+    ssi.m(); // ok
+    let o = { p: 12, m() { } };
+    let so = { ...o };
+    let sso = { ...o, ...o };
+    so.p;
+    so.m(); // ok
+    sso.p;
+    sso.m(); // ok
+    

--- a/tests/baselines/reference/spreadMethods.js
+++ b/tests/baselines/reference/spreadMethods.js
@@ -1,0 +1,63 @@
+//// [spreadMethods.ts]
+class K { p = 12; m() { } }
+interface I { p: number, m(): void }
+let k = new K()
+let sk = { ...k };
+let ssk = { ...k, ...k };
+sk.p;
+sk.m(); // error
+ssk.p;
+ssk.m(); // error
+let i: I = { p: 12, m() { } };
+let si = { ...i };
+let ssi = { ...i, ...i };
+si.p;
+si.m(); // ok
+ssi.p;
+ssi.m(); // ok
+let o = { p: 12, m() { } };
+let so = { ...o };
+let sso = { ...o, ...o };
+so.p;
+so.m(); // ok
+sso.p;
+sso.m(); // ok
+
+
+//// [spreadMethods.js]
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
+    }
+    return t;
+};
+var K = (function () {
+    function K() {
+        this.p = 12;
+    }
+    K.prototype.m = function () { };
+    return K;
+}());
+var k = new K();
+var sk = __assign({}, k);
+var ssk = __assign({}, k, k);
+sk.p;
+sk.m(); // error
+ssk.p;
+ssk.m(); // error
+var i = { p: 12, m: function () { } };
+var si = __assign({}, i);
+var ssi = __assign({}, i, i);
+si.p;
+si.m(); // ok
+ssi.p;
+ssi.m(); // ok
+var o = { p: 12, m: function () { } };
+var so = __assign({}, o);
+var sso = __assign({}, o, o);
+so.p;
+so.m(); // ok
+sso.p;
+sso.m(); // ok

--- a/tests/cases/conformance/types/spread/spreadMethods.ts
+++ b/tests/cases/conformance/types/spread/spreadMethods.ts
@@ -1,0 +1,23 @@
+class K { p = 12; m() { } }
+interface I { p: number, m(): void }
+let k = new K()
+let sk = { ...k };
+let ssk = { ...k, ...k };
+sk.p;
+sk.m(); // error
+ssk.p;
+ssk.m(); // error
+let i: I = { p: 12, m() { } };
+let si = { ...i };
+let ssi = { ...i, ...i };
+si.p;
+si.m(); // ok
+ssi.p;
+ssi.m(); // ok
+let o = { p: 12, m() { } };
+let so = { ...o };
+let sso = { ...o, ...o };
+so.p;
+so.m(); // ok
+sso.p;
+sso.m(); // ok


### PR DESCRIPTION
Omit class methods from spreads. Others stay.

Fixes #13148 (though the other half of the bug is addressed by #13288, which fixes the type of `Object.assign`)

Previously, all methods were omitted except those from the object literal
that contained the spread. This gets rid of the ugly third argument to
`getSpreadType`.

It also fixes a bug that arose from removing the spread type late in the
development of object spread; methods from the left-hand-side of a
multi-spread object literal were not removed. The spread type code
normalised spreads so the left-hand is never an object, but that code was
removed.