### PR TITLE
goToDefinition: Use the name of a declaration (if possible) when creating DefinitionInfo

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4318,10 +4318,6 @@ namespace ts {
         return createTextSpan(start, end - start);
     }
 
-    export function createTextSpanFromNode(node: Node, sourceFile?: SourceFile): TextSpan {
-        return createTextSpanFromBounds(node.getStart(sourceFile), node.getEnd());
-    }
-
     export function textChangeRangeNewSpan(range: TextChangeRange) {
         return createTextSpan(range.span.start, range.newLength);
     }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4318,6 +4318,10 @@ namespace ts {
         return createTextSpan(start, end - start);
     }
 
+    export function createTextSpanFromNode(node: Node, sourceFile?: SourceFile): TextSpan {
+        return createTextSpanFromBounds(node.getStart(sourceFile), node.getEnd());
+    }
+
     export function textChangeRangeNewSpan(range: TextChangeRange) {
         return createTextSpan(range.span.start, range.newLength);
     }

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -47,9 +47,9 @@ namespace FourSlash {
         /**
          * Inserted in source files by surrounding desired text
          * in a range with `[|` and `|]`. For example,
-         * 
+         *
          * [|text in range|]
-         * 
+         *
          * is a range with `text in range` "selected".
          */
         ranges: Range[];
@@ -540,53 +540,66 @@ namespace FourSlash {
         }
 
         public verifyGoToDefinitionIs(endMarker: string | string[]) {
-            this.verifyGoToDefinitionWorker(endMarker instanceof Array ? endMarker : [endMarker]);
+            this.verifyGoToXWorker(endMarker instanceof Array ? endMarker : [endMarker], () => this.getGoToDefinition());
         }
 
         public verifyGoToDefinition(arg0: any, endMarkerNames?: string | string[]) {
+            this.verifyGoToX(arg0, endMarkerNames, () => this.getGoToDefinition());
+        }
+
+        private getGoToDefinition(): ts.DefinitionInfo[] {
+            return this.languageService.getDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition)
+        }
+
+        public verifyGoToType(arg0: any, endMarkerNames?: string | string[]) {
+            this.verifyGoToX(arg0, endMarkerNames, () =>
+                this.languageService.getTypeDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition));
+        }
+
+        private verifyGoToX(arg0: any, endMarkerNames: string | string[] | undefined, getDefs: () => ts.DefinitionInfo[] | undefined) {
             if (endMarkerNames) {
-                this.verifyGoToDefinitionPlain(arg0, endMarkerNames);
+                this.verifyGoToXPlain(arg0, endMarkerNames, getDefs);
             }
             else if (arg0 instanceof Array) {
                 const pairs: [string | string[], string | string[]][] = arg0;
                 for (const [start, end] of pairs) {
-                    this.verifyGoToDefinitionPlain(start, end);
+                    this.verifyGoToXPlain(start, end, getDefs);
                 }
             }
             else {
                 const obj: { [startMarkerName: string]: string | string[] } = arg0;
                 for (const startMarkerName in obj) {
                     if (ts.hasProperty(obj, startMarkerName)) {
-                        this.verifyGoToDefinitionPlain(startMarkerName, obj[startMarkerName]);
+                        this.verifyGoToXPlain(startMarkerName, obj[startMarkerName], getDefs);
                     }
                 }
             }
         }
 
-        private verifyGoToDefinitionPlain(startMarkerNames: string | string[], endMarkerNames: string | string[]) {
+        private verifyGoToXPlain(startMarkerNames: string | string[], endMarkerNames: string | string[], getDefs: () => ts.DefinitionInfo[] | undefined) {
             if (startMarkerNames instanceof Array) {
                 for (const start of startMarkerNames) {
-                    this.verifyGoToDefinitionSingle(start, endMarkerNames);
+                    this.verifyGoToXSingle(start, endMarkerNames, getDefs);
                 }
             }
             else {
-                this.verifyGoToDefinitionSingle(startMarkerNames, endMarkerNames);
+                this.verifyGoToXSingle(startMarkerNames, endMarkerNames, getDefs);
             }
         }
 
         public verifyGoToDefinitionForMarkers(markerNames: string[]) {
             for (const markerName of markerNames) {
-                this.verifyGoToDefinitionSingle(`${markerName}Reference`, `${markerName}Definition`);
+                this.verifyGoToXSingle(`${markerName}Reference`, `${markerName}Definition`, () => this.getGoToDefinition());
             }
         }
 
-        private verifyGoToDefinitionSingle(startMarkerName: string, endMarkerNames: string | string[]) {
+        private verifyGoToXSingle(startMarkerName: string, endMarkerNames: string | string[], getDefs: () => ts.DefinitionInfo[] | undefined) {
             this.goToMarker(startMarkerName);
-            this.verifyGoToDefinitionWorker(endMarkerNames instanceof Array ? endMarkerNames : [endMarkerNames]);
+            this.verifyGoToXWorker(endMarkerNames instanceof Array ? endMarkerNames : [endMarkerNames], getDefs);
         }
 
-        private verifyGoToDefinitionWorker(endMarkers: string[]) {
-            const definitions = this.languageService.getDefinitionAtPosition(this.activeFile.fileName, this.currentCaretPosition) || [];
+        private verifyGoToXWorker(endMarkers: string[], getDefs: () => ts.DefinitionInfo[] | undefined) {
+            const definitions = getDefs() || [];
 
             if (endMarkers.length !== definitions.length) {
                 this.raiseError(`goToDefinitions failed - expected to find ${endMarkers.length} definitions but got ${definitions.length}`);
@@ -1987,7 +2000,7 @@ namespace FourSlash {
          * Compares expected text to the text that would be in the sole range
          * (ie: [|...|]) in the file after applying the codefix sole codefix
          * in the source file.
-         * 
+         *
          * Because codefixes are only applied on the working file, it is unsafe
          * to apply this more than once (consider a refactoring across files).
          */
@@ -3042,10 +3055,6 @@ namespace FourSlashInterface {
             this.state.goToEOF();
         }
 
-        public type(definitionIndex = 0) {
-            this.state.goToTypeDefinition(definitionIndex);
-        }
-
         public implementation() {
             this.state.goToImplementation();
         }
@@ -3211,6 +3220,13 @@ namespace FourSlashInterface {
         public goToDefinition(startsAndEnds: { [startMarkerName: string]: string | string[] }): void;
         public goToDefinition(arg0: any, endMarkerName?: string | string[]) {
             this.state.verifyGoToDefinition(arg0, endMarkerName);
+        }
+
+        public goToType(startMarkerName: string | string[], endMarkerName: string | string[]): void;
+        public goToType(startsAndEnds: [string | string[], string | string[]][]): void;
+        public goToType(startsAndEnds: { [startMarkerName: string]: string | string[] }): void;
+        public goToType(arg0: any, endMarkerName?: string | string[]) {
+            this.state.verifyGoToType(arg0, endMarkerName);
         }
 
         public goToDefinitionForMarkers(...markerNames: string[]) {

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -325,7 +325,7 @@ namespace ts.FindAllReferences {
                 fileName: targetLabel.getSourceFile().fileName,
                 kind: ScriptElementKind.label,
                 name: labelName,
-                textSpan: createTextSpanFromBounds(targetLabel.getStart(), targetLabel.getEnd()),
+                textSpan: createTextSpanFromNode(targetLabel, sourceFile),
                 displayParts: [displayPart(labelName, SymbolDisplayPartKind.text)]
             };
 
@@ -871,7 +871,7 @@ namespace ts.FindAllReferences {
                     fileName: node.getSourceFile().fileName,
                     kind: ScriptElementKind.variableElement,
                     name: "this",
-                    textSpan: createTextSpanFromBounds(node.getStart(), node.getEnd()),
+                    textSpan: createTextSpanFromNode(node),
                     displayParts
                 },
                 references: references
@@ -942,7 +942,7 @@ namespace ts.FindAllReferences {
                     fileName: node.getSourceFile().fileName,
                     kind: ScriptElementKind.variableElement,
                     name: type.text,
-                    textSpan: createTextSpanFromBounds(node.getStart(), node.getEnd()),
+                    textSpan: createTextSpanFromNode(node),
                     displayParts: [displayPart(getTextOfNode(node), SymbolDisplayPartKind.stringLiteral)]
                 },
                 references: references

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -15,10 +15,8 @@ namespace ts.GoToDefinition {
         const typeReferenceDirective = findReferenceInPosition(sourceFile.typeReferenceDirectives, position);
         if (typeReferenceDirective) {
             const referenceFile = program.getResolvedTypeReferenceDirectives()[typeReferenceDirective.fileName];
-            if (referenceFile && referenceFile.resolvedFileName) {
-                return [getDefinitionInfoForFileReference(typeReferenceDirective.fileName, referenceFile.resolvedFileName)];
-            }
-            return undefined;
+            return referenceFile && referenceFile.resolvedFileName &&
+                [getDefinitionInfoForFileReference(typeReferenceDirective.fileName, referenceFile.resolvedFileName)];
         }
 
         const node = getTouchingPropertyName(sourceFile, position);
@@ -30,7 +28,7 @@ namespace ts.GoToDefinition {
         if (isJumpStatementTarget(node)) {
             const labelName = (<Identifier>node).text;
             const label = getTargetLabel((<BreakOrContinueStatement>node.parent), (<Identifier>node).text);
-            return label ? [createDefinitionInfo(label, ScriptElementKind.label, labelName, /*containerName*/ undefined)] : undefined;
+            return label ? [createDefinitionInfoFromName(label, ScriptElementKind.label, labelName, /*containerName*/ undefined)] : undefined;
         }
 
         const typeChecker = program.getTypeChecker();
@@ -171,33 +169,38 @@ namespace ts.GoToDefinition {
 
         function tryAddSignature(signatureDeclarations: Declaration[], selectConstructors: boolean, symbolKind: string, symbolName: string, containerName: string, result: DefinitionInfo[]) {
             const declarations: Declaration[] = [];
-            let definition: Declaration;
+            let definition: Declaration | undefined;
 
-            forEach(signatureDeclarations, d => {
-                if ((selectConstructors && d.kind === SyntaxKind.Constructor) ||
-                    (!selectConstructors && (d.kind === SyntaxKind.FunctionDeclaration || d.kind === SyntaxKind.MethodDeclaration || d.kind === SyntaxKind.MethodSignature))) {
+            for (const d of signatureDeclarations) {
+                if (selectConstructors ? d.kind === SyntaxKind.Constructor : isSignatureDeclaration(d)) {
                     declarations.push(d);
                     if ((<FunctionLikeDeclaration>d).body) definition = d;
                 }
-            });
-
-            if (definition) {
-                result.push(createDefinitionInfo(definition, symbolKind, symbolName, containerName));
-                return true;
-            }
-            else if (declarations.length) {
-                result.push(createDefinitionInfo(lastOrUndefined(declarations), symbolKind, symbolName, containerName));
-                return true;
             }
 
+            if (declarations.length) {
+                result.push(createDefinitionInfo(definition || lastOrUndefined(declarations), symbolKind, symbolName, containerName));
+                return true;
+            }
             return false;
         }
     }
 
-    function createDefinitionInfo(node: Node, symbolKind: string, symbolName: string, containerName: string): DefinitionInfo {
+    function isSignatureDeclaration(node: Node): boolean {
+        return node.kind === SyntaxKind.FunctionDeclaration || node.kind === SyntaxKind.MethodDeclaration || node.kind === SyntaxKind.MethodSignature
+    }
+
+    /** Creates a DefinitionInfo from a Declaration, using the declaration's name if possible. */
+    function createDefinitionInfo(node: Declaration, symbolKind: string, symbolName: string, containerName: string): DefinitionInfo {
+        return createDefinitionInfoFromName(node.name || node, symbolKind, symbolName, containerName);
+    }
+
+    /** Creates a DefinitionInfo directly from the name of a declaration. */
+    function createDefinitionInfoFromName(name: Node, symbolKind: string, symbolName: string, containerName: string): DefinitionInfo {
+        const sourceFile = name.getSourceFile();
         return {
-            fileName: node.getSourceFile().fileName,
-            textSpan: createTextSpanFromBounds(node.getStart(), node.getEnd()),
+            fileName: sourceFile.fileName,
+            textSpan: createTextSpanFromNode(name, sourceFile),
             kind: symbolKind,
             name: symbolName,
             containerKind: undefined,

--- a/src/services/navigateTo.ts
+++ b/src/services/navigateTo.ts
@@ -199,7 +199,7 @@ namespace ts.NavigateTo {
                 matchKind: PatternMatchKind[rawItem.matchKind],
                 isCaseSensitive: rawItem.isCaseSensitive,
                 fileName: rawItem.fileName,
-                textSpan: createTextSpanFromBounds(declaration.getStart(), declaration.getEnd()),
+                textSpan: createTextSpanFromNode(declaration),
                 // TODO(jfreeman): What should be the containerName when the container has a computed name?
                 containerName: container && container.name ? (<Identifier>container.name).text : "",
                 containerKind: container && container.name ? getNodeKind(container) : ""

--- a/src/services/navigationBar.ts
+++ b/src/services/navigationBar.ts
@@ -591,7 +591,7 @@ namespace ts.NavigationBar {
     function getNodeSpan(node: Node): TextSpan {
         return node.kind === SyntaxKind.SourceFile
             ? createTextSpanFromBounds(node.getFullStart(), node.getEnd())
-            : createTextSpanFromBounds(node.getStart(curSourceFile), node.getEnd());
+            : createTextSpanFromNode(node, curSourceFile);
     }
 
     function getFunctionOrClassName(node: FunctionExpression | FunctionDeclaration | ArrowFunction | ClassLikeDeclaration): string {
@@ -626,15 +626,15 @@ namespace ts.NavigationBar {
 
     /**
      * Matches all whitespace characters in a string. Eg:
-     * 
+     *
      * "app.
-     * 
+     *
      * onactivated"
-     * 
+     *
      * matches because of the newline, whereas
-     * 
+     *
      * "app.onactivated"
-     * 
+     *
      * does not match.
      */
     const whiteSpaceRegex = /\s+/g;

--- a/src/services/outliningElementsCollector.ts
+++ b/src/services/outliningElementsCollector.ts
@@ -8,7 +8,7 @@ namespace ts.OutliningElementsCollector {
             if (hintSpanNode && startElement && endElement) {
                 const span: OutliningSpan = {
                     textSpan: createTextSpanFromBounds(startElement.pos, endElement.end),
-                    hintSpan: createTextSpanFromBounds(hintSpanNode.getStart(), hintSpanNode.end),
+                    hintSpan: createTextSpanFromNode(hintSpanNode, sourceFile),
                     bannerText: collapseText,
                     autoCollapse: autoCollapse
                 };
@@ -135,7 +135,7 @@ namespace ts.OutliningElementsCollector {
 
                         // Block was a standalone block.  In this case we want to only collapse
                         // the span of the block, independent of any parent span.
-                        const span = createTextSpanFromBounds(n.getStart(), n.end);
+                        const span = createTextSpanFromNode(n);
                         elements.push({
                             textSpan: span,
                             hintSpan: span,

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1112,6 +1112,10 @@ namespace ts {
             return !tripleSlashDirectivePrefixRegex.test(commentText);
         }
     }
+
+    export function createTextSpanFromNode(node: Node, sourceFile?: SourceFile): TextSpan {
+        return createTextSpanFromBounds(node.getStart(sourceFile), node.getEnd());
+    }
 }
 
 // Display-part writer helpers

--- a/tests/cases/fourslash/ambientShorthandGotoDefinition.ts
+++ b/tests/cases/fourslash/ambientShorthandGotoDefinition.ts
@@ -1,13 +1,13 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: declarations.d.ts
-/////*module*/declare module "jquery"
+////declare module /*module*/"jquery"
 
 // @Filename: user.ts
 ///////<reference path="declarations.d.ts"/>
 ////import /*importFoo*/foo, {bar} from "jquery";
-////import /*importBaz*/* as /*idBaz*/baz from "jquery";
-/////*importBang*/import /*idBang*/bang = require("jquery");
+////import * as /*importBaz*/baz from "jquery";
+////import /*importBang*/bang = require("jquery");
 ////foo/*useFoo*/(bar/*useBar*/, baz/*useBaz*/, bang/*useBang*/);
 
 verify.quickInfoAt("useFoo", "import foo");
@@ -22,11 +22,11 @@ verify.goToDefinition("useBar", "module");
 verify.quickInfoAt("useBaz", "import baz");
 verify.goToDefinition({
     useBaz: "importBaz",
-    idBaz: "module"
+    importBaz: "module"
 });
 
 verify.quickInfoAt("useBang", "import bang = require(\"jquery\")");
 verify.goToDefinition({
     useBang: "importBang",
-    idBang: "module"
+    importBang: "module"
 });

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -110,7 +110,6 @@ declare namespace FourSlashInterface {
         marker(name?: string): void;
         bof(): void;
         eof(): void;
-        type(definitionIndex?: number): void;
         implementation(): void;
         position(position: number, fileIndex?: number): any;
         position(position: number, fileName?: string): any;
@@ -165,6 +164,8 @@ declare namespace FourSlashInterface {
         goToDefinition(startsAndEnds: { [startMarkerName: string]: string | string[] }): void;
         /** Verifies goToDefinition for each `${markerName}Reference` -> `${markerName}Definition` */
         goToDefinitionForMarkers(...markerNames: string[]): void;
+        goToType(startsAndEnds: { [startMarkerName: string]: string | string[] }): void;
+        goToType(startMarkerNames: string | string[], endMarkerNames: string | string[]): void;
         verifyGetEmitOutputForCurrentFile(expected: string): void;
         verifyGetEmitOutputContentsForCurrentFile(expected: ts.OutputFile[]): void;
         /**

--- a/tests/cases/fourslash/goToDefinitionAlias.ts
+++ b/tests/cases/fourslash/goToDefinitionAlias.ts
@@ -1,9 +1,9 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: b.ts
-/////*alias1Definition*/import alias1 = require("fileb");
+////import /*alias1Definition*/alias1 = require("fileb");
 ////module Module {
-////    /*alias2Definition*/export import alias2 = alias1;
+////    export import /*alias2Definition*/alias2 = alias1;
 ////}
 ////
 ////// Type position

--- a/tests/cases/fourslash/goToDefinitionAmbiants.ts
+++ b/tests/cases/fourslash/goToDefinitionAmbiants.ts
@@ -1,11 +1,11 @@
 /// <reference path='fourslash.ts' />
 
 ////declare var /*ambientVariableDefinition*/ambientVar;
-/////*ambientFunctionDefinition*/declare function ambientFunction();
+////declare function /*ambientFunctionDefinition*/ambientFunction();
 ////declare class ambientClass {
 ////    /*constructorDefinition*/constructor();
-////    /*staticMethodDefinition*/static method();
-////    /*instanceMethodDefinition*/public method();
+////    static /*staticMethodDefinition*/method();
+////    public /*instanceMethodDefinition*/method();
 ////}
 ////
 /////*ambientVariableReference*/ambientVar = 1;

--- a/tests/cases/fourslash/goToDefinitionDecorator.ts
+++ b/tests/cases/fourslash/goToDefinitionDecorator.ts
@@ -9,10 +9,10 @@
 
 
 // @Filename: a.ts
-/////*decoratorDefinition*/function decorator(target) {
+////function /*decoratorDefinition*/decorator(target) {
 ////    return target;
 ////}
-/////*decoratorFactoryDefinition*/function decoratorFactory(...args) {
+////function /*decoratorFactoryDefinition*/decoratorFactory(...args) {
 ////    return target => target;
 ////}
 

--- a/tests/cases/fourslash/goToDefinitionDecoratorOverloads.ts
+++ b/tests/cases/fourslash/goToDefinitionDecoratorOverloads.ts
@@ -3,8 +3,8 @@
 
 ////async function f() {}
 ////
-/////*defDecString*/function dec(target: any, propertyKey: string): void;
-/////*defDecSymbol*/function dec(target: any, propertyKey: symbol): void;
+////function /*defDecString*/dec(target: any, propertyKey: string): void;
+////function /*defDecSymbol*/dec(target: any, propertyKey: symbol): void;
 ////function dec(target: any, propertyKey: string | symbol) {}
 ////
 ////declare const s: symbol;

--- a/tests/cases/fourslash/goToDefinitionDifferentFile.ts
+++ b/tests/cases/fourslash/goToDefinitionDifferentFile.ts
@@ -2,10 +2,10 @@
 
 // @Filename: goToDefinitionDifferentFile_Definition.ts
 ////var /*remoteVariableDefinition*/remoteVariable;
-/////*remoteFunctionDefinition*/function remoteFunction() { }
-/////*remoteClassDefinition*/class remoteClass { }
-/////*remoteInterfaceDefinition*/interface remoteInterface{ }
-/////*remoteModuleDefinition*/module remoteModule{ export var foo = 1;}
+////function /*remoteFunctionDefinition*/remoteFunction() { }
+////class /*remoteClassDefinition*/remoteClass { }
+////interface /*remoteInterfaceDefinition*/remoteInterface{ }
+////module /*remoteModuleDefinition*/remoteModule{ export var foo = 1;}
 
 // @Filename: goToDefinitionDifferentFile_Consumption.ts
 /////*remoteVariableReference*/remoteVariable = 1;

--- a/tests/cases/fourslash/goToDefinitionDifferentFileIndirectly.ts
+++ b/tests/cases/fourslash/goToDefinitionDifferentFileIndirectly.ts
@@ -2,10 +2,10 @@
 
 // @Filename: Remote2.ts
 ////var /*remoteVariableDefinition*/rem2Var;
-/////*remoteFunctionDefinition*/function rem2Fn() { }
-/////*remoteClassDefinition*/class rem2Cls { }
-/////*remoteInterfaceDefinition*/interface rem2Int{}
-/////*remoteModuleDefinition*/module rem2Mod { export var foo; }
+////function /*remoteFunctionDefinition*/rem2Fn() { }
+////class /*remoteClassDefinition*/rem2Cls { }
+////interface /*remoteInterfaceDefinition*/rem2Int{}
+////module /*remoteModuleDefinition*/rem2Mod { export var foo; }
 
 // @Filename: Remote1.ts
 ////var remVar;

--- a/tests/cases/fourslash/goToDefinitionExternalModuleName3.ts
+++ b/tests/cases/fourslash/goToDefinitionExternalModuleName3.ts
@@ -5,7 +5,7 @@
 ////var x = new n.Foo();
 
 // @Filename: a.ts
-/////*2*/declare module "e" {
+////declare module /*2*/"e" {
 ////    class Foo { }
 ////}
 

--- a/tests/cases/fourslash/goToDefinitionExternalModuleName5.ts
+++ b/tests/cases/fourslash/goToDefinitionExternalModuleName5.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts'/>
 
 // @Filename: a.ts
-/////*2*/declare module "external/*1*/" {
+////declare module /*2*/"external/*1*/" {
 ////    class Foo { }
 ////}
 

--- a/tests/cases/fourslash/goToDefinitionExternalModuleName6.ts
+++ b/tests/cases/fourslash/goToDefinitionExternalModuleName6.ts
@@ -4,7 +4,7 @@
 ////import * from 'e/*1*/';
 
 // @Filename: a.ts
-/////*2*/declare module "e" {
+////declare module /*2*/"e" {
 ////    class Foo { }
 ////}
 

--- a/tests/cases/fourslash/goToDefinitionExternalModuleName7.ts
+++ b/tests/cases/fourslash/goToDefinitionExternalModuleName7.ts
@@ -4,7 +4,7 @@
 ////import {Foo, Bar} from 'e/*1*/';
 
 // @Filename: a.ts
-/////*2*/declare module "e" {
+////declare module /*2*/"e" {
 ////    class Foo { }
 ////}
 

--- a/tests/cases/fourslash/goToDefinitionExternalModuleName8.ts
+++ b/tests/cases/fourslash/goToDefinitionExternalModuleName8.ts
@@ -4,7 +4,7 @@
 ////export {Foo, Bar} from 'e/*1*/';
 
 // @Filename: a.ts
-/////*2*/declare module "e" {
+////declare module /*2*/"e" {
 ////    class Foo { }
 ////}
 

--- a/tests/cases/fourslash/goToDefinitionExternalModuleName9.ts
+++ b/tests/cases/fourslash/goToDefinitionExternalModuleName9.ts
@@ -4,7 +4,7 @@
 ////export * from 'e/*1*/';
 
 // @Filename: a.ts
-/////*2*/declare module "e" {
+////declare module /*2*/"e" {
 ////    class Foo { }
 ////}
 

--- a/tests/cases/fourslash/goToDefinitionFoo.ts
+++ b/tests/cases/fourslash/goToDefinitionFoo.ts
@@ -1,0 +1,6 @@
+/// <reference path='fourslash.ts' />
+
+////function /*def*/f() {}
+/////*use*/f(123);
+
+verify.goToDefinition("use", "def");

--- a/tests/cases/fourslash/goToDefinitionFunctionOverloads.ts
+++ b/tests/cases/fourslash/goToDefinitionFunctionOverloads.ts
@@ -1,8 +1,8 @@
 /// <reference path='fourslash.ts' />
 
-/////*functionOverload1*/function /*functionOverload*/functionOverload(value: number);
-/////*functionOverload2*/function functionOverload(value: string);
-/////*functionOverloadDefinition*/function functionOverload() {}
+////function /*functionOverload1*/functionOverload(value: number);
+////function /*functionOverload2*/functionOverload(value: string);
+////function /*functionOverloadDefinition*/functionOverload() {}
 ////
 /////*functionOverloadReference1*/functionOverload(123);
 /////*functionOverloadReference2*/functionOverload("123");
@@ -12,5 +12,5 @@ verify.goToDefinition({
     functionOverloadReference1: "functionOverload1",
     functionOverloadReference2: "functionOverload2",
     brokenOverload: "functionOverload1",
-    functionOverload: "functionOverloadDefinition"
+    functionOverload1: "functionOverloadDefinition"
 });

--- a/tests/cases/fourslash/goToDefinitionFunctionOverloadsInClass.ts
+++ b/tests/cases/fourslash/goToDefinitionFunctionOverloadsInClass.ts
@@ -3,10 +3,10 @@
 ////class clsInOverload {
 ////    static fnOverload();
 ////    static /*staticFunctionOverload*/fnOverload(foo: string);
-////    /*staticFunctionOverloadDefinition*/static fnOverload(foo: any) { }
+////    static /*staticFunctionOverloadDefinition*/fnOverload(foo: any) { }
 ////    public /*functionOverload*/fnOverload(): any;
 ////    public fnOverload(foo: string);
-////    /*functionOverloadDefinition*/public fnOverload(foo: any) { return "foo" }
+////    public /*functionOverloadDefinition*/fnOverload(foo: any) { return "foo" }
 ////
 ////    constructor() { }
 ////}

--- a/tests/cases/fourslash/goToDefinitionImplicitConstructor.ts
+++ b/tests/cases/fourslash/goToDefinitionImplicitConstructor.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts' />
 
-/////*constructorDefinition*/class ImplicitConstructor {
+////class /*constructorDefinition*/ImplicitConstructor {
 ////}
 ////var implicitConstructor = new /*constructorReference*/ImplicitConstructor();
 

--- a/tests/cases/fourslash/goToDefinitionImportedNames.ts
+++ b/tests/cases/fourslash/goToDefinitionImportedNames.ts
@@ -7,7 +7,7 @@
 // @Filename: a.ts
 ////export module Module {
 ////}
-/////*classDefinition*/export class Class {
+////export class /*classDefinition*/Class {
 ////    private f;
 ////}
 ////export interface Interface {

--- a/tests/cases/fourslash/goToDefinitionImportedNames2.ts
+++ b/tests/cases/fourslash/goToDefinitionImportedNames2.ts
@@ -7,7 +7,7 @@
 // @Filename: a.ts
 ////export module Module {
 ////}
-/////*classDefinition*/export class Class {
+////export class /*classDefinition*/Class {
 ////    private f;
 ////}
 ////export interface Interface {

--- a/tests/cases/fourslash/goToDefinitionImportedNames3.ts
+++ b/tests/cases/fourslash/goToDefinitionImportedNames3.ts
@@ -20,7 +20,7 @@
 // @Filename: a.ts
 ////export module Module {
 ////}
-/////*classDefinition*/export class Class {
+////export class /*classDefinition*/Class {
 ////    private f;
 ////}
 ////export interface Interface {

--- a/tests/cases/fourslash/goToDefinitionImportedNames4.ts
+++ b/tests/cases/fourslash/goToDefinitionImportedNames4.ts
@@ -7,7 +7,7 @@
 // @Filename: a.ts
 ////export module Module {
 ////}
-/////*classDefinition*/export class Class {
+////export class /*classDefinition*/Class {
 ////    private f;
 ////}
 ////export interface Interface {

--- a/tests/cases/fourslash/goToDefinitionImportedNames5.ts
+++ b/tests/cases/fourslash/goToDefinitionImportedNames5.ts
@@ -7,7 +7,7 @@
 // @Filename: a.ts
 ////export module Module {
 ////}
-/////*classDefinition*/export class Class {
+////export class /*classDefinition*/Class {
 ////    private f;
 ////}
 ////export interface Interface {

--- a/tests/cases/fourslash/goToDefinitionImportedNames7.ts
+++ b/tests/cases/fourslash/goToDefinitionImportedNames7.ts
@@ -5,7 +5,7 @@
 
 
 // @Filename: a.ts
-/////*classDefinition*/class Class {
+////class /*classDefinition*/Class {
 ////    private f;
 ////}
 ////export default Class;

--- a/tests/cases/fourslash/goToDefinitionInMemberDeclaration.ts
+++ b/tests/cases/fourslash/goToDefinitionInMemberDeclaration.ts
@@ -1,14 +1,14 @@
 /// <reference path='fourslash.ts' />
 
-/////*interfaceDefinition*/interface IFoo { method1(): number; }
+////interface /*interfaceDefinition*/IFoo { method1(): number; }
 ////
-/////*classDefinition*/class Foo implements IFoo {
+////class /*classDefinition*/Foo implements IFoo {
 ////    public method1(): number { return 0; }
 ////}
 ////
-/////*enumDefinition*/enum Enum { value1, value2 };
+////enum /*enumDefinition*/Enum { value1, value2 };
 ////
-/////*selfDefinition*/class Bar {
+////class /*selfDefinition*/Bar {
 ////    public _interface: IFo/*interfaceReference*/o = new Fo/*classReferenceInInitializer*/o();
 ////    public _class: Fo/*classReference*/o = new Foo();
 ////    public _list: IF/*interfaceReferenceInList*/oo[]=[];

--- a/tests/cases/fourslash/goToDefinitionInTypeArgument.ts
+++ b/tests/cases/fourslash/goToDefinitionInTypeArgument.ts
@@ -1,8 +1,8 @@
 /// <reference path='fourslash.ts' />
 
-/////*fooDefinition*/class Foo<T> { }
+////class /*fooDefinition*/Foo<T> { }
 ////
-/////*barDefinition*/class Bar { }
+////class /*barDefinition*/Bar { }
 ////
 ////var x = new Fo/*fooReference*/o<Ba/*barReference*/r>();
 

--- a/tests/cases/fourslash/goToDefinitionInterfaceAfterImplement.ts
+++ b/tests/cases/fourslash/goToDefinitionInterfaceAfterImplement.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
-/////*interfaceDefinition*/interface sInt {
+////interface /*interfaceDefinition*/sInt {
 ////    sVar: number;
 ////    sFn: () => void;
 ////}

--- a/tests/cases/fourslash/goToDefinitionMethodOverloads.ts
+++ b/tests/cases/fourslash/goToDefinitionMethodOverloads.ts
@@ -1,12 +1,12 @@
 /// <reference path='fourslash.ts' />
 
 ////class MethodOverload {
-////    /*staticMethodOverload1*/static /*staticMethodOverload1Name*/method();
-////    /*staticMethodOverload2*/static method(foo: string);
-////    /*staticMethodDefinition*/static method(foo?: any) { }
-////    /*instanceMethodOverload1*/public /*instanceMethodOverload1Name*/method(): any;
-////    /*instanceMethodOverload2*/public method(foo: string);
-/////*instanceMethodDefinition*/public method(foo?: any) { return "foo" }
+////    static /*staticMethodOverload1*/method();
+////    static /*staticMethodOverload2*/method(foo: string);
+////    static /*staticMethodDefinition*/method(foo?: any) { }
+////    public /*instanceMethodOverload1*/method(): any;
+////    public /*instanceMethodOverload2*/method(foo: string);
+////    public /*instanceMethodDefinition*/method(foo?: any) { return "foo" }
 ////}
 
 ////// static method
@@ -23,6 +23,6 @@ verify.goToDefinition({
     staticMethodReference2: "staticMethodOverload2",
     instanceMethodReference1: "instanceMethodOverload1",
     instanceMethodReference2: "instanceMethodOverload2",
-    staticMethodOverload1Name: "staticMethodDefinition",
-    instanceMethodOverload1Name: "instanceMethodDefinition"
+    staticMethodOverload1: "staticMethodDefinition",
+    instanceMethodOverload1: "instanceMethodDefinition"
 });

--- a/tests/cases/fourslash/goToDefinitionMultipleDefinitions.ts
+++ b/tests/cases/fourslash/goToDefinitionMultipleDefinitions.ts
@@ -1,16 +1,16 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: a.ts
-/////*interfaceDefinition1*/interface IFoo {
+////interface /*interfaceDefinition1*/IFoo {
 ////    instance1: number;
 ////}
 
 // @Filename: b.ts
-/////*interfaceDefinition2*/interface IFoo {
+////interface /*interfaceDefinition2*/IFoo {
 ////    instance2: number;
 ////}
 ////
-/////*interfaceDefinition3*/interface IFoo {
+////interface /*interfaceDefinition3*/IFoo {
 ////    instance3: number;
 ////}
 ////
@@ -19,12 +19,12 @@
 verify.goToDefinition("interfaceReference", ["interfaceDefinition1", "interfaceDefinition2", "interfaceDefinition3"]);
 
 // @Filename: c.ts
-/////*moduleDefinition1*/module Module {
+////module /*moduleDefinition1*/Module {
 ////    export class c1 { }
 ////}
 
 // @Filename: d.ts
-/////*moduleDefinition2*/module Module {
+////module /*moduleDefinition2*/Module {
 ////    export class c2 { }
 ////}
 

--- a/tests/cases/fourslash/goToDefinitionObjectLiteralProperties.ts
+++ b/tests/cases/fourslash/goToDefinitionObjectLiteralProperties.ts
@@ -2,8 +2,8 @@
 
 ////var o = {
 ////    /*valueDefinition*/value: 0,
-////    /*getterDefinition*/get getter() {return 0 },
-////    /*setterDefinition*/set setter(v: number) { },
+////    get /*getterDefinition*/getter() {return 0 },
+////    set /*setterDefinition*/setter(v: number) { },
 ////    /*methodDefinition*/method: () => { },
 ////    /*es6StyleMethodDefinition*/es6StyleMethod() { }
 ////};

--- a/tests/cases/fourslash/goToDefinitionOverloadsInMultiplePropertyAccesses.ts
+++ b/tests/cases/fourslash/goToDefinitionOverloadsInMultiplePropertyAccesses.ts
@@ -5,7 +5,7 @@
 ////namespace A {
 ////    export namespace B {
 ////        export function f(value: number): void;
-////        /*1*/export function f(value: string): void;
+////        export function /*1*/f(value: string): void;
 ////        export function f(value: number | string) {}
 ////    }
 ////}

--- a/tests/cases/fourslash/goToDefinitionPartialImplementation.ts
+++ b/tests/cases/fourslash/goToDefinitionPartialImplementation.ts
@@ -2,14 +2,14 @@
 
 // @Filename: goToDefinitionPartialImplementation_1.ts
 ////module A {
-////    /*Part1Definition*/export interface IA {
+////    export interface /*Part1Definition*/IA {
 ////        y: string;
 ////    }
 ////}
 
 // @Filename: goToDefinitionPartialImplementation_2.ts
 ////module A {
-////    /*Part2Definition*/export interface IA {
+////    export interface /*Part2Definition*/IA {
 ////        x: number;
 ////    }
 ////

--- a/tests/cases/fourslash/goToDefinitionSameFile.ts
+++ b/tests/cases/fourslash/goToDefinitionSameFile.ts
@@ -1,10 +1,10 @@
 /// <reference path='fourslash.ts' />
 
 ////var /*localVariableDefinition*/localVariable;
-/////*localFunctionDefinition*/function localFunction() { }
-/////*localClassDefinition*/class localClass { }
-/////*localInterfaceDefinition*/interface localInterface{ }
-/////*localModuleDefinition*/module localModule{ export var foo = 1;}
+////function /*localFunctionDefinition*/localFunction() { }
+////class /*localClassDefinition*/localClass { }
+////interface /*localInterfaceDefinition*/localInterface{ }
+////module /*localModuleDefinition*/localModule{ export var foo = 1;}
 ////
 ////
 /////*localVariableReference*/localVariable = 1;

--- a/tests/cases/fourslash/goToDefinitionSimple.ts
+++ b/tests/cases/fourslash/goToDefinitionSimple.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: Definition.ts
-//// /*2*/class c { }
+////class /*2*/c { }
 
 // @Filename: Consumption.ts
 //// var n = new /*1*/c();

--- a/tests/cases/fourslash/goToDefinitionTaggedTemplateOverloads.ts
+++ b/tests/cases/fourslash/goToDefinitionTaggedTemplateOverloads.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
-/////*defFNumber*/function f(strs: TemplateStringsArray, x: number): void;
-/////*defFBool*/function f(strs: TemplateStringsArray, x: boolean): void;
+////function /*defFNumber*/f(strs: TemplateStringsArray, x: number): void;
+////function /*defFBool*/f(strs: TemplateStringsArray, x: boolean): void;
 ////function f(strs: TemplateStringsArray, x: number | boolean) {}
 ////
 /////*useFNumber*/f`${0}`;

--- a/tests/cases/fourslash/goToDefinitionThis.ts
+++ b/tests/cases/fourslash/goToDefinitionThis.ts
@@ -3,7 +3,7 @@
 ////function f(/*fnDecl*/this: number) {
 ////    return /*fnUse*/this;
 ////}
-/////*cls*/class C {
+////class /*cls*/C {
 ////    constructor() { return /*clsUse*/this; }
 ////    get self(/*getterDecl*/this: number) { return /*getterUse*/this; }
 ////}

--- a/tests/cases/fourslash/goToDefinitionTypePredicate.ts
+++ b/tests/cases/fourslash/goToDefinitionTypePredicate.ts
@@ -1,6 +1,6 @@
 /// <reference path='fourslash.ts'/>
 
-//// /*classDeclaration*/class A {}
+//// class /*classDeclaration*/A {}
 //// function f(/*parameterDeclaration*/parameter: any): /*parameterName*/parameter is /*typeReference*/A {
 ////     return typeof parameter === "string";
 //// }

--- a/tests/cases/fourslash/goToDefinition_super.ts
+++ b/tests/cases/fourslash/goToDefinition_super.ts
@@ -4,7 +4,7 @@
 ////    /*ctr*/constructor() {}
 ////    x() {}
 ////}
-/////*B*/class B extends A {}
+////class /*B*/B extends A {}
 ////class C extends B {
 ////    constructor() {
 ////        /*super*/super();

--- a/tests/cases/fourslash/goToModuleAliasDefinition.ts
+++ b/tests/cases/fourslash/goToModuleAliasDefinition.ts
@@ -1,10 +1,10 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: a.ts
-//// /*2*/export class Foo {}
+////export class /*2*/Foo {}
 
 // @Filename: b.ts
-//// /*3*/import n = require('a');
+//// import /*3*/n = require('a');
 //// var x = new /*1*/n.Foo();
 
 // Won't-fixed: Should go to '2' instead

--- a/tests/cases/fourslash/goToTypeDefinition.ts
+++ b/tests/cases/fourslash/goToTypeDefinition.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: goToTypeDefinition_Definition.ts
-/////*definition*/class C {
+////class /*definition*/C {
 ////    p;
 ////}
 ////var c: C;
@@ -9,6 +9,4 @@
 // @Filename: goToTypeDefinition_Consumption.ts
 /////*reference*/c = undefined;
 
-goTo.marker('reference');
-goTo.type();
-verify.caretAtMarker('definition');
+verify.goToType("reference", "definition");

--- a/tests/cases/fourslash/goToTypeDefinition2.ts
+++ b/tests/cases/fourslash/goToTypeDefinition2.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: goToTypeDefinition2_Definition.ts
-/////*definition*/interface I1 {
+////interface /*definition*/I1 {
 ////    p;
 ////}
 ////type propertyType = I1;
@@ -13,6 +13,4 @@
 ////var i2: I2;
 ////i2.prop/*reference*/erty;
 
-goTo.marker('reference');
-goTo.type();
-verify.caretAtMarker('definition');
+verify.goToType("reference", "definition");

--- a/tests/cases/fourslash/goToTypeDefinitionAliases.ts
+++ b/tests/cases/fourslash/goToTypeDefinitionAliases.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: goToTypeDefinitioAliases_module1.ts
-/////*definition*/interface I {
+////interface /*definition*/I {
 ////    p;
 ////}
 ////export {I as I2};
@@ -15,10 +15,7 @@
 ////import {/*reference1*/v2 as v3} from "./goToTypeDefinitioAliases_module2";
 /////*reference2*/v3;
 
-goTo.marker('reference1');
-goTo.type();
-verify.caretAtMarker('definition');
-
-goTo.marker('reference2');
-goTo.type();
-verify.caretAtMarker('definition');
+verify.goToType({
+    reference1: "definition",
+    reference2: "definition"
+});

--- a/tests/cases/fourslash/goToTypeDefinitionEnumMembers.ts
+++ b/tests/cases/fourslash/goToTypeDefinitionEnumMembers.ts
@@ -8,6 +8,4 @@
 ////
 /////*reference*/x;
 
-goTo.marker('reference');
-goTo.type();
-verify.caretAtMarker('definition');
+verify.goToType("reference", "definition");

--- a/tests/cases/fourslash/goToTypeDefinitionModule.ts
+++ b/tests/cases/fourslash/goToTypeDefinitionModule.ts
@@ -1,19 +1,16 @@
 /// <reference path='fourslash.ts' />
 
-// @Filename: goToTypeDefinitioAliases_module1.ts
-/////*definition*/module M {
+// @Filename: module1.ts
+////module /*definition*/M {
 ////    export var p;
 ////}
 ////var m: typeof M;
 
-// @Filename: goToTypeDefinitioAliases_module3.ts
+// @Filename: module3.ts
 /////*reference1*/M;
 /////*reference2*/m;
 
-goTo.marker('reference1');
-goTo.type();
-verify.caretAtMarker('definition');
-
-goTo.marker('reference2');
-goTo.type();
-verify.caretAtMarker('definition');
+verify.goToType({
+    reference1: "definition",
+    reference2: "definition"
+});

--- a/tests/cases/fourslash/goToTypeDefinitionPrimitives.ts
+++ b/tests/cases/fourslash/goToTypeDefinitionPrimitives.ts
@@ -12,14 +12,9 @@
 /////*reference3*/y;
 /////*reference4*/y;
 
-goTo.marker('reference1');
-verify.typeDefinitionCountIs(0);
-
-goTo.marker('reference1');
-verify.typeDefinitionCountIs(0);
-
-goTo.marker('reference2');
-verify.typeDefinitionCountIs(0);
-
-goTo.marker('reference4');
-verify.typeDefinitionCountIs(0);
+verify.goToType({
+    reference1: [],
+    reference2: [],
+    reference3: [],
+    reference4: []
+});

--- a/tests/cases/fourslash/goToTypeDefinitionUnionType.ts
+++ b/tests/cases/fourslash/goToTypeDefinitionUnionType.ts
@@ -1,15 +1,15 @@
 /// <reference path='fourslash.ts' />
 
-/////*definition0*/class C {
+////class /*definition0*/C {
 ////    p;
 ////}
 ////
-/////*definition1*/interface I {
+////interface /*definition1*/I {
 ////    x;
 ////}
 ////
 ////module M {
-////    /*definition2*/export interface I {
+////    export interface /*definition2*/I {
 ////        y;
 ////    }
 ////}
@@ -18,14 +18,4 @@
 ////
 /////*reference*/x;
 
-goTo.marker('reference');
-goTo.type(0);
-verify.caretAtMarker('definition0');
-
-goTo.marker('reference');
-goTo.type(1);
-verify.caretAtMarker('definition1');
-
-goTo.marker('reference');
-goTo.type(2);
-verify.caretAtMarker('definition2');
+verify.goToType("reference", ["definition0", "definition1", "definition2"]);

--- a/tests/cases/fourslash/quickInfoMeaning.ts
+++ b/tests/cases/fourslash/quickInfoMeaning.ts
@@ -14,7 +14,7 @@
 
 // @Filename: foo_user.ts
 ///////<reference path="foo.d.ts" />
-/////*foo_type_declaration*/import foo = require("foo_module");
+////import /*foo_type_declaration*/foo = require("foo_module");
 ////const x = foo/*foo_value*/;
 ////const i: foo/*foo_type*/ = { x: 1, y: 2 };
 
@@ -37,7 +37,7 @@ verify.goToDefinitionIs("foo_type_declaration");
 
 
 // @Filename: bar.d.ts
-/////*bar_type_declaration*/declare interface bar { x: number; y: number }
+////declare interface /*bar_type_declaration*/bar { x: number; y: number }
 ////declare module "bar_module" {
 ////    const x: number;
 ////    export = x;
@@ -45,7 +45,7 @@ verify.goToDefinitionIs("foo_type_declaration");
 
 // @Filename: bar_user.ts
 ///////<reference path="bar.d.ts" />
-/////*bar_value_declaration*/import bar = require("bar_module");
+////import /*bar_value_declaration*/bar = require("bar_module");
 ////const x = bar/*bar_value*/;
 ////const i: bar/*bar_type*/ = { x: 1, y: 2 };
 

--- a/tests/cases/fourslash/server/jsdocTypedefTagGoToDefinition.ts
+++ b/tests/cases/fourslash/server/jsdocTypedefTagGoToDefinition.ts
@@ -5,7 +5,7 @@
 
 //// /**
 ////  * @typedef {Object} Person
-////  * /*1*/@property {string} personName
+////  * @property {string} /*1*/personName
 ////  * @property {number} personAge
 ////  */
 ////

--- a/tests/cases/fourslash/server/typedefinition01.ts
+++ b/tests/cases/fourslash/server/typedefinition01.ts
@@ -5,8 +5,6 @@
 ////var x/*1*/ = new n.Foo();
 
 // @Filename: a.ts
-//// /*2*/export class Foo {}
+////export class /*2*/Foo {}
 
-goTo.marker('1');
-goTo.type();
-verify.caretAtMarker('2');
+verify.goToType("1", "2");

--- a/tests/cases/fourslash/shims-pp/getDefinitionAtPosition.ts
+++ b/tests/cases/fourslash/shims-pp/getDefinitionAtPosition.ts
@@ -2,10 +2,10 @@
 
 // @Filename: goToDefinitionDifferentFile_Definition.ts
 ////var /*remoteVariableDefinition*/remoteVariable;
-/////*remoteFunctionDefinition*/function remoteFunction() { }
-/////*remoteClassDefinition*/class remoteClass { }
-/////*remoteInterfaceDefinition*/interface remoteInterface{ }
-/////*remoteModuleDefinition*/module remoteModule{ export var foo = 1;}
+////function /*remoteFunctionDefinition*/remoteFunction() { }
+////class /*remoteClassDefinition*/remoteClass { }
+////interface /*remoteInterfaceDefinition*/remoteInterface{ }
+////module /*remoteModuleDefinition*/remoteModule{ export var foo = 1;}
 
 // @Filename: goToDefinitionDifferentFile_Consumption.ts
 /////*remoteVariableReference*/remoteVariable = 1;

--- a/tests/cases/fourslash/shims-pp/goToTypeDefinition.ts
+++ b/tests/cases/fourslash/shims-pp/goToTypeDefinition.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: goToTypeDefinition_Definition.ts
-/////*definition*/class C {
+////class /*definition*/C {
 ////    p;
 ////}
 ////var c: C;
@@ -9,6 +9,4 @@
 // @Filename: goToTypeDefinition_Consumption.ts
 /////*reference*/c = undefined;
 
-goTo.marker('reference');
-goTo.type();
-verify.caretAtMarker('definition');
+verify.goToType("reference", "definition");

--- a/tests/cases/fourslash/shims/getDefinitionAtPosition.ts
+++ b/tests/cases/fourslash/shims/getDefinitionAtPosition.ts
@@ -2,10 +2,10 @@
 
 // @Filename: goToDefinitionDifferentFile_Definition.ts
 ////var /*remoteVariableDefinition*/remoteVariable;
-/////*remoteFunctionDefinition*/function remoteFunction() { }
-/////*remoteClassDefinition*/class remoteClass { }
-/////*remoteInterfaceDefinition*/interface remoteInterface{ }
-/////*remoteModuleDefinition*/module remoteModule{ export var foo = 1;}
+////function /*remoteFunctionDefinition*/remoteFunction() { }
+////class /*remoteClassDefinition*/remoteClass { }
+////interface /*remoteInterfaceDefinition*/remoteInterface{ }
+////module /*remoteModuleDefinition*/remoteModule{ export var foo = 1;}
 
 // @Filename: goToDefinitionDifferentFile_Consumption.ts
 /////*remoteVariableReference*/remoteVariable = 1;

--- a/tests/cases/fourslash/shims/goToTypeDefinition.ts
+++ b/tests/cases/fourslash/shims/goToTypeDefinition.ts
@@ -1,7 +1,7 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: goToTypeDefinition_Definition.ts
-/////*definition*/class C {
+////class /*definition*/C {
 ////    p;
 ////}
 ////var c: C;
@@ -9,6 +9,4 @@
 // @Filename: goToTypeDefinition_Consumption.ts
 /////*reference*/c = undefined;
 
-goTo.marker('reference');
-goTo.type();
-verify.caretAtMarker('definition');
+verify.goToType("reference", "definition");

--- a/tests/cases/fourslash/tsxGoToDefinitionClasses.ts
+++ b/tests/cases/fourslash/tsxGoToDefinitionClasses.ts
@@ -6,7 +6,7 @@
 ////     interface IntrinsicElements { }
 ////     interface ElementAttributesProperty { props; }
 //// }
-//// /*ct*/class MyClass {
+//// class /*ct*/MyClass {
 ////     props: {
 ////         /*pt*/foo: string;
 ////     }


### PR DESCRIPTION
Fixes #12270