### PR TITLE
Quick fix indentation support

### DIFF
--- a/src/compiler/moduleNameResolver.ts
+++ b/src/compiler/moduleNameResolver.ts
@@ -391,7 +391,7 @@ namespace ts {
                     }
                 }
             }
-            
+
             function getCommonPrefix(directory: Path, resolution: string) {
                 if (resolution === undefined) {
                     return undefined;
@@ -421,7 +421,7 @@ namespace ts {
             trace(host, Diagnostics.Resolving_module_0_from_1, moduleName, containingFile);
         }
         const containingDirectory = getDirectoryPath(containingFile);
-        let perFolderCache = cache && cache.getOrCreateCacheForDirectory(containingDirectory);
+        const perFolderCache = cache && cache.getOrCreateCacheForDirectory(containingDirectory);
         let result = perFolderCache && perFolderCache[moduleName];
 
         if (result) {
@@ -1030,7 +1030,7 @@ namespace ts {
      * - { value: <some-value> } - found - stop searching
      */
     type SearchResult<T> = { value: T | undefined } | undefined;
-    
+
     /**
      * Wraps value to SearchResult.
      * @returns undefined if value is undefined or { value } otherwise

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2042,7 +2042,7 @@ namespace FourSlash {
                     continue;
                 }
 
-                const newActions = this.languageService.getCodeFixesAtPosition(fileName, diagnostic.start, diagnostic.length, [diagnostic.code]);
+                const newActions = this.languageService.getCodeFixesAtPosition(fileName, diagnostic.start, diagnostic.length, [diagnostic.code], this.copyFormatOptions());
                 if (newActions && newActions.length) {
                     actions = actions ? actions.concat(newActions) : newActions;
                 }

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -442,6 +442,12 @@ namespace ts.server.protocol {
           * Errorcodes we want to get the fixes for.
           */
         errorCodes?: number[];
+
+        /**
+         * An optional set of settings to be used when computing indentation.
+         * If argument is omitted - then it will use settings for file that were previously set via 'configure' request or global settings.
+         */
+        options?: EditorSettings;
     }
 
     /**

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1255,8 +1255,9 @@ namespace ts.server {
             const scriptInfo = project.getScriptInfoForNormalizedPath(file);
             const startPosition = getStartPosition();
             const endPosition = getEndPosition();
+            const options = args.options ? convertFormatOptions(args.options) : this.projectService.getFormatCodeOptions(file);
 
-            const codeActions = project.getLanguageService().getCodeFixesAtPosition(file, startPosition, endPosition, args.errorCodes);
+            const codeActions = project.getLanguageService().getCodeFixesAtPosition(file, startPosition, endPosition, args.errorCodes, options);
             if (!codeActions) {
                 return undefined;
             }

--- a/src/services/codeFixProvider.ts
+++ b/src/services/codeFixProvider.ts
@@ -13,6 +13,20 @@ namespace ts {
         newLineCharacter: string;
         host: LanguageServiceHost;
         cancellationToken: CancellationToken;
+        formatInfo: CodeFixFormatInfo
+    }
+
+    export class CodeFixFormatInfo {
+        /**
+         * Has one level of indentation beyond the indentation at the error span.
+         */
+        public newLineAndIndentationStr: string;
+        /**
+         * @param indentationlevel The indentation, in columns, for the beginning of the span where the error is reported.
+         */
+        constructor(public editorSettings: EditorSettings, public indentationlevel: number) {
+            this.newLineAndIndentationStr = editorSettings.newLineCharacter + ts.formatting.getIndentationString(indentationlevel + editorSettings.tabSize, editorSettings);
+        }
     }
 
     export namespace codefix {

--- a/src/services/codefixes/fixClassDoesntImplementInheritedAbstractMember.ts
+++ b/src/services/codefixes/fixClassDoesntImplementInheritedAbstractMember.ts
@@ -30,7 +30,7 @@ namespace ts.codefix {
             const extendsSymbols = checker.getPropertiesOfType(instantiatedExtendsType);
             const abstractAndNonPrivateExtendsSymbols = extendsSymbols.filter(symbolPointsToNonPrivateAndAbstractMember);
 
-            const insertion = getMissingMembersInsertion(classDecl, abstractAndNonPrivateExtendsSymbols, checker, context.newLineCharacter);
+            const insertion = getMissingMembersInsertion(classDecl, abstractAndNonPrivateExtendsSymbols, checker, context.formatInfo);
 
             if (insertion.length) {
                 return [{

--- a/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
+++ b/src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts
@@ -31,9 +31,9 @@ namespace ts.codefix {
             const implementedTypeSymbols = checker.getPropertiesOfType(implementedType);
             const nonPrivateMembers = implementedTypeSymbols.filter(symbol => !(getModifierFlags(symbol.valueDeclaration) & ModifierFlags.Private));
 
-            let insertion = getMissingIndexSignatureInsertion(implementedType, IndexKind.Number, classDecl, hasNumericIndexSignature);
-            insertion += getMissingIndexSignatureInsertion(implementedType, IndexKind.String, classDecl, hasStringIndexSignature);
-            insertion += getMissingMembersInsertion(classDecl, nonPrivateMembers, checker, context.newLineCharacter);
+            let insertion = getMissingIndexSignatureInsertion(implementedType, IndexKind.Number, classDecl, hasNumericIndexSignature, context.formatInfo.newLineAndIndentationStr);
+            insertion += getMissingIndexSignatureInsertion(implementedType, IndexKind.String, classDecl, hasStringIndexSignature, context.formatInfo.newLineAndIndentationStr);
+            insertion += getMissingMembersInsertion(classDecl, nonPrivateMembers, checker, context.formatInfo);
 
             const message = formatStringFromArgs(getLocaleSpecificMessage(Diagnostics.Implement_interface_0), [implementedTypeNode.getText()]);
             if (insertion) {
@@ -43,13 +43,13 @@ namespace ts.codefix {
 
         return result;
 
-        function getMissingIndexSignatureInsertion(type: InterfaceType, kind: IndexKind, enclosingDeclaration: ClassLikeDeclaration, hasIndexSigOfKind: boolean) {
+        function getMissingIndexSignatureInsertion(type: InterfaceType, kind: IndexKind, enclosingDeclaration: ClassLikeDeclaration, hasIndexSigOfKind: boolean, newLineAndIndentation: string) {
             if (!hasIndexSigOfKind) {
                 const IndexInfoOfKind = checker.getIndexInfoOfType(type, kind);
                 if (IndexInfoOfKind) {
                     const writer = getSingleLineStringWriter();
                     checker.getSymbolDisplayBuilder().buildIndexSignatureDisplay(IndexInfoOfKind, writer, kind, enclosingDeclaration);
-                    const result = writer.string();
+                    const result = newLineAndIndentation + writer.string();
                     releaseStringWriter(writer);
 
                     return result;

--- a/src/services/codefixes/fixClassSuperMustPrecedeThisAccess.ts
+++ b/src/services/codefixes/fixClassSuperMustPrecedeThisAccess.ts
@@ -16,7 +16,7 @@ namespace ts.codefix {
                 return undefined;
             }
 
-            // figure out if the this access is actuall inside the supercall
+            // figure out if the this access is actually inside the supercall
             // i.e. super(this.a), since in that case we won't suggest a fix
             if (superCall.expression && superCall.expression.kind == SyntaxKind.CallExpression) {
                 const arguments = (<CallExpression>superCall.expression).arguments;
@@ -30,7 +30,7 @@ namespace ts.codefix {
             const newPosition = getOpenBraceEnd(<ConstructorDeclaration>constructor, sourceFile);
             const changes = [{
                 fileName: sourceFile.fileName, textChanges: [{
-                    newText: superCall.getText(sourceFile),
+                    newText: context.formatInfo.newLineAndIndentationStr + superCall.getText(sourceFile),
                     span: { start: newPosition, length: 0 }
                 },
                 {

--- a/src/services/codefixes/fixConstructorForDerivedNeedSuperCall.ts
+++ b/src/services/codefixes/fixConstructorForDerivedNeedSuperCall.ts
@@ -11,9 +11,10 @@ namespace ts.codefix {
             }
 
             const newPosition = getOpenBraceEnd(<ConstructorDeclaration>token.parent, sourceFile);
+
             return [{
                 description: getLocaleSpecificMessage(Diagnostics.Add_missing_super_call),
-                changes: [{ fileName: sourceFile.fileName, textChanges: [{ newText: "super();", span: { start: newPosition, length: 0 } }] }]
+                changes: [{ fileName: sourceFile.fileName, textChanges: [{ newText: `${context.formatInfo.newLineAndIndentationStr}super();`, span: { start: newPosition, length: 0 } }] }]
             }];
         }
     });

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -8,6 +8,9 @@ namespace ts.formatting {
             Unknown = -1
         }
 
+        /**
+         * @returns Indentation in units of columns shifted.
+         */
         export function getIndentation(position: number, sourceFile: SourceFile, options: EditorSettings): number {
             if (position > sourceFile.text.length) {
                 return getBaseIndentation(options); // past EOF

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1676,25 +1676,29 @@ namespace ts {
             return [];
         }
 
-        function getCodeFixesAtPosition(fileName: string, start: number, end: number, errorCodes: number[]): CodeAction[] {
+        function getCodeFixesAtPosition(fileName: string, start: number, end: number, errorCodes: number[], editorSettings: EditorSettings): CodeAction[] {
             synchronizeHostData();
             const sourceFile = getValidSourceFile(fileName);
             const span = { start, length: end - start };
             const newLineChar = getNewLineOrDefaultFromHost(host);
+            if (!editorSettings.newLineCharacter) {
+                editorSettings.newLineCharacter = newLineChar;
+            }
 
             let allFixes: CodeAction[] = [];
 
             forEach(errorCodes, error => {
                 cancellationToken.throwIfCancellationRequested();
 
-                const context = {
+                const context: CodeFixContext = {
                     errorCode: error,
                     sourceFile: sourceFile,
                     span: span,
                     program: program,
                     newLineCharacter: newLineChar,
                     host: host,
-                    cancellationToken: cancellationToken
+                    cancellationToken: cancellationToken,
+                    formatInfo: new CodeFixFormatInfo(editorSettings, ts.formatting.SmartIndenter.getIndentation(span.start, sourceFile, editorSettings))
                 };
 
                 const fixes = codefix.getFixes(context);

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -243,7 +243,7 @@ namespace ts {
 
         isValidBraceCompletionAtPosition(fileName: string, position: number, openingBrace: number): boolean;
 
-        getCodeFixesAtPosition(fileName: string, start: number, end: number, errorCodes: number[]): CodeAction[];
+        getCodeFixesAtPosition(fileName: string, start: number, end: number, errorCodes: number[], editorSettings: EditorSettings): CodeAction[];
 
         getEmitOutput(fileName: string, emitOnlyDtsFiles?: boolean): EmitOutput;
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #12249 and part of #12264.

Changes the quickfixes that require it to provide formatting. Language services shouldn't need to make a formatting call after inserting a quickfix anymore.

Note that we add an `editorSettings` optional field to the formatting request. If it is omitted, we make a best-effort attempt to use cached settings. In order to mitigate this, an analogous change in editors is advised.

Thoughts, @mhegazy, @billti, @mjbvz, @dbaeumer?
