### PR TITLE
WIP/RFC - first jab at implementing Flow-style annotations-in-comments

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -796,6 +796,9 @@ namespace ts {
         // Start position of text of current token
         let tokenPos: number;
 
+        // how many /* :: embedded comments */ are we in?
+        let embeddedCommentStack: number;
+
         let token: SyntaxKind;
         let tokenValue: string;
         let precedingLineBreak: boolean;
@@ -1220,7 +1223,7 @@ namespace ts {
             hasExtendedUnicodeEscape = false;
             precedingLineBreak = false;
             tokenIsUnterminated = false;
-            while (true) {
+            scan: while (true) {
                 tokenPos = pos;
                 if (pos >= end) {
                     return token = SyntaxKind.EndOfFileToken;
@@ -1307,6 +1310,13 @@ namespace ts {
                         pos++;
                         return token = SyntaxKind.CloseParenToken;
                     case CharacterCodes.asterisk:
+                        if (embeddedCommentStack > 0) {
+                            if (text.charCodeAt(pos + 1) === CharacterCodes.slash) {
+                               embeddedCommentStack--;
+                               pos += 2;
+                               continue;
+                            }
+                        }
                         if (text.charCodeAt(pos + 1) === CharacterCodes.equals) {
                             return pos += 2, token = SyntaxKind.AsteriskEqualsToken;
                         }
@@ -1374,8 +1384,31 @@ namespace ts {
                             pos += 2;
 
                             let commentClosed = false;
+                            let initialColon: boolean | undefined = undefined;
+                            let doubleColon = false;
                             while (pos < end) {
                                 const ch = text.charCodeAt(pos);
+
+                                if (initialColon === undefined) {
+                                    if (isWhiteSpace(ch)) {
+                                        initialColon = undefined;
+                                    }
+                                    else if (ch === CharacterCodes.colon) {
+                                        initialColon = true;
+                                        embeddedCommentStack++;
+                                        // we don't increment pos for the single colon case, so
+                                        // the colon in /* : string */ will be parsed again and correctly
+                                        // interpreted as the start of a type annotation.
+                                        if (text.charCodeAt(pos + 1) === CharacterCodes.colon) {
+                                            doubleColon = true;
+                                            pos += 2;
+                                        }
+                                        continue scan;
+                                    }
+                                    else {
+                                        initialColon = false;
+                                    }
+                                }
 
                                 if (ch === CharacterCodes.asterisk && text.charCodeAt(pos + 1) === CharacterCodes.slash) {
                                     pos += 2;
@@ -1850,6 +1883,7 @@ namespace ts {
             const saveTokenValue = tokenValue;
             const saveHasExtendedUnicodeEscape = hasExtendedUnicodeEscape;
             const saveTokenIsUnterminated = tokenIsUnterminated;
+            const saveEmbeddedCommentStack = embeddedCommentStack;
 
             setText(text, start, length);
             const result = callback();
@@ -1863,6 +1897,7 @@ namespace ts {
             tokenValue = saveTokenValue;
             hasExtendedUnicodeEscape = saveHasExtendedUnicodeEscape;
             tokenIsUnterminated = saveTokenIsUnterminated;
+            embeddedCommentStack = saveEmbeddedCommentStack;
 
             return result;
         }
@@ -1905,6 +1940,7 @@ namespace ts {
             token = SyntaxKind.Unknown;
             precedingLineBreak = false;
 
+            embeddedCommentStack = 0;
             tokenValue = undefined;
             hasExtendedUnicodeEscape = false;
             tokenIsUnterminated = false;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
See #9694 .

My workplace, and many community projects, are aware of the analysis capabilities of Typescript, but shy away from having a build step added to projects that are currently written in raw JS. This makes Typescript a non-starter. Facebook's Flow has a nifty feature whereby annotations can be added as comments inline in JS, meaning no build step is required. E.g.

```ts
const s /*: string */ = 'asdf';

function f(s /*: string */) /*: number */ {
    return 4;
}

/*::
interface MyObject {
    s: string;
    n: number;
}
*/
const o /*: MyObject */ = {s: 'asdf', n: 123}
```

This seems to have seen wide approval and support from the Flow community.

This PR implements this feature in Typescript. It's clearly uglier that direct annotations, but it's a much more succinct way of adding Typescript annotations to valid Javascript than JSDoc.


Two constructs are supported. `/*: typename*/` is interpreted as `: typename`, as in the first two examples above. `/* :: statements; ... */` is interpreted as `statements; ...`.

It may also be worth considering `/* <parameter> */ -> <parameter> ` to allow manually specifying generic parameters where elision is not possible. This would also allow angle bracket type assertions. Note that this would be a convenience extension - as currently implemented, this is already possible with `/* :: <parameter> */`

This is a first go to see how easy this was to implement - I am aware that the CLA needs to be signed, test cases need to be written, that the issue needs to be tagged as needing a proposal (and that there is no guarantee this will happen!), and said proposal needs to be written and accepted, and that this is a language change and will thus be either highly contentious or rejected outright.