### PR TITLE
Object rest skips only class methods

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3125,9 +3125,8 @@ namespace ts {
             for (const prop of getPropertiesOfType(source)) {
                 const inNamesToRemove = prop.name in names;
                 const isPrivate = getDeclarationModifierFlagsFromSymbol(prop) & (ModifierFlags.Private | ModifierFlags.Protected);
-                const isMethod = prop.flags & SymbolFlags.Method;
                 const isSetOnlyAccessor = prop.flags & SymbolFlags.SetAccessor && !(prop.flags & SymbolFlags.GetAccessor);
-                if (!inNamesToRemove && !isPrivate && !isMethod && !isSetOnlyAccessor) {
+                if (!inNamesToRemove && !isPrivate && !isClassMethod(prop) && !isSetOnlyAccessor) {
                     members[prop.name] = prop;
                 }
             }

--- a/tests/baselines/reference/objectRest.js
+++ b/tests/baselines/reference/objectRest.js
@@ -29,8 +29,15 @@ class Removable {
     removed: string;
     remainder: string;
 }
+interface I {
+    m(): void;
+    removed: string;
+    remainder: string;
+}
 var removable = new Removable();
 var { removed, ...removableRest } = removable;
+var i: I = removable;
+var { removed, ...removableRest2 } = i;
 
 let computed = 'b';
 let computed2 = 'a';
@@ -74,6 +81,8 @@ class Removable {
 }
 var removable = new Removable();
 var { removed } = removable, removableRest = __rest(removable, ["removed"]);
+var i = removable;
+var { removed } = i, removableRest2 = __rest(i, ["removed"]);
 let computed = 'b';
 let computed2 = 'a';
 var _g = computed, stillNotGreat = o[_g], _h = computed2, soSo = o[_h], o = __rest(o, [typeof _g === "symbol" ? _g : _g + "", typeof _h === "symbol" ? _h : _h + ""]);

--- a/tests/baselines/reference/objectRest.symbols
+++ b/tests/baselines/reference/objectRest.symbols
@@ -1,42 +1,42 @@
 === tests/cases/conformance/types/rest/objectRest.ts ===
 var o = { a: 1, b: 'no' }
->o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
+>o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 42, 51))
 >a : Symbol(a, Decl(objectRest.ts, 0, 9))
 >b : Symbol(b, Decl(objectRest.ts, 0, 15))
 
 var { ...clone } = o;
 >clone : Symbol(clone, Decl(objectRest.ts, 1, 5))
->o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
+>o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 42, 51))
 
 var { a, ...justB } = o;
 >a : Symbol(a, Decl(objectRest.ts, 2, 5), Decl(objectRest.ts, 3, 5))
 >justB : Symbol(justB, Decl(objectRest.ts, 2, 8))
->o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
+>o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 42, 51))
 
 var { a, b: renamed, ...empty } = o;
 >a : Symbol(a, Decl(objectRest.ts, 2, 5), Decl(objectRest.ts, 3, 5))
 >b : Symbol(b, Decl(objectRest.ts, 0, 15))
 >renamed : Symbol(renamed, Decl(objectRest.ts, 3, 8), Decl(objectRest.ts, 4, 5), Decl(objectRest.ts, 5, 5), Decl(objectRest.ts, 9, 5))
 >empty : Symbol(empty, Decl(objectRest.ts, 3, 20))
->o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
+>o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 42, 51))
 
 var { ['b']: renamed, ...justA } = o;
 >'b' : Symbol(renamed, Decl(objectRest.ts, 3, 8), Decl(objectRest.ts, 4, 5), Decl(objectRest.ts, 5, 5), Decl(objectRest.ts, 9, 5))
 >renamed : Symbol(renamed, Decl(objectRest.ts, 3, 8), Decl(objectRest.ts, 4, 5), Decl(objectRest.ts, 5, 5), Decl(objectRest.ts, 9, 5))
 >justA : Symbol(justA, Decl(objectRest.ts, 4, 21), Decl(objectRest.ts, 5, 19), Decl(objectRest.ts, 6, 31))
->o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
+>o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 42, 51))
 
 var { 'b': renamed, ...justA } = o;
 >renamed : Symbol(renamed, Decl(objectRest.ts, 3, 8), Decl(objectRest.ts, 4, 5), Decl(objectRest.ts, 5, 5), Decl(objectRest.ts, 9, 5))
 >justA : Symbol(justA, Decl(objectRest.ts, 4, 21), Decl(objectRest.ts, 5, 19), Decl(objectRest.ts, 6, 31))
->o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
+>o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 42, 51))
 
 var { b: { '0': n, '1': oooo }, ...justA } = o;
 >b : Symbol(b, Decl(objectRest.ts, 0, 15))
 >n : Symbol(n, Decl(objectRest.ts, 6, 10))
 >oooo : Symbol(oooo, Decl(objectRest.ts, 6, 18))
 >justA : Symbol(justA, Decl(objectRest.ts, 4, 21), Decl(objectRest.ts, 5, 19), Decl(objectRest.ts, 6, 31))
->o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
+>o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 42, 51))
 
 let o2 = { c: 'terrible idea?', d: 'yes' };
 >o2 : Symbol(o2, Decl(objectRest.ts, 8, 3))
@@ -138,41 +138,63 @@ class Removable {
     remainder: string;
 >remainder : Symbol(Removable.remainder, Decl(objectRest.ts, 27, 20))
 }
+interface I {
+>I : Symbol(I, Decl(objectRest.ts, 29, 1))
+
+    m(): void;
+>m : Symbol(I.m, Decl(objectRest.ts, 30, 13))
+
+    removed: string;
+>removed : Symbol(I.removed, Decl(objectRest.ts, 31, 14))
+
+    remainder: string;
+>remainder : Symbol(I.remainder, Decl(objectRest.ts, 32, 20))
+}
 var removable = new Removable();
->removable : Symbol(removable, Decl(objectRest.ts, 30, 3))
+>removable : Symbol(removable, Decl(objectRest.ts, 35, 3))
 >Removable : Symbol(Removable, Decl(objectRest.ts, 18, 35))
 
 var { removed, ...removableRest } = removable;
->removed : Symbol(removed, Decl(objectRest.ts, 31, 5))
->removableRest : Symbol(removableRest, Decl(objectRest.ts, 31, 14))
->removable : Symbol(removable, Decl(objectRest.ts, 30, 3))
+>removed : Symbol(removed, Decl(objectRest.ts, 36, 5), Decl(objectRest.ts, 38, 5))
+>removableRest : Symbol(removableRest, Decl(objectRest.ts, 36, 14))
+>removable : Symbol(removable, Decl(objectRest.ts, 35, 3))
+
+var i: I = removable;
+>i : Symbol(i, Decl(objectRest.ts, 37, 3))
+>I : Symbol(I, Decl(objectRest.ts, 29, 1))
+>removable : Symbol(removable, Decl(objectRest.ts, 35, 3))
+
+var { removed, ...removableRest2 } = i;
+>removed : Symbol(removed, Decl(objectRest.ts, 36, 5), Decl(objectRest.ts, 38, 5))
+>removableRest2 : Symbol(removableRest2, Decl(objectRest.ts, 38, 14))
+>i : Symbol(i, Decl(objectRest.ts, 37, 3))
 
 let computed = 'b';
->computed : Symbol(computed, Decl(objectRest.ts, 33, 3))
+>computed : Symbol(computed, Decl(objectRest.ts, 40, 3))
 
 let computed2 = 'a';
->computed2 : Symbol(computed2, Decl(objectRest.ts, 34, 3))
+>computed2 : Symbol(computed2, Decl(objectRest.ts, 41, 3))
 
 var { [computed]: stillNotGreat, [computed2]: soSo,  ...o } = o;
->computed : Symbol(computed, Decl(objectRest.ts, 33, 3))
->stillNotGreat : Symbol(stillNotGreat, Decl(objectRest.ts, 35, 5))
->computed2 : Symbol(computed2, Decl(objectRest.ts, 34, 3))
->soSo : Symbol(soSo, Decl(objectRest.ts, 35, 32))
->o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
->o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
+>computed : Symbol(computed, Decl(objectRest.ts, 40, 3))
+>stillNotGreat : Symbol(stillNotGreat, Decl(objectRest.ts, 42, 5))
+>computed2 : Symbol(computed2, Decl(objectRest.ts, 41, 3))
+>soSo : Symbol(soSo, Decl(objectRest.ts, 42, 32))
+>o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 42, 51))
+>o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 42, 51))
 
 ({ [computed]: stillNotGreat, [computed2]: soSo, ...o } = o);
->computed : Symbol(computed, Decl(objectRest.ts, 33, 3))
->stillNotGreat : Symbol(stillNotGreat, Decl(objectRest.ts, 35, 5))
->computed2 : Symbol(computed2, Decl(objectRest.ts, 34, 3))
->soSo : Symbol(soSo, Decl(objectRest.ts, 35, 32))
->o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
->o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 35, 51))
+>computed : Symbol(computed, Decl(objectRest.ts, 40, 3))
+>stillNotGreat : Symbol(stillNotGreat, Decl(objectRest.ts, 42, 5))
+>computed2 : Symbol(computed2, Decl(objectRest.ts, 41, 3))
+>soSo : Symbol(soSo, Decl(objectRest.ts, 42, 32))
+>o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 42, 51))
+>o : Symbol(o, Decl(objectRest.ts, 0, 3), Decl(objectRest.ts, 42, 51))
 
 var noContextualType = ({ aNumber = 12, ...notEmptyObject }) => aNumber + notEmptyObject['anythingGoes'];
->noContextualType : Symbol(noContextualType, Decl(objectRest.ts, 38, 3))
->aNumber : Symbol(aNumber, Decl(objectRest.ts, 38, 25))
->notEmptyObject : Symbol(notEmptyObject, Decl(objectRest.ts, 38, 39))
->aNumber : Symbol(aNumber, Decl(objectRest.ts, 38, 25))
->notEmptyObject : Symbol(notEmptyObject, Decl(objectRest.ts, 38, 39))
+>noContextualType : Symbol(noContextualType, Decl(objectRest.ts, 45, 3))
+>aNumber : Symbol(aNumber, Decl(objectRest.ts, 45, 25))
+>notEmptyObject : Symbol(notEmptyObject, Decl(objectRest.ts, 45, 39))
+>aNumber : Symbol(aNumber, Decl(objectRest.ts, 45, 25))
+>notEmptyObject : Symbol(notEmptyObject, Decl(objectRest.ts, 45, 39))
 

--- a/tests/baselines/reference/objectRest.types
+++ b/tests/baselines/reference/objectRest.types
@@ -158,6 +158,18 @@ class Removable {
     remainder: string;
 >remainder : string
 }
+interface I {
+>I : I
+
+    m(): void;
+>m : () => void
+
+    removed: string;
+>removed : string
+
+    remainder: string;
+>remainder : string
+}
 var removable = new Removable();
 >removable : Removable
 >new Removable() : Removable
@@ -167,6 +179,16 @@ var { removed, ...removableRest } = removable;
 >removed : string
 >removableRest : { both: number; remainder: string; }
 >removable : Removable
+
+var i: I = removable;
+>i : I
+>I : I
+>removable : Removable
+
+var { removed, ...removableRest2 } = i;
+>removed : string
+>removableRest2 : { m(): void; remainder: string; }
+>i : I
 
 let computed = 'b';
 >computed : string

--- a/tests/cases/conformance/types/rest/objectRest.ts
+++ b/tests/cases/conformance/types/rest/objectRest.ts
@@ -29,8 +29,15 @@ class Removable {
     removed: string;
     remainder: string;
 }
+interface I {
+    m(): void;
+    removed: string;
+    remainder: string;
+}
 var removable = new Removable();
 var { removed, ...removableRest } = removable;
+var i: I = removable;
+var { removed, ...removableRest2 } = i;
 
 let computed = 'b';
 let computed2 = 'a';


### PR DESCRIPTION
Object rest should behave the same as object spread. I forgot to make this change yesterday.

@mhegazy, mind reviewing this two-line change since you looked at the previous one?