### PR TITLE
Change the module specifier search order

### DIFF
--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -420,10 +420,10 @@ namespace ts.codefix {
                         const options = context.program.getCompilerOptions();
 
                         return tryGetModuleNameFromAmbientModule() ||
-                            tryGetModuleNameFromBaseUrl() ||
-                            tryGetModuleNameFromRootDirs() ||
                             tryGetModuleNameFromTypeRoots() ||
                             tryGetModuleNameAsNodeModule() ||
+                            tryGetModuleNameFromBaseUrl() ||
+                            tryGetModuleNameFromRootDirs() ||
                             removeFileExtension(getRelativePath(moduleFileName, sourceDirectory));
 
                         function tryGetModuleNameFromAmbientModule(): string {

--- a/tests/cases/fourslash/importNameCodeFixNewImportTypeRoots1.ts
+++ b/tests/cases/fourslash/importNameCodeFixNewImportTypeRoots1.ts
@@ -1,0 +1,23 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: a/f1.ts
+//// [|foo/*0*/();|]
+
+// @Filename: types/random/index.ts
+//// export function foo() {};
+
+// @Filename: tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "baseUrl": ".",
+////         "typeRoots": [
+////             "./types"
+////         ]
+////     }
+//// }
+
+verify.importFixAtPosition([
+`import { foo } from "random";
+
+foo();`
+]);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #13129 

Module specifiers obtained from "typeRoot" should be "better" than from "baseUrl", as the later can still be in a "typeRoot" folder.
