### PR TITLE
`object` should not be assignable to a type parameter

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7469,19 +7469,23 @@ namespace ts {
                     }
                     else {
                         let constraint = getConstraintOfTypeParameter(<TypeParameter>source);
-
-                        if (!constraint || constraint.flags & TypeFlags.Any) {
-                            constraint = emptyObjectType;
+                        if (!constraint && target.flags & TypeFlags.NonPrimitive) {
+                            result = Ternary.False;
                         }
+                        else {
+                            if (!constraint || constraint.flags & TypeFlags.Any) {
+                                constraint = emptyObjectType;
+                            }
 
-                        // The constraint may need to be further instantiated with its 'this' type.
-                        constraint = getTypeWithThisArgument(constraint, source);
+                            // The constraint may need to be further instantiated with its 'this' type.
+                            constraint = getTypeWithThisArgument(constraint, source);
 
-                        // Report constraint errors only if the constraint is not the empty object type
-                        const reportConstraintErrors = reportErrors && constraint !== emptyObjectType;
-                        if (result = isRelatedTo(constraint, target, reportConstraintErrors)) {
-                            errorInfo = saveErrorInfo;
-                            return result;
+                            // Report constraint errors only if the constraint is not the empty object type
+                            const reportConstraintErrors = reportErrors && constraint !== emptyObjectType;
+                            if (result = isRelatedTo(constraint, target, reportConstraintErrors)) {
+                                errorInfo = saveErrorInfo;
+                                return result;
+                            }
                         }
                     }
                 }

--- a/tests/baselines/reference/nonPrimitiveInGeneric.errors.txt
+++ b/tests/baselines/reference/nonPrimitiveInGeneric.errors.txt
@@ -1,14 +1,19 @@
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(7,17): error TS2345: Argument of type '123' is not assignable to parameter of type 'object'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(8,17): error TS2345: Argument of type 'string' is not assignable to parameter of type 'object'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(14,7): error TS2345: Argument of type '123' is not assignable to parameter of type 'object'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(15,7): error TS2345: Argument of type 'string' is not assignable to parameter of type 'object'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(21,8): error TS2344: Type 'number' does not satisfy the constraint 'object'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(22,8): error TS2344: Type 'string' does not satisfy the constraint 'object'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(26,14): error TS2344: Type 'number' does not satisfy the constraint 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(2,9): error TS2322: Type 'T' is not assignable to type 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(9,17): error TS2345: Argument of type '123' is not assignable to parameter of type 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(10,17): error TS2345: Argument of type 'string' is not assignable to parameter of type 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(18,7): error TS2345: Argument of type '123' is not assignable to parameter of type 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(19,7): error TS2345: Argument of type 'string' is not assignable to parameter of type 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(25,8): error TS2344: Type 'number' does not satisfy the constraint 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(26,8): error TS2344: Type 'string' does not satisfy the constraint 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(30,14): error TS2344: Type 'number' does not satisfy the constraint 'object'.
 
 
-==== tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts (7 errors) ====
-    function generic<T>(t: T) {}
+==== tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts (8 errors) ====
+    function generic<T>(t: T) {
+        var o: object = t; // expect error
+            ~
+!!! error TS2322: Type 'T' is not assignable to type 'object'.
+    }
     var a = {};
     var b = "42";
     
@@ -21,7 +26,9 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(26,14): erro
                     ~
 !!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'object'.
     
-    function bound<T extends object>(t: T) {}
+    function bound<T extends object>(t: T) {
+        var o: object = t; // ok
+    }
     
     bound({});
     bound(a);

--- a/tests/baselines/reference/nonPrimitiveInGeneric.js
+++ b/tests/baselines/reference/nonPrimitiveInGeneric.js
@@ -1,5 +1,7 @@
 //// [nonPrimitiveInGeneric.ts]
-function generic<T>(t: T) {}
+function generic<T>(t: T) {
+    var o: object = t; // expect error
+}
 var a = {};
 var b = "42";
 
@@ -8,7 +10,9 @@ generic<object>(a);
 generic<object>(123); // expect error
 generic<object>(b); // expect error
 
-function bound<T extends object>(t: T) {}
+function bound<T extends object>(t: T) {
+    var o: object = t; // ok
+}
 
 bound({});
 bound(a);
@@ -37,14 +41,18 @@ var u: Proxy<Blah>; // ok
 
 
 //// [nonPrimitiveInGeneric.js]
-function generic(t) { }
+function generic(t) {
+    var o = t; // expect error
+}
 var a = {};
 var b = "42";
 generic({});
 generic(a);
 generic(123); // expect error
 generic(b); // expect error
-function bound(t) { }
+function bound(t) {
+    var o = t; // ok
+}
 bound({});
 bound(a);
 bound(123); // expect error

--- a/tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts
+++ b/tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts
@@ -1,4 +1,6 @@
-function generic<T>(t: T) {}
+function generic<T>(t: T) {
+    var o: object = t; // expect error
+}
 var a = {};
 var b = "42";
 
@@ -7,7 +9,9 @@ generic<object>(a);
 generic<object>(123); // expect error
 generic<object>(b); // expect error
 
-function bound<T extends object>(t: T) {}
+function bound<T extends object>(t: T) {
+    var o: object = t; // ok
+}
 
 bound({});
 bound(a);


### PR DESCRIPTION
The new non-primitive `object` should be assignable to an unconstrained type parameter.

@ahejlsberg pointed out that 

```
function f<T>(t: T) {
  object o = t; // should not work
  number n = t; // currently doesn't work
}
```