### PR TITLE
Unconstrained type parameter not assignable to 'object' type

### DIFF
--- a/tests/baselines/reference/nonPrimitiveInGeneric.errors.txt
+++ b/tests/baselines/reference/nonPrimitiveInGeneric.errors.txt
@@ -1,14 +1,19 @@
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(7,17): error TS2345: Argument of type '123' is not assignable to parameter of type 'object'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(8,17): error TS2345: Argument of type 'string' is not assignable to parameter of type 'object'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(14,7): error TS2345: Argument of type '123' is not assignable to parameter of type 'object'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(15,7): error TS2345: Argument of type 'string' is not assignable to parameter of type 'object'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(21,8): error TS2344: Type 'number' does not satisfy the constraint 'object'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(22,8): error TS2344: Type 'string' does not satisfy the constraint 'object'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(26,14): error TS2344: Type 'number' does not satisfy the constraint 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(2,9): error TS2322: Type 'T' is not assignable to type 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(9,17): error TS2345: Argument of type '123' is not assignable to parameter of type 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(10,17): error TS2345: Argument of type 'string' is not assignable to parameter of type 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(18,7): error TS2345: Argument of type '123' is not assignable to parameter of type 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(19,7): error TS2345: Argument of type 'string' is not assignable to parameter of type 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(25,8): error TS2344: Type 'number' does not satisfy the constraint 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(26,8): error TS2344: Type 'string' does not satisfy the constraint 'object'.
+tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(34,14): error TS2344: Type 'number' does not satisfy the constraint 'object'.
 
 
-==== tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts (7 errors) ====
-    function generic<T>(t: T) {}
+==== tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts (8 errors) ====
+    function generic<T>(t: T) {
+        var o: object = t; // expect error
+            ~
+!!! error TS2322: Type 'T' is not assignable to type 'object'.
+    }
     var a = {};
     var b = "42";
     
@@ -21,7 +26,9 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(26,14): erro
                     ~
 !!! error TS2345: Argument of type 'string' is not assignable to parameter of type 'object'.
     
-    function bound<T extends object>(t: T) {}
+    function bound<T extends object>(t: T) {
+        var o: object = t; // ok
+    }
     
     bound({});
     bound(a);
@@ -43,6 +50,10 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(26,14): erro
            ~~~~~~
 !!! error TS2344: Type 'string' does not satisfy the constraint 'object'.
     
+    function bound3<T extends {}>(t: T) {
+        var o: object = t; // ok
+    }
+    
     interface Proxy<T extends object> {}
     
     var x: Proxy<number>; // error
@@ -53,7 +64,7 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts(26,14): erro
     
     
     interface Blah {
-      foo: number;
+        foo: number;
     }
     
     var u: Proxy<Blah>; // ok

--- a/tests/baselines/reference/nonPrimitiveInGeneric.js
+++ b/tests/baselines/reference/nonPrimitiveInGeneric.js
@@ -1,5 +1,7 @@
 //// [nonPrimitiveInGeneric.ts]
-function generic<T>(t: T) {}
+function generic<T>(t: T) {
+    var o: object = t; // expect error
+}
 var a = {};
 var b = "42";
 
@@ -8,7 +10,9 @@ generic<object>(a);
 generic<object>(123); // expect error
 generic<object>(b); // expect error
 
-function bound<T extends object>(t: T) {}
+function bound<T extends object>(t: T) {
+    var o: object = t; // ok
+}
 
 bound({});
 bound(a);
@@ -22,6 +26,10 @@ bound2<Object>();
 bound2<number>(); // expect error
 bound2<string>(); // expect error
 
+function bound3<T extends {}>(t: T) {
+    var o: object = t; // ok
+}
+
 interface Proxy<T extends object> {}
 
 var x: Proxy<number>; // error
@@ -30,21 +38,25 @@ var z: Proxy<undefined> ; // ok
 
 
 interface Blah {
-  foo: number;
+    foo: number;
 }
 
 var u: Proxy<Blah>; // ok
 
 
 //// [nonPrimitiveInGeneric.js]
-function generic(t) { }
+function generic(t) {
+    var o = t; // expect error
+}
 var a = {};
 var b = "42";
 generic({});
 generic(a);
 generic(123); // expect error
 generic(b); // expect error
-function bound(t) { }
+function bound(t) {
+    var o = t; // ok
+}
 bound({});
 bound(a);
 bound(123); // expect error
@@ -54,6 +66,9 @@ bound2();
 bound2();
 bound2(); // expect error
 bound2(); // expect error
+function bound3(t) {
+    var o = t; // ok
+}
 var x; // error
 var y; // ok
 var z; // ok

--- a/tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts
+++ b/tests/cases/conformance/types/nonPrimitive/nonPrimitiveInGeneric.ts
@@ -1,4 +1,6 @@
-function generic<T>(t: T) {}
+function generic<T>(t: T) {
+    var o: object = t; // expect error
+}
 var a = {};
 var b = "42";
 
@@ -7,7 +9,9 @@ generic<object>(a);
 generic<object>(123); // expect error
 generic<object>(b); // expect error
 
-function bound<T extends object>(t: T) {}
+function bound<T extends object>(t: T) {
+    var o: object = t; // ok
+}
 
 bound({});
 bound(a);
@@ -21,6 +25,10 @@ bound2<Object>();
 bound2<number>(); // expect error
 bound2<string>(); // expect error
 
+function bound3<T extends {}>(t: T) {
+    var o: object = t; // ok
+}
+
 interface Proxy<T extends object> {}
 
 var x: Proxy<number>; // error
@@ -29,7 +37,7 @@ var z: Proxy<undefined> ; // ok
 
 
 interface Blah {
-  foo: number;
+    foo: number;
 }
 
 var u: Proxy<Blah>; // ok


### PR DESCRIPTION
With this PR an unconstrained type parameter cannot be assigned to the `object` type:

```ts
function f1<T>(x: T) {
    let o: object = x;  // Now an error
}

function f2<T extends object>(x: T) {
    let o: object = x;  // Ok
}
```

This PR also includes some minor changes to remove unnecessary code and use type flags instead of object comparisons.