### PR TITLE
Include properties of an `export =` value in import completions.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -108,7 +108,7 @@ namespace ts {
             getAliasedSymbol: resolveAlias,
             getEmitResolver,
             getExportsOfModule: getExportsOfModuleAsArray,
-            resolveExternalModuleSymbol,
+            getExportsAndPropertiesOfModule,
             getAmbientModules,
             getJsxElementAttributesType,
             getJsxIntrinsicTagNames,
@@ -1526,6 +1526,15 @@ namespace ts {
 
         function getExportsOfModuleAsArray(moduleSymbol: Symbol): Symbol[] {
             return symbolsToArray(getExportsOfModule(moduleSymbol));
+        }
+
+        function getExportsAndPropertiesOfModule(moduleSymbol: Symbol): Symbol[] {
+            const exports = getExportsOfModuleAsArray(moduleSymbol);
+            const exportEquals = resolveExternalModuleSymbol(moduleSymbol);
+            if (exportEquals !== moduleSymbol) {
+                addRange(exports, getPropertiesOfType(getTypeOfSymbol(exportEquals)));
+            }
+            return exports;
         }
 
         function tryGetMemberInModuleExports(memberName: string, moduleSymbol: Symbol): Symbol | undefined {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -108,6 +108,7 @@ namespace ts {
             getAliasedSymbol: resolveAlias,
             getEmitResolver,
             getExportsOfModule: getExportsOfModuleAsArray,
+            resolveExternalModuleSymbol,
             getAmbientModules,
             getJsxElementAttributesType,
             getJsxIntrinsicTagNames,

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2370,7 +2370,8 @@ namespace ts {
         isValidPropertyAccess(node: PropertyAccessExpression | QualifiedName, propertyName: string): boolean;
         getAliasedSymbol(symbol: Symbol): Symbol;
         getExportsOfModule(moduleSymbol: Symbol): Symbol[];
-        /* @internal */ resolveExternalModuleSymbol(moduleSymbol: Symbol): Symbol;
+        /** Unlike `getExportsOfModule`, this includes properties of an `export =` value. */
+        /* @internal */ getExportsAndPropertiesOfModule(moduleSymbol: Symbol): Symbol[];
 
         getJsxElementAttributesType(elementNode: JsxOpeningLikeElement): Type;
         getJsxIntrinsicTagNames(): Symbol[];

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2370,6 +2370,7 @@ namespace ts {
         isValidPropertyAccess(node: PropertyAccessExpression | QualifiedName, propertyName: string): boolean;
         getAliasedSymbol(symbol: Symbol): Symbol;
         getExportsOfModule(moduleSymbol: Symbol): Symbol[];
+        /* @internal */ resolveExternalModuleSymbol(moduleSymbol: Symbol): Symbol;
 
         getJsxElementAttributesType(elementNode: JsxOpeningLikeElement): Type;
         getJsxIntrinsicTagNames(): Symbol[];

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1318,20 +1318,14 @@ namespace ts.Completions {
             isMemberCompletion = true;
             isNewIdentifierLocation = false;
 
-            let exports: Symbol[];
-            const moduleSpecifierSymbol = typeChecker.getSymbolAtLocation(importOrExportDeclaration.moduleSpecifier);
-            if (moduleSpecifierSymbol) {
-                exports = typeChecker.getExportsOfModule(moduleSpecifierSymbol);
-                const exportEquals = typeChecker.resolveExternalModuleSymbol(moduleSpecifierSymbol);
-                if (exportEquals !== moduleSpecifierSymbol) {
-                    // Location doesn't matter so long as it's not an identifier.
-                    const exportEqualsType = typeChecker.getTypeOfSymbolAtLocation(exportEquals, moduleSpecifier);
-                    exports = ts.concatenate(exports, typeChecker.getPropertiesOfType(exportEqualsType));
-                }
+            const moduleSpecifierSymbol = typeChecker.getSymbolAtLocation(moduleSpecifier);
+            if (!moduleSpecifierSymbol) {
+                symbols = emptyArray;
+                return true;
             }
 
-            symbols = exports ? filterNamedImportOrExportCompletionItems(exports, namedImportsOrExports.elements) : emptyArray;
-
+            const exports = typeChecker.getExportsAndPropertiesOfModule(moduleSpecifierSymbol);
+            symbols = filterNamedImportOrExportCompletionItems(exports, namedImportsOrExports.elements);
             return true;
         }
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1322,6 +1322,12 @@ namespace ts.Completions {
             const moduleSpecifierSymbol = typeChecker.getSymbolAtLocation(importOrExportDeclaration.moduleSpecifier);
             if (moduleSpecifierSymbol) {
                 exports = typeChecker.getExportsOfModule(moduleSpecifierSymbol);
+                const exportEquals = typeChecker.resolveExternalModuleSymbol(moduleSpecifierSymbol);
+                if (exportEquals !== moduleSpecifierSymbol) {
+                    // Location doesn't matter so long as it's not an identifier.
+                    const exportEqualsType = typeChecker.getTypeOfSymbolAtLocation(exportEquals, moduleSpecifier);
+                    exports = ts.concatenate(exports, typeChecker.getPropertiesOfType(exportEqualsType));
+                }
             }
 
             symbols = exports ? filterNamedImportOrExportCompletionItems(exports, namedImportsOrExports.elements) : emptyArray;

--- a/tests/cases/fourslash/completionListForExportEquals.ts
+++ b/tests/cases/fourslash/completionListForExportEquals.ts
@@ -1,0 +1,16 @@
+
+///<reference path="fourslash.ts"/>
+
+// @Filename: /node_modules/foo/index.d.ts
+////export = Foo;
+////declare var Foo: Foo.Static;
+////declare namespace Foo {
+////    interface Static {
+////        foo(): void;
+////    }
+////}
+
+// @Filename: /a.ts
+////import { /**/ } from "foo";
+
+verify.completionsAt("", ["Static", "foo"]);

--- a/tests/cases/fourslash/completionListForExportEquals2.ts
+++ b/tests/cases/fourslash/completionListForExportEquals2.ts
@@ -1,0 +1,14 @@
+
+///<reference path="fourslash.ts"/>
+
+// @Filename: /node_modules/foo/index.d.ts
+////export = Foo;
+////interface Foo { bar: number; }
+////declare namespace Foo {
+////    interface Static {}
+////}
+
+// @Filename: /a.ts
+////import { /**/ } from "foo";
+
+verify.completionsAt("", ["Static"]);

--- a/tests/cases/fourslash/completionListInImportClause04.ts
+++ b/tests/cases/fourslash/completionListInImportClause04.ts
@@ -11,10 +11,7 @@
 // @Filename: app.ts
 ////import {/*1*/} from './foo';
 
-goTo.marker('1');
-verify.completionListContains('prop1');
-verify.completionListContains('prop2');
-verify.not.completionListContains('Foo');
+verify.completionsAt("1", ["prototype", "prop1", "prop2"]);
 verify.numberOfErrorsInCurrentFile(0);
 goTo.marker('2');
 verify.numberOfErrorsInCurrentFile(0);

--- a/tests/cases/fourslash/fourslash.ts
+++ b/tests/cases/fourslash/fourslash.ts
@@ -138,6 +138,7 @@ declare namespace FourSlashInterface {
     class verify extends verifyNegatable {
         assertHasRanges(ranges: Range[]): void;
         caretAtMarker(markerName?: string): void;
+        completionsAt(markerName: string, completions: string[]): void;
         indentationIs(numberOfSpaces: number): void;
         indentationAtPositionIs(fileName: string, position: number, numberOfSpaces: number, indentStyle?: ts.IndentStyle, baseIndentSize?: number): void;
         textAtCaretIs(text: string): void;


### PR DESCRIPTION
Fixes #13218

Wish there was a way to do this without exposing `resolveExternalModuleSymbol`, but I wouldn't be comfortable modifying `getExportsOfModule`.

