### PR TITLE
Use tsconfig inheritance

### DIFF
--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -1,17 +1,9 @@
 {
+    "extends": "../tsconfig-base",
     "compilerOptions": {
-        "noImplicitAny": true,
-        "noImplicitThis": true,
         "removeComments": true,
-        "preserveConstEnums": true,
-        "pretty": true,
         "outFile": "../../built/local/tsc.js",
-        "sourceMap": true,
         "declaration": true,
-        "stripInternal": true,
-        "target": "es5",
-        "noUnusedLocals": true,
-        "noUnusedParameters": true,
         "types": [ ]
     },
     "files": [

--- a/src/harness/tsconfig.json
+++ b/src/harness/tsconfig.json
@@ -1,19 +1,12 @@
 {
+    "extends": "../tsconfig-base",
     "compilerOptions": {
-        "noImplicitAny": true,
-        "pretty": true,
         "removeComments": false,
-        "preserveConstEnums": true,
         "outFile": "../../built/local/run.js",
-        "sourceMap": true,
         "declaration": false,
-        "stripInternal": true,
         "types": [
             "node", "mocha", "chai"
-        ],
-        "target": "es5",
-        "noUnusedLocals": true,
-        "noUnusedParameters": true
+        ]
     },
     "files": [
         "../compiler/core.ts",
@@ -85,7 +78,7 @@
         "../services/codefixes/importFixes.ts",
         "../services/codefixes/unusedIdentifierFixes.ts",
         "../services/harness.ts",
-        
+
         "sourceMapRecorder.ts",
         "harnessLanguageService.ts",
         "fourslash.ts",

--- a/src/server/cancellationToken/tsconfig.json
+++ b/src/server/cancellationToken/tsconfig.json
@@ -1,19 +1,11 @@
 {
+    "extends": "../../tsconfig-base",
     "compilerOptions": {
-        "noImplicitAny": true,
-        "noImplicitThis": true,
         "removeComments": true,
-        "preserveConstEnums": true,
-        "pretty": true,
         "module": "commonjs",
-        "sourceMap": true,
-        "stripInternal": true,
         "types": [
             "node"
-        ],
-        "target": "es5",
-        "noUnusedLocals": true,
-        "noUnusedParameters": true
+        ]
     },
     "files": [
         "cancellationToken.ts"

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -1,19 +1,11 @@
 {
+    "extends": "../tsconfig-base",
     "compilerOptions": {
-        "noImplicitAny": true,
-        "noImplicitThis": true,
         "removeComments": true,
-        "preserveConstEnums": true,
-        "pretty": true,
         "outFile": "../../built/local/tsserver.js",
-        "sourceMap": true,
-        "stripInternal": true,
         "types": [
             "node"
-        ],
-        "target": "es5",
-        "noUnusedLocals": true,
-        "noUnusedParameters": true
+        ]
     },
     "files": [
         "../services/shims.ts",

--- a/src/server/typingsInstaller/tsconfig.json
+++ b/src/server/typingsInstaller/tsconfig.json
@@ -1,19 +1,11 @@
 {
+    "extends": "../../tsconfig-base",
     "compilerOptions": {
-        "noImplicitAny": true,
-        "noImplicitThis": true,
         "removeComments": true,
-        "preserveConstEnums": true,
-        "pretty": true,
         "outFile": "../../../built/local/typingsInstaller.js",
-        "sourceMap": true,
-        "stripInternal": true,
         "types": [
             "node"
-        ],
-        "target": "es5",
-        "noUnusedLocals": true,
-        "noUnusedParameters": true
+        ]
     },
     "files": [
         "../types.ts",

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -3,7 +3,6 @@
     "compilerOptions": {
         "removeComments": false,
         "outFile": "../../built/local/typescriptServices.js",
-        "noResolve": false,
         "declaration": true,
         "types": []
     },

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -1,18 +1,10 @@
 ﻿{
+    "extends": "../tsconfig-base",
     "compilerOptions": {
-        "noImplicitAny": true,
-        "noImplicitThis": true,
         "removeComments": false,
-        "preserveConstEnums": true,
-        "pretty": true,
         "outFile": "../../built/local/typescriptServices.js",
-        "sourceMap": true,
-        "stripInternal": true,
         "noResolve": false,
         "declaration": true,
-        "target": "es5",
-        "noUnusedLocals": true,
-        "noUnusedParameters": true,
         "types": []
     },
     "files": [

--- a/src/tsconfig-base.json
+++ b/src/tsconfig-base.json
@@ -1,0 +1,14 @@
+{
+    "compilerOptions": {
+        "lib": ["es5"],
+        "noImplicitAny": true,
+        "noImplicitThis": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true,
+        "pretty": true,
+        "preserveConstEnums": true,
+        "stripInternal": true,
+        "sourceMap": true,
+        "target": "es5"
+    }
+}


### PR DESCRIPTION
Why not? I've tested with both `jake` and `gulp` with this and it seems to work.
This also sets `"lib": ["es5"],` so that we don't use DOM typings.