### PR TITLE
Stop using "dom" types

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -456,7 +456,7 @@ function compileFile(outFile, sources, prereqs, prefixes, useBuiltCompiler, opts
             options += " --stripInternal";
         }
 
-        options += " --target es5 --noUnusedLocals --noUnusedParameters";
+        options += " --target es5 --lib es5,scripthost --noUnusedLocals --noUnusedParameters";
 
         var cmd = host + " " + compilerPath + " " + options + " ";
         cmd = cmd + sources.join(" ");
@@ -726,7 +726,7 @@ compileFile(
 
         // Appending exports at the end of the server library
         var tsserverLibraryDefinitionFileContents =
-            fs.readFileSync(tsserverLibraryDefinitionFile).toString() + 
+            fs.readFileSync(tsserverLibraryDefinitionFile).toString() +
             "\r\nexport = ts;" +
             "\r\nexport as namespace ts;";
 

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -1,5 +1,8 @@
 /// <reference path="core.ts"/>
 
+declare function setTimeout(handler: (...args: any[]) => void, timeout: number): any;
+declare function clearTimeout(handle: any): void;
+
 namespace ts {
     export type FileWatcherCallback = (fileName: string, removed?: boolean) => void;
     export type DirectoryWatcherCallback = (fileName: string) => void;

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -40,7 +40,21 @@ declare namespace NodeJS {
         ActiveXObject: typeof ActiveXObject;
     }
 }
+
+declare var window: {};
+declare var XMLHttpRequest: {
+    new(): XMLHttpRequest;
+}
+interface XMLHttpRequest  {
+    readonly readyState: number;
+    readonly responseText: string;
+    readonly status: number;
+    open(method: string, url: string, async?: boolean, user?: string, password?: string): void;
+    send(data?: string): void;
+    setRequestHeader(header: string, value: string): void;
+}
 /* tslint:enable:no-var-keyword */
+
 
 namespace Utils {
     // Setup some globals based on the current environment

--- a/src/harness/harness.ts
+++ b/src/harness/harness.ts
@@ -55,7 +55,6 @@ interface XMLHttpRequest  {
 }
 /* tslint:enable:no-var-keyword */
 
-
 namespace Utils {
     // Setup some globals based on the current environment
     export const enum ExecutionEnvironment {

--- a/src/tsconfig-base.json
+++ b/src/tsconfig-base.json
@@ -1,5 +1,6 @@
 {
     "compilerOptions": {
+        "lib": ["es5", "scripthost"],
         "noEmitOnError": true,
         "noImplicitAny": true,
         "noImplicitThis": true,


### PR DESCRIPTION
We only used "dom" for `setTimeout` and `clearTimeout`, where "dom" typings aren't accurate to what occurs in node anyway.