### PR TITLE
Improved checking of nullable operands in expressions

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14483,6 +14483,7 @@ namespace ts {
                 case SyntaxKind.PlusToken:
                 case SyntaxKind.MinusToken:
                 case SyntaxKind.TildeToken:
+                    checkNonNullType(operandType, node.operand);
                     if (maybeTypeOfKind(operandType, TypeFlags.ESSymbol)) {
                         error(node.operand, Diagnostics.The_0_operator_cannot_be_applied_to_type_symbol, tokenToString(node.operator));
                     }
@@ -14494,7 +14495,7 @@ namespace ts {
                         booleanType;
                 case SyntaxKind.PlusPlusToken:
                 case SyntaxKind.MinusMinusToken:
-                    const ok = checkArithmeticOperandType(node.operand, getNonNullableType(operandType),
+                    const ok = checkArithmeticOperandType(node.operand, checkNonNullType(operandType, node.operand),
                         Diagnostics.An_arithmetic_operand_must_be_of_type_any_number_or_an_enum_type);
                     if (ok) {
                         // run check only if former checks succeeded to avoid reporting cascading errors
@@ -14510,7 +14511,7 @@ namespace ts {
             if (operandType === silentNeverType) {
                 return silentNeverType;
             }
-            const ok = checkArithmeticOperandType(node.operand, getNonNullableType(operandType),
+            const ok = checkArithmeticOperandType(node.operand, checkNonNullType(operandType, node.operand),
                 Diagnostics.An_arithmetic_operand_must_be_of_type_any_number_or_an_enum_type);
             if (ok) {
                 // run check only if former checks succeeded to avoid reporting cascading errors

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14585,7 +14585,6 @@ namespace ts {
             }
             // NOTE: do not raise error if right is unknown as related error was already reported
             if (!(isTypeAny(rightType) ||
-                  rightType.flags & TypeFlags.Nullable ||
                   getSignaturesOfType(rightType, SignatureKind.Call).length ||
                   getSignaturesOfType(rightType, SignatureKind.Construct).length ||
                   isTypeSubtypeOf(rightType, globalFunctionType))) {
@@ -14598,6 +14597,8 @@ namespace ts {
             if (leftType === silentNeverType || rightType === silentNeverType) {
                 return silentNeverType;
             }
+            leftType = checkNonNullType(leftType, left);
+            rightType = checkNonNullType(rightType, right);
             // TypeScript 1.0 spec (April 2014): 4.15.5
             // The in operator requires the left operand to be of type Any, the String primitive type, or the Number primitive type,
             // and the right operand to be of type Any, an object type, or a type parameter type.
@@ -14952,8 +14953,8 @@ namespace ts {
                 case SyntaxKind.LessThanEqualsToken:
                 case SyntaxKind.GreaterThanEqualsToken:
                     if (checkForDisallowedESSymbolOperand(operator)) {
-                        leftType = getBaseTypeOfLiteralType(leftType);
-                        rightType = getBaseTypeOfLiteralType(rightType);
+                        leftType = getBaseTypeOfLiteralType(checkNonNullType(leftType, left));
+                        rightType = getBaseTypeOfLiteralType(checkNonNullType(rightType, right));
                         if (!isTypeComparableTo(leftType, rightType) && !isTypeComparableTo(rightType, leftType)) {
                             reportOperatorError();
                         }

--- a/tests/baselines/reference/additionOperatorWithNullValueAndInvalidOperator.errors.txt
+++ b/tests/baselines/reference/additionOperatorWithNullValueAndInvalidOperator.errors.txt
@@ -1,14 +1,14 @@
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(11,10): error TS2365: Operator '+' cannot be applied to types 'boolean' and 'boolean'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(12,10): error TS2365: Operator '+' cannot be applied to types 'Object' and 'Object'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(13,10): error TS2365: Operator '+' cannot be applied to types 'void' and 'void'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(14,10): error TS2365: Operator '+' cannot be applied to types 'boolean' and 'boolean'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(15,10): error TS2365: Operator '+' cannot be applied to types 'Object' and 'Object'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(16,10): error TS2365: Operator '+' cannot be applied to types 'void' and 'void'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(19,10): error TS2365: Operator '+' cannot be applied to types 'Number' and 'Number'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(20,10): error TS2365: Operator '+' cannot be applied to types 'true' and 'true'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(21,10): error TS2365: Operator '+' cannot be applied to types '{ a: string; }' and '{ a: string; }'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(22,11): error TS2365: Operator '+' cannot be applied to types 'void' and 'void'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(23,11): error TS2365: Operator '+' cannot be applied to types '() => void' and '() => void'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(11,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(12,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(13,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(14,14): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(15,14): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(16,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(19,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(20,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(21,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(22,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts(23,11): error TS2531: Object is possibly 'null'.
 
 
 ==== tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndInvalidOperator.ts (11 errors) ====
@@ -23,37 +23,37 @@ tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOpe
     
     // null + boolean/Object
     var r1 = null + a;
-             ~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'boolean' and 'boolean'.
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r2 = null + b;
-             ~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'Object' and 'Object'.
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r3 = null + c;
-             ~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'void' and 'void'.
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r4 = a + null;
-             ~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'boolean' and 'boolean'.
+                 ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r5 = b + null;
-             ~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'Object' and 'Object'.
+                 ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r6 = null + c;
-             ~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'void' and 'void'.
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
     
     // other cases
     var r7 = null + d;
-             ~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'Number' and 'Number'.
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r8 = null + true;
-             ~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'true' and 'true'.
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r9 = null + { a: '' };
-             ~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types '{ a: string; }' and '{ a: string; }'.
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r10 = null + foo();
-              ~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'void' and 'void'.
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r11 = null + (() => { });
-              ~~~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types '() => void' and '() => void'.
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.

--- a/tests/baselines/reference/additionOperatorWithNullValueAndValidOperator.errors.txt
+++ b/tests/baselines/reference/additionOperatorWithNullValueAndValidOperator.errors.txt
@@ -1,0 +1,63 @@
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndValidOperator.ts(15,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndValidOperator.ts(16,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndValidOperator.ts(17,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndValidOperator.ts(18,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndValidOperator.ts(19,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndValidOperator.ts(20,14): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndValidOperator.ts(21,14): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndValidOperator.ts(22,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndValidOperator.ts(23,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndValidOperator.ts(24,20): error TS2531: Object is possibly 'null'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithNullValueAndValidOperator.ts (10 errors) ====
+    // If one operand is the null or undefined value, it is treated as having the type of the other operand.
+    
+    enum E { a, b, c }
+    
+    var a: any;
+    var b: number;
+    var c: E;
+    var d: string;
+    
+    // null + any
+    var r1: any = null + a;
+    var r2: any = a + null;
+    
+    // null + number/enum
+    var r3 = null + b;
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r4 = null + 1;
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r5 = null + c;
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r6 = null + E.a;
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r7 = null + E['a'];
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r8 = b + null;
+                 ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r9 = 1 + null;
+                 ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r10 = c + null
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r11 = E.a + null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r12 = E['a'] + null;
+                       ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    // null + string
+    var r13 = null + d;
+    var r14 = null + '';
+    var r15 = d + null;
+    var r16 = '' + null;

--- a/tests/baselines/reference/additionOperatorWithOnlyNullValueOrUndefinedValue.errors.txt
+++ b/tests/baselines/reference/additionOperatorWithOnlyNullValueOrUndefinedValue.errors.txt
@@ -1,20 +1,32 @@
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithOnlyNullValueOrUndefinedValue.ts(2,10): error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithOnlyNullValueOrUndefinedValue.ts(3,10): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithOnlyNullValueOrUndefinedValue.ts(4,10): error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithOnlyNullValueOrUndefinedValue.ts(5,10): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithOnlyNullValueOrUndefinedValue.ts(2,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithOnlyNullValueOrUndefinedValue.ts(2,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithOnlyNullValueOrUndefinedValue.ts(3,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithOnlyNullValueOrUndefinedValue.ts(3,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithOnlyNullValueOrUndefinedValue.ts(4,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithOnlyNullValueOrUndefinedValue.ts(4,22): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithOnlyNullValueOrUndefinedValue.ts(5,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithOnlyNullValueOrUndefinedValue.ts(5,22): error TS2532: Object is possibly 'undefined'.
 
 
-==== tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithOnlyNullValueOrUndefinedValue.ts (4 errors) ====
+==== tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithOnlyNullValueOrUndefinedValue.ts (8 errors) ====
     // bug 819721
     var r1 = null + null;
-             ~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r2 = null + undefined;
-             ~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var r3 = undefined + null;
-             ~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                         ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r4 = undefined + undefined;
-             ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                         ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.

--- a/tests/baselines/reference/additionOperatorWithTypeParameter.errors.txt
+++ b/tests/baselines/reference/additionOperatorWithTypeParameter.errors.txt
@@ -8,8 +8,8 @@ tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOpe
 tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithTypeParameter.ts(27,15): error TS2365: Operator '+' cannot be applied to types 'Object' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithTypeParameter.ts(28,15): error TS2365: Operator '+' cannot be applied to types 'E' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithTypeParameter.ts(29,15): error TS2365: Operator '+' cannot be applied to types 'void' and 'T'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithTypeParameter.ts(32,15): error TS2365: Operator '+' cannot be applied to types 'T' and 'T'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithTypeParameter.ts(33,15): error TS2365: Operator '+' cannot be applied to types 'T' and 'T'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithTypeParameter.ts(32,19): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithTypeParameter.ts(33,19): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithTypeParameter.ts(34,15): error TS2365: Operator '+' cannot be applied to types 'T' and 'T'.
 tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithTypeParameter.ts(35,15): error TS2365: Operator '+' cannot be applied to types 'T' and 'U'.
 tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithTypeParameter.ts(36,15): error TS2365: Operator '+' cannot be applied to types 'T' and '() => void'.
@@ -69,11 +69,11 @@ tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOpe
     
         // other cases
         var r15 = t + null;
-                  ~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'T' and 'T'.
+                      ~~~~
+!!! error TS2531: Object is possibly 'null'.
         var r16 = t + undefined;
-                  ~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'T' and 'T'.
+                      ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
         var r17 = t + t;
                   ~~~~~
 !!! error TS2365: Operator '+' cannot be applied to types 'T' and 'T'.

--- a/tests/baselines/reference/additionOperatorWithUndefinedValueAndInvalidOperands.errors.txt
+++ b/tests/baselines/reference/additionOperatorWithUndefinedValueAndInvalidOperands.errors.txt
@@ -1,14 +1,14 @@
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(11,10): error TS2365: Operator '+' cannot be applied to types 'boolean' and 'boolean'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(12,10): error TS2365: Operator '+' cannot be applied to types 'Object' and 'Object'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(13,10): error TS2365: Operator '+' cannot be applied to types 'void' and 'void'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(14,10): error TS2365: Operator '+' cannot be applied to types 'boolean' and 'boolean'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(15,10): error TS2365: Operator '+' cannot be applied to types 'Object' and 'Object'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(16,10): error TS2365: Operator '+' cannot be applied to types 'void' and 'void'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(19,10): error TS2365: Operator '+' cannot be applied to types 'Number' and 'Number'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(20,10): error TS2365: Operator '+' cannot be applied to types 'true' and 'true'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(21,10): error TS2365: Operator '+' cannot be applied to types '{ a: string; }' and '{ a: string; }'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(22,11): error TS2365: Operator '+' cannot be applied to types 'void' and 'void'.
-tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(23,11): error TS2365: Operator '+' cannot be applied to types '() => void' and '() => void'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(11,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(12,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(13,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(14,14): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(15,14): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(16,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(19,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(20,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(21,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(22,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts(23,11): error TS2532: Object is possibly 'undefined'.
 
 
 ==== tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndInvalidOperands.ts (11 errors) ====
@@ -23,37 +23,37 @@ tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOpe
     
     // undefined + boolean/Object
     var r1 = undefined + a;
-             ~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'boolean' and 'boolean'.
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var r2 = undefined + b;
-             ~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'Object' and 'Object'.
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var r3 = undefined + c;
-             ~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'void' and 'void'.
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var r4 = a + undefined;
-             ~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'boolean' and 'boolean'.
+                 ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var r5 = b + undefined;
-             ~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'Object' and 'Object'.
+                 ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var r6 = undefined + c;
-             ~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'void' and 'void'.
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     
     // other cases
     var r7 = undefined + d;
-             ~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'Number' and 'Number'.
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var r8 = undefined + true;
-             ~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'true' and 'true'.
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var r9 = undefined + { a: '' };
-             ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types '{ a: string; }' and '{ a: string; }'.
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var r10 = undefined + foo();
-              ~~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'void' and 'void'.
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var r11 = undefined + (() => { });
-              ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types '() => void' and '() => void'.
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.

--- a/tests/baselines/reference/additionOperatorWithUndefinedValueAndValidOperator.errors.txt
+++ b/tests/baselines/reference/additionOperatorWithUndefinedValueAndValidOperator.errors.txt
@@ -1,0 +1,63 @@
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndValidOperator.ts(15,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndValidOperator.ts(16,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndValidOperator.ts(17,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndValidOperator.ts(18,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndValidOperator.ts(19,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndValidOperator.ts(20,14): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndValidOperator.ts(21,14): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndValidOperator.ts(22,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndValidOperator.ts(23,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndValidOperator.ts(24,20): error TS2532: Object is possibly 'undefined'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/additionOperator/additionOperatorWithUndefinedValueAndValidOperator.ts (10 errors) ====
+    // If one operand is the null or undefined value, it is treated as having the type of the other operand.
+    
+    enum E { a, b, c }
+    
+    var a: any;
+    var b: number;
+    var c: E;
+    var d: string;
+    
+    // undefined + any
+    var r1: any = undefined + a;
+    var r2: any = a + undefined;
+    
+    // undefined + number/enum
+    var r3 = undefined + b;
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var r4 = undefined + 1;
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var r5 = undefined + c;
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var r6 = undefined + E.a;
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var r7 = undefined + E['a'];
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var r8 = b + undefined;
+                 ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var r9 = 1 + undefined;
+                 ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var r10 = c + undefined
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var r11 = E.a + undefined;
+                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var r12 = E['a'] + undefined;
+                       ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    // undefined + string
+    var r13 = undefined + d;
+    var r14 = undefined + '';
+    var r15 = d + undefined;
+    var r16 = '' + undefined;

--- a/tests/baselines/reference/ambientWithStatements.errors.txt
+++ b/tests/baselines/reference/ambientWithStatements.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/ambientWithStatements.ts(2,5): error TS1036: Statements are not allowed in ambient contexts.
 tests/cases/compiler/ambientWithStatements.ts(3,5): error TS1104: A 'continue' statement can only be used within an enclosing iteration statement.
-tests/cases/compiler/ambientWithStatements.ts(7,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
+tests/cases/compiler/ambientWithStatements.ts(7,15): error TS2531: Object is possibly 'null'.
 tests/cases/compiler/ambientWithStatements.ts(11,5): error TS1108: A 'return' statement can only be used within a function body.
 tests/cases/compiler/ambientWithStatements.ts(25,5): error TS2410: The 'with' statement is not supported. All symbols in a 'with' block will have type 'any'.
 
@@ -18,7 +18,7 @@ tests/cases/compiler/ambientWithStatements.ts(25,5): error TS2410: The 'with' st
         var x;
         for (x in null) { }
                   ~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
+!!! error TS2531: Object is possibly 'null'.
         if (true) { } else { }
         1;
         L: var y;

--- a/tests/baselines/reference/arithmeticOperatorWithNullValueAndInvalidOperands.errors.txt
+++ b/tests/baselines/reference/arithmeticOperatorWithNullValueAndInvalidOperands.errors.txt
@@ -1,234 +1,246 @@
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(9,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(9,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(9,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(10,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(10,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(10,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(11,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(11,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(11,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(13,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(13,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(13,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(14,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(14,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(14,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(15,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(15,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(17,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(15,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(17,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(17,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(18,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(18,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(18,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(19,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(19,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(19,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(21,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(21,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(21,19): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(22,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(22,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(22,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(23,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(23,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(26,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(23,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(26,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(26,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(27,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(27,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(27,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(28,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(28,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(28,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(30,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(30,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(30,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(31,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(31,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(31,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(32,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(32,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(34,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(32,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(34,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(34,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(35,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(35,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(35,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(36,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(36,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(36,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(38,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(38,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(38,19): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(39,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(39,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(39,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(40,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(40,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(43,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(40,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(43,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(43,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(44,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(44,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(44,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(45,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(45,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(45,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(47,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(47,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(47,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(48,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(48,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(48,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(49,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(49,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(51,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(49,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(51,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(51,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(52,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(52,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(52,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(53,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(53,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(53,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(55,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(55,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(55,19): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(56,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(56,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(56,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(57,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(57,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(60,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(57,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(60,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(60,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(61,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(61,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(61,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(62,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(62,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(62,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(64,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(64,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(64,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(65,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(65,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(65,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(66,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(66,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(68,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(66,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(68,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(68,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(69,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(69,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(69,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(70,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(70,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(70,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(72,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(72,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(72,19): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(73,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(73,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(73,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(74,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(74,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(77,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(74,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(77,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(77,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(78,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(78,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(78,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(79,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(79,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(79,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(81,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(81,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(81,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(82,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(82,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(82,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(83,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(83,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(85,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(83,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(85,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(85,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(86,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(86,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(86,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(87,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(87,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(87,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(89,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(89,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(89,20): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(90,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(90,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(90,18): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(91,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(91,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(94,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(91,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(94,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(94,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(95,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(95,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(95,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(96,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(96,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(96,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(98,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(98,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(98,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(99,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(99,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(99,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(100,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(100,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(102,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(100,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(102,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(102,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(103,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(103,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(103,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(104,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(104,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(104,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(106,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(106,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(106,20): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(107,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(107,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(107,18): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(108,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(108,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(111,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(108,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(111,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(111,21): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(112,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(112,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(112,21): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(113,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(113,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(113,21): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(115,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(115,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(115,18): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(116,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(116,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(116,18): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(117,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(117,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(119,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(117,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(119,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(119,21): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(120,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(120,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(120,21): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(121,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(121,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(121,21): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(123,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(123,21): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(123,21): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(124,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(124,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(124,19): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(125,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(125,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(128,12): error TS2447: The '&' operator is not allowed for boolean types. Consider using '&&' instead.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(129,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(125,19): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(128,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(128,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(129,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(129,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(130,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(130,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(130,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(132,12): error TS2447: The '&' operator is not allowed for boolean types. Consider using '&&' instead.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(132,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(132,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(133,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(133,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(133,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(134,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(134,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(136,12): error TS2447: The '&' operator is not allowed for boolean types. Consider using '&&' instead.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(137,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(134,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(136,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(136,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(137,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(137,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(138,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(138,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(138,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(140,12): error TS2447: The '&' operator is not allowed for boolean types. Consider using '&&' instead.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(140,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(140,19): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(141,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(141,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(141,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(142,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(142,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(145,12): error TS2447: The '^' operator is not allowed for boolean types. Consider using '!==' instead.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(146,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(142,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(145,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(145,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(146,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(146,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(147,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(147,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(147,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(149,12): error TS2447: The '^' operator is not allowed for boolean types. Consider using '!==' instead.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(149,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(149,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(150,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(150,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(150,16): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(151,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(151,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(153,12): error TS2447: The '^' operator is not allowed for boolean types. Consider using '!==' instead.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(154,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(151,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(153,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(153,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(154,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(154,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(155,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(155,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(155,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(157,12): error TS2447: The '^' operator is not allowed for boolean types. Consider using '!==' instead.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(157,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(157,19): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(158,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(158,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(158,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(159,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(159,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(162,13): error TS2447: The '|' operator is not allowed for boolean types. Consider using '||' instead.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(163,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(159,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(162,13): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(162,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(163,13): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(163,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(164,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(164,13): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(164,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(166,13): error TS2447: The '|' operator is not allowed for boolean types. Consider using '||' instead.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(166,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(166,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(167,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(167,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(167,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(168,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(168,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(170,13): error TS2447: The '|' operator is not allowed for boolean types. Consider using '||' instead.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(171,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(168,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(170,13): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(170,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(171,13): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(171,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(172,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(172,13): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(172,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(174,13): error TS2447: The '|' operator is not allowed for boolean types. Consider using '||' instead.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(174,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(174,20): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(175,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(175,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(175,18): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(176,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(176,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts(176,18): error TS2531: Object is possibly 'null'.
 
 
-==== tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts (228 errors) ====
+==== tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndInvalidOperands.ts (240 errors) ====
     // If one operand is the null or undefined value, it is treated as having the type of the
     // other operand.
     
@@ -239,17 +251,17 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
     // operator *
     var r1a1 = null * a;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r1a2 = null * b;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r1a3 = null * c;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -257,31 +269,31 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r1b2 = b * null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r1b3 = c * null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     var r1c1 = null * true;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r1c2 = null * '';
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r1c3 = null * {};
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -289,32 +301,32 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                       ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r1d2 = '' * null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r1d3 = {} * null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     // operator /
     var r2a1 = null / a;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r2a2 = null / b;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r2a3 = null / c;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -322,31 +334,31 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r2b2 = b / null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r2b3 = c / null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     var r2c1 = null / true;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r2c2 = null / '';
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r2c3 = null / {};
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -354,32 +366,32 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                       ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r2d2 = '' / null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r2d3 = {} / null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     // operator %
     var r3a1 = null % a;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r3a2 = null % b;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r3a3 = null % c;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -387,31 +399,31 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r3b2 = b % null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r3b3 = c % null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     var r3c1 = null % true;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r3c2 = null % '';
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r3c3 = null % {};
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -419,32 +431,32 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                       ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r3d2 = '' % null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r3d3 = {} % null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     // operator -
     var r4a1 = null - a;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r4a2 = null - b;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r4a3 = null - c;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -452,31 +464,31 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r4b2 = b - null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r4b3 = c - null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     var r4c1 = null - true;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r4c2 = null - '';
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r4c3 = null - {};
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -484,32 +496,32 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                       ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r4d2 = '' - null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r4d3 = {} - null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     // operator <<
     var r5a1 = null << a;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r5a2 = null << b;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r5a3 = null << c;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -517,31 +529,31 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r5b2 = b << null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r5b3 = c << null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     var r5c1 = null << true;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~~~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r5c2 = null << '';
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r5c3 = null << {};
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -549,32 +561,32 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                        ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r5d2 = '' << null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r5d3 = {} << null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     // operator >>
     var r6a1 = null >> a;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r6a2 = null >> b;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r6a3 = null >> c;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -582,31 +594,31 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r6b2 = b >> null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r6b3 = c >> null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     var r6c1 = null >> true;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~~~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r6c2 = null >> '';
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r6c3 = null >> {};
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -614,32 +626,32 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                        ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r6d2 = '' >> null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r6d3 = {} >> null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     // operator >>>
     var r7a1 = null >>> a;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                         ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r7a2 = null >>> b;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                         ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r7a3 = null >>> c;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                         ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -647,31 +659,31 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r7b2 = b >>> null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r7b3 = c >>> null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     var r7c1 = null >>> true;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                         ~~~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r7c2 = null >>> '';
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                         ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r7c3 = null >>> {};
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                         ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -679,185 +691,209 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                         ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r7d2 = '' >>> null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                       ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r7d3 = {} >>> null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                       ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     // operator &
     var r8a1 = null & a;
-               ~~~~~~~~
-!!! error TS2447: The '&' operator is not allowed for boolean types. Consider using '&&' instead.
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                      ~
+!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r8a2 = null & b;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r8a3 = null & c;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
     var r8b1 = a & null;
-               ~~~~~~~~
-!!! error TS2447: The '&' operator is not allowed for boolean types. Consider using '&&' instead.
+               ~
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r8b2 = b & null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r8b3 = c & null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     var r8c1 = null & true;
-               ~~~~~~~~~~~
-!!! error TS2447: The '&' operator is not allowed for boolean types. Consider using '&&' instead.
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                      ~~~~
+!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r8c2 = null & '';
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r8c3 = null & {};
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
     var r8d1 = true & null;
-               ~~~~~~~~~~~
-!!! error TS2447: The '&' operator is not allowed for boolean types. Consider using '&&' instead.
+               ~~~~
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+                      ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r8d2 = '' & null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r8d3 = {} & null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     // operator ^
     var r9a1 = null ^ a;
-               ~~~~~~~~
-!!! error TS2447: The '^' operator is not allowed for boolean types. Consider using '!==' instead.
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                      ~
+!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r9a2 = null ^ b;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r9a3 = null ^ c;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
     var r9b1 = a ^ null;
-               ~~~~~~~~
-!!! error TS2447: The '^' operator is not allowed for boolean types. Consider using '!==' instead.
+               ~
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r9b2 = b ^ null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r9b3 = c ^ null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     var r9c1 = null ^ true;
-               ~~~~~~~~~~~
-!!! error TS2447: The '^' operator is not allowed for boolean types. Consider using '!==' instead.
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                      ~~~~
+!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r9c2 = null ^ '';
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r9c3 = null ^ {};
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
     var r9d1 = true ^ null;
-               ~~~~~~~~~~~
-!!! error TS2447: The '^' operator is not allowed for boolean types. Consider using '!==' instead.
+               ~~~~
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+                      ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r9d2 = '' ^ null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r9d3 = {} ^ null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     // operator |
     var r10a1 = null | a;
-                ~~~~~~~~
-!!! error TS2447: The '|' operator is not allowed for boolean types. Consider using '||' instead.
+                ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                       ~
+!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r10a2 = null | b;
                 ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r10a3 = null | c;
                 ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
     var r10b1 = a | null;
-                ~~~~~~~~
-!!! error TS2447: The '|' operator is not allowed for boolean types. Consider using '||' instead.
+                ~
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r10b2 = b | null;
                 ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r10b3 = c | null;
                 ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     var r10c1 = null | true;
-                ~~~~~~~~~~~
-!!! error TS2447: The '|' operator is not allowed for boolean types. Consider using '||' instead.
+                ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                       ~~~~
+!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r10c2 = null | '';
                 ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r10c3 = null | {};
                 ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
     var r10d1 = true | null;
-                ~~~~~~~~~~~
-!!! error TS2447: The '|' operator is not allowed for boolean types. Consider using '||' instead.
+                ~~~~
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+                       ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var r10d2 = '' | null;
                 ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r10d3 = {} | null;
                 ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.

--- a/tests/baselines/reference/arithmeticOperatorWithNullValueAndValidOperands.errors.txt
+++ b/tests/baselines/reference/arithmeticOperatorWithNullValueAndValidOperands.errors.txt
@@ -1,0 +1,353 @@
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(13,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(14,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(15,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(16,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(17,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(18,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(19,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(20,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(23,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(24,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(25,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(26,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(27,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(28,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(29,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(30,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(33,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(34,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(35,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(36,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(37,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(38,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(39,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(40,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(43,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(44,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(45,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(46,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(47,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(48,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(49,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(50,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(53,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(54,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(55,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(56,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(57,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(58,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(59,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(60,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(63,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(64,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(65,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(66,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(67,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(68,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(69,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(70,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(73,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(74,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(75,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(76,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(77,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(78,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(79,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(80,19): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(83,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(84,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(85,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(86,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(87,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(88,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(89,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(90,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(93,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(94,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(95,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(96,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(97,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(98,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(99,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(100,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(103,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(104,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(105,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(106,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(107,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(108,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(109,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts(110,17): error TS2531: Object is possibly 'null'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithNullValueAndValidOperands.ts (80 errors) ====
+    // If one operand is the null or undefined value, it is treated as having the type of the
+    // other operand.
+    
+    enum E {
+        a,
+        b
+    }
+    
+    var a: any;
+    var b: number;
+    
+    // operator *
+    var ra1 = null * a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var ra2 = null * b;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var ra3 = null * 1;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var ra4 = null * E.a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var ra5 = a * null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var ra6 = b * null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var ra7 = 0 * null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var ra8 = E.b * null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    // operator /
+    var rb1 = null / a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rb2 = null / b;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rb3 = null / 1;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rb4 = null / E.a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rb5 = a / null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rb6 = b / null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rb7 = 0 / null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rb8 = E.b / null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    // operator %
+    var rc1 = null % a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rc2 = null % b;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rc3 = null % 1;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rc4 = null % E.a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rc5 = a % null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rc6 = b % null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rc7 = 0 % null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rc8 = E.b % null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    // operator -
+    var rd1 = null - a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rd2 = null - b;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rd3 = null - 1;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rd4 = null - E.a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rd5 = a - null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rd6 = b - null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rd7 = 0 - null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rd8 = E.b - null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    // operator <<
+    var re1 = null << a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var re2 = null << b;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var re3 = null << 1;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var re4 = null << E.a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var re5 = a << null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var re6 = b << null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var re7 = 0 << null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var re8 = E.b << null;
+                     ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    // operator >>
+    var rf1 = null >> a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rf2 = null >> b;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rf3 = null >> 1;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rf4 = null >> E.a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rf5 = a >> null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rf6 = b >> null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rf7 = 0 >> null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rf8 = E.b >> null;
+                     ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    // operator >>>
+    var rg1 = null >>> a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rg2 = null >>> b;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rg3 = null >>> 1;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rg4 = null >>> E.a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rg5 = a >>> null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rg6 = b >>> null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rg7 = 0 >>> null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rg8 = E.b >>> null;
+                      ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    // operator &
+    var rh1 = null & a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rh2 = null & b;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rh3 = null & 1;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rh4 = null & E.a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rh5 = a & null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rh6 = b & null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rh7 = 0 & null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rh8 = E.b & null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    // operator ^
+    var ri1 = null ^ a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var ri2 = null ^ b;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var ri3 = null ^ 1;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var ri4 = null ^ E.a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var ri5 = a ^ null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var ri6 = b ^ null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var ri7 = 0 ^ null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var ri8 = E.b ^ null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    // operator |
+    var rj1 = null | a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rj2 = null | b;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rj3 = null | 1;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rj4 = null | E.a;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rj5 = a | null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rj6 = b | null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rj7 = 0 | null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rj8 = E.b | null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.

--- a/tests/baselines/reference/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.errors.txt
+++ b/tests/baselines/reference/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.errors.txt
@@ -1,302 +1,302 @@
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(2,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(2,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(3,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(3,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(4,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(4,23): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(5,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(5,23): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(8,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(8,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(9,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(9,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(10,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(10,23): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(11,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(11,23): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(14,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(14,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(15,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(15,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(16,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(16,23): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(17,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(17,23): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(20,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(20,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(21,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(21,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(22,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(22,23): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(23,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(23,23): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(26,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(26,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(27,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(27,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(28,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(28,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(29,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(29,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(32,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(32,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(33,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(33,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(34,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(34,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(35,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(35,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(38,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(38,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(39,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(39,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(40,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(40,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(41,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(41,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(44,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(44,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(45,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(45,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(46,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(46,23): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(47,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(47,23): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(50,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(50,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(51,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(51,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(52,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(52,23): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(53,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(53,23): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(56,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(56,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(57,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(57,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(58,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(58,23): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(59,11): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(59,23): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(2,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(2,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(3,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(3,18): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(4,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(4,23): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(5,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(5,23): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(8,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(8,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(9,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(9,18): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(10,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(10,23): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(11,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(11,23): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(14,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(14,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(15,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(15,18): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(16,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(16,23): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(17,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(17,23): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(20,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(20,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(21,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(21,18): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(22,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(22,23): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(23,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(23,23): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(26,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(26,19): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(27,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(27,19): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(28,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(28,24): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(29,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(29,24): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(32,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(32,19): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(33,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(33,19): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(34,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(34,24): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(35,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(35,24): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(38,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(38,20): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(39,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(39,20): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(40,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(40,25): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(41,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(41,25): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(44,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(44,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(45,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(45,18): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(46,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(46,23): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(47,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(47,23): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(50,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(50,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(51,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(51,18): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(52,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(52,23): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(53,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(53,23): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(56,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(56,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(57,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(57,18): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(58,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(58,23): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(59,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts(59,23): error TS2532: Object is possibly 'undefined'.
 
 
 ==== tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithOnlyNullValueOrUndefinedValue.ts (80 errors) ====
     // operator *
     var ra1 = null * null;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var ra2 = null * undefined;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var ra3 = undefined * null;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                           ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var ra4 = undefined * undefined;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                           ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator /
     var rb1 = null / null;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var rb2 = null / undefined;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var rb3 = undefined / null;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                           ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var rb4 = undefined / undefined;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                           ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator %
     var rc1 = null % null;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var rc2 = null % undefined;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var rc3 = undefined % null;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                           ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var rc4 = undefined % undefined;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                           ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator -
     var rd1 = null - null;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var rd2 = null - undefined;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var rd3 = undefined - null;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                           ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var rd4 = undefined - undefined;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                           ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator <<
     var re1 = null << null;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var re2 = null << undefined;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var re3 = undefined << null;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var re4 = undefined << undefined;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator >>
     var rf1 = null >> null;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var rf2 = null >> undefined;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                       ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var rf3 = undefined >> null;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var rf4 = undefined >> undefined;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator >>>
     var rg1 = null >>> null;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var rg2 = null >>> undefined;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var rg3 = undefined >>> null;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var rg4 = undefined >>> undefined;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator &
     var rh1 = null & null;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var rh2 = null & undefined;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var rh3 = undefined & null;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                           ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var rh4 = undefined & undefined;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                           ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator ^
     var ri1 = null ^ null;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var ri2 = null ^ undefined;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var ri3 = undefined ^ null;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                           ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var ri4 = undefined ^ undefined;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                           ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator |
     var rj1 = null | null;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var rj2 = null | undefined;
               ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var rj3 = undefined | null;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                           ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var rj4 = undefined | undefined;
               ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                           ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.

--- a/tests/baselines/reference/arithmeticOperatorWithUndefinedValueAndInvalidOperands.errors.txt
+++ b/tests/baselines/reference/arithmeticOperatorWithUndefinedValueAndInvalidOperands.errors.txt
@@ -1,234 +1,246 @@
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(9,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(9,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(9,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(10,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(10,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(10,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(11,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(11,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(11,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(13,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(13,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(13,16): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(14,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(14,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(14,16): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(15,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(15,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(17,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(15,16): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(17,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(17,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(18,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(18,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(18,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(19,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(19,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(19,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(21,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(21,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(21,19): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(22,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(22,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(22,17): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(23,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(23,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(26,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(23,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(26,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(26,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(27,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(27,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(27,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(28,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(28,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(28,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(30,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(30,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(30,16): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(31,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(31,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(31,16): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(32,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(32,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(34,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(32,16): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(34,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(34,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(35,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(35,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(35,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(36,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(36,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(36,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(38,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(38,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(38,19): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(39,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(39,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(39,17): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(40,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(40,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(43,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(40,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(43,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(43,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(44,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(44,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(44,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(45,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(45,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(45,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(47,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(47,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(47,16): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(48,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(48,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(48,16): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(49,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(49,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(51,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(49,16): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(51,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(51,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(52,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(52,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(52,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(53,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(53,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(53,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(55,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(55,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(55,19): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(56,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(56,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(56,17): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(57,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(57,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(60,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(57,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(60,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(60,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(61,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(61,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(61,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(62,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(62,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(62,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(64,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(64,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(64,16): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(65,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(65,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(65,16): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(66,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(66,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(68,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(66,16): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(68,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(68,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(69,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(69,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(69,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(70,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(70,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(70,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(72,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(72,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(72,19): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(73,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(73,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(73,17): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(74,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(74,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(77,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(74,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(77,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(77,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(78,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(78,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(78,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(79,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(79,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(79,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(81,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(81,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(81,17): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(82,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(82,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(82,17): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(83,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(83,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(85,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(83,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(85,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(85,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(86,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(86,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(86,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(87,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(87,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(87,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(89,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(89,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(89,20): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(90,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(90,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(90,18): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(91,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(91,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(94,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(91,18): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(94,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(94,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(95,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(95,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(95,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(96,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(96,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(96,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(98,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(98,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(98,17): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(99,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(99,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(99,17): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(100,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(100,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(102,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(100,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(102,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(102,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(103,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(103,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(103,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(104,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(104,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(104,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(106,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(106,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(106,20): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(107,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(107,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(107,18): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(108,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(108,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(111,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(108,18): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(111,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(111,26): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(112,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(112,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(112,26): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(113,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(113,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(113,26): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(115,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(115,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(115,18): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(116,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(116,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(116,18): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(117,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(117,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(119,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(117,18): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(119,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(119,26): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(120,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(120,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(120,26): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(121,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(121,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(121,26): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(123,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(123,21): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(123,21): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(124,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(124,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(124,19): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(125,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(125,19): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(128,12): error TS2447: The '&' operator is not allowed for boolean types. Consider using '&&' instead.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(129,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(125,19): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(128,12): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(128,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(129,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(129,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(130,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(130,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(130,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(132,12): error TS2447: The '&' operator is not allowed for boolean types. Consider using '&&' instead.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(132,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(132,16): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(133,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(133,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(133,16): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(134,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(134,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(136,12): error TS2447: The '&' operator is not allowed for boolean types. Consider using '&&' instead.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(137,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(134,16): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(136,12): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(136,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(137,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(137,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(138,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(138,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(138,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(140,12): error TS2447: The '&' operator is not allowed for boolean types. Consider using '&&' instead.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(140,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(140,19): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(141,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(141,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(141,17): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(142,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(142,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(145,12): error TS2447: The '^' operator is not allowed for boolean types. Consider using '!==' instead.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(146,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(142,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(145,12): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(145,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(146,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(146,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(147,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(147,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(147,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(149,12): error TS2447: The '^' operator is not allowed for boolean types. Consider using '!==' instead.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(149,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(149,16): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(150,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(150,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(150,16): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(151,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(151,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(153,12): error TS2447: The '^' operator is not allowed for boolean types. Consider using '!==' instead.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(154,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(151,16): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(153,12): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(153,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(154,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(154,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(155,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(155,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(155,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(157,12): error TS2447: The '^' operator is not allowed for boolean types. Consider using '!==' instead.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(157,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(157,19): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(158,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(158,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(158,17): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(159,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(159,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(162,13): error TS2447: The '|' operator is not allowed for boolean types. Consider using '||' instead.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(163,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(159,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(162,13): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(162,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(163,13): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(163,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(164,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(164,13): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(164,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(166,13): error TS2447: The '|' operator is not allowed for boolean types. Consider using '||' instead.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(166,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(166,17): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(167,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(167,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(167,17): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(168,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(168,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(170,13): error TS2447: The '|' operator is not allowed for boolean types. Consider using '||' instead.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(171,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(168,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(170,13): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(170,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(171,13): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(171,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(172,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(172,13): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(172,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(174,13): error TS2447: The '|' operator is not allowed for boolean types. Consider using '||' instead.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(174,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(174,20): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(175,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(175,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(175,18): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(176,13): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(176,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts(176,18): error TS2532: Object is possibly 'undefined'.
 
 
-==== tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts (228 errors) ====
+==== tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndInvalidOperands.ts (240 errors) ====
     // If one operand is the undefined or undefined value, it is treated as having the type of the
     // other operand.
     
@@ -239,17 +251,17 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
     // operator *
     var r1a1 = undefined * a;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r1a2 = undefined * b;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r1a3 = undefined * c;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -257,31 +269,31 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r1b2 = b * undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r1b3 = c * undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var r1c1 = undefined * true;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r1c2 = undefined * '';
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r1c3 = undefined * {};
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -289,32 +301,32 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                       ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r1d2 = '' * undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r1d3 = {} * undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator /
     var r2a1 = undefined / a;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r2a2 = undefined / b;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r2a3 = undefined / c;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -322,31 +334,31 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r2b2 = b / undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r2b3 = c / undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var r2c1 = undefined / true;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r2c2 = undefined / '';
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r2c3 = undefined / {};
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -354,32 +366,32 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                       ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r2d2 = '' / undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r2d3 = {} / undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator %
     var r3a1 = undefined % a;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r3a2 = undefined % b;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r3a3 = undefined % c;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -387,31 +399,31 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r3b2 = b % undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r3b3 = c % undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var r3c1 = undefined % true;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r3c2 = undefined % '';
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r3c3 = undefined % {};
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -419,32 +431,32 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                       ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r3d2 = '' % undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r3d3 = {} % undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator -
     var r4a1 = undefined - a;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r4a2 = undefined - b;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r4a3 = undefined - c;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -452,31 +464,31 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r4b2 = b - undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r4b3 = c - undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var r4c1 = undefined - true;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r4c2 = undefined - '';
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r4c3 = undefined - {};
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -484,32 +496,32 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                       ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r4d2 = '' - undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r4d3 = {} - undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator <<
     var r5a1 = undefined << a;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r5a2 = undefined << b;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r5a3 = undefined << c;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -517,31 +529,31 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r5b2 = b << undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r5b3 = c << undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var r5c1 = undefined << true;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~~~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r5c2 = undefined << '';
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r5c3 = undefined << {};
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -549,32 +561,32 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                        ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r5d2 = '' << undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r5d3 = {} << undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator >>
     var r6a1 = undefined >> a;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r6a2 = undefined >> b;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r6a3 = undefined >> c;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -582,31 +594,31 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r6b2 = b >> undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r6b3 = c >> undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var r6c1 = undefined >> true;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~~~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r6c2 = undefined >> '';
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r6c3 = undefined >> {};
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -614,32 +626,32 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                        ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r6d2 = '' >> undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r6d3 = {} >> undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator >>>
     var r7a1 = undefined >>> a;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                              ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r7a2 = undefined >>> b;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                              ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r7a3 = undefined >>> c;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                              ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -647,31 +659,31 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r7b2 = b >>> undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r7b3 = c >>> undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var r7c1 = undefined >>> true;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                              ~~~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r7c2 = undefined >>> '';
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                              ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r7c3 = undefined >>> {};
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                              ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -679,185 +691,209 @@ tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeti
                ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                         ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r7d2 = '' >>> undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                       ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r7d3 = {} >>> undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                       ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator &
     var r8a1 = undefined & a;
-               ~~~~~~~~~~~~~
-!!! error TS2447: The '&' operator is not allowed for boolean types. Consider using '&&' instead.
+               ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                           ~
+!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r8a2 = undefined & b;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r8a3 = undefined & c;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
     var r8b1 = a & undefined;
-               ~~~~~~~~~~~~~
-!!! error TS2447: The '&' operator is not allowed for boolean types. Consider using '&&' instead.
+               ~
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+                   ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var r8b2 = b & undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r8b3 = c & undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var r8c1 = undefined & true;
-               ~~~~~~~~~~~~~~~~
-!!! error TS2447: The '&' operator is not allowed for boolean types. Consider using '&&' instead.
+               ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                           ~~~~
+!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r8c2 = undefined & '';
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r8c3 = undefined & {};
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
     var r8d1 = true & undefined;
-               ~~~~~~~~~~~~~~~~
-!!! error TS2447: The '&' operator is not allowed for boolean types. Consider using '&&' instead.
+               ~~~~
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+                      ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var r8d2 = '' & undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r8d3 = {} & undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator ^
     var r9a1 = undefined ^ a;
-               ~~~~~~~~~~~~~
-!!! error TS2447: The '^' operator is not allowed for boolean types. Consider using '!==' instead.
+               ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                           ~
+!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r9a2 = undefined ^ b;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r9a3 = undefined ^ c;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
     var r9b1 = a ^ undefined;
-               ~~~~~~~~~~~~~
-!!! error TS2447: The '^' operator is not allowed for boolean types. Consider using '!==' instead.
+               ~
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+                   ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var r9b2 = b ^ undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r9b3 = c ^ undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                    ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var r9c1 = undefined ^ true;
-               ~~~~~~~~~~~~~~~~
-!!! error TS2447: The '^' operator is not allowed for boolean types. Consider using '!==' instead.
+               ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                           ~~~~
+!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r9c2 = undefined ^ '';
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r9c3 = undefined ^ {};
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                            ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
     var r9d1 = true ^ undefined;
-               ~~~~~~~~~~~~~~~~
-!!! error TS2447: The '^' operator is not allowed for boolean types. Consider using '!==' instead.
+               ~~~~
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+                      ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var r9d2 = '' ^ undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r9d3 = {} ^ undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // operator |
     var r10a1 = undefined | a;
-                ~~~~~~~~~~~~~
-!!! error TS2447: The '|' operator is not allowed for boolean types. Consider using '||' instead.
+                ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                            ~
+!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r10a2 = undefined | b;
                 ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r10a3 = undefined | c;
                 ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
     var r10b1 = a | undefined;
-                ~~~~~~~~~~~~~
-!!! error TS2447: The '|' operator is not allowed for boolean types. Consider using '||' instead.
+                ~
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var r10b2 = b | undefined;
                 ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r10b3 = c | undefined;
                 ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var r10c1 = undefined | true;
-                ~~~~~~~~~~~~~~~~
-!!! error TS2447: The '|' operator is not allowed for boolean types. Consider using '||' instead.
+                ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                            ~~~~
+!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r10c2 = undefined | '';
                 ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r10c3 = undefined | {};
                 ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
     var r10d1 = true | undefined;
-                ~~~~~~~~~~~~~~~~
-!!! error TS2447: The '|' operator is not allowed for boolean types. Consider using '||' instead.
+                ~~~~
+!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+                       ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var r10d2 = '' | undefined;
                 ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r10d3 = {} | undefined;
                 ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.

--- a/tests/baselines/reference/arithmeticOperatorWithUndefinedValueAndValidOperands.errors.txt
+++ b/tests/baselines/reference/arithmeticOperatorWithUndefinedValueAndValidOperands.errors.txt
@@ -1,0 +1,353 @@
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(13,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(14,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(15,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(16,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(17,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(18,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(19,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(20,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(23,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(24,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(25,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(26,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(27,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(28,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(29,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(30,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(33,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(34,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(35,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(36,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(37,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(38,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(39,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(40,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(43,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(44,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(45,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(46,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(47,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(48,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(49,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(50,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(53,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(54,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(55,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(56,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(57,16): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(58,16): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(59,16): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(60,18): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(63,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(64,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(65,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(66,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(67,16): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(68,16): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(69,16): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(70,18): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(73,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(74,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(75,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(76,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(77,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(78,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(79,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(80,19): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(83,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(84,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(85,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(86,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(87,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(88,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(89,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(90,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(93,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(94,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(95,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(96,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(97,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(98,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(99,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(100,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(103,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(104,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(105,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(106,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(107,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(108,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(109,15): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts(110,17): error TS2532: Object is possibly 'undefined'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/arithmeticOperator/arithmeticOperatorWithUndefinedValueAndValidOperands.ts (80 errors) ====
+    // If one operand is the undefined or undefined value, it is treated as having the type of the
+    // other operand.
+    
+    enum E {
+        a,
+        b
+    }
+    
+    var a: any;
+    var b: number;
+    
+    // operator *
+    var ra1 = undefined * a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var ra2 = undefined * b;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var ra3 = undefined * 1;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var ra4 = undefined * E.a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var ra5 = a * undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var ra6 = b * undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var ra7 = 0 * undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var ra8 = E.b * undefined;
+                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    // operator /
+    var rb1 = undefined / a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rb2 = undefined / b;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rb3 = undefined / 1;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rb4 = undefined / E.a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rb5 = a / undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rb6 = b / undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rb7 = 0 / undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rb8 = E.b / undefined;
+                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    // operator %
+    var rc1 = undefined % a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rc2 = undefined % b;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rc3 = undefined % 1;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rc4 = undefined % E.a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rc5 = a % undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rc6 = b % undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rc7 = 0 % undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rc8 = E.b % undefined;
+                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    // operator -
+    var rd1 = undefined - a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rd2 = undefined - b;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rd3 = undefined - 1;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rd4 = undefined - E.a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rd5 = a - undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rd6 = b - undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rd7 = 0 - undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rd8 = E.b - undefined;
+                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    // operator <<
+    var re1 = undefined << a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var re2 = undefined << b;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var re3 = undefined << 1;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var re4 = undefined << E.a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var re5 = a << undefined;
+                   ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var re6 = b << undefined;
+                   ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var re7 = 0 << undefined;
+                   ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var re8 = E.b << undefined;
+                     ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    // operator >>
+    var rf1 = undefined >> a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rf2 = undefined >> b;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rf3 = undefined >> 1;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rf4 = undefined >> E.a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rf5 = a >> undefined;
+                   ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rf6 = b >> undefined;
+                   ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rf7 = 0 >> undefined;
+                   ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rf8 = E.b >> undefined;
+                     ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    // operator >>>
+    var rg1 = undefined >>> a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rg2 = undefined >>> b;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rg3 = undefined >>> 1;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rg4 = undefined >>> E.a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rg5 = a >>> undefined;
+                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rg6 = b >>> undefined;
+                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rg7 = 0 >>> undefined;
+                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rg8 = E.b >>> undefined;
+                      ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    // operator &
+    var rh1 = undefined & a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rh2 = undefined & b;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rh3 = undefined & 1;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rh4 = undefined & E.a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rh5 = a & undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rh6 = b & undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rh7 = 0 & undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rh8 = E.b & undefined;
+                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    // operator ^
+    var ri1 = undefined ^ a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var ri2 = undefined ^ b;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var ri3 = undefined ^ 1;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var ri4 = undefined ^ E.a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var ri5 = a ^ undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var ri6 = b ^ undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var ri7 = 0 ^ undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var ri8 = E.b ^ undefined;
+                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    // operator |
+    var rj1 = undefined | a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rj2 = undefined | b;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rj3 = undefined | 1;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rj4 = undefined | E.a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rj5 = a | undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rj6 = b | undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rj7 = 0 | undefined;
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rj8 = E.b | undefined;
+                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es2017.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es2017.errors.txt
@@ -4,10 +4,11 @@ tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclarati
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,33): error TS2304: Cannot find name 'await'.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,38): error TS1005: ';' expected.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,39): error TS1128: Declaration or statement expected.
+tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,49): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts(1,53): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts (7 errors) ====
+==== tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration10_es2017.ts (8 errors) ====
     async function foo(a = await => await): Promise<void> {
                        ~~~~~~~~~
 !!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
@@ -21,6 +22,8 @@ tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclarati
 !!! error TS1005: ';' expected.
                                           ~
 !!! error TS1128: Declaration or statement expected.
+                                                    ~~~~
+!!! error TS2532: Object is possibly 'undefined'.
                                                         ~
 !!! error TS1109: Expression expected.
     }

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es5.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es5.errors.txt
@@ -4,10 +4,11 @@ tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration1
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,33): error TS2304: Cannot find name 'await'.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,38): error TS1005: ';' expected.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,39): error TS1128: Declaration or statement expected.
+tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,49): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts(1,53): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts (7 errors) ====
+==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration10_es5.ts (8 errors) ====
     async function foo(a = await => await): Promise<void> {
                        ~~~~~~~~~
 !!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
@@ -21,6 +22,8 @@ tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration1
 !!! error TS1005: ';' expected.
                                           ~
 !!! error TS1128: Declaration or statement expected.
+                                                    ~~~~
+!!! error TS2532: Object is possibly 'undefined'.
                                                         ~
 !!! error TS1109: Expression expected.
     }

--- a/tests/baselines/reference/asyncFunctionDeclaration10_es6.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration10_es6.errors.txt
@@ -4,10 +4,11 @@ tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration1
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,33): error TS2304: Cannot find name 'await'.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,38): error TS1005: ';' expected.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,39): error TS1128: Declaration or statement expected.
+tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,49): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts(1,53): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts (7 errors) ====
+==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration10_es6.ts (8 errors) ====
     async function foo(a = await => await): Promise<void> {
                        ~~~~~~~~~
 !!! error TS2371: A parameter initializer is only allowed in a function or constructor implementation.
@@ -21,6 +22,8 @@ tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration1
 !!! error TS1005: ';' expected.
                                           ~
 !!! error TS1128: Declaration or statement expected.
+                                                    ~~~~
+!!! error TS2532: Object is possibly 'undefined'.
                                                         ~
 !!! error TS1109: Expression expected.
     }

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es2017.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es2017.errors.txt
@@ -2,10 +2,11 @@ tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclarati
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,20): error TS2304: Cannot find name 'await'.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,25): error TS1005: ';' expected.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,26): error TS1128: Declaration or statement expected.
+tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,36): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts(1,40): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts (5 errors) ====
+==== tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclaration5_es2017.ts (6 errors) ====
     async function foo(await): Promise<void> {
                        ~~~~~
 !!! error TS1138: Parameter declaration expected.
@@ -15,6 +16,8 @@ tests/cases/conformance/async/es2017/functionDeclarations/asyncFunctionDeclarati
 !!! error TS1005: ';' expected.
                              ~
 !!! error TS1128: Declaration or statement expected.
+                                       ~~~~
+!!! error TS2532: Object is possibly 'undefined'.
                                            ~
 !!! error TS1109: Expression expected.
     }

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es5.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es5.errors.txt
@@ -2,10 +2,11 @@ tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,20): error TS2304: Cannot find name 'await'.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,25): error TS1005: ';' expected.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,26): error TS1128: Declaration or statement expected.
+tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,36): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts(1,40): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts (5 errors) ====
+==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5_es5.ts (6 errors) ====
     async function foo(await): Promise<void> {
                        ~~~~~
 !!! error TS1138: Parameter declaration expected.
@@ -15,6 +16,8 @@ tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration5
 !!! error TS1005: ';' expected.
                              ~
 !!! error TS1128: Declaration or statement expected.
+                                       ~~~~
+!!! error TS2532: Object is possibly 'undefined'.
                                            ~
 !!! error TS1109: Expression expected.
     }

--- a/tests/baselines/reference/asyncFunctionDeclaration5_es6.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration5_es6.errors.txt
@@ -2,10 +2,11 @@ tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,20): error TS2304: Cannot find name 'await'.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,25): error TS1005: ';' expected.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,26): error TS1128: Declaration or statement expected.
+tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,36): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts(1,40): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts (5 errors) ====
+==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5_es6.ts (6 errors) ====
     async function foo(await): Promise<void> {
                        ~~~~~
 !!! error TS1138: Parameter declaration expected.
@@ -15,6 +16,8 @@ tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration5
 !!! error TS1005: ';' expected.
                              ~
 !!! error TS1128: Declaration or statement expected.
+                                       ~~~~
+!!! error TS2532: Object is possibly 'undefined'.
                                            ~
 !!! error TS1109: Expression expected.
     }

--- a/tests/baselines/reference/binaryArithmatic1.errors.txt
+++ b/tests/baselines/reference/binaryArithmatic1.errors.txt
@@ -1,0 +1,7 @@
+tests/cases/compiler/binaryArithmatic1.ts(1,13): error TS2531: Object is possibly 'null'.
+
+
+==== tests/cases/compiler/binaryArithmatic1.ts (1 errors) ====
+    var v = 4 | null;
+                ~~~~
+!!! error TS2531: Object is possibly 'null'.

--- a/tests/baselines/reference/binaryArithmatic2.errors.txt
+++ b/tests/baselines/reference/binaryArithmatic2.errors.txt
@@ -1,0 +1,7 @@
+tests/cases/compiler/binaryArithmatic2.ts(1,13): error TS2532: Object is possibly 'undefined'.
+
+
+==== tests/cases/compiler/binaryArithmatic2.ts (1 errors) ====
+    var v = 4 | undefined;
+                ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.

--- a/tests/baselines/reference/binaryArithmatic3.errors.txt
+++ b/tests/baselines/reference/binaryArithmatic3.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/compiler/binaryArithmatic3.ts(1,9): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/compiler/binaryArithmatic3.ts(1,21): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/compiler/binaryArithmatic3.ts(1,9): error TS2532: Object is possibly 'undefined'.
+tests/cases/compiler/binaryArithmatic3.ts(1,21): error TS2532: Object is possibly 'undefined'.
 
 
 ==== tests/cases/compiler/binaryArithmatic3.ts (2 errors) ====
     var v = undefined | undefined;
             ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                         ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.

--- a/tests/baselines/reference/binaryArithmatic4.errors.txt
+++ b/tests/baselines/reference/binaryArithmatic4.errors.txt
@@ -1,10 +1,10 @@
-tests/cases/compiler/binaryArithmatic4.ts(1,9): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/compiler/binaryArithmatic4.ts(1,16): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/compiler/binaryArithmatic4.ts(1,9): error TS2531: Object is possibly 'null'.
+tests/cases/compiler/binaryArithmatic4.ts(1,16): error TS2531: Object is possibly 'null'.
 
 
 ==== tests/cases/compiler/binaryArithmatic4.ts (2 errors) ====
     var v = null | null;
             ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                    ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.

--- a/tests/baselines/reference/bitwiseNotOperatorWithAnyOtherType.errors.txt
+++ b/tests/baselines/reference/bitwiseNotOperatorWithAnyOtherType.errors.txt
@@ -1,3 +1,5 @@
+tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts(35,24): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts(36,24): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts(47,26): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts(47,33): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts(48,26): error TS2531: Object is possibly 'null'.
@@ -6,7 +8,7 @@ tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNot
 tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts(49,38): error TS2532: Object is possibly 'undefined'.
 
 
-==== tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts (6 errors) ====
+==== tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts (8 errors) ====
     
     // ~ operator on any type
     
@@ -42,7 +44,11 @@ tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNot
     
     // any type literal
     var ResultIsNumber6 = ~undefined;
+                           ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsNumber7 = ~null;
+                           ~~~~
+!!! error TS2531: Object is possibly 'null'.
     
     // any type expressions
     var ResultIsNumber8 = ~ANY2[0]

--- a/tests/baselines/reference/bitwiseNotOperatorWithAnyOtherType.errors.txt
+++ b/tests/baselines/reference/bitwiseNotOperatorWithAnyOtherType.errors.txt
@@ -1,9 +1,12 @@
-tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts(47,26): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
-tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts(48,26): error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
-tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts(49,26): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts(47,26): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts(47,33): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts(48,26): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts(48,33): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts(49,26): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts(49,38): error TS2532: Object is possibly 'undefined'.
 
 
-==== tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts (3 errors) ====
+==== tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNotOperatorWithAnyOtherType.ts (6 errors) ====
     
     // ~ operator on any type
     
@@ -51,14 +54,20 @@ tests/cases/conformance/expressions/unaryOperators/bitwiseNotOperator/bitwiseNot
     var ResultIsNumber14 = ~A.foo();
     var ResultIsNumber15 = ~(ANY + ANY1);
     var ResultIsNumber16 = ~(null + undefined);
-                             ~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsNumber17 = ~(null + null);
-                             ~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+                             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var ResultIsNumber18 = ~(undefined + undefined);
-                             ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                                         ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     
     // multiple ~ operators
     var ResultIsNumber19 = ~~ANY;

--- a/tests/baselines/reference/comparisonOperatorWithIdenticalPrimitiveType.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithIdenticalPrimitiveType.errors.txt
@@ -1,0 +1,130 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(15,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(15,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(16,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(16,23): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(24,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(24,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(25,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(25,23): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(33,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(33,19): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(34,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(34,24): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(42,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(42,19): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(43,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts(43,24): error TS2532: Object is possibly 'undefined'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithIdenticalPrimitiveType.ts (16 errors) ====
+    enum E { a, b, c }
+    
+    var a: number;
+    var b: boolean;
+    var c: string;
+    var d: void;
+    var e: E;
+    
+    // operator <
+    var ra1 = a < a;
+    var ra2 = b < b;
+    var ra3 = c < c;
+    var ra4 = d < d;
+    var ra5 = e < e;
+    var ra6 = null < null;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                     ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var ra7 = undefined < undefined;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                          ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    // operator >
+    var rb1 = a > a;
+    var rb2 = b > b;
+    var rb3 = c > c;
+    var rb4 = d > d;
+    var rb5 = e > e;
+    var rb6 = null > null;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                     ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rb7 = undefined > undefined;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                          ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    // operator <=
+    var rc1 = a <= a;
+    var rc2 = b <= b;
+    var rc3 = c <= c;
+    var rc4 = d <= d;
+    var rc5 = e <= e;
+    var rc6 = null <= null;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                      ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rc7 = undefined <= undefined;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                           ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    // operator >=
+    var rd1 = a >= a;
+    var rd2 = b >= b;
+    var rd3 = c >= c;
+    var rd4 = d >= d;
+    var rd5 = e >= e;
+    var rd6 = null >= null;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                      ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var rd7 = undefined >= undefined;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                           ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    // operator ==
+    var re1 = a == a;
+    var re2 = b == b;
+    var re3 = c == c;
+    var re4 = d == d;
+    var re5 = e == e;
+    var re6 = null == null;
+    var re7 = undefined == undefined;
+    
+    // operator !=
+    var rf1 = a != a;
+    var rf2 = b != b;
+    var rf3 = c != c;
+    var rf4 = d != d;
+    var rf5 = e != e;
+    var rf6 = null != null;
+    var rf7 = undefined != undefined;
+    
+    // operator ===
+    var rg1 = a === a;
+    var rg2 = b === b;
+    var rg3 = c === c;
+    var rg4 = d === d;
+    var rg5 = e === e;
+    var rg6 = null === null;
+    var rg7 = undefined === undefined;
+    
+    // operator !==
+    var rh1 = a !== a;
+    var rh2 = b !== b;
+    var rh3 = c !== c;
+    var rh4 = d !== d;
+    var rh5 = e !== e;
+    var rh6 = null !== null;
+    var rh7 = undefined !== undefined;

--- a/tests/baselines/reference/comparisonOperatorWithOneOperandIsNull.errors.txt
+++ b/tests/baselines/reference/comparisonOperatorWithOneOperandIsNull.errors.txt
@@ -1,0 +1,360 @@
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(4,22): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(5,22): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(6,23): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(7,23): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(13,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(14,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(15,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(16,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(32,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(33,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(34,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(35,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(36,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(37,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(38,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(40,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(41,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(42,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(43,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(44,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(45,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(46,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(49,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(50,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(51,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(52,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(53,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(54,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(55,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(57,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(58,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(59,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(60,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(61,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(62,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(63,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(66,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(67,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(68,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(69,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(70,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(71,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(72,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(74,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(75,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(76,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(77,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(78,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(79,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(80,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(83,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(84,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(85,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(86,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(87,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(88,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(89,12): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(91,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(92,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(93,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(94,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(95,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(96,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts(97,17): error TS2531: Object is possibly 'null'.
+
+
+==== tests/cases/conformance/expressions/binaryOperators/comparisonOperator/comparisonOperatorWithOneOperandIsNull.ts (64 errors) ====
+    enum E { a, b, c }
+    
+    function foo<T>(t: T) {
+        var foo_r1 = t < null;
+                         ~~~~
+!!! error TS2531: Object is possibly 'null'.
+        var foo_r2 = t > null;
+                         ~~~~
+!!! error TS2531: Object is possibly 'null'.
+        var foo_r3 = t <= null;
+                          ~~~~
+!!! error TS2531: Object is possibly 'null'.
+        var foo_r4 = t >= null;
+                          ~~~~
+!!! error TS2531: Object is possibly 'null'.
+        var foo_r5 = t == null;
+        var foo_r6 = t != null;
+        var foo_r7 = t === null;
+        var foo_r8 = t !== null;
+    
+        var foo_r1 = null < t;
+                     ~~~~
+!!! error TS2531: Object is possibly 'null'.
+        var foo_r2 = null > t;
+                     ~~~~
+!!! error TS2531: Object is possibly 'null'.
+        var foo_r3 = null <= t;
+                     ~~~~
+!!! error TS2531: Object is possibly 'null'.
+        var foo_r4 = null >= t;
+                     ~~~~
+!!! error TS2531: Object is possibly 'null'.
+        var foo_r5 = null == t;
+        var foo_r6 = null != t;
+        var foo_r7 = null === t;
+        var foo_r8 = null !== t;
+    }
+    
+    var a: boolean;
+    var b: number;
+    var c: string;
+    var d: void;
+    var e: E;
+    var f: {};
+    var g: string[];
+    
+    // operator <
+    var r1a1 = null < a;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r1a2 = null < b;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r1a3 = null < c;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r1a4 = null < d;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r1a5 = null < e;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r1a6 = null < f;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r1a7 = null < g;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    var r1b1 = a < null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r1b2 = b < null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r1b3 = c < null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r1b4 = d < null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r1b5 = e < null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r1b6 = f < null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r1b7 = g < null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    // operator >
+    var r2a1 = null > a;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r2a2 = null > b;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r2a3 = null > c;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r2a4 = null > d;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r2a5 = null > e;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r2a6 = null > f;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r2a7 = null > g;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    var r2b1 = a > null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r2b2 = b > null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r2b3 = c > null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r2b4 = d > null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r2b5 = e > null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r2b6 = f > null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r2b7 = g > null;
+                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    // operator <=
+    var r3a1 = null <= a;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r3a2 = null <= b;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r3a3 = null <= c;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r3a4 = null <= d;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r3a5 = null <= e;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r3a6 = null <= f;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r3a7 = null <= g;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    var r3b1 = a <= null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r3b2 = b <= null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r3b3 = c <= null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r3b4 = d <= null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r3b5 = e <= null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r3b6 = f <= null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r3b7 = g <= null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    // operator >=
+    var r4a1 = null >= a;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r4a2 = null >= b;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r4a3 = null >= c;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r4a4 = null >= d;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r4a5 = null >= e;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r4a6 = null >= f;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r4a7 = null >= g;
+               ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    var r4b1 = a >= null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r4b2 = b >= null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r4b3 = c >= null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r4b4 = d >= null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r4b5 = e >= null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r4b6 = f >= null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r4b7 = g >= null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    
+    // operator ==
+    var r5a1 = null == a;
+    var r5a2 = null == b;
+    var r5a3 = null == c;
+    var r5a4 = null == d;
+    var r5a5 = null == e;
+    var r5a6 = null == f;
+    var r5a7 = null == g;
+    
+    var r5b1 = a == null;
+    var r5b2 = b == null;
+    var r5b3 = c == null;
+    var r5b4 = d == null;
+    var r5b5 = e == null;
+    var r5b6 = f == null;
+    var r5b7 = g == null;
+    
+    // operator !=
+    var r6a1 = null != a;
+    var r6a2 = null != b;
+    var r6a3 = null != c;
+    var r6a4 = null != d;
+    var r6a5 = null != e;
+    var r6a6 = null != f;
+    var r6a7 = null != g;
+    
+    var r6b1 = a != null;
+    var r6b2 = b != null;
+    var r6b3 = c != null;
+    var r6b4 = d != null;
+    var r6b5 = e != null;
+    var r6b6 = f != null;
+    var r6b7 = g != null;
+    
+    // operator ===
+    var r7a1 = null === a;
+    var r7a2 = null === b;
+    var r7a3 = null === c;
+    var r7a4 = null === d;
+    var r7a5 = null === e;
+    var r7a6 = null === f;
+    var r7a7 = null === g;
+    
+    var r7b1 = a === null;
+    var r7b2 = b === null;
+    var r7b3 = c === null;
+    var r7b4 = d === null;
+    var r7b5 = e === null;
+    var r7b6 = f === null;
+    var r7b7 = g === null;
+    
+    // operator !==
+    var r8a1 = null !== a;
+    var r8a2 = null !== b;
+    var r8a3 = null !== c;
+    var r8a4 = null !== d;
+    var r8a5 = null !== e;
+    var r8a6 = null !== f;
+    var r8a7 = null !== g;
+    
+    var r8b1 = a !== null;
+    var r8b2 = b !== null;
+    var r8b3 = c !== null;
+    var r8b4 = d !== null;
+    var r8b5 = e !== null;
+    var r8b6 = f !== null;
+    var r8b7 = g !== null;

--- a/tests/baselines/reference/compoundAdditionAssignmentLHSCanBeAssigned.errors.txt
+++ b/tests/baselines/reference/compoundAdditionAssignmentLHSCanBeAssigned.errors.txt
@@ -1,0 +1,65 @@
+tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentLHSCanBeAssigned.ts(32,7): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentLHSCanBeAssigned.ts(33,7): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentLHSCanBeAssigned.ts(39,7): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentLHSCanBeAssigned.ts(40,7): error TS2532: Object is possibly 'undefined'.
+
+
+==== tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentLHSCanBeAssigned.ts (4 errors) ====
+    enum E { a, b }
+    
+    var a: any;
+    var b: void;
+    
+    var x1: any;
+    x1 += a;
+    x1 += b;
+    x1 += true;
+    x1 += 0;
+    x1 += '';
+    x1 += E.a;
+    x1 += {};
+    x1 += null;
+    x1 += undefined;
+    
+    var x2: string;
+    x2 += a;
+    x2 += b;
+    x2 += true;
+    x2 += 0;
+    x2 += '';
+    x2 += E.a;
+    x2 += {};
+    x2 += null;
+    x2 += undefined;
+    
+    var x3: number;
+    x3 += a;
+    x3 += 0;
+    x3 += E.a;
+    x3 += null;
+          ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    x3 += undefined;
+          ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    var x4: E;
+    x4 += a;
+    x4 += 0;
+    x4 += E.a;
+    x4 += null;
+          ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    x4 += undefined;
+          ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    var x5: boolean;
+    x5 += a;
+    
+    var x6: {};
+    x6 += a;
+    x6 += '';
+    
+    var x7: void;
+    x7 += a;

--- a/tests/baselines/reference/compoundAdditionAssignmentWithInvalidOperands.errors.txt
+++ b/tests/baselines/reference/compoundAdditionAssignmentWithInvalidOperands.errors.txt
@@ -3,22 +3,22 @@ tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmen
 tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(8,1): error TS2365: Operator '+=' cannot be applied to types 'boolean' and '0'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(9,1): error TS2365: Operator '+=' cannot be applied to types 'boolean' and 'E.a'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(10,1): error TS2365: Operator '+=' cannot be applied to types 'boolean' and '{}'.
-tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(11,1): error TS2365: Operator '+=' cannot be applied to types 'boolean' and 'boolean'.
-tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(12,1): error TS2365: Operator '+=' cannot be applied to types 'boolean' and 'boolean'.
+tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(11,7): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(12,7): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(15,1): error TS2365: Operator '+=' cannot be applied to types '{}' and 'void'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(16,1): error TS2365: Operator '+=' cannot be applied to types '{}' and 'true'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(17,1): error TS2365: Operator '+=' cannot be applied to types '{}' and '0'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(18,1): error TS2365: Operator '+=' cannot be applied to types '{}' and 'E.a'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(19,1): error TS2365: Operator '+=' cannot be applied to types '{}' and '{}'.
-tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(20,1): error TS2365: Operator '+=' cannot be applied to types '{}' and '{}'.
-tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(21,1): error TS2365: Operator '+=' cannot be applied to types '{}' and '{}'.
+tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(20,7): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(21,7): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(24,1): error TS2365: Operator '+=' cannot be applied to types 'void' and 'void'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(25,1): error TS2365: Operator '+=' cannot be applied to types 'void' and 'true'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(26,1): error TS2365: Operator '+=' cannot be applied to types 'void' and '0'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(27,1): error TS2365: Operator '+=' cannot be applied to types 'void' and 'E.a'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(28,1): error TS2365: Operator '+=' cannot be applied to types 'void' and '{}'.
-tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(29,1): error TS2365: Operator '+=' cannot be applied to types 'void' and 'void'.
-tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(30,1): error TS2365: Operator '+=' cannot be applied to types 'void' and 'void'.
+tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(29,7): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(30,7): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(33,1): error TS2365: Operator '+=' cannot be applied to types 'number' and 'void'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(34,1): error TS2365: Operator '+=' cannot be applied to types 'number' and 'true'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmentWithInvalidOperands.ts(35,1): error TS2365: Operator '+=' cannot be applied to types 'number' and '{}'.
@@ -49,11 +49,11 @@ tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmen
     ~~~~~~~~
 !!! error TS2365: Operator '+=' cannot be applied to types 'boolean' and '{}'.
     x1 += null;
-    ~~~~~~~~~~
-!!! error TS2365: Operator '+=' cannot be applied to types 'boolean' and 'boolean'.
+          ~~~~
+!!! error TS2531: Object is possibly 'null'.
     x1 += undefined;
-    ~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+=' cannot be applied to types 'boolean' and 'boolean'.
+          ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     
     var x2: {};
     x2 += a;
@@ -72,11 +72,11 @@ tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmen
     ~~~~~~~~
 !!! error TS2365: Operator '+=' cannot be applied to types '{}' and '{}'.
     x2 += null;
-    ~~~~~~~~~~
-!!! error TS2365: Operator '+=' cannot be applied to types '{}' and '{}'.
+          ~~~~
+!!! error TS2531: Object is possibly 'null'.
     x2 += undefined;
-    ~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+=' cannot be applied to types '{}' and '{}'.
+          ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     
     var x3: void;
     x3 += a;
@@ -95,11 +95,11 @@ tests/cases/conformance/expressions/assignmentOperator/compoundAdditionAssignmen
     ~~~~~~~~
 !!! error TS2365: Operator '+=' cannot be applied to types 'void' and '{}'.
     x3 += null;
-    ~~~~~~~~~~
-!!! error TS2365: Operator '+=' cannot be applied to types 'void' and 'void'.
+          ~~~~
+!!! error TS2531: Object is possibly 'null'.
     x3 += undefined;
-    ~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+=' cannot be applied to types 'void' and 'void'.
+          ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     
     var x4: number;
     x4 += a;

--- a/tests/baselines/reference/compoundArithmeticAssignmentLHSCanBeAssigned.errors.txt
+++ b/tests/baselines/reference/compoundArithmeticAssignmentLHSCanBeAssigned.errors.txt
@@ -1,0 +1,47 @@
+tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentLHSCanBeAssigned.ts(11,7): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentLHSCanBeAssigned.ts(12,7): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentLHSCanBeAssigned.ts(18,7): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentLHSCanBeAssigned.ts(19,7): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentLHSCanBeAssigned.ts(25,7): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentLHSCanBeAssigned.ts(26,7): error TS2532: Object is possibly 'undefined'.
+
+
+==== tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentLHSCanBeAssigned.ts (6 errors) ====
+    enum E { a, b, c }
+    
+    var a: any;
+    var b: number;
+    var c: E;
+    
+    var x1: any;
+    x1 *= a;
+    x1 *= b;
+    x1 *= c;
+    x1 *= null;
+          ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    x1 *= undefined;
+          ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    var x2: number;
+    x2 *= a;
+    x2 *= b;
+    x2 *= c;
+    x2 *= null;
+          ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    x2 *= undefined;
+          ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    var x3: E;
+    x3 *= a;
+    x3 *= b;
+    x3 *= c;
+    x3 *= null;
+          ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    x3 *= undefined;
+          ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.

--- a/tests/baselines/reference/compoundArithmeticAssignmentWithInvalidOperands.errors.txt
+++ b/tests/baselines/reference/compoundArithmeticAssignmentWithInvalidOperands.errors.txt
@@ -10,9 +10,9 @@ tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignm
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(13,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(13,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(14,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(14,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(14,7): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(15,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(15,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(15,7): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(18,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(19,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(19,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
@@ -25,9 +25,9 @@ tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignm
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(24,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(24,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(25,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(25,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(25,7): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(26,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(26,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(26,7): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(29,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(30,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(30,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
@@ -40,9 +40,9 @@ tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignm
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(35,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(35,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(36,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(36,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(36,7): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(37,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(37,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(37,7): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(40,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(41,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(41,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
@@ -55,9 +55,9 @@ tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignm
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(46,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(46,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(47,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(47,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(47,7): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(48,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(48,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(48,7): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(51,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(52,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignmentWithInvalidOperands.ts(53,7): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
@@ -108,12 +108,12 @@ tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignm
     ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
           ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     x1 *= undefined;
     ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
           ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var x2: string;
     x2 *= a;
@@ -149,12 +149,12 @@ tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignm
     ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
           ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     x2 *= undefined;
     ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
           ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var x3: {};
     x3 *= a;
@@ -190,12 +190,12 @@ tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignm
     ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
           ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     x3 *= undefined;
     ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
           ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var x4: void;
     x4 *= a;
@@ -231,12 +231,12 @@ tests/cases/conformance/expressions/assignmentOperator/compoundArithmeticAssignm
     ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
           ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     x4 *= undefined;
     ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
           ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var x5: number;
     x5 *= b;

--- a/tests/baselines/reference/compoundAssignmentLHSIsValue.errors.txt
+++ b/tests/baselines/reference/compoundAssignmentLHSIsValue.errors.txt
@@ -17,6 +17,7 @@ tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsVa
 tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts(41,1): error TS2539: Cannot assign to 'foo' because it is not a variable.
 tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts(42,1): error TS2539: Cannot assign to 'foo' because it is not a variable.
 tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts(45,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
+tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts(45,1): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts(46,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
 tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts(47,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts(48,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
@@ -55,6 +56,7 @@ tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsVa
 tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts(104,2): error TS2539: Cannot assign to 'foo' because it is not a variable.
 tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts(105,2): error TS2539: Cannot assign to 'foo' because it is not a variable.
 tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts(106,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
+tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts(106,1): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts(107,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
 tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts(108,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts(109,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
@@ -74,7 +76,7 @@ tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsVa
 tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts(123,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
 
 
-==== tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts (74 errors) ====
+==== tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsValue.ts (76 errors) ====
     
     // expected error for all the LHS of compound assignments (arithmetic and addition)
     var value: any;
@@ -158,6 +160,8 @@ tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsVa
     null *= value;
     ~~~~
 !!! error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
+    ~~~~
+!!! error TS2531: Object is possibly 'null'.
     null += value;
     ~~~~
 !!! error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
@@ -295,6 +299,8 @@ tests/cases/conformance/expressions/assignmentOperator/compoundAssignmentLHSIsVa
     (null) *= value;
     ~~~~~~
 !!! error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
+    ~~~~~~
+!!! error TS2531: Object is possibly 'null'.
     (null) += value;
     ~~~~~~
 !!! error TS2364: The left-hand side of an assignment expression must be a variable or a property access.

--- a/tests/baselines/reference/compoundExponentiationAssignmentLHSCanBeAssigned1.errors.txt
+++ b/tests/baselines/reference/compoundExponentiationAssignmentLHSCanBeAssigned1.errors.txt
@@ -1,0 +1,47 @@
+tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCanBeAssigned1.ts(11,8): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCanBeAssigned1.ts(12,8): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCanBeAssigned1.ts(18,8): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCanBeAssigned1.ts(19,8): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCanBeAssigned1.ts(25,8): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCanBeAssigned1.ts(26,8): error TS2532: Object is possibly 'undefined'.
+
+
+==== tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCanBeAssigned1.ts (6 errors) ====
+    enum E { a, b, c }
+    
+    var a: any;
+    var b: number;
+    var c: E;
+    
+    var x1: any;
+    x1 **= a;
+    x1 **= b;
+    x1 **= c;
+    x1 **= null;
+           ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    x1 **= undefined;
+           ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    var x2: number;
+    x2 **= a;
+    x2 **= b;
+    x2 **= c;
+    x2 **= null;
+           ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    x2 **= undefined;
+           ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    var x3: E;
+    x3 **= a;
+    x3 **= b;
+    x3 **= c;
+    x3 **= null;
+           ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    x3 **= undefined;
+           ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.

--- a/tests/baselines/reference/compoundExponentiationAssignmentLHSCannotBeAssigned.errors.txt
+++ b/tests/baselines/reference/compoundExponentiationAssignmentLHSCannotBeAssigned.errors.txt
@@ -10,9 +10,9 @@ tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignm
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(13,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(13,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(14,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(14,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(14,8): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(15,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(15,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(15,8): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(18,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(19,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(19,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
@@ -25,9 +25,9 @@ tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignm
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(24,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(24,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(25,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(25,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(25,8): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(26,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(26,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(26,8): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(29,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(30,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(30,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
@@ -40,9 +40,9 @@ tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignm
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(35,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(35,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(36,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(36,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(36,8): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(37,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(37,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(37,8): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(40,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(41,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(41,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
@@ -55,9 +55,9 @@ tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignm
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(46,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(46,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(47,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(47,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(47,8): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(48,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(48,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(48,8): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(51,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(52,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSCannotBeAssigned.ts(53,8): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
@@ -108,12 +108,12 @@ tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignm
     ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
            ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     x1 **= undefined;
     ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
            ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var x2: string;
     x2 **= a;
@@ -149,12 +149,12 @@ tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignm
     ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
            ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     x2 **= undefined;
     ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
            ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var x3: {};
     x3 **= a;
@@ -190,12 +190,12 @@ tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignm
     ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
            ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     x3 **= undefined;
     ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
            ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var x4: void;
     x4 **= a;
@@ -231,12 +231,12 @@ tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignm
     ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
            ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     x4 **= undefined;
     ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
            ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var x5: number;
     x5 **= b;

--- a/tests/baselines/reference/compoundExponentiationAssignmentLHSIsValue.errors.txt
+++ b/tests/baselines/reference/compoundExponentiationAssignmentLHSIsValue.errors.txt
@@ -8,6 +8,7 @@ tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignm
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts(30,1): error TS2539: Cannot assign to 'E' because it is not a variable.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts(32,1): error TS2539: Cannot assign to 'foo' because it is not a variable.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts(35,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
+tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts(35,1): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts(36,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts(37,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts(38,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
@@ -28,6 +29,7 @@ tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignm
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts(75,2): error TS2539: Cannot assign to 'E' because it is not a variable.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts(76,2): error TS2539: Cannot assign to 'foo' because it is not a variable.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts(77,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
+tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts(77,1): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts(78,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts(79,1): error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts(80,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
@@ -38,7 +40,7 @@ tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignm
 tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts(85,1): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 
 
-==== tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts (38 errors) ====
+==== tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignmentLHSIsValue.ts (40 errors) ====
     // expected error for all the LHS of compound assignments (arithmetic and addition)
     var value: any;
     
@@ -94,6 +96,8 @@ tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignm
     null **= value;
     ~~~~
 !!! error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
+    ~~~~
+!!! error TS2531: Object is possibly 'null'.
     true **= value;
     ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
@@ -176,6 +180,8 @@ tests/cases/conformance/es7/exponentiationOperator/compoundExponentiationAssignm
     (null) **= value;
     ~~~~~~
 !!! error TS2364: The left-hand side of an assignment expression must be a variable or a property access.
+    ~~~~~~
+!!! error TS2531: Object is possibly 'null'.
     (true) **= value;
     ~~~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.

--- a/tests/baselines/reference/contextuallyTypedIifeStrict.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedIifeStrict.errors.txt
@@ -1,0 +1,45 @@
+tests/cases/conformance/expressions/functions/contextuallyTypedIifeStrict.ts(14,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/functions/contextuallyTypedIifeStrict.ts(15,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/functions/contextuallyTypedIifeStrict.ts(16,17): error TS2532: Object is possibly 'undefined'.
+
+
+==== tests/cases/conformance/expressions/functions/contextuallyTypedIifeStrict.ts (3 errors) ====
+    // arrow
+    (jake => { })("build");
+    // function expression
+    (function (cats) { })("lol");
+    // Lots of Irritating Superfluous Parentheses
+    (function (x) { } ("!"));
+    ((((function (y) { }))))("-");
+    // multiple arguments
+    ((a, b, c) => { })("foo", 101, false);
+    // default parameters
+    ((m = 10) => m + 1)(12);
+    ((n = 10) => n + 1)();
+    // optional parameters
+    ((j?) => j + 1)(12);
+             ~
+!!! error TS2532: Object is possibly 'undefined'.
+    ((k?) => k + 1)();
+             ~
+!!! error TS2532: Object is possibly 'undefined'.
+    ((l, o?) => l + o)(12); // o should be any
+                    ~
+!!! error TS2532: Object is possibly 'undefined'.
+    // rest parameters
+    ((...numbers) => numbers.every(n => n > 0))(5,6,7);
+    ((...mixed) => mixed.every(n => !!n))(5,'oops','oh no');
+    ((...noNumbers) => noNumbers.some(n => n > 0))();
+    ((first, ...rest) => first ? [] : rest.map(n => n > 0))(8,9,10);
+    // destructuring parameters (with defaults too!)
+    (({ q }) => q)({ q : 13 });
+    (({ p = 14 }) => p)({ p : 15 });
+    (({ r = 17 } = { r: 18 }) => r)({r : 19});
+    (({ u = 22 } = { u: 23 }) => u)();
+    // contextually typed parameters.
+    let twelve = (f => f(12))(i => i);
+    let eleven = (o => o.a(11))({ a: function(n) { return n; } });
+    // missing arguments
+    (function(x, undefined) { return x; })(42);
+    ((x, y, z) => 42)();
+    

--- a/tests/baselines/reference/decrementOperatorWithAnyOtherTypeInvalidOperations.errors.txt
+++ b/tests/baselines/reference/decrementOperatorWithAnyOtherTypeInvalidOperations.errors.txt
@@ -9,9 +9,11 @@ tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOp
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(33,23): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(34,24): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(37,26): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(38,26): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(38,26): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
+tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(38,26): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(39,26): error TS2539: Cannot assign to 'undefined' because it is not a variable.
-tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(41,24): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(41,24): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
+tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(41,24): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(42,24): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(43,24): error TS2539: Cannot assign to 'undefined' because it is not a variable.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(46,26): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
@@ -56,7 +58,7 @@ tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOp
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(72,12): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts (56 errors) ====
+==== tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts (58 errors) ====
     // -- operator on any type
     var ANY1: any;
     var ANY2: any[] = ["", ""];
@@ -118,14 +120,18 @@ tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOp
 !!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
     var ResultIsNumber12 = --null;
                              ~~~~
-!!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
+!!! error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
+                             ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var ResultIsNumber13 = --undefined;
                              ~~~~~~~~~
 !!! error TS2539: Cannot assign to 'undefined' because it is not a variable.
     
     var ResultIsNumber14 = null--;
                            ~~~~
-!!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
+!!! error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
+                           ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var ResultIsNumber15 = {}--;
                            ~~
 !!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.

--- a/tests/baselines/reference/decrementOperatorWithAnyOtherTypeInvalidOperations.errors.txt
+++ b/tests/baselines/reference/decrementOperatorWithAnyOtherTypeInvalidOperations.errors.txt
@@ -17,21 +17,27 @@ tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOp
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(46,26): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(47,26): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(48,26): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(48,27): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(48,27): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(48,34): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(49,26): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(49,27): error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(49,27): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(49,34): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(50,26): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(50,27): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(50,27): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(50,39): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(51,26): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(52,26): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(54,24): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(55,24): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(56,24): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(56,25): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(56,25): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(56,32): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(57,24): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(57,25): error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(57,25): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(57,32): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(58,24): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(58,25): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(58,25): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(58,37): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(59,24): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(60,24): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(63,3): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
@@ -50,7 +56,7 @@ tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOp
 tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts(72,12): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts (50 errors) ====
+==== tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOperatorWithAnyOtherTypeInvalidOperations.ts (56 errors) ====
     // -- operator on any type
     var ANY1: any;
     var ANY2: any[] = ["", ""];
@@ -137,18 +143,24 @@ tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOp
     var ResultIsNumber19 = --(null + undefined);
                              ~~~~~~~~~~~~~~~~~~
 !!! error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-                              ~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                     ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsNumber20 = --(null + null);
                              ~~~~~~~~~~~~~
 !!! error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-                              ~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+                              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                     ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var ResultIsNumber21 = --(undefined + undefined);
                              ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-                              ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                                          ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsNumber22 = --obj1.x;
                              ~~~~~~
 !!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
@@ -165,18 +177,24 @@ tests/cases/conformance/expressions/unaryOperators/decrementOperator/decrementOp
     var ResultIsNumber26 = (null + undefined)--;
                            ~~~~~~~~~~~~~~~~~~
 !!! error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-                            ~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                            ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                   ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsNumber27 = (null + null)--;
                            ~~~~~~~~~~~~~
 !!! error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-                            ~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+                            ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var ResultIsNumber28 = (undefined + undefined)--;
                            ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-                            ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                            ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                                        ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsNumber29 = obj1.x--;
                            ~~~~~~
 !!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.

--- a/tests/baselines/reference/deleteOperatorWithAnyOtherType.errors.txt
+++ b/tests/baselines/reference/deleteOperatorWithAnyOtherType.errors.txt
@@ -9,12 +9,15 @@ tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperator
 tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(42,32): error TS2703: The operand of a delete operator must be a property reference
 tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(43,32): error TS2703: The operand of a delete operator must be a property reference
 tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(44,33): error TS2703: The operand of a delete operator must be a property reference
-tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(45,33): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(45,33): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(45,33): error TS2703: The operand of a delete operator must be a property reference
-tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(46,33): error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(45,40): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(46,33): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(46,33): error TS2703: The operand of a delete operator must be a property reference
-tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(47,33): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(46,40): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(47,33): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(47,33): error TS2703: The operand of a delete operator must be a property reference
+tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(47,45): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(50,32): error TS2703: The operand of a delete operator must be a property reference
 tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(50,39): error TS2703: The operand of a delete operator must be a property reference
 tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(51,32): error TS2703: The operand of a delete operator must be a property reference
@@ -25,7 +28,7 @@ tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperator
 tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts(57,8): error TS2703: The operand of a delete operator must be a property reference
 
 
-==== tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts (25 errors) ====
+==== tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperatorWithAnyOtherType.ts (28 errors) ====
     // delete  operator on any type
     
     var ANY: any;
@@ -93,20 +96,26 @@ tests/cases/conformance/expressions/unaryOperators/deleteOperator/deleteOperator
                                     ~~~~~~~~~~
 !!! error TS2703: The operand of a delete operator must be a property reference
     var ResultIsBoolean17 = delete (null + undefined);
-                                    ~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
                                     ~~~~~~~~~~~~~~~~
 !!! error TS2703: The operand of a delete operator must be a property reference
+                                           ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsBoolean18 = delete (null + null);
-                                    ~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+                                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
                                     ~~~~~~~~~~~
 !!! error TS2703: The operand of a delete operator must be a property reference
+                                           ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var ResultIsBoolean19 = delete (undefined + undefined);
-                                    ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
                                     ~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2703: The operand of a delete operator must be a property reference
+                                                ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     
     // multiple delete  operators
     var ResultIsBoolean20 = delete delete ANY;

--- a/tests/baselines/reference/emitExponentiationOperator4.errors.txt
+++ b/tests/baselines/reference/emitExponentiationOperator4.errors.txt
@@ -1,0 +1,70 @@
+tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperator4.ts(14,1): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperator4.ts(15,1): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperator4.ts(16,1): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperator4.ts(17,1): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperator4.ts(18,1): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperator4.ts(21,6): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperator4.ts(22,6): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperator4.ts(23,6): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperator4.ts(24,6): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperator4.ts(25,6): error TS2532: Object is possibly 'undefined'.
+
+
+==== tests/cases/conformance/es7/exponentiationOperator/emitExponentiationOperator4.ts (10 errors) ====
+    var temp: any;
+    
+    (<number>temp) ** 3;
+    (<number>--temp) ** 3;
+    (<number>++temp) ** 3;
+    (<number>temp--) ** 3;
+    (<number>temp++) ** 3;
+    
+    1 ** (<number>--temp) ** 3;
+    1 ** (<number>++temp) ** 3;
+    1 ** (<number>temp--) ** 3;
+    1 ** (<number>temp++) ** 3;
+    
+    (void --temp) ** 3;
+    ~~~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    (void temp--) ** 3;
+    ~~~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    (void 3) ** 4;
+    ~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    (void temp++) ** 4;
+    ~~~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    (void temp--) ** 4;
+    ~~~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    
+    1 ** (void --temp) ** 3;
+         ~~~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    1 ** (void temp--) ** 3;
+         ~~~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    1 ** (void 3) ** 4;
+         ~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    1 ** (void temp++) ** 4;
+         ~~~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    1 ** (void temp--) ** 4;
+         ~~~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    
+    (~ --temp) ** 3;
+    (~ temp--) ** 3;
+    (~ 3) ** 4;
+    (~ temp++) ** 4;
+    (~ temp--) ** 4;
+    
+    1 ** (~ --temp) ** 3;
+    1 ** (~ temp--) ** 3;
+    1 ** (~ 3) ** 4;
+    1 ** (~ temp++) ** 4;
+    1 ** (~ temp--) ** 4;

--- a/tests/baselines/reference/equalityStrictNulls.errors.txt
+++ b/tests/baselines/reference/equalityStrictNulls.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/types/typeRelationships/comparable/equalityStrictNulls.ts(60,9): error TS2365: Operator '>' cannot be applied to types 'number' and 'undefined'.
-tests/cases/conformance/types/typeRelationships/comparable/equalityStrictNulls.ts(62,9): error TS2365: Operator '<' cannot be applied to types 'number' and 'undefined'.
-tests/cases/conformance/types/typeRelationships/comparable/equalityStrictNulls.ts(64,9): error TS2365: Operator '>=' cannot be applied to types 'number' and 'undefined'.
-tests/cases/conformance/types/typeRelationships/comparable/equalityStrictNulls.ts(66,9): error TS2365: Operator '<=' cannot be applied to types 'number' and 'undefined'.
+tests/cases/conformance/types/typeRelationships/comparable/equalityStrictNulls.ts(60,13): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/types/typeRelationships/comparable/equalityStrictNulls.ts(62,13): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/types/typeRelationships/comparable/equalityStrictNulls.ts(64,14): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/types/typeRelationships/comparable/equalityStrictNulls.ts(66,14): error TS2532: Object is possibly 'undefined'.
 
 
 ==== tests/cases/conformance/types/typeRelationships/comparable/equalityStrictNulls.ts (4 errors) ====
@@ -65,20 +65,20 @@ tests/cases/conformance/types/typeRelationships/comparable/equalityStrictNulls.t
     
     function f4(x: number) {
         if (x > undefined) {
-            ~~~~~~~~~~~~~
-!!! error TS2365: Operator '>' cannot be applied to types 'number' and 'undefined'.
+                ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
         }
         if (x < undefined) {
-            ~~~~~~~~~~~~~
-!!! error TS2365: Operator '<' cannot be applied to types 'number' and 'undefined'.
+                ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
         }
         if (x >= undefined) {
-            ~~~~~~~~~~~~~~
-!!! error TS2365: Operator '>=' cannot be applied to types 'number' and 'undefined'.
+                 ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
         }
         if (x <= undefined) {
-            ~~~~~~~~~~~~~~
-!!! error TS2365: Operator '<=' cannot be applied to types 'number' and 'undefined'.
+                 ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
         }
     }
     function f5(x: string) {

--- a/tests/baselines/reference/exponentiationOperatorSyntaxError2.errors.txt
+++ b/tests/baselines/reference/exponentiationOperatorSyntaxError2.errors.txt
@@ -42,15 +42,25 @@ tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxE
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(25,6): error TS17006: An unary expression with the 'typeof' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(26,6): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(26,6): error TS17006: An unary expression with the 'typeof' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(28,1): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(28,1): error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(29,1): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(29,1): error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(30,1): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(30,1): error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(31,1): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(31,1): error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(32,1): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(32,1): error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(34,6): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(34,6): error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(35,6): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(35,6): error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(36,6): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(36,6): error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(37,6): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(37,6): error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(38,6): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(38,6): error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(40,1): error TS17006: An unary expression with the '~' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(41,1): error TS17006: An unary expression with the '~' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
@@ -89,7 +99,7 @@ tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxE
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts(68,1): error TS17007: A type assertion expression is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
 
 
-==== tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts (89 errors) ====
+==== tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxError2.ts (99 errors) ====
     
     // Error: early syntax error using ES7 SimpleUnaryExpression on left-hand side without ()
     var temp: any;
@@ -207,33 +217,53 @@ tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorSyntaxE
     
     void --temp ** 3;
     ~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    ~~~~~~~~~~~
 !!! error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
     void temp-- ** 3;
+    ~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     ~~~~~~~~~~~
 !!! error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
     void 3 ** 4;
     ~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    ~~~~~~
 !!! error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
     void temp++ ** 4;
     ~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    ~~~~~~~~~~~
 !!! error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
     void temp-- ** 4;
+    ~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     ~~~~~~~~~~~
 !!! error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
     
     1 ** void --temp ** 3;
          ~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+         ~~~~~~~~~~~
 !!! error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
     1 ** void temp-- ** 3;
+         ~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
          ~~~~~~~~~~~
 !!! error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
     1 ** void 3 ** 4;
          ~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+         ~~~~~~
 !!! error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
     1 ** void temp++ ** 4;
          ~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+         ~~~~~~~~~~~
 !!! error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
     1 ** void temp-- ** 4 ;
+         ~~~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
          ~~~~~~~~~~~
 !!! error TS17006: An unary expression with the 'void' operator is not allowed in the left-hand side of an exponentiation expression. Consider enclosing the expression in parentheses.
     

--- a/tests/baselines/reference/exponentiationOperatorWithNullValueAndInvalidOperands.errors.txt
+++ b/tests/baselines/reference/exponentiationOperatorWithNullValueAndInvalidOperands.errors.txt
@@ -1,27 +1,27 @@
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(9,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(9,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(9,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(10,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(10,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(10,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(11,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(11,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(11,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(13,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(13,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(13,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(14,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(14,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(14,17): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(15,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(15,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(17,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(15,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(17,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(17,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(18,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(18,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(18,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(19,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(19,12): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(19,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(21,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(21,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(21,20): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(22,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(22,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(22,18): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(23,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(23,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts(23,18): error TS2531: Object is possibly 'null'.
 
 
 ==== tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndInvalidOperands.ts (24 errors) ====
@@ -35,17 +35,17 @@ tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNul
     // operator **
     var r1a1 = null ** a;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r1a2 = null ** b;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r1a3 = null ** c;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -53,31 +53,31 @@ tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNul
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r1b2 = b ** null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r1b3 = c ** null;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     
     var r1c1 = null ** true;
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~~~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r1c2 = null ** '';
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r1c3 = null ** {};
                ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                        ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -85,14 +85,14 @@ tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNul
                ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                        ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r1d2 = '' ** null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r1d3 = {} ** null;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.

--- a/tests/baselines/reference/exponentiationOperatorWithNullValueAndValidOperands.errors.txt
+++ b/tests/baselines/reference/exponentiationOperatorWithNullValueAndValidOperands.errors.txt
@@ -1,0 +1,47 @@
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndValidOperands.ts(13,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndValidOperands.ts(14,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndValidOperands.ts(15,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndValidOperands.ts(16,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndValidOperands.ts(17,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndValidOperands.ts(18,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndValidOperands.ts(19,15): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndValidOperands.ts(20,17): error TS2531: Object is possibly 'null'.
+
+
+==== tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithNullValueAndValidOperands.ts (8 errors) ====
+    // If one operand is the null or undefined value, it is treated as having the type of the
+    // other operand.
+    
+    enum E {
+        a,
+        b
+    }
+    
+    var a: any;
+    var b: number;
+    
+    // operator **
+    var r1 = null ** a;
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r2 = null ** b;
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r3 = null ** 1;
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r4 = null ** E.a;
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r5 = a ** null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r6 = b ** null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r7 = 0 ** null;
+                  ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    var r8 = E.b ** null;
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.

--- a/tests/baselines/reference/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.errors.txt
+++ b/tests/baselines/reference/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.errors.txt
@@ -1,33 +1,33 @@
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts(2,10): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts(2,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts(3,10): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts(3,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts(4,10): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts(4,23): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts(5,10): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts(5,23): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts(2,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts(2,18): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts(3,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts(3,18): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts(4,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts(4,23): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts(5,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts(5,23): error TS2532: Object is possibly 'undefined'.
 
 
 ==== tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithOnlyNullValueOrUndefinedValue.ts (8 errors) ====
     // operator **
     var r1 = null ** null;
              ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                      ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r2 = null ** undefined;
              ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r3 = undefined ** null;
              ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                           ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var r4 = undefined ** undefined;
              ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                           ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     

--- a/tests/baselines/reference/exponentiationOperatorWithUndefinedValueAndInvalidOperands.errors.txt
+++ b/tests/baselines/reference/exponentiationOperatorWithUndefinedValueAndInvalidOperands.errors.txt
@@ -1,27 +1,27 @@
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(9,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(9,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(9,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(10,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(10,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(10,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(11,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(11,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(11,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(13,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(13,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(13,17): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(14,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(14,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(14,17): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(15,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(15,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(17,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(15,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(17,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(17,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(18,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(18,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(18,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(19,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(19,12): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(19,25): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(21,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(21,20): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(21,20): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(22,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(22,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(22,18): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(23,12): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(23,18): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts(23,18): error TS2532: Object is possibly 'undefined'.
 
 
 ==== tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndInvalidOperands.ts (24 errors) ====
@@ -35,17 +35,17 @@ tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUnd
     // operator **
     var r1a1 = undefined ** a;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r1a2 = undefined ** b;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r1a3 = undefined ** c;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -53,31 +53,31 @@ tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUnd
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r1b2 = b ** undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r1b3 = c ** undefined;
                ~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                     ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var r1c1 = undefined ** true;
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~~~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r1c2 = undefined ** '';
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     var r1c3 = undefined ** {};
                ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                             ~~
 !!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
     
@@ -85,14 +85,14 @@ tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUnd
                ~~~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                        ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r1d2 = '' ** undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var r1d3 = {} ** undefined;
                ~~
 !!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
                      ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.

--- a/tests/baselines/reference/exponentiationOperatorWithUndefinedValueAndValidOperands.errors.txt
+++ b/tests/baselines/reference/exponentiationOperatorWithUndefinedValueAndValidOperands.errors.txt
@@ -1,0 +1,47 @@
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndValidOperands.ts(13,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndValidOperands.ts(14,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndValidOperands.ts(15,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndValidOperands.ts(16,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndValidOperands.ts(17,16): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndValidOperands.ts(18,16): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndValidOperands.ts(19,16): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndValidOperands.ts(20,18): error TS2532: Object is possibly 'undefined'.
+
+
+==== tests/cases/conformance/es7/exponentiationOperator/exponentiationOperatorWithUndefinedValueAndValidOperands.ts (8 errors) ====
+    // If one operand is the undefined or undefined value, it is treated as having the type of the
+    // other operand.
+    
+    enum E {
+        a,
+        b
+    }
+    
+    var a: any;
+    var b: number;
+    
+    // operator *
+    var rk1 = undefined ** a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rk2 = undefined ** b;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rk3 = undefined ** 1;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rk4 = undefined ** E.a;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rk5 = a ** undefined;
+                   ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rk6 = b ** undefined;
+                   ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rk7 = 0 ** undefined;
+                   ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    var rk8 = E.b ** undefined;
+                     ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.

--- a/tests/baselines/reference/functionsMissingReturnStatementsAndExpressions.errors.txt
+++ b/tests/baselines/reference/functionsMissingReturnStatementsAndExpressions.errors.txt
@@ -1,10 +1,11 @@
 tests/cases/compiler/functionsMissingReturnStatementsAndExpressions.ts(3,16): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 tests/cases/compiler/functionsMissingReturnStatementsAndExpressions.ts(101,17): error TS2355: A function whose declared type is neither 'void' nor 'any' must return a value.
 tests/cases/compiler/functionsMissingReturnStatementsAndExpressions.ts(106,16): error TS2378: A 'get' accessor must return a value.
+tests/cases/compiler/functionsMissingReturnStatementsAndExpressions.ts(128,15): error TS2532: Object is possibly 'undefined'.
 tests/cases/compiler/functionsMissingReturnStatementsAndExpressions.ts(129,5): error TS1003: Identifier expected.
 
 
-==== tests/cases/compiler/functionsMissingReturnStatementsAndExpressions.ts (4 errors) ====
+==== tests/cases/compiler/functionsMissingReturnStatementsAndExpressions.ts (5 errors) ====
     
     
     function f1(): string {
@@ -139,6 +140,8 @@ tests/cases/compiler/functionsMissingReturnStatementsAndExpressions.ts(129,5): e
             // if no return statements are present but we are a get accessor.
             throw null;
             throw undefined.
+                  ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
         }
         ~
 !!! error TS1003: Identifier expected.

--- a/tests/baselines/reference/inOperatorWithInvalidOperands.errors.txt
+++ b/tests/baselines/reference/inOperatorWithInvalidOperands.errors.txt
@@ -1,6 +1,8 @@
 tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(12,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
 tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(13,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
 tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(14,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(16,11): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(17,11): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(19,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
 tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(20,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
 tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(30,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter
@@ -11,13 +13,13 @@ tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInv
 tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(35,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter
 tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(36,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter
 tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(37,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(38,16): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter
-tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(39,17): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(38,16): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(39,17): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(43,11): error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
 tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts(43,17): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter
 
 
-==== tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts (17 errors) ====
+==== tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInvalidOperands.ts (19 errors) ====
     enum E { a }
     
     var x: any;
@@ -40,7 +42,11 @@ tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInv
 !!! error TS2360: The left-hand side of an 'in' expression must be of type 'any', 'string', 'number', or 'symbol'.
     var ra4 = a4 in x;
     var ra5 = null in x;
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var ra6 = undefined in x;
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ra7 = E.a in x;
     var ra8 = false in x;
               ~~~~~
@@ -83,10 +89,10 @@ tests/cases/conformance/expressions/binaryOperators/inOperator/inOperatorWithInv
 !!! error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter
     var rb9 = x in null;
                    ~~~~
-!!! error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter
+!!! error TS2531: Object is possibly 'null'.
     var rb10 = x in undefined;
                     ~~~~~~~~~
-!!! error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter
+!!! error TS2532: Object is possibly 'undefined'.
     
     
     // both operands are invalid

--- a/tests/baselines/reference/incrementOperatorWithAnyOtherTypeInvalidOperations.errors.txt
+++ b/tests/baselines/reference/incrementOperatorWithAnyOtherTypeInvalidOperations.errors.txt
@@ -17,21 +17,27 @@ tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOp
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(46,26): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(47,26): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(48,26): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(48,27): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(48,27): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(48,34): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(49,26): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(49,27): error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(49,27): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(49,34): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(50,26): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(50,27): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(50,27): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(50,39): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(51,26): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(52,26): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(54,24): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(55,24): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(56,24): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(56,25): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(56,25): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(56,32): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(57,24): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(57,25): error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(57,25): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(57,32): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(58,24): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(58,25): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(58,25): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(58,37): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(59,24): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(60,24): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(63,3): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
@@ -45,7 +51,7 @@ tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOp
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(69,12): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts (45 errors) ====
+==== tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts (51 errors) ====
     // ++ operator on any type
     var ANY1: any;
     var ANY2: any[] = [1, 2];
@@ -132,18 +138,24 @@ tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOp
     var ResultIsNumber19 = ++(null + undefined);
                              ~~~~~~~~~~~~~~~~~~
 !!! error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-                              ~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                     ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsNumber20 = ++(null + null);
                              ~~~~~~~~~~~~~
 !!! error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-                              ~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+                              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                     ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var ResultIsNumber21 = ++(undefined + undefined);
                              ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-                              ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                                          ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsNumber22 = ++obj1.x;
                              ~~~~~~
 !!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
@@ -160,18 +172,24 @@ tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOp
     var ResultIsNumber26 = (null + undefined)++;
                            ~~~~~~~~~~~~~~~~~~
 !!! error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-                            ~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                            ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                   ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsNumber27 = (null + null)++;
                            ~~~~~~~~~~~~~
 !!! error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-                            ~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+                            ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var ResultIsNumber28 = (undefined + undefined)++;
                            ~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
-                            ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                            ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                                        ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsNumber29 = obj1.x++;
                            ~~~~~~
 !!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.

--- a/tests/baselines/reference/incrementOperatorWithAnyOtherTypeInvalidOperations.errors.txt
+++ b/tests/baselines/reference/incrementOperatorWithAnyOtherTypeInvalidOperations.errors.txt
@@ -9,9 +9,11 @@ tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOp
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(33,23): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(34,24): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(37,26): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(38,26): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(38,26): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
+tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(38,26): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(39,26): error TS2539: Cannot assign to 'undefined' because it is not a variable.
-tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(41,24): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(41,24): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
+tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(41,24): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(42,24): error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(43,24): error TS2539: Cannot assign to 'undefined' because it is not a variable.
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(46,26): error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
@@ -51,7 +53,7 @@ tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOp
 tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts(69,12): error TS1109: Expression expected.
 
 
-==== tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts (51 errors) ====
+==== tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOperatorWithAnyOtherTypeInvalidOperations.ts (53 errors) ====
     // ++ operator on any type
     var ANY1: any;
     var ANY2: any[] = [1, 2];
@@ -113,14 +115,18 @@ tests/cases/conformance/expressions/unaryOperators/incrementOperator/incrementOp
 !!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
     var ResultIsNumber12 = ++null;
                              ~~~~
-!!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
+!!! error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
+                             ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var ResultIsNumber13 = ++undefined;
                              ~~~~~~~~~
 !!! error TS2539: Cannot assign to 'undefined' because it is not a variable.
     
     var ResultIsNumber14 = null++;
                            ~~~~
-!!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.
+!!! error TS2357: The operand of an increment or decrement operator must be a variable or a property access.
+                           ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var ResultIsNumber15 = {}++;
                            ~~
 !!! error TS2356: An arithmetic operand must be of type 'any', 'number' or an enum type.

--- a/tests/baselines/reference/literals.errors.txt
+++ b/tests/baselines/reference/literals.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/expressions/literals/literals.ts(9,10): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/literals/literals.ts(9,17): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/literals/literals.ts(10,9): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/literals/literals.ts(10,21): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/literals/literals.ts(9,10): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/literals/literals.ts(9,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/literals/literals.ts(10,9): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/literals/literals.ts(10,21): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/literals/literals.ts(20,9): error TS1085: Octal literals are not available when targeting ECMAScript 5 and higher. Use the syntax '0o1'.
 tests/cases/conformance/expressions/literals/literals.ts(25,9): error TS1085: Octal literals are not available when targeting ECMAScript 5 and higher. Use the syntax '-0o3'.
 
@@ -17,14 +17,14 @@ tests/cases/conformance/expressions/literals/literals.ts(25,9): error TS1085: Oc
     
     var nu = null / null;
              ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                     ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var u = undefined / undefined;
             ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                         ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     var b: boolean;
     var b = true;

--- a/tests/baselines/reference/logicalNotOperatorWithAnyOtherType.errors.txt
+++ b/tests/baselines/reference/logicalNotOperatorWithAnyOtherType.errors.txt
@@ -1,10 +1,13 @@
-tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithAnyOtherType.ts(45,27): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
-tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithAnyOtherType.ts(46,27): error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
-tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithAnyOtherType.ts(47,27): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithAnyOtherType.ts(45,27): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithAnyOtherType.ts(45,34): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithAnyOtherType.ts(46,27): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithAnyOtherType.ts(46,34): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithAnyOtherType.ts(47,27): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithAnyOtherType.ts(47,39): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithAnyOtherType.ts(57,1): error TS2695: Left side of comma operator is unused and has no side effects.
 
 
-==== tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithAnyOtherType.ts (4 errors) ====
+==== tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNotOperatorWithAnyOtherType.ts (7 errors) ====
     // ! operator on any type
     
     var ANY: any;
@@ -50,14 +53,20 @@ tests/cases/conformance/expressions/unaryOperators/logicalNotOperator/logicalNot
     var ResultIsBoolean15 = !A.foo();
     var ResultIsBoolean16 = !(ANY + ANY1);
     var ResultIsBoolean17 = !(null + undefined);
-                              ~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                     ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsBoolean18 = !(null + null);
-                              ~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+                              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                     ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var ResultIsBoolean19 = !(undefined + undefined);
-                              ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                                          ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     
     // multiple ! operators
     var ResultIsBoolean20 = !!ANY;

--- a/tests/baselines/reference/moduleVariableArrayIndexer.errors.txt
+++ b/tests/baselines/reference/moduleVariableArrayIndexer.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/moduleVariableArrayIndexer.ts(3,13): error TS2532: Object is possibly 'undefined'.
+
+
+==== tests/cases/compiler/moduleVariableArrayIndexer.ts (1 errors) ====
+    module Bar {
+        export var a = 1;
+        var t = undefined[a][a]; // CG: var t = undefined[Bar.a][a];
+                ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+    }
+    

--- a/tests/baselines/reference/negateOperatorInvalidOperations.errors.txt
+++ b/tests/baselines/reference/negateOperatorInvalidOperations.errors.txt
@@ -1,12 +1,12 @@
 tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorInvalidOperations.ts(4,15): error TS1109: Expression expected.
 tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorInvalidOperations.ts(4,25): error TS1005: '=' expected.
 tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorInvalidOperations.ts(4,26): error TS1109: Expression expected.
-tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorInvalidOperations.ts(7,17): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorInvalidOperations.ts(7,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorInvalidOperations.ts(8,17): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorInvalidOperations.ts(8,24): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorInvalidOperations.ts(9,17): error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
-tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorInvalidOperations.ts(9,29): error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorInvalidOperations.ts(7,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorInvalidOperations.ts(7,24): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorInvalidOperations.ts(8,17): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorInvalidOperations.ts(8,24): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorInvalidOperations.ts(9,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorInvalidOperations.ts(9,29): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorInvalidOperations.ts(12,14): error TS1109: Expression expected.
 
 
@@ -25,19 +25,19 @@ tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperator
     // invalid expressions
     var NUMBER2 = -(null - undefined);
                     ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                            ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     var NUMBER3 = -(null - null);
                     ~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
                            ~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2531: Object is possibly 'null'.
     var NUMBER4 = -(undefined - undefined);
                     ~~~~~~~~~
-!!! error TS2362: The left-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
                                 ~~~~~~~~~
-!!! error TS2363: The right-hand side of an arithmetic operation must be of type 'any', 'number' or an enum type.
+!!! error TS2532: Object is possibly 'undefined'.
     
     // miss operand
     var NUMBER =-;

--- a/tests/baselines/reference/negateOperatorWithAnyOtherType.errors.txt
+++ b/tests/baselines/reference/negateOperatorWithAnyOtherType.errors.txt
@@ -1,7 +1,9 @@
+tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithAnyOtherType.ts(34,24): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithAnyOtherType.ts(35,23): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithAnyOtherType.ts(51,1): error TS2695: Left side of comma operator is unused and has no side effects.
 
 
-==== tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithAnyOtherType.ts (1 errors) ====
+==== tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperatorWithAnyOtherType.ts (3 errors) ====
     // - operator on any type
     
     var ANY: any;
@@ -36,7 +38,11 @@ tests/cases/conformance/expressions/unaryOperators/negateOperator/negateOperator
     
     // any type literal
     var ResultIsNumber7 = -undefined;
+                           ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsNumber = -null;
+                          ~~~~
+!!! error TS2531: Object is possibly 'null'.
     
     // any type expressions
     var ResultIsNumber8 = -ANY2[0];

--- a/tests/baselines/reference/nonPrimitiveStrictNull.errors.txt
+++ b/tests/baselines/reference/nonPrimitiveStrictNull.errors.txt
@@ -12,21 +12,17 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(22,5): erro
   Type 'null' is not assignable to type 'object'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(27,5): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(29,5): error TS2532: Object is possibly 'undefined'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(29,7): error TS2339: Property 'toString' does not exist on type 'never'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(33,5): error TS2533: Object is possibly 'null' or 'undefined'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(33,7): error TS2339: Property 'toString' does not exist on type 'never'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(39,5): error TS2531: Object is possibly 'null'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(39,7): error TS2339: Property 'toString' does not exist on type 'never'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(41,5): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(45,5): error TS2532: Object is possibly 'undefined'.
-tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(45,7): error TS2339: Property 'toString' does not exist on type 'never'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(47,5): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(52,14): error TS2344: Type 'number' does not satisfy the constraint 'object'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(53,14): error TS2344: Type 'null' does not satisfy the constraint 'object'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(54,14): error TS2344: Type 'undefined' does not satisfy the constraint 'object'.
 
 
-==== tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts (22 errors) ====
+==== tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts (18 errors) ====
     
     var a: object
     declare var b: object | null
@@ -80,16 +76,12 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(54,14): err
         d.toString(); // error, undefined
         ~
 !!! error TS2532: Object is possibly 'undefined'.
-          ~~~~~~~~
-!!! error TS2339: Property 'toString' does not exist on type 'never'.
     }
     
     if (d == null) {
         d.toString(); // error, undefined | null
         ~
 !!! error TS2533: Object is possibly 'null' or 'undefined'.
-          ~~~~~~~~
-!!! error TS2339: Property 'toString' does not exist on type 'never'.
     } else {
         d.toString(); // object
     }
@@ -98,8 +90,6 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(54,14): err
         d.toString(); // error, null
         ~
 !!! error TS2531: Object is possibly 'null'.
-          ~~~~~~~~
-!!! error TS2339: Property 'toString' does not exist on type 'never'.
     } else {
         d.toString(); // error, object | undefined
         ~
@@ -110,8 +100,6 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveStrictNull.ts(54,14): err
         d.toString(); // error, undefined
         ~
 !!! error TS2532: Object is possibly 'undefined'.
-          ~~~~~~~~
-!!! error TS2339: Property 'toString' does not exist on type 'never'.
     } else {
         d.toString(); // error, object | null
         ~

--- a/tests/baselines/reference/null.errors.txt
+++ b/tests/baselines/reference/null.errors.txt
@@ -1,0 +1,28 @@
+tests/cases/compiler/null.ts(4,9): error TS2531: Object is possibly 'null'.
+
+
+==== tests/cases/compiler/null.ts (1 errors) ====
+    
+    var x=null; 
+    var y=3+x;  
+    var z=3+null; 
+            ~~~~
+!!! error TS2531: Object is possibly 'null'.
+    class C {
+    }
+    function f() {
+        return null;
+        return new C();
+    }
+    function g() {
+        return null;
+        return 3;
+    }
+    interface I {
+        x:any;
+        y:number;
+    }
+    var w:I={x:null,y:3};
+    
+    
+    

--- a/tests/baselines/reference/nullKeyword.errors.txt
+++ b/tests/baselines/reference/nullKeyword.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/compiler/nullKeyword.ts(1,6): error TS2339: Property 'foo' does not exist on type 'null'.
+tests/cases/compiler/nullKeyword.ts(1,1): error TS2531: Object is possibly 'null'.
 
 
 ==== tests/cases/compiler/nullKeyword.ts (1 errors) ====
     null.foo;
-         ~~~
-!!! error TS2339: Property 'foo' does not exist on type 'null'.
+    ~~~~
+!!! error TS2531: Object is possibly 'null'.

--- a/tests/baselines/reference/operatorAddNullUndefined.errors.txt
+++ b/tests/baselines/reference/operatorAddNullUndefined.errors.txt
@@ -1,32 +1,68 @@
-tests/cases/compiler/operatorAddNullUndefined.ts(2,10): error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
-tests/cases/compiler/operatorAddNullUndefined.ts(3,10): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
-tests/cases/compiler/operatorAddNullUndefined.ts(4,10): error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
-tests/cases/compiler/operatorAddNullUndefined.ts(5,10): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/compiler/operatorAddNullUndefined.ts(2,10): error TS2531: Object is possibly 'null'.
+tests/cases/compiler/operatorAddNullUndefined.ts(2,17): error TS2531: Object is possibly 'null'.
+tests/cases/compiler/operatorAddNullUndefined.ts(3,10): error TS2531: Object is possibly 'null'.
+tests/cases/compiler/operatorAddNullUndefined.ts(3,17): error TS2532: Object is possibly 'undefined'.
+tests/cases/compiler/operatorAddNullUndefined.ts(4,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/compiler/operatorAddNullUndefined.ts(4,22): error TS2531: Object is possibly 'null'.
+tests/cases/compiler/operatorAddNullUndefined.ts(5,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/compiler/operatorAddNullUndefined.ts(5,22): error TS2532: Object is possibly 'undefined'.
+tests/cases/compiler/operatorAddNullUndefined.ts(6,14): error TS2531: Object is possibly 'null'.
+tests/cases/compiler/operatorAddNullUndefined.ts(7,14): error TS2532: Object is possibly 'undefined'.
+tests/cases/compiler/operatorAddNullUndefined.ts(8,10): error TS2531: Object is possibly 'null'.
+tests/cases/compiler/operatorAddNullUndefined.ts(9,10): error TS2532: Object is possibly 'undefined'.
+tests/cases/compiler/operatorAddNullUndefined.ts(14,11): error TS2531: Object is possibly 'null'.
+tests/cases/compiler/operatorAddNullUndefined.ts(15,11): error TS2532: Object is possibly 'undefined'.
+tests/cases/compiler/operatorAddNullUndefined.ts(16,17): error TS2531: Object is possibly 'null'.
+tests/cases/compiler/operatorAddNullUndefined.ts(17,17): error TS2532: Object is possibly 'undefined'.
 
 
-==== tests/cases/compiler/operatorAddNullUndefined.ts (4 errors) ====
+==== tests/cases/compiler/operatorAddNullUndefined.ts (16 errors) ====
     enum E { x }
     var x1 = null + null;
-             ~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var x2 = null + undefined;
-             ~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var x3 = undefined + null;
-             ~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                         ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var x4 = undefined + undefined;
-             ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                         ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var x5 = 1 + null;
+                 ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var x6 = 1 + undefined;
+                 ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var x7 = null + 1;
+             ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var x8 = undefined + 1;
+             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var x9 = "test" + null;
     var x10 = "test" + undefined;
     var x11 = null + "test";
     var x12 = undefined + "test";
     var x13 = null + E.x
+              ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var x14 = undefined + E.x
+              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var x15 = E.x + null
+                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var x16 = E.x + undefined
+                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.

--- a/tests/baselines/reference/plusOperatorWithAnyOtherType.errors.txt
+++ b/tests/baselines/reference/plusOperatorWithAnyOtherType.errors.txt
@@ -1,10 +1,13 @@
-tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts(46,26): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
-tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts(47,26): error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
-tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts(48,26): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts(46,26): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts(46,33): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts(47,26): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts(47,33): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts(48,26): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts(48,38): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts(54,1): error TS2695: Left side of comma operator is unused and has no side effects.
 
 
-==== tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts (4 errors) ====
+==== tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts (7 errors) ====
     // + operator on any type
     
     var ANY: any;
@@ -51,14 +54,20 @@ tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWith
     var ResultIsNumber15 = +A.foo();
     var ResultIsNumber16 = +(ANY + ANY1);
     var ResultIsNumber17 = +(null + undefined);
-                             ~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsNumber18 = +(null + null);
-                             ~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+                             ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                    ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var ResultIsNumber19 = +(undefined + undefined);
-                             ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                             ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                                         ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     
     // miss assignment operators
     +ANY;

--- a/tests/baselines/reference/plusOperatorWithAnyOtherType.errors.txt
+++ b/tests/baselines/reference/plusOperatorWithAnyOtherType.errors.txt
@@ -1,3 +1,5 @@
+tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts(34,24): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts(35,24): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts(46,26): error TS2531: Object is possibly 'null'.
 tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts(46,33): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts(47,26): error TS2531: Object is possibly 'null'.
@@ -7,7 +9,7 @@ tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWith
 tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts(54,1): error TS2695: Left side of comma operator is unused and has no side effects.
 
 
-==== tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts (7 errors) ====
+==== tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWithAnyOtherType.ts (9 errors) ====
     // + operator on any type
     
     var ANY: any;
@@ -42,7 +44,11 @@ tests/cases/conformance/expressions/unaryOperators/plusOperator/plusOperatorWith
     
     // any type literal
     var ResultIsNumber7 = +undefined;
+                           ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsNumber8 = +null;
+                           ~~~~
+!!! error TS2531: Object is possibly 'null'.
     
     // any type expressions
     var ResultIsNumber9 = +ANY2[0];

--- a/tests/baselines/reference/propertyAccess4.errors.txt
+++ b/tests/baselines/reference/propertyAccess4.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/compiler/propertyAccess4.ts(1,6): error TS2339: Property 'toBAZ' does not exist on type 'null'.
+tests/cases/compiler/propertyAccess4.ts(1,1): error TS2531: Object is possibly 'null'.
 
 
 ==== tests/cases/compiler/propertyAccess4.ts (1 errors) ====
     null.toBAZ();
-         ~~~~~
-!!! error TS2339: Property 'toBAZ' does not exist on type 'null'.
+    ~~~~
+!!! error TS2531: Object is possibly 'null'.

--- a/tests/baselines/reference/propertyAccess5.errors.txt
+++ b/tests/baselines/reference/propertyAccess5.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/compiler/propertyAccess5.ts(1,11): error TS2339: Property 'toBAZ' does not exist on type 'undefined'.
+tests/cases/compiler/propertyAccess5.ts(1,1): error TS2532: Object is possibly 'undefined'.
 
 
 ==== tests/cases/compiler/propertyAccess5.ts (1 errors) ====
     undefined.toBAZ();
-              ~~~~~
-!!! error TS2339: Property 'toBAZ' does not exist on type 'undefined'.
+    ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.

--- a/tests/baselines/reference/typeofOperatorWithAnyOtherType.errors.txt
+++ b/tests/baselines/reference/typeofOperatorWithAnyOtherType.errors.txt
@@ -1,6 +1,9 @@
-tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithAnyOtherType.ts(46,32): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
-tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithAnyOtherType.ts(47,32): error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
-tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithAnyOtherType.ts(48,32): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithAnyOtherType.ts(46,32): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithAnyOtherType.ts(46,39): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithAnyOtherType.ts(47,32): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithAnyOtherType.ts(47,39): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithAnyOtherType.ts(48,32): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithAnyOtherType.ts(48,44): error TS2532: Object is possibly 'undefined'.
 tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithAnyOtherType.ts(58,1): error TS2695: Left side of comma operator is unused and has no side effects.
 tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithAnyOtherType.ts(68,1): error TS7028: Unused label.
 tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithAnyOtherType.ts(69,1): error TS7028: Unused label.
@@ -11,7 +14,7 @@ tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperator
 tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithAnyOtherType.ts(74,1): error TS7028: Unused label.
 
 
-==== tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithAnyOtherType.ts (11 errors) ====
+==== tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperatorWithAnyOtherType.ts (14 errors) ====
     // typeof  operator on any type
     
     var ANY: any;
@@ -58,14 +61,20 @@ tests/cases/conformance/expressions/unaryOperators/typeofOperator/typeofOperator
     var ResultIsString15 = typeof A.foo();
     var ResultIsString16 = typeof (ANY + ANY1);
     var ResultIsString17 = typeof (null + undefined);
-                                   ~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                          ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsString18 = typeof (null + null);
-                                   ~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+                                   ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                          ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var ResultIsString19 = typeof (undefined + undefined);
-                                   ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                                   ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                                               ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     
     // multiple typeof  operators
     var ResultIsString20 = typeof typeof ANY;

--- a/tests/baselines/reference/voidOperatorWithAnyOtherType.errors.txt
+++ b/tests/baselines/reference/voidOperatorWithAnyOtherType.errors.txt
@@ -1,9 +1,12 @@
-tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithAnyOtherType.ts(46,27): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
-tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithAnyOtherType.ts(47,27): error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
-tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithAnyOtherType.ts(48,27): error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithAnyOtherType.ts(46,27): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithAnyOtherType.ts(46,34): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithAnyOtherType.ts(47,27): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithAnyOtherType.ts(47,34): error TS2531: Object is possibly 'null'.
+tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithAnyOtherType.ts(48,27): error TS2532: Object is possibly 'undefined'.
+tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithAnyOtherType.ts(48,39): error TS2532: Object is possibly 'undefined'.
 
 
-==== tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithAnyOtherType.ts (3 errors) ====
+==== tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWithAnyOtherType.ts (6 errors) ====
     // void  operator on any type
     
     var ANY: any;
@@ -50,14 +53,20 @@ tests/cases/conformance/expressions/unaryOperators/voidOperator/voidOperatorWith
     var ResultIsAny15 = void A.foo();
     var ResultIsAny16 = void (ANY + ANY1);
     var ResultIsAny17 = void (null + undefined);
-                              ~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                     ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     var ResultIsAny18 = void (null + null);
-                              ~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'null' and 'null'.
+                              ~~~~
+!!! error TS2531: Object is possibly 'null'.
+                                     ~~~~
+!!! error TS2531: Object is possibly 'null'.
     var ResultIsAny19 = void (undefined + undefined);
-                              ~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2365: Operator '+' cannot be applied to types 'undefined' and 'undefined'.
+                              ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
+                                          ~~~~~~~~~
+!!! error TS2532: Object is possibly 'undefined'.
     
     // multiple void  operators
     var ResultIsAny20 = void void ANY;

--- a/tests/baselines/reference/widenedTypes.errors.txt
+++ b/tests/baselines/reference/widenedTypes.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/compiler/widenedTypes.ts(2,1): error TS2358: The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter.
-tests/cases/compiler/widenedTypes.ts(6,7): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter
+tests/cases/compiler/widenedTypes.ts(5,1): error TS2531: Object is possibly 'null'.
+tests/cases/compiler/widenedTypes.ts(6,7): error TS2531: Object is possibly 'null'.
 tests/cases/compiler/widenedTypes.ts(8,15): error TS2531: Object is possibly 'null'.
 tests/cases/compiler/widenedTypes.ts(10,14): error TS2695: Left side of comma operator is unused and has no side effects.
 tests/cases/compiler/widenedTypes.ts(11,1): error TS2322: Type '""' is not assignable to type 'number'.
@@ -11,7 +12,7 @@ tests/cases/compiler/widenedTypes.ts(24,5): error TS2322: Type '{ x: number; y: 
     Type 'number' is not assignable to type 'string'.
 
 
-==== tests/cases/compiler/widenedTypes.ts (8 errors) ====
+==== tests/cases/compiler/widenedTypes.ts (9 errors) ====
     
     null instanceof (() => { });
     ~~~~
@@ -19,9 +20,11 @@ tests/cases/compiler/widenedTypes.ts(24,5): error TS2322: Type '{ x: number; y: 
     ({}) instanceof null; // Ok because null is a subtype of function
     
     null in {};
+    ~~~~
+!!! error TS2531: Object is possibly 'null'.
     "" in null;
           ~~~~
-!!! error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter
+!!! error TS2531: Object is possibly 'null'.
     
     for (var a in null) { }
                   ~~~~

--- a/tests/baselines/reference/widenedTypes.errors.txt
+++ b/tests/baselines/reference/widenedTypes.errors.txt
@@ -1,6 +1,6 @@
 tests/cases/compiler/widenedTypes.ts(2,1): error TS2358: The left-hand side of an 'instanceof' expression must be of type 'any', an object type or a type parameter.
 tests/cases/compiler/widenedTypes.ts(6,7): error TS2361: The right-hand side of an 'in' expression must be of type 'any', an object type or a type parameter
-tests/cases/compiler/widenedTypes.ts(8,15): error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
+tests/cases/compiler/widenedTypes.ts(8,15): error TS2531: Object is possibly 'null'.
 tests/cases/compiler/widenedTypes.ts(10,14): error TS2695: Left side of comma operator is unused and has no side effects.
 tests/cases/compiler/widenedTypes.ts(11,1): error TS2322: Type '""' is not assignable to type 'number'.
 tests/cases/compiler/widenedTypes.ts(18,1): error TS2322: Type '""' is not assignable to type 'number'.
@@ -25,7 +25,7 @@ tests/cases/compiler/widenedTypes.ts(24,5): error TS2322: Type '{ x: number; y: 
     
     for (var a in null) { }
                   ~~~~
-!!! error TS2407: The right-hand side of a 'for...in' statement must be of type 'any', an object type or a type parameter.
+!!! error TS2531: Object is possibly 'null'.
     
     var t = [3, (3, null)];
                  ~


### PR DESCRIPTION
This PR improves our checking of nullable operands in expressions. Specifically, we now error in the following cases:

* If either operand of a `+` operator is nullable, and neither operand is of type `any` or `string`.
* If either operand of a `-`, `*`, `**`, `/`, `%`, `<<`, `>>`, `>>>`, `&`, `|`, or `^` operator is nullable.
* If either operand of a `<`, `>`, `<=`, `>=`, or `in` operator is nullable.
* If the right operand of an `instanceof` operator is nullable.
* If the operand of a `+`, `-`, `~`, `++`, or `--` unary operator is nullable.

An operand is considered nullable if the type of the operand is `null` or `undefined` or a union type that includes `null` or `undefined`. Note that the union type case only only occurs in `--strictNullChecks` mode because `null` and `undefined` disappear from unions in classic type checking mode.

Fixes #12795.