### PR TITLE
fix: patch more functions for ObjectKeyword

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -350,6 +350,7 @@ namespace ts {
                 case SyntaxKind.UndefinedKeyword:
                 case SyntaxKind.FromKeyword:
                 case SyntaxKind.GlobalKeyword:
+                case SyntaxKind.ObjectKeyword:
                 case SyntaxKind.OfKeyword:
                     writeTokenText(kind);
                     return;

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -320,6 +320,7 @@ namespace ts {
                 case SyntaxKind.NeverKeyword:
                 case SyntaxKind.VoidKeyword:
                 case SyntaxKind.SymbolKeyword:
+                case SyntaxKind.ObjectKeyword:
                 case SyntaxKind.ConstructorType:
                 case SyntaxKind.FunctionType:
                 case SyntaxKind.TypeQuery:
@@ -1687,6 +1688,9 @@ namespace ts {
 
                 case SyntaxKind.StringKeyword:
                     return createIdentifier("String");
+
+                case SyntaxKind.ObjectKeyword:
+                    return createIdentifier("Object");
 
                 case SyntaxKind.LiteralType:
                     switch ((<LiteralTypeNode>node).literal.kind) {

--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -1,4 +1,4 @@
-﻿/// <reference path="../factory.ts" />
+/// <reference path="../factory.ts" />
 /// <reference path="../visitor.ts" />
 /// <reference path="./destructuring.ts" />
 
@@ -1689,9 +1689,6 @@ namespace ts {
                 case SyntaxKind.StringKeyword:
                     return createIdentifier("String");
 
-                case SyntaxKind.ObjectKeyword:
-                    return createIdentifier("Object");
-
                 case SyntaxKind.LiteralType:
                     switch ((<LiteralTypeNode>node).literal.kind) {
                         case SyntaxKind.StringLiteral:
@@ -1732,6 +1729,7 @@ namespace ts {
                 case SyntaxKind.TypeLiteral:
                 case SyntaxKind.AnyKeyword:
                 case SyntaxKind.ThisType:
+                case SyntaxKind.ObjectKeyword:
                     break;
 
                 default:

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -660,6 +660,7 @@ namespace ts {
             case SyntaxKind.SymbolKeyword:
             case SyntaxKind.UndefinedKeyword:
             case SyntaxKind.NeverKeyword:
+            case SyntaxKind.ObjectKeyword:
                 return true;
             case SyntaxKind.VoidKeyword:
                 return node.parent.kind !== SyntaxKind.VoidExpression;
@@ -3732,6 +3733,7 @@ namespace ts {
             || kind === SyntaxKind.SymbolKeyword
             || kind === SyntaxKind.VoidKeyword
             || kind === SyntaxKind.NeverKeyword
+            || kind === SyntaxKind.ObjectKeyword
             || kind === SyntaxKind.ExpressionWithTypeArguments;
     }
 

--- a/src/services/formatting/tokenRange.ts
+++ b/src/services/formatting/tokenRange.ts
@@ -120,7 +120,7 @@ namespace ts.formatting {
             static UnaryPredecrementExpressions = TokenRange.FromTokens([SyntaxKind.Identifier, SyntaxKind.OpenParenToken, SyntaxKind.ThisKeyword, SyntaxKind.NewKeyword]);
             static UnaryPostdecrementExpressions = TokenRange.FromTokens([SyntaxKind.Identifier, SyntaxKind.CloseParenToken, SyntaxKind.CloseBracketToken, SyntaxKind.NewKeyword]);
             static Comments = TokenRange.FromTokens([SyntaxKind.SingleLineCommentTrivia, SyntaxKind.MultiLineCommentTrivia]);
-            static TypeNames = TokenRange.FromTokens([SyntaxKind.Identifier, SyntaxKind.NumberKeyword, SyntaxKind.StringKeyword, SyntaxKind.BooleanKeyword, SyntaxKind.SymbolKeyword, SyntaxKind.VoidKeyword, SyntaxKind.AnyKeyword]);
+            static TypeNames = TokenRange.FromTokens([SyntaxKind.Identifier, SyntaxKind.NumberKeyword, SyntaxKind.StringKeyword, SyntaxKind.BooleanKeyword, SyntaxKind.SymbolKeyword, SyntaxKind.VoidKeyword, SyntaxKind.AnyKeyword, SyntaxKind.ObjectKeyword]);
         }
     }
 }

--- a/tests/baselines/reference/decoratorMetadata.js
+++ b/tests/baselines/reference/decoratorMetadata.js
@@ -18,6 +18,18 @@ class MyComponent {
     }
 }
 
+
+@decorator
+class NonPrimitiveComponent {
+    constructor(public obj: object) {
+    }
+
+    @decorator
+    method(x: object) {
+    }
+}
+
+
 //// [service.js]
 "use strict";
 var Service = (function () {
@@ -57,3 +69,21 @@ MyComponent = __decorate([
     decorator,
     __metadata("design:paramtypes", [service_1.default])
 ], MyComponent);
+var NonPrimitiveComponent = (function () {
+    function NonPrimitiveComponent(obj) {
+        this.obj = obj;
+    }
+    NonPrimitiveComponent.prototype.method = function (x) {
+    };
+    return NonPrimitiveComponent;
+}());
+__decorate([
+    decorator,
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", [Object]),
+    __metadata("design:returntype", void 0)
+], NonPrimitiveComponent.prototype, "method", null);
+NonPrimitiveComponent = __decorate([
+    decorator,
+    __metadata("design:paramtypes", [Object])
+], NonPrimitiveComponent);

--- a/tests/baselines/reference/decoratorMetadata.symbols
+++ b/tests/baselines/reference/decoratorMetadata.symbols
@@ -28,3 +28,24 @@ class MyComponent {
 >x : Symbol(x, Decl(component.ts, 10, 11))
     }
 }
+
+
+@decorator
+>decorator : Symbol(decorator, Decl(component.ts, 2, 11))
+
+class NonPrimitiveComponent {
+>NonPrimitiveComponent : Symbol(NonPrimitiveComponent, Decl(component.ts, 12, 1))
+
+    constructor(public obj: object) {
+>obj : Symbol(NonPrimitiveComponent.obj, Decl(component.ts, 17, 16))
+    }
+
+    @decorator
+>decorator : Symbol(decorator, Decl(component.ts, 2, 11))
+
+    method(x: object) {
+>method : Symbol(NonPrimitiveComponent.method, Decl(component.ts, 18, 5))
+>x : Symbol(x, Decl(component.ts, 21, 11))
+    }
+}
+

--- a/tests/baselines/reference/decoratorMetadata.types
+++ b/tests/baselines/reference/decoratorMetadata.types
@@ -28,3 +28,24 @@ class MyComponent {
 >x : this
     }
 }
+
+
+@decorator
+>decorator : any
+
+class NonPrimitiveComponent {
+>NonPrimitiveComponent : NonPrimitiveComponent
+
+    constructor(public obj: object) {
+>obj : object
+    }
+
+    @decorator
+>decorator : any
+
+    method(x: object) {
+>method : (x: object) => void
+>x : object
+    }
+}
+

--- a/tests/cases/conformance/decorators/decoratorMetadata.ts
+++ b/tests/cases/conformance/decorators/decoratorMetadata.ts
@@ -19,3 +19,14 @@ class MyComponent {
     method(x: this) {
     }
 }
+
+
+@decorator
+class NonPrimitiveComponent {
+    constructor(public obj: object) {
+    }
+
+    @decorator
+    method(x: object) {
+    }
+}


### PR DESCRIPTION
Related to #13505 

This pull request patches more functions for ObjectKeyword. It includes
 * formatting: add `object` as `TypeName` 
 * transformation: explicitly strip `object` keyword 
 * emitter: explicit emit `Object` type for decorator metadata 
 * utility: add `object` as TypeNode 

 @rbuckton @andy-ms @sandersn 
I really appreciate your review when you are available 😃 