### PR TITLE
Move `"types": []` to tsconfig-base

### DIFF
--- a/src/compiler/tsconfig.json
+++ b/src/compiler/tsconfig.json
@@ -3,8 +3,7 @@
     "compilerOptions": {
         "removeComments": true,
         "outFile": "../../built/local/tsc.js",
-        "declaration": true,
-        "types": [ ]
+        "declaration": true
     },
     "files": [
         "core.ts",

--- a/src/services/tsconfig.json
+++ b/src/services/tsconfig.json
@@ -3,8 +3,7 @@
     "compilerOptions": {
         "removeComments": false,
         "outFile": "../../built/local/typescriptServices.js",
-        "declaration": true,
-        "types": []
+        "declaration": true
     },
     "files": [
         "../compiler/core.ts",

--- a/src/tsconfig-base.json
+++ b/src/tsconfig-base.json
@@ -9,6 +9,7 @@
         "preserveConstEnums": true,
         "stripInternal": true,
         "sourceMap": true,
-        "target": "es5"
+        "target": "es5",
+        "types": []
     }
 }


### PR DESCRIPTION
We were getting warnings because the compilation of `processDiagnosticMessages.ts` was pulling in types unnecessarily. tsconfig-base is also used when compiling `processDiagnosticMessages.ts`, which doesn't have its own `tsconfig.json`, but does have compiler options added from tsconfig-base in the gulpfile. (See #13451.)