### PR TITLE
List position based formatting

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -716,7 +716,7 @@ namespace ts.formatting {
                 let startLine = parentStartLine;
                 let indentationOnListStartToken = parentDynamicIndentation.getIndentation();
 
-                if (listStartToken !== SyntaxKind.Unknown) {
+                if (listStartToken !== SyntaxKind.Unknown && nodes.end !== undefined /* TODO: nodes.end must not be `undefined` */) {
                     // introduce a new indentation scope for lists (including list start and end tokens)
                     while (formattingScanner.isOnToken()) {
                         const tokenInfo = formattingScanner.readTokenInfo(parent);

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -31,7 +31,7 @@ namespace ts.formatting {
      * the first token in line so it should be indented
      */
     interface DynamicIndentation {
-        getIndentationForToken(tokenLine: number, tokenKind: SyntaxKind, container: Node): number;
+        getIndentationForToken(tokenLine: number, tokenKind: SyntaxKind, container: Node, suppressDelta: boolean): number;
         getIndentationForComment(owningToken: SyntaxKind, tokenIndentation: number, container: Node): number;
         /**
          * Indentation for open and close tokens of the node if it is block or another node that needs special indentation
@@ -369,7 +369,7 @@ namespace ts.formatting {
         let previousRangeStartLine: number;
 
         let lastIndentedLine: number;
-        let indentationOnLastIndentedLine: number;
+        let indentationOnLastIndentedLine = Constants.Unknown;
 
         const edits: TextChange[] = [];
 
@@ -506,7 +506,7 @@ namespace ts.formatting {
                     }
                     return tokenIndentation !== Constants.Unknown ? tokenIndentation : indentation;
                 },
-                getIndentationForToken: (line, kind, container) => {
+                getIndentationForToken: (line, kind, container, suppressDelta) => {
                     if (nodeStartLine !== line && node.decorators) {
                         if (kind === getFirstNonDecoratorTokenOfNode(node)) {
                             // if this token is the first token following the list of decorators, we do not need to indent
@@ -517,7 +517,6 @@ namespace ts.formatting {
                         // open and close brace, 'else' and 'while' (in do statement) tokens has indentation of the parent
                         case SyntaxKind.OpenBraceToken:
                         case SyntaxKind.CloseBraceToken:
-                        case SyntaxKind.OpenParenToken:
                         case SyntaxKind.CloseParenToken:
                         case SyntaxKind.ElseKeyword:
                         case SyntaxKind.WhileKeyword:
@@ -541,8 +540,23 @@ namespace ts.formatting {
                             break;
                         }
                     }
-                    // if token line equals to the line of containing node (this is a first token in the node) - use node indentation
-                    return nodeStartLine !== line ? indentation + getEffectiveDelta(delta, container) : indentation;
+                    if (suppressDelta) {
+                        // if list end token is LessThanToken '>' then its delta should be explicitly suppressed
+                        // so that LessThanToken as a binary operator can still be indented.
+                        // foo.then
+                        //     <
+                        //         number,
+                        //         string,
+                        //     >();
+                        // vs
+                        // var a = xValue
+                        //     > yValue;
+                        return indentation;
+                    }
+                    else {
+                        // if token line equals to the line of containing node (this is a first token in the node) - use node indentation
+                        return nodeStartLine !== line ? indentation + getEffectiveDelta(delta, container) : indentation;
+                    }
                 },
                 getIndentation: () => indentation,
                 getDelta: child => getEffectiveDelta(delta, child),
@@ -700,6 +714,7 @@ namespace ts.formatting {
 
                 let listDynamicIndentation = parentDynamicIndentation;
                 let startLine = parentStartLine;
+                let indentationOnListStartToken = parentDynamicIndentation.getIndentation();
 
                 if (listStartToken !== SyntaxKind.Unknown) {
                     // introduce a new indentation scope for lists (including list start and end tokens)
@@ -712,11 +727,22 @@ namespace ts.formatting {
                         else if (tokenInfo.token.kind === listStartToken) {
                             // consume list start token
                             startLine = sourceFile.getLineAndCharacterOfPosition(tokenInfo.token.pos).line;
-                            const indentation =
-                                computeIndentation(tokenInfo.token, startLine, Constants.Unknown, parent, parentDynamicIndentation, parentStartLine);
 
-                            listDynamicIndentation = getDynamicIndentation(parent, parentStartLine, indentation.indentation, indentation.delta);
-                            consumeTokenAndAdvanceScanner(tokenInfo, parent, listDynamicIndentation, parent);
+                            consumeTokenAndAdvanceScanner(tokenInfo, parent, parentDynamicIndentation, parent);
+
+                            if (indentationOnLastIndentedLine !== Constants.Unknown) {
+                                // scanner just processed list start token so consider last indentation as list indentation
+                                // function foo(): { // last indentation was 0, list item will be indented based on this value
+                                //   foo: number;
+                                // }: {};
+                                indentationOnListStartToken = indentationOnLastIndentedLine;
+                            }
+                            else {
+                                const startLinePosition = getLineStartPositionForPosition(tokenInfo.token.pos, sourceFile);
+                                indentationOnListStartToken = SmartIndenter.findFirstNonWhitespaceColumn(startLinePosition, tokenInfo.token.pos, sourceFile, options);
+                            }
+
+                            listDynamicIndentation = getDynamicIndentation(parent, parentStartLine, indentationOnListStartToken, options.indentSize);
                         }
                         else {
                             // consume any tokens that precede the list as child elements of 'node' using its indentation scope
@@ -740,13 +766,13 @@ namespace ts.formatting {
                         // without this check close paren will be interpreted as list end token for function expression which is wrong
                         if (tokenInfo.token.kind === listEndToken && rangeContainsRange(parent, tokenInfo.token)) {
                             // consume list end token
-                            consumeTokenAndAdvanceScanner(tokenInfo, parent, listDynamicIndentation, parent);
+                            consumeTokenAndAdvanceScanner(tokenInfo, parent, listDynamicIndentation, parent, /*isListEndToken*/ true);
                         }
                     }
                 }
             }
 
-            function consumeTokenAndAdvanceScanner(currentTokenInfo: TokenInfo, parent: Node, dynamicIndentation: DynamicIndentation, container: Node): void {
+            function consumeTokenAndAdvanceScanner(currentTokenInfo: TokenInfo, parent: Node, dynamicIndentation: DynamicIndentation, container: Node, isListEndToken?: boolean): void {
                 Debug.assert(rangeContainsRange(parent, currentTokenInfo.token));
 
                 const lastTriviaWasNewLine = formattingScanner.lastTrailingTriviaWasNewLine();
@@ -787,7 +813,7 @@ namespace ts.formatting {
 
                 if (indentToken) {
                     const tokenIndentation = (isTokenInRange && !rangeContainsError(currentTokenInfo.token)) ?
-                        dynamicIndentation.getIndentationForToken(tokenStart.line, currentTokenInfo.token.kind, container) :
+                        dynamicIndentation.getIndentationForToken(tokenStart.line, currentTokenInfo.token.kind, container, isListEndToken) :
                         Constants.Unknown;
 
                     let indentNextTokenOrTrivia = true;
@@ -1145,6 +1171,9 @@ namespace ts.formatting {
                 if ((<TypeReferenceNode>node).typeArguments === list) {
                     return SyntaxKind.LessThanToken;
                 }
+                break;
+            case SyntaxKind.TypeLiteral:
+                return SyntaxKind.OpenBraceToken;
         }
 
         return SyntaxKind.Unknown;
@@ -1156,6 +1185,8 @@ namespace ts.formatting {
                 return SyntaxKind.CloseParenToken;
             case SyntaxKind.LessThanToken:
                 return SyntaxKind.GreaterThanToken;
+            case SyntaxKind.OpenBraceToken:
+                return SyntaxKind.CloseBraceToken;
         }
 
         return SyntaxKind.Unknown;

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -72,6 +72,12 @@ namespace ts.formatting {
                 }
             }
 
+            const containerList = getListByPosition(position, precedingToken.parent);
+            // use list position if the preceding token is before any list items
+            if (containerList && !rangeContainsRange(containerList, precedingToken)) {
+                return getActualIndentationForListStartLine(containerList, sourceFile, options) + options.indentSize;
+            }
+
             // try to find node that can contribute to indentation and includes 'position' starting from 'precedingToken'
             // if such node is found - compute initial indentation for 'position' inside this node
             let previous: Node;
@@ -340,6 +346,13 @@ namespace ts.formatting {
                 case SyntaxKind.NamedExports:
                     return getListIfVisualStartEndIsInListRange((<NamedImportsOrExports>node).elements, start, end, node);
             }
+        }
+
+        function getActualIndentationForListStartLine(list: NodeArray<Node>, sourceFile: SourceFile, options: EditorSettings): number {
+            if (!list) {
+                return Value.Unknown;
+            }
+            return findColumnForFirstNonWhitespaceCharacterInLine(sourceFile.getLineAndCharacterOfPosition(list.pos), sourceFile, options);
         }
 
         function getActualIndentationForListItem(node: Node, sourceFile: SourceFile, options: EditorSettings): number {

--- a/tests/cases/fourslash/formattingOnChainedCallbacks.ts
+++ b/tests/cases/fourslash/formattingOnChainedCallbacks.ts
@@ -20,6 +20,50 @@
 ////    /*n2*/
 ////    .then();
 
+// @Filename: listSmart.ts
+////Promise
+////    .resolve().then(
+////    /*listSmart1*/
+////    3,
+////    /*listSmart2*/
+////    [
+////        3
+////        /*listSmart3*/
+////    ]
+////    /*listSmart4*/
+////    );
+
+// @Filename: listZeroIndent.ts
+////Promise.resolve([
+////]).then(
+////    /*listZeroIndent1*/
+////    [
+////    /*listZeroIndent2*/
+////        3
+////    ]
+////    );
+
+// @Filename: listTypeParameter1.ts
+////foo.then
+////    <
+////    /*listTypeParameter1*/
+////    void
+////    /*listTypeParameter2*/
+////    >(
+////    function (): void {
+////    },
+////    function (): void {
+////    }
+////    );
+
+// @Filename: listComment.ts
+////Promise
+////    .then(
+////    // euphonium
+////    "k"
+////    // oboe
+////    );
+
 
 goTo.marker('1');
 edit.insertLine('');
@@ -50,3 +94,67 @@ goTo.marker('n1');
 verify.indentationIs(8);
 goTo.marker('n2');
 verify.indentationIs(4);
+
+goTo.file(1);
+format.document();
+verify.currentFileContentIs(`Promise
+    .resolve().then(
+
+        3,
+
+        [
+            3
+
+        ]
+
+    );`);
+goTo.marker("listSmart1");
+verify.indentationIs(8);
+goTo.marker("listSmart2");
+verify.indentationIs(8);
+goTo.marker("listSmart3");
+verify.indentationIs(12);
+goTo.marker("listSmart4");
+verify.indentationIs(8);
+
+goTo.file(2);
+format.document();
+verify.currentFileContentIs(`Promise.resolve([
+]).then(
+
+    [
+
+        3
+    ]
+);`);
+goTo.marker("listZeroIndent1");
+verify.indentationIs(4);
+goTo.marker("listZeroIndent2");
+verify.indentationIs(8);
+
+goTo.file(3);
+format.document();
+verify.currentFileContentIs(`foo.then
+    <
+
+        void
+
+    >(
+        function(): void {
+        },
+        function(): void {
+        }
+    );`);
+goTo.marker("listTypeParameter1");
+verify.indentationIs(8);
+goTo.marker("listTypeParameter2");
+verify.indentationIs(8);
+
+goTo.file(4);
+format.document();
+verify.currentFileContentIs(`Promise
+    .then(
+        // euphonium
+        "k"
+        // oboe
+    );`)

--- a/tests/cases/fourslash/formattingOnTypeLiteral.ts
+++ b/tests/cases/fourslash/formattingOnTypeLiteral.ts
@@ -1,0 +1,37 @@
+/// <reference path='fourslash.ts' />
+
+////function _uniteVertices<p extends string, a>(
+////    minority: Pinned<p, Vertex<a>>,
+////    majorityCounter: number,
+////    majority: Pinned<p, Vertex<a>>
+////): {
+////   /*start*/
+////        majorityCounter: number;
+////        vertecis: Pinned<p, {
+////            oldVertexId: VertexId;
+////            vertex: Vertex<a>;
+////        }>;
+////    /*end*/
+////    } {
+////}
+
+format.document();
+verify.currentFileContentIs(`function _uniteVertices<p extends string, a>(
+    minority: Pinned<p, Vertex<a>>,
+    majorityCounter: number,
+    majority: Pinned<p, Vertex<a>>
+): {
+
+    majorityCounter: number;
+    vertecis: Pinned<p, {
+        oldVertexId: VertexId;
+        vertex: Vertex<a>;
+    }>;
+
+} {
+}`);
+
+goTo.marker("start");
+verify.indentationIs(4);
+goTo.marker("end");
+verify.indentationIs(4);

--- a/tests/cases/fourslash/smartIndentOnListEnd.ts
+++ b/tests/cases/fourslash/smartIndentOnListEnd.ts
@@ -1,0 +1,12 @@
+﻿/// <reference path='fourslash.ts'/>
+
+////var a = []
+/////*1*/
+////| {}
+/////*2*/
+////| "";
+
+goTo.marker("1");
+verify.indentationIs(4)
+goTo.marker("2");
+verify.indentationIs(4)

--- a/tests/cases/fourslash/smartIndentOnUnclosedFunctionDeclaration04.ts
+++ b/tests/cases/fourslash/smartIndentOnUnclosedFunctionDeclaration04.ts
@@ -3,15 +3,18 @@
 ////function f<A,B,C>/*1*/(/*2*/a: A, /*3*/b:/*4*/B, c/*5*/, d: C/*6*/
 
 
-function verifyIndentationAfterNewLine(marker: string, indentation: number): void {
+function verifyIndentationAfterNewLine(marker: string, indentation: number, positionWorkaround: number, expectedText: string): void {
     goTo.marker(marker);
     edit.insert("\r\n");
+    // The next two lines are to workaround #13433
+    goTo.position(positionWorkaround);
+    verify.textAtCaretIs(expectedText);
     verify.indentationIs(indentation);
 }
 
-verifyIndentationAfterNewLine("1", 4);
-verifyIndentationAfterNewLine("2", 4);
-verifyIndentationAfterNewLine("3", 4);
-verifyIndentationAfterNewLine("4", 8);
-verifyIndentationAfterNewLine("5", 4);
-verifyIndentationAfterNewLine("6", 4);
+verifyIndentationAfterNewLine("1", 4, 25, '(');
+verifyIndentationAfterNewLine("2", 8, 36, 'a');
+verifyIndentationAfterNewLine("3", 8, 51, 'b');
+verifyIndentationAfterNewLine("4", 12, 67, 'B');
+verifyIndentationAfterNewLine("5", 8, 81, ',');
+verifyIndentationAfterNewLine("6", 8, 89, '');


### PR DESCRIPTION
Fixes #5830, fixes #5890, fixes #6252, fixes #6320, fixes #6451, fixes #10681, fixes #13688, and maybe more.

Previous behavior:

```ts
foo.then
  <
  void // list does not add indentation
  >();

foo
  .then(
  () => {}
  );

function foo(
  param1: number,
  param2: number
): {
    attribute: number // incorrectly double indented
  } {
}
```

New behavior:

```ts
foo.then
  <
    void // every list adds indentation
  >();

foo
  .then( // list starts on single-indented line
    () => {} // new formatter is list-position-sensitive, its children are now double indented
  );

function foo(
  param1: number,
  param2: number
): { // list starts on non-indented line
  attribute: number // correctly single indented
} {
}
```
