### PR TITLE
Include selected local subdirs in baseline-accept

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -1101,6 +1101,10 @@ task("tests-debug", ["setDebugMode", "tests"]);
 desc("Makes the most recent test results the new baseline, overwriting the old baseline");
 task("baseline-accept", function () {
     acceptBaseline(localBaseline, refBaseline);
+    // accept baselines from subdirs too
+    ["transpile", "JSDocParsing"].forEach(function(folder) {
+        acceptBaseline(localBaseline + folder, refBaseline + folder);
+    });
 });
 
 function acceptBaseline(sourceFolder, targetFolder) {


### PR DESCRIPTION
Working on #13217, was not able to get a transpile to test to accept, solved in response to @RyanCavanaugh https://github.com/Microsoft/TypeScript/pull/13217#issuecomment-273843791.

This PR is quick and dirty.  It may be sufficient as-is, or may elicit a discussion re: a more elegant way to do this...  Should it just be a completely recursive solution (search all subdirs), or are only selected folders intended to be named in `$ jake baseline-accept`?
