### PR TITLE
getFirstToken returns jsdoc as single comment

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -421,7 +421,7 @@
         LastBinaryOperator = CaretEqualsToken,
         FirstNode = QualifiedName,
         FirstJSDocNode = JSDocTypeExpression,
-        LastJSDocNode = JSDocLiteralType,
+        LastJSDocNode = JSDocNeverKeyword,
         FirstJSDocTagNode = JSDocComment,
         LastJSDocTagNode = JSDocNeverKeyword
     }

--- a/src/harness/unittests/jsDocParsing.ts
+++ b/src/harness/unittests/jsDocParsing.ts
@@ -288,5 +288,19 @@ namespace ts {
   */`);
             });
         });
+        describe("getFirstToken", () => {
+            it("gets jsdoc", () => {
+                const first = ts.createSourceFile("foo.ts", "/** comment */var a = true;", ts.ScriptTarget.ES5, /*setParentNodes*/ true);
+                assert.isDefined(first);
+                assert.equal(first.kind, 263);
+            });
+        });
+        describe("getLastToken", () => {
+            it("gets jsdoc", () => {
+                const last = ts.createSourceFile("foo.ts", "var a = true;/** comment */", ts.ScriptTarget.ES5, /*setParentNodes*/ true);
+                assert.isDefined(last);
+                assert.equal(last.kind, 263);
+            });
+        });
     });
 }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -194,8 +194,9 @@ namespace ts {
             }
 
             const child = children[0];
-
-            return child.kind < SyntaxKind.FirstNode ? child : child.getFirstToken(sourceFile);
+            return child.kind < SyntaxKind.FirstNode || SyntaxKind.FirstJSDocNode <= child.kind && child.kind <= SyntaxKind.LastJSDocNode ?
+                child :
+                child.getFirstToken(sourceFile);
         }
 
         public getLastToken(sourceFile?: SourceFile): Node {
@@ -206,7 +207,9 @@ namespace ts {
                 return undefined;
             }
 
-            return child.kind < SyntaxKind.FirstNode ? child : child.getLastToken(sourceFile);
+            return child.kind < SyntaxKind.FirstNode || SyntaxKind.FirstJSDocNode <= child.kind && child.kind <= SyntaxKind.LastJSDocNode ?
+                child :
+                child.getLastToken(sourceFile);
         }
     }
 


### PR DESCRIPTION
Fixes #13519 

This is a bit odd, but it's the way that 2.0 and earlier behaved. 2.1 broke it with the jsdoc parser rewrite.

Also update `LastJSDocNode` since it had fallen out of date.