### PR TITLE
export the type `Log` that is used by exported functions

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1,6 +1,6 @@
 /* @internal */
 namespace ts.Completions {
-    type Log = (message: string) => void;
+    export type Log = (message: string) => void;
 
     export function getCompletionsAtPosition(host: LanguageServiceHost, typeChecker: TypeChecker, log: Log, compilerOptions: CompilerOptions, sourceFile: SourceFile, position: number): CompletionInfo | undefined {
         if (isInReferenceComment(sourceFile, position)) {


### PR DESCRIPTION
closes https://github.com/Microsoft/TypeScript/issues/13559 :rose:
