### PR TITLE
getFirstToken skips JSDoc

### DIFF
--- a/src/harness/unittests/jsDocParsing.ts
+++ b/src/harness/unittests/jsDocParsing.ts
@@ -290,16 +290,21 @@ namespace ts {
         });
         describe("getFirstToken", () => {
             it("gets jsdoc", () => {
-                const first = ts.createSourceFile("foo.ts", "/** comment */var a = true;", ts.ScriptTarget.ES5, /*setParentNodes*/ true);
+                const root = ts.createSourceFile("foo.ts", "/** comment */var a = true;", ts.ScriptTarget.ES5, /*setParentNodes*/ true);
+                assert.isDefined(root);
+                assert.equal(root.kind, ts.SyntaxKind.SourceFile);
+                const first = root.getFirstToken();
                 assert.isDefined(first);
-                assert.equal(first.kind, 263);
+                assert.equal(first.kind, ts.SyntaxKind.VarKeyword);
             });
         });
         describe("getLastToken", () => {
             it("gets jsdoc", () => {
-                const last = ts.createSourceFile("foo.ts", "var a = true;/** comment */", ts.ScriptTarget.ES5, /*setParentNodes*/ true);
+                const root = ts.createSourceFile("foo.ts", "var a = true;/** comment */", ts.ScriptTarget.ES5, /*setParentNodes*/ true);
+                assert.isDefined(root);
+                const last = root.getLastToken();
                 assert.isDefined(last);
-                assert.equal(last.kind, 263);
+                assert.equal(last.kind, ts.SyntaxKind.EndOfFileToken);
             });
         });
     });

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -193,8 +193,8 @@ namespace ts {
                 return undefined;
             }
 
-            const child = children[0];
-            return child.kind < SyntaxKind.FirstNode || SyntaxKind.FirstJSDocNode <= child.kind && child.kind <= SyntaxKind.LastJSDocNode ?
+            const child = ts.find(children, kid => kid.kind < SyntaxKind.FirstJSDocNode || kid.kind > SyntaxKind.LastJSDocNode);
+            return child.kind < SyntaxKind.FirstNode ?
                 child :
                 child.getFirstToken(sourceFile);
         }
@@ -207,9 +207,7 @@ namespace ts {
                 return undefined;
             }
 
-            return child.kind < SyntaxKind.FirstNode || SyntaxKind.FirstJSDocNode <= child.kind && child.kind <= SyntaxKind.LastJSDocNode ?
-                child :
-                child.getLastToken(sourceFile);
+            return child.kind < SyntaxKind.FirstNode ? child : child.getLastToken(sourceFile);
         }
     }
 


### PR DESCRIPTION
Fixes #13519.

This is a better fix than #13599 because (1) it behaves like 2.0 (2) jsdoc should generally not be treated as tokens unless it is specifically requested.

Also fixes broken tests associated with #13599.