### PR TITLE
Support find-all-references on mapped types.

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2712,6 +2712,7 @@
         containingType?: UnionOrIntersectionType;  // Containing union or intersection type for synthetic property
         leftSpread?: Symbol;                // Left source for synthetic spread property
         rightSpread?: Symbol;               // Right source for synthetic spread property
+        mappedTypeOrigin?: Symbol;          // For a property on a mapped type, points back to the orignal 'T' from 'keyof T'.
         hasNonUniformType?: boolean;        // True if constituents have non-uniform types
         isPartial?: boolean;                // True if syntheric property of union type occurs in some but not all constituents
         isDiscriminantProperty?: boolean;   // True if discriminant synthetic property

--- a/tests/baselines/reference/mappedTypes1.js
+++ b/tests/baselines/reference/mappedTypes1.js
@@ -139,9 +139,9 @@ declare let x2: string;
 declare let x3: number;
 declare let x4: {
     toString: void;
-    valueOf: void;
     toFixed: void;
     toExponential: void;
     toPrecision: void;
+    valueOf: void;
     toLocaleString: void;
 };

--- a/tests/baselines/reference/mappedTypes1.types
+++ b/tests/baselines/reference/mappedTypes1.types
@@ -165,7 +165,7 @@ let x3 = f3();
 >f3 : <T1 extends number>() => { [P in keyof T1]: void; }
 
 let x4 = f4();
->x4 : { toString: void; valueOf: void; toFixed: void; toExponential: void; toPrecision: void; toLocaleString: void; }
->f4() : { toString: void; valueOf: void; toFixed: void; toExponential: void; toPrecision: void; toLocaleString: void; }
+>x4 : { toString: void; toFixed: void; toExponential: void; toPrecision: void; valueOf: void; toLocaleString: void; }
+>f4() : { toString: void; toFixed: void; toExponential: void; toPrecision: void; valueOf: void; toLocaleString: void; }
 >f4 : <T1 extends Number>() => { [P in keyof T1]: void; }
 

--- a/tests/cases/fourslash/findAllRefsForMappedType.ts
+++ b/tests/cases/fourslash/findAllRefsForMappedType.ts
@@ -1,0 +1,9 @@
+/// <reference path='fourslash.ts'/>
+
+////interface T { [|a|]: number };
+////type U { [K in keyof T]: string };
+////type V = { [K in keyof U]: boolean };
+////const u: U = { [|a|]: "" }
+////const v: V = { [|a|]: true }
+
+verify.rangesReferenceEachOther();


### PR DESCRIPTION
* Need to put a 'mappedTypeOrigin' property in SymbolLinks

Fixes #12450

Thanks @ahejlsberg and @sandersn for the help.