### PR TITLE
More exhaustive needsDotDotForPropertyAccess for integer literals

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1054,9 +1054,11 @@ namespace ts {
         // Also emit a dot if expression is a integer const enum value - it will appear in generated code as numeric literal
         function needsDotDotForPropertyAccess(expression: Expression) {
             if (expression.kind === SyntaxKind.NumericLiteral) {
-                // check if numeric literal was originally written with a dot
+                // check if numeric literal is a decimal literal that was originally written with a dot
                 const text = getLiteralTextOfNode(<LiteralExpression>expression);
-                return text.indexOf(tokenToString(SyntaxKind.DotToken)) < 0;
+                return getNumericLiteralFlags(text, /*hint*/ NumericLiteralFlags.All) === NumericLiteralFlags.None
+                    && !(<LiteralExpression>expression).isOctalLiteral
+                    && text.indexOf(tokenToString(SyntaxKind.DotToken)) < 0;
             }
             else if (isPropertyAccessExpression(expression) || isElementAccessExpression(expression)) {
                 // check if constant enum value is integer

--- a/tests/baselines/reference/propertyAccessNumericLiterals.es6.js
+++ b/tests/baselines/reference/propertyAccessNumericLiterals.es6.js
@@ -1,0 +1,14 @@
+//// [propertyAccessNumericLiterals.es6.ts]
+0xffffffff.toString();
+0o01234.toString();
+0b01101101.toString();
+1234..toString();
+1e0.toString();
+
+
+//// [propertyAccessNumericLiterals.es6.js]
+0xffffffff.toString();
+0o01234.toString();
+0b01101101.toString();
+1234..toString();
+1e0.toString();

--- a/tests/baselines/reference/propertyAccessNumericLiterals.es6.symbols
+++ b/tests/baselines/reference/propertyAccessNumericLiterals.es6.symbols
@@ -1,0 +1,21 @@
+=== tests/cases/conformance/es6/propertyAccess/propertyAccessNumericLiterals.es6.ts ===
+0xffffffff.toString();
+>0xffffffff.toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
+>toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
+
+0o01234.toString();
+>0o01234.toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
+>toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
+
+0b01101101.toString();
+>0b01101101.toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
+>toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
+
+1234..toString();
+>1234..toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
+>toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
+
+1e0.toString();
+>1e0.toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
+>toString : Symbol(Number.toString, Decl(lib.es5.d.ts, --, --))
+

--- a/tests/baselines/reference/propertyAccessNumericLiterals.es6.types
+++ b/tests/baselines/reference/propertyAccessNumericLiterals.es6.types
@@ -1,0 +1,31 @@
+=== tests/cases/conformance/es6/propertyAccess/propertyAccessNumericLiterals.es6.ts ===
+0xffffffff.toString();
+>0xffffffff.toString() : string
+>0xffffffff.toString : (radix?: number) => string
+>0xffffffff : 4294967295
+>toString : (radix?: number) => string
+
+0o01234.toString();
+>0o01234.toString() : string
+>0o01234.toString : (radix?: number) => string
+>0o01234 : 668
+>toString : (radix?: number) => string
+
+0b01101101.toString();
+>0b01101101.toString() : string
+>0b01101101.toString : (radix?: number) => string
+>0b01101101 : 109
+>toString : (radix?: number) => string
+
+1234..toString();
+>1234..toString() : string
+>1234..toString : (radix?: number) => string
+>1234. : 1234
+>toString : (radix?: number) => string
+
+1e0.toString();
+>1e0.toString() : string
+>1e0.toString : (radix?: number) => string
+>1e0 : 1
+>toString : (radix?: number) => string
+

--- a/tests/baselines/reference/propertyAccessNumericLiterals.js
+++ b/tests/baselines/reference/propertyAccessNumericLiterals.js
@@ -1,0 +1,15 @@
+//// [propertyAccessNumericLiterals.ts]
+0xffffffff.toString();
+0o01234.toString();
+0b01101101.toString();
+1234..toString();
+1e0.toString();
+000.toString();
+
+//// [propertyAccessNumericLiterals.js]
+0xffffffff.toString();
+668..toString();
+109..toString();
+1234..toString();
+1e0.toString();
+000.toString();

--- a/tests/baselines/reference/propertyAccessNumericLiterals.symbols
+++ b/tests/baselines/reference/propertyAccessNumericLiterals.symbols
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/expressions/propertyAccess/propertyAccessNumericLiterals.ts ===
+0xffffffff.toString();
+>0xffffffff.toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+
+0o01234.toString();
+>0o01234.toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+
+0b01101101.toString();
+>0b01101101.toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+
+1234..toString();
+>1234..toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+
+1e0.toString();
+>1e0.toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+
+000.toString();
+>000.toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+>toString : Symbol(Number.toString, Decl(lib.d.ts, --, --))
+

--- a/tests/baselines/reference/propertyAccessNumericLiterals.types
+++ b/tests/baselines/reference/propertyAccessNumericLiterals.types
@@ -1,0 +1,37 @@
+=== tests/cases/conformance/expressions/propertyAccess/propertyAccessNumericLiterals.ts ===
+0xffffffff.toString();
+>0xffffffff.toString() : string
+>0xffffffff.toString : (radix?: number) => string
+>0xffffffff : 4294967295
+>toString : (radix?: number) => string
+
+0o01234.toString();
+>0o01234.toString() : string
+>0o01234.toString : (radix?: number) => string
+>0o01234 : 668
+>toString : (radix?: number) => string
+
+0b01101101.toString();
+>0b01101101.toString() : string
+>0b01101101.toString : (radix?: number) => string
+>0b01101101 : 109
+>toString : (radix?: number) => string
+
+1234..toString();
+>1234..toString() : string
+>1234..toString : (radix?: number) => string
+>1234. : 1234
+>toString : (radix?: number) => string
+
+1e0.toString();
+>1e0.toString() : string
+>1e0.toString : (radix?: number) => string
+>1e0 : 1
+>toString : (radix?: number) => string
+
+000.toString();
+>000.toString() : string
+>000.toString : (radix?: number) => string
+>000 : 0
+>toString : (radix?: number) => string
+

--- a/tests/cases/conformance/es6/propertyAccess/propertyAccessNumericLiterals.es6.ts
+++ b/tests/cases/conformance/es6/propertyAccess/propertyAccessNumericLiterals.es6.ts
@@ -1,0 +1,6 @@
+// @target: es6
+0xffffffff.toString();
+0o01234.toString();
+0b01101101.toString();
+1234..toString();
+1e0.toString();

--- a/tests/cases/conformance/expressions/propertyAccess/propertyAccessNumericLiterals.ts
+++ b/tests/cases/conformance/expressions/propertyAccess/propertyAccessNumericLiterals.ts
@@ -1,0 +1,7 @@
+// @target: es3
+0xffffffff.toString();
+0o01234.toString();
+0b01101101.toString();
+1234..toString();
+1e0.toString();
+000.toString();


### PR DESCRIPTION
Modifies `needsDotDotForPropertyAccess` to return `false` for the following cases:

* Hexadecimal integer literals: `0x00000000.toString()`
* Binary integer literals (ES6+): `0b0000000000000000.toString()`
* Octal integer literals (ES6+): `0o000.toString()`
* Unprefixed octal integer literals: `000.toString()`
* Scientific E notation integer literals: `1e0.toString()`

Fixes #13646
