### PR TITLE
For goToDefinition, verify that tryGetSignatureDeclaration returns a signature declaration and not a FunctionType.

### DIFF
--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -187,7 +187,15 @@ namespace ts.GoToDefinition {
     }
 
     function isSignatureDeclaration(node: Node): boolean {
-        return node.kind === SyntaxKind.FunctionDeclaration || node.kind === SyntaxKind.MethodDeclaration || node.kind === SyntaxKind.MethodSignature
+        switch (node.kind) {
+            case ts.SyntaxKind.Constructor:
+            case ts.SyntaxKind.FunctionDeclaration:
+            case ts.SyntaxKind.MethodDeclaration:
+            case ts.SyntaxKind.MethodSignature:
+                return true;
+            default:
+                return false;
+        }
     }
 
     /** Creates a DefinitionInfo from a Declaration, using the declaration's name if possible. */
@@ -254,6 +262,11 @@ namespace ts.GoToDefinition {
 
     function tryGetSignatureDeclaration(typeChecker: TypeChecker, node: Node): SignatureDeclaration | undefined {
         const callLike = getAncestorCallLikeExpression(node);
-        return callLike && typeChecker.getResolvedSignature(callLike).declaration;
+        const decl = callLike && typeChecker.getResolvedSignature(callLike).declaration;
+        if (decl && isSignatureDeclaration(decl)) {
+            return decl;
+        }
+        // Don't go to a function type, go to the value having that type.
+        return undefined;
     }
 }

--- a/tests/cases/fourslash/goToDefinitionFunctionType.ts
+++ b/tests/cases/fourslash/goToDefinitionFunctionType.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts'/>
+
+// Tests that goToDefinition does not go to a function type; it goes to the value.
+
+////const /*constDefinition*/c: () => void;
+/////*constReference*/c();
+////function test(/*cbDefinition*/cb: () => void) {
+////    /*cbReference*/cb();
+////}
+////class C {
+////    /*propDefinition*/prop: () => void;
+////    m() {
+////        this./*propReference*/prop();
+////    }
+////}
+
+verify.goToDefinitionForMarkers("const", "cb", "prop");


### PR DESCRIPTION
Fixes #13593