### PR TITLE
remove an odd new-line for catch clause

### DIFF
--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -1923,7 +1923,6 @@ namespace ts {
         }
 
         function emitCatchClause(node: CatchClause) {
-            writeLine();
             const openParenPos = writeToken(SyntaxKind.CatchKeyword, node.pos);
             write(" ");
             writeToken(SyntaxKind.OpenParenToken, openParenPos);


### PR DESCRIPTION
A new line has been written by `writeLineOrSpace` in `emitTryStatement`, so the first `writeLine` in `emitCatchClause` is not needed.

I think this is a bug because: if I modify `emitTryStatement` and make it write a space after `try` block, I'll get `}` + ` ` (space) + `\n` + indentation + `catch (` + ... - The `\n` is obviously redundant.