### PR TITLE
Special checks for BarEqual and PlusEqual

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14970,8 +14970,16 @@ namespace ts {
                         return silentNeverType;
                     }
 
-                    leftType = checkNonNullType(leftType, left);
-                    rightType = checkNonNullType(rightType, right);
+                    const leftBarZero = (rightType.flags & TypeFlags.NumberLiteral)
+                        && (<LiteralType>rightType).text === "0"
+                        && (operator === SyntaxKind.BarToken || operator === SyntaxKind.BarEqualsToken);
+                    if (leftBarZero) {
+                        leftType = getNonNullableType(leftType);
+                    }
+                    else {
+                        leftType = checkNonNullType(leftType, left);
+                        rightType = checkNonNullType(rightType, right);
+                    }
 
                     let suggestedOperator: SyntaxKind;
                     // if a user tries to apply a bitwise operator to 2 boolean operands

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10457,7 +10457,7 @@ namespace ts {
 
             // We only narrow variables and parameters occurring in a non-assignment position. For all other
             // entities we simply return the declared type.
-            if (!(localOrExportSymbol.flags & SymbolFlags.Variable) || assignmentKind === AssignmentKind.Definite || !declaration) {
+            if (!(localOrExportSymbol.flags & SymbolFlags.Variable) || assignmentKind === AssignmentKind.Definite || assignmentKind === AssignmentKind.NarrowingTypeCompund || !declaration) {
                 return type;
             }
             // The declaration container is the innermost function that encloses the declaration of the variable

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1673,7 +1673,7 @@ namespace ts {
     }
 
     export const enum AssignmentKind {
-        None, Definite, Compound
+        None, Definite, Compound, NarrowingTypeCompund
     }
 
     export function getAssignmentTargetKind(node: Node): AssignmentKind {
@@ -1682,9 +1682,16 @@ namespace ts {
             switch (parent.kind) {
                 case SyntaxKind.BinaryExpression:
                     const binaryOperator = (<BinaryExpression>parent).operatorToken.kind;
-                    return isAssignmentOperator(binaryOperator) && (<BinaryExpression>parent).left === node ?
-                        binaryOperator === SyntaxKind.EqualsToken ? AssignmentKind.Definite : AssignmentKind.Compound :
-                        AssignmentKind.None;
+                    if (!isAssignmentOperator(binaryOperator) || (<BinaryExpression>parent).left !== node) {
+                        return AssignmentKind.None;
+                    }
+                    if (binaryOperator === SyntaxKind.EqualsToken) {
+                        return AssignmentKind.Definite;
+                    }
+                    if (binaryOperator === SyntaxKind.BarEqualsToken || binaryOperator === SyntaxKind.PlusEqualsToken) {
+                        return AssignmentKind.NarrowingTypeCompund;
+                    }
+                    return AssignmentKind.Compound;
                 case SyntaxKind.PrefixUnaryExpression:
                 case SyntaxKind.PostfixUnaryExpression:
                     const unaryOperator = (<PrefixUnaryExpression | PostfixUnaryExpression>parent).operator;


### PR DESCRIPTION
This PR allow some common usages of `Bar`, `BarEqual`, and `PlusEqual` like:
```
function test(num?: number, str?: string) {
  console.log('num: ', num | 0); // `undefined | 0` is `0`
  num |= 0; // force `num` to be a valid number
  str += ""; // force `str` to be a valid string
  let output: string | number = num + 1;

  // re-narrow types using not the flowType `number`, but its initial type `string | number`
  output += ' / ' + str.substring(0, 10);
  console.log(output);
}
test();
```
