### PR TITLE
ES6 and above targets emit Object.assign for object spread

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11721,7 +11721,7 @@ namespace ts {
                     member = prop;
                 }
                 else if (memberDecl.kind === SyntaxKind.SpreadAssignment) {
-                    if (languageVersion < ScriptTarget.ESNext) {
+                    if (languageVersion < ScriptTarget.ES2015) {
                         checkExternalEmitHelpers(memberDecl, ExternalEmitHelpers.Assign);
                     }
                     if (propertiesArray.length > 0) {

--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -402,6 +402,11 @@ namespace ts {
     };
 
     export function createAssignHelper(context: TransformationContext, attributesSegments: Expression[]) {
+        if (context.getCompilerOptions().target === ScriptTarget.ES2015) {
+            return createCall(createPropertyAccess(createIdentifier("Object"), "assign"),
+                              /*typeArguments*/ undefined,
+                              attributesSegments);
+        }
         context.requestEmitHelper(assignHelper);
         return createCall(
             getHelperName("__assign"),

--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -402,7 +402,7 @@ namespace ts {
     };
 
     export function createAssignHelper(context: TransformationContext, attributesSegments: Expression[]) {
-        if (context.getCompilerOptions().target === ScriptTarget.ES2015) {
+        if (context.getCompilerOptions().target >= ScriptTarget.ES2015) {
             return createCall(createPropertyAccess(createIdentifier("Object"), "assign"),
                               /*typeArguments*/ undefined,
                               attributesSegments);

--- a/tests/baselines/reference/importHelpersES6.js
+++ b/tests/baselines/reference/importHelpersES6.js
@@ -6,9 +6,11 @@ declare var dec: any;
 
 }
 
+const o = { a: 1 };
+const y = { ...o };
+
 //// [tslib.d.ts]
 export declare function __extends(d: Function, b: Function): void;
-export declare function __assign(t: any, ...sources: any[]): any;
 export declare function __decorate(decorators: Function[], target: any, key?: string | symbol, desc?: any): any;
 export declare function __param(paramIndex: number, decorator: Function): Function;
 export declare function __metadata(metadataKey: any, metadataValue: any): Function;
@@ -23,3 +25,5 @@ A = tslib_1.__decorate([
     dec
 ], A);
 export { A };
+const o = { a: 1 };
+const y = Object.assign({}, o);

--- a/tests/baselines/reference/importHelpersES6.symbols
+++ b/tests/baselines/reference/importHelpersES6.symbols
@@ -8,6 +8,14 @@ declare var dec: any;
 
 }
 
+const o = { a: 1 };
+>o : Symbol(o, Decl(a.ts, 5, 5))
+>a : Symbol(a, Decl(a.ts, 5, 11))
+
+const y = { ...o };
+>y : Symbol(y, Decl(a.ts, 6, 5))
+>o : Symbol(o, Decl(a.ts, 5, 5))
+
 === tests/cases/compiler/tslib.d.ts ===
 export declare function __extends(d: Function, b: Function): void;
 >__extends : Symbol(__extends, Decl(tslib.d.ts, --, --))
@@ -15,11 +23,6 @@ export declare function __extends(d: Function, b: Function): void;
 >Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
 >b : Symbol(b, Decl(tslib.d.ts, --, --))
 >Function : Symbol(Function, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
-
-export declare function __assign(t: any, ...sources: any[]): any;
->__assign : Symbol(__assign, Decl(tslib.d.ts, --, --))
->t : Symbol(t, Decl(tslib.d.ts, --, --))
->sources : Symbol(sources, Decl(tslib.d.ts, --, --))
 
 export declare function __decorate(decorators: Function[], target: any, key?: string | symbol, desc?: any): any;
 >__decorate : Symbol(__decorate, Decl(tslib.d.ts, --, --))

--- a/tests/baselines/reference/importHelpersES6.types
+++ b/tests/baselines/reference/importHelpersES6.types
@@ -8,6 +8,17 @@ declare var dec: any;
 
 }
 
+const o = { a: 1 };
+>o : { a: number; }
+>{ a: 1 } : { a: number; }
+>a : number
+>1 : 1
+
+const y = { ...o };
+>y : { a: number; }
+>{ ...o } : { a: number; }
+>o : { a: number; }
+
 === tests/cases/compiler/tslib.d.ts ===
 export declare function __extends(d: Function, b: Function): void;
 >__extends : (d: Function, b: Function) => void
@@ -15,11 +26,6 @@ export declare function __extends(d: Function, b: Function): void;
 >Function : Function
 >b : Function
 >Function : Function
-
-export declare function __assign(t: any, ...sources: any[]): any;
->__assign : (t: any, ...sources: any[]) => any
->t : any
->sources : any[]
 
 export declare function __decorate(decorators: Function[], target: any, key?: string | symbol, desc?: any): any;
 >__decorate : (decorators: Function[], target: any, key?: string | symbol, desc?: any) => any

--- a/tests/baselines/reference/objectRest2.js
+++ b/tests/baselines/reference/objectRest2.js
@@ -15,14 +15,6 @@ rootConnection('test');
 
 
 //// [objectRest2.js]
-var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var s, i = 1, n = arguments.length; i < n; i++) {
-        s = arguments[i];
-        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
-            t[p] = s[p];
-    }
-    return t;
-};
 var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
     return new (P || (P = Promise))(function (resolve, reject) {
         function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
@@ -35,7 +27,7 @@ function rootConnection(name) {
     return {
         resolve: (context, args) => __awaiter(this, void 0, void 0, function* () {
             const { objects } = yield { objects: 12 };
-            return __assign({}, connectionFromArray(objects, args));
+            return Object.assign({}, connectionFromArray(objects, args));
         })
     };
 }

--- a/tests/baselines/reference/objectRestForOf.js
+++ b/tests/baselines/reference/objectRestForOf.js
@@ -15,14 +15,6 @@ for (const norest of array.map(a => ({ ...a, x: 'a string' }))) {
 
 
 //// [objectRestForOf.js]
-var __assign = (this && this.__assign) || Object.assign || function(t) {
-    for (var s, i = 1, n = arguments.length; i < n; i++) {
-        s = arguments[i];
-        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
-            t[p] = s[p];
-    }
-    return t;
-};
 var __rest = (this && this.__rest) || function (s, e) {
     var t = {};
     for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p) && e.indexOf(p) < 0)
@@ -43,6 +35,6 @@ for (let _b of array) {
     ({ x: xx } = _b, rrestOff = __rest(_b, ["x"]));
     [xx, rrestOff];
 }
-for (const norest of array.map(a => (__assign({}, a, { x: 'a string' })))) {
+for (const norest of array.map(a => (Object.assign({}, a, { x: 'a string' })))) {
     [norest.x, norest.y];
 }

--- a/tests/cases/compiler/importHelpersES6.ts
+++ b/tests/cases/compiler/importHelpersES6.ts
@@ -7,9 +7,11 @@ declare var dec: any;
 
 }
 
+const o = { a: 1 };
+const y = { ...o };
+
 // @filename: tslib.d.ts
 export declare function __extends(d: Function, b: Function): void;
-export declare function __assign(t: any, ...sources: any[]): any;
 export declare function __decorate(decorators: Function[], target: any, key?: string | symbol, desc?: any): any;
 export declare function __param(paramIndex: number, decorator: Function): Function;
 export declare function __metadata(metadataKey: any, metadataValue: any): Function;


### PR DESCRIPTION
Previously, they would always emit `__assign` and its helper definition, even though `Object.assign` is always available in ES2015 and above.

Fixes #12901
