### PR TITLE
support untyped imports in shims

### DIFF
--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -385,7 +385,10 @@ namespace ts {
             if (settingsJson == null || settingsJson == "") {
                 throw Error("LanguageServiceShimHostAdapter.getCompilationSettings: empty compilationSettings");
             }
-            return <CompilerOptions>JSON.parse(settingsJson);
+            const compilerOptions = <CompilerOptions>JSON.parse(settingsJson);
+            // permit language service to handle all files (filtering should be performed on the host side)
+            compilerOptions.allowNonTsExtensions = true;
+            return compilerOptions;
         }
 
         public getScriptFileNames(): string[] {
@@ -1061,12 +1064,6 @@ namespace ts {
                 const compilerOptions = <CompilerOptions>JSON.parse(compilerOptionsJson);
                 const result = resolveModuleName(moduleName, normalizeSlashes(fileName), compilerOptions, this.host);
                 const resolvedFileName = result.resolvedModule ? result.resolvedModule.resolvedFileName : undefined;
-                if (resolvedFileName && !compilerOptions.allowJs && fileExtensionIs(resolvedFileName, ".js")) {
-                    return {
-                        resolvedFileName: undefined,
-                        failedLookupLocations: []
-                    };
-                }
                 return {
                     resolvedFileName,
                     failedLookupLocations: result.failedLookupLocations


### PR DESCRIPTION
fixes https://github.com/Microsoft/TypeScript/issues/13194

1. With untyped imports it is ok to resolve module name to a `.js` file even if `allowJs` is not specified = otherwise this imports will be reported as missing
2. language service should be able to see and process files that originate from untyped modules.

Both fixes are done on the shim layer to make sure that this behavior is specific only to shim users and does not affect other consumers of language service API