### PR TITLE
really write output file only if needed

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -76,6 +76,7 @@ namespace ts {
         hash: string;
         byteOrderMark: boolean;
         mtime: Date;
+        updated: boolean;
     }
 
     export function createCompilerHost(options: CompilerOptions, setParentNodes?: boolean): CompilerHost {
@@ -143,22 +144,53 @@ namespace ts {
                 const fingerprint = outputFingerprints.get(fileName);
                 // If output has not been changed, and the file has no external modification
                 if (fingerprint &&
-                    fingerprint.byteOrderMark === writeByteOrderMark &&
+                    fingerprint.byteOrderMark === !!writeByteOrderMark &&
                     fingerprint.hash === hash &&
                     fingerprint.mtime.getTime() === mtimeBefore.getTime()) {
                     return;
                 }
             }
 
-            sys.writeFile(fileName, data, writeByteOrderMark);
+            writeFileIfDiff(fileName, data, writeByteOrderMark, hash);
+        }
 
-            const mtimeAfter = sys.getModifiedTime(fileName);
+        function writeFileIfDiff(fileName: string, data: string, writeByteOrderMark: boolean, hash?: string) {
+            let oldContent: string | undefined, info: {
+                bom?: string
+            };
+            if (!outputFingerprints) {
+                outputFingerprints = createMap<OutputFingerprint>();
+            }
+            hash = hash !== undefined ? hash : sys.createHash(data);
+
+            info = {};
+            try {
+                oldContent = sys.readFile(fileName, undefined, info);
+            }
+            catch (e) {
+            }
+            const sameBOM = info.bom === undefined || (info.bom === "\uFEFF") === !!writeByteOrderMark;
+            const isSame = oldContent !== undefined && oldContent === data && sameBOM;
+
+            if (!isSame) {
+                sys.writeFile(fileName, data, writeByteOrderMark);
+            }
+            const mtime = sys.getModifiedTime(fileName);
 
             outputFingerprints.set(fileName, {
                 hash,
-                byteOrderMark: writeByteOrderMark,
-                mtime: mtimeAfter
+                byteOrderMark: !!writeByteOrderMark,
+                mtime,
+                updated: !isSame
             });
+        }
+
+        function isOutputFileUpdated(fileName: string): boolean {
+            if (outputFingerprints) {
+                const fingerprint = outputFingerprints.get(fileName);
+                return !!fingerprint.updated;
+            }
+            return false;
         }
 
         function writeFile(fileName: string, data: string, writeByteOrderMark: boolean, onError?: (message: string) => void) {
@@ -170,7 +202,7 @@ namespace ts {
                     writeFileIfUpdated(fileName, data, writeByteOrderMark);
                 }
                 else {
-                    sys.writeFile(fileName, data, writeByteOrderMark);
+                    writeFileIfDiff(fileName, data, writeByteOrderMark);
                 }
 
                 performance.mark("afterIOWrite");
@@ -195,6 +227,7 @@ namespace ts {
             getDefaultLibLocation,
             getDefaultLibFileName: options => combinePaths(getDefaultLibLocation(), getDefaultLibFileName(options)),
             writeFile,
+            isOutputFileUpdated,
             getCurrentDirectory: memoize(() => sys.getCurrentDirectory()),
             useCaseSensitiveFileNames: () => sys.useCaseSensitiveFileNames,
             getCanonicalFileName,

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -29,7 +29,7 @@ namespace ts {
         }
     }
 
-    function reportEmittedFiles(files: string[]): void {
+    function reportEmittedFiles(host: CompilerHost, files: string[]): void {
         if (!files || files.length == 0) {
             return;
         }
@@ -38,8 +38,9 @@ namespace ts {
 
         for (const file of files) {
             const filepath = getNormalizedAbsolutePath(file, currentDir);
+            const updated = host.isOutputFileUpdated ? host.isOutputFileUpdated(filepath) : true;
 
-            sys.write(`TSFILE: ${filepath}${sys.newLine}`);
+            sys.write(`TSFILE${updated ? "" : " (no changes)"}: ${filepath}${sys.newLine}`);
         }
     }
 
@@ -569,7 +570,7 @@ namespace ts {
 
             reportDiagnostics(sortAndDeduplicateDiagnostics(diagnostics), compilerHost);
 
-            reportEmittedFiles(emitOutput.emittedFiles);
+            reportEmittedFiles(compilerHost, emitOutput.emittedFiles);
 
             if (emitOutput.emitSkipped && diagnostics.length > 0) {
                 // If the emitter didn't emit anything, then pass that value along.

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3616,6 +3616,7 @@
         getDefaultLibFileName(options: CompilerOptions): string;
         getDefaultLibLocation?(): string;
         writeFile: WriteFileCallback;
+        isOutputFileUpdated?(fileName: string): boolean;
         getCurrentDirectory(): string;
         getDirectories(path: string): string[];
         getCanonicalFileName(fileName: string): string;

--- a/src/services/transpile.ts
+++ b/src/services/transpile.ts
@@ -85,6 +85,7 @@
                     outputText = text;
                 }
             },
+            isOutputFileUpdated: (name) => fileExtensionIs(name, ".map") ? !!sourceMapText : !!outputText,
             getDefaultLibFileName: () => "lib.d.ts",
             useCaseSensitiveFileNames: () => false,
             getCanonicalFileName: fileName => fileName,


### PR DESCRIPTION
This PR makes `tsc` only does really writing if an output file's content / BOM has been changed.

If one file is not updated, the log message will be:
* `TSFILE (no changes): R:/Google/a.js`

## Intention
Although this slows down the compiler a little, I thinks it's a bad design to always write disk a lot everytime I change a single little file in my project.

For example, I'm migrating a JavaScript project to TypeScript, and I want to keep most of the built code same as the old, so I need to call `tsc` often. Here `tsc --watch` is useful, but it changes files' mtime frequently and make `diff` tools and `zip` do some unnecessary works.