### PR TITLE
Use "ts2.2" (or "ts2.3", etc.) NPM tag in typingsInstaller

### DIFF
--- a/src/harness/unittests/typingsInstaller.ts
+++ b/src/harness/unittests/typingsInstaller.ts
@@ -44,6 +44,8 @@ namespace ts.projectSystem {
         });
     }
 
+    import typingsName = server.typingsInstaller.typingsName;
+
     describe("typingsInstaller", () => {
         it("configured projects (typings installed) 1", () => {
             const file1 = {
@@ -519,32 +521,32 @@ namespace ts.projectSystem {
             const commander = {
                 path: "/a/data/node_modules/@types/commander/index.d.ts",
                 content: "declare const commander: { x: number }",
-                typings: "@types/commander"
+                typings: typingsName("commander")
             };
             const jquery = {
                 path: "/a/data/node_modules/@types/jquery/index.d.ts",
                 content: "declare const jquery: { x: number }",
-                typings: "@types/jquery"
+                typings: typingsName("jquery")
             };
             const lodash = {
                 path: "/a/data/node_modules/@types/lodash/index.d.ts",
                 content: "declare const lodash: { x: number }",
-                typings: "@types/lodash"
+                typings: typingsName("lodash")
             };
             const cordova = {
                 path: "/a/data/node_modules/@types/cordova/index.d.ts",
                 content: "declare const cordova: { x: number }",
-                typings: "@types/cordova"
+                typings: typingsName("cordova")
             };
             const grunt = {
                 path: "/a/data/node_modules/@types/grunt/index.d.ts",
                 content: "declare const grunt: { x: number }",
-                typings: "@types/grunt"
+                typings: typingsName("grunt")
             };
             const gulp = {
                 path: "/a/data/node_modules/@types/gulp/index.d.ts",
                 content: "declare const gulp: { x: number }",
-                typings: "@types/gulp"
+                typings: typingsName("gulp")
             };
 
             const host = createServerHost([lodashJs, commanderJs, file3]);
@@ -554,7 +556,7 @@ namespace ts.projectSystem {
                 }
                 installWorker(_requestId: number, args: string[], _cwd: string, cb: TI.RequestCompletedAction): void {
                     let typingFiles: (FileOrFolder & { typings: string })[] = [];
-                    if (args.indexOf("@types/commander") >= 0) {
+                    if (args.indexOf(typingsName("commander")) >= 0) {
                         typingFiles = [commander, jquery, lodash, cordova];
                     }
                     else {
@@ -982,7 +984,7 @@ namespace ts.projectSystem {
                         return;
                     }
                     if (response.kind === server.EventEndInstallTypes) {
-                        assert.deepEqual(response.packagesToInstall, ["@types/commander"]);
+                        assert.deepEqual(response.packagesToInstall, [typingsName("commander")]);
                         seenTelemetryEvent = true;
                         return;
                     }

--- a/src/server/typingsInstaller/typingsInstaller.ts
+++ b/src/server/typingsInstaller/typingsInstaller.ts
@@ -295,8 +295,7 @@ namespace ts.server.typingsInstaller {
                 this.log.writeLine(`Installing typings ${JSON.stringify(typingsToInstall)}`);
             }
             const filteredTypings = this.filterTypings(typingsToInstall);
-            const scopedTypings = filteredTypings.map(x => `@types/${x}`);
-            if (scopedTypings.length === 0) {
+            if (filteredTypings.length === 0) {
                 if (this.log.isEnabled()) {
                     this.log.writeLine(`All typings are known to be missing or invalid - no need to go any further`);
                 }
@@ -316,6 +315,7 @@ namespace ts.server.typingsInstaller {
                 projectName: req.projectName
             });
 
+            const scopedTypings = filteredTypings.map(typingsName);
             this.installTypingsAsync(requestId, scopedTypings, cachePath, ok => {
                 try {
                     if (!ok) {
@@ -429,4 +429,10 @@ namespace ts.server.typingsInstaller {
         protected abstract installWorker(requestId: number, args: string[], cwd: string, onRequestCompleted: RequestCompletedAction): void;
         protected abstract sendResponse(response: SetTypings | InvalidateCachedTypings | BeginInstallTypes | EndInstallTypes): void;
     }
+
+    /* @internal */
+    export function typingsName(packageName: string): string {
+        return `@types/${packageName}@ts${versionMajorMinor}`;
+    }
+    const versionMajorMinor = version.split(".").slice(0, 2).join(".");
 }


### PR DESCRIPTION
Fixes #13710
Relies on Microsoft/types-publisher#293