### PR TITLE
Fix base class check to allow 'object' type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3991,7 +3991,7 @@ namespace ts {
         // A valid base type is any non-generic object type or intersection of non-generic
         // object types.
         function isValidBaseType(type: Type): boolean {
-            return type.flags & TypeFlags.Object && !isGenericMappedType(type) ||
+            return type.flags & (TypeFlags.Object | TypeFlags.NonPrimitive) && !isGenericMappedType(type) ||
                 type.flags & TypeFlags.Intersection && !forEach((<IntersectionType>type).types, t => !isValidBaseType(t));
         }
 
@@ -4944,7 +4944,7 @@ namespace ts {
                 t.flags & TypeFlags.NumberLike ? globalNumberType :
                 t.flags & TypeFlags.BooleanLike ? globalBooleanType :
                 t.flags & TypeFlags.ESSymbol ? getGlobalESSymbolType() :
-                t.flags & TypeFlags.NonPrimitive ? globalObjectType :
+                t.flags & TypeFlags.NonPrimitive ? emptyObjectType :
                 t;
         }
 

--- a/tests/baselines/reference/mixinClassesAnonymous.js
+++ b/tests/baselines/reference/mixinClassesAnonymous.js
@@ -56,6 +56,14 @@ class Thing3 extends Thing2 {
     }
 }
 
+// Repro from #13805
+
+const Timestamped = <CT extends Constructor<object>>(Base: CT) => {
+    return class extends Base {
+        timestamp = new Date();
+    };
+}
+
 
 //// [mixinClassesAnonymous.js]
 var __extends = (this && this.__extends) || (function () {
@@ -138,3 +146,15 @@ var Thing3 = (function (_super) {
     };
     return Thing3;
 }(Thing2));
+// Repro from #13805
+var Timestamped = function (Base) {
+    return (function (_super) {
+        __extends(class_2, _super);
+        function class_2() {
+            var _this = _super !== null && _super.apply(this, arguments) || this;
+            _this.timestamp = new Date();
+            return _this;
+        }
+        return class_2;
+    }(Base));
+};

--- a/tests/baselines/reference/mixinClassesAnonymous.symbols
+++ b/tests/baselines/reference/mixinClassesAnonymous.symbols
@@ -167,3 +167,22 @@ class Thing3 extends Thing2 {
     }
 }
 
+// Repro from #13805
+
+const Timestamped = <CT extends Constructor<object>>(Base: CT) => {
+>Timestamped : Symbol(Timestamped, Decl(mixinClassesAnonymous.ts, 59, 5))
+>CT : Symbol(CT, Decl(mixinClassesAnonymous.ts, 59, 21))
+>Constructor : Symbol(Constructor, Decl(mixinClassesAnonymous.ts, 0, 0))
+>Base : Symbol(Base, Decl(mixinClassesAnonymous.ts, 59, 53))
+>CT : Symbol(CT, Decl(mixinClassesAnonymous.ts, 59, 21))
+
+    return class extends Base {
+>Base : Symbol(Base, Decl(mixinClassesAnonymous.ts, 59, 53))
+
+        timestamp = new Date();
+>timestamp : Symbol((Anonymous class).timestamp, Decl(mixinClassesAnonymous.ts, 60, 31))
+>Date : Symbol(Date, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+
+    };
+}
+

--- a/tests/baselines/reference/mixinClassesAnonymous.types
+++ b/tests/baselines/reference/mixinClassesAnonymous.types
@@ -198,3 +198,25 @@ class Thing3 extends Thing2 {
     }
 }
 
+// Repro from #13805
+
+const Timestamped = <CT extends Constructor<object>>(Base: CT) => {
+>Timestamped : <CT extends Constructor<object>>(Base: CT) => { new (...args: any[]): (Anonymous class); prototype: <any>.(Anonymous class); } & CT
+><CT extends Constructor<object>>(Base: CT) => {    return class extends Base {        timestamp = new Date();    };} : <CT extends Constructor<object>>(Base: CT) => { new (...args: any[]): (Anonymous class); prototype: <any>.(Anonymous class); } & CT
+>CT : CT
+>Constructor : Constructor<T>
+>Base : CT
+>CT : CT
+
+    return class extends Base {
+>class extends Base {        timestamp = new Date();    } : { new (...args: any[]): (Anonymous class); prototype: <any>.(Anonymous class); } & CT
+>Base : object
+
+        timestamp = new Date();
+>timestamp : Date
+>new Date() : Date
+>Date : DateConstructor
+
+    };
+}
+

--- a/tests/baselines/reference/nonPrimitiveAssignError.errors.txt
+++ b/tests/baselines/reference/nonPrimitiveAssignError.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts(5,1): error TS2322: Type 'object' is not assignable to type '{ foo: string; }'.
-  Property 'foo' is missing in type 'Object'.
+  Property 'foo' is missing in type '{}'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts(13,1): error TS2322: Type 'number' is not assignable to type 'object'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts(14,1): error TS2322: Type 'true' is not assignable to type 'object'.
 tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts(15,1): error TS2322: Type 'string' is not assignable to type 'object'.
@@ -16,7 +16,7 @@ tests/cases/conformance/types/nonPrimitive/nonPrimitiveAssignError.ts(19,1): err
     y = a; // expect error
     ~
 !!! error TS2322: Type 'object' is not assignable to type '{ foo: string; }'.
-!!! error TS2322:   Property 'foo' is missing in type 'Object'.
+!!! error TS2322:   Property 'foo' is missing in type '{}'.
     a = x;
     a = y;
     

--- a/tests/cases/conformance/classes/mixinClassesAnonymous.ts
+++ b/tests/cases/conformance/classes/mixinClassesAnonymous.ts
@@ -54,3 +54,11 @@ class Thing3 extends Thing2 {
         this.print();
     }
 }
+
+// Repro from #13805
+
+const Timestamped = <CT extends Constructor<object>>(Base: CT) => {
+    return class extends Base {
+        timestamp = new Date();
+    };
+}


### PR DESCRIPTION
Fixes #13805.

This PR also changes the apparent type of `object` to be the empty object type `{}` instead of the `Object` type declared in lib.d.ts. It should have been this way in the first place.