### PR TITLE
inject pre-finally and after-finally edges into flow graph to possibly ignore pre-finally during flow walk

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9813,7 +9813,19 @@ namespace ts {
                         }
                     }
                     let type: FlowType;
-                    if (flow.flags & FlowFlags.Assignment) {
+                    if (flow.flags & FlowFlags.AfterFinally) {
+                        // block flow edge: finally -> pre-try (for larger explanation check comment in binder.ts - bindTryStatement 
+                        (<AfterFinallyFlow>flow).locked = true;
+                        type = getTypeAtFlowNode((<AfterFinallyFlow>flow).antecedent);
+                        (<AfterFinallyFlow>flow).locked = false;
+                    }
+                    else if (flow.flags & FlowFlags.PreFinally) {
+                        // locked pre-finally flows are filtered out in getTypeAtFlowBranchLabel
+                        // so here just redirect to antecedent
+                        flow = (<PreFinallyFlow>flow).antecedent;
+                        continue;
+                    }
+                    else if (flow.flags & FlowFlags.Assignment) {
                         type = getTypeAtFlowAssignment(<FlowAssignment>flow);
                         if (!type) {
                             flow = (<FlowAssignment>flow).antecedent;
@@ -9969,6 +9981,12 @@ namespace ts {
                 let subtypeReduction = false;
                 let seenIncomplete = false;
                 for (const antecedent of flow.antecedents) {
+                    if (antecedent.flags & FlowFlags.PreFinally && (<PreFinallyFlow>antecedent).lock.locked) {
+                        // if flow correspond to branch from pre-try to finally and this branch is locked - this means that 
+                        // we initially have started following the flow outside the finally block.
+                        // in this case we should ignore this branch.
+                        continue;
+                    }
                     const flowType = getTypeAtFlowNode(antecedent);
                     const type = getTypeFromFlowType(flowType);
                     // If the type at a particular antecedent path is the declared type and the

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2069,8 +2069,23 @@
         ArrayMutation  = 1 << 8,  // Potential array mutation
         Referenced     = 1 << 9,  // Referenced as antecedent once
         Shared         = 1 << 10, // Referenced as antecedent more than once
+        PreFinally     = 1 << 11, // Injected edge that links pre-finally label and pre-try flow
+        AfterFinally   = 1 << 12, // Injected edge that links post-finally flow with the rest of the graph
         Label = BranchLabel | LoopLabel,
         Condition = TrueCondition | FalseCondition
+    }
+
+    export interface FlowLock {
+        locked?: boolean;
+    }
+
+    export interface AfterFinallyFlow extends FlowNode, FlowLock {
+        antecedent: FlowNode;
+    }
+
+    export interface PreFinallyFlow extends FlowNode {
+        antecedent: FlowNode;
+        lock: FlowLock;
     }
 
     export interface FlowNode {

--- a/tests/baselines/reference/flowAfterFinally1.js
+++ b/tests/baselines/reference/flowAfterFinally1.js
@@ -1,0 +1,25 @@
+//// [flowAfterFinally1.ts]
+declare function openFile(): void
+declare function closeFile(): void
+declare function someOperation(): {}
+
+var result: {}
+openFile()
+try {
+  result = someOperation()
+} finally {
+  closeFile()
+}
+
+result // should not error here
+
+//// [flowAfterFinally1.js]
+var result;
+openFile();
+try {
+    result = someOperation();
+}
+finally {
+    closeFile();
+}
+result; // should not error here

--- a/tests/baselines/reference/flowAfterFinally1.symbols
+++ b/tests/baselines/reference/flowAfterFinally1.symbols
@@ -1,0 +1,29 @@
+=== tests/cases/compiler/flowAfterFinally1.ts ===
+declare function openFile(): void
+>openFile : Symbol(openFile, Decl(flowAfterFinally1.ts, 0, 0))
+
+declare function closeFile(): void
+>closeFile : Symbol(closeFile, Decl(flowAfterFinally1.ts, 0, 33))
+
+declare function someOperation(): {}
+>someOperation : Symbol(someOperation, Decl(flowAfterFinally1.ts, 1, 34))
+
+var result: {}
+>result : Symbol(result, Decl(flowAfterFinally1.ts, 4, 3))
+
+openFile()
+>openFile : Symbol(openFile, Decl(flowAfterFinally1.ts, 0, 0))
+
+try {
+  result = someOperation()
+>result : Symbol(result, Decl(flowAfterFinally1.ts, 4, 3))
+>someOperation : Symbol(someOperation, Decl(flowAfterFinally1.ts, 1, 34))
+
+} finally {
+  closeFile()
+>closeFile : Symbol(closeFile, Decl(flowAfterFinally1.ts, 0, 33))
+}
+
+result // should not error here
+>result : Symbol(result, Decl(flowAfterFinally1.ts, 4, 3))
+

--- a/tests/baselines/reference/flowAfterFinally1.types
+++ b/tests/baselines/reference/flowAfterFinally1.types
@@ -1,0 +1,33 @@
+=== tests/cases/compiler/flowAfterFinally1.ts ===
+declare function openFile(): void
+>openFile : () => void
+
+declare function closeFile(): void
+>closeFile : () => void
+
+declare function someOperation(): {}
+>someOperation : () => {}
+
+var result: {}
+>result : {}
+
+openFile()
+>openFile() : void
+>openFile : () => void
+
+try {
+  result = someOperation()
+>result = someOperation() : {}
+>result : {}
+>someOperation() : {}
+>someOperation : () => {}
+
+} finally {
+  closeFile()
+>closeFile() : void
+>closeFile : () => void
+}
+
+result // should not error here
+>result : {}
+

--- a/tests/cases/compiler/flowAfterFinally1.ts
+++ b/tests/cases/compiler/flowAfterFinally1.ts
@@ -1,0 +1,14 @@
+// @strictNullChecks: true
+declare function openFile(): void
+declare function closeFile(): void
+declare function someOperation(): {}
+
+var result: {}
+openFile()
+try {
+  result = someOperation()
+} finally {
+  closeFile()
+}
+
+result // should not error here


### PR DESCRIPTION
fix proposal for #12205 

I've tried the approach with copying the flow graph in finally block and decided not to use it since in presence of nested try-finally blocks in becomes quite complicated. As an alternative I'd like to propose different approach: for try-finally blocks we inject two extra edges in the flow graph. One edge will link pre-try flow with pre-finally label, another will act as a proxy for post-finally flow. If during the flow walk we touch the post-finally flow edge we can mark matching pre-finally edge as blocked so it will be ignored. The overhead of this approach is also much smaller than copying - max two objects per protected region which sounds like a reasonable thing.

// cc @ahejlsberg, @mhegazy 