### PR TITLE
Object literal freshness errors with spreads

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11864,6 +11864,8 @@ namespace ts {
                 if (spread.flags & TypeFlags.Object) {
                     // only set the symbol and flags if this is a (fresh) object type
                     spread.flags |= propagatedFlags;
+                    spread.flags |= TypeFlags.FreshLiteral;
+                    (spread as ObjectType).objectFlags |= ObjectFlags.ObjectLiteral;
                     spread.symbol = node.symbol;
                 }
                 return spread;

--- a/tests/baselines/reference/objectLiteralFreshnessWithSpread.errors.txt
+++ b/tests/baselines/reference/objectLiteralFreshnessWithSpread.errors.txt
@@ -1,0 +1,11 @@
+tests/cases/compiler/objectLiteralFreshnessWithSpread.ts(2,35): error TS2322: Type '{ z: number; b: number; extra: number; a: number; }' is not assignable to type '{ a: any; b: any; }'.
+  Object literal may only specify known properties, and 'z' does not exist in type '{ a: any; b: any; }'.
+
+
+==== tests/cases/compiler/objectLiteralFreshnessWithSpread.ts (1 errors) ====
+    let x = { b: 1, extra: 2 }
+    let xx: { a, b }  = { a: 1, ...x, z: 3 } // error for 'z', no error for 'extra'
+                                      ~~~~
+!!! error TS2322: Type '{ z: number; b: number; extra: number; a: number; }' is not assignable to type '{ a: any; b: any; }'.
+!!! error TS2322:   Object literal may only specify known properties, and 'z' does not exist in type '{ a: any; b: any; }'.
+    

--- a/tests/baselines/reference/objectLiteralFreshnessWithSpread.js
+++ b/tests/baselines/reference/objectLiteralFreshnessWithSpread.js
@@ -1,0 +1,16 @@
+//// [objectLiteralFreshnessWithSpread.ts]
+let x = { b: 1, extra: 2 }
+let xx: { a, b }  = { a: 1, ...x, z: 3 } // error for 'z', no error for 'extra'
+
+
+//// [objectLiteralFreshnessWithSpread.js]
+var __assign = (this && this.__assign) || Object.assign || function(t) {
+    for (var s, i = 1, n = arguments.length; i < n; i++) {
+        s = arguments[i];
+        for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+            t[p] = s[p];
+    }
+    return t;
+};
+var x = { b: 1, extra: 2 };
+var xx = __assign({ a: 1 }, x, { z: 3 }); // error for 'z', no error for 'extra'

--- a/tests/cases/compiler/objectLiteralFreshnessWithSpread.ts
+++ b/tests/cases/compiler/objectLiteralFreshnessWithSpread.ts
@@ -1,0 +1,2 @@
+let x = { b: 1, extra: 2 }
+let xx: { a, b }  = { a: 1, ...x, z: 3 } // error for 'z', no error for 'extra'


### PR DESCRIPTION
Previously, object literals with spreads in them would not issue object literal freshness errors.  

Fixes #13878
Fixes #15908 