### PR TITLE
add projectUsesOutFile field to protocol.CompileOnSaveAffectedFileListSingleProject

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -3031,6 +3031,54 @@ namespace ts.projectSystem {
         });
     });
 
+    describe("emit with outFile or out setting", () => {
+        function test(opts: CompilerOptions, expectedUsesOutFile: boolean) {
+            const f1 = {
+                path: "/a/a.ts",
+                content: "let x = 1"
+            };
+            const f2 = {
+                path: "/a/b.ts",
+                content: "let y = 1"
+            };
+            const config = {
+                path: "/a/tsconfig.json",
+                content: JSON.stringify({
+                    compilerOptions: opts,
+                    compileOnSave: true
+                })
+            };
+            const host = createServerHost([f1, f2, config]);
+            const session = createSession(host);
+            session.executeCommand(<protocol.OpenRequest>{
+                seq: 1,
+                type: "request",
+                command: "open",
+                arguments: { file: f1.path }
+            });
+            checkNumberOfProjects(session.getProjectService(), { configuredProjects: 1 });
+            const { response } = session.executeCommand(<protocol.CompileOnSaveAffectedFileListRequest>{
+                seq: 2,
+                type: "request",
+                command: "compileOnSaveAffectedFileList",
+                arguments: { file: f1.path }
+            });
+            assert.equal((<protocol.CompileOnSaveAffectedFileListSingleProject[]>response).length, 1, "expected output for 1 project");
+            assert.equal((<protocol.CompileOnSaveAffectedFileListSingleProject[]>response)[0].fileNames.length, 2, "expected output for 1 project");
+            assert.equal((<protocol.CompileOnSaveAffectedFileListSingleProject[]>response)[0].projectUsesOutFile, expectedUsesOutFile, "usesOutFile");
+        }
+
+        it ("projectUsesOutFile should not be returned if not set", () => {
+            test({}, /*expectedUsesOutFile*/ false);
+        });
+        it ("projectUsesOutFile should be true if outFile is set", () => {
+            test({ outFile: "/a/out.js" }, /*expectedUsesOutFile*/ true);
+        });
+        it ("projectUsesOutFile should be true if out is set", () => {
+            test({ out: "/a/out.js" }, /*expectedUsesOutFile*/ true);
+        });
+    });
+
     describe("import helpers", () => {
         it("should not crash in tsserver", () => {
             const f1 = {

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1239,6 +1239,11 @@ namespace ts.server.protocol {
          * List of files names that should be recompiled
          */
         fileNames: string[];
+
+        /**
+         * true if project uses outFile or out compiler option
+         */
+        projectUsesOutFile: boolean;
     }
 
     /**

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1040,7 +1040,8 @@ namespace ts.server {
                 if (project.compileOnSaveEnabled && project.languageServiceEnabled) {
                     result.push({
                         projectFileName: project.getProjectName(),
-                        fileNames: project.getCompileOnSaveAffectedFileList(info)
+                        fileNames: project.getCompileOnSaveAffectedFileList(info),
+                        projectUsesOutFile: !!project.getCompilerOptions().outFile || !!project.getCompilerOptions().out
                     });
                 }
             }


### PR DESCRIPTION
clients can leverage this knowledge to reduce amount of EmitFile requests