### PR TITLE
Fix assigned type of assignment nested in literals

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9469,9 +9469,17 @@ namespace ts {
         }
 
         function getAssignedTypeOfBinaryExpression(node: BinaryExpression): Type {
-            return node.parent.kind === SyntaxKind.ArrayLiteralExpression || node.parent.kind === SyntaxKind.PropertyAssignment ?
+            const isDestructuringDefaultAssignment =
+                node.parent.kind === SyntaxKind.ArrayLiteralExpression && isDestructuringAssignmentTarget(node.parent) ||
+                node.parent.kind === SyntaxKind.PropertyAssignment && isDestructuringAssignmentTarget(node.parent.parent);
+            return isDestructuringDefaultAssignment ?
                 getTypeWithDefault(getAssignedType(node), node.right) :
                 getTypeOfExpression(node.right);
+        }
+
+        function isDestructuringAssignmentTarget(parent: Node) {
+            return parent.parent.kind === SyntaxKind.BinaryExpression && (parent.parent as BinaryExpression).left === parent ||
+                parent.parent.kind === SyntaxKind.ForOfStatement && (parent.parent as ForOfStatement).initializer === parent;
         }
 
         function getAssignedTypeOfArrayLiteralElement(node: ArrayLiteralExpression, element: Expression): Type {

--- a/tests/baselines/reference/assignmentNestedInLiterals.js
+++ b/tests/baselines/reference/assignmentNestedInLiterals.js
@@ -5,9 +5,17 @@ target = [x = 1, y = x];
 var aegis, a, b;
 aegis = { x: a = 1, y: b = a };
 
+var kowloona, c, d;
+for (kowloona of [c = 1, d = c]) {
+}
+
 
 //// [assignmentNestedInLiterals.js]
 var target, x, y;
 target = [x = 1, y = x];
 var aegis, a, b;
 aegis = { x: a = 1, y: b = a };
+var kowloona, c, d;
+for (var _i = 0, _a = [c = 1, d = c]; _i < _a.length; _i++) {
+    kowloona = _a[_i];
+}

--- a/tests/baselines/reference/assignmentNestedInLiterals.js
+++ b/tests/baselines/reference/assignmentNestedInLiterals.js
@@ -1,0 +1,13 @@
+//// [assignmentNestedInLiterals.ts]
+var target, x, y;
+target = [x = 1, y = x];
+
+var aegis, a, b;
+aegis = { x: a = 1, y: b = a };
+
+
+//// [assignmentNestedInLiterals.js]
+var target, x, y;
+target = [x = 1, y = x];
+var aegis, a, b;
+aegis = { x: a = 1, y: b = a };

--- a/tests/baselines/reference/assignmentNestedInLiterals.symbols
+++ b/tests/baselines/reference/assignmentNestedInLiterals.symbols
@@ -1,0 +1,25 @@
+=== tests/cases/compiler/assignmentNestedInLiterals.ts ===
+var target, x, y;
+>target : Symbol(target, Decl(assignmentNestedInLiterals.ts, 0, 3))
+>x : Symbol(x, Decl(assignmentNestedInLiterals.ts, 0, 11))
+>y : Symbol(y, Decl(assignmentNestedInLiterals.ts, 0, 14))
+
+target = [x = 1, y = x];
+>target : Symbol(target, Decl(assignmentNestedInLiterals.ts, 0, 3))
+>x : Symbol(x, Decl(assignmentNestedInLiterals.ts, 0, 11))
+>y : Symbol(y, Decl(assignmentNestedInLiterals.ts, 0, 14))
+>x : Symbol(x, Decl(assignmentNestedInLiterals.ts, 0, 11))
+
+var aegis, a, b;
+>aegis : Symbol(aegis, Decl(assignmentNestedInLiterals.ts, 3, 3))
+>a : Symbol(a, Decl(assignmentNestedInLiterals.ts, 3, 10))
+>b : Symbol(b, Decl(assignmentNestedInLiterals.ts, 3, 13))
+
+aegis = { x: a = 1, y: b = a };
+>aegis : Symbol(aegis, Decl(assignmentNestedInLiterals.ts, 3, 3))
+>x : Symbol(x, Decl(assignmentNestedInLiterals.ts, 4, 9))
+>a : Symbol(a, Decl(assignmentNestedInLiterals.ts, 3, 10))
+>y : Symbol(y, Decl(assignmentNestedInLiterals.ts, 4, 19))
+>b : Symbol(b, Decl(assignmentNestedInLiterals.ts, 3, 13))
+>a : Symbol(a, Decl(assignmentNestedInLiterals.ts, 3, 10))
+

--- a/tests/baselines/reference/assignmentNestedInLiterals.symbols
+++ b/tests/baselines/reference/assignmentNestedInLiterals.symbols
@@ -23,3 +23,15 @@ aegis = { x: a = 1, y: b = a };
 >b : Symbol(b, Decl(assignmentNestedInLiterals.ts, 3, 13))
 >a : Symbol(a, Decl(assignmentNestedInLiterals.ts, 3, 10))
 
+var kowloona, c, d;
+>kowloona : Symbol(kowloona, Decl(assignmentNestedInLiterals.ts, 6, 3))
+>c : Symbol(c, Decl(assignmentNestedInLiterals.ts, 6, 13))
+>d : Symbol(d, Decl(assignmentNestedInLiterals.ts, 6, 16))
+
+for (kowloona of [c = 1, d = c]) {
+>kowloona : Symbol(kowloona, Decl(assignmentNestedInLiterals.ts, 6, 3))
+>c : Symbol(c, Decl(assignmentNestedInLiterals.ts, 6, 13))
+>d : Symbol(d, Decl(assignmentNestedInLiterals.ts, 6, 16))
+>c : Symbol(c, Decl(assignmentNestedInLiterals.ts, 6, 13))
+}
+

--- a/tests/baselines/reference/assignmentNestedInLiterals.types
+++ b/tests/baselines/reference/assignmentNestedInLiterals.types
@@ -1,0 +1,35 @@
+=== tests/cases/compiler/assignmentNestedInLiterals.ts ===
+var target, x, y;
+>target : any
+>x : any
+>y : any
+
+target = [x = 1, y = x];
+>target = [x = 1, y = x] : number[]
+>target : any
+>[x = 1, y = x] : number[]
+>x = 1 : 1
+>x : any
+>1 : 1
+>y = x : number
+>y : any
+>x : number
+
+var aegis, a, b;
+>aegis : any
+>a : any
+>b : any
+
+aegis = { x: a = 1, y: b = a };
+>aegis = { x: a = 1, y: b = a } : { x: number; y: number; }
+>aegis : any
+>{ x: a = 1, y: b = a } : { x: number; y: number; }
+>x : number
+>a = 1 : 1
+>a : any
+>1 : 1
+>y : number
+>b = a : number
+>b : any
+>a : number
+

--- a/tests/baselines/reference/assignmentNestedInLiterals.types
+++ b/tests/baselines/reference/assignmentNestedInLiterals.types
@@ -33,3 +33,19 @@ aegis = { x: a = 1, y: b = a };
 >b : any
 >a : number
 
+var kowloona, c, d;
+>kowloona : any
+>c : any
+>d : any
+
+for (kowloona of [c = 1, d = c]) {
+>kowloona : any
+>[c = 1, d = c] : number[]
+>c = 1 : 1
+>c : any
+>1 : 1
+>d = c : number
+>d : any
+>c : number
+}
+

--- a/tests/cases/compiler/assignmentNestedInLiterals.ts
+++ b/tests/cases/compiler/assignmentNestedInLiterals.ts
@@ -4,3 +4,7 @@ target = [x = 1, y = x];
 
 var aegis, a, b;
 aegis = { x: a = 1, y: b = a };
+
+var kowloona, c, d;
+for (kowloona of [c = 1, d = c]) {
+}

--- a/tests/cases/compiler/assignmentNestedInLiterals.ts
+++ b/tests/cases/compiler/assignmentNestedInLiterals.ts
@@ -1,0 +1,6 @@
+// @noImplicitAny: true
+var target, x, y;
+target = [x = 1, y = x];
+
+var aegis, a, b;
+aegis = { x: a = 1, y: b = a };


### PR DESCRIPTION
Fixes #12946

Previously, this code would cause the compiler to recur infinitely:

```ts
// @noImplicitAny: true
var target, x, y;
target = [x = 1, y = x];
```

That's because the assigned type of an assignment that is nested in an array literal includes the type of the array literal itself. In other words, to get the assigned type of `x=1`, the compiler will union the type of `1` and `[x=1, y=x]`. This cause infinite recursion.

The union code is intended to support destructuring assignment defaults, so this change makes the recursion only happen when the array literal is on the left-hand side of an assignment.

Note that it also applies to object literals, and to the initializer of for-of loops.