### PR TITLE
Update es5.d.ts

### DIFF
--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -222,7 +222,7 @@ interface ObjectConstructor {
       * Returns the names of the enumerable properties and methods of an object.
       * @param o Object that contains the properties and methods. This can be an object that you created or an existing Document Object Model (DOM) object.
       */
-    keys(o: any): string[];
+    keys<T>(o: T): Array<keyof T>;
 }
 
 /**


### PR DESCRIPTION
Before:

```ts
const foo = {
  bar: 1,
  baz: 2
};

const keysOfFoo = Object.keys(foo); // string[]
````

Now:

```ts
const foo = {
  bar: 1,
  baz: 2
};

const keysOfFoo = Object.keys(foo); // ("bar" | "baz")[]
````
