### PR TITLE
Properly handle private and protected properties in intersections

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -1787,6 +1787,10 @@
         "category": "Error",
         "code": 2545
     },
+    "Property '{0}' has conflicting declarations and is inaccessible in type '{1}'.": {
+        "category": "Error",
+        "code": 2546
+    },
     "JSX element attributes type '{0}' may not be a union type.": {
         "category": "Error",
         "code": 2600

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2727,8 +2727,12 @@
         Instantiated      = 1 << 0,         // Instantiated symbol
         SyntheticProperty = 1 << 1,         // Property in union or intersection type
         Readonly          = 1 << 2,         // Readonly transient symbol
-        Partial           = 1 << 3,         // Property present in some but not all constituents
-        HasNonUniformType = 1 << 4,         // Constituents have non-uniform types
+        Partial           = 1 << 3,         // Synthetic property present in some but not all constituents
+        HasNonUniformType = 1 << 4,         // Synthetic property with non-uniform type in constituents
+        ContainsPublic    = 1 << 5,         // Synthetic property with public constituent(s)
+        ContainsProtected = 1 << 6,         // Synthetic property with protected constituent(s)
+        ContainsPrivate   = 1 << 7,         // Synthetic property with private constituent(s)
+        ContainsStatic    = 1 << 8,         // Synthetic property with static constituent(s)
     }
 
     /* @internal */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2600,37 +2600,34 @@
 
     export const enum SymbolFlags {
         None                    = 0,
-        FunctionScopedVariable  = 0x00000001,  // Variable (var) or parameter
-        BlockScopedVariable     = 0x00000002,  // A block-scoped variable (let or const)
-        Property                = 0x00000004,  // Property or enum member
-        EnumMember              = 0x00000008,  // Enum member
-        Function                = 0x00000010,  // Function
-        Class                   = 0x00000020,  // Class
-        Interface               = 0x00000040,  // Interface
-        ConstEnum               = 0x00000080,  // Const enum
-        RegularEnum             = 0x00000100,  // Enum
-        ValueModule             = 0x00000200,  // Instantiated module
-        NamespaceModule         = 0x00000400,  // Uninstantiated module
-        TypeLiteral             = 0x00000800,  // Type Literal or mapped type
-        ObjectLiteral           = 0x00001000,  // Object Literal
-        Method                  = 0x00002000,  // Method
-        Constructor             = 0x00004000,  // Constructor
-        GetAccessor             = 0x00008000,  // Get accessor
-        SetAccessor             = 0x00010000,  // Set accessor
-        Signature               = 0x00020000,  // Call, construct, or index signature
-        TypeParameter           = 0x00040000,  // Type parameter
-        TypeAlias               = 0x00080000,  // Type alias
-        ExportValue             = 0x00100000,  // Exported value marker (see comment in declareModuleMember in binder)
-        ExportType              = 0x00200000,  // Exported type marker (see comment in declareModuleMember in binder)
-        ExportNamespace         = 0x00400000,  // Exported namespace marker (see comment in declareModuleMember in binder)
-        Alias                   = 0x00800000,  // An alias for another symbol (see comment in isAliasSymbolDeclaration in checker)
-        Instantiated            = 0x01000000,  // Instantiated symbol
-        Merged                  = 0x02000000,  // Merged symbol (created during program binding)
-        Transient               = 0x04000000,  // Transient symbol (created during type check)
-        Prototype               = 0x08000000,  // Prototype property (no source representation)
-        SyntheticProperty       = 0x10000000,  // Property in union or intersection type
-        Optional                = 0x20000000,  // Optional property
-        ExportStar              = 0x40000000,  // Export * declaration
+        FunctionScopedVariable  = 1 << 0,   // Variable (var) or parameter
+        BlockScopedVariable     = 1 << 1,   // A block-scoped variable (let or const)
+        Property                = 1 << 2,   // Property or enum member
+        EnumMember              = 1 << 3,   // Enum member
+        Function                = 1 << 4,   // Function
+        Class                   = 1 << 5,   // Class
+        Interface               = 1 << 6,   // Interface
+        ConstEnum               = 1 << 7,   // Const enum
+        RegularEnum             = 1 << 8,   // Enum
+        ValueModule             = 1 << 9,   // Instantiated module
+        NamespaceModule         = 1 << 10,  // Uninstantiated module
+        TypeLiteral             = 1 << 11,  // Type Literal or mapped type
+        ObjectLiteral           = 1 << 12,  // Object Literal
+        Method                  = 1 << 13,  // Method
+        Constructor             = 1 << 14,  // Constructor
+        GetAccessor             = 1 << 15,  // Get accessor
+        SetAccessor             = 1 << 16,  // Set accessor
+        Signature               = 1 << 17,  // Call, construct, or index signature
+        TypeParameter           = 1 << 18,  // Type parameter
+        TypeAlias               = 1 << 19,  // Type alias
+        ExportValue             = 1 << 20,  // Exported value marker (see comment in declareModuleMember in binder)
+        ExportType              = 1 << 21,  // Exported type marker (see comment in declareModuleMember in binder)
+        ExportNamespace         = 1 << 22,  // Exported namespace marker (see comment in declareModuleMember in binder)
+        Alias                   = 1 << 23,  // An alias for another symbol (see comment in isAliasSymbolDeclaration in checker)
+        Prototype               = 1 << 24,  // Prototype property (no source representation)
+        ExportStar              = 1 << 25,  // Export * declaration
+        Optional                = 1 << 26,  // Optional property
+        Transient               = 1 << 27,  // Transient symbol (created during type check)
 
         Enum = RegularEnum | ConstEnum,
         Variable = FunctionScopedVariable | BlockScopedVariable,
@@ -2690,11 +2687,9 @@
         name: string;                           // Name of symbol
         declarations?: Declaration[];           // Declarations associated with this symbol
         valueDeclaration?: Declaration;         // First value declaration of the symbol
-
         members?: SymbolTable;                  // Class, interface or literal instance members
         exports?: SymbolTable;                  // Module exports
         globalExports?: SymbolTable;            // Conditional global UMD exports
-        /* @internal */ isReadonly?: boolean;   // readonly? (set only for intersections and unions)
         /* @internal */ id?: number;            // Unique id (used to look up SymbolLinks)
         /* @internal */ mergeId?: number;       // Merge id (used to look up merged symbol)
         /* @internal */ parent?: Symbol;        // Parent symbol
@@ -2719,8 +2714,6 @@
         leftSpread?: Symbol;                // Left source for synthetic spread property
         rightSpread?: Symbol;               // Right source for synthetic spread property
         mappedTypeOrigin?: Symbol;          // For a property on a mapped type, points back to the orignal 'T' from 'keyof T'.
-        hasNonUniformType?: boolean;        // True if constituents have non-uniform types
-        isPartial?: boolean;                // True if syntheric property of union type occurs in some but not all constituents
         isDiscriminantProperty?: boolean;   // True if discriminant synthetic property
         resolvedExports?: SymbolTable;      // Resolved exports of module
         exportsChecked?: boolean;           // True if exports of external module have been checked
@@ -2730,7 +2723,18 @@
     }
 
     /* @internal */
-    export interface TransientSymbol extends Symbol, SymbolLinks { }
+    export const enum CheckFlags {
+        Instantiated      = 1 << 0,         // Instantiated symbol
+        SyntheticProperty = 1 << 1,         // Property in union or intersection type
+        Readonly          = 1 << 2,         // Readonly transient symbol
+        Partial           = 1 << 3,         // Property present in some but not all constituents
+        HasNonUniformType = 1 << 4,         // Constituents have non-uniform types
+    }
+
+    /* @internal */
+    export interface TransientSymbol extends Symbol, SymbolLinks {
+        checkFlags: CheckFlags;
+    }
 
     export type SymbolTable = Map<Symbol>;
 

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -277,7 +277,7 @@ namespace ts.FindAllReferences {
 
         // if this symbol is visible from its parent container, e.g. exported, then bail out
         // if symbol correspond to the union property - bail out
-        if (symbol.parent || (symbol.flags & SymbolFlags.SyntheticProperty)) {
+        if (symbol.parent || (symbol.flags & SymbolFlags.Transient && (<TransientSymbol>symbol).checkFlags & CheckFlags.SyntheticProperty)) {
             return undefined;
         }
 

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -51,7 +51,7 @@ namespace ts.SymbolDisplay {
         if (flags & SymbolFlags.Constructor) return ScriptElementKind.constructorImplementationElement;
 
         if (flags & SymbolFlags.Property) {
-            if (flags & SymbolFlags.SyntheticProperty) {
+            if (flags & SymbolFlags.Transient && (<TransientSymbol>symbol).checkFlags & CheckFlags.SyntheticProperty) {
                 // If union property is result of union of non method (property/accessors/variables), it is labeled as property
                 const unionPropertyKind = forEach(typeChecker.getRootSymbols(symbol), rootSymbol => {
                     const rootSymbolFlags = rootSymbol.getFlags();

--- a/tests/baselines/reference/mixinAccessModifiers.errors.txt
+++ b/tests/baselines/reference/mixinAccessModifiers.errors.txt
@@ -1,0 +1,156 @@
+tests/cases/conformance/classes/mixinAccessModifiers.ts(39,4): error TS2546: Property 'p' has conflicting declarations and is inaccessible in type 'Private & Private2'.
+tests/cases/conformance/classes/mixinAccessModifiers.ts(43,4): error TS2546: Property 'p' has conflicting declarations and is inaccessible in type 'Private & Protected'.
+tests/cases/conformance/classes/mixinAccessModifiers.ts(47,4): error TS2546: Property 'p' has conflicting declarations and is inaccessible in type 'Private & Public'.
+tests/cases/conformance/classes/mixinAccessModifiers.ts(51,4): error TS2445: Property 'p' is protected and only accessible within class 'Protected & Protected2' and its subclasses.
+tests/cases/conformance/classes/mixinAccessModifiers.ts(66,7): error TS2415: Class 'C1' incorrectly extends base class 'Private & Private2'.
+  Type 'C1' is not assignable to type 'Private'.
+    Property 'p' has conflicting declarations and is inaccessible in type 'C1'.
+tests/cases/conformance/classes/mixinAccessModifiers.ts(67,7): error TS2415: Class 'C2' incorrectly extends base class 'Private & Protected'.
+  Type 'C2' is not assignable to type 'Private'.
+    Property 'p' has conflicting declarations and is inaccessible in type 'C2'.
+tests/cases/conformance/classes/mixinAccessModifiers.ts(68,7): error TS2415: Class 'C3' incorrectly extends base class 'Private & Public'.
+  Type 'C3' is not assignable to type 'Private'.
+    Property 'p' has conflicting declarations and is inaccessible in type 'C3'.
+tests/cases/conformance/classes/mixinAccessModifiers.ts(85,6): error TS2445: Property 'p' is protected and only accessible within class 'C4' and its subclasses.
+tests/cases/conformance/classes/mixinAccessModifiers.ts(90,6): error TS2445: Property 's' is protected and only accessible within class 'typeof C4' and its subclasses.
+tests/cases/conformance/classes/mixinAccessModifiers.ts(98,6): error TS2445: Property 'p' is protected and only accessible within class 'C4' and its subclasses.
+tests/cases/conformance/classes/mixinAccessModifiers.ts(103,6): error TS2445: Property 's' is protected and only accessible within class 'typeof C4' and its subclasses.
+
+
+==== tests/cases/conformance/classes/mixinAccessModifiers.ts (11 errors) ====
+    
+    type Constructable = new (...args: any[]) => object;
+    
+    class Private {
+    	constructor (...args: any[]) {}
+    	private p: string;
+    }
+    
+    class Private2 {
+    	constructor (...args: any[]) {}
+    	private p: string;
+    }
+    
+    class Protected {
+    	constructor (...args: any[]) {}
+    	protected p: string;
+    	protected static s: string;
+    }
+    
+    class Protected2 {
+    	constructor (...args: any[]) {}
+    	protected p: string;
+    	protected static s: string;
+    }
+    
+    class Public {
+    	constructor (...args: any[]) {}
+    	public p: string;
+    	public static s: string;
+    }
+    
+    class Public2 {
+    	constructor (...args: any[]) {}
+    	public p: string;
+    	public static s: string;
+    }
+    
+    function f1(x: Private & Private2) {
+    	x.p;  // Error, private constituent makes property inaccessible
+    	  ~
+!!! error TS2546: Property 'p' has conflicting declarations and is inaccessible in type 'Private & Private2'.
+    }
+    
+    function f2(x: Private & Protected) {
+    	x.p;  // Error, private constituent makes property inaccessible
+    	  ~
+!!! error TS2546: Property 'p' has conflicting declarations and is inaccessible in type 'Private & Protected'.
+    }
+    
+    function f3(x: Private & Public) {
+    	x.p;  // Error, private constituent makes property inaccessible
+    	  ~
+!!! error TS2546: Property 'p' has conflicting declarations and is inaccessible in type 'Private & Public'.
+    }
+    
+    function f4(x: Protected & Protected2) {
+    	x.p;  // Error, protected when all constituents are protected
+    	  ~
+!!! error TS2445: Property 'p' is protected and only accessible within class 'Protected & Protected2' and its subclasses.
+    }
+    
+    function f5(x: Protected & Public) {
+    	x.p;  // Ok, public if any constituent is public
+    }
+    
+    function f6(x: Public & Public2) {
+    	x.p;  // Ok, public if any constituent is public
+    }
+    
+    declare function Mix<T, U>(c1: T, c2: U): T & U;
+    
+    // Can't derive from type with inaccessible properties
+    
+    class C1 extends Mix(Private, Private2) {}
+          ~~
+!!! error TS2415: Class 'C1' incorrectly extends base class 'Private & Private2'.
+!!! error TS2415:   Type 'C1' is not assignable to type 'Private'.
+!!! error TS2415:     Property 'p' has conflicting declarations and is inaccessible in type 'C1'.
+    class C2 extends Mix(Private, Protected) {}
+          ~~
+!!! error TS2415: Class 'C2' incorrectly extends base class 'Private & Protected'.
+!!! error TS2415:   Type 'C2' is not assignable to type 'Private'.
+!!! error TS2415:     Property 'p' has conflicting declarations and is inaccessible in type 'C2'.
+    class C3 extends Mix(Private, Public) {}
+          ~~
+!!! error TS2415: Class 'C3' incorrectly extends base class 'Private & Public'.
+!!! error TS2415:   Type 'C3' is not assignable to type 'Private'.
+!!! error TS2415:     Property 'p' has conflicting declarations and is inaccessible in type 'C3'.
+    
+    class C4 extends Mix(Protected, Protected2) {
+    	f(c4: C4, c5: C5, c6: C6) {
+    		c4.p;
+    		c5.p;
+    		c6.p;
+    	}
+    	static g() {
+    		C4.s;
+    		C5.s;
+    		C6.s
+    	}
+    }
+    
+    class C5 extends Mix(Protected, Public) {
+    	f(c4: C4, c5: C5, c6: C6) {
+    		c4.p;  // Error, not in class deriving from Protected2
+    		   ~
+!!! error TS2445: Property 'p' is protected and only accessible within class 'C4' and its subclasses.
+    		c5.p;
+    		c6.p;
+    	}
+    	static g() {
+    		C4.s;  // Error, not in class deriving from Protected2
+    		   ~
+!!! error TS2445: Property 's' is protected and only accessible within class 'typeof C4' and its subclasses.
+    		C5.s;
+    		C6.s
+    	}
+    }
+    
+    class C6 extends Mix(Public, Public2) {
+    	f(c4: C4, c5: C5, c6: C6) {
+    		c4.p;  // Error, not in class deriving from Protected2
+    		   ~
+!!! error TS2445: Property 'p' is protected and only accessible within class 'C4' and its subclasses.
+    		c5.p;
+    		c6.p;
+    	}
+    	static g() {
+    		C4.s;  // Error, not in class deriving from Protected2
+    		   ~
+!!! error TS2445: Property 's' is protected and only accessible within class 'typeof C4' and its subclasses.
+    		C5.s;
+    		C6.s
+    	}
+    }
+    

--- a/tests/baselines/reference/mixinAccessModifiers.js
+++ b/tests/baselines/reference/mixinAccessModifiers.js
@@ -1,0 +1,323 @@
+//// [mixinAccessModifiers.ts]
+
+type Constructable = new (...args: any[]) => object;
+
+class Private {
+	constructor (...args: any[]) {}
+	private p: string;
+}
+
+class Private2 {
+	constructor (...args: any[]) {}
+	private p: string;
+}
+
+class Protected {
+	constructor (...args: any[]) {}
+	protected p: string;
+	protected static s: string;
+}
+
+class Protected2 {
+	constructor (...args: any[]) {}
+	protected p: string;
+	protected static s: string;
+}
+
+class Public {
+	constructor (...args: any[]) {}
+	public p: string;
+	public static s: string;
+}
+
+class Public2 {
+	constructor (...args: any[]) {}
+	public p: string;
+	public static s: string;
+}
+
+function f1(x: Private & Private2) {
+	x.p;  // Error, private constituent makes property inaccessible
+}
+
+function f2(x: Private & Protected) {
+	x.p;  // Error, private constituent makes property inaccessible
+}
+
+function f3(x: Private & Public) {
+	x.p;  // Error, private constituent makes property inaccessible
+}
+
+function f4(x: Protected & Protected2) {
+	x.p;  // Error, protected when all constituents are protected
+}
+
+function f5(x: Protected & Public) {
+	x.p;  // Ok, public if any constituent is public
+}
+
+function f6(x: Public & Public2) {
+	x.p;  // Ok, public if any constituent is public
+}
+
+declare function Mix<T, U>(c1: T, c2: U): T & U;
+
+// Can't derive from type with inaccessible properties
+
+class C1 extends Mix(Private, Private2) {}
+class C2 extends Mix(Private, Protected) {}
+class C3 extends Mix(Private, Public) {}
+
+class C4 extends Mix(Protected, Protected2) {
+	f(c4: C4, c5: C5, c6: C6) {
+		c4.p;
+		c5.p;
+		c6.p;
+	}
+	static g() {
+		C4.s;
+		C5.s;
+		C6.s
+	}
+}
+
+class C5 extends Mix(Protected, Public) {
+	f(c4: C4, c5: C5, c6: C6) {
+		c4.p;  // Error, not in class deriving from Protected2
+		c5.p;
+		c6.p;
+	}
+	static g() {
+		C4.s;  // Error, not in class deriving from Protected2
+		C5.s;
+		C6.s
+	}
+}
+
+class C6 extends Mix(Public, Public2) {
+	f(c4: C4, c5: C5, c6: C6) {
+		c4.p;  // Error, not in class deriving from Protected2
+		c5.p;
+		c6.p;
+	}
+	static g() {
+		C4.s;  // Error, not in class deriving from Protected2
+		C5.s;
+		C6.s
+	}
+}
+
+
+//// [mixinAccessModifiers.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var Private = (function () {
+    function Private() {
+        var args = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            args[_i] = arguments[_i];
+        }
+    }
+    return Private;
+}());
+var Private2 = (function () {
+    function Private2() {
+        var args = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            args[_i] = arguments[_i];
+        }
+    }
+    return Private2;
+}());
+var Protected = (function () {
+    function Protected() {
+        var args = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            args[_i] = arguments[_i];
+        }
+    }
+    return Protected;
+}());
+var Protected2 = (function () {
+    function Protected2() {
+        var args = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            args[_i] = arguments[_i];
+        }
+    }
+    return Protected2;
+}());
+var Public = (function () {
+    function Public() {
+        var args = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            args[_i] = arguments[_i];
+        }
+    }
+    return Public;
+}());
+var Public2 = (function () {
+    function Public2() {
+        var args = [];
+        for (var _i = 0; _i < arguments.length; _i++) {
+            args[_i] = arguments[_i];
+        }
+    }
+    return Public2;
+}());
+function f1(x) {
+    x.p; // Error, private constituent makes property inaccessible
+}
+function f2(x) {
+    x.p; // Error, private constituent makes property inaccessible
+}
+function f3(x) {
+    x.p; // Error, private constituent makes property inaccessible
+}
+function f4(x) {
+    x.p; // Error, protected when all constituents are protected
+}
+function f5(x) {
+    x.p; // Ok, public if any constituent is public
+}
+function f6(x) {
+    x.p; // Ok, public if any constituent is public
+}
+// Can't derive from type with inaccessible properties
+var C1 = (function (_super) {
+    __extends(C1, _super);
+    function C1() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C1;
+}(Mix(Private, Private2)));
+var C2 = (function (_super) {
+    __extends(C2, _super);
+    function C2() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C2;
+}(Mix(Private, Protected)));
+var C3 = (function (_super) {
+    __extends(C3, _super);
+    function C3() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return C3;
+}(Mix(Private, Public)));
+var C4 = (function (_super) {
+    __extends(C4, _super);
+    function C4() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    C4.prototype.f = function (c4, c5, c6) {
+        c4.p;
+        c5.p;
+        c6.p;
+    };
+    C4.g = function () {
+        C4.s;
+        C5.s;
+        C6.s;
+    };
+    return C4;
+}(Mix(Protected, Protected2)));
+var C5 = (function (_super) {
+    __extends(C5, _super);
+    function C5() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    C5.prototype.f = function (c4, c5, c6) {
+        c4.p; // Error, not in class deriving from Protected2
+        c5.p;
+        c6.p;
+    };
+    C5.g = function () {
+        C4.s; // Error, not in class deriving from Protected2
+        C5.s;
+        C6.s;
+    };
+    return C5;
+}(Mix(Protected, Public)));
+var C6 = (function (_super) {
+    __extends(C6, _super);
+    function C6() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    C6.prototype.f = function (c4, c5, c6) {
+        c4.p; // Error, not in class deriving from Protected2
+        c5.p;
+        c6.p;
+    };
+    C6.g = function () {
+        C4.s; // Error, not in class deriving from Protected2
+        C5.s;
+        C6.s;
+    };
+    return C6;
+}(Mix(Public, Public2)));
+
+
+//// [mixinAccessModifiers.d.ts]
+declare type Constructable = new (...args: any[]) => object;
+declare class Private {
+    constructor(...args: any[]);
+    private p;
+}
+declare class Private2 {
+    constructor(...args: any[]);
+    private p;
+}
+declare class Protected {
+    constructor(...args: any[]);
+    protected p: string;
+    protected static s: string;
+}
+declare class Protected2 {
+    constructor(...args: any[]);
+    protected p: string;
+    protected static s: string;
+}
+declare class Public {
+    constructor(...args: any[]);
+    p: string;
+    static s: string;
+}
+declare class Public2 {
+    constructor(...args: any[]);
+    p: string;
+    static s: string;
+}
+declare function f1(x: Private & Private2): void;
+declare function f2(x: Private & Protected): void;
+declare function f3(x: Private & Public): void;
+declare function f4(x: Protected & Protected2): void;
+declare function f5(x: Protected & Public): void;
+declare function f6(x: Public & Public2): void;
+declare function Mix<T, U>(c1: T, c2: U): T & U;
+declare class C1 extends Private & Private2 {
+}
+declare class C2 extends Private & Protected {
+}
+declare class C3 extends Private & Public {
+}
+declare class C4 extends Protected & Protected2 {
+    f(c4: C4, c5: C5, c6: C6): void;
+    static g(): void;
+}
+declare class C5 extends Protected & Public {
+    f(c4: C4, c5: C5, c6: C6): void;
+    static g(): void;
+}
+declare class C6 extends Public & Public2 {
+    f(c4: C4, c5: C5, c6: C6): void;
+    static g(): void;
+}

--- a/tests/baselines/reference/mixinPrivateAndProtected.errors.txt
+++ b/tests/baselines/reference/mixinPrivateAndProtected.errors.txt
@@ -1,0 +1,116 @@
+tests/cases/compiler/mixinPrivateAndProtected.ts(46,3): error TS2445: Property 'ptd' is protected and only accessible within class 'A' and its subclasses.
+tests/cases/compiler/mixinPrivateAndProtected.ts(47,3): error TS2341: Property 'pvt' is private and only accessible within class 'A'.
+tests/cases/compiler/mixinPrivateAndProtected.ts(50,4): error TS2445: Property 'ptd' is protected and only accessible within class 'mixB<typeof A>.(Anonymous class) & A' and its subclasses.
+tests/cases/compiler/mixinPrivateAndProtected.ts(51,4): error TS2546: Property 'pvt' has conflicting declarations and is inaccessible in type 'mixB<typeof A>.(Anonymous class) & A'.
+tests/cases/compiler/mixinPrivateAndProtected.ts(54,5): error TS2445: Property 'ptd' is protected and only accessible within class 'mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB<typeof A>.(Anonymous class) & A' and its subclasses.
+tests/cases/compiler/mixinPrivateAndProtected.ts(55,5): error TS2546: Property 'pvt' has conflicting declarations and is inaccessible in type 'mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB<typeof A>.(Anonymous class) & A'.
+tests/cases/compiler/mixinPrivateAndProtected.ts(58,6): error TS2445: Property 'ptd' is protected and only accessible within class 'mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB2<typeof A>.(Anonymous class) & A' and its subclasses.
+tests/cases/compiler/mixinPrivateAndProtected.ts(59,6): error TS2546: Property 'pvt' has conflicting declarations and is inaccessible in type 'mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB2<typeof A>.(Anonymous class) & A'.
+
+
+==== tests/cases/compiler/mixinPrivateAndProtected.ts (8 errors) ====
+    // Repro from #13830
+    
+    type Constructor<T> = new(...args: any[]) => T;
+    
+    class A {
+        public pb: number = 2;
+        protected ptd: number = 1;
+        private pvt: number = 0;
+    }
+    
+    function mixB<T extends Constructor<{}>>(Cls: T) {
+        return class extends Cls {
+            protected ptd: number = 10;
+            private pvt: number = 0;
+        };
+    }
+    
+    function mixB2<T extends Constructor<A>>(Cls: T) {
+        return class extends Cls {
+            protected ptd: number = 10;
+        };
+    }
+    
+    const
+        AB = mixB(A),
+        AB2 = mixB2(A);
+    
+    function mixC<T extends Constructor<{}>>(Cls: T) {
+        return class extends Cls {
+            protected ptd: number = 100;
+            private pvt: number = 0;
+        };
+    }
+    
+    const
+        AB2C = mixC(AB2),
+        ABC = mixC(AB);
+    
+    const
+        a = new A(),
+        ab = new AB(),
+        abc = new ABC(),
+        ab2c = new AB2C();
+    
+    a.pb.toFixed();
+    a.ptd.toFixed();    // Error
+      ~~~
+!!! error TS2445: Property 'ptd' is protected and only accessible within class 'A' and its subclasses.
+    a.pvt.toFixed();    // Error
+      ~~~
+!!! error TS2341: Property 'pvt' is private and only accessible within class 'A'.
+    
+    ab.pb.toFixed();
+    ab.ptd.toFixed();   // Error
+       ~~~
+!!! error TS2445: Property 'ptd' is protected and only accessible within class 'mixB<typeof A>.(Anonymous class) & A' and its subclasses.
+    ab.pvt.toFixed();   // Error
+       ~~~
+!!! error TS2546: Property 'pvt' has conflicting declarations and is inaccessible in type 'mixB<typeof A>.(Anonymous class) & A'.
+    
+    abc.pb.toFixed();
+    abc.ptd.toFixed();  // Error
+        ~~~
+!!! error TS2445: Property 'ptd' is protected and only accessible within class 'mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB<typeof A>.(Anonymous class) & A' and its subclasses.
+    abc.pvt.toFixed();  // Error
+        ~~~
+!!! error TS2546: Property 'pvt' has conflicting declarations and is inaccessible in type 'mixC<{ new (...args: any[]): mixB<typeof A>.(Anonymous class); prototype: mixB<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB<typeof A>.(Anonymous class) & A'.
+    
+    ab2c.pb.toFixed();
+    ab2c.ptd.toFixed(); // Error
+         ~~~
+!!! error TS2445: Property 'ptd' is protected and only accessible within class 'mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB2<typeof A>.(Anonymous class) & A' and its subclasses.
+    ab2c.pvt.toFixed(); // Error
+         ~~~
+!!! error TS2546: Property 'pvt' has conflicting declarations and is inaccessible in type 'mixC<{ new (...args: any[]): mixB2<typeof A>.(Anonymous class); prototype: mixB2<any>.(Anonymous class); } & typeof A>.(Anonymous class) & mixB2<typeof A>.(Anonymous class) & A'.
+    
+    // Repro from #13924
+    
+    class Person {
+    	constructor(public name: string) {}
+    
+    	protected myProtectedFunction() {
+    		// do something
+    	}
+    }
+    
+    function PersonMixin<T extends Constructor<Person>>(Base: T) {
+    	return class extends Base {
+    		constructor(...args: any[]) {
+    			super(...args);
+    		}
+    
+    		myProtectedFunction() {
+    			super.myProtectedFunction();
+    			// do more things
+    		}
+    	};
+    }
+    
+    class Customer extends PersonMixin(Person) {
+    	accountBalance: number;
+        f() {
+        }
+    }
+    

--- a/tests/baselines/reference/mixinPrivateAndProtected.js
+++ b/tests/baselines/reference/mixinPrivateAndProtected.js
@@ -1,0 +1,197 @@
+//// [mixinPrivateAndProtected.ts]
+// Repro from #13830
+
+type Constructor<T> = new(...args: any[]) => T;
+
+class A {
+    public pb: number = 2;
+    protected ptd: number = 1;
+    private pvt: number = 0;
+}
+
+function mixB<T extends Constructor<{}>>(Cls: T) {
+    return class extends Cls {
+        protected ptd: number = 10;
+        private pvt: number = 0;
+    };
+}
+
+function mixB2<T extends Constructor<A>>(Cls: T) {
+    return class extends Cls {
+        protected ptd: number = 10;
+    };
+}
+
+const
+    AB = mixB(A),
+    AB2 = mixB2(A);
+
+function mixC<T extends Constructor<{}>>(Cls: T) {
+    return class extends Cls {
+        protected ptd: number = 100;
+        private pvt: number = 0;
+    };
+}
+
+const
+    AB2C = mixC(AB2),
+    ABC = mixC(AB);
+
+const
+    a = new A(),
+    ab = new AB(),
+    abc = new ABC(),
+    ab2c = new AB2C();
+
+a.pb.toFixed();
+a.ptd.toFixed();    // Error
+a.pvt.toFixed();    // Error
+
+ab.pb.toFixed();
+ab.ptd.toFixed();   // Error
+ab.pvt.toFixed();   // Error
+
+abc.pb.toFixed();
+abc.ptd.toFixed();  // Error
+abc.pvt.toFixed();  // Error
+
+ab2c.pb.toFixed();
+ab2c.ptd.toFixed(); // Error
+ab2c.pvt.toFixed(); // Error
+
+// Repro from #13924
+
+class Person {
+	constructor(public name: string) {}
+
+	protected myProtectedFunction() {
+		// do something
+	}
+}
+
+function PersonMixin<T extends Constructor<Person>>(Base: T) {
+	return class extends Base {
+		constructor(...args: any[]) {
+			super(...args);
+		}
+
+		myProtectedFunction() {
+			super.myProtectedFunction();
+			// do more things
+		}
+	};
+}
+
+class Customer extends PersonMixin(Person) {
+	accountBalance: number;
+    f() {
+    }
+}
+
+
+//// [mixinPrivateAndProtected.js]
+// Repro from #13830
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var A = (function () {
+    function A() {
+        this.pb = 2;
+        this.ptd = 1;
+        this.pvt = 0;
+    }
+    return A;
+}());
+function mixB(Cls) {
+    return (function (_super) {
+        __extends(class_1, _super);
+        function class_1() {
+            var _this = _super !== null && _super.apply(this, arguments) || this;
+            _this.ptd = 10;
+            _this.pvt = 0;
+            return _this;
+        }
+        return class_1;
+    }(Cls));
+}
+function mixB2(Cls) {
+    return (function (_super) {
+        __extends(class_2, _super);
+        function class_2() {
+            var _this = _super !== null && _super.apply(this, arguments) || this;
+            _this.ptd = 10;
+            return _this;
+        }
+        return class_2;
+    }(Cls));
+}
+var AB = mixB(A), AB2 = mixB2(A);
+function mixC(Cls) {
+    return (function (_super) {
+        __extends(class_3, _super);
+        function class_3() {
+            var _this = _super !== null && _super.apply(this, arguments) || this;
+            _this.ptd = 100;
+            _this.pvt = 0;
+            return _this;
+        }
+        return class_3;
+    }(Cls));
+}
+var AB2C = mixC(AB2), ABC = mixC(AB);
+var a = new A(), ab = new AB(), abc = new ABC(), ab2c = new AB2C();
+a.pb.toFixed();
+a.ptd.toFixed(); // Error
+a.pvt.toFixed(); // Error
+ab.pb.toFixed();
+ab.ptd.toFixed(); // Error
+ab.pvt.toFixed(); // Error
+abc.pb.toFixed();
+abc.ptd.toFixed(); // Error
+abc.pvt.toFixed(); // Error
+ab2c.pb.toFixed();
+ab2c.ptd.toFixed(); // Error
+ab2c.pvt.toFixed(); // Error
+// Repro from #13924
+var Person = (function () {
+    function Person(name) {
+        this.name = name;
+    }
+    Person.prototype.myProtectedFunction = function () {
+        // do something
+    };
+    return Person;
+}());
+function PersonMixin(Base) {
+    return (function (_super) {
+        __extends(class_4, _super);
+        function class_4() {
+            var args = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                args[_i] = arguments[_i];
+            }
+            return _super.apply(this, args) || this;
+        }
+        class_4.prototype.myProtectedFunction = function () {
+            _super.prototype.myProtectedFunction.call(this);
+            // do more things
+        };
+        return class_4;
+    }(Base));
+}
+var Customer = (function (_super) {
+    __extends(Customer, _super);
+    function Customer() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Customer.prototype.f = function () {
+    };
+    return Customer;
+}(PersonMixin(Person)));

--- a/tests/cases/compiler/mixinPrivateAndProtected.ts
+++ b/tests/cases/compiler/mixinPrivateAndProtected.ts
@@ -1,0 +1,88 @@
+// Repro from #13830
+
+type Constructor<T> = new(...args: any[]) => T;
+
+class A {
+    public pb: number = 2;
+    protected ptd: number = 1;
+    private pvt: number = 0;
+}
+
+function mixB<T extends Constructor<{}>>(Cls: T) {
+    return class extends Cls {
+        protected ptd: number = 10;
+        private pvt: number = 0;
+    };
+}
+
+function mixB2<T extends Constructor<A>>(Cls: T) {
+    return class extends Cls {
+        protected ptd: number = 10;
+    };
+}
+
+const
+    AB = mixB(A),
+    AB2 = mixB2(A);
+
+function mixC<T extends Constructor<{}>>(Cls: T) {
+    return class extends Cls {
+        protected ptd: number = 100;
+        private pvt: number = 0;
+    };
+}
+
+const
+    AB2C = mixC(AB2),
+    ABC = mixC(AB);
+
+const
+    a = new A(),
+    ab = new AB(),
+    abc = new ABC(),
+    ab2c = new AB2C();
+
+a.pb.toFixed();
+a.ptd.toFixed();    // Error
+a.pvt.toFixed();    // Error
+
+ab.pb.toFixed();
+ab.ptd.toFixed();   // Error
+ab.pvt.toFixed();   // Error
+
+abc.pb.toFixed();
+abc.ptd.toFixed();  // Error
+abc.pvt.toFixed();  // Error
+
+ab2c.pb.toFixed();
+ab2c.ptd.toFixed(); // Error
+ab2c.pvt.toFixed(); // Error
+
+// Repro from #13924
+
+class Person {
+	constructor(public name: string) {}
+
+	protected myProtectedFunction() {
+		// do something
+	}
+}
+
+function PersonMixin<T extends Constructor<Person>>(Base: T) {
+	return class extends Base {
+		constructor(...args: any[]) {
+			super(...args);
+		}
+
+		myProtectedFunction() {
+			super.myProtectedFunction();
+			// do more things
+		}
+	};
+}
+
+class Customer extends PersonMixin(Person) {
+	accountBalance: number;
+    f() {
+    }
+}

--- a/tests/cases/conformance/classes/mixinAccessModifiers.ts
+++ b/tests/cases/conformance/classes/mixinAccessModifiers.ts
@@ -1,0 +1,108 @@
+// @declaration: true
+
+type Constructable = new (...args: any[]) => object;
+
+class Private {
+	constructor (...args: any[]) {}
+	private p: string;
+}
+
+class Private2 {
+	constructor (...args: any[]) {}
+	private p: string;
+}
+
+class Protected {
+	constructor (...args: any[]) {}
+	protected p: string;
+	protected static s: string;
+}
+
+class Protected2 {
+	constructor (...args: any[]) {}
+	protected p: string;
+	protected static s: string;
+}
+
+class Public {
+	constructor (...args: any[]) {}
+	public p: string;
+	public static s: string;
+}
+
+class Public2 {
+	constructor (...args: any[]) {}
+	public p: string;
+	public static s: string;
+}
+
+function f1(x: Private & Private2) {
+	x.p;  // Error, private constituent makes property inaccessible
+}
+
+function f2(x: Private & Protected) {
+	x.p;  // Error, private constituent makes property inaccessible
+}
+
+function f3(x: Private & Public) {
+	x.p;  // Error, private constituent makes property inaccessible
+}
+
+function f4(x: Protected & Protected2) {
+	x.p;  // Error, protected when all constituents are protected
+}
+
+function f5(x: Protected & Public) {
+	x.p;  // Ok, public if any constituent is public
+}
+
+function f6(x: Public & Public2) {
+	x.p;  // Ok, public if any constituent is public
+}
+
+declare function Mix<T, U>(c1: T, c2: U): T & U;
+
+// Can't derive from type with inaccessible properties
+
+class C1 extends Mix(Private, Private2) {}
+class C2 extends Mix(Private, Protected) {}
+class C3 extends Mix(Private, Public) {}
+
+class C4 extends Mix(Protected, Protected2) {
+	f(c4: C4, c5: C5, c6: C6) {
+		c4.p;
+		c5.p;
+		c6.p;
+	}
+	static g() {
+		C4.s;
+		C5.s;
+		C6.s
+	}
+}
+
+class C5 extends Mix(Protected, Public) {
+	f(c4: C4, c5: C5, c6: C6) {
+		c4.p;  // Error, not in class deriving from Protected2
+		c5.p;
+		c6.p;
+	}
+	static g() {
+		C4.s;  // Error, not in class deriving from Protected2
+		C5.s;
+		C6.s
+	}
+}
+
+class C6 extends Mix(Public, Public2) {
+	f(c4: C4, c5: C5, c6: C6) {
+		c4.p;  // Error, not in class deriving from Protected2
+		c5.p;
+		c6.p;
+	}
+	static g() {
+		C4.s;  // Error, not in class deriving from Protected2
+		C5.s;
+		C6.s
+	}
+}


### PR DESCRIPTION
With this PR we properly handle `private` and `protected` properties in intersection types. This fixes several issues related to use of `private` and `protected` in mixins (which use intersections to construct the resulting types).

This PR also introduces a new `CheckFlags` enum type representing bit flags that are present in every `TransientSymbol` (i.e. every symbol created by the type checker) and moves the `Instantiated` and `SyntheticProperty` flags from `SymbolFlags` to the new `CheckFlags`. Furthermore, the `Merged` flag is removed from `SymbolFlags` since the `Transient` flag already provides the same information.

Fixes #13830.
Fixes #13924.
