### PR TITLE
Fix #13951: VS 2017 complains about unsupported extensions

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -1650,6 +1650,115 @@ namespace ts.projectSystem {
             assert(completions && completions.entries[0].name !== "hello", `unexpected hello entry in completion list`);
         });
 
+        it("no tsconfig script block diagnostic errors", () => {
+
+            //  #1. Ensure no diagnostic errors when allowJs is true
+            const file1 = {
+                path: "/a/b/f1.ts",
+                content: ` `
+            };
+            const file2 = {
+                path: "/a/b/f2.html",
+                content: `var hello = "hello";`
+            };
+            const config1 = {
+                path: "/a/b/tsconfig.json",
+                content: JSON.stringify({ compilerOptions: { allowJs: true } })
+            };
+
+            let host = createServerHost([file1, file2, config1, libFile], { executingFilePath: combinePaths(getDirectoryPath(libFile.path), "tsc.js") });
+            let session = createSession(host);
+
+            // Specify .html extension as mixed content in a configure host request
+            const extraFileExtensions = [{ extension: ".html", scriptKind: ScriptKind.JS, isMixedContent: true }];
+            const configureHostRequest = makeSessionRequest<protocol.ConfigureRequestArguments>(CommandNames.Configure, { extraFileExtensions });
+            session.executeCommand(configureHostRequest).response;
+
+            openFilesForSession([file1], session);
+            let projectService = session.getProjectService();
+
+            checkNumberOfProjects(projectService, { configuredProjects: 1 });
+
+            let diagnostics = projectService.configuredProjects[0].getLanguageService().getCompilerOptionsDiagnostics();
+            assert.deepEqual(diagnostics, []);
+
+            //  #2. Ensure no errors when allowJs is false
+            const config2 = {
+                path: "/a/b/tsconfig.json",
+                content: JSON.stringify({ compilerOptions: { allowJs: false } })
+            };
+
+            host = createServerHost([file1, file2, config2, libFile], { executingFilePath: combinePaths(getDirectoryPath(libFile.path), "tsc.js") });
+            session = createSession(host);
+
+            session.executeCommand(configureHostRequest).response;
+
+            openFilesForSession([file1], session);
+            projectService = session.getProjectService();
+
+            checkNumberOfProjects(projectService, { configuredProjects: 1 });
+
+            diagnostics = projectService.configuredProjects[0].getLanguageService().getCompilerOptionsDiagnostics();
+            assert.deepEqual(diagnostics, []);
+
+            //  #3. Ensure no errors when compiler options aren't specified
+            const config3 = {
+                path: "/a/b/tsconfig.json",
+                content: JSON.stringify({ })
+            };
+
+            host = createServerHost([file1, file2, config3, libFile], { executingFilePath: combinePaths(getDirectoryPath(libFile.path), "tsc.js") });
+            session = createSession(host);
+
+            session.executeCommand(configureHostRequest).response;
+
+            openFilesForSession([file1], session);
+            projectService = session.getProjectService();
+
+            checkNumberOfProjects(projectService, { configuredProjects: 1 });
+
+            diagnostics = projectService.configuredProjects[0].getLanguageService().getCompilerOptionsDiagnostics();
+            assert.deepEqual(diagnostics, []);
+
+            //  #4. Ensure no errors when files are explicitly specified in tsconfig
+            const config4 = {
+                path: "/a/b/tsconfig.json",
+                content: JSON.stringify({ compilerOptions: { allowJs: true }, files: [file1.path, file2.path] })
+            };
+
+            host = createServerHost([file1, file2, config4, libFile], { executingFilePath: combinePaths(getDirectoryPath(libFile.path), "tsc.js") });
+            session = createSession(host);
+
+            session.executeCommand(configureHostRequest).response;
+
+            openFilesForSession([file1], session);
+            projectService = session.getProjectService();
+
+            checkNumberOfProjects(projectService, { configuredProjects: 1 });
+
+            diagnostics = projectService.configuredProjects[0].getLanguageService().getCompilerOptionsDiagnostics();
+            assert.deepEqual(diagnostics, []);
+
+            //  #4. Ensure no errors when files are explicitly excluded in tsconfig
+            const config5 = {
+                path: "/a/b/tsconfig.json",
+                content: JSON.stringify({ compilerOptions: { allowJs: true }, exclude: [file2.path] })
+            };
+
+            host = createServerHost([file1, file2, config5, libFile], { executingFilePath: combinePaths(getDirectoryPath(libFile.path), "tsc.js") });
+            session = createSession(host);
+
+            session.executeCommand(configureHostRequest).response;
+
+            openFilesForSession([file1], session);
+            projectService = session.getProjectService();
+
+            checkNumberOfProjects(projectService, { configuredProjects: 1 });
+
+            diagnostics = projectService.configuredProjects[0].getLanguageService().getCompilerOptionsDiagnostics();
+            assert.deepEqual(diagnostics, []);
+        });
+
         it("project structure update is deferred if files are not added\removed", () => {
             const file1 = {
                 path: "/a/b/f1.ts",

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -165,8 +165,8 @@ namespace ts.server {
                 this.compilerOptions.allowNonTsExtensions = true;
                 this.compilerOptions.allowJs = true;
             }
-            else if (hasExplicitListOfFiles) {
-                // If files are listed explicitly, allow all extensions
+            else if (hasExplicitListOfFiles || this.compilerOptions.allowJs) {
+                // If files are listed explicitly or allowJs is specified, allow all extensions
                 this.compilerOptions.allowNonTsExtensions = true;
             }
 


### PR DESCRIPTION
Fixes #13951  (VS 2017 complains about unsupported extensions) 

Issue: There are scenarios when allowJs is set to true in a tsconfig.json where the user can see a diagnostic error in the Error List stating:  _File ".XXX" has an unsupported extensions_ even though the host does support these mixedContent extensions. This occurs because only some tsconfig.json configurations (and user actions) lead to allowNonTsExtensions being set to true (ex:  if the user explicitly specifies "files", when the compiler options are empty, when applyChangesInOpenFiles occurs <closing and reopening a .html file>).  When this internal compiler option isn't set then the diagnostic error can occur.

Fix: always set allowNonTsExtensions to true when the user sets allowJs to true in the tsconfig.json.
