### PR TITLE
Improve discriminated union error messages

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7771,18 +7771,14 @@ namespace ts {
                 if (target.flags & TypeFlags.Union && containsType(targetTypes, source)) {
                     return Ternary.True;
                 }
-                const discriminantType = findMatchingDiscriminantType(source, target);
-                if (discriminantType) {
-                    return isRelatedTo(source, discriminantType, reportErrors);
-                }
-
-                const len = targetTypes.length;
-                for (let i = 0; i < len; i++) {
-                    const related = isRelatedTo(source, targetTypes[i], reportErrors && i === len - 1);
+                for (const type of targetTypes) {
+                    const related = isRelatedTo(source, type, /*reportErrors*/ false);
                     if (related) {
                         return related;
                     }
                 }
+                const discriminantType = findMatchingDiscriminantType(source, target);
+                isRelatedTo(source, discriminantType || targetTypes[targetTypes.length - 1], reportErrors);
                 return Ternary.False;
             }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -7777,8 +7777,10 @@ namespace ts {
                         return related;
                     }
                 }
-                const discriminantType = findMatchingDiscriminantType(source, target);
-                isRelatedTo(source, discriminantType || targetTypes[targetTypes.length - 1], reportErrors);
+                if (reportErrors) {
+                    const discriminantType = findMatchingDiscriminantType(source, target);
+                    isRelatedTo(source, discriminantType || targetTypes[targetTypes.length - 1], /*reportErrors*/ true);
+                }
                 return Ternary.False;
             }
 

--- a/tests/baselines/reference/discriminatedUnionErrorMessage.errors.txt
+++ b/tests/baselines/reference/discriminatedUnionErrorMessage.errors.txt
@@ -1,0 +1,23 @@
+tests/cases/compiler/discriminatedUnionErrorMessage.ts(8,5): error TS2322: Type '{ kind: "sq"; x: number; y: number; }' is not assignable to type 'Shape'.
+  Type '{ kind: "sq"; x: number; y: number; }' is not assignable to type 'Square'.
+    Property 'size' is missing in type '{ kind: "sq"; x: number; y: number; }'.
+
+
+==== tests/cases/compiler/discriminatedUnionErrorMessage.ts (1 errors) ====
+    type Square = { kind: "sq", size: number }
+    type Rectangle = { kind: "rt", x: number, y: number }
+    type Circle = { kind: "cr", radius: number }
+    type Shape =
+        | Square
+        | Rectangle
+        | Circle;
+    let shape: Shape = {
+        ~~~~~
+!!! error TS2322: Type '{ kind: "sq"; x: number; y: number; }' is not assignable to type 'Shape'.
+!!! error TS2322:   Type '{ kind: "sq"; x: number; y: number; }' is not assignable to type 'Square'.
+!!! error TS2322:     Property 'size' is missing in type '{ kind: "sq"; x: number; y: number; }'.
+        kind: "sq",
+        x: 12,
+        y: 13,
+    }
+    

--- a/tests/baselines/reference/discriminatedUnionErrorMessage.js
+++ b/tests/baselines/reference/discriminatedUnionErrorMessage.js
@@ -1,0 +1,21 @@
+//// [discriminatedUnionErrorMessage.ts]
+type Square = { kind: "sq", size: number }
+type Rectangle = { kind: "rt", x: number, y: number }
+type Circle = { kind: "cr", radius: number }
+type Shape =
+    | Square
+    | Rectangle
+    | Circle;
+let shape: Shape = {
+    kind: "sq",
+    x: 12,
+    y: 13,
+}
+
+
+//// [discriminatedUnionErrorMessage.js]
+var shape = {
+    kind: "sq",
+    x: 12,
+    y: 13
+};

--- a/tests/cases/compiler/discriminatedUnionErrorMessage.ts
+++ b/tests/cases/compiler/discriminatedUnionErrorMessage.ts
@@ -1,0 +1,12 @@
+type Square = { kind: "sq", size: number }
+type Rectangle = { kind: "rt", x: number, y: number }
+type Circle = { kind: "cr", radius: number }
+type Shape =
+    | Square
+    | Rectangle
+    | Circle;
+let shape: Shape = {
+    kind: "sq",
+    x: 12,
+    y: 13,
+}


### PR DESCRIPTION
Assignability errors for discriminated unions now check the value of the discriminant to decide which member of the union to check for assignability.

Previously, assignability didn't know about discriminated unions and would check every member, issuing errors for the last member of the union if assignability failed.

For example:

```ts
type Square = { kind: "sq", size: number }
type Rectangle = { kind: "rt", x: number, y: number }
type Circle = { kind: "cr", radius: number }
type Shape =
    | Square
    | Rectangle
    | Circle;
let shape: Shape = {
    kind: "sq",
    x: 12,
    y: 13,
}
```

`typeRelatedToSomeType` now checks whether each property in the source type is a discriminant. It finds `kind` and proceeds to look for the type in the target union that has `kind: "sq"`. If it finds it, which it does in this example (`Square`), then it checks only assignbility to `Square`.

The result is that the error now says that property 'size' is missing in type `{ kind: "sq", x: number, y: number }` instead of saying that that "sq" is not assignable to type "cr" like it did before.

Fixes #10867
