### PR TITLE
When performing find-all-refs for a keyword, use the first result as the definition.

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -406,19 +406,22 @@ namespace ts.FindAllReferences {
 
     function getAllReferencesForKeyword(sourceFiles: SourceFile[], keywordKind: ts.SyntaxKind, cancellationToken: CancellationToken): ReferencedSymbol[] {
         const name = tokenToString(keywordKind);
-        const definition: ReferencedSymbolDefinitionInfo = {
-            containerKind: "",
-            containerName: "",
-            fileName: "",
-            kind: ScriptElementKind.keyword,
-            name,
-            textSpan: createTextSpan(0, 1),
-            displayParts: [{ text: name, kind: ScriptElementKind.keyword }]
-        }
         const references: ReferenceEntry[] = [];
         for (const sourceFile of sourceFiles) {
             cancellationToken.throwIfCancellationRequested();
             addReferencesForKeywordInFile(sourceFile, keywordKind, name, cancellationToken, references);
+        }
+
+        if (!references.length) return undefined;
+
+        const definition: ReferencedSymbolDefinitionInfo = {
+            containerKind: "",
+            containerName: "",
+            fileName: references[0].fileName,
+            kind: ScriptElementKind.keyword,
+            name,
+            textSpan: references[0].textSpan,
+            displayParts: [{ text: name, kind: ScriptElementKind.keyword }]
         }
 
         return [{ definition, references }];


### PR DESCRIPTION
Fixes #13846 in Visual Studio.
This still doesn't work in VSCode; nor label references, nor string literal references.
