### PR TITLE
[Wip] Fix 11566 : allow null return in SFC

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -346,6 +346,7 @@ namespace ts {
         });
 
         let jsxElementType: Type;
+        let jsxStatelessElementType: Type;
         let _jsxNamespace: string;
         let _jsxFactoryEntity: EntityName;
 
@@ -358,7 +359,8 @@ namespace ts {
             ElementAttributesPropertyNameContainer: "ElementAttributesProperty",
             Element: "Element",
             IntrinsicAttributes: "IntrinsicAttributes",
-            IntrinsicClassAttributes: "IntrinsicClassAttributes"
+            IntrinsicClassAttributes: "IntrinsicClassAttributes",
+            StatelessElement: "StatelessElement"
         };
 
         const subtypeRelation = createMap<RelationComparisonResult>();
@@ -12197,13 +12199,13 @@ namespace ts {
         function defaultTryGetJsxStatelessFunctionAttributesType(openingLikeElement: JsxOpeningLikeElement, elementType: Type, elemInstanceType: Type, elementClassType?: Type): Type {
             Debug.assert(!(elementType.flags & TypeFlags.Union));
             if (!elementClassType || !isTypeAssignableTo(elemInstanceType, elementClassType)) {
-                if (jsxElementType) {
+                if (jsxStatelessElementType) {
                     // We don't call getResolvedSignature here because we have already resolve the type of JSX Element.
                     const callSignature = getResolvedJsxStatelessFunctionSignature(openingLikeElement, elementType, /*candidatesOutArray*/ undefined);
                     if (callSignature !== unknownSignature) {
                         const callReturnType = callSignature && getReturnTypeOfSignature(callSignature);
                         let paramType = callReturnType && (callSignature.parameters.length === 0 ? emptyObjectType : getTypeOfSymbol(callSignature.parameters[0]));
-                        if (callReturnType && isTypeAssignableTo(callReturnType, jsxElementType)) {
+                        if (callReturnType && isTypeAssignableTo(callReturnType, jsxStatelessElementType)) {
                             // Intersect in JSX.IntrinsicAttributes if it exists
                             const intrinsicAttributes = getJsxType(JsxNames.IntrinsicAttributes);
                             if (intrinsicAttributes !== unknownType) {
@@ -12231,7 +12233,7 @@ namespace ts {
             Debug.assert(!(elementType.flags & TypeFlags.Union));
             if (!elementClassType || !isTypeAssignableTo(elemInstanceType, elementClassType)) {
                 // Is this is a stateless function component? See if its single signature's return type is assignable to the JSX Element Type
-                if (jsxElementType) {
+                if (jsxStatelessElementType) {
                     // We don't call getResolvedSignature because here we have already resolve the type of JSX Element.
                     const candidatesOutArray: Signature[] = [];
                     getResolvedJsxStatelessFunctionSignature(openingLikeElement, elementType, candidatesOutArray);
@@ -12240,7 +12242,7 @@ namespace ts {
                     for (const candidate of candidatesOutArray) {
                         const callReturnType = getReturnTypeOfSignature(candidate);
                         const paramType = callReturnType && (candidate.parameters.length === 0 ? emptyObjectType : getTypeOfSymbol(candidate.parameters[0]));
-                        if (callReturnType && isTypeAssignableTo(callReturnType, jsxElementType)) {
+                        if (callReturnType && isTypeAssignableTo(callReturnType, jsxStatelessElementType)) {
                             let shouldBeCandidate = true;
                             for (const attribute of openingLikeElement.attributes.properties) {
                                 if (isJsxAttribute(attribute) &&
@@ -21280,6 +21282,7 @@ namespace ts {
             globalRegExpType = getGlobalType("RegExp");
 
             jsxElementType = getExportedTypeFromNamespace("JSX", JsxNames.Element);
+            jsxStatelessElementType = getExportedTypeFromNamespace("JSX", JsxNames.StatelessElement)
             getGlobalClassDecoratorType = memoize(() => getGlobalType("ClassDecorator"));
             getGlobalPropertyDecoratorType = memoize(() => getGlobalType("PropertyDecorator"));
             getGlobalMethodDecoratorType = memoize(() => getGlobalType("MethodDecorator"));

--- a/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes01.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes01.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx(16,15): error TS2322: Type '{ foo: "f"; }' is not assignable to type '{ foo: "A" | "B" | "C"; }'.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx(17,15): error TS2322: Type '{ foo: "f"; }' is not assignable to type '{ foo: "A" | "B" | "C"; }'.
   Types of property 'foo' are incompatible.
     Type '"f"' is not assignable to type '"A" | "B" | "C"'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx(17,15): error TS2322: Type '{ foo: "f"; }' is not assignable to type '{ foo: "A" | "B" | "C"; }'.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx(18,15): error TS2322: Type '{ foo: "f"; }' is not assignable to type '{ foo: "A" | "B" | "C"; }'.
   Types of property 'foo' are incompatible.
     Type '"f"' is not assignable to type '"A" | "B" | "C"'.
 
@@ -9,6 +9,7 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStr
 ==== tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx (2 errors) ====
     
     namespace JSX {
+        export type StatelessElement = JSX.Element | null;
         export interface IntrinsicElements {
             span: {};
         }

--- a/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes01.js
+++ b/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes01.js
@@ -1,6 +1,7 @@
 //// [contextuallyTypedStringLiteralsInJsxAttributes01.tsx]
 
 namespace JSX {
+    export type StatelessElement = JSX.Element | null;
     export interface IntrinsicElements {
         span: {};
     }
@@ -27,6 +28,7 @@ var FooComponent = function (props) { return <span>{props.foo}</span>; };
 
 //// [contextuallyTypedStringLiteralsInJsxAttributes01.d.ts]
 declare namespace JSX {
+    type StatelessElement = JSX.Element | null;
     interface IntrinsicElements {
         span: {};
     }

--- a/tests/baselines/reference/tsxAttributeResolution14.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution14.errors.txt
@@ -9,6 +9,7 @@ tests/cases/conformance/jsx/file.tsx(16,28): error TS2322: Type '{ justRandomPro
 ==== tests/cases/conformance/jsx/react.d.ts (0 errors) ====
     
     declare module JSX {
+        type StatelessElement = JSX.Element | null;
     	interface Element { }
     	interface IntrinsicElements {
             div: any;

--- a/tests/baselines/reference/tsxAttributeResolution14.js
+++ b/tests/baselines/reference/tsxAttributeResolution14.js
@@ -3,6 +3,7 @@
 //// [react.d.ts]
 
 declare module JSX {
+    type StatelessElement = JSX.Element | null;
 	interface Element { }
 	interface IntrinsicElements {
         div: any;

--- a/tests/baselines/reference/tsxDefaultAttributesResolution1.symbols
+++ b/tests/baselines/reference/tsxDefaultAttributesResolution1.symbols
@@ -20,8 +20,8 @@ class Poisoned extends React.Component<Prop, {}> {
 >render : Symbol(Poisoned.render, Decl(file.tsx, 6, 50))
 
         return <div>Hello</div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
     }
 }
 

--- a/tests/baselines/reference/tsxDefaultAttributesResolution2.symbols
+++ b/tests/baselines/reference/tsxDefaultAttributesResolution2.symbols
@@ -20,8 +20,8 @@ class Poisoned extends React.Component<Prop, {}> {
 >render : Symbol(Poisoned.render, Decl(file.tsx, 6, 50))
 
         return <div>Hello</div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
     }
 }
 

--- a/tests/baselines/reference/tsxSpreadAttributesResolution1.symbols
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution1.symbols
@@ -13,8 +13,8 @@ class Poisoned extends React.Component<{}, {}> {
 >render : Symbol(Poisoned.render, Decl(file.tsx, 3, 48))
 
         return <div>Hello</div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
     }
 }
 

--- a/tests/baselines/reference/tsxSpreadAttributesResolution11.symbols
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution11.symbols
@@ -49,8 +49,8 @@ class OverWriteAttr extends React.Component<Prop, {}> {
 >render : Symbol(OverWriteAttr.render, Decl(file.tsx, 18, 55))
 
         return <div>Hello</div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
     }
 }
 

--- a/tests/baselines/reference/tsxSpreadAttributesResolution3.symbols
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution3.symbols
@@ -24,8 +24,8 @@ class Poisoned extends React.Component<PoisonedProp, {}> {
 >render : Symbol(Poisoned.render, Decl(file.tsx, 8, 58))
 
         return <div>Hello</div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
     }
 }
 

--- a/tests/baselines/reference/tsxSpreadAttributesResolution4.symbols
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution4.symbols
@@ -24,8 +24,8 @@ class Poisoned extends React.Component<PoisonedProp, {}> {
 >render : Symbol(Poisoned.render, Decl(file.tsx, 8, 58))
 
         return <div>Hello</div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
     }
 }
 
@@ -57,8 +57,8 @@ class EmptyProp extends React.Component<{}, {}> {
 >render : Symbol(EmptyProp.render, Decl(file.tsx, 22, 49))
 
         return <div>Default hi</div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
     }
 }
 

--- a/tests/baselines/reference/tsxSpreadAttributesResolution8.symbols
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution8.symbols
@@ -46,8 +46,8 @@ class OverWriteAttr extends React.Component<Prop, {}> {
 >render : Symbol(OverWriteAttr.render, Decl(file.tsx, 18, 55))
 
         return <div>Hello</div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
     }
 }
 

--- a/tests/baselines/reference/tsxSpreadAttributesResolution9.symbols
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution9.symbols
@@ -24,8 +24,8 @@ class Opt extends React.Component<OptionProp, {}> {
 >render : Symbol(Opt.render, Decl(file.tsx, 8, 51))
 
         return <div>Hello</div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
     }
 }
 

--- a/tests/baselines/reference/tsxStatelessFunctionComponents3.symbols
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents3.symbols
@@ -6,7 +6,7 @@ import React = require('react');
 const Foo = (props: any) => <div/>;
 >Foo : Symbol(Foo, Decl(file.tsx, 3, 5))
 >props : Symbol(props, Decl(file.tsx, 3, 13))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
 
 // Should be OK
 const foo = <Foo />;
@@ -20,14 +20,14 @@ var MainMenu: React.StatelessComponent<{}> = (props) => (<div>
 >React : Symbol(React, Decl(file.tsx, 0, 0))
 >StatelessComponent : Symbol(React.StatelessComponent, Decl(react.d.ts, 197, 40))
 >props : Symbol(props, Decl(file.tsx, 9, 46))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
 
     <h3>Main Menu</h3>
->h3 : Symbol(JSX.IntrinsicElements.h3, Decl(react.d.ts, 2409, 48))
->h3 : Symbol(JSX.IntrinsicElements.h3, Decl(react.d.ts, 2409, 48))
+>h3 : Symbol(JSX.IntrinsicElements.h3, Decl(react.d.ts, 2412, 48))
+>h3 : Symbol(JSX.IntrinsicElements.h3, Decl(react.d.ts, 2412, 48))
 
 </div>);
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
 
 var App: React.StatelessComponent<{ children }> = ({children}) => (
 >App : Symbol(App, Decl(file.tsx, 13, 3))
@@ -37,12 +37,12 @@ var App: React.StatelessComponent<{ children }> = ({children}) => (
 >children : Symbol(children, Decl(file.tsx, 13, 52))
 
     <div >
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
 
         <MainMenu/>
 >MainMenu : Symbol(MainMenu, Decl(file.tsx, 9, 3))
 
 	</div>
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
 
 );

--- a/tests/baselines/reference/tsxUnionElementType1.symbols
+++ b/tests/baselines/reference/tsxUnionElementType1.symbols
@@ -9,8 +9,8 @@ function SFC1(prop: { x: number }) {
 >x : Symbol(x, Decl(file.tsx, 3, 21))
 
     return <div>hello</div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
 
 };
 
@@ -20,8 +20,8 @@ function SFC2(prop: { x: boolean }) {
 >x : Symbol(x, Decl(file.tsx, 7, 21))
 
     return <h1>World </h1>;
->h1 : Symbol(JSX.IntrinsicElements.h1, Decl(react.d.ts, 2407, 47))
->h1 : Symbol(JSX.IntrinsicElements.h1, Decl(react.d.ts, 2407, 47))
+>h1 : Symbol(JSX.IntrinsicElements.h1, Decl(react.d.ts, 2410, 47))
+>h1 : Symbol(JSX.IntrinsicElements.h1, Decl(react.d.ts, 2410, 47))
 }
 
 var SFCComp = SFC1 || SFC2;

--- a/tests/baselines/reference/tsxUnionElementType5.symbols
+++ b/tests/baselines/reference/tsxUnionElementType5.symbols
@@ -7,16 +7,16 @@ function EmptySFC1() {
 >EmptySFC1 : Symbol(EmptySFC1, Decl(file.tsx, 1, 32))
 
     return <div>hello</div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
 }
 
 function EmptySFC2() {
 >EmptySFC2 : Symbol(EmptySFC2, Decl(file.tsx, 5, 1))
 
     return <div>Hello</div>;
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
->div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2397, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2400, 45))
 }
 
 function SFC2(prop: { x: boolean }) {
@@ -25,8 +25,8 @@ function SFC2(prop: { x: boolean }) {
 >x : Symbol(x, Decl(file.tsx, 11, 21))
 
     return <h1>World</h1>;
->h1 : Symbol(JSX.IntrinsicElements.h1, Decl(react.d.ts, 2407, 47))
->h1 : Symbol(JSX.IntrinsicElements.h1, Decl(react.d.ts, 2407, 47))
+>h1 : Symbol(JSX.IntrinsicElements.h1, Decl(react.d.ts, 2410, 47))
+>h1 : Symbol(JSX.IntrinsicElements.h1, Decl(react.d.ts, 2410, 47))
 }
 
 var EmptySFCComp = EmptySFC1 || EmptySFC2;

--- a/tests/baselines/reference/tsxUnionTypeComponent1.symbols
+++ b/tests/baselines/reference/tsxUnionTypeComponent1.symbols
@@ -39,8 +39,8 @@ class MyComponent extends React.Component<ComponentProps, {}> {
 <MyComponent AnyComponent={() => <button>test</button>}/>
 >MyComponent : Symbol(MyComponent, Decl(file.tsx, 5, 1))
 >AnyComponent : Symbol(AnyComponent, Decl(file.tsx, 15, 12))
->button : Symbol(JSX.IntrinsicElements.button, Decl(react.d.ts, 2383, 43))
->button : Symbol(JSX.IntrinsicElements.button, Decl(react.d.ts, 2383, 43))
+>button : Symbol(JSX.IntrinsicElements.button, Decl(react.d.ts, 2386, 43))
+>button : Symbol(JSX.IntrinsicElements.button, Decl(react.d.ts, 2386, 43))
 
 // Component Class as Props
 class MyButtonComponent extends React.Component<{},{}> {

--- a/tests/cases/conformance/jsx/tsxAttributeResolution14.tsx
+++ b/tests/cases/conformance/jsx/tsxAttributeResolution14.tsx
@@ -3,6 +3,7 @@
 
 //@filename: react.d.ts
 declare module JSX {
+    type StatelessElement = JSX.Element | null;
 	interface Element { }
 	interface IntrinsicElements {
         div: any;

--- a/tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx
+++ b/tests/cases/conformance/types/contextualTypes/jsxAttributes/contextuallyTypedStringLiteralsInJsxAttributes01.tsx
@@ -2,6 +2,7 @@
 // @declaration: true
 
 namespace JSX {
+    export type StatelessElement = JSX.Element | null;
     export interface IntrinsicElements {
         span: {};
     }

--- a/tests/cases/fourslash/tsxCompletion12.ts
+++ b/tests/cases/fourslash/tsxCompletion12.ts
@@ -5,6 +5,7 @@
 // @noLib: true
 
 //// declare module JSX {
+////     type StatelessElement = JSX.Element | null;
 ////     interface Element { }
 ////     interface IntrinsicElements {
 ////     }

--- a/tests/cases/fourslash/tsxCompletion13.ts
+++ b/tests/cases/fourslash/tsxCompletion13.ts
@@ -5,6 +5,7 @@
 // @noLib: true
 
 //// declare module JSX {
+////     type StatelessElement = JSX.Element | null;
 ////     interface Element { }
 ////     interface IntrinsicElements {
 ////     }

--- a/tests/cases/fourslash/tsxCompletionUnionElementType.ts
+++ b/tests/cases/fourslash/tsxCompletionUnionElementType.ts
@@ -5,6 +5,7 @@
 // @noLib: true
 
 //// declare module JSX {
+////     type StatelessElement = JSX.Element | null;
 ////     interface Element { }
 ////     interface IntrinsicElements {
 ////     }

--- a/tests/cases/fourslash/tsxFindAllReferences10.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences10.ts
@@ -5,6 +5,7 @@
 // @noLib: true
 
 //// declare module JSX {
+////     type StatelessElement = JSX.Element | null;
 ////     interface Element { }
 ////     interface IntrinsicElements {
 ////     }

--- a/tests/cases/fourslash/tsxFindAllReferences7.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences7.ts
@@ -5,6 +5,7 @@
 // @noLib: true
 
 //// declare module JSX {
+////     type StatelessElement = JSX.Element | null;
 ////     interface Element { }
 ////     interface IntrinsicElements {
 ////     }

--- a/tests/cases/fourslash/tsxFindAllReferences9.ts
+++ b/tests/cases/fourslash/tsxFindAllReferences9.ts
@@ -5,6 +5,7 @@
 // @noLib: true
 
 //// declare module JSX {
+////     type StatelessElement = JSX.Element | null;
 ////     interface Element { }
 ////     interface IntrinsicElements {
 ////     }

--- a/tests/cases/fourslash/tsxGoToDefinitionStatelessFunction1.ts
+++ b/tests/cases/fourslash/tsxGoToDefinitionStatelessFunction1.ts
@@ -5,6 +5,7 @@
 // @noLib: true
 
 //// declare module JSX {
+////     type StatelessElement = JSX.Element | null;
 ////     interface Element { }
 ////     interface IntrinsicElements {
 ////     }

--- a/tests/cases/fourslash/tsxRename10.ts
+++ b/tests/cases/fourslash/tsxRename10.ts
@@ -5,6 +5,7 @@
 // @noLib: true
 
 //// declare module JSX {
+////     type StatelessElement = JSX.Element | null;
 ////     interface Element { }
 ////     interface IntrinsicElements {
 ////     }

--- a/tests/cases/fourslash/tsxRename11.ts
+++ b/tests/cases/fourslash/tsxRename11.ts
@@ -5,6 +5,7 @@
 // @noLib: true
 
 //// declare module JSX {
+////     type StatelessElement = JSX.Element | null;
 ////     interface Element { }
 ////     interface IntrinsicElements {
 ////     }

--- a/tests/cases/fourslash/tsxRename7.ts
+++ b/tests/cases/fourslash/tsxRename7.ts
@@ -5,6 +5,7 @@
 // @noLib: true
 
 //// declare module JSX {
+////     type StatelessElement = JSX.Element | null;
 ////     interface Element { }
 ////     interface IntrinsicElements {
 ////     }

--- a/tests/lib/react.d.ts
+++ b/tests/lib/react.d.ts
@@ -2359,6 +2359,9 @@ declare namespace JSX {
     interface ElementClass extends React.Component<any, any> {
         render(): JSX.Element | null;
     }
+
+    type StatelessElement = JSX.Element | null;
+
     interface ElementAttributesProperty { props: {}; }
 
     interface IntrinsicAttributes extends React.Attributes { }


### PR DESCRIPTION
Fix #11566.... This PR is need to be open against master when this PR #13640 is merged.

When check return type of SFC, instead of checking against just JSX.Element, we check the return type against JSX.Element and null.

The change [here](https://github.com/Microsoft/TypeScript/compare/wip-master-statelessOverload...master-fix11566?expand=1#diff-a30bc4b88d94b780bd32ec558d052f74) will be the one ported to DefinitelyTyped