### PR TITLE
switch FileExtensionInfo to always mean .js file and deduplicate entries in getSupportedExtensions

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -840,7 +840,7 @@ namespace ts {
       * @param basePath A root directory to resolve relative path entries in the config
       *    file to. e.g. outDir
       */
-    export function parseJsonConfigFileContent(json: any, host: ParseConfigHost, basePath: string, existingOptions: CompilerOptions = {}, configFileName?: string, resolutionStack: Path[] = [], extraFileExtensions: FileExtensionInfo[] = []): ParsedCommandLine {
+    export function parseJsonConfigFileContent(json: any, host: ParseConfigHost, basePath: string, existingOptions: CompilerOptions = {}, configFileName?: string, resolutionStack: Path[] = [], extraFileExtensions: JsFileExtensionInfo[] = []): ParsedCommandLine {
         const errors: Diagnostic[] = [];
         basePath = normalizeSlashes(basePath);
         const getCanonicalFileName = createGetCanonicalFileName(host.useCaseSensitiveFileNames);
@@ -1186,7 +1186,7 @@ namespace ts {
      * @param host The host used to resolve files and directories.
      * @param errors An array for diagnostic reporting.
      */
-    function matchFileNames(fileNames: string[], include: string[], exclude: string[], basePath: string, options: CompilerOptions, host: ParseConfigHost, errors: Diagnostic[], extraFileExtensions: FileExtensionInfo[]): ExpandResult {
+    function matchFileNames(fileNames: string[], include: string[], exclude: string[], basePath: string, options: CompilerOptions, host: ParseConfigHost, errors: Diagnostic[], extraFileExtensions: JsFileExtensionInfo[]): ExpandResult {
         basePath = normalizePath(basePath);
 
         // The exclude spec list is converted into a regular expression, which allows us to quickly
@@ -1361,7 +1361,7 @@ namespace ts {
      */
     function hasFileWithHigherPriorityExtension(file: string, literalFiles: Map<string>, wildcardFiles: Map<string>, extensions: string[], keyMapper: (value: string) => string) {
         const extensionPriority = getExtensionPriority(file, extensions);
-        const adjustedExtensionPriority = adjustExtensionPriority(extensionPriority);
+        const adjustedExtensionPriority = adjustExtensionPriority(extensionPriority, extensions);
         for (let i = ExtensionPriority.Highest; i < adjustedExtensionPriority; i++) {
             const higherPriorityExtension = extensions[i];
             const higherPriorityPath = keyMapper(changeExtension(file, higherPriorityExtension));
@@ -1383,7 +1383,7 @@ namespace ts {
      */
     function removeWildcardFilesWithLowerPriorityExtension(file: string, wildcardFiles: Map<string>, extensions: string[], keyMapper: (value: string) => string) {
         const extensionPriority = getExtensionPriority(file, extensions);
-        const nextExtensionPriority = getNextLowestExtensionPriority(extensionPriority);
+        const nextExtensionPriority = getNextLowestExtensionPriority(extensionPriority, extensions);
         for (let i = nextExtensionPriority; i < extensions.length; i++) {
             const lowerPriorityExtension = extensions[i];
             const lowerPriorityPath = keyMapper(changeExtension(file, lowerPriorityExtension));

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3153,9 +3153,8 @@
         ThisProperty
     }
 
-    export interface FileExtensionInfo {
+    export interface JsFileExtensionInfo {
         extension: string;
-        scriptKind: ScriptKind;
         isMixedContent: boolean;
     }
 

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -1589,6 +1589,41 @@ namespace ts.projectSystem {
             checkProjectActualFiles(projectService.inferredProjects[1], [file2.path]);
         });
 
+        it ("loading files with correct priority", () => {
+            const f1 = {
+                path: "/a/main.ts",
+                content: "let x = 1"
+            };
+            const f2 = {
+                path: "/a/main.js",
+                content: "var y = 1"
+            };
+            const config = {
+                path: "/a/tsconfig.json",
+                content: JSON.stringify({
+                    compilerOptions: { allowJs: true }
+                })
+            };
+            const host = createServerHost([f1, f2, config]);
+            const projectService = createProjectService(host);
+            projectService.setHostConfiguration({
+                extraFileExtensions: [
+                    { extension: ".js", isMixedContent: false },
+                    { extension: ".html", isMixedContent: true }
+                ]
+            });
+            projectService.openClientFile(f1.path);
+            projectService.checkNumberOfProjects({ configuredProjects: 1 });
+            checkProjectActualFiles(projectService.configuredProjects[0], [ f1.path ]);
+
+            projectService.closeClientFile(f1.path);
+
+            projectService.openClientFile(f2.path);
+            projectService.checkNumberOfProjects({ configuredProjects: 1, inferredProjects: 1 });
+            checkProjectActualFiles(projectService.configuredProjects[0], [ f1.path ]);
+            checkProjectActualFiles(projectService.inferredProjects[0], [ f2.path ]);
+        });
+
         it("tsconfig script block support", () => {
             const file1 = {
                 path: "/a/b/f1.ts",

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -107,7 +107,7 @@ namespace ts.server {
     export interface HostConfiguration {
         formatCodeOptions: FormatCodeSettings;
         hostInfo: string;
-        extraFileExtensions?: FileExtensionInfo[];
+        extraFileExtensions?: JsFileExtensionInfo[];
     }
 
     interface ConfigFileConversionResult {
@@ -132,7 +132,7 @@ namespace ts.server {
     interface FilePropertyReader<T> {
         getFileName(f: T): string;
         getScriptKind(f: T): ScriptKind;
-        hasMixedContent(f: T, extraFileExtensions: FileExtensionInfo[]): boolean;
+        hasMixedContent(f: T, extraFileExtensions: JsFileExtensionInfo[]): boolean;
     }
 
     const fileNamePropertyReader: FilePropertyReader<string> = {

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1003,7 +1003,7 @@ namespace ts.server.protocol {
         /**
          * The host's additional supported file extensions
          */
-        extraFileExtensions?: FileExtensionInfo[];
+        extraFileExtensions?: JsFileExtensionInfo[];
     }
 
     /**

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1001,7 +1001,7 @@ namespace ts.server.protocol {
         formatOptions?: FormatCodeSettings;
 
         /**
-         * The host's additional supported file extensions
+         * The host's additional supported .js file extensions
          */
         extraFileExtensions?: JsFileExtensionInfo[];
     }


### PR DESCRIPTION
fixes #13950 

// @mhegazy this is alternative fix proposal, which one do you prefer?