### PR TITLE
[Master] Fix 12952 : throw exception when parsing conflict marker in JSX

### DIFF
--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -3862,6 +3862,9 @@ namespace ts {
                     parseErrorAtPosition(openingTagName.pos, openingTagName.end - openingTagName.pos, Diagnostics.JSX_element_0_has_no_corresponding_closing_tag, getTextOfNodeFromSourceText(sourceText, openingTagName));
                     break;
                 }
+                else if (token() === SyntaxKind.ConflictMarkerTrivia) {
+                    break;
+                }
                 result.push(parseJsxChild());
             }
 

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1716,8 +1716,17 @@ namespace ts {
             while (pos < end) {
                 pos++;
                 char = text.charCodeAt(pos);
-                if ((char === CharacterCodes.openBrace) || (char === CharacterCodes.lessThan)) {
+                if (char === CharacterCodes.openBrace) {
                     break;
+                }
+                if (char === CharacterCodes.lessThan) {
+                    if (isConflictMarkerTrivia(text, pos)) {
+                        pos = scanConflictMarkerTrivia(text, pos, error);
+                        return token = SyntaxKind.ConflictMarkerTrivia;
+                    }
+                    else {
+                        break;
+                    }
                 }
             }
             return token = SyntaxKind.JsxText;

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -1724,9 +1724,7 @@ namespace ts {
                         pos = scanConflictMarkerTrivia(text, pos, error);
                         return token = SyntaxKind.ConflictMarkerTrivia;
                     }
-                    else {
-                        break;
-                    }
+                    break;
                 }
             }
             return token = SyntaxKind.JsxText;

--- a/tests/baselines/reference/conflictMarkerTrivia3.errors.txt
+++ b/tests/baselines/reference/conflictMarkerTrivia3.errors.txt
@@ -1,0 +1,15 @@
+tests/cases/compiler/conflictMarkerTrivia3.tsx(1,11): error TS17004: Cannot use JSX unless the '--jsx' flag is provided.
+tests/cases/compiler/conflictMarkerTrivia3.tsx(1,16): error TS1005: '</' expected.
+tests/cases/compiler/conflictMarkerTrivia3.tsx(2,1): error TS1185: Merge conflict marker encountered.
+
+
+==== tests/cases/compiler/conflictMarkerTrivia3.tsx (3 errors) ====
+    const x = <div>
+              ~~~~~
+!!! error TS17004: Cannot use JSX unless the '--jsx' flag is provided.
+                   
+    <<<<<<< HEAD
+    ~~~~~~~~~~~~
+!!! error TS1005: '</' expected.
+    ~~~~~~~
+!!! error TS1185: Merge conflict marker encountered.

--- a/tests/baselines/reference/conflictMarkerTrivia3.js
+++ b/tests/baselines/reference/conflictMarkerTrivia3.js
@@ -1,0 +1,6 @@
+//// [conflictMarkerTrivia3.tsx]
+const x = <div>
+<<<<<<< HEAD
+
+//// [conflictMarkerTrivia3.js]
+var x = <div></>;

--- a/tests/baselines/reference/conflictMarkerTrivia4.errors.txt
+++ b/tests/baselines/reference/conflictMarkerTrivia4.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/conflictMarkerTrivia4.ts(1,12): error TS2304: Cannot find name 'div'.
+tests/cases/compiler/conflictMarkerTrivia4.ts(2,1): error TS1185: Merge conflict marker encountered.
+tests/cases/compiler/conflictMarkerTrivia4.ts(2,13): error TS1109: Expression expected.
+
+
+==== tests/cases/compiler/conflictMarkerTrivia4.ts (3 errors) ====
+    const x = <div>
+               ~~~
+!!! error TS2304: Cannot find name 'div'.
+    <<<<<<< HEAD
+    ~~~~~~~
+!!! error TS1185: Merge conflict marker encountered.
+                
+!!! error TS1109: Expression expected.

--- a/tests/baselines/reference/conflictMarkerTrivia4.js
+++ b/tests/baselines/reference/conflictMarkerTrivia4.js
@@ -1,0 +1,6 @@
+//// [conflictMarkerTrivia4.ts]
+const x = <div>
+<<<<<<< HEAD
+
+//// [conflictMarkerTrivia4.js]
+var x = ;

--- a/tests/cases/compiler/conflictMarkerTrivia3.tsx
+++ b/tests/cases/compiler/conflictMarkerTrivia3.tsx
@@ -1,0 +1,2 @@
+﻿const x = <div>
+<<<<<<< HEAD

--- a/tests/cases/compiler/conflictMarkerTrivia4.ts
+++ b/tests/cases/compiler/conflictMarkerTrivia4.ts
@@ -1,0 +1,2 @@
+﻿const x = <div>
+<<<<<<< HEAD


### PR DESCRIPTION
Fix #12952 