### PR TITLE
Literal assertions

### DIFF
--- a/tests/baselines/reference/literalAssertions.errors.txt
+++ b/tests/baselines/reference/literalAssertions.errors.txt
@@ -1,0 +1,44 @@
+tests/cases/conformance/expressions/typeAssertions/literalAssertions.ts(2,1): error TS2352: Type '0' cannot be converted to type '1'.
+tests/cases/conformance/expressions/typeAssertions/literalAssertions.ts(5,1): error TS2352: Type 'false' cannot be converted to type 'string | true'.
+tests/cases/conformance/expressions/typeAssertions/literalAssertions.ts(8,1): error TS2352: Type '"hello"' cannot be converted to type '"str"'.
+tests/cases/conformance/expressions/typeAssertions/literalAssertions.ts(10,1): error TS2352: Type '"hello"' cannot be converted to type '"str" | 123'.
+tests/cases/conformance/expressions/typeAssertions/literalAssertions.ts(15,1): error TS2352: Type '"hello"' cannot be converted to type '"str" & { _brand: any; }'.
+  Type '"hello"' is not comparable to type '"str"'.
+tests/cases/conformance/expressions/typeAssertions/literalAssertions.ts(17,1): error TS2352: Type '"hello"' cannot be converted to type '1 | ("str" & { _brand: any; })'.
+
+
+==== tests/cases/conformance/expressions/typeAssertions/literalAssertions.ts (6 errors) ====
+    0 as 0; // OK
+    0 as 1; // Error
+    ~~~~~~
+!!! error TS2352: Type '0' cannot be converted to type '1'.
+    
+    false as (false | string); // OK
+    false as (true | string);  // Error
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2352: Type 'false' cannot be converted to type 'string | true'.
+    false as (boolean | string);  // OK
+    
+    'hello' as 'str'; // Error
+    ~~~~~~~~~~~~~~~~
+!!! error TS2352: Type '"hello"' cannot be converted to type '"str"'.
+    'hello' as 'hello'; // OK
+    'hello' as ('str' | 123); // Error
+    ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2352: Type '"hello"' cannot be converted to type '"str" | 123'.
+    'hello' as ('hello' | 123); // OK
+    'hello' as ('str' & 'hello'); // OK
+    'hello' as ('str' | 'hello'); // OK
+    'hello' as (1 | 2 | string); // OK
+    'hello' as ('str' & { _brand: any }); // Error
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2352: Type '"hello"' cannot be converted to type '"str" & { _brand: any; }'.
+!!! error TS2352:   Type '"hello"' is not comparable to type '"str"'.
+    'hello' as ('hello' & { _brand: any }); // OK
+    'hello' as ('str' & { _brand: any } | 1); // Error
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2352: Type '"hello"' cannot be converted to type '1 | ("str" & { _brand: any; })'.
+    'hello' as ('hello' & { _brand: any } | 1); // OK
+    
+    ('string' as string as 'literal'); // OK
+    

--- a/tests/baselines/reference/literalAssertions.js
+++ b/tests/baselines/reference/literalAssertions.js
@@ -1,0 +1,41 @@
+//// [literalAssertions.ts]
+0 as 0; // OK
+0 as 1; // Error
+
+false as (false | string); // OK
+false as (true | string);  // Error
+false as (boolean | string);  // OK
+
+'hello' as 'str'; // Error
+'hello' as 'hello'; // OK
+'hello' as ('str' | 123); // Error
+'hello' as ('hello' | 123); // OK
+'hello' as ('str' & 'hello'); // OK
+'hello' as ('str' | 'hello'); // OK
+'hello' as (1 | 2 | string); // OK
+'hello' as ('str' & { _brand: any }); // Error
+'hello' as ('hello' & { _brand: any }); // OK
+'hello' as ('str' & { _brand: any } | 1); // Error
+'hello' as ('hello' & { _brand: any } | 1); // OK
+
+('string' as string as 'literal'); // OK
+
+
+//// [literalAssertions.js]
+0; // OK
+0; // Error
+false; // OK
+false; // Error
+false; // OK
+'hello'; // Error
+'hello'; // OK
+'hello'; // Error
+'hello'; // OK
+'hello'; // OK
+'hello'; // OK
+'hello'; // OK
+'hello'; // Error
+'hello'; // OK
+'hello'; // Error
+'hello'; // OK
+'string'; // OK

--- a/tests/baselines/reference/stringLiteralsAssertionsInEqualityComparisons02.errors.txt
+++ b/tests/baselines/reference/stringLiteralsAssertionsInEqualityComparisons02.errors.txt
@@ -1,15 +1,21 @@
 tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparisons02.ts(3,9): error TS2365: Operator '===' cannot be applied to types '"foo"' and '"baz"'.
+tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparisons02.ts(3,19): error TS2352: Type '"bar"' cannot be converted to type '"baz"'.
+tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparisons02.ts(4,20): error TS2352: Type '"bar"' cannot be converted to type '"foo"'.
 tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparisons02.ts(5,9): error TS2365: Operator '==' cannot be applied to types 'string' and 'number'.
 tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparisons02.ts(5,19): error TS2352: Type 'string' cannot be converted to type 'number'.
 
 
-==== tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparisons02.ts (3 errors) ====
+==== tests/cases/conformance/types/literal/stringLiteralsAssertionsInEqualityComparisons02.ts (5 errors) ====
     type EnhancedString = string & { enhancements: any };
     
     var a = "foo" === "bar" as "baz";
             ~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2365: Operator '===' cannot be applied to types '"foo"' and '"baz"'.
+                      ~~~~~~~~~~~~~~
+!!! error TS2352: Type '"bar"' cannot be converted to type '"baz"'.
     var b = "foo" !== ("bar" as "foo");
+                       ~~~~~~~~~~~~~~
+!!! error TS2352: Type '"bar"' cannot be converted to type '"foo"'.
     var c = "foo" == (<number>"bar");
             ~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2365: Operator '==' cannot be applied to types 'string' and 'number'.

--- a/tests/baselines/reference/stringLiteralsWithTypeAssertions01.errors.txt
+++ b/tests/baselines/reference/stringLiteralsWithTypeAssertions01.errors.txt
@@ -1,0 +1,25 @@
+tests/cases/conformance/types/literal/stringLiteralsWithTypeAssertions01.ts(3,9): error TS2352: Type '"foo"' cannot be converted to type '"bar"'.
+tests/cases/conformance/types/literal/stringLiteralsWithTypeAssertions01.ts(4,9): error TS2352: Type '"bar"' cannot be converted to type '"foo"'.
+tests/cases/conformance/types/literal/stringLiteralsWithTypeAssertions01.ts(7,9): error TS2352: Type '"foo" | "bar"' cannot be converted to type '"baz"'.
+  Type '"bar"' is not comparable to type '"baz"'.
+tests/cases/conformance/types/literal/stringLiteralsWithTypeAssertions01.ts(8,9): error TS2352: Type '"baz"' cannot be converted to type '"foo" | "bar"'.
+
+
+==== tests/cases/conformance/types/literal/stringLiteralsWithTypeAssertions01.ts (4 errors) ====
+    let fooOrBar: "foo" | "bar";
+    
+    let a = "foo" as "bar";
+            ~~~~~~~~~~~~~~
+!!! error TS2352: Type '"foo"' cannot be converted to type '"bar"'.
+    let b = "bar" as "foo";
+            ~~~~~~~~~~~~~~
+!!! error TS2352: Type '"bar"' cannot be converted to type '"foo"'.
+    let c = fooOrBar as "foo";
+    let d = fooOrBar as "bar";
+    let e = fooOrBar as "baz";
+            ~~~~~~~~~~~~~~~~~
+!!! error TS2352: Type '"foo" | "bar"' cannot be converted to type '"baz"'.
+!!! error TS2352:   Type '"bar"' is not comparable to type '"baz"'.
+    let f = "baz" as typeof fooOrBar;
+            ~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2352: Type '"baz"' cannot be converted to type '"foo" | "bar"'.

--- a/tests/cases/conformance/expressions/typeAssertions/literalAssertions.ts
+++ b/tests/cases/conformance/expressions/typeAssertions/literalAssertions.ts
@@ -1,0 +1,20 @@
+0 as 0; // OK
+0 as 1; // Error
+
+false as (false | string); // OK
+false as (true | string);  // Error
+false as (boolean | string);  // OK
+
+'hello' as 'str'; // Error
+'hello' as 'hello'; // OK
+'hello' as ('str' | 123); // Error
+'hello' as ('hello' | 123); // OK
+'hello' as ('str' & 'hello'); // OK
+'hello' as ('str' | 'hello'); // OK
+'hello' as (1 | 2 | string); // OK
+'hello' as ('str' & { _brand: any }); // Error
+'hello' as ('hello' & { _brand: any }); // OK
+'hello' as ('str' & { _brand: any } | 1); // Error
+'hello' as ('hello' & { _brand: any } | 1); // OK
+
+('string' as string as 'literal'); // OK


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #14156 

Disallow unrelated literal type assertions. E.g.

```ts
0 as 0; // OK
0 as 1; // Error

false as (false | string); // OK
false as (true | string);  // Error
false as (boolean | string);  // OK

'hello' as 'str'; // Error
'hello' as 'hello'; // OK
'hello' as ('str' | 123); // Error
'hello' as ('hello' | 123); // OK
'hello' as ('str' & 'hello'); // OK
'hello' as ('str' | 'hello'); // OK
'hello' as (1 | 2 | string); // OK
'hello' as ('str' & { _brand: any }); // Error
'hello' as ('hello' & { _brand: any }); // OK
'hello' as ('str' & { _brand: any } | 1); // Error
'hello' as ('hello' & { _brand: any } | 1); // OK

('string' as string as 'literal'); // OK
```
