### PR TITLE
Merge compiler options deep

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -851,6 +851,26 @@ namespace ts {
     }
 
     /**
+     * Merge compiler options of a config file (tsconfig.json) with "extend" config.
+     * For primitive types overrides values from extend with value from main config file.
+     * For arrays (e.g. "lib"") concats and dedup them.
+     *
+     * @param baseOptions
+     * @param options
+     */
+    export function mergeCompilerOptions(baseOptions: CompilerOptions, options: CompilerOptions): CompilerOptions {
+        return Object.keys(options).reduce((newOptions, key) => {
+            const param = options[key];
+            if (!newOptions.hasOwnProperty(key) || !Array.isArray(newOptions[key])) {
+                newOptions[key] = param;
+                return newOptions;
+            }
+            newOptions[key] = deduplicate<any>((newOptions[key] as any).concat(param));
+            return newOptions;
+        }, assign({}, baseOptions));
+    }
+
+    /**
       * Parse the contents of a config file (tsconfig.json).
       * @param json The contents of the config file to parse
       * @param host Instance of ParseConfigHost used to enumerate files in folder.
@@ -896,7 +916,8 @@ namespace ts {
             if (files && !json["files"]) {
                 json["files"] = files;
             }
-            options = assign({}, baseOptions, options);
+
+            options = mergeCompilerOptions(baseOptions, options);
         }
 
         options = extend(existingOptions, options);


### PR DESCRIPTION
Hi,
It's probably more conversation starter then actual PR. If you find it useful/appropriate I'll add tests.

The problem:

Imagine that we have such `tsconfig.json`:

```json
{
    "extends": "./../tsconfig.base",
    "compilerOptions": {
        "declaration": true,
        "lib": ["es2015", "es2016"]
    },
    "include": [ "*.ts" ]
}
```

And `tsconfig.base.json` is:

```json
{
    "compilerOptions": {
        "noUnusedLocals": true,
        "noImplicitAny": true,
        "sourceMap": true,
        "target": "es6",
        "lib": ["es5", "dom"]
    }
}
```

As a result of extending base config we will get compilerOptions which looks like that:

```json
{
    "compilerOptions": {
        "declaration": true,
        "noUnusedLocals": true,
        "noImplicitAny": true,
        "sourceMap": true,
        "target": "es6",
        "lib": ["es2015", "es2016"]
    }
}
```

As you can see, "lib" now only contains items from `tsconfig.json`. It means we can't add extra items to libs, we can only completely redeclare them. And i'm not sure if it was intended or not.

The only bad thing with merging "lib" i can think of is it becomes impossible to redeclare them. But probably it's not an issue.

What do you think?
