### PR TITLE
Prefer constraint type for object literal completion

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11630,7 +11630,7 @@ namespace ts {
         }
 
         // In a typed function call, an argument or substitution expression is contextually typed by the type of the corresponding parameter.
-        function getContextualTypeForArgument(callTarget: CallLikeExpression, arg: Expression, completion: boolean = false): Type {
+        function getContextualTypeForArgument(callTarget: CallLikeExpression, arg: Expression, completion = false): Type {
             const args = getEffectiveCallArguments(callTarget);
             const argIndex = indexOf(args, arg);
             if (argIndex >= 0) {
@@ -11740,7 +11740,7 @@ namespace ts {
             return getContextualTypeForObjectLiteralElement(node);
         }
 
-        function getContextualTypeForObjectLiteralElement(element: ObjectLiteralElementLike, completion: boolean = false) {
+        function getContextualTypeForObjectLiteralElement(element: ObjectLiteralElementLike, completion = false) {
             const objectLiteral = <ObjectLiteralExpression>element.parent;
             let type = getApparentTypeOfContextualType(objectLiteral);
             if (type) {
@@ -11829,7 +11829,7 @@ namespace ts {
          * @param completion the function was invoked for completion
          * @returns the contextual type of an expression.
          */
-        function getContextualType(node: Expression, completion: boolean = false): Type {
+        function getContextualType(node: Expression, completion = false): Type {
             if (isInsideWithStatementBody(node)) {
                 // We cannot answer semantic questions within a with block, do not proceed any further
                 return undefined;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4853,8 +4853,8 @@ namespace ts {
         }
 
         function getConstraintTypeFromMappedType(type: MappedType) {
-            return type.completionConstraintType ||
-                (type.completionConstraintType = instantiateType(getConstraintOfTypeParameter(getTypeParameterFromMappedType(type)), type.mapper || identityMapper) || unknownType);
+            return type.constraintType ||
+                (type.constraintType = instantiateType(getConstraintOfTypeParameter(getTypeParameterFromMappedType(type)), type.mapper || identityMapper) || unknownType);
         }
 
         function getTemplateTypeFromMappedType(type: MappedType) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2961,14 +2961,15 @@
         ObjectLiteral    = 1 << 7,  // Originates in an object literal
         EvolvingArray    = 1 << 8,  // Evolving array type
         ObjectLiteralPatternWithComputedProperties = 1 << 9,  // Object literal pattern with computed properties
-        NonPrimitive        = 1 << 10,  // NonPrimitive object type
+        NonPrimitive = 1 << 10,  // NonPrimitive object type
+        AnonymousWithConstraint = 1 << 11, // Anonymous type with assigned constraint. Used for completion
         ClassOrInterface = Class | Interface
     }
 
     // Object types (TypeFlags.ObjectType)
     export interface ObjectType extends Type {
         objectFlags: ObjectFlags;
-        constraintType?: Type; // Contraint type for this object type. Used in completion with object literals
+        completionConstraintType?: Type; // Contraint type for this object type. Used in completion with object literals
     }
 
     /** Class and interface types (TypeFlags.Class and TypeFlags.Interface). */
@@ -3049,7 +3050,7 @@
     export interface MappedType extends ObjectType {
         declaration: MappedTypeNode;
         typeParameter?: TypeParameter;
-        constraintType?: Type;
+        completionConstraintType?: Type;
         templateType?: Type;
         modifiersType?: Type;
         mapper?: TypeMapper;  // Instantiation mapper

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2436,6 +2436,7 @@
         getAugmentedPropertiesOfType(type: Type): Symbol[];
         getRootSymbols(symbol: Symbol): Symbol[];
         getContextualType(node: Expression): Type;
+        getContextualTypeForCompletion(node: Expression): Type;
         getResolvedSignature(node: CallLikeExpression, candidatesOutArray?: Signature[]): Signature;
         getSignatureFromDeclaration(declaration: SignatureDeclaration): Signature;
         isImplementationOfOverload(node: FunctionLikeDeclaration): boolean;
@@ -2967,6 +2968,7 @@
     // Object types (TypeFlags.ObjectType)
     export interface ObjectType extends Type {
         objectFlags: ObjectFlags;
+        constraintType?: Type; // Contraint type for this object type. Used in completion with object literals
     }
 
     /** Class and interface types (TypeFlags.Class and TypeFlags.Interface). */

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3050,7 +3050,7 @@
     export interface MappedType extends ObjectType {
         declaration: MappedTypeNode;
         typeParameter?: TypeParameter;
-        completionConstraintType?: Type;
+        constraintType?: Type;
         templateType?: Type;
         modifiersType?: Type;
         mapper?: TypeMapper;  // Instantiation mapper

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -1264,7 +1264,7 @@ namespace ts.Completions {
 
                 // If the object literal is being assigned to something of type 'null | { hello: string }',
                 // it clearly isn't trying to satisfy the 'null' type. So we grab the non-nullable type if possible.
-                typeForObject = typeChecker.getContextualType(<ObjectLiteralExpression>objectLikeContainer);
+                typeForObject = typeChecker.getContextualTypeForCompletion(<ObjectLiteralExpression>objectLikeContainer);
                 typeForObject = typeForObject && typeForObject.getNonNullableType();
 
                 existingMembers = (<ObjectLiteralExpression>objectLikeContainer).properties;

--- a/tests/cases/fourslash/completionListInInferredObjectLiteral01.ts
+++ b/tests/cases/fourslash/completionListInInferredObjectLiteral01.ts
@@ -19,15 +19,15 @@
 ////funcB({ /*2*/ });
 ////funcB({ strict: true, /*3*/ });
 
-goTo.marker(1);
+goTo.marker("1");
 verify.completionListContains("hello");
 verify.completionListContains("world");
 
-goTo.marker(2);
+goTo.marker("2");
 verify.completionListContains("hello");
 verify.completionListContains("world");
 verify.completionListContains("strict");
 
-goTo.marker(3);
+goTo.marker("3");
 verify.completionListContains("hello");
 verify.completionListContains("world");

--- a/tests/cases/fourslash/completionListInInferredObjectLiteral01.ts
+++ b/tests/cases/fourslash/completionListInInferredObjectLiteral01.ts
@@ -1,0 +1,33 @@
+/// <reference path='fourslash.ts'/>
+
+// @strictNullChecks: true
+////interface Thing {
+////    hello?: number;
+////    world?: string;
+////}
+////
+////interface ThingStrict {
+////    hello?: number;
+////    world?: string;
+////    strict: boolean;
+////}
+////
+////declare function funcA<T extends Thing>(x : T): void;
+////declare function funcB<T extends ThingStrict>(x : T): void;
+////
+////funcA({ /*1*/ });
+////funcB({ /*2*/ });
+////funcB({ strict: true, /*3*/ });
+
+goTo.marker(1);
+verify.completionListContains("hello");
+verify.completionListContains("world");
+
+goTo.marker(2);
+verify.completionListContains("hello");
+verify.completionListContains("world");
+verify.completionListContains("strict");
+
+goTo.marker(3);
+verify.completionListContains("hello");
+verify.completionListContains("world");

--- a/tests/cases/fourslash/completionListInInferredObjectLiteral02.ts
+++ b/tests/cases/fourslash/completionListInInferredObjectLiteral02.ts
@@ -1,0 +1,41 @@
+/// <reference path='fourslash.ts'/>
+
+// @strictNullChecks: true
+////interface Thing {
+////    hello?: number;
+////    world?: string;
+////}
+////
+////interface ThingStrict {
+////    hello?: number;
+////    world?: string;
+////    strict: boolean;
+////}
+////
+////interface ThingIndex {
+////    [key: string]: Thing;
+////}
+////
+////interface ThingStrictIndex {
+////    [key: string]: ThingStrict;
+////}
+////
+////declare function funcA<T extends ThingIndex>(x : T): void;
+////declare function funcB<T extends ThingStrictIndex>(x : T): void;
+////
+////funcA({ test: { /*1*/ } });
+////funcB({ test: { /*2*/ } });
+////funcB({ test: { strict: true, /*3*/ } });
+
+goTo.marker(1);
+verify.completionListContains("hello");
+verify.completionListContains("world");
+
+goTo.marker(2);
+verify.completionListContains("hello");
+verify.completionListContains("world");
+verify.completionListContains("strict");
+
+goTo.marker(3);
+verify.completionListContains("hello");
+verify.completionListContains("world");

--- a/tests/cases/fourslash/completionListInInferredObjectLiteral02.ts
+++ b/tests/cases/fourslash/completionListInInferredObjectLiteral02.ts
@@ -27,15 +27,15 @@
 ////funcB({ test: { /*2*/ } });
 ////funcB({ test: { strict: true, /*3*/ } });
 
-goTo.marker(1);
+goTo.marker("1");
 verify.completionListContains("hello");
 verify.completionListContains("world");
 
-goTo.marker(2);
+goTo.marker("2");
 verify.completionListContains("hello");
 verify.completionListContains("world");
 verify.completionListContains("strict");
 
-goTo.marker(3);
+goTo.marker("3");
 verify.completionListContains("hello");
 verify.completionListContains("world");


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[x] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[x] You've signed the CLA
[x] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #9900
Fixes #12968

Store constraint type when inferring and prefer it when resolving contextual type for completion.
I'm not sure what i'm doing it by correct way, anyway i just want to move these issues forward 😃 
