### PR TITLE
Added null type in reference to  #14229

### DIFF
--- a/lib/lib.d.ts
+++ b/lib/lib.d.ts
@@ -6629,7 +6629,7 @@ declare var DOMException: {
 }
 
 interface DOMImplementation {
-    createDocument(namespaceURI: string | null, qualifiedName: string | null, doctype: DocumentType): Document;
+    createDocument(namespaceURI: string | null, qualifiedName: string | null, doctype: DocumentType | null): Document;
     createDocumentType(qualifiedName: string, publicId: string, systemId: string): DocumentType;
     createHTMLDocument(title: string): Document;
     hasFeature(): boolean;


### PR DESCRIPTION
This fixes Issue #14229 by adding a `null` as a possible type for `doctype` in `createDocument`.