### PR TITLE
isConstructorType checks base constraint for undefined

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -3952,7 +3952,7 @@ namespace ts {
             }
             if (type.flags & TypeFlags.TypeVariable) {
                 const constraint = getBaseConstraintOfType(<TypeVariable>type);
-                return isValidBaseType(constraint) && isMixinConstructorType(constraint);
+                return constraint && isValidBaseType(constraint) && isMixinConstructorType(constraint);
             }
             return false;
         }

--- a/tests/baselines/reference/baseConstraintOfDecorator.errors.txt
+++ b/tests/baselines/reference/baseConstraintOfDecorator.errors.txt
@@ -1,0 +1,23 @@
+tests/cases/compiler/baseConstraintOfDecorator.ts(2,5): error TS2322: Type 'typeof decoratorFunc' is not assignable to type 'TFunction'.
+tests/cases/compiler/baseConstraintOfDecorator.ts(2,40): error TS2507: Type 'TFunction' is not a constructor function type.
+
+
+==== tests/cases/compiler/baseConstraintOfDecorator.ts (2 errors) ====
+    export function classExtender<TFunction>(superClass: TFunction, _instanceModifier: (instance: any, args: any[]) => void): TFunction {
+        return class decoratorFunc extends superClass {
+        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                                           ~~~~~~~~~~
+!!! error TS2507: Type 'TFunction' is not a constructor function type.
+            constructor(...args: any[]) {
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                super(...args);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                _instanceModifier(this, args);
+    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+            }
+    ~~~~~~~~~
+        };
+    ~~~~~~
+!!! error TS2322: Type 'typeof decoratorFunc' is not assignable to type 'TFunction'.
+    }
+    

--- a/tests/baselines/reference/baseConstraintOfDecorator.js
+++ b/tests/baselines/reference/baseConstraintOfDecorator.js
@@ -1,0 +1,40 @@
+//// [baseConstraintOfDecorator.ts]
+export function classExtender<TFunction>(superClass: TFunction, _instanceModifier: (instance: any, args: any[]) => void): TFunction {
+    return class decoratorFunc extends superClass {
+        constructor(...args: any[]) {
+            super(...args);
+            _instanceModifier(this, args);
+        }
+    };
+}
+
+
+//// [baseConstraintOfDecorator.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+exports.__esModule = true;
+function classExtender(superClass, _instanceModifier) {
+    return (function (_super) {
+        __extends(decoratorFunc, _super);
+        function decoratorFunc() {
+            var args = [];
+            for (var _i = 0; _i < arguments.length; _i++) {
+                args[_i] = arguments[_i];
+            }
+            var _this = _super.apply(this, args) || this;
+            _instanceModifier(_this, args);
+            return _this;
+        }
+        return decoratorFunc;
+    }(superClass));
+}
+exports.classExtender = classExtender;

--- a/tests/cases/compiler/baseConstraintOfDecorator.ts
+++ b/tests/cases/compiler/baseConstraintOfDecorator.ts
@@ -1,0 +1,8 @@
+export function classExtender<TFunction>(superClass: TFunction, _instanceModifier: (instance: any, args: any[]) => void): TFunction {
+    return class decoratorFunc extends superClass {
+        constructor(...args: any[]) {
+            super(...args);
+            _instanceModifier(this, args);
+        }
+    };
+}


### PR DESCRIPTION
Previously, `isConstructorType` assumed there was always a base constraint for all type variables. When the base constraint it missing, it caused a crash because the base constraint was undefined.

`isConstructorType` uses `getBaseConstraintOfType` to get the constraint on the type variable. All other callers to `getBaseConstraintOfType` check for undefined before using the constraint, so the fix is to check for undefined here too.

Fixes #14238
