### PR TITLE
Add support for handling .js file incorrectly in fixAddMissingMember code fix

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3351,6 +3351,11 @@
         "category": "Message",
         "code": 90017
     },
+    "Initialize property '{0}' in the constructor.": {
+        "category": "Message",
+        "code": 90018
+    },
+
     "Octal literal types must use ES2015 syntax. Use the syntax '{0}'.": {
         "category": "Error",
         "code": 8017

--- a/src/services/codefixes/fixAddMissingMember.ts
+++ b/src/services/codefixes/fixAddMissingMember.ts
@@ -23,45 +23,67 @@ namespace ts.codefix {
             return undefined;
         }
 
-        if (!(token.parent && token.parent.kind === SyntaxKind.PropertyAccessExpression)) {
+        if (!isPropertyAccessExpression(token.parent) || token.parent.expression.kind !== SyntaxKind.ThisKeyword) {
             return undefined;
         }
 
-        if ((token.parent as PropertyAccessExpression).expression.kind !== SyntaxKind.ThisKeyword) {
-            return undefined;
+        return isInJavaScriptFile(sourceFile) ? getActionsForAddMissingMemberInJavaScriptFile() : getActionsForAddMissingMemberInTypeScriptFile();
+
+
+        function getActionsForAddMissingMemberInTypeScriptFile(): CodeAction[] | undefined {
+            let typeString = "any";
+
+            if (token.parent.parent.kind === SyntaxKind.BinaryExpression) {
+                const binaryExpression = token.parent.parent as BinaryExpression;
+
+                const checker = context.program.getTypeChecker();
+                const widenedType = checker.getWidenedType(checker.getBaseTypeOfLiteralType(checker.getTypeAtLocation(binaryExpression.right)));
+                typeString = checker.typeToString(widenedType);
+            }
+
+            const startPos = classDeclaration.members.pos;
+
+            return [{
+                description: formatStringFromArgs(getLocaleSpecificMessage(Diagnostics.Add_declaration_for_missing_property_0), [token.getText()]),
+                changes: [{
+                    fileName: sourceFile.fileName,
+                    textChanges: [{
+                        span: { start: startPos, length: 0 },
+                        newText: `${token.getFullText(sourceFile)}: ${typeString};`
+                    }]
+                }]
+            },
+            {
+                description: formatStringFromArgs(getLocaleSpecificMessage(Diagnostics.Add_index_signature_for_missing_property_0), [token.getText()]),
+                changes: [{
+                    fileName: sourceFile.fileName,
+                    textChanges: [{
+                        span: { start: startPos, length: 0 },
+                        newText: `[name: string]: ${typeString};`
+                    }]
+                }]
+            }];
         }
 
-        let typeString = "any";
+        function getActionsForAddMissingMemberInJavaScriptFile(): CodeAction[] | undefined {
+            const classConstructor = getFirstConstructorWithBody(classDeclaration);
+            if (!classConstructor) {
+                return undefined;
+            }
 
-        if (token.parent.parent.kind === SyntaxKind.BinaryExpression) {
-            const binaryExpression = token.parent.parent as BinaryExpression;
+            const memberName = token.getText();
+            const startPos = classConstructor.body.getEnd() - 1;
 
-            const checker = context.program.getTypeChecker();
-            const widenedType = checker.getWidenedType(checker.getBaseTypeOfLiteralType(checker.getTypeAtLocation(binaryExpression.right)));
-            typeString = checker.typeToString(widenedType);
+            return [{
+                description: formatStringFromArgs(getLocaleSpecificMessage(Diagnostics.Initialize_property_0_in_the_constructor), [memberName]),
+                changes: [{
+                    fileName: sourceFile.fileName,
+                    textChanges: [{
+                        span: { start: startPos, length: 0 },
+                        newText: `this.${memberName} = undefined;`
+                    }]
+                }]
+            }];
         }
-
-        const startPos = classDeclaration.members.pos;
-
-        return [{
-            description: formatStringFromArgs(getLocaleSpecificMessage(Diagnostics.Add_declaration_for_missing_property_0), [token.getText()]),
-            changes: [{
-                fileName: sourceFile.fileName,
-                textChanges: [{
-                    span: { start: startPos, length: 0 },
-                    newText: `${token.getFullText(sourceFile)}: ${typeString};`
-                }]
-            }]
-        },
-        {
-            description: formatStringFromArgs(getLocaleSpecificMessage(Diagnostics.Add_index_signature_for_missing_property_0), [token.getText()]),
-            changes: [{
-                fileName: sourceFile.fileName,
-                textChanges: [{
-                    span: { start: startPos, length: 0 },
-                    newText: `[name: string]: ${typeString};`
-                }]
-            }]
-        }];
     }
 }


### PR DESCRIPTION
Missing tests, but there is not a way to get the error to show at the moment. 
