### PR TITLE
Allow primitive types in JSDoc to start wtih uppercase letters

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5897,15 +5897,52 @@ namespace ts {
             return getTypeFromNonGenericTypeReference(node, symbol);
         }
 
+        function getPrimitiveTypeFromJSDocTypeReference(node: JSDocTypeReference): Type {
+            if (isIdentifier(node.name)) {
+                switch (node.name.text) {
+                    case "String":
+                        return stringType;
+                    case "Number":
+                        return numberType;
+                    case "Boolean":
+                        return booleanType;
+                    case "Void":
+                        return voidType;
+                    case "Undefined":
+                        return undefinedType;
+                    case "Null":
+                        return nullType;
+                    case "Object":
+                        return anyType;
+                    case "Function":
+                        return anyFunctionType;
+                    case "Array":
+                    case "array":
+                        return !node.typeArguments || !node.typeArguments.length ? createArrayType(anyType) : undefined;
+                    case "Promise":
+                    case "promise":
+                        return !node.typeArguments || !node.typeArguments.length ? createPromiseType(anyType) : undefined;
+                }
+            }
+        }
+
+        function getTypeFromJSDocNullableTypeNode(node: JSDocNullableType) {
+            const type = getTypeFromTypeNode(node.type);
+            return strictNullChecks ? getUnionType([type, nullType]) : type;
+        }
+
         function getTypeFromTypeReference(node: TypeReferenceNode | ExpressionWithTypeArguments | JSDocTypeReference): Type {
             const links = getNodeLinks(node);
             if (!links.resolvedType) {
                 let symbol: Symbol;
                 let type: Type;
                 if (node.kind === SyntaxKind.JSDocTypeReference) {
-                    const typeReferenceName = getTypeReferenceName(node);
-                    symbol = resolveTypeReferenceName(typeReferenceName);
-                    type = getTypeReferenceType(node, symbol);
+                    type = getPrimitiveTypeFromJSDocTypeReference(<JSDocTypeReference>node);
+                    if (!type) {
+                        const typeReferenceName = getTypeReferenceName(node);
+                        symbol = resolveTypeReferenceName(typeReferenceName);
+                        type = getTypeReferenceType(node, symbol);
+                    }
                 }
                 else {
                     // We only support expressions that are simple qualified names. For other expressions this produces undefined.
@@ -6812,12 +6849,6 @@ namespace ts {
                     return neverType;
                 case SyntaxKind.ObjectKeyword:
                     return nonPrimitiveType;
-                case SyntaxKind.JSDocNullKeyword:
-                    return nullType;
-                case SyntaxKind.JSDocUndefinedKeyword:
-                    return undefinedType;
-                case SyntaxKind.JSDocNeverKeyword:
-                    return neverType;
                 case SyntaxKind.ThisType:
                 case SyntaxKind.ThisKeyword:
                     return getTypeFromThisTypeNode(node);
@@ -6844,8 +6875,9 @@ namespace ts {
                     return getTypeFromUnionTypeNode(<UnionTypeNode>node);
                 case SyntaxKind.IntersectionType:
                     return getTypeFromIntersectionTypeNode(<IntersectionTypeNode>node);
-                case SyntaxKind.ParenthesizedType:
                 case SyntaxKind.JSDocNullableType:
+                    return getTypeFromJSDocNullableTypeNode(<JSDocNullableType>node);
+                case SyntaxKind.ParenthesizedType:
                 case SyntaxKind.JSDocNonNullableType:
                 case SyntaxKind.JSDocConstructorType:
                 case SyntaxKind.JSDocThisType:

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -381,9 +381,6 @@
         JSDocPropertyTag,
         JSDocTypeLiteral,
         JSDocLiteralType,
-        JSDocNullKeyword,
-        JSDocUndefinedKeyword,
-        JSDocNeverKeyword,
 
         // Synthesized list
         SyntaxList,
@@ -423,9 +420,9 @@
         LastBinaryOperator = CaretEqualsToken,
         FirstNode = QualifiedName,
         FirstJSDocNode = JSDocTypeExpression,
-        LastJSDocNode = JSDocNeverKeyword,
+        LastJSDocNode = JSDocLiteralType,
         FirstJSDocTagNode = JSDocComment,
-        LastJSDocTagNode = JSDocNeverKeyword
+        LastJSDocTagNode = JSDocLiteralType
     }
 
     export const enum NodeFlags {

--- a/tests/baselines/reference/jsDocTypes.js
+++ b/tests/baselines/reference/jsDocTypes.js
@@ -1,0 +1,137 @@
+//// [tests/cases/conformance/salsa/jsDocTypes.ts] ////
+
+//// [a.js]
+
+/** @type {String} */
+var S;
+
+/** @type {string} */
+var s;
+
+/** @type {Number} */
+var N;
+
+/** @type {number} */
+var n;
+
+/** @type {Boolean} */
+var B;
+
+/** @type {boolean} */
+var b;
+
+/** @type {Void} */
+var V;
+
+/** @type {void} */
+var v;
+
+/** @type {Undefined} */
+var U;
+
+/** @type {undefined} */
+var u;
+
+/** @type {Null} */
+var Nl;
+
+/** @type {null} */
+var nl;
+
+/** @type {Array} */
+var A;
+
+/** @type {array} */
+var a;
+
+/** @type {Promise} */
+var P;
+
+/** @type {promise} */
+var p;
+
+/** @type {?number} */
+var nullable;
+
+/** @type {Object} */
+var Obj;
+
+
+
+//// [b.ts]
+var S: string;
+var s: string;
+var N: number;
+var n: number
+var B: boolean;
+var b: boolean;
+var V :void;
+var v: void;
+var U: undefined;
+var u: undefined;
+var Nl: null;
+var nl: null;
+var A: any[];
+var a: any[];
+var P: Promise<any>;
+var p: Promise<any>;
+var nullable: number | null;
+var Obj: any;
+
+
+//// [a.js]
+/** @type {String} */
+var S;
+/** @type {string} */
+var s;
+/** @type {Number} */
+var N;
+/** @type {number} */
+var n;
+/** @type {Boolean} */
+var B;
+/** @type {boolean} */
+var b;
+/** @type {Void} */
+var V;
+/** @type {void} */
+var v;
+/** @type {Undefined} */
+var U;
+/** @type {undefined} */
+var u;
+/** @type {Null} */
+var Nl;
+/** @type {null} */
+var nl;
+/** @type {Array} */
+var A;
+/** @type {array} */
+var a;
+/** @type {Promise} */
+var P;
+/** @type {promise} */
+var p;
+/** @type {?number} */
+var nullable;
+/** @type {Object} */
+var Obj;
+//// [b.js]
+var S;
+var s;
+var N;
+var n;
+var B;
+var b;
+var V;
+var v;
+var U;
+var u;
+var Nl;
+var nl;
+var A;
+var a;
+var P;
+var p;
+var nullable;
+var Obj;

--- a/tests/baselines/reference/jsDocTypes.symbols
+++ b/tests/baselines/reference/jsDocTypes.symbols
@@ -1,0 +1,133 @@
+=== tests/cases/conformance/salsa/a.js ===
+
+/** @type {String} */
+var S;
+>S : Symbol(S, Decl(a.js, 2, 3), Decl(b.ts, 0, 3))
+
+/** @type {string} */
+var s;
+>s : Symbol(s, Decl(a.js, 5, 3), Decl(b.ts, 1, 3))
+
+/** @type {Number} */
+var N;
+>N : Symbol(N, Decl(a.js, 8, 3), Decl(b.ts, 2, 3))
+
+/** @type {number} */
+var n;
+>n : Symbol(n, Decl(a.js, 11, 3), Decl(b.ts, 3, 3))
+
+/** @type {Boolean} */
+var B;
+>B : Symbol(B, Decl(a.js, 14, 3), Decl(b.ts, 4, 3))
+
+/** @type {boolean} */
+var b;
+>b : Symbol(b, Decl(a.js, 17, 3), Decl(b.ts, 5, 3))
+
+/** @type {Void} */
+var V;
+>V : Symbol(V, Decl(a.js, 20, 3), Decl(b.ts, 6, 3))
+
+/** @type {void} */
+var v;
+>v : Symbol(v, Decl(a.js, 23, 3), Decl(b.ts, 7, 3))
+
+/** @type {Undefined} */
+var U;
+>U : Symbol(U, Decl(a.js, 26, 3), Decl(b.ts, 8, 3))
+
+/** @type {undefined} */
+var u;
+>u : Symbol(u, Decl(a.js, 29, 3), Decl(b.ts, 9, 3))
+
+/** @type {Null} */
+var Nl;
+>Nl : Symbol(Nl, Decl(a.js, 32, 3), Decl(b.ts, 10, 3))
+
+/** @type {null} */
+var nl;
+>nl : Symbol(nl, Decl(a.js, 35, 3), Decl(b.ts, 11, 3))
+
+/** @type {Array} */
+var A;
+>A : Symbol(A, Decl(a.js, 38, 3), Decl(b.ts, 12, 3))
+
+/** @type {array} */
+var a;
+>a : Symbol(a, Decl(a.js, 41, 3), Decl(b.ts, 13, 3))
+
+/** @type {Promise} */
+var P;
+>P : Symbol(P, Decl(a.js, 44, 3), Decl(b.ts, 14, 3))
+
+/** @type {promise} */
+var p;
+>p : Symbol(p, Decl(a.js, 47, 3), Decl(b.ts, 15, 3))
+
+/** @type {?number} */
+var nullable;
+>nullable : Symbol(nullable, Decl(a.js, 50, 3), Decl(b.ts, 16, 3))
+
+/** @type {Object} */
+var Obj;
+>Obj : Symbol(Obj, Decl(a.js, 53, 3), Decl(b.ts, 17, 3))
+
+
+
+=== tests/cases/conformance/salsa/b.ts ===
+var S: string;
+>S : Symbol(S, Decl(a.js, 2, 3), Decl(b.ts, 0, 3))
+
+var s: string;
+>s : Symbol(s, Decl(a.js, 5, 3), Decl(b.ts, 1, 3))
+
+var N: number;
+>N : Symbol(N, Decl(a.js, 8, 3), Decl(b.ts, 2, 3))
+
+var n: number
+>n : Symbol(n, Decl(a.js, 11, 3), Decl(b.ts, 3, 3))
+
+var B: boolean;
+>B : Symbol(B, Decl(a.js, 14, 3), Decl(b.ts, 4, 3))
+
+var b: boolean;
+>b : Symbol(b, Decl(a.js, 17, 3), Decl(b.ts, 5, 3))
+
+var V :void;
+>V : Symbol(V, Decl(a.js, 20, 3), Decl(b.ts, 6, 3))
+
+var v: void;
+>v : Symbol(v, Decl(a.js, 23, 3), Decl(b.ts, 7, 3))
+
+var U: undefined;
+>U : Symbol(U, Decl(a.js, 26, 3), Decl(b.ts, 8, 3))
+
+var u: undefined;
+>u : Symbol(u, Decl(a.js, 29, 3), Decl(b.ts, 9, 3))
+
+var Nl: null;
+>Nl : Symbol(Nl, Decl(a.js, 32, 3), Decl(b.ts, 10, 3))
+
+var nl: null;
+>nl : Symbol(nl, Decl(a.js, 35, 3), Decl(b.ts, 11, 3))
+
+var A: any[];
+>A : Symbol(A, Decl(a.js, 38, 3), Decl(b.ts, 12, 3))
+
+var a: any[];
+>a : Symbol(a, Decl(a.js, 41, 3), Decl(b.ts, 13, 3))
+
+var P: Promise<any>;
+>P : Symbol(P, Decl(a.js, 44, 3), Decl(b.ts, 14, 3))
+>Promise : Symbol(Promise, Decl(lib.d.ts, --, --))
+
+var p: Promise<any>;
+>p : Symbol(p, Decl(a.js, 47, 3), Decl(b.ts, 15, 3))
+>Promise : Symbol(Promise, Decl(lib.d.ts, --, --))
+
+var nullable: number | null;
+>nullable : Symbol(nullable, Decl(a.js, 50, 3), Decl(b.ts, 16, 3))
+
+var Obj: any;
+>Obj : Symbol(Obj, Decl(a.js, 53, 3), Decl(b.ts, 17, 3))
+

--- a/tests/baselines/reference/jsDocTypes.types
+++ b/tests/baselines/reference/jsDocTypes.types
@@ -1,0 +1,136 @@
+=== tests/cases/conformance/salsa/a.js ===
+
+/** @type {String} */
+var S;
+>S : string
+
+/** @type {string} */
+var s;
+>s : string
+
+/** @type {Number} */
+var N;
+>N : number
+
+/** @type {number} */
+var n;
+>n : number
+
+/** @type {Boolean} */
+var B;
+>B : boolean
+
+/** @type {boolean} */
+var b;
+>b : boolean
+
+/** @type {Void} */
+var V;
+>V : void
+
+/** @type {void} */
+var v;
+>v : void
+
+/** @type {Undefined} */
+var U;
+>U : undefined
+
+/** @type {undefined} */
+var u;
+>u : undefined
+
+/** @type {Null} */
+var Nl;
+>Nl : null
+
+/** @type {null} */
+var nl;
+>nl : null
+
+/** @type {Array} */
+var A;
+>A : any[]
+
+/** @type {array} */
+var a;
+>a : any[]
+
+/** @type {Promise} */
+var P;
+>P : Promise<any>
+
+/** @type {promise} */
+var p;
+>p : Promise<any>
+
+/** @type {?number} */
+var nullable;
+>nullable : number | null
+
+/** @type {Object} */
+var Obj;
+>Obj : any
+
+
+
+=== tests/cases/conformance/salsa/b.ts ===
+var S: string;
+>S : string
+
+var s: string;
+>s : string
+
+var N: number;
+>N : number
+
+var n: number
+>n : number
+
+var B: boolean;
+>B : boolean
+
+var b: boolean;
+>b : boolean
+
+var V :void;
+>V : void
+
+var v: void;
+>v : void
+
+var U: undefined;
+>U : undefined
+
+var u: undefined;
+>u : undefined
+
+var Nl: null;
+>Nl : null
+>null : null
+
+var nl: null;
+>nl : null
+>null : null
+
+var A: any[];
+>A : any[]
+
+var a: any[];
+>a : any[]
+
+var P: Promise<any>;
+>P : Promise<any>
+>Promise : Promise<T>
+
+var p: Promise<any>;
+>p : Promise<any>
+>Promise : Promise<T>
+
+var nullable: number | null;
+>nullable : number | null
+>null : null
+
+var Obj: any;
+>Obj : any
+

--- a/tests/baselines/reference/jsFileCompilationRestParamJsDocFunction.types
+++ b/tests/baselines/reference/jsFileCompilationRestParamJsDocFunction.types
@@ -11,8 +11,8 @@
  * @returns {*} Returns the result of `func`.
  */
 function apply(func, thisArg, args) {
->apply : (func: Function, thisArg: any, ...args: any[]) => any
->func : Function
+>apply : (func: {}, thisArg: any, ...args: any[]) => any
+>func : {}
 >thisArg : any
 >args : any[]
 
@@ -29,7 +29,7 @@ function apply(func, thisArg, args) {
 >0 : 0
 >func.call(thisArg) : any
 >func.call : (this: Function, thisArg: any, ...argArray: any[]) => any
->func : Function
+>func : {}
 >call : (this: Function, thisArg: any, ...argArray: any[]) => any
 >thisArg : any
 
@@ -37,7 +37,7 @@ function apply(func, thisArg, args) {
 >1 : 1
 >func.call(thisArg, args[0]) : any
 >func.call : (this: Function, thisArg: any, ...argArray: any[]) => any
->func : Function
+>func : {}
 >call : (this: Function, thisArg: any, ...argArray: any[]) => any
 >thisArg : any
 >args[0] : any
@@ -48,7 +48,7 @@ function apply(func, thisArg, args) {
 >2 : 2
 >func.call(thisArg, args[0], args[1]) : any
 >func.call : (this: Function, thisArg: any, ...argArray: any[]) => any
->func : Function
+>func : {}
 >call : (this: Function, thisArg: any, ...argArray: any[]) => any
 >thisArg : any
 >args[0] : any
@@ -62,7 +62,7 @@ function apply(func, thisArg, args) {
 >3 : 3
 >func.call(thisArg, args[0], args[1], args[2]) : any
 >func.call : (this: Function, thisArg: any, ...argArray: any[]) => any
->func : Function
+>func : {}
 >call : (this: Function, thisArg: any, ...argArray: any[]) => any
 >thisArg : any
 >args[0] : any
@@ -78,12 +78,12 @@ function apply(func, thisArg, args) {
     return func.apply(thisArg, args);
 >func.apply(thisArg, args) : any
 >func.apply : (this: Function, thisArg: any, argArray?: any) => any
->func : Function
+>func : {}
 >apply : (this: Function, thisArg: any, argArray?: any) => any
 >thisArg : any
 >args : any[]
 }
 
 export default apply;
->apply : (func: Function, thisArg: any, ...args: any[]) => any
+>apply : (func: {}, thisArg: any, ...args: any[]) => any
 

--- a/tests/cases/conformance/salsa/jsDocTypes.ts
+++ b/tests/cases/conformance/salsa/jsDocTypes.ts
@@ -1,0 +1,80 @@
+// @allowJS: true
+// @suppressOutputPathCheck: true
+// @strictNullChecks: true
+
+// @filename: a.js
+/** @type {String} */
+var S;
+
+/** @type {string} */
+var s;
+
+/** @type {Number} */
+var N;
+
+/** @type {number} */
+var n;
+
+/** @type {Boolean} */
+var B;
+
+/** @type {boolean} */
+var b;
+
+/** @type {Void} */
+var V;
+
+/** @type {void} */
+var v;
+
+/** @type {Undefined} */
+var U;
+
+/** @type {undefined} */
+var u;
+
+/** @type {Null} */
+var Nl;
+
+/** @type {null} */
+var nl;
+
+/** @type {Array} */
+var A;
+
+/** @type {array} */
+var a;
+
+/** @type {Promise} */
+var P;
+
+/** @type {promise} */
+var p;
+
+/** @type {?number} */
+var nullable;
+
+/** @type {Object} */
+var Obj;
+
+
+
+// @filename: b.ts
+var S: string;
+var s: string;
+var N: number;
+var n: number
+var B: boolean;
+var b: boolean;
+var V :void;
+var v: void;
+var U: undefined;
+var u: undefined;
+var Nl: null;
+var nl: null;
+var A: any[];
+var a: any[];
+var P: Promise<any>;
+var p: Promise<any>;
+var nullable: number | null;
+var Obj: any;


### PR DESCRIPTION
This PR:
- Treats `Number`, `String`, `Boolean`, `Object`, `Void`, `Undefinded`, `Null`, `array` and `promise`  in JSDoc as `number`, `string`, `boolean`, `any`, `void`, `undefined`, `null`, `any[]` and `Promise<any>` respectively.
- Remove unused `JSDocNullKeyword`, `JSDocUndefinedKeyword` and `JSDocNevereyword`
- Add support for nullable JSDoc types (e.g. `?number` => `number | null`)

Fixes https://github.com/Microsoft/TypeScript/issues/14230
Fixes https://github.com/Microsoft/TypeScript/issues/14242