### PR TITLE
Fix emit for downlevel generated catch variable

### DIFF
--- a/tests/baselines/reference/emitter.forAwait.es5.js
+++ b/tests/baselines/reference/emitter.forAwait.es5.js
@@ -68,36 +68,36 @@ var __asyncValues = (this && this.__asyncIterator) || function (o) {
 };
 function f1() {
     return __awaiter(this, void 0, void 0, function () {
-        var y, y_1, y_1_1, x, _a, e_1, _b;
-        return __generator(this, function (_c) {
-            switch (_c.label) {
+        var y, y_1, y_1_1, x, e_1_1, e_1, _a;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
                 case 0:
-                    _c.trys.push([0, 6, 7, 12]);
+                    _b.trys.push([0, 6, 7, 12]);
                     y_1 = __asyncValues(y);
                     return [4 /*yield*/, y_1.next()];
                 case 1:
-                    y_1_1 = _c.sent();
-                    _c.label = 2;
+                    y_1_1 = _b.sent();
+                    _b.label = 2;
                 case 2:
                     if (!!y_1_1.done) return [3 /*break*/, 5];
                     x = y_1_1.value;
-                    _c.label = 3;
+                    _b.label = 3;
                 case 3: return [4 /*yield*/, y_1.next()];
                 case 4:
-                    y_1_1 = _c.sent();
+                    y_1_1 = _b.sent();
                     return [3 /*break*/, 2];
                 case 5: return [3 /*break*/, 12];
                 case 6:
-                    _a = _c.sent();
+                    e_1_1 = _b.sent();
                     e_1 = { error: e_1_1 };
                     return [3 /*break*/, 12];
                 case 7:
-                    _c.trys.push([7, , 10, 11]);
-                    if (!(y_1_1 && !y_1_1.done && (_b = y_1.return))) return [3 /*break*/, 9];
-                    return [4 /*yield*/, _b.call(y_1)];
+                    _b.trys.push([7, , 10, 11]);
+                    if (!(y_1_1 && !y_1_1.done && (_a = y_1.return))) return [3 /*break*/, 9];
+                    return [4 /*yield*/, _a.call(y_1)];
                 case 8:
-                    _c.sent();
-                    _c.label = 9;
+                    _b.sent();
+                    _b.label = 9;
                 case 9: return [3 /*break*/, 11];
                 case 10:
                     if (e_1) throw e_1.error;
@@ -151,36 +151,36 @@ var __asyncValues = (this && this.__asyncIterator) || function (o) {
 };
 function f2() {
     return __awaiter(this, void 0, void 0, function () {
-        var x, y, y_1, y_1_1, _a, e_1, _b;
-        return __generator(this, function (_c) {
-            switch (_c.label) {
+        var x, y, y_1, y_1_1, e_1_1, e_1, _a;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
                 case 0:
-                    _c.trys.push([0, 6, 7, 12]);
+                    _b.trys.push([0, 6, 7, 12]);
                     y_1 = __asyncValues(y);
                     return [4 /*yield*/, y_1.next()];
                 case 1:
-                    y_1_1 = _c.sent();
-                    _c.label = 2;
+                    y_1_1 = _b.sent();
+                    _b.label = 2;
                 case 2:
                     if (!!y_1_1.done) return [3 /*break*/, 5];
                     x = y_1_1.value;
-                    _c.label = 3;
+                    _b.label = 3;
                 case 3: return [4 /*yield*/, y_1.next()];
                 case 4:
-                    y_1_1 = _c.sent();
+                    y_1_1 = _b.sent();
                     return [3 /*break*/, 2];
                 case 5: return [3 /*break*/, 12];
                 case 6:
-                    _a = _c.sent();
+                    e_1_1 = _b.sent();
                     e_1 = { error: e_1_1 };
                     return [3 /*break*/, 12];
                 case 7:
-                    _c.trys.push([7, , 10, 11]);
-                    if (!(y_1_1 && !y_1_1.done && (_b = y_1.return))) return [3 /*break*/, 9];
-                    return [4 /*yield*/, _b.call(y_1)];
+                    _b.trys.push([7, , 10, 11]);
+                    if (!(y_1_1 && !y_1_1.done && (_a = y_1.return))) return [3 /*break*/, 9];
+                    return [4 /*yield*/, _a.call(y_1)];
                 case 8:
-                    _c.sent();
-                    _c.label = 9;
+                    _b.sent();
+                    _b.label = 9;
                 case 9: return [3 /*break*/, 11];
                 case 10:
                     if (e_1) throw e_1.error;
@@ -239,36 +239,36 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 function f3() {
     return __asyncGenerator(this, arguments, function f3_1() {
-        var y, y_1, y_1_1, x, _a, e_1, _b;
-        return __generator(this, function (_c) {
-            switch (_c.label) {
+        var y, y_1, y_1_1, x, e_1_1, e_1, _a;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
                 case 0:
-                    _c.trys.push([0, 6, 7, 12]);
+                    _b.trys.push([0, 6, 7, 12]);
                     y_1 = __asyncValues(y);
                     return [4 /*yield*/, ["await", y_1.next()]];
                 case 1:
-                    y_1_1 = _c.sent();
-                    _c.label = 2;
+                    y_1_1 = _b.sent();
+                    _b.label = 2;
                 case 2:
                     if (!!y_1_1.done) return [3 /*break*/, 5];
                     x = y_1_1.value;
-                    _c.label = 3;
+                    _b.label = 3;
                 case 3: return [4 /*yield*/, ["await", y_1.next()]];
                 case 4:
-                    y_1_1 = _c.sent();
+                    y_1_1 = _b.sent();
                     return [3 /*break*/, 2];
                 case 5: return [3 /*break*/, 12];
                 case 6:
-                    _a = _c.sent();
+                    e_1_1 = _b.sent();
                     e_1 = { error: e_1_1 };
                     return [3 /*break*/, 12];
                 case 7:
-                    _c.trys.push([7, , 10, 11]);
-                    if (!(y_1_1 && !y_1_1.done && (_b = y_1.return))) return [3 /*break*/, 9];
-                    return [4 /*yield*/, ["await", _b.call(y_1)]];
+                    _b.trys.push([7, , 10, 11]);
+                    if (!(y_1_1 && !y_1_1.done && (_a = y_1.return))) return [3 /*break*/, 9];
+                    return [4 /*yield*/, ["await", _a.call(y_1)]];
                 case 8:
-                    _c.sent();
-                    _c.label = 9;
+                    _b.sent();
+                    _b.label = 9;
                 case 9: return [3 /*break*/, 11];
                 case 10:
                     if (e_1) throw e_1.error;
@@ -327,36 +327,36 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 };
 function f4() {
     return __asyncGenerator(this, arguments, function f4_1() {
-        var x, y, y_1, y_1_1, _a, e_1, _b;
-        return __generator(this, function (_c) {
-            switch (_c.label) {
+        var x, y, y_1, y_1_1, e_1_1, e_1, _a;
+        return __generator(this, function (_b) {
+            switch (_b.label) {
                 case 0:
-                    _c.trys.push([0, 6, 7, 12]);
+                    _b.trys.push([0, 6, 7, 12]);
                     y_1 = __asyncValues(y);
                     return [4 /*yield*/, ["await", y_1.next()]];
                 case 1:
-                    y_1_1 = _c.sent();
-                    _c.label = 2;
+                    y_1_1 = _b.sent();
+                    _b.label = 2;
                 case 2:
                     if (!!y_1_1.done) return [3 /*break*/, 5];
                     x = y_1_1.value;
-                    _c.label = 3;
+                    _b.label = 3;
                 case 3: return [4 /*yield*/, ["await", y_1.next()]];
                 case 4:
-                    y_1_1 = _c.sent();
+                    y_1_1 = _b.sent();
                     return [3 /*break*/, 2];
                 case 5: return [3 /*break*/, 12];
                 case 6:
-                    _a = _c.sent();
+                    e_1_1 = _b.sent();
                     e_1 = { error: e_1_1 };
                     return [3 /*break*/, 12];
                 case 7:
-                    _c.trys.push([7, , 10, 11]);
-                    if (!(y_1_1 && !y_1_1.done && (_b = y_1.return))) return [3 /*break*/, 9];
-                    return [4 /*yield*/, ["await", _b.call(y_1)]];
+                    _b.trys.push([7, , 10, 11]);
+                    if (!(y_1_1 && !y_1_1.done && (_a = y_1.return))) return [3 /*break*/, 9];
+                    return [4 /*yield*/, ["await", _a.call(y_1)]];
                 case 8:
-                    _c.sent();
-                    _c.label = 9;
+                    _b.sent();
+                    _b.label = 9;
                 case 9: return [3 /*break*/, 11];
                 case 10:
                     if (e_1) throw e_1.error;


### PR DESCRIPTION
Fixes an issue where the downlevel emit for generators does not account for generated identifiers in purely synthetic catch variables.

Fixes #14334
