### PR TITLE
Fix gulpfile now that it is set to latest

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -390,7 +390,7 @@ gulp.task(builtLocalCompiler, false, [servicesFile], () => {
         .pipe(localCompilerProject())
         .pipe(prependCopyright())
         .pipe(sourcemaps.write("."))
-        .pipe(gulp.dest("."));
+        .pipe(gulp.dest("src/compiler"));
 });
 
 gulp.task(servicesFile, false, ["lib", "generate-diagnostics"], () => {
@@ -422,7 +422,7 @@ gulp.task(servicesFile, false, ["lib", "generate-diagnostics"], () => {
                 file.path = nodeStandaloneDefinitionsFile;
                 return content.replace(/declare (namespace|module) ts/g, 'declare module "typescript"');
             }))
-    ]).pipe(gulp.dest("."));
+    ]).pipe(gulp.dest("src/services"));
 });
 
 // cancellationToken.js
@@ -448,7 +448,7 @@ gulp.task(typingsInstallerJs, false, [servicesFile], () => {
         .pipe(cancellationTokenProject())
         .pipe(prependCopyright())
         .pipe(sourcemaps.write("."))
-        .pipe(gulp.dest("."));
+        .pipe(gulp.dest("src/server/typingsInstaller"));
 });
 
 const serverFile = path.join(builtLocalDirectory, "tsserver.js");
@@ -461,7 +461,7 @@ gulp.task(serverFile, false, [servicesFile, typingsInstallerJs, cancellationToke
         .pipe(serverProject())
         .pipe(prependCopyright())
         .pipe(sourcemaps.write("."))
-        .pipe(gulp.dest("."));
+        .pipe(gulp.dest("src/server"));
 });
 
 const tsserverLibraryFile = path.join(builtLocalDirectory, "tsserverlibrary.js");
@@ -556,7 +556,7 @@ gulp.task(run, false, [servicesFile], () => {
         .pipe(sourcemaps.init())
         .pipe(testProject())
         .pipe(sourcemaps.write(".", { includeContent: false, sourceRoot: "../../" }))
-        .pipe(gulp.dest("."));
+        .pipe(gulp.dest("src/harness"));
 });
 
 const internalTests = "internal/";
@@ -778,7 +778,7 @@ gulp.task("browserify", "Runs browserify on run.js to produce a file suitable fo
                 });
         }))
         .pipe(sourcemaps.write(".", { includeContent: false }))
-        .pipe(gulp.dest("."));
+        .pipe(gulp.dest("src/harness"));
 });
 
 


### PR DESCRIPTION
Fixes #14038 and #14368.

Gulp-typescript was held back in #13362 due to a change in a newer version.
#14113 changed the version but didn't update the gulpfile.
Trying to follow the advice from https://github.com/Microsoft/TypeScript/pull/13362#issuecomment-271397218.
