### PR TITLE
Add TouchEvent support

### DIFF
--- a/lib/lib.d.ts
+++ b/lib/lib.d.ts
@@ -4320,6 +4320,7 @@ interface EventInit {
     scoped?: boolean;
     bubbles?: boolean;
     cancelable?: boolean;
+    composed?: boolean;
 }
 
 interface EventModifierInit extends UIEventInit {
@@ -15938,9 +15939,15 @@ interface TouchEvent extends UIEvent {
     readonly which: number;
 }
 
+interface TouchEventInit extends EventModifierInit {
+    touches?: Touch[];
+    targetTouches?: Touch[];
+    changedTouches?: Touch[];
+}
+
 declare var TouchEvent: {
     prototype: TouchEvent;
-    new(): TouchEvent;
+    new (typeArg: string, touchEventInit?: TouchEventInit): TouchEvent;
 }
 
 interface TouchList {


### PR DESCRIPTION
Currently the creation of new TouchEvent is impossible.

Add TouchEventInit interface.
Add correct TouchEvent constructor signature.

Add composed?: boolean to EventInit interface as per MDN.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #14435
