### PR TITLE
Allow the right-hand side of an 'in' expression to be of non-primitive object type

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -15546,7 +15546,7 @@ namespace ts {
             if (!(isTypeComparableTo(leftType, stringType) || isTypeOfKind(leftType, TypeFlags.NumberLike | TypeFlags.ESSymbol))) {
                 error(left, Diagnostics.The_left_hand_side_of_an_in_expression_must_be_of_type_any_string_number_or_symbol);
             }
-            if (!isTypeAnyOrAllConstituentTypesHaveKind(rightType, TypeFlags.Object | TypeFlags.TypeVariable)) {
+            if (!isTypeAnyOrAllConstituentTypesHaveKind(rightType, TypeFlags.Object | TypeFlags.TypeVariable | TypeFlags.NonPrimitive)) {
                 error(right, Diagnostics.The_right_hand_side_of_an_in_expression_must_be_of_type_any_an_object_type_or_a_type_parameter);
             }
             return booleanType;

--- a/tests/baselines/reference/nonPrimitiveRhsSideOfInExpression.js
+++ b/tests/baselines/reference/nonPrimitiveRhsSideOfInExpression.js
@@ -1,0 +1,17 @@
+//// [nonPrimitiveRhsSideOfInExpression.ts]
+let o: object = {};
+
+function f(): object {
+	return {};
+}
+
+const b1 = "foo" in o;
+const b2 = "bar" in f();
+
+//// [nonPrimitiveRhsSideOfInExpression.js]
+var o = {};
+function f() {
+    return {};
+}
+var b1 = "foo" in o;
+var b2 = "bar" in f();

--- a/tests/baselines/reference/nonPrimitiveRhsSideOfInExpression.symbols
+++ b/tests/baselines/reference/nonPrimitiveRhsSideOfInExpression.symbols
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/types/nonPrimitive/nonPrimitiveRhsSideOfInExpression.ts ===
+let o: object = {};
+>o : Symbol(o, Decl(nonPrimitiveRhsSideOfInExpression.ts, 0, 3))
+
+function f(): object {
+>f : Symbol(f, Decl(nonPrimitiveRhsSideOfInExpression.ts, 0, 19))
+
+	return {};
+}
+
+const b1 = "foo" in o;
+>b1 : Symbol(b1, Decl(nonPrimitiveRhsSideOfInExpression.ts, 6, 5))
+>o : Symbol(o, Decl(nonPrimitiveRhsSideOfInExpression.ts, 0, 3))
+
+const b2 = "bar" in f();
+>b2 : Symbol(b2, Decl(nonPrimitiveRhsSideOfInExpression.ts, 7, 5))
+>f : Symbol(f, Decl(nonPrimitiveRhsSideOfInExpression.ts, 0, 19))
+

--- a/tests/baselines/reference/nonPrimitiveRhsSideOfInExpression.types
+++ b/tests/baselines/reference/nonPrimitiveRhsSideOfInExpression.types
@@ -1,0 +1,25 @@
+=== tests/cases/conformance/types/nonPrimitive/nonPrimitiveRhsSideOfInExpression.ts ===
+let o: object = {};
+>o : object
+>{} : {}
+
+function f(): object {
+>f : () => object
+
+	return {};
+>{} : {}
+}
+
+const b1 = "foo" in o;
+>b1 : boolean
+>"foo" in o : boolean
+>"foo" : "foo"
+>o : object
+
+const b2 = "bar" in f();
+>b2 : boolean
+>"bar" in f() : boolean
+>"bar" : "bar"
+>f() : object
+>f : () => object
+

--- a/tests/cases/conformance/types/nonPrimitive/nonPrimitiveRhsSideOfInExpression.ts
+++ b/tests/cases/conformance/types/nonPrimitive/nonPrimitiveRhsSideOfInExpression.ts
@@ -1,0 +1,8 @@
+let o: object = {};
+
+function f(): object {
+	return {};
+}
+
+const b1 = "foo" in o;
+const b2 = "bar" in f();


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #14269

(The issue does not yet have a 'bug' label but I think it can be fixed in the same way as PR #14195)

Thanks!
