### PR TITLE
use ES6 library when building tslint rules

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -328,8 +328,14 @@ function compileFile(outFile, sources, prereqs, prefixes, useBuiltCompiler, opts
         if (opts.stripInternal) {
             options += " --stripInternal";
         }
-
-        options += " --target es5 --lib es5,scripthost --noUnusedLocals --noUnusedParameters";
+        options += " --target es5";
+        if (opts.lib) {
+            options += " --lib " + opts.lib
+        }
+        else {
+            options += " --lib es5,scripthost"
+        }
+        options += " --noUnusedLocals --noUnusedParameters";
 
         var cmd = host + " " + compilerPath + " " + options + " ";
         cmd = cmd + sources.join(" ");
@@ -1110,7 +1116,7 @@ desc("Compiles tslint rules to js");
 task("build-rules", ["build-rules-start"].concat(tslintRulesOutFiles).concat(["build-rules-end"]));
 tslintRulesFiles.forEach(function (ruleFile, i) {
     compileFile(tslintRulesOutFiles[i], [ruleFile], [ruleFile], [], /*useBuiltCompiler*/ false,
-        { noOutFile: true, generateDeclarations: false, outDir: path.join(builtLocalDirectory, "tslint") });
+        { noOutFile: true, generateDeclarations: false, outDir: path.join(builtLocalDirectory, "tslint"), lib: "es6" });
 });
 
 desc("Emit the start of the build-rules fold");

--- a/scripts/parallel-lint.js
+++ b/scripts/parallel-lint.js
@@ -1,5 +1,6 @@
 var tslint = require("tslint");
 var fs = require("fs");
+var path = require("path");
 
 function getLinterOptions() {
     return {
@@ -9,7 +10,7 @@ function getLinterOptions() {
     };
 }
 function getLinterConfiguration() {
-    return require("../tslint.json");
+    return tslint.Configuration.loadConfigurationFromPath(path.join(__dirname, "../tslint.json"));
 }
 
 function lintFileContents(options, configuration, path, contents) {


### PR DESCRIPTION
use lib=ES6  when building tslint rules - similar to configuration used by tslint [itself](https://github.com/palantir/tslint/blob/next/src/tsconfig.json#L13)