### PR TITLE
Set inference result to `any` instead of `{}` for .js files if generic type parameter inference found no candidates

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9598,7 +9598,7 @@ namespace ts {
                                 getInferenceMapper(context)));
                     }
                     else {
-                        inferredType = emptyObjectType;
+                        inferredType = context.useAnyForNoInferences ? anyType : emptyObjectType;
                     }
 
                     inferenceSucceeded = true;
@@ -9613,9 +9613,6 @@ namespace ts {
                         if (!isTypeAssignableTo(inferredType, getTypeWithThisArgument(instantiatedConstraint, inferredType))) {
                             context.inferredTypes[index] = inferredType = instantiatedConstraint;
                         }
-                    }
-                    if (context.useAnyForNoInferences && !inferences.length && inferredType === emptyObjectType) {
-                        context.inferredTypes[index] = inferredType = anyType;
                     }
                 }
                 else if (context.failedTypeParameterIndex === undefined || context.failedTypeParameterIndex > index) {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3235,6 +3235,7 @@
         mapper?: TypeMapper;                // Type mapper for this inference context
         failedTypeParameterIndex?: number;  // Index of type parameter for which inference failed
         // It is optional because in contextual signature instantiation, nothing fails
+        useAnyForNoInferences?: boolean;    // Use any instead of {} for no inferences
     }
 
     /* @internal */

--- a/tests/baselines/reference/inferingFromAny.symbols
+++ b/tests/baselines/reference/inferingFromAny.symbols
@@ -1,0 +1,282 @@
+=== tests/cases/conformance/salsa/a.ts ===
+
+var a: any;
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var t: [any, any];
+>t : Symbol(t, Decl(a.ts, 2, 3), Decl(a.js, 2, 3), Decl(a.js, 11, 3), Decl(a.js, 12, 3), Decl(a.js, 13, 3))
+
+declare function f1<T>(t: T): T
+>f1 : Symbol(f1, Decl(a.ts, 2, 18))
+>T : Symbol(T, Decl(a.ts, 3, 20))
+>t : Symbol(t, Decl(a.ts, 3, 23))
+>T : Symbol(T, Decl(a.ts, 3, 20))
+>T : Symbol(T, Decl(a.ts, 3, 20))
+
+declare function f2<T>(t: T[]): T;
+>f2 : Symbol(f2, Decl(a.ts, 3, 31))
+>T : Symbol(T, Decl(a.ts, 4, 20))
+>t : Symbol(t, Decl(a.ts, 4, 23))
+>T : Symbol(T, Decl(a.ts, 4, 20))
+>T : Symbol(T, Decl(a.ts, 4, 20))
+
+declare function f3<T, U>(t: [T, U]): [T, U];
+>f3 : Symbol(f3, Decl(a.ts, 4, 34))
+>T : Symbol(T, Decl(a.ts, 5, 20))
+>U : Symbol(U, Decl(a.ts, 5, 22))
+>t : Symbol(t, Decl(a.ts, 5, 26))
+>T : Symbol(T, Decl(a.ts, 5, 20))
+>U : Symbol(U, Decl(a.ts, 5, 22))
+>T : Symbol(T, Decl(a.ts, 5, 20))
+>U : Symbol(U, Decl(a.ts, 5, 22))
+
+declare function f4<T>(x: { bar: T; baz: T }): T;
+>f4 : Symbol(f4, Decl(a.ts, 5, 45))
+>T : Symbol(T, Decl(a.ts, 6, 20))
+>x : Symbol(x, Decl(a.ts, 6, 23))
+>bar : Symbol(bar, Decl(a.ts, 6, 27))
+>T : Symbol(T, Decl(a.ts, 6, 20))
+>baz : Symbol(baz, Decl(a.ts, 6, 35))
+>T : Symbol(T, Decl(a.ts, 6, 20))
+>T : Symbol(T, Decl(a.ts, 6, 20))
+
+declare function f5<T>(x: (a: T) => void): T;
+>f5 : Symbol(f5, Decl(a.ts, 6, 49))
+>T : Symbol(T, Decl(a.ts, 7, 20))
+>x : Symbol(x, Decl(a.ts, 7, 23))
+>a : Symbol(a, Decl(a.ts, 7, 27))
+>T : Symbol(T, Decl(a.ts, 7, 20))
+>T : Symbol(T, Decl(a.ts, 7, 20))
+
+declare function f6<T>(x: new (a: T) => {}): T;
+>f6 : Symbol(f6, Decl(a.ts, 7, 45))
+>T : Symbol(T, Decl(a.ts, 8, 20))
+>x : Symbol(x, Decl(a.ts, 8, 23))
+>a : Symbol(a, Decl(a.ts, 8, 31))
+>T : Symbol(T, Decl(a.ts, 8, 20))
+>T : Symbol(T, Decl(a.ts, 8, 20))
+
+declare function f7<T>(x: (a: any) => a is T): T;
+>f7 : Symbol(f7, Decl(a.ts, 8, 47))
+>T : Symbol(T, Decl(a.ts, 9, 20))
+>x : Symbol(x, Decl(a.ts, 9, 23))
+>a : Symbol(a, Decl(a.ts, 9, 27))
+>a : Symbol(a, Decl(a.ts, 9, 27))
+>T : Symbol(T, Decl(a.ts, 9, 20))
+>T : Symbol(T, Decl(a.ts, 9, 20))
+
+declare function f8<T>(x: () => T): T;
+>f8 : Symbol(f8, Decl(a.ts, 9, 49))
+>T : Symbol(T, Decl(a.ts, 10, 20))
+>x : Symbol(x, Decl(a.ts, 10, 23))
+>T : Symbol(T, Decl(a.ts, 10, 20))
+>T : Symbol(T, Decl(a.ts, 10, 20))
+
+declare function f9<T>(x: new () => T): T;
+>f9 : Symbol(f9, Decl(a.ts, 10, 38))
+>T : Symbol(T, Decl(a.ts, 11, 20))
+>x : Symbol(x, Decl(a.ts, 11, 23))
+>T : Symbol(T, Decl(a.ts, 11, 20))
+>T : Symbol(T, Decl(a.ts, 11, 20))
+
+declare function f10<T>(x: { [x: string]: T }): T;
+>f10 : Symbol(f10, Decl(a.ts, 11, 42))
+>T : Symbol(T, Decl(a.ts, 12, 21))
+>x : Symbol(x, Decl(a.ts, 12, 24))
+>x : Symbol(x, Decl(a.ts, 12, 30))
+>T : Symbol(T, Decl(a.ts, 12, 21))
+>T : Symbol(T, Decl(a.ts, 12, 21))
+
+declare function f11<T>(x: { [x: number]: T }): T;
+>f11 : Symbol(f11, Decl(a.ts, 12, 50))
+>T : Symbol(T, Decl(a.ts, 13, 21))
+>x : Symbol(x, Decl(a.ts, 13, 24))
+>x : Symbol(x, Decl(a.ts, 13, 30))
+>T : Symbol(T, Decl(a.ts, 13, 21))
+>T : Symbol(T, Decl(a.ts, 13, 21))
+
+declare function f12<T, U>(x: T | U): [T, U];
+>f12 : Symbol(f12, Decl(a.ts, 13, 50))
+>T : Symbol(T, Decl(a.ts, 14, 21))
+>U : Symbol(U, Decl(a.ts, 14, 23))
+>x : Symbol(x, Decl(a.ts, 14, 27))
+>T : Symbol(T, Decl(a.ts, 14, 21))
+>U : Symbol(U, Decl(a.ts, 14, 23))
+>T : Symbol(T, Decl(a.ts, 14, 21))
+>U : Symbol(U, Decl(a.ts, 14, 23))
+
+declare function f13<T, U>(x: T & U): [T, U];
+>f13 : Symbol(f13, Decl(a.ts, 14, 45))
+>T : Symbol(T, Decl(a.ts, 15, 21))
+>U : Symbol(U, Decl(a.ts, 15, 23))
+>x : Symbol(x, Decl(a.ts, 15, 27))
+>T : Symbol(T, Decl(a.ts, 15, 21))
+>U : Symbol(U, Decl(a.ts, 15, 23))
+>T : Symbol(T, Decl(a.ts, 15, 21))
+>U : Symbol(U, Decl(a.ts, 15, 23))
+
+declare function f14<T, U>(x: { a: T | U, b: U & T }): [T, U];
+>f14 : Symbol(f14, Decl(a.ts, 15, 45))
+>T : Symbol(T, Decl(a.ts, 16, 21))
+>U : Symbol(U, Decl(a.ts, 16, 23))
+>x : Symbol(x, Decl(a.ts, 16, 27))
+>a : Symbol(a, Decl(a.ts, 16, 31))
+>T : Symbol(T, Decl(a.ts, 16, 21))
+>U : Symbol(U, Decl(a.ts, 16, 23))
+>b : Symbol(b, Decl(a.ts, 16, 41))
+>U : Symbol(U, Decl(a.ts, 16, 23))
+>T : Symbol(T, Decl(a.ts, 16, 21))
+>T : Symbol(T, Decl(a.ts, 16, 21))
+>U : Symbol(U, Decl(a.ts, 16, 23))
+
+interface I<T> { }
+>I : Symbol(I, Decl(a.ts, 16, 62))
+>T : Symbol(T, Decl(a.ts, 17, 12))
+
+declare function f15<T>(x: I<T>): T;
+>f15 : Symbol(f15, Decl(a.ts, 17, 18))
+>T : Symbol(T, Decl(a.ts, 18, 21))
+>x : Symbol(x, Decl(a.ts, 18, 24))
+>I : Symbol(I, Decl(a.ts, 16, 62))
+>T : Symbol(T, Decl(a.ts, 18, 21))
+>T : Symbol(T, Decl(a.ts, 18, 21))
+
+declare function f16<T>(x: Partial<T>): T;
+>f16 : Symbol(f16, Decl(a.ts, 18, 36))
+>T : Symbol(T, Decl(a.ts, 19, 21))
+>x : Symbol(x, Decl(a.ts, 19, 24))
+>Partial : Symbol(Partial, Decl(lib.d.ts, --, --))
+>T : Symbol(T, Decl(a.ts, 19, 21))
+>T : Symbol(T, Decl(a.ts, 19, 21))
+
+declare function f17<T, K>(x: {[P in keyof T]: K}): T;
+>f17 : Symbol(f17, Decl(a.ts, 19, 42))
+>T : Symbol(T, Decl(a.ts, 20, 21))
+>K : Symbol(K, Decl(a.ts, 20, 23))
+>x : Symbol(x, Decl(a.ts, 20, 27))
+>P : Symbol(P, Decl(a.ts, 20, 32))
+>T : Symbol(T, Decl(a.ts, 20, 21))
+>K : Symbol(K, Decl(a.ts, 20, 23))
+>T : Symbol(T, Decl(a.ts, 20, 21))
+
+declare function f18<T, K extends keyof T>(x: {[P in K]: T[P]}): T;
+>f18 : Symbol(f18, Decl(a.ts, 20, 54))
+>T : Symbol(T, Decl(a.ts, 21, 21))
+>K : Symbol(K, Decl(a.ts, 21, 23))
+>T : Symbol(T, Decl(a.ts, 21, 21))
+>x : Symbol(x, Decl(a.ts, 21, 43))
+>P : Symbol(P, Decl(a.ts, 21, 48))
+>K : Symbol(K, Decl(a.ts, 21, 23))
+>T : Symbol(T, Decl(a.ts, 21, 21))
+>P : Symbol(P, Decl(a.ts, 21, 48))
+>T : Symbol(T, Decl(a.ts, 21, 21))
+
+declare function f19<T, K extends keyof T>(k: K, x: T[K]): T;
+>f19 : Symbol(f19, Decl(a.ts, 21, 67))
+>T : Symbol(T, Decl(a.ts, 22, 21))
+>K : Symbol(K, Decl(a.ts, 22, 23))
+>T : Symbol(T, Decl(a.ts, 22, 21))
+>k : Symbol(k, Decl(a.ts, 22, 43))
+>K : Symbol(K, Decl(a.ts, 22, 23))
+>x : Symbol(x, Decl(a.ts, 22, 48))
+>T : Symbol(T, Decl(a.ts, 22, 21))
+>K : Symbol(K, Decl(a.ts, 22, 23))
+>T : Symbol(T, Decl(a.ts, 22, 21))
+
+=== tests/cases/conformance/salsa/a.js ===
+var a = f1(a);
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+>f1 : Symbol(f1, Decl(a.ts, 2, 18))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var a = f2(a);
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+>f2 : Symbol(f2, Decl(a.ts, 3, 31))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var t = f3(a);
+>t : Symbol(t, Decl(a.ts, 2, 3), Decl(a.js, 2, 3), Decl(a.js, 11, 3), Decl(a.js, 12, 3), Decl(a.js, 13, 3))
+>f3 : Symbol(f3, Decl(a.ts, 4, 34))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var a = f4(a);
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+>f4 : Symbol(f4, Decl(a.ts, 5, 45))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var a = f5(a);
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+>f5 : Symbol(f5, Decl(a.ts, 6, 49))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var a = f6(a);
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+>f6 : Symbol(f6, Decl(a.ts, 7, 45))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var a = f7(a);
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+>f7 : Symbol(f7, Decl(a.ts, 8, 47))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var a = f8(a);
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+>f8 : Symbol(f8, Decl(a.ts, 9, 49))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var a = f9(a);
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+>f9 : Symbol(f9, Decl(a.ts, 10, 38))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var a = f10(a);
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+>f10 : Symbol(f10, Decl(a.ts, 11, 42))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var a = f11(a);
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+>f11 : Symbol(f11, Decl(a.ts, 12, 50))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var t = f12(a);
+>t : Symbol(t, Decl(a.ts, 2, 3), Decl(a.js, 2, 3), Decl(a.js, 11, 3), Decl(a.js, 12, 3), Decl(a.js, 13, 3))
+>f12 : Symbol(f12, Decl(a.ts, 13, 50))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var t = f13(a);
+>t : Symbol(t, Decl(a.ts, 2, 3), Decl(a.js, 2, 3), Decl(a.js, 11, 3), Decl(a.js, 12, 3), Decl(a.js, 13, 3))
+>f13 : Symbol(f13, Decl(a.ts, 14, 45))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var t = f14(a);
+>t : Symbol(t, Decl(a.ts, 2, 3), Decl(a.js, 2, 3), Decl(a.js, 11, 3), Decl(a.js, 12, 3), Decl(a.js, 13, 3))
+>f14 : Symbol(f14, Decl(a.ts, 15, 45))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var a = f15(a);
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+>f15 : Symbol(f15, Decl(a.ts, 17, 18))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var a = f16(a);
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+>f16 : Symbol(f16, Decl(a.ts, 18, 36))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var a = f17(a);
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+>f17 : Symbol(f17, Decl(a.ts, 19, 42))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var a = f18(a);
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+>f18 : Symbol(f18, Decl(a.ts, 20, 54))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+
+var a = f19(a, a);
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+>f19 : Symbol(f19, Decl(a.ts, 21, 67))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+>a : Symbol(a, Decl(a.ts, 1, 3), Decl(a.js, 0, 3), Decl(a.js, 1, 3), Decl(a.js, 3, 3), Decl(a.js, 4, 3), Decl(a.js, 5, 3), Decl(a.js, 6, 3), Decl(a.js, 7, 3), Decl(a.js, 8, 3), Decl(a.js, 9, 3), Decl(a.js, 10, 3), Decl(a.js, 14, 3), Decl(a.js, 15, 3), Decl(a.js, 16, 3), Decl(a.js, 17, 3), Decl(a.js, 18, 3))
+

--- a/tests/baselines/reference/inferingFromAny.types
+++ b/tests/baselines/reference/inferingFromAny.types
@@ -1,0 +1,301 @@
+=== tests/cases/conformance/salsa/a.ts ===
+
+var a: any;
+>a : any
+
+var t: [any, any];
+>t : [any, any]
+
+declare function f1<T>(t: T): T
+>f1 : <T>(t: T) => T
+>T : T
+>t : T
+>T : T
+>T : T
+
+declare function f2<T>(t: T[]): T;
+>f2 : <T>(t: T[]) => T
+>T : T
+>t : T[]
+>T : T
+>T : T
+
+declare function f3<T, U>(t: [T, U]): [T, U];
+>f3 : <T, U>(t: [T, U]) => [T, U]
+>T : T
+>U : U
+>t : [T, U]
+>T : T
+>U : U
+>T : T
+>U : U
+
+declare function f4<T>(x: { bar: T; baz: T }): T;
+>f4 : <T>(x: { bar: T; baz: T; }) => T
+>T : T
+>x : { bar: T; baz: T; }
+>bar : T
+>T : T
+>baz : T
+>T : T
+>T : T
+
+declare function f5<T>(x: (a: T) => void): T;
+>f5 : <T>(x: (a: T) => void) => T
+>T : T
+>x : (a: T) => void
+>a : T
+>T : T
+>T : T
+
+declare function f6<T>(x: new (a: T) => {}): T;
+>f6 : <T>(x: new (a: T) => {}) => T
+>T : T
+>x : new (a: T) => {}
+>a : T
+>T : T
+>T : T
+
+declare function f7<T>(x: (a: any) => a is T): T;
+>f7 : <T>(x: (a: any) => a is T) => T
+>T : T
+>x : (a: any) => a is T
+>a : any
+>a : any
+>T : T
+>T : T
+
+declare function f8<T>(x: () => T): T;
+>f8 : <T>(x: () => T) => T
+>T : T
+>x : () => T
+>T : T
+>T : T
+
+declare function f9<T>(x: new () => T): T;
+>f9 : <T>(x: new () => T) => T
+>T : T
+>x : new () => T
+>T : T
+>T : T
+
+declare function f10<T>(x: { [x: string]: T }): T;
+>f10 : <T>(x: { [x: string]: T; }) => T
+>T : T
+>x : { [x: string]: T; }
+>x : string
+>T : T
+>T : T
+
+declare function f11<T>(x: { [x: number]: T }): T;
+>f11 : <T>(x: { [x: number]: T; }) => T
+>T : T
+>x : { [x: number]: T; }
+>x : number
+>T : T
+>T : T
+
+declare function f12<T, U>(x: T | U): [T, U];
+>f12 : <T, U>(x: T | U) => [T, U]
+>T : T
+>U : U
+>x : T | U
+>T : T
+>U : U
+>T : T
+>U : U
+
+declare function f13<T, U>(x: T & U): [T, U];
+>f13 : <T, U>(x: T & U) => [T, U]
+>T : T
+>U : U
+>x : T & U
+>T : T
+>U : U
+>T : T
+>U : U
+
+declare function f14<T, U>(x: { a: T | U, b: U & T }): [T, U];
+>f14 : <T, U>(x: { a: T | U; b: U & T; }) => [T, U]
+>T : T
+>U : U
+>x : { a: T | U; b: U & T; }
+>a : T | U
+>T : T
+>U : U
+>b : U & T
+>U : U
+>T : T
+>T : T
+>U : U
+
+interface I<T> { }
+>I : I<T>
+>T : T
+
+declare function f15<T>(x: I<T>): T;
+>f15 : <T>(x: I<T>) => T
+>T : T
+>x : I<T>
+>I : I<T>
+>T : T
+>T : T
+
+declare function f16<T>(x: Partial<T>): T;
+>f16 : <T>(x: Partial<T>) => T
+>T : T
+>x : Partial<T>
+>Partial : Partial<T>
+>T : T
+>T : T
+
+declare function f17<T, K>(x: {[P in keyof T]: K}): T;
+>f17 : <T, K>(x: { [P in keyof T]: K; }) => T
+>T : T
+>K : K
+>x : { [P in keyof T]: K; }
+>P : P
+>T : T
+>K : K
+>T : T
+
+declare function f18<T, K extends keyof T>(x: {[P in K]: T[P]}): T;
+>f18 : <T, K extends keyof T>(x: { [P in K]: T[P]; }) => T
+>T : T
+>K : K
+>T : T
+>x : { [P in K]: T[P]; }
+>P : P
+>K : K
+>T : T
+>P : P
+>T : T
+
+declare function f19<T, K extends keyof T>(k: K, x: T[K]): T;
+>f19 : <T, K extends keyof T>(k: K, x: T[K]) => T
+>T : T
+>K : K
+>T : T
+>k : K
+>K : K
+>x : T[K]
+>T : T
+>K : K
+>T : T
+
+=== tests/cases/conformance/salsa/a.js ===
+var a = f1(a);
+>a : any
+>f1(a) : any
+>f1 : <T>(t: T) => T
+>a : any
+
+var a = f2(a);
+>a : any
+>f2(a) : any
+>f2 : <T>(t: T[]) => T
+>a : any
+
+var t = f3(a);
+>t : [any, any]
+>f3(a) : [any, any]
+>f3 : <T, U>(t: [T, U]) => [T, U]
+>a : any
+
+var a = f4(a);
+>a : any
+>f4(a) : any
+>f4 : <T>(x: { bar: T; baz: T; }) => T
+>a : any
+
+var a = f5(a);
+>a : any
+>f5(a) : any
+>f5 : <T>(x: (a: T) => void) => T
+>a : any
+
+var a = f6(a);
+>a : any
+>f6(a) : any
+>f6 : <T>(x: new (a: T) => {}) => T
+>a : any
+
+var a = f7(a);
+>a : any
+>f7(a) : any
+>f7 : <T>(x: (a: any) => a is T) => T
+>a : any
+
+var a = f8(a);
+>a : any
+>f8(a) : any
+>f8 : <T>(x: () => T) => T
+>a : any
+
+var a = f9(a);
+>a : any
+>f9(a) : any
+>f9 : <T>(x: new () => T) => T
+>a : any
+
+var a = f10(a);
+>a : any
+>f10(a) : any
+>f10 : <T>(x: { [x: string]: T; }) => T
+>a : any
+
+var a = f11(a);
+>a : any
+>f11(a) : any
+>f11 : <T>(x: { [x: number]: T; }) => T
+>a : any
+
+var t = f12(a);
+>t : [any, any]
+>f12(a) : [any, any]
+>f12 : <T, U>(x: T | U) => [T, U]
+>a : any
+
+var t = f13(a);
+>t : [any, any]
+>f13(a) : [any, any]
+>f13 : <T, U>(x: T & U) => [T, U]
+>a : any
+
+var t = f14(a);
+>t : [any, any]
+>f14(a) : [any, any]
+>f14 : <T, U>(x: { a: T | U; b: U & T; }) => [T, U]
+>a : any
+
+var a = f15(a);
+>a : any
+>f15(a) : any
+>f15 : <T>(x: I<T>) => T
+>a : any
+
+var a = f16(a);
+>a : any
+>f16(a) : any
+>f16 : <T>(x: Partial<T>) => T
+>a : any
+
+var a = f17(a);
+>a : any
+>f17(a) : any
+>f17 : <T, K>(x: { [P in keyof T]: K; }) => T
+>a : any
+
+var a = f18(a);
+>a : any
+>f18(a) : any
+>f18 : <T, K extends keyof T>(x: { [P in K]: T[P]; }) => T
+>a : any
+
+var a = f19(a, a);
+>a : any
+>f19(a, a) : any
+>f19 : <T, K extends keyof T>(k: K, x: T[K]) => T
+>a : any
+>a : any
+

--- a/tests/cases/conformance/salsa/inferingFromAny.ts
+++ b/tests/cases/conformance/salsa/inferingFromAny.ts
@@ -1,0 +1,47 @@
+// @allowJs: true
+// @noEmit: true
+
+// @fileName: a.ts
+var a: any;
+var t: [any, any];
+declare function f1<T>(t: T): T
+declare function f2<T>(t: T[]): T;
+declare function f3<T, U>(t: [T, U]): [T, U];
+declare function f4<T>(x: { bar: T; baz: T }): T;
+declare function f5<T>(x: (a: T) => void): T;
+declare function f6<T>(x: new (a: T) => {}): T;
+declare function f7<T>(x: (a: any) => a is T): T;
+declare function f8<T>(x: () => T): T;
+declare function f9<T>(x: new () => T): T;
+declare function f10<T>(x: { [x: string]: T }): T;
+declare function f11<T>(x: { [x: number]: T }): T;
+declare function f12<T, U>(x: T | U): [T, U];
+declare function f13<T, U>(x: T & U): [T, U];
+declare function f14<T, U>(x: { a: T | U, b: U & T }): [T, U];
+interface I<T> { }
+declare function f15<T>(x: I<T>): T;
+declare function f16<T>(x: Partial<T>): T;
+declare function f17<T, K>(x: {[P in keyof T]: K}): T;
+declare function f18<T, K extends keyof T>(x: {[P in K]: T[P]}): T;
+declare function f19<T, K extends keyof T>(k: K, x: T[K]): T;
+
+// @fileName: a.js
+var a = f1(a);
+var a = f2(a);
+var t = f3(a);
+var a = f4(a);
+var a = f5(a);
+var a = f6(a);
+var a = f7(a);
+var a = f8(a);
+var a = f9(a);
+var a = f10(a);
+var a = f11(a);
+var t = f12(a);
+var t = f13(a);
+var t = f14(a);
+var a = f15(a);
+var a = f16(a);
+var a = f17(a);
+var a = f18(a);
+var a = f19(a, a);


### PR DESCRIPTION
//CC @ahejlsberg 