### PR TITLE
Remove undefined from the type of default  initialised parameters when narrowing

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10929,7 +10929,7 @@ namespace ts {
                 declaration.initializer &&
                 getFalsyFlags(declaredType) & TypeFlags.Undefined &&
                 !(getFalsyFlags(checkExpression(declaration.initializer)) & TypeFlags.Undefined);
-            return annotationIncludesUndefined ? getNonNullableType(declaredType) : declaredType;
+            return annotationIncludesUndefined ? getTypeWithFacts(declaredType, TypeFacts.NEUndefined) : declaredType;
         }
 
         function checkIdentifier(node: Identifier): Type {

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10238,13 +10238,9 @@ namespace ts {
             return false;
         }
 
-        function isFlowNarrowable(reference: Node, type: Type, couldBeUninitialized?: boolean) {
-            return reference.flowNode && (type.flags & TypeFlags.Narrowable || couldBeUninitialized);
-        }
-
         function getFlowTypeOfReference(reference: Node, declaredType: Type, initialType = declaredType, flowContainer?: Node, couldBeUninitialized?: boolean) {
             let key: string;
-            if (!isFlowNarrowable(reference, declaredType, couldBeUninitialized)) {
+            if (!reference.flowNode || !couldBeUninitialized && !(declaredType.flags & TypeFlags.Narrowable)) {
                 return declaredType;
             }
             const visitedFlowStart = visitedFlowCount;

--- a/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.js
+++ b/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.js
@@ -18,10 +18,12 @@ function foo2(x = "string", b: number) {
 
 function foo3(x: string | undefined = "string", b: number) {
     x.length; // ok, should be string
+    x = undefined;
 }
 
 function foo4(x: string | undefined = undefined, b: number) {
     x; // should be string | undefined
+    x = undefined;
 }
 
 
@@ -72,10 +74,12 @@ function foo2(x, b) {
 function foo3(x, b) {
     if (x === void 0) { x = "string"; }
     x.length; // ok, should be string
+    x = undefined;
 }
 function foo4(x, b) {
     if (x === void 0) { x = undefined; }
     x; // should be string | undefined
+    x = undefined;
 }
 // .d.ts should have `string | undefined` for foo1, foo2, foo3 and foo4
 foo1(undefined, 1);

--- a/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.js
+++ b/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.js
@@ -26,6 +26,13 @@ function foo4(x: string | undefined = undefined, b: number) {
     x = undefined;
 }
 
+type OptionalNullableString = string | null | undefined;
+function allowsNull(val: OptionalNullableString = "") {
+    val = null;
+    val = 'string and null are both ok';
+}
+allowsNull(null); // still allows passing null
+
 
 
 // .d.ts should have `string | undefined` for foo1, foo2, foo3 and foo4
@@ -81,6 +88,12 @@ function foo4(x, b) {
     x; // should be string | undefined
     x = undefined;
 }
+function allowsNull(val) {
+    if (val === void 0) { val = ""; }
+    val = null;
+    val = 'string and null are both ok';
+}
+allowsNull(null); // still allows passing null
 // .d.ts should have `string | undefined` for foo1, foo2, foo3 and foo4
 foo1(undefined, 1);
 foo2(undefined, 1);
@@ -111,6 +124,8 @@ declare function foo1(x: string | undefined, b: number): void;
 declare function foo2(x: string | undefined, b: number): void;
 declare function foo3(x: string | undefined, b: number): void;
 declare function foo4(x: string | undefined, b: number): void;
+declare type OptionalNullableString = string | null | undefined;
+declare function allowsNull(val?: OptionalNullableString): void;
 declare function removeUndefinedButNotFalse(x?: boolean): false | undefined;
 declare const cond: boolean;
 declare function removeNothing(y?: boolean | undefined): boolean;

--- a/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.symbols
+++ b/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.symbols
@@ -66,16 +66,24 @@ function foo3(x: string | undefined = "string", b: number) {
 >x.length : Symbol(String.length, Decl(lib.d.ts, --, --))
 >x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 17, 14))
 >length : Symbol(String.length, Decl(lib.d.ts, --, --))
+
+    x = undefined;
+>x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 17, 14))
+>undefined : Symbol(undefined)
 }
 
 function foo4(x: string | undefined = undefined, b: number) {
->foo4 : Symbol(foo4, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 19, 1))
->x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 21, 14))
+>foo4 : Symbol(foo4, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 20, 1))
+>x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 22, 14))
 >undefined : Symbol(undefined)
->b : Symbol(b, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 21, 48))
+>b : Symbol(b, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 22, 48))
 
     x; // should be string | undefined
->x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 21, 14))
+>x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 22, 14))
+
+    x = undefined;
+>x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 22, 14))
+>undefined : Symbol(undefined)
 }
 
 
@@ -94,40 +102,40 @@ foo3(undefined, 1);
 >undefined : Symbol(undefined)
 
 foo4(undefined, 1);
->foo4 : Symbol(foo4, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 19, 1))
+>foo4 : Symbol(foo4, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 20, 1))
 >undefined : Symbol(undefined)
 
 
 function removeUndefinedButNotFalse(x = true) {
->removeUndefinedButNotFalse : Symbol(removeUndefinedButNotFalse, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 31, 19))
->x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 34, 36))
+>removeUndefinedButNotFalse : Symbol(removeUndefinedButNotFalse, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 33, 19))
+>x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 36, 36))
 
     if (x === false) {
->x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 34, 36))
+>x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 36, 36))
 
         return x;
->x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 34, 36))
+>x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 36, 36))
     }
 }
 
 declare const cond: boolean;
->cond : Symbol(cond, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 40, 13))
+>cond : Symbol(cond, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 42, 13))
 
 function removeNothing(y = cond ? true : undefined) {
->removeNothing : Symbol(removeNothing, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 40, 28))
->y : Symbol(y, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 41, 23))
->cond : Symbol(cond, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 40, 13))
+>removeNothing : Symbol(removeNothing, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 42, 28))
+>y : Symbol(y, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 43, 23))
+>cond : Symbol(cond, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 42, 13))
 >undefined : Symbol(undefined)
 
     if (y !== undefined) {
->y : Symbol(y, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 41, 23))
+>y : Symbol(y, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 43, 23))
 >undefined : Symbol(undefined)
 
         if (y === false) {
->y : Symbol(y, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 41, 23))
+>y : Symbol(y, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 43, 23))
 
             return y;
->y : Symbol(y, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 41, 23))
+>y : Symbol(y, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 43, 23))
         }
     }
     return true;

--- a/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.symbols
+++ b/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.symbols
@@ -86,6 +86,23 @@ function foo4(x: string | undefined = undefined, b: number) {
 >undefined : Symbol(undefined)
 }
 
+type OptionalNullableString = string | null | undefined;
+>OptionalNullableString : Symbol(OptionalNullableString, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 25, 1))
+
+function allowsNull(val: OptionalNullableString = "") {
+>allowsNull : Symbol(allowsNull, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 27, 56))
+>val : Symbol(val, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 28, 20))
+>OptionalNullableString : Symbol(OptionalNullableString, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 25, 1))
+
+    val = null;
+>val : Symbol(val, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 28, 20))
+
+    val = 'string and null are both ok';
+>val : Symbol(val, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 28, 20))
+}
+allowsNull(null); // still allows passing null
+>allowsNull : Symbol(allowsNull, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 27, 56))
+
 
 
 // .d.ts should have `string | undefined` for foo1, foo2, foo3 and foo4
@@ -107,35 +124,35 @@ foo4(undefined, 1);
 
 
 function removeUndefinedButNotFalse(x = true) {
->removeUndefinedButNotFalse : Symbol(removeUndefinedButNotFalse, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 33, 19))
->x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 36, 36))
+>removeUndefinedButNotFalse : Symbol(removeUndefinedButNotFalse, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 40, 19))
+>x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 43, 36))
 
     if (x === false) {
->x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 36, 36))
+>x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 43, 36))
 
         return x;
->x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 36, 36))
+>x : Symbol(x, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 43, 36))
     }
 }
 
 declare const cond: boolean;
->cond : Symbol(cond, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 42, 13))
+>cond : Symbol(cond, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 49, 13))
 
 function removeNothing(y = cond ? true : undefined) {
->removeNothing : Symbol(removeNothing, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 42, 28))
->y : Symbol(y, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 43, 23))
->cond : Symbol(cond, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 42, 13))
+>removeNothing : Symbol(removeNothing, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 49, 28))
+>y : Symbol(y, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 50, 23))
+>cond : Symbol(cond, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 49, 13))
 >undefined : Symbol(undefined)
 
     if (y !== undefined) {
->y : Symbol(y, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 43, 23))
+>y : Symbol(y, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 50, 23))
 >undefined : Symbol(undefined)
 
         if (y === false) {
->y : Symbol(y, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 43, 23))
+>y : Symbol(y, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 50, 23))
 
             return y;
->y : Symbol(y, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 43, 23))
+>y : Symbol(y, Decl(defaultParameterAddsUndefinedWithStrictNullChecks.ts, 50, 23))
         }
     }
     return true;

--- a/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.types
+++ b/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.types
@@ -116,6 +116,31 @@ function foo4(x: string | undefined = undefined, b: number) {
 >undefined : undefined
 }
 
+type OptionalNullableString = string | null | undefined;
+>OptionalNullableString : OptionalNullableString
+>null : null
+
+function allowsNull(val: OptionalNullableString = "") {
+>allowsNull : (val?: OptionalNullableString) => void
+>val : OptionalNullableString
+>OptionalNullableString : OptionalNullableString
+>"" : ""
+
+    val = null;
+>val = null : null
+>val : OptionalNullableString
+>null : null
+
+    val = 'string and null are both ok';
+>val = 'string and null are both ok' : "string and null are both ok"
+>val : OptionalNullableString
+>'string and null are both ok' : "string and null are both ok"
+}
+allowsNull(null); // still allows passing null
+>allowsNull(null) : void
+>allowsNull : (val?: OptionalNullableString) => void
+>null : null
+
 
 
 // .d.ts should have `string | undefined` for foo1, foo2, foo3 and foo4

--- a/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.types
+++ b/tests/baselines/reference/defaultParameterAddsUndefinedWithStrictNullChecks.types
@@ -86,7 +86,7 @@ function foo2(x = "string", b: number) {
 
 function foo3(x: string | undefined = "string", b: number) {
 >foo3 : (x: string | undefined, b: number) => void
->x : string
+>x : string | undefined
 >"string" : "string"
 >b : number
 
@@ -94,6 +94,11 @@ function foo3(x: string | undefined = "string", b: number) {
 >x.length : number
 >x : string
 >length : number
+
+    x = undefined;
+>x = undefined : undefined
+>x : string | undefined
+>undefined : undefined
 }
 
 function foo4(x: string | undefined = undefined, b: number) {
@@ -104,6 +109,11 @@ function foo4(x: string | undefined = undefined, b: number) {
 
     x; // should be string | undefined
 >x : string | undefined
+
+    x = undefined;
+>x = undefined : undefined
+>x : string | undefined
+>undefined : undefined
 }
 
 

--- a/tests/cases/compiler/defaultParameterAddsUndefinedWithStrictNullChecks.ts
+++ b/tests/cases/compiler/defaultParameterAddsUndefinedWithStrictNullChecks.ts
@@ -19,10 +19,12 @@ function foo2(x = "string", b: number) {
 
 function foo3(x: string | undefined = "string", b: number) {
     x.length; // ok, should be string
+    x = undefined;
 }
 
 function foo4(x: string | undefined = undefined, b: number) {
     x; // should be string | undefined
+    x = undefined;
 }
 
 

--- a/tests/cases/compiler/defaultParameterAddsUndefinedWithStrictNullChecks.ts
+++ b/tests/cases/compiler/defaultParameterAddsUndefinedWithStrictNullChecks.ts
@@ -27,6 +27,13 @@ function foo4(x: string | undefined = undefined, b: number) {
     x = undefined;
 }
 
+type OptionalNullableString = string | null | undefined;
+function allowsNull(val: OptionalNullableString = "") {
+    val = null;
+    val = 'string and null are both ok';
+}
+allowsNull(null); // still allows passing null
+
 
 
 // .d.ts should have `string | undefined` for foo1, foo2, foo3 and foo4


### PR DESCRIPTION
When narrowing, remove optionality from the initial type of parameters with initialisers. Note that the type of the initialiser is not used; its presence just means that the initial type of the parameter
can't contain undefined. It could contain any other member of a declared union type.

This fix builds on the previous fix #12033, but is slightly more complex in that it changes the initial type before control flow analysis rather than just throwing undefined away from the declared type.

The code refactors most of the complexity into `checkIdentifier`, out of `getFlowTypeOfReference`, since it's only needed there. Suggestions on simplifying the mess of conditionals are welcome!

Fixes #14487 
Fixes #14425 
Fixes #14236 
