### PR TITLE
Fix more gulp.dests to use the relative path of the tsconfig instead of `.`

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -416,7 +416,7 @@ gulp.task(servicesFile, false, ["lib", "generate-diagnostics"], () => {
                 file.path = nodeDefinitionsFile;
                 return content + "\r\nexport = ts;";
             }))
-            .pipe(gulp.dest(".")),
+            .pipe(gulp.dest("src/services")),
         completedDts.pipe(clone())
             .pipe(insert.transform((content, file) => {
                 file.path = nodeStandaloneDefinitionsFile;
@@ -477,12 +477,12 @@ gulp.task(tsserverLibraryFile, false, [servicesFile], (done) => {
     return merge2([
         js.pipe(prependCopyright())
             .pipe(sourcemaps.write("."))
-            .pipe(gulp.dest(".")),
+            .pipe(gulp.dest("src/server")),
         dts.pipe(prependCopyright(/*outputCopyright*/true))
             .pipe(insert.transform((content) => {
                 return content + "\r\nexport = ts;\r\nexport as namespace ts;";
             }))
-            .pipe(gulp.dest("."))
+            .pipe(gulp.dest("src/server"))
     ]);
 });
 


### PR DESCRIPTION
`gulp runtests-parallel` was broken because a few of these were missed last time in #14384.