### PR TITLE
fix missing code markup at doc/spec.md

### DIFF
--- a/doc/spec.md
+++ b/doc/spec.md
@@ -5051,7 +5051,7 @@ The body of an enum declaration defines zero or more enum members which are the 
 
 &emsp;&emsp;*EnumMember:*  
 &emsp;&emsp;&emsp;*PropertyName*  
-&emsp;&emsp;&emsp;*PropertyName*&emsp;=&emsp;*EnumValue*
+&emsp;&emsp;&emsp;*PropertyName*&emsp;`=`&emsp;*EnumValue*
 
 &emsp;&emsp;*EnumValue:*  
 &emsp;&emsp;&emsp;*AssignmentExpression*


### PR DESCRIPTION
This is a documentation markup fix.

I suspect the `=` sign should be marked as a literal but it isn't which generates a warning in a grammar-generator we're using in an in house project.