### PR TITLE
RulesProvider performance improvements

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -205,7 +205,7 @@ namespace ts.server {
             this.lsHost = new LSHost(this.projectService.host, this, this.projectService.cancellationToken);
             this.lsHost.setCompilationSettings(this.compilerOptions);
 
-            this.languageService = ts.createLanguageService(this.lsHost, this.documentRegistry);
+            this.languageService = ts.createLanguageService(this.lsHost, this.documentRegistry, this.projectService.getFormatCodeOptions());
 
             if (!languageServiceEnabled) {
                 this.disableLanguageService();

--- a/src/services/formatting/rulesProvider.ts
+++ b/src/services/formatting/rulesProvider.ts
@@ -5,11 +5,15 @@ namespace ts.formatting {
     export class RulesProvider {
         private globalRules: Rules;
         private options: ts.FormatCodeSettings;
-        private activeRules: Rule[];
+        private activeFormatOptionsRules: Rule[];
         private rulesMap: RulesMap;
 
         constructor() {
             this.globalRules = new Rules();
+
+            // Initialize the rulesMap with the high priority rules
+            this.rulesMap = RulesMap.create(this.globalRules.HighPriorityCommonRules.slice(0), this.globalRules.LowPriorityCommonRules.slice(0));
+            this.activeFormatOptionsRules = [];
         }
 
         public getRuleName(rule: Rule): string {
@@ -26,17 +30,16 @@ namespace ts.formatting {
 
         public ensureUpToDate(options: ts.FormatCodeSettings) {
             if (!this.options || !ts.compareDataObjects(this.options, options)) {
-                const activeRules = this.createActiveRules(options);
-                const rulesMap = RulesMap.create(activeRules);
+                const newFormatOptionsRules = this.createFormatOptionsRules(options);
 
-                this.activeRules = activeRules;
-                this.rulesMap = rulesMap;
+                this.rulesMap.Update(this.activeFormatOptionsRules, newFormatOptionsRules);
+                this.activeFormatOptionsRules = newFormatOptionsRules;
                 this.options = ts.clone(options);
             }
         }
 
-        private createActiveRules(options: ts.FormatCodeSettings): Rule[] {
-            let rules = this.globalRules.HighPriorityCommonRules.slice(0);
+        private createFormatOptionsRules(options: ts.FormatCodeSettings): Rule[] {
+            const rules = [];
 
             if (options.insertSpaceAfterConstructor) {
                 rules.push(this.globalRules.SpaceAfterConstructor);
@@ -157,8 +160,6 @@ namespace ts.formatting {
             else {
                 rules.push(this.globalRules.NoSpaceAfterTypeAssertion);
             }
-
-            rules = rules.concat(this.globalRules.LowPriorityCommonRules);
 
             return rules;
         }

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -31,6 +31,8 @@ namespace ts {
     /** The version of the language service API */
     export const servicesVersion = "0.5";
 
+    const ruleProvider: formatting.RulesProvider = new formatting.RulesProvider();
+
     function createNode<TKind extends SyntaxKind>(kind: TKind, pos: number, end: number, parent?: Node): NodeObject | TokenObject<TKind> | IdentifierObject {
         const node = kind >= SyntaxKind.FirstNode ? new NodeObject(kind, pos, end) :
             kind === SyntaxKind.Identifier ? new IdentifierObject(SyntaxKind.Identifier, pos, end) :
@@ -973,10 +975,9 @@ namespace ts {
     }
 
     export function createLanguageService(host: LanguageServiceHost,
-        documentRegistry: DocumentRegistry = createDocumentRegistry(host.useCaseSensitiveFileNames && host.useCaseSensitiveFileNames(), host.getCurrentDirectory())): LanguageService {
+        documentRegistry: DocumentRegistry = createDocumentRegistry(host.useCaseSensitiveFileNames && host.useCaseSensitiveFileNames(), host.getCurrentDirectory()), formatOptions?: FormatCodeSettings): LanguageService {
 
         const syntaxTreeCache: SyntaxTreeCache = new SyntaxTreeCache(host);
-        let ruleProvider: formatting.RulesProvider;
         let program: Program;
         let lastProjectVersion: string;
 
@@ -989,6 +990,11 @@ namespace ts {
         // Check if the localized messages json is set, otherwise query the host for it
         if (!localizedDiagnosticMessages && host.getLocalizedDiagnosticMessages) {
             localizedDiagnosticMessages = host.getLocalizedDiagnosticMessages();
+        }
+
+        // Update rules provider with code formatting options
+        if (formatOptions) {
+            ruleProvider.ensureUpToDate(formatOptions);
         }
 
         function log(message: string) {
@@ -1008,11 +1014,7 @@ namespace ts {
         }
 
         function getRuleProvider(options: FormatCodeSettings) {
-            // Ensure rules are initialized and up to date wrt to formatting options
-            if (!ruleProvider) {
-                ruleProvider = new formatting.RulesProvider();
-            }
-
+            // Ensure rules are up to date wrt to formatting options
             ruleProvider.ensureUpToDate(options);
             return ruleProvider;
         }

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1049,6 +1049,10 @@ namespace ts {
     }
 
     export function compareDataObjects(dst: any, src: any): boolean {
+        if (!dst || !src || Object.keys(dst).length !== Object.keys(src).length) {
+            return false;
+        }
+
         for (const e in dst) {
             if (typeof dst[e] === "object") {
                 if (!compareDataObjects(dst[e], src[e])) {


### PR DESCRIPTION
1.	Make the RulesProvider’s RulesMap updatable so we don’t have to drop it and recreate each time
2.	Initialize the non-configurable (high priority) rules once when services.ts is loaded (currently about 66 rules)
3.	On the first call to createLanguageService initialize the remaining user-configurable rules & low priority rules (currently about 32 rules). 
4.	On subsequent calls to createLanguageService & formatting (anywhere we getRulesProvider) check if the user-options have changed. If any of these are different we only update the associated user-configurable rules (and low priority rules) instead of dropping and recreating the entire map.

Fixes:
 •	TS: [[TSServer] Formatting RulesProvider (re)initialization performance issues](https://github.com/Microsoft/TypeScript/issues/13429)
•	VS: Bug 373219: [TypeScript Perf] WebForms_DDRIT.0300.Typing HTML5 HTML regressed Duration_AccumulatedElapsedTime (60ms)

