### PR TITLE
Make docComment template indent whitespace-only

### DIFF
--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -2248,22 +2248,23 @@ namespace FourSlash {
 
             if (expected === undefined) {
                 if (actual) {
-                    this.raiseError(name + " failed - expected no template but got {newText: \"" + actual.newText + "\" caretOffset: " + actual.caretOffset + "}");
+                    this.raiseError(`${name} failed - expected no template but got {newText: "${actual.newText}", caretOffset: ${actual.caretOffset}}`);
                 }
 
                 return;
             }
             else {
                 if (actual === undefined) {
-                    this.raiseError(name + " failed - expected the template {newText: \"" + actual.newText + "\" caretOffset: " + actual.caretOffset + "} but got nothing instead");
+                    this.raiseError(`${name} failed - expected the template {newText: "${expected.newText}", caretOffset: "${expected.caretOffset}"} but got nothing instead`);
+                    
                 }
 
                 if (actual.newText !== expected.newText) {
-                    this.raiseError(name + " failed - expected insertion:\n" + this.clarifyNewlines(expected.newText) + "\nactual insertion:\n" + this.clarifyNewlines(actual.newText));
+                    this.raiseError(`${name} failed - expected insertion:\n"${this.clarifyNewlines(expected.newText)}"\nactual insertion:\n"${this.clarifyNewlines(actual.newText)}"`);
                 }
 
                 if (actual.caretOffset !== expected.caretOffset) {
-                    this.raiseError(name + " failed - expected caretOffset: " + expected.caretOffset + ",\nactual caretOffset:" + actual.caretOffset);
+                    this.raiseError(`${name} failed - expected caretOffset: ${expected.caretOffset}\nactual caretOffset:${actual.caretOffset}`);
                 }
             }
         }

--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -178,7 +178,8 @@ namespace ts.JsDoc {
         const posLineAndChar = sourceFile.getLineAndCharacterOfPosition(position);
         const lineStart = sourceFile.getLineStarts()[posLineAndChar.line];
 
-        const indentationStr = sourceFile.text.substr(lineStart, posLineAndChar.character);
+        // replace non-whitespace characters in prefix with spaces.
+        const indentationStr = sourceFile.text.substr(lineStart, posLineAndChar.character).replace(/\S/i, () => " ");
         const isJavaScriptFile = hasJavaScriptFileExtension(sourceFile.fileName);
 
         let docParams = "";

--- a/tests/cases/fourslash/docCommentTemplateIndentation.ts
+++ b/tests/cases/fourslash/docCommentTemplateIndentation.ts
@@ -1,13 +1,13 @@
 /// <reference path='fourslash.ts' />
 
 // @Filename: indents.ts
-/////*0*/
+////    a   /*2*/
 ////    /*1*/
-////        /*2*/function foo() { }
+/////*0*/        function foo() { }
 
 const noIndentEmptyScaffolding = "/**\r\n * \r\n */";
 const oneIndentEmptyScaffolding = "/**\r\n     * \r\n     */";
-const twoIndentEmptyScaffolding = "/**\r\n         * \r\n         */\r\n        ";
+const twoIndentEmptyScaffolding = "/**\r\n         * \r\n         */";
 const noIndentOffset = 8;
 const oneIndentOffset = noIndentOffset + 4;
 const twoIndentOffset = oneIndentOffset + 4;


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes https://github.com/Microsoft/TypeScript/issues/14272
