### PR TITLE
send error if obtaining of types-registry package failed

### DIFF
--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -2127,6 +2127,17 @@ namespace ts.server.protocol {
         payload: any;
     }
 
+    export type TypesInstallerInitializationFailedEventName = "typesInstallerInitializationFailed";
+
+    export interface TypesInstallerInitializationFailedEvent extends Event {
+        event: TypesInstallerInitializationFailedEventName;
+        body: TypesInstallerInitializationFailedEventBody;
+    }
+
+    export interface TypesInstallerInitializationFailedEventBody {
+        message: string;
+    }
+
     export type TypingsInstalledTelemetryEventName = "typingsInstalled";
 
     export interface TypingsInstalledTelemetryEventBody extends TelemetryEventBody {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -304,9 +304,21 @@ namespace ts.server {
             });
         }
 
-        private handleMessage(response: SetTypings | InvalidateCachedTypings | BeginInstallTypes | EndInstallTypes) {
+        private handleMessage(response: SetTypings | InvalidateCachedTypings | BeginInstallTypes | EndInstallTypes | InitializationFailedResponse) {
             if (this.logger.hasLevel(LogLevel.verbose)) {
                 this.logger.info(`Received response: ${JSON.stringify(response)}`);
+            }
+
+            if (response.kind === EventInitializationFailed) {
+                if (!this.eventSender) {
+                    return;
+                }
+                const body: protocol.TypesInstallerInitializationFailedEventBody = {
+                    message: response.message
+                }
+                const eventName: protocol.TypesInstallerInitializationFailedEventName = "typesInstallerInitializationFailed";
+                this.eventSender.event(body, eventName);
+                return;
             }
 
             if (response.kind === EventBeginInstallTypes) {

--- a/src/server/shared.ts
+++ b/src/server/shared.ts
@@ -5,6 +5,7 @@ namespace ts.server {
     export const ActionInvalidate: ActionInvalidate = "action::invalidate";
     export const EventBeginInstallTypes: EventBeginInstallTypes = "event::beginInstallTypes";
     export const EventEndInstallTypes: EventEndInstallTypes = "event::endInstallTypes";
+    export const EventInitializationFailed: EventInitializationFailed = "event::initializationFailed";
 
     export namespace Arguments {
         export const GlobalCacheLocation = "--globalTypingsCacheLocation";

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -47,9 +47,15 @@ declare namespace ts.server {
     export type ActionInvalidate = "action::invalidate";
     export type EventBeginInstallTypes = "event::beginInstallTypes";
     export type EventEndInstallTypes = "event::endInstallTypes";
+    export type EventInitializationFailed = "event::initializationFailed";
 
     export interface TypingInstallerResponse {
-        readonly kind: ActionSet | ActionInvalidate | EventBeginInstallTypes | EventEndInstallTypes;
+        readonly kind: ActionSet | ActionInvalidate | EventBeginInstallTypes | EventEndInstallTypes | EventInitializationFailed;
+    }
+
+    export interface InitializationFailedResponse extends TypingInstallerResponse {
+        readonly kind: EventInitializationFailed;
+        readonly message: string;
     }
 
     export interface ProjectResponse extends TypingInstallerResponse {

--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -74,6 +74,8 @@ namespace ts.server.typingsInstaller {
         private readonly npmPath: string;
         readonly typesRegistry: Map<void>;
 
+        private delayedInitializationError: InitializationFailedResponse;
+
         constructor(globalTypingsCacheLocation: string, throttleLimit: number, log: Log) {
             super(
                 sys,
@@ -99,6 +101,11 @@ namespace ts.server.typingsInstaller {
                 if (this.log.isEnabled()) {
                     this.log.writeLine(`Error updating ${TypesRegistryPackageName} package: ${(<Error>e).message}`);
                 }
+                // store error info to report it later when it is known that server is already listening to events from typings installer
+                this.delayedInitializationError = {
+                    kind: "event::initializationFailed",
+                    message: (<Error>e).message
+                };
             }
 
             this.typesRegistry = loadTypesRegistryFile(getTypesRegistryFileLocation(globalTypingsCacheLocation), this.installTypingHost, this.log);
@@ -106,6 +113,11 @@ namespace ts.server.typingsInstaller {
 
         listen() {
             process.on("message", (req: DiscoverTypings | CloseProject) => {
+                if (this.delayedInitializationError) {
+                    // report initializationFailed error
+                    this.sendResponse(this.delayedInitializationError);
+                    this.delayedInitializationError = undefined;
+                }
                 switch (req.kind) {
                     case "discover":
                         this.install(req);
@@ -116,7 +128,7 @@ namespace ts.server.typingsInstaller {
             });
         }
 
-        protected sendResponse(response: SetTypings | InvalidateCachedTypings | BeginInstallTypes | EndInstallTypes) {
+        protected sendResponse(response: SetTypings | InvalidateCachedTypings | BeginInstallTypes | EndInstallTypes | InitializationFailedResponse) {
             if (this.log.isEnabled()) {
                 this.log.writeLine(`Sending response: ${JSON.stringify(response)}`);
             }


### PR DESCRIPTION
fixes #14398 
NOTE: types installer does not immediately send the error to the parent process since it will be prone to races - event can be sent before parent process started listening to events. Instead types installer sends error after it for the first time receives request from the parent process