### PR TITLE
Expose `forEachChild` as a method of Node

### DIFF
--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -209,6 +209,10 @@ namespace ts {
 
             return child.kind < SyntaxKind.FirstNode ? child : child.getLastToken(sourceFile);
         }
+
+        public forEachChild<T>(cbNode: (node: Node) => T, cbNodeArray?: (nodes: Node[]) => T): T {
+            return forEachChild(this, cbNode, cbNodeArray);
+        }
     }
 
     class TokenOrIdentifierObject implements Node {
@@ -280,6 +284,10 @@ namespace ts {
         }
 
         public getLastToken(): Node {
+            return undefined;
+        }
+
+        public forEachChild<T>(): T {
             return undefined;
         }
     }

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -14,6 +14,8 @@ namespace ts {
         getText(sourceFile?: SourceFile): string;
         getFirstToken(sourceFile?: SourceFile): Node;
         getLastToken(sourceFile?: SourceFile): Node;
+        // See ts.forEachChild for documentation.
+        forEachChild<T>(cbNode: (node: Node) => T, cbNodeArray?: (nodes: Node[]) => T): T;
     }
 
     export interface Symbol {


### PR DESCRIPTION
Just a suggestion. I think this would make using the services API a lot more convenient.