### PR TITLE
Fix Per Request Cancellation Tokens

### DIFF
--- a/src/server/cancellationToken/cancellationToken.ts
+++ b/src/server/cancellationToken/cancellationToken.ts
@@ -48,7 +48,7 @@ function createCancellationToken(args: string[]): ServerCancellationToken {
         return {
             isCancellationRequested: () =>  perRequestPipeName !== undefined && pipeExists(perRequestPipeName),
             setRequest(requestId: number) {
-                currentRequestId = currentRequestId;
+                currentRequestId = requestId;
                 perRequestPipeName = namePrefix + requestId;
             },
             resetRequest(requestId: number) {


### PR DESCRIPTION
Fixes #14593

While working on https://github.com/Microsoft/vscode/pull/22437, I believe there is a bug in the per request cancellation in the  `setRequest` function on the line `currentRequestId = currentRequestId ;` This causes `currentRequestId` to always be undefined

Fix is to assign the `currentRequestId` to `requestId`
