### PR TITLE
Infer class property declarations from assignments in nested arrow functions

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -2332,6 +2332,7 @@ namespace ts {
 
         function bindThisPropertyAssignment(node: BinaryExpression) {
             Debug.assert(isInJavaScriptFile(node));
+            const container = getThisContainer(node, /*includeArrowFunctions*/false);
             switch (container.kind) {
                 case SyntaxKind.FunctionDeclaration:
                 case SyntaxKind.FunctionExpression:
@@ -2342,6 +2343,7 @@ namespace ts {
                     break;
 
                 case SyntaxKind.Constructor:
+                case SyntaxKind.PropertyDeclaration:
                 case SyntaxKind.MethodDeclaration:
                 case SyntaxKind.GetAccessor:
                 case SyntaxKind.SetAccessor:

--- a/tests/baselines/reference/inferringClassMembersFromAssignments.js
+++ b/tests/baselines/reference/inferringClassMembersFromAssignments.js
@@ -20,6 +20,15 @@ class C {
             this.inMethod = "string"
         }
         this.inMultiple = "string";
+
+        var action = () => {
+            if (Math.random()) {
+                this.inNestedArrowFunction = 0;
+            }
+            else {
+                this.inNestedArrowFunction = "string"
+            }
+        };
     }
     get() {
         if (Math.random()) {
@@ -38,6 +47,14 @@ class C {
             this.inSetter = "string"
         }
     }
+    prop = () => {
+        if (Math.random()) {
+            this.inPropertyDeclaration = 0;
+        }
+        else {
+            this.inPropertyDeclaration = "string"
+        }
+    }
     static method() {
         if (Math.random()) {
             this.inStaticMethod = 0;
@@ -45,6 +62,15 @@ class C {
         else {
             this.inStaticMethod = "string"
         }
+
+        var action = () => {
+            if (Math.random()) {
+                this.inStaticNestedArrowFunction = 0;
+            }
+            else {
+                this.inStaticNestedArrowFunction = "string"
+            }
+        };
     }
     static get() {
         if (Math.random()) {
@@ -62,6 +88,14 @@ class C {
             this.inStaticSetter = "string"
         }
     }
+    static prop = () => {
+        if (Math.random()) {
+            this.inStaticPropertyDeclaration = 0;
+        }
+        else {
+            this.inStaticPropertyDeclaration = "string"
+        }
+    }
 }
 
 //// [b.ts]
@@ -75,6 +109,8 @@ var stringOrNumberOrUndefined: string | number | undefined;
 var stringOrNumberOrUndefined = c.inMethod;
 var stringOrNumberOrUndefined = c.inGetter;
 var stringOrNumberOrUndefined = c.inSetter;
+var stringOrNumberOrUndefined = c.inPropertyDeclaration;
+var stringOrNumberOrUndefined = c.inNestedArrowFunction
 
 var stringOrNumberOrBoolean: string | number | boolean;
 
@@ -84,11 +120,23 @@ var stringOrNumberOrBoolean = c.inMultiple;
 var stringOrNumberOrUndefined = C.inStaticMethod;
 var stringOrNumberOrUndefined = C.inStaticGetter;
 var stringOrNumberOrUndefined = C.inStaticSetter;
+var stringOrNumberOrUndefined = C.inStaticPropertyDeclaration;
+var stringOrNumberOrUndefined = C.inStaticNestedArrowFunction;
 
 
 //// [output.js]
+var _this = this;
 var C = (function () {
     function C() {
+        var _this = this;
+        this.prop = function () {
+            if (Math.random()) {
+                _this.inPropertyDeclaration = 0;
+            }
+            else {
+                _this.inPropertyDeclaration = "string";
+            }
+        };
         if (Math.random()) {
             this.inConstructor = 0;
         }
@@ -98,6 +146,7 @@ var C = (function () {
         this.inMultiple = 0;
     }
     C.prototype.method = function () {
+        var _this = this;
         if (Math.random()) {
             this.inMethod = 0;
         }
@@ -105,6 +154,14 @@ var C = (function () {
             this.inMethod = "string";
         }
         this.inMultiple = "string";
+        var action = function () {
+            if (Math.random()) {
+                _this.inNestedArrowFunction = 0;
+            }
+            else {
+                _this.inNestedArrowFunction = "string";
+            }
+        };
     };
     C.prototype.get = function () {
         if (Math.random()) {
@@ -124,12 +181,21 @@ var C = (function () {
         }
     };
     C.method = function () {
+        var _this = this;
         if (Math.random()) {
             this.inStaticMethod = 0;
         }
         else {
             this.inStaticMethod = "string";
         }
+        var action = function () {
+            if (Math.random()) {
+                _this.inStaticNestedArrowFunction = 0;
+            }
+            else {
+                _this.inStaticNestedArrowFunction = "string";
+            }
+        };
     };
     C.get = function () {
         if (Math.random()) {
@@ -149,6 +215,14 @@ var C = (function () {
     };
     return C;
 }());
+C.prop = function () {
+    if (Math.random()) {
+        _this.inStaticPropertyDeclaration = 0;
+    }
+    else {
+        _this.inStaticPropertyDeclaration = "string";
+    }
+};
 var c = new C();
 var stringOrNumber;
 var stringOrNumber = c.inConstructor;
@@ -156,8 +230,12 @@ var stringOrNumberOrUndefined;
 var stringOrNumberOrUndefined = c.inMethod;
 var stringOrNumberOrUndefined = c.inGetter;
 var stringOrNumberOrUndefined = c.inSetter;
+var stringOrNumberOrUndefined = c.inPropertyDeclaration;
+var stringOrNumberOrUndefined = c.inNestedArrowFunction;
 var stringOrNumberOrBoolean;
 var stringOrNumberOrBoolean = c.inMultiple;
 var stringOrNumberOrUndefined = C.inStaticMethod;
 var stringOrNumberOrUndefined = C.inStaticGetter;
 var stringOrNumberOrUndefined = C.inStaticSetter;
+var stringOrNumberOrUndefined = C.inStaticPropertyDeclaration;
+var stringOrNumberOrUndefined = C.inStaticNestedArrowFunction;

--- a/tests/baselines/reference/inferringClassMembersFromAssignments.symbols
+++ b/tests/baselines/reference/inferringClassMembersFromAssignments.symbols
@@ -21,9 +21,9 @@ class C {
 >inConstructor : Symbol(C.inConstructor, Decl(a.js, 3, 28), Decl(a.js, 6, 14))
         }
         this.inMultiple = 0;
->this.inMultiple : Symbol(C.inMultiple, Decl(a.js, 8, 9), Decl(a.js, 17, 9), Decl(a.js, 26, 9))
+>this.inMultiple : Symbol(C.inMultiple, Decl(a.js, 8, 9), Decl(a.js, 17, 9), Decl(a.js, 35, 9))
 >this : Symbol(C, Decl(a.js, 0, 0))
->inMultiple : Symbol(C.inMultiple, Decl(a.js, 8, 9), Decl(a.js, 17, 9), Decl(a.js, 26, 9))
+>inMultiple : Symbol(C.inMultiple, Decl(a.js, 8, 9), Decl(a.js, 17, 9), Decl(a.js, 35, 9))
     }
     method() {
 >method : Symbol(C.method, Decl(a.js, 10, 5))
@@ -45,12 +45,33 @@ class C {
 >inMethod : Symbol(C.inMethod, Decl(a.js, 12, 28), Decl(a.js, 15, 14))
         }
         this.inMultiple = "string";
->this.inMultiple : Symbol(C.inMultiple, Decl(a.js, 8, 9), Decl(a.js, 17, 9), Decl(a.js, 26, 9))
+>this.inMultiple : Symbol(C.inMultiple, Decl(a.js, 8, 9), Decl(a.js, 17, 9), Decl(a.js, 35, 9))
 >this : Symbol(C, Decl(a.js, 0, 0))
->inMultiple : Symbol(C.inMultiple, Decl(a.js, 8, 9), Decl(a.js, 17, 9), Decl(a.js, 26, 9))
+>inMultiple : Symbol(C.inMultiple, Decl(a.js, 8, 9), Decl(a.js, 17, 9), Decl(a.js, 35, 9))
+
+        var action = () => {
+>action : Symbol(action, Decl(a.js, 20, 11))
+
+            if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.d.ts, --, --))
+
+                this.inNestedArrowFunction = 0;
+>this.inNestedArrowFunction : Symbol(C.inNestedArrowFunction, Decl(a.js, 21, 32), Decl(a.js, 24, 18))
+>this : Symbol(C, Decl(a.js, 0, 0))
+>inNestedArrowFunction : Symbol(C.inNestedArrowFunction, Decl(a.js, 21, 32), Decl(a.js, 24, 18))
+            }
+            else {
+                this.inNestedArrowFunction = "string"
+>this.inNestedArrowFunction : Symbol(C.inNestedArrowFunction, Decl(a.js, 21, 32), Decl(a.js, 24, 18))
+>this : Symbol(C, Decl(a.js, 0, 0))
+>inNestedArrowFunction : Symbol(C.inNestedArrowFunction, Decl(a.js, 21, 32), Decl(a.js, 24, 18))
+            }
+        };
     }
     get() {
->get : Symbol(C.get, Decl(a.js, 19, 5))
+>get : Symbol(C.get, Decl(a.js, 28, 5))
 
         if (Math.random()) {
 >Math.random : Symbol(Math.random, Decl(lib.d.ts, --, --))
@@ -58,23 +79,23 @@ class C {
 >random : Symbol(Math.random, Decl(lib.d.ts, --, --))
 
             this.inGetter = 0;
->this.inGetter : Symbol(C.inGetter, Decl(a.js, 21, 28), Decl(a.js, 24, 14))
+>this.inGetter : Symbol(C.inGetter, Decl(a.js, 30, 28), Decl(a.js, 33, 14))
 >this : Symbol(C, Decl(a.js, 0, 0))
->inGetter : Symbol(C.inGetter, Decl(a.js, 21, 28), Decl(a.js, 24, 14))
+>inGetter : Symbol(C.inGetter, Decl(a.js, 30, 28), Decl(a.js, 33, 14))
         }
         else {
             this.inGetter = "string"
->this.inGetter : Symbol(C.inGetter, Decl(a.js, 21, 28), Decl(a.js, 24, 14))
+>this.inGetter : Symbol(C.inGetter, Decl(a.js, 30, 28), Decl(a.js, 33, 14))
 >this : Symbol(C, Decl(a.js, 0, 0))
->inGetter : Symbol(C.inGetter, Decl(a.js, 21, 28), Decl(a.js, 24, 14))
+>inGetter : Symbol(C.inGetter, Decl(a.js, 30, 28), Decl(a.js, 33, 14))
         }
         this.inMultiple = false;
->this.inMultiple : Symbol(C.inMultiple, Decl(a.js, 8, 9), Decl(a.js, 17, 9), Decl(a.js, 26, 9))
+>this.inMultiple : Symbol(C.inMultiple, Decl(a.js, 8, 9), Decl(a.js, 17, 9), Decl(a.js, 35, 9))
 >this : Symbol(C, Decl(a.js, 0, 0))
->inMultiple : Symbol(C.inMultiple, Decl(a.js, 8, 9), Decl(a.js, 17, 9), Decl(a.js, 26, 9))
+>inMultiple : Symbol(C.inMultiple, Decl(a.js, 8, 9), Decl(a.js, 17, 9), Decl(a.js, 35, 9))
     }
     set() {
->set : Symbol(C.set, Decl(a.js, 28, 5))
+>set : Symbol(C.set, Decl(a.js, 37, 5))
 
         if (Math.random()) {
 >Math.random : Symbol(Math.random, Decl(lib.d.ts, --, --))
@@ -82,19 +103,39 @@ class C {
 >random : Symbol(Math.random, Decl(lib.d.ts, --, --))
 
             this.inSetter = 0;
->this.inSetter : Symbol(C.inSetter, Decl(a.js, 30, 28), Decl(a.js, 33, 14))
+>this.inSetter : Symbol(C.inSetter, Decl(a.js, 39, 28), Decl(a.js, 42, 14))
 >this : Symbol(C, Decl(a.js, 0, 0))
->inSetter : Symbol(C.inSetter, Decl(a.js, 30, 28), Decl(a.js, 33, 14))
+>inSetter : Symbol(C.inSetter, Decl(a.js, 39, 28), Decl(a.js, 42, 14))
         }
         else {
             this.inSetter = "string"
->this.inSetter : Symbol(C.inSetter, Decl(a.js, 30, 28), Decl(a.js, 33, 14))
+>this.inSetter : Symbol(C.inSetter, Decl(a.js, 39, 28), Decl(a.js, 42, 14))
 >this : Symbol(C, Decl(a.js, 0, 0))
->inSetter : Symbol(C.inSetter, Decl(a.js, 30, 28), Decl(a.js, 33, 14))
+>inSetter : Symbol(C.inSetter, Decl(a.js, 39, 28), Decl(a.js, 42, 14))
+        }
+    }
+    prop = () => {
+>prop : Symbol(C.prop, Decl(a.js, 45, 5))
+
+        if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.d.ts, --, --))
+
+            this.inPropertyDeclaration = 0;
+>this.inPropertyDeclaration : Symbol(C.inPropertyDeclaration, Decl(a.js, 47, 28), Decl(a.js, 50, 14))
+>this : Symbol(C, Decl(a.js, 0, 0))
+>inPropertyDeclaration : Symbol(C.inPropertyDeclaration, Decl(a.js, 47, 28), Decl(a.js, 50, 14))
+        }
+        else {
+            this.inPropertyDeclaration = "string"
+>this.inPropertyDeclaration : Symbol(C.inPropertyDeclaration, Decl(a.js, 47, 28), Decl(a.js, 50, 14))
+>this : Symbol(C, Decl(a.js, 0, 0))
+>inPropertyDeclaration : Symbol(C.inPropertyDeclaration, Decl(a.js, 47, 28), Decl(a.js, 50, 14))
         }
     }
     static method() {
->method : Symbol(C.method, Decl(a.js, 36, 5))
+>method : Symbol(C.method, Decl(a.js, 53, 5))
 
         if (Math.random()) {
 >Math.random : Symbol(Math.random, Decl(lib.d.ts, --, --))
@@ -102,19 +143,40 @@ class C {
 >random : Symbol(Math.random, Decl(lib.d.ts, --, --))
 
             this.inStaticMethod = 0;
->this.inStaticMethod : Symbol(C.inStaticMethod, Decl(a.js, 38, 28), Decl(a.js, 41, 14))
+>this.inStaticMethod : Symbol(C.inStaticMethod, Decl(a.js, 55, 28), Decl(a.js, 58, 14))
 >this : Symbol(C, Decl(a.js, 0, 0))
->inStaticMethod : Symbol(C.inStaticMethod, Decl(a.js, 38, 28), Decl(a.js, 41, 14))
+>inStaticMethod : Symbol(C.inStaticMethod, Decl(a.js, 55, 28), Decl(a.js, 58, 14))
         }
         else {
             this.inStaticMethod = "string"
->this.inStaticMethod : Symbol(C.inStaticMethod, Decl(a.js, 38, 28), Decl(a.js, 41, 14))
+>this.inStaticMethod : Symbol(C.inStaticMethod, Decl(a.js, 55, 28), Decl(a.js, 58, 14))
 >this : Symbol(C, Decl(a.js, 0, 0))
->inStaticMethod : Symbol(C.inStaticMethod, Decl(a.js, 38, 28), Decl(a.js, 41, 14))
+>inStaticMethod : Symbol(C.inStaticMethod, Decl(a.js, 55, 28), Decl(a.js, 58, 14))
         }
+
+        var action = () => {
+>action : Symbol(action, Decl(a.js, 62, 11))
+
+            if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.d.ts, --, --))
+
+                this.inStaticNestedArrowFunction = 0;
+>this.inStaticNestedArrowFunction : Symbol(C.inStaticNestedArrowFunction, Decl(a.js, 63, 32), Decl(a.js, 66, 18))
+>this : Symbol(C, Decl(a.js, 0, 0))
+>inStaticNestedArrowFunction : Symbol(C.inStaticNestedArrowFunction, Decl(a.js, 63, 32), Decl(a.js, 66, 18))
+            }
+            else {
+                this.inStaticNestedArrowFunction = "string"
+>this.inStaticNestedArrowFunction : Symbol(C.inStaticNestedArrowFunction, Decl(a.js, 63, 32), Decl(a.js, 66, 18))
+>this : Symbol(C, Decl(a.js, 0, 0))
+>inStaticNestedArrowFunction : Symbol(C.inStaticNestedArrowFunction, Decl(a.js, 63, 32), Decl(a.js, 66, 18))
+            }
+        };
     }
     static get() {
->get : Symbol(C.get, Decl(a.js, 44, 5))
+>get : Symbol(C.get, Decl(a.js, 70, 5))
 
         if (Math.random()) {
 >Math.random : Symbol(Math.random, Decl(lib.d.ts, --, --))
@@ -122,19 +184,19 @@ class C {
 >random : Symbol(Math.random, Decl(lib.d.ts, --, --))
 
             this.inStaticGetter = 0;
->this.inStaticGetter : Symbol(C.inStaticGetter, Decl(a.js, 46, 28), Decl(a.js, 49, 14))
+>this.inStaticGetter : Symbol(C.inStaticGetter, Decl(a.js, 72, 28), Decl(a.js, 75, 14))
 >this : Symbol(C, Decl(a.js, 0, 0))
->inStaticGetter : Symbol(C.inStaticGetter, Decl(a.js, 46, 28), Decl(a.js, 49, 14))
+>inStaticGetter : Symbol(C.inStaticGetter, Decl(a.js, 72, 28), Decl(a.js, 75, 14))
         }
         else {
             this.inStaticGetter = "string"
->this.inStaticGetter : Symbol(C.inStaticGetter, Decl(a.js, 46, 28), Decl(a.js, 49, 14))
+>this.inStaticGetter : Symbol(C.inStaticGetter, Decl(a.js, 72, 28), Decl(a.js, 75, 14))
 >this : Symbol(C, Decl(a.js, 0, 0))
->inStaticGetter : Symbol(C.inStaticGetter, Decl(a.js, 46, 28), Decl(a.js, 49, 14))
+>inStaticGetter : Symbol(C.inStaticGetter, Decl(a.js, 72, 28), Decl(a.js, 75, 14))
         }
     }
     static set() {
->set : Symbol(C.set, Decl(a.js, 52, 5))
+>set : Symbol(C.set, Decl(a.js, 78, 5))
 
         if (Math.random()) {
 >Math.random : Symbol(Math.random, Decl(lib.d.ts, --, --))
@@ -142,15 +204,35 @@ class C {
 >random : Symbol(Math.random, Decl(lib.d.ts, --, --))
 
             this.inStaticSetter = 0;
->this.inStaticSetter : Symbol(C.inStaticSetter, Decl(a.js, 54, 28), Decl(a.js, 57, 14))
+>this.inStaticSetter : Symbol(C.inStaticSetter, Decl(a.js, 80, 28), Decl(a.js, 83, 14))
 >this : Symbol(C, Decl(a.js, 0, 0))
->inStaticSetter : Symbol(C.inStaticSetter, Decl(a.js, 54, 28), Decl(a.js, 57, 14))
+>inStaticSetter : Symbol(C.inStaticSetter, Decl(a.js, 80, 28), Decl(a.js, 83, 14))
         }
         else {
             this.inStaticSetter = "string"
->this.inStaticSetter : Symbol(C.inStaticSetter, Decl(a.js, 54, 28), Decl(a.js, 57, 14))
+>this.inStaticSetter : Symbol(C.inStaticSetter, Decl(a.js, 80, 28), Decl(a.js, 83, 14))
 >this : Symbol(C, Decl(a.js, 0, 0))
->inStaticSetter : Symbol(C.inStaticSetter, Decl(a.js, 54, 28), Decl(a.js, 57, 14))
+>inStaticSetter : Symbol(C.inStaticSetter, Decl(a.js, 80, 28), Decl(a.js, 83, 14))
+        }
+    }
+    static prop = () => {
+>prop : Symbol(C.prop, Decl(a.js, 86, 5))
+
+        if (Math.random()) {
+>Math.random : Symbol(Math.random, Decl(lib.d.ts, --, --))
+>Math : Symbol(Math, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>random : Symbol(Math.random, Decl(lib.d.ts, --, --))
+
+            this.inStaticPropertyDeclaration = 0;
+>this.inStaticPropertyDeclaration : Symbol(C.inStaticPropertyDeclaration, Decl(a.js, 88, 28), Decl(a.js, 91, 14))
+>this : Symbol(C, Decl(a.js, 0, 0))
+>inStaticPropertyDeclaration : Symbol(C.inStaticPropertyDeclaration, Decl(a.js, 88, 28), Decl(a.js, 91, 14))
+        }
+        else {
+            this.inStaticPropertyDeclaration = "string"
+>this.inStaticPropertyDeclaration : Symbol(C.inStaticPropertyDeclaration, Decl(a.js, 88, 28), Decl(a.js, 91, 14))
+>this : Symbol(C, Decl(a.js, 0, 0))
+>inStaticPropertyDeclaration : Symbol(C.inStaticPropertyDeclaration, Decl(a.js, 88, 28), Decl(a.js, 91, 14))
         }
     }
 }
@@ -170,51 +252,75 @@ var stringOrNumber = c.inConstructor;
 >inConstructor : Symbol(C.inConstructor, Decl(a.js, 3, 28), Decl(a.js, 6, 14))
 
 var stringOrNumberOrUndefined: string | number | undefined;
->stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 16, 3), Decl(b.ts, 17, 3), Decl(b.ts, 18, 3))
+>stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 10, 3), Decl(b.ts, 11, 3), Decl(b.ts, 18, 3), Decl(b.ts, 19, 3), Decl(b.ts, 20, 3), Decl(b.ts, 21, 3), Decl(b.ts, 22, 3))
 
 var stringOrNumberOrUndefined = c.inMethod;
->stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 16, 3), Decl(b.ts, 17, 3), Decl(b.ts, 18, 3))
+>stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 10, 3), Decl(b.ts, 11, 3), Decl(b.ts, 18, 3), Decl(b.ts, 19, 3), Decl(b.ts, 20, 3), Decl(b.ts, 21, 3), Decl(b.ts, 22, 3))
 >c.inMethod : Symbol(C.inMethod, Decl(a.js, 12, 28), Decl(a.js, 15, 14))
 >c : Symbol(c, Decl(b.ts, 0, 3))
 >inMethod : Symbol(C.inMethod, Decl(a.js, 12, 28), Decl(a.js, 15, 14))
 
 var stringOrNumberOrUndefined = c.inGetter;
->stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 16, 3), Decl(b.ts, 17, 3), Decl(b.ts, 18, 3))
->c.inGetter : Symbol(C.inGetter, Decl(a.js, 21, 28), Decl(a.js, 24, 14))
+>stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 10, 3), Decl(b.ts, 11, 3), Decl(b.ts, 18, 3), Decl(b.ts, 19, 3), Decl(b.ts, 20, 3), Decl(b.ts, 21, 3), Decl(b.ts, 22, 3))
+>c.inGetter : Symbol(C.inGetter, Decl(a.js, 30, 28), Decl(a.js, 33, 14))
 >c : Symbol(c, Decl(b.ts, 0, 3))
->inGetter : Symbol(C.inGetter, Decl(a.js, 21, 28), Decl(a.js, 24, 14))
+>inGetter : Symbol(C.inGetter, Decl(a.js, 30, 28), Decl(a.js, 33, 14))
 
 var stringOrNumberOrUndefined = c.inSetter;
->stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 16, 3), Decl(b.ts, 17, 3), Decl(b.ts, 18, 3))
->c.inSetter : Symbol(C.inSetter, Decl(a.js, 30, 28), Decl(a.js, 33, 14))
+>stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 10, 3), Decl(b.ts, 11, 3), Decl(b.ts, 18, 3), Decl(b.ts, 19, 3), Decl(b.ts, 20, 3), Decl(b.ts, 21, 3), Decl(b.ts, 22, 3))
+>c.inSetter : Symbol(C.inSetter, Decl(a.js, 39, 28), Decl(a.js, 42, 14))
 >c : Symbol(c, Decl(b.ts, 0, 3))
->inSetter : Symbol(C.inSetter, Decl(a.js, 30, 28), Decl(a.js, 33, 14))
+>inSetter : Symbol(C.inSetter, Decl(a.js, 39, 28), Decl(a.js, 42, 14))
+
+var stringOrNumberOrUndefined = c.inPropertyDeclaration;
+>stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 10, 3), Decl(b.ts, 11, 3), Decl(b.ts, 18, 3), Decl(b.ts, 19, 3), Decl(b.ts, 20, 3), Decl(b.ts, 21, 3), Decl(b.ts, 22, 3))
+>c.inPropertyDeclaration : Symbol(C.inPropertyDeclaration, Decl(a.js, 47, 28), Decl(a.js, 50, 14))
+>c : Symbol(c, Decl(b.ts, 0, 3))
+>inPropertyDeclaration : Symbol(C.inPropertyDeclaration, Decl(a.js, 47, 28), Decl(a.js, 50, 14))
+
+var stringOrNumberOrUndefined = c.inNestedArrowFunction
+>stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 10, 3), Decl(b.ts, 11, 3), Decl(b.ts, 18, 3), Decl(b.ts, 19, 3), Decl(b.ts, 20, 3), Decl(b.ts, 21, 3), Decl(b.ts, 22, 3))
+>c.inNestedArrowFunction : Symbol(C.inNestedArrowFunction, Decl(a.js, 21, 32), Decl(a.js, 24, 18))
+>c : Symbol(c, Decl(b.ts, 0, 3))
+>inNestedArrowFunction : Symbol(C.inNestedArrowFunction, Decl(a.js, 21, 32), Decl(a.js, 24, 18))
 
 var stringOrNumberOrBoolean: string | number | boolean;
->stringOrNumberOrBoolean : Symbol(stringOrNumberOrBoolean, Decl(b.ts, 11, 3), Decl(b.ts, 13, 3))
+>stringOrNumberOrBoolean : Symbol(stringOrNumberOrBoolean, Decl(b.ts, 13, 3), Decl(b.ts, 15, 3))
 
 var stringOrNumberOrBoolean = c.inMultiple;
->stringOrNumberOrBoolean : Symbol(stringOrNumberOrBoolean, Decl(b.ts, 11, 3), Decl(b.ts, 13, 3))
->c.inMultiple : Symbol(C.inMultiple, Decl(a.js, 8, 9), Decl(a.js, 17, 9), Decl(a.js, 26, 9))
+>stringOrNumberOrBoolean : Symbol(stringOrNumberOrBoolean, Decl(b.ts, 13, 3), Decl(b.ts, 15, 3))
+>c.inMultiple : Symbol(C.inMultiple, Decl(a.js, 8, 9), Decl(a.js, 17, 9), Decl(a.js, 35, 9))
 >c : Symbol(c, Decl(b.ts, 0, 3))
->inMultiple : Symbol(C.inMultiple, Decl(a.js, 8, 9), Decl(a.js, 17, 9), Decl(a.js, 26, 9))
+>inMultiple : Symbol(C.inMultiple, Decl(a.js, 8, 9), Decl(a.js, 17, 9), Decl(a.js, 35, 9))
 
 
 var stringOrNumberOrUndefined = C.inStaticMethod;
->stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 16, 3), Decl(b.ts, 17, 3), Decl(b.ts, 18, 3))
->C.inStaticMethod : Symbol(C.inStaticMethod, Decl(a.js, 38, 28), Decl(a.js, 41, 14))
+>stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 10, 3), Decl(b.ts, 11, 3), Decl(b.ts, 18, 3), Decl(b.ts, 19, 3), Decl(b.ts, 20, 3), Decl(b.ts, 21, 3), Decl(b.ts, 22, 3))
+>C.inStaticMethod : Symbol(C.inStaticMethod, Decl(a.js, 55, 28), Decl(a.js, 58, 14))
 >C : Symbol(C, Decl(a.js, 0, 0))
->inStaticMethod : Symbol(C.inStaticMethod, Decl(a.js, 38, 28), Decl(a.js, 41, 14))
+>inStaticMethod : Symbol(C.inStaticMethod, Decl(a.js, 55, 28), Decl(a.js, 58, 14))
 
 var stringOrNumberOrUndefined = C.inStaticGetter;
->stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 16, 3), Decl(b.ts, 17, 3), Decl(b.ts, 18, 3))
->C.inStaticGetter : Symbol(C.inStaticGetter, Decl(a.js, 46, 28), Decl(a.js, 49, 14))
+>stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 10, 3), Decl(b.ts, 11, 3), Decl(b.ts, 18, 3), Decl(b.ts, 19, 3), Decl(b.ts, 20, 3), Decl(b.ts, 21, 3), Decl(b.ts, 22, 3))
+>C.inStaticGetter : Symbol(C.inStaticGetter, Decl(a.js, 72, 28), Decl(a.js, 75, 14))
 >C : Symbol(C, Decl(a.js, 0, 0))
->inStaticGetter : Symbol(C.inStaticGetter, Decl(a.js, 46, 28), Decl(a.js, 49, 14))
+>inStaticGetter : Symbol(C.inStaticGetter, Decl(a.js, 72, 28), Decl(a.js, 75, 14))
 
 var stringOrNumberOrUndefined = C.inStaticSetter;
->stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 16, 3), Decl(b.ts, 17, 3), Decl(b.ts, 18, 3))
->C.inStaticSetter : Symbol(C.inStaticSetter, Decl(a.js, 54, 28), Decl(a.js, 57, 14))
+>stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 10, 3), Decl(b.ts, 11, 3), Decl(b.ts, 18, 3), Decl(b.ts, 19, 3), Decl(b.ts, 20, 3), Decl(b.ts, 21, 3), Decl(b.ts, 22, 3))
+>C.inStaticSetter : Symbol(C.inStaticSetter, Decl(a.js, 80, 28), Decl(a.js, 83, 14))
 >C : Symbol(C, Decl(a.js, 0, 0))
->inStaticSetter : Symbol(C.inStaticSetter, Decl(a.js, 54, 28), Decl(a.js, 57, 14))
+>inStaticSetter : Symbol(C.inStaticSetter, Decl(a.js, 80, 28), Decl(a.js, 83, 14))
+
+var stringOrNumberOrUndefined = C.inStaticPropertyDeclaration;
+>stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 10, 3), Decl(b.ts, 11, 3), Decl(b.ts, 18, 3), Decl(b.ts, 19, 3), Decl(b.ts, 20, 3), Decl(b.ts, 21, 3), Decl(b.ts, 22, 3))
+>C.inStaticPropertyDeclaration : Symbol(C.inStaticPropertyDeclaration, Decl(a.js, 88, 28), Decl(a.js, 91, 14))
+>C : Symbol(C, Decl(a.js, 0, 0))
+>inStaticPropertyDeclaration : Symbol(C.inStaticPropertyDeclaration, Decl(a.js, 88, 28), Decl(a.js, 91, 14))
+
+var stringOrNumberOrUndefined = C.inStaticNestedArrowFunction;
+>stringOrNumberOrUndefined : Symbol(stringOrNumberOrUndefined, Decl(b.ts, 5, 3), Decl(b.ts, 7, 3), Decl(b.ts, 8, 3), Decl(b.ts, 9, 3), Decl(b.ts, 10, 3), Decl(b.ts, 11, 3), Decl(b.ts, 18, 3), Decl(b.ts, 19, 3), Decl(b.ts, 20, 3), Decl(b.ts, 21, 3), Decl(b.ts, 22, 3))
+>C.inStaticNestedArrowFunction : Symbol(C.inStaticNestedArrowFunction, Decl(a.js, 63, 32), Decl(a.js, 66, 18))
+>C : Symbol(C, Decl(a.js, 0, 0))
+>inStaticNestedArrowFunction : Symbol(C.inStaticNestedArrowFunction, Decl(a.js, 63, 32), Decl(a.js, 66, 18))
 

--- a/tests/baselines/reference/inferringClassMembersFromAssignments.types
+++ b/tests/baselines/reference/inferringClassMembersFromAssignments.types
@@ -62,6 +62,33 @@ class C {
 >this : this
 >inMultiple : string | number | boolean
 >"string" : "string"
+
+        var action = () => {
+>action : () => void
+>() => {            if (Math.random()) {                this.inNestedArrowFunction = 0;            }            else {                this.inNestedArrowFunction = "string"            }        } : () => void
+
+            if (Math.random()) {
+>Math.random() : number
+>Math.random : () => number
+>Math : Math
+>random : () => number
+
+                this.inNestedArrowFunction = 0;
+>this.inNestedArrowFunction = 0 : 0
+>this.inNestedArrowFunction : string | number | undefined
+>this : this
+>inNestedArrowFunction : string | number | undefined
+>0 : 0
+            }
+            else {
+                this.inNestedArrowFunction = "string"
+>this.inNestedArrowFunction = "string" : "string"
+>this.inNestedArrowFunction : string | number | undefined
+>this : this
+>inNestedArrowFunction : string | number | undefined
+>"string" : "string"
+            }
+        };
     }
     get() {
 >get : () => void
@@ -119,6 +146,32 @@ class C {
 >"string" : "string"
         }
     }
+    prop = () => {
+>prop : () => void
+>() => {        if (Math.random()) {            this.inPropertyDeclaration = 0;        }        else {            this.inPropertyDeclaration = "string"        }    } : () => void
+
+        if (Math.random()) {
+>Math.random() : number
+>Math.random : () => number
+>Math : Math
+>random : () => number
+
+            this.inPropertyDeclaration = 0;
+>this.inPropertyDeclaration = 0 : 0
+>this.inPropertyDeclaration : string | number | undefined
+>this : this
+>inPropertyDeclaration : string | number | undefined
+>0 : 0
+        }
+        else {
+            this.inPropertyDeclaration = "string"
+>this.inPropertyDeclaration = "string" : "string"
+>this.inPropertyDeclaration : string | number | undefined
+>this : this
+>inPropertyDeclaration : string | number | undefined
+>"string" : "string"
+        }
+    }
     static method() {
 >method : () => void
 
@@ -143,6 +196,33 @@ class C {
 >inStaticMethod : string | number | undefined
 >"string" : "string"
         }
+
+        var action = () => {
+>action : () => void
+>() => {            if (Math.random()) {                this.inStaticNestedArrowFunction = 0;            }            else {                this.inStaticNestedArrowFunction = "string"            }        } : () => void
+
+            if (Math.random()) {
+>Math.random() : number
+>Math.random : () => number
+>Math : Math
+>random : () => number
+
+                this.inStaticNestedArrowFunction = 0;
+>this.inStaticNestedArrowFunction = 0 : 0
+>this.inStaticNestedArrowFunction : string | number | undefined
+>this : typeof C
+>inStaticNestedArrowFunction : string | number | undefined
+>0 : 0
+            }
+            else {
+                this.inStaticNestedArrowFunction = "string"
+>this.inStaticNestedArrowFunction = "string" : "string"
+>this.inStaticNestedArrowFunction : string | number | undefined
+>this : typeof C
+>inStaticNestedArrowFunction : string | number | undefined
+>"string" : "string"
+            }
+        };
     }
     static get() {
 >get : () => void
@@ -194,6 +274,32 @@ class C {
 >"string" : "string"
         }
     }
+    static prop = () => {
+>prop : () => void
+>() => {        if (Math.random()) {            this.inStaticPropertyDeclaration = 0;        }        else {            this.inStaticPropertyDeclaration = "string"        }    } : () => void
+
+        if (Math.random()) {
+>Math.random() : number
+>Math.random : () => number
+>Math : Math
+>random : () => number
+
+            this.inStaticPropertyDeclaration = 0;
+>this.inStaticPropertyDeclaration = 0 : 0
+>this.inStaticPropertyDeclaration : string | number | undefined
+>this : typeof C
+>inStaticPropertyDeclaration : string | number | undefined
+>0 : 0
+        }
+        else {
+            this.inStaticPropertyDeclaration = "string"
+>this.inStaticPropertyDeclaration = "string" : "string"
+>this.inStaticPropertyDeclaration : string | number | undefined
+>this : typeof C
+>inStaticPropertyDeclaration : string | number | undefined
+>"string" : "string"
+        }
+    }
 }
 
 === tests/cases/conformance/salsa/b.ts ===
@@ -232,6 +338,18 @@ var stringOrNumberOrUndefined = c.inSetter;
 >c : C
 >inSetter : string | number | undefined
 
+var stringOrNumberOrUndefined = c.inPropertyDeclaration;
+>stringOrNumberOrUndefined : string | number | undefined
+>c.inPropertyDeclaration : string | number | undefined
+>c : C
+>inPropertyDeclaration : string | number | undefined
+
+var stringOrNumberOrUndefined = c.inNestedArrowFunction
+>stringOrNumberOrUndefined : string | number | undefined
+>c.inNestedArrowFunction : string | number | undefined
+>c : C
+>inNestedArrowFunction : string | number | undefined
+
 var stringOrNumberOrBoolean: string | number | boolean;
 >stringOrNumberOrBoolean : string | number | boolean
 
@@ -259,4 +377,16 @@ var stringOrNumberOrUndefined = C.inStaticSetter;
 >C.inStaticSetter : string | number | undefined
 >C : typeof C
 >inStaticSetter : string | number | undefined
+
+var stringOrNumberOrUndefined = C.inStaticPropertyDeclaration;
+>stringOrNumberOrUndefined : string | number | undefined
+>C.inStaticPropertyDeclaration : string | number | undefined
+>C : typeof C
+>inStaticPropertyDeclaration : string | number | undefined
+
+var stringOrNumberOrUndefined = C.inStaticNestedArrowFunction;
+>stringOrNumberOrUndefined : string | number | undefined
+>C.inStaticNestedArrowFunction : string | number | undefined
+>C : typeof C
+>inStaticNestedArrowFunction : string | number | undefined
 

--- a/tests/cases/conformance/salsa/inferringClassMembersFromAssignments.ts
+++ b/tests/cases/conformance/salsa/inferringClassMembersFromAssignments.ts
@@ -21,6 +21,15 @@ class C {
             this.inMethod = "string"
         }
         this.inMultiple = "string";
+
+        var action = () => {
+            if (Math.random()) {
+                this.inNestedArrowFunction = 0;
+            }
+            else {
+                this.inNestedArrowFunction = "string"
+            }
+        };
     }
     get() {
         if (Math.random()) {
@@ -39,6 +48,14 @@ class C {
             this.inSetter = "string"
         }
     }
+    prop = () => {
+        if (Math.random()) {
+            this.inPropertyDeclaration = 0;
+        }
+        else {
+            this.inPropertyDeclaration = "string"
+        }
+    }
     static method() {
         if (Math.random()) {
             this.inStaticMethod = 0;
@@ -46,6 +63,15 @@ class C {
         else {
             this.inStaticMethod = "string"
         }
+
+        var action = () => {
+            if (Math.random()) {
+                this.inStaticNestedArrowFunction = 0;
+            }
+            else {
+                this.inStaticNestedArrowFunction = "string"
+            }
+        };
     }
     static get() {
         if (Math.random()) {
@@ -63,6 +89,14 @@ class C {
             this.inStaticSetter = "string"
         }
     }
+    static prop = () => {
+        if (Math.random()) {
+            this.inStaticPropertyDeclaration = 0;
+        }
+        else {
+            this.inStaticPropertyDeclaration = "string"
+        }
+    }
 }
 
 // @filename: b.ts
@@ -76,6 +110,8 @@ var stringOrNumberOrUndefined: string | number | undefined;
 var stringOrNumberOrUndefined = c.inMethod;
 var stringOrNumberOrUndefined = c.inGetter;
 var stringOrNumberOrUndefined = c.inSetter;
+var stringOrNumberOrUndefined = c.inPropertyDeclaration;
+var stringOrNumberOrUndefined = c.inNestedArrowFunction
 
 var stringOrNumberOrBoolean: string | number | boolean;
 
@@ -85,3 +121,5 @@ var stringOrNumberOrBoolean = c.inMultiple;
 var stringOrNumberOrUndefined = C.inStaticMethod;
 var stringOrNumberOrUndefined = C.inStaticGetter;
 var stringOrNumberOrUndefined = C.inStaticSetter;
+var stringOrNumberOrUndefined = C.inStaticPropertyDeclaration;
+var stringOrNumberOrUndefined = C.inStaticNestedArrowFunction;


### PR DESCRIPTION
We were only inferring from assignments directly within the method/constructor bodies, but not within nested arrow functions.
Also infer from property declaration initializes if they exist.