### PR TITLE
Global size limit (2.1)

### DIFF
--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -983,6 +983,41 @@ namespace ts.projectSystem {
             checkProjectRootFiles(projectService.configuredProjects[0], [commonFile1.path, commonFile2.path]);
         });
 
+        it("should disable features when the files are too large", () => {
+            const file1 = {
+                path: "/a/b/f1.js",
+                content: "let x =1;",
+                fileSize: 10 * 1024 * 1024
+            };
+            const file2 = {
+                path: "/a/b/f2.js",
+                content: "let y =1;",
+                fileSize: 6 * 1024 * 1024
+            };
+            const file3 = {
+                path: "/a/b/f3.js",
+                content: "let y =1;",
+                fileSize: 6 * 1024 * 1024
+            };
+
+            const proj1name = "proj1", proj2name = "proj2", proj3name = "proj3";
+
+            const host = createServerHost([file1, file2, file3]);
+            const projectService = createProjectService(host);
+
+            projectService.openExternalProject({ rootFiles: toExternalFiles([file1.path]), options: {}, projectFileName: proj1name });
+            const proj1 = projectService.findProject(proj1name);
+            assert.isTrue(proj1.languageServiceEnabled);
+
+            projectService.openExternalProject({ rootFiles: toExternalFiles([file2.path]), options: {}, projectFileName: proj2name });
+            const proj2 = projectService.findProject(proj2name);
+            assert.isTrue(proj2.languageServiceEnabled);
+
+            projectService.openExternalProject({ rootFiles: toExternalFiles([file3.path]), options: {}, projectFileName: proj3name });
+            const proj3 = projectService.findProject(proj3name);
+            assert.isFalse(proj3.languageServiceEnabled);
+        });
+
         it("should use only one inferred project if 'useOneInferredProject' is set", () => {
             const file1 = {
                 path: "/a/b/main.ts",

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -563,11 +563,11 @@ namespace ts.server {
             switch (project.projectKind) {
                 case ProjectKind.External:
                     removeItemFromSet(this.externalProjects, <ExternalProject>project);
-                    this.projectToSizeMap.delete((project as ExternalProject).externalProjectName);
+                    delete this.projectToSizeMap[(project as ExternalProject).externalProjectName];
                     break;
                 case ProjectKind.Configured:
                     removeItemFromSet(this.configuredProjects, <ConfiguredProject>project);
-                    this.projectToSizeMap.delete((project as ConfiguredProject).canonicalConfigFilePath);
+                    delete this.projectToSizeMap[(project as ConfiguredProject).canonicalConfigFilePath];
                     break;
                 case ProjectKind.Inferred:
                     removeItemFromSet(this.inferredProjects, <InferredProject>project);
@@ -860,10 +860,10 @@ namespace ts.server {
             }
 
             let availableSpace = maxProgramSizeForNonTsFiles;
-            this.projectToSizeMap.set(name, 0);
-            this.projectToSizeMap.forEach(size => {
-                availableSpace -= size;
-            });
+            this.projectToSizeMap[name] = 0;
+            for (const key in this.projectToSizeMap) {
+                availableSpace -= (this.projectToSizeMap[key] || 0);
+            }
 
             let totalNonTsFileSize = 0;
             for (const f of fileNames) {
@@ -873,12 +873,12 @@ namespace ts.server {
                 }
                 totalNonTsFileSize += this.host.getFileSize(fileName);
                 if (totalNonTsFileSize > availableSpace) {
-                    this.projectToSizeMap.set(name, totalNonTsFileSize);
+                    this.projectToSizeMap[name] = totalNonTsFileSize;
                     return true;
                 }
             }
 
-            this.projectToSizeMap.set(name, totalNonTsFileSize);
+            this.projectToSizeMap[name] = totalNonTsFileSize;
             return false;
         }
 

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -878,8 +878,12 @@ namespace ts.server {
                 }
             }
 
+            if (totalNonTsFileSize > availableSpace) {
+                return true;
+            }
+
             this.projectToSizeMap[name] = totalNonTsFileSize;
-            return totalNonTsFileSize > availableSpace;
+            return false;
         }
 
         private createAndAddExternalProject(projectFileName: string, files: protocol.ExternalFile[], options: protocol.ExternalProjectCompilerOptions, typeAcquisition: TypeAcquisition) {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -879,7 +879,7 @@ namespace ts.server {
             }
 
             this.projectToSizeMap[name] = totalNonTsFileSize;
-            return totalNonTsFileSize < availableSpace;
+            return totalNonTsFileSize > availableSpace;
         }
 
         private createAndAddExternalProject(projectFileName: string, files: protocol.ExternalFile[], options: protocol.ExternalProjectCompilerOptions, typeAcquisition: TypeAcquisition) {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -873,7 +873,7 @@ namespace ts.server {
                 }
                 totalNonTsFileSize += this.host.getFileSize(fileName);
                 if (totalNonTsFileSize > maxProgramSizeForNonTsFiles) {
-                    this.projectToSizeMap[name] = totalNonTsFileSize;
+                    // Keep the size as zero since it's disabled
                     return true;
                 }
             }

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -872,14 +872,14 @@ namespace ts.server {
                     continue;
                 }
                 totalNonTsFileSize += this.host.getFileSize(fileName);
-                if (totalNonTsFileSize > availableSpace) {
+                if (totalNonTsFileSize > maxProgramSizeForNonTsFiles) {
                     this.projectToSizeMap[name] = totalNonTsFileSize;
                     return true;
                 }
             }
 
             this.projectToSizeMap[name] = totalNonTsFileSize;
-            return false;
+            return totalNonTsFileSize < availableSpace;
         }
 
         private createAndAddExternalProject(projectFileName: string, files: protocol.ExternalFile[], options: protocol.ExternalProjectCompilerOptions, typeAcquisition: TypeAcquisition) {

--- a/src/server/editorServices.ts
+++ b/src/server/editorServices.ts
@@ -254,6 +254,7 @@ namespace ts.server {
 
         private compilerOptionsForInferredProjects: CompilerOptions;
         private compileOnSaveForInferredProjects: boolean;
+        private readonly projectToSizeMap: Map<number> = createMap<number>();
         private readonly directoryWatchers: DirectoryWatchers;
         private readonly throttledOperations: ThrottledOperations;
 
@@ -562,9 +563,11 @@ namespace ts.server {
             switch (project.projectKind) {
                 case ProjectKind.External:
                     removeItemFromSet(this.externalProjects, <ExternalProject>project);
+                    this.projectToSizeMap.delete((project as ExternalProject).externalProjectName);
                     break;
                 case ProjectKind.Configured:
                     removeItemFromSet(this.configuredProjects, <ConfiguredProject>project);
+                    this.projectToSizeMap.delete((project as ConfiguredProject).canonicalConfigFilePath);
                     break;
                 case ProjectKind.Inferred:
                     removeItemFromSet(this.inferredProjects, <InferredProject>project);
@@ -851,10 +854,17 @@ namespace ts.server {
             return { success: true, projectOptions, configFileErrors: errors };
         }
 
-        private exceededTotalSizeLimitForNonTsFiles<T>(options: CompilerOptions, fileNames: T[], propertyReader: FilePropertyReader<T>) {
+        private exceededTotalSizeLimitForNonTsFiles<T>(name: string, options: CompilerOptions, fileNames: T[], propertyReader: FilePropertyReader<T>) {
             if (options && options.disableSizeLimit || !this.host.getFileSize) {
                 return false;
             }
+
+            let availableSpace = maxProgramSizeForNonTsFiles;
+            this.projectToSizeMap.set(name, 0);
+            this.projectToSizeMap.forEach(size => {
+                availableSpace -= size;
+            });
+
             let totalNonTsFileSize = 0;
             for (const f of fileNames) {
                 const fileName = propertyReader.getFileName(f);
@@ -862,10 +872,13 @@ namespace ts.server {
                     continue;
                 }
                 totalNonTsFileSize += this.host.getFileSize(fileName);
-                if (totalNonTsFileSize > maxProgramSizeForNonTsFiles) {
+                if (totalNonTsFileSize > availableSpace) {
+                    this.projectToSizeMap.set(name, totalNonTsFileSize);
                     return true;
                 }
             }
+
+            this.projectToSizeMap.set(name, totalNonTsFileSize);
             return false;
         }
 
@@ -876,7 +889,7 @@ namespace ts.server {
                 this,
                 this.documentRegistry,
                 compilerOptions,
-                /*languageServiceEnabled*/ !this.exceededTotalSizeLimitForNonTsFiles(compilerOptions, files, externalFilePropertyReader),
+                /*languageServiceEnabled*/ !this.exceededTotalSizeLimitForNonTsFiles(projectFileName, compilerOptions, files, externalFilePropertyReader),
                 options.compileOnSave === undefined ? true : options.compileOnSave);
 
             this.addFilesToProjectAndUpdateGraph(project, files, externalFilePropertyReader, /*clientFileName*/ undefined, typeAcquisition, /*configFileErrors*/ undefined);
@@ -896,7 +909,7 @@ namespace ts.server {
         }
 
         private createAndAddConfiguredProject(configFileName: NormalizedPath, projectOptions: ProjectOptions, configFileErrors: Diagnostic[], clientFileName?: string) {
-            const sizeLimitExceeded = this.exceededTotalSizeLimitForNonTsFiles(projectOptions.compilerOptions, projectOptions.files, fileNamePropertyReader);
+            const sizeLimitExceeded = this.exceededTotalSizeLimitForNonTsFiles(configFileName, projectOptions.compilerOptions, projectOptions.files, fileNamePropertyReader);
             const project = new ConfiguredProject(
                 configFileName,
                 this,
@@ -1049,7 +1062,7 @@ namespace ts.server {
                 return configFileErrors;
             }
 
-            if (this.exceededTotalSizeLimitForNonTsFiles(projectOptions.compilerOptions, projectOptions.files, fileNamePropertyReader)) {
+            if (this.exceededTotalSizeLimitForNonTsFiles(project.canonicalConfigFilePath, projectOptions.compilerOptions, projectOptions.files, fileNamePropertyReader)) {
                 project.setCompilerOptions(projectOptions.compilerOptions);
                 if (!project.languageServiceEnabled) {
                     // language service is already disabled
@@ -1411,7 +1424,7 @@ namespace ts.server {
             if (externalProject) {
                 if (!tsConfigFiles) {
                     const compilerOptions = convertCompilerOptions(proj.options);
-                    if (this.exceededTotalSizeLimitForNonTsFiles(compilerOptions, proj.rootFiles, externalFilePropertyReader)) {
+                    if (this.exceededTotalSizeLimitForNonTsFiles(proj.projectFileName, compilerOptions, proj.rootFiles, externalFilePropertyReader)) {
                         externalProject.disableLanguageService();
                     }
                     else {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -886,7 +886,7 @@ namespace ts.server {
 
     export class ExternalProject extends Project {
         private typeAcquisition: TypeAcquisition;
-        constructor(externalProjectName: string,
+        constructor(public externalProjectName: string,
             projectService: ProjectService,
             documentRegistry: ts.DocumentRegistry,
             compilerOptions: CompilerOptions,


### PR DESCRIPTION
Applies the 20 MB .js size limit globally, rather than per-project, to stop TS Server from OOMing.

This is based on the 2.1 branch so that we can consider taking it for Update 1