### PR TITLE
Do not report semantic diagnostics for infered and external projects with only .js files

### DIFF
--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -26,14 +26,7 @@ namespace ts.server {
     }
 
     function shouldSkipSematicCheck(project: Project) {
-        if (project.getCompilerOptions().skipLibCheck !== undefined) {
-            return false;
-        }
-
-        if ((project.projectKind === ProjectKind.Inferred || project.projectKind === ProjectKind.External) && project.isJsOnlyProject()) {
-            return true;
-        }
-        return false;
+        return (project.projectKind === ProjectKind.Inferred || project.projectKind === ProjectKind.External) && project.isJsOnlyProject();
     }
 
     interface FileStart {


### PR DESCRIPTION
Fixes  https://github.com/Microsoft/TypeScript/issues/14565

//CC: @vladima, @zhengbli and @RyanCavanaugh 