### PR TITLE
[Master] Only emit "use strict" when users ask for or the file is external module

### DIFF
--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -89,7 +89,8 @@ namespace ts {
             startLexicalEnvironment();
 
             const statements: Statement[] = [];
-            const statementOffset = addPrologueDirectives(statements, node.statements, /*ensureUseStrict*/ !compilerOptions.noImplicitUseStrict, sourceElementVisitor);
+            const ensureUseStrict = compilerOptions.alwaysStrict || (!compilerOptions.noImplicitUseStrict && isExternalModule(currentSourceFile));
+            const statementOffset = addPrologueDirectives(statements, node.statements, ensureUseStrict, sourceElementVisitor);
 
             if (shouldEmitUnderscoreUnderscoreESModule()) {
                 append(statements, createUnderscoreUnderscoreESModule());

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -225,7 +225,8 @@ namespace ts {
             startLexicalEnvironment();
 
             // Add any prologue directives.
-            const statementOffset = addPrologueDirectives(statements, node.statements, /*ensureUseStrict*/ !compilerOptions.noImplicitUseStrict, sourceElementVisitor);
+            const ensureUseStrict = compilerOptions.alwaysStrict || (!compilerOptions.noImplicitUseStrict && isExternalModule(currentSourceFile));
+            const statementOffset = addPrologueDirectives(statements, node.statements, ensureUseStrict, sourceElementVisitor);
 
             // var __moduleName = context_1 && context_1.id;
             statements.push(

--- a/tests/baselines/reference/importHelpersInIsolatedModules.js
+++ b/tests/baselines/reference/importHelpersInIsolatedModules.js
@@ -68,7 +68,6 @@ C = tslib_1.__decorate([
     dec
 ], C);
 //// [script.js]
-"use strict";
 var tslib_1 = require("tslib");
 var A = (function () {
     function A() {

--- a/tests/baselines/reference/isolatedModulesPlainFile-CommonJS.js
+++ b/tests/baselines/reference/isolatedModulesPlainFile-CommonJS.js
@@ -5,5 +5,4 @@ run(1);
 
 
 //// [isolatedModulesPlainFile-CommonJS.js]
-"use strict";
 run(1);

--- a/tests/baselines/reference/isolatedModulesPlainFile-System.js
+++ b/tests/baselines/reference/isolatedModulesPlainFile-System.js
@@ -6,7 +6,6 @@ run(1);
 
 //// [isolatedModulesPlainFile-System.js]
 System.register([], function (exports_1, context_1) {
-    "use strict";
     var __moduleName = context_1 && context_1.id;
     return {
         setters: [],

--- a/tests/baselines/reference/transpile/Does not generate semantic diagnostics.js
+++ b/tests/baselines/reference/transpile/Does not generate semantic diagnostics.js
@@ -1,3 +1,2 @@
-"use strict";
 var x = 0;
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates expected syntactic diagnostics.js
+++ b/tests/baselines/reference/transpile/Generates expected syntactic diagnostics.js
@@ -1,4 +1,3 @@
-"use strict";
 a;
 b;
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates no diagnostics for missing file references.js
+++ b/tests/baselines/reference/transpile/Generates no diagnostics for missing file references.js
@@ -1,4 +1,3 @@
-"use strict";
 /// <reference path="file2.ts" />
 var x = 0;
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs.js
+++ b/tests/baselines/reference/transpile/Generates no diagnostics with valid inputs.js
@@ -1,3 +1,2 @@
-"use strict";
 var x = 0;
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Report an error when compiler-options module-kind is out-of-range.js
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options module-kind is out-of-range.js
@@ -1,2 +1,1 @@
-"use strict";
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Report an error when compiler-options target-script is out-of-range.js
+++ b/tests/baselines/reference/transpile/Report an error when compiler-options target-script is out-of-range.js
@@ -1,2 +1,1 @@
-"use strict";
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Sets module name.js
+++ b/tests/baselines/reference/transpile/Sets module name.js
@@ -1,5 +1,4 @@
 System.register("NamedModule", [], function (exports_1, context_1) {
-    "use strict";
     var __moduleName = context_1 && context_1.id;
     var x;
     return {

--- a/tests/baselines/reference/transpile/Support options with lib values.js
+++ b/tests/baselines/reference/transpile/Support options with lib values.js
@@ -1,3 +1,2 @@
-"use strict";
 var a = 10;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Support options with types values.js
+++ b/tests/baselines/reference/transpile/Support options with types values.js
@@ -1,3 +1,2 @@
-"use strict";
 var a = 10;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports backslashes in file name.js
+++ b/tests/baselines/reference/transpile/Supports backslashes in file name.js
@@ -1,3 +1,2 @@
-"use strict";
 var x;
 //# sourceMappingURL=b.js.map

--- a/tests/baselines/reference/transpile/Supports setting allowJs.js
+++ b/tests/baselines/reference/transpile/Supports setting allowJs.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting allowSyntheticDefaultImports.js
+++ b/tests/baselines/reference/transpile/Supports setting allowSyntheticDefaultImports.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting allowUnreachableCode.js
+++ b/tests/baselines/reference/transpile/Supports setting allowUnreachableCode.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting allowUnusedLabels.js
+++ b/tests/baselines/reference/transpile/Supports setting allowUnusedLabels.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting baseUrl.js
+++ b/tests/baselines/reference/transpile/Supports setting baseUrl.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting charset.js
+++ b/tests/baselines/reference/transpile/Supports setting charset.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting declaration.js
+++ b/tests/baselines/reference/transpile/Supports setting declaration.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting declarationDir.js
+++ b/tests/baselines/reference/transpile/Supports setting declarationDir.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting emitBOM.js
+++ b/tests/baselines/reference/transpile/Supports setting emitBOM.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting emitDecoratorMetadata.js
+++ b/tests/baselines/reference/transpile/Supports setting emitDecoratorMetadata.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting experimentalDecorators.js
+++ b/tests/baselines/reference/transpile/Supports setting experimentalDecorators.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting forceConsistentCasingInFileNames.js
+++ b/tests/baselines/reference/transpile/Supports setting forceConsistentCasingInFileNames.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting isolatedModules.js
+++ b/tests/baselines/reference/transpile/Supports setting isolatedModules.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting jsx.js
+++ b/tests/baselines/reference/transpile/Supports setting jsx.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting jsxFactory.js
+++ b/tests/baselines/reference/transpile/Supports setting jsxFactory.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting lib.js
+++ b/tests/baselines/reference/transpile/Supports setting lib.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting locale.js
+++ b/tests/baselines/reference/transpile/Supports setting locale.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting module.js
+++ b/tests/baselines/reference/transpile/Supports setting module.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting moduleResolution.js
+++ b/tests/baselines/reference/transpile/Supports setting moduleResolution.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting newLine.js
+++ b/tests/baselines/reference/transpile/Supports setting newLine.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noEmit.js
+++ b/tests/baselines/reference/transpile/Supports setting noEmit.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noEmitHelpers.js
+++ b/tests/baselines/reference/transpile/Supports setting noEmitHelpers.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noEmitOnError.js
+++ b/tests/baselines/reference/transpile/Supports setting noEmitOnError.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noErrorTruncation.js
+++ b/tests/baselines/reference/transpile/Supports setting noErrorTruncation.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noFallthroughCasesInSwitch.js
+++ b/tests/baselines/reference/transpile/Supports setting noFallthroughCasesInSwitch.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitAny.js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitAny.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitReturns.js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitReturns.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noImplicitThis.js
+++ b/tests/baselines/reference/transpile/Supports setting noImplicitThis.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noLib.js
+++ b/tests/baselines/reference/transpile/Supports setting noLib.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting noResolve.js
+++ b/tests/baselines/reference/transpile/Supports setting noResolve.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting out.js
+++ b/tests/baselines/reference/transpile/Supports setting out.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting outDir.js
+++ b/tests/baselines/reference/transpile/Supports setting outDir.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting outFile.js
+++ b/tests/baselines/reference/transpile/Supports setting outFile.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting paths.js
+++ b/tests/baselines/reference/transpile/Supports setting paths.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting preserveConstEnums.js
+++ b/tests/baselines/reference/transpile/Supports setting preserveConstEnums.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting reactNamespace.js
+++ b/tests/baselines/reference/transpile/Supports setting reactNamespace.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting removeComments.js
+++ b/tests/baselines/reference/transpile/Supports setting removeComments.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting rootDir.js
+++ b/tests/baselines/reference/transpile/Supports setting rootDir.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting rootDirs.js
+++ b/tests/baselines/reference/transpile/Supports setting rootDirs.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting skipDefaultLibCheck.js
+++ b/tests/baselines/reference/transpile/Supports setting skipDefaultLibCheck.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting skipLibCheck.js
+++ b/tests/baselines/reference/transpile/Supports setting skipLibCheck.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting strictNullChecks.js
+++ b/tests/baselines/reference/transpile/Supports setting strictNullChecks.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting stripInternal.js
+++ b/tests/baselines/reference/transpile/Supports setting stripInternal.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting suppressExcessPropertyErrors.js
+++ b/tests/baselines/reference/transpile/Supports setting suppressExcessPropertyErrors.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting suppressImplicitAnyIndexErrors.js
+++ b/tests/baselines/reference/transpile/Supports setting suppressImplicitAnyIndexErrors.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting typeRoots.js
+++ b/tests/baselines/reference/transpile/Supports setting typeRoots.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports setting types.js
+++ b/tests/baselines/reference/transpile/Supports setting types.js
@@ -1,3 +1,2 @@
-"use strict";
 x;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/Supports urls in file name.js
+++ b/tests/baselines/reference/transpile/Supports urls in file name.js
@@ -1,3 +1,2 @@
-"use strict";
 var x;
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/Uses correct newLine character.js
+++ b/tests/baselines/reference/transpile/Uses correct newLine character.js
@@ -1,3 +1,2 @@
-"use strict";
 var x = 0;
 //# sourceMappingURL=file.js.map

--- a/tests/baselines/reference/transpile/transpile .js files.js
+++ b/tests/baselines/reference/transpile/transpile .js files.js
@@ -1,3 +1,2 @@
-"use strict";
 var a = 10;
 //# sourceMappingURL=input.js.map

--- a/tests/baselines/reference/transpile/transpile file as tsx if jsx is specified.js
+++ b/tests/baselines/reference/transpile/transpile file as tsx if jsx is specified.js
@@ -1,3 +1,2 @@
-"use strict";
 var x = React.createElement("div", null);
 //# sourceMappingURL=file.js.map


### PR DESCRIPTION
We will emit "use strict" even on the file that we won't parse in strict mode. This PR restrict that