### PR TITLE
Expose transformers option for transpileModule

### DIFF
--- a/src/harness/unittests/transform.ts
+++ b/src/harness/unittests/transform.ts
@@ -3,48 +3,74 @@
 
 namespace ts {
     describe("TransformAPI", () => {
-        function transformsCorrectly(name: string, source: string, transformers: TransformerFactory<SourceFile>[]) {
-            it(name, () => {
-                Harness.Baseline.runBaseline(`transformApi/transformsCorrectly.${name}.js`, () => {
-                    const transformed = transform(createSourceFile("source.ts", source, ScriptTarget.ES2015), transformers);
-                    const printer = createPrinter({ newLine: NewLineKind.CarriageReturnLineFeed }, {
-                        onEmitNode: transformed.emitNodeWithNotification,
-                        substituteNode: transformed.substituteNode
-                    });
-                    const result = printer.printBundle(createBundle(transformed.transformed));
-                    transformed.dispose();
-                    return result;
-                });
+        function replaceUndefinedWithVoid0(context: ts.TransformationContext) {
+            const previousOnSubstituteNode = context.onSubstituteNode;
+            context.enableSubstitution(SyntaxKind.Identifier);
+            context.onSubstituteNode = (hint, node) => {
+                node = previousOnSubstituteNode(hint, node);
+                if (hint === EmitHint.Expression && node.kind === SyntaxKind.Identifier && (<Identifier>node).text === "undefined") {
+                    node = createPartiallyEmittedExpression(
+                        addSyntheticTrailingComment(
+                            setTextRange(
+                                createVoidZero(),
+                                node),
+                            SyntaxKind.MultiLineCommentTrivia, "undefined"));
+                }
+                return node;
+            };
+            return (file: ts.SourceFile) => file;
+        }
+
+        function replaceIdentifiersNamedOldNameWithNewName(context: ts.TransformationContext) {
+            const previousOnSubstituteNode = context.onSubstituteNode;
+            context.enableSubstitution(SyntaxKind.Identifier);
+            context.onSubstituteNode = (hint, node) => {
+                node = previousOnSubstituteNode(hint, node);
+                if (node.kind === SyntaxKind.Identifier && (<Identifier>node).text === "oldName") {
+                    node = setTextRange(createIdentifier("newName"), node);
+                }
+                return node;
+            };
+            return (file: ts.SourceFile) => file;
+        }
+
+        function transformSourceFile(sourceText: string, transformers: TransformerFactory<SourceFile>[]) {
+            const transformed = transform(createSourceFile("source.ts", sourceText, ScriptTarget.ES2015), transformers);
+            const printer = createPrinter({ newLine: NewLineKind.CarriageReturnLineFeed }, {
+                onEmitNode: transformed.emitNodeWithNotification,
+                substituteNode: transformed.substituteNode
+            });
+            const result = printer.printBundle(createBundle(transformed.transformed));
+            transformed.dispose();
+            return result;
+        }
+
+        function testBaseline(testName: string, test: () => string) {
+            it(testName, () => {
+                Harness.Baseline.runBaseline(`transformApi/transformsCorrectly.${testName}.js`, test);
             });
         }
 
-        transformsCorrectly("substitution", `
-            var a = undefined;
-        `, [
-            context => {
-                const previousOnSubstituteNode = context.onSubstituteNode;
-                context.enableSubstitution(SyntaxKind.Identifier);
-                context.onSubstituteNode = (hint, node) => {
-                    node = previousOnSubstituteNode(hint, node);
-                    if (hint === EmitHint.Expression && node.kind === SyntaxKind.Identifier && (<Identifier>node).text === "undefined") {
-                        node = createPartiallyEmittedExpression(
-                            addSyntheticTrailingComment(
-                                setTextRange(
-                                    createVoidZero(),
-                                    node),
-                                SyntaxKind.MultiLineCommentTrivia, "undefined"));
-                    }
-                    return node;
-                };
-                return file => file;
-            }
-        ]);
+        testBaseline("substitution", () => {
+            return transformSourceFile(`var a = undefined;`, [replaceUndefinedWithVoid0]);
+        });
 
-        // https://github.com/Microsoft/TypeScript/issues/15192
-        transformsCorrectly("types", `let a: () => void`, [
-            context => file => visitNode(file, function visitor(node: Node): VisitResult<Node> {
-                return visitEachChild(node, visitor, context);
-            })
-        ]);
+        testBaseline("types", () => {
+            return transformSourceFile(`let a: () => void`, [
+                 context => file => visitNode(file, function visitor(node: Node): VisitResult<Node> {
+                    return visitEachChild(node, visitor, context);
+                })
+            ]);
+        });
+
+        testBaseline("fromTranspileModule", () => {
+            return ts.transpileModule(`var oldName = undefined;`, {
+                transformers: {
+                    before: [replaceUndefinedWithVoid0],
+                    after: [replaceIdentifiersNamedOldNameWithNewName]
+                }
+            }).outputText;
+        });
     });
 }
+

--- a/src/services/transpile.ts
+++ b/src/services/transpile.ts
@@ -5,6 +5,7 @@ namespace ts {
         reportDiagnostics?: boolean;
         moduleName?: string;
         renamedDependencies?: MapLike<string>;
+        transformers?: CustomTransformers;
     }
 
     export interface TranspileOutput {
@@ -103,7 +104,7 @@ namespace ts {
             addRange(/*to*/ diagnostics, /*from*/ program.getOptionsDiagnostics());
         }
         // Emit
-        program.emit();
+        program.emit(/*targetSourceFile*/ undefined, /*writeFile*/ undefined, /*cancellationToken*/ undefined, /*emitOnlyDtsFiles*/ undefined, transpileOptions.transformers);
 
         Debug.assert(outputText !== undefined, "Output generation failed");
 

--- a/tests/baselines/reference/transformApi/transformsCorrectly.fromTranspileModule.js
+++ b/tests/baselines/reference/transformApi/transformsCorrectly.fromTranspileModule.js
@@ -1,0 +1,1 @@
+var newName = void 0 /*undefined*/;


### PR DESCRIPTION
Fixes #14569. Tooling and test libraries (ts-loader, awesome-typescript-loader, ts-jest, etc) often use transpileModule for a 'fast' mode. This allows them to support custom transformers without having to switch to Program#emit.