### PR TITLE
Allow specifying the location of typingSafeList.json

### DIFF
--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -219,6 +219,7 @@ namespace ts.server {
             host: ServerHost,
             eventPort: number,
             readonly globalTypingsCacheLocation: string,
+            readonly typingSafeListLocation: string,
             private newLine: string) {
             this.throttledOperations = new ThrottledOperations(host);
             if (eventPort) {
@@ -259,6 +260,9 @@ namespace ts.server {
             }
             if (this.logger.loggingEnabled() && this.logger.getLogFileName()) {
                 args.push(Arguments.LogFile, combinePaths(getDirectoryPath(normalizeSlashes(this.logger.getLogFileName())), `ti-${process.pid}.log`));
+            }
+            if (this.typingSafeListLocation) {
+                args.push(Arguments.TypingSafeListLocation, this.typingSafeListLocation);
             }
             const execArgv: string[] = [];
             {
@@ -378,11 +382,12 @@ namespace ts.server {
             useSingleInferredProject: boolean,
             disableAutomaticTypingAcquisition: boolean,
             globalTypingsCacheLocation: string,
+            typingSafeListLocation: string,
             telemetryEnabled: boolean,
             logger: server.Logger) {
                 const typingsInstaller = disableAutomaticTypingAcquisition
                     ? undefined
-                    : new NodeTypingsInstaller(telemetryEnabled, logger, host, installerEventPort, globalTypingsCacheLocation, host.newLine);
+                    : new NodeTypingsInstaller(telemetryEnabled, logger, host, installerEventPort, globalTypingsCacheLocation, typingSafeListLocation, host.newLine);
 
                 super(
                     host,
@@ -728,6 +733,8 @@ namespace ts.server {
     if (localeStr) {
         validateLocaleAndSetLanguage(localeStr, sys);
     }
+    
+    const typingSafeListLocation = findArgument("--typingSafeListLocation");
 
     const useSingleInferredProject = hasArgument("--useSingleInferredProject");
     const disableAutomaticTypingAcquisition = hasArgument("--disableAutomaticTypingAcquisition");
@@ -741,6 +748,7 @@ namespace ts.server {
         useSingleInferredProject,
         disableAutomaticTypingAcquisition,
         getGlobalTypingsCacheLocation(),
+        typingSafeListLocation,
         telemetryEnabled,
         logger);
     process.on("uncaughtException", function (err: Error) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -733,7 +733,7 @@ namespace ts.server {
     if (localeStr) {
         validateLocaleAndSetLanguage(localeStr, sys);
     }
-    
+
     const typingSafeListLocation = findArgument("--typingSafeListLocation");
 
     const useSingleInferredProject = hasArgument("--useSingleInferredProject");

--- a/src/server/shared.ts
+++ b/src/server/shared.ts
@@ -11,6 +11,7 @@ namespace ts.server {
         export const GlobalCacheLocation = "--globalTypingsCacheLocation";
         export const LogFile = "--logFile";
         export const EnableTelemetry = "--enableTelemetry";
+        export const TypingSafeListLocation = "--typingSafeListLocation";
     }
 
     export function hasArgument(argumentName: string) {

--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -76,11 +76,11 @@ namespace ts.server.typingsInstaller {
 
         private delayedInitializationError: InitializationFailedResponse;
 
-        constructor(globalTypingsCacheLocation: string, throttleLimit: number, log: Log) {
+        constructor(globalTypingsCacheLocation: string, typingSafeListLocation: string, throttleLimit: number, log: Log) {
             super(
                 sys,
                 globalTypingsCacheLocation,
-                toPath("typingSafeList.json", __dirname, createGetCanonicalFileName(sys.useCaseSensitiveFileNames)),
+                typingSafeListLocation ? toPath(typingSafeListLocation, "", createGetCanonicalFileName(sys.useCaseSensitiveFileNames)) : toPath("typingSafeList.json", __dirname, createGetCanonicalFileName(sys.useCaseSensitiveFileNames)),
                 throttleLimit,
                 log);
             if (this.log.isEnabled()) {
@@ -164,6 +164,7 @@ namespace ts.server.typingsInstaller {
 
     const logFilePath = findArgument(server.Arguments.LogFile);
     const globalTypingsCacheLocation = findArgument(server.Arguments.GlobalCacheLocation);
+    const typingSafeListLocation = findArgument(server.Arguments.TypingSafeListLocation);
 
     const log = new FileLog(logFilePath);
     if (log.isEnabled()) {
@@ -177,6 +178,6 @@ namespace ts.server.typingsInstaller {
         }
         process.exit(0);
     });
-    const installer = new NodeTypingsInstaller(globalTypingsCacheLocation, /*throttleLimit*/5, log);
+    const installer = new NodeTypingsInstaller(globalTypingsCacheLocation, typingSafeListLocation, /*throttleLimit*/5, log);
     installer.listen();
 }


### PR DESCRIPTION
This is needed for VS to be able to use tsserver.js from an arbitrary location that may not have typingsafelist.json next to it.