### PR TITLE
Default to 'any' for unsupplied generics in JavaScript

### DIFF
--- a/tests/baselines/reference/genericDefaultsJs.symbols
+++ b/tests/baselines/reference/genericDefaultsJs.symbols
@@ -1,0 +1,226 @@
+=== tests/cases/compiler/decls.d.ts ===
+declare function f0<T>(x?: T): T;
+>f0 : Symbol(f0, Decl(decls.d.ts, 0, 0))
+>T : Symbol(T, Decl(decls.d.ts, 0, 20))
+>x : Symbol(x, Decl(decls.d.ts, 0, 23))
+>T : Symbol(T, Decl(decls.d.ts, 0, 20))
+>T : Symbol(T, Decl(decls.d.ts, 0, 20))
+
+declare function f1<T, U = number>(x?: T): [T, U];
+>f1 : Symbol(f1, Decl(decls.d.ts, 0, 33))
+>T : Symbol(T, Decl(decls.d.ts, 1, 20))
+>U : Symbol(U, Decl(decls.d.ts, 1, 22))
+>x : Symbol(x, Decl(decls.d.ts, 1, 35))
+>T : Symbol(T, Decl(decls.d.ts, 1, 20))
+>T : Symbol(T, Decl(decls.d.ts, 1, 20))
+>U : Symbol(U, Decl(decls.d.ts, 1, 22))
+
+declare class C0<T> {
+>C0 : Symbol(C0, Decl(decls.d.ts, 1, 50))
+>T : Symbol(T, Decl(decls.d.ts, 2, 17))
+
+    y: T;
+>y : Symbol(C0.y, Decl(decls.d.ts, 2, 21))
+>T : Symbol(T, Decl(decls.d.ts, 2, 17))
+
+    constructor(x?: T);
+>x : Symbol(x, Decl(decls.d.ts, 4, 16))
+>T : Symbol(T, Decl(decls.d.ts, 2, 17))
+}
+declare class C1<T, U = number> {
+>C1 : Symbol(C1, Decl(decls.d.ts, 5, 1))
+>T : Symbol(T, Decl(decls.d.ts, 6, 17))
+>U : Symbol(U, Decl(decls.d.ts, 6, 19))
+
+    y: [T, U];
+>y : Symbol(C1.y, Decl(decls.d.ts, 6, 33))
+>T : Symbol(T, Decl(decls.d.ts, 6, 17))
+>U : Symbol(U, Decl(decls.d.ts, 6, 19))
+
+    constructor(x?: T);
+>x : Symbol(x, Decl(decls.d.ts, 8, 16))
+>T : Symbol(T, Decl(decls.d.ts, 6, 17))
+}
+=== tests/cases/compiler/main.js ===
+const f0_v0 = f0();
+>f0_v0 : Symbol(f0_v0, Decl(main.js, 0, 5))
+>f0 : Symbol(f0, Decl(decls.d.ts, 0, 0))
+
+const f0_v1 = f0(1);
+>f0_v1 : Symbol(f0_v1, Decl(main.js, 1, 5))
+>f0 : Symbol(f0, Decl(decls.d.ts, 0, 0))
+
+const f1_c0 = f1();
+>f1_c0 : Symbol(f1_c0, Decl(main.js, 3, 5))
+>f1 : Symbol(f1, Decl(decls.d.ts, 0, 33))
+
+const f1_c1 = f1(1);
+>f1_c1 : Symbol(f1_c1, Decl(main.js, 4, 5))
+>f1 : Symbol(f1, Decl(decls.d.ts, 0, 33))
+
+const C0_v0 = new C0();
+>C0_v0 : Symbol(C0_v0, Decl(main.js, 6, 5))
+>C0 : Symbol(C0, Decl(decls.d.ts, 1, 50))
+
+const C0_v0_y = C0_v0.y;
+>C0_v0_y : Symbol(C0_v0_y, Decl(main.js, 7, 5))
+>C0_v0.y : Symbol(C0.y, Decl(decls.d.ts, 2, 21))
+>C0_v0 : Symbol(C0_v0, Decl(main.js, 6, 5))
+>y : Symbol(C0.y, Decl(decls.d.ts, 2, 21))
+
+const C0_v1 = new C0(1);
+>C0_v1 : Symbol(C0_v1, Decl(main.js, 9, 5))
+>C0 : Symbol(C0, Decl(decls.d.ts, 1, 50))
+
+const C0_v1_y = C0_v1.y;
+>C0_v1_y : Symbol(C0_v1_y, Decl(main.js, 10, 5))
+>C0_v1.y : Symbol(C0.y, Decl(decls.d.ts, 2, 21))
+>C0_v1 : Symbol(C0_v1, Decl(main.js, 9, 5))
+>y : Symbol(C0.y, Decl(decls.d.ts, 2, 21))
+
+const C1_v0 = new C1();
+>C1_v0 : Symbol(C1_v0, Decl(main.js, 12, 5))
+>C1 : Symbol(C1, Decl(decls.d.ts, 5, 1))
+
+const C1_v0_y = C1_v0.y;
+>C1_v0_y : Symbol(C1_v0_y, Decl(main.js, 13, 5))
+>C1_v0.y : Symbol(C1.y, Decl(decls.d.ts, 6, 33))
+>C1_v0 : Symbol(C1_v0, Decl(main.js, 12, 5))
+>y : Symbol(C1.y, Decl(decls.d.ts, 6, 33))
+
+const C1_v1 = new C1(1);
+>C1_v1 : Symbol(C1_v1, Decl(main.js, 15, 5))
+>C1 : Symbol(C1, Decl(decls.d.ts, 5, 1))
+
+const C1_v1_y = C1_v1.y;
+>C1_v1_y : Symbol(C1_v1_y, Decl(main.js, 16, 5))
+>C1_v1.y : Symbol(C1.y, Decl(decls.d.ts, 6, 33))
+>C1_v1 : Symbol(C1_v1, Decl(main.js, 15, 5))
+>y : Symbol(C1.y, Decl(decls.d.ts, 6, 33))
+
+class C0_B0 extends C0 {}
+>C0_B0 : Symbol(C0_B0, Decl(main.js, 16, 24))
+>C0 : Symbol(C0, Decl(decls.d.ts, 1, 50))
+
+class C0_B1 extends C0 {
+>C0_B1 : Symbol(C0_B1, Decl(main.js, 18, 25))
+>C0 : Symbol(C0, Decl(decls.d.ts, 1, 50))
+
+    constructor() {
+        super();
+>super : Symbol(C0, Decl(decls.d.ts, 1, 50))
+    }
+}
+class C0_B2 extends C0 {
+>C0_B2 : Symbol(C0_B2, Decl(main.js, 23, 1))
+>C0 : Symbol(C0, Decl(decls.d.ts, 1, 50))
+
+    constructor() {
+        super(1);
+>super : Symbol(C0, Decl(decls.d.ts, 1, 50))
+    }
+}
+
+const C0_B0_v0 = new C0_B0();
+>C0_B0_v0 : Symbol(C0_B0_v0, Decl(main.js, 30, 5))
+>C0_B0 : Symbol(C0_B0, Decl(main.js, 16, 24))
+
+const C0_B0_v0_y = C0_B0_v0.y;
+>C0_B0_v0_y : Symbol(C0_B0_v0_y, Decl(main.js, 31, 5))
+>C0_B0_v0.y : Symbol(C0.y, Decl(decls.d.ts, 2, 21))
+>C0_B0_v0 : Symbol(C0_B0_v0, Decl(main.js, 30, 5))
+>y : Symbol(C0.y, Decl(decls.d.ts, 2, 21))
+
+const C0_B0_v1 = new C0_B0(1);
+>C0_B0_v1 : Symbol(C0_B0_v1, Decl(main.js, 33, 5))
+>C0_B0 : Symbol(C0_B0, Decl(main.js, 16, 24))
+
+const C0_B0_v1_y = C0_B0_v1.y;
+>C0_B0_v1_y : Symbol(C0_B0_v1_y, Decl(main.js, 34, 5))
+>C0_B0_v1.y : Symbol(C0.y, Decl(decls.d.ts, 2, 21))
+>C0_B0_v1 : Symbol(C0_B0_v1, Decl(main.js, 33, 5))
+>y : Symbol(C0.y, Decl(decls.d.ts, 2, 21))
+
+const C0_B1_v0 = new C0_B1();
+>C0_B1_v0 : Symbol(C0_B1_v0, Decl(main.js, 36, 5))
+>C0_B1 : Symbol(C0_B1, Decl(main.js, 18, 25))
+
+const C0_B1_v0_y = C0_B1_v0.y;
+>C0_B1_v0_y : Symbol(C0_B1_v0_y, Decl(main.js, 37, 5))
+>C0_B1_v0.y : Symbol(C0.y, Decl(decls.d.ts, 2, 21))
+>C0_B1_v0 : Symbol(C0_B1_v0, Decl(main.js, 36, 5))
+>y : Symbol(C0.y, Decl(decls.d.ts, 2, 21))
+
+const C0_B2_v0 = new C0_B2();
+>C0_B2_v0 : Symbol(C0_B2_v0, Decl(main.js, 39, 5))
+>C0_B2 : Symbol(C0_B2, Decl(main.js, 23, 1))
+
+const C0_B2_v0_y = C0_B2_v0.y;
+>C0_B2_v0_y : Symbol(C0_B2_v0_y, Decl(main.js, 40, 5))
+>C0_B2_v0.y : Symbol(C0.y, Decl(decls.d.ts, 2, 21))
+>C0_B2_v0 : Symbol(C0_B2_v0, Decl(main.js, 39, 5))
+>y : Symbol(C0.y, Decl(decls.d.ts, 2, 21))
+
+class C1_B0 extends C1 {}
+>C1_B0 : Symbol(C1_B0, Decl(main.js, 40, 30))
+>C1 : Symbol(C1, Decl(decls.d.ts, 5, 1))
+
+class C1_B1 extends C1 {
+>C1_B1 : Symbol(C1_B1, Decl(main.js, 42, 25))
+>C1 : Symbol(C1, Decl(decls.d.ts, 5, 1))
+
+    constructor() {
+        super();
+>super : Symbol(C1, Decl(decls.d.ts, 5, 1))
+    }
+}
+class C1_B2 extends C1 {
+>C1_B2 : Symbol(C1_B2, Decl(main.js, 47, 1))
+>C1 : Symbol(C1, Decl(decls.d.ts, 5, 1))
+
+    constructor() {
+        super(1);
+>super : Symbol(C1, Decl(decls.d.ts, 5, 1))
+    }
+}
+
+const C1_B0_v0 = new C1_B0();
+>C1_B0_v0 : Symbol(C1_B0_v0, Decl(main.js, 54, 5))
+>C1_B0 : Symbol(C1_B0, Decl(main.js, 40, 30))
+
+const C1_B0_v0_y = C1_B0_v0.y;
+>C1_B0_v0_y : Symbol(C1_B0_v0_y, Decl(main.js, 55, 5))
+>C1_B0_v0.y : Symbol(C1.y, Decl(decls.d.ts, 6, 33))
+>C1_B0_v0 : Symbol(C1_B0_v0, Decl(main.js, 54, 5))
+>y : Symbol(C1.y, Decl(decls.d.ts, 6, 33))
+
+const C1_B0_v1 = new C1_B0(1);
+>C1_B0_v1 : Symbol(C1_B0_v1, Decl(main.js, 57, 5))
+>C1_B0 : Symbol(C1_B0, Decl(main.js, 40, 30))
+
+const C1_B0_v1_y = C1_B0_v1.y;
+>C1_B0_v1_y : Symbol(C1_B0_v1_y, Decl(main.js, 58, 5))
+>C1_B0_v1.y : Symbol(C1.y, Decl(decls.d.ts, 6, 33))
+>C1_B0_v1 : Symbol(C1_B0_v1, Decl(main.js, 57, 5))
+>y : Symbol(C1.y, Decl(decls.d.ts, 6, 33))
+
+const C1_B1_v0 = new C1_B1();
+>C1_B1_v0 : Symbol(C1_B1_v0, Decl(main.js, 60, 5))
+>C1_B1 : Symbol(C1_B1, Decl(main.js, 42, 25))
+
+const C1_B1_v0_y = C1_B1_v0.y;
+>C1_B1_v0_y : Symbol(C1_B1_v0_y, Decl(main.js, 61, 5))
+>C1_B1_v0.y : Symbol(C1.y, Decl(decls.d.ts, 6, 33))
+>C1_B1_v0 : Symbol(C1_B1_v0, Decl(main.js, 60, 5))
+>y : Symbol(C1.y, Decl(decls.d.ts, 6, 33))
+
+const C1_B2_v0 = new C1_B2();
+>C1_B2_v0 : Symbol(C1_B2_v0, Decl(main.js, 63, 5))
+>C1_B2 : Symbol(C1_B2, Decl(main.js, 47, 1))
+
+const C1_B2_v0_y = C1_B2_v0.y;
+>C1_B2_v0_y : Symbol(C1_B2_v0_y, Decl(main.js, 64, 5))
+>C1_B2_v0.y : Symbol(C1.y, Decl(decls.d.ts, 6, 33))
+>C1_B2_v0 : Symbol(C1_B2_v0, Decl(main.js, 63, 5))
+>y : Symbol(C1.y, Decl(decls.d.ts, 6, 33))
+

--- a/tests/baselines/reference/genericDefaultsJs.types
+++ b/tests/baselines/reference/genericDefaultsJs.types
@@ -1,0 +1,254 @@
+=== tests/cases/compiler/decls.d.ts ===
+declare function f0<T>(x?: T): T;
+>f0 : <T>(x?: T) => T
+>T : T
+>x : T
+>T : T
+>T : T
+
+declare function f1<T, U = number>(x?: T): [T, U];
+>f1 : <T, U = number>(x?: T) => [T, U]
+>T : T
+>U : U
+>x : T
+>T : T
+>T : T
+>U : U
+
+declare class C0<T> {
+>C0 : C0<T>
+>T : T
+
+    y: T;
+>y : T
+>T : T
+
+    constructor(x?: T);
+>x : T
+>T : T
+}
+declare class C1<T, U = number> {
+>C1 : C1<T, U>
+>T : T
+>U : U
+
+    y: [T, U];
+>y : [T, U]
+>T : T
+>U : U
+
+    constructor(x?: T);
+>x : T
+>T : T
+}
+=== tests/cases/compiler/main.js ===
+const f0_v0 = f0();
+>f0_v0 : any
+>f0() : any
+>f0 : <T>(x?: T) => T
+
+const f0_v1 = f0(1);
+>f0_v1 : 1
+>f0(1) : 1
+>f0 : <T>(x?: T) => T
+>1 : 1
+
+const f1_c0 = f1();
+>f1_c0 : [any, number]
+>f1() : [any, number]
+>f1 : <T, U = number>(x?: T) => [T, U]
+
+const f1_c1 = f1(1);
+>f1_c1 : [number, number]
+>f1(1) : [number, number]
+>f1 : <T, U = number>(x?: T) => [T, U]
+>1 : 1
+
+const C0_v0 = new C0();
+>C0_v0 : C0<any>
+>new C0() : C0<any>
+>C0 : typeof C0
+
+const C0_v0_y = C0_v0.y;
+>C0_v0_y : any
+>C0_v0.y : any
+>C0_v0 : C0<any>
+>y : any
+
+const C0_v1 = new C0(1);
+>C0_v1 : C0<number>
+>new C0(1) : C0<number>
+>C0 : typeof C0
+>1 : 1
+
+const C0_v1_y = C0_v1.y;
+>C0_v1_y : number
+>C0_v1.y : number
+>C0_v1 : C0<number>
+>y : number
+
+const C1_v0 = new C1();
+>C1_v0 : C1<any, number>
+>new C1() : C1<any, number>
+>C1 : typeof C1
+
+const C1_v0_y = C1_v0.y;
+>C1_v0_y : [any, number]
+>C1_v0.y : [any, number]
+>C1_v0 : C1<any, number>
+>y : [any, number]
+
+const C1_v1 = new C1(1);
+>C1_v1 : C1<number, number>
+>new C1(1) : C1<number, number>
+>C1 : typeof C1
+>1 : 1
+
+const C1_v1_y = C1_v1.y;
+>C1_v1_y : [number, number]
+>C1_v1.y : [number, number]
+>C1_v1 : C1<number, number>
+>y : [number, number]
+
+class C0_B0 extends C0 {}
+>C0_B0 : C0_B0
+>C0 : C0<any>
+
+class C0_B1 extends C0 {
+>C0_B1 : C0_B1
+>C0 : C0<any>
+
+    constructor() {
+        super();
+>super() : void
+>super : typeof C0
+    }
+}
+class C0_B2 extends C0 {
+>C0_B2 : C0_B2
+>C0 : C0<any>
+
+    constructor() {
+        super(1);
+>super(1) : void
+>super : typeof C0
+>1 : 1
+    }
+}
+
+const C0_B0_v0 = new C0_B0();
+>C0_B0_v0 : C0_B0
+>new C0_B0() : C0_B0
+>C0_B0 : typeof C0_B0
+
+const C0_B0_v0_y = C0_B0_v0.y;
+>C0_B0_v0_y : any
+>C0_B0_v0.y : any
+>C0_B0_v0 : C0_B0
+>y : any
+
+const C0_B0_v1 = new C0_B0(1);
+>C0_B0_v1 : C0_B0
+>new C0_B0(1) : C0_B0
+>C0_B0 : typeof C0_B0
+>1 : 1
+
+const C0_B0_v1_y = C0_B0_v1.y;
+>C0_B0_v1_y : any
+>C0_B0_v1.y : any
+>C0_B0_v1 : C0_B0
+>y : any
+
+const C0_B1_v0 = new C0_B1();
+>C0_B1_v0 : C0_B1
+>new C0_B1() : C0_B1
+>C0_B1 : typeof C0_B1
+
+const C0_B1_v0_y = C0_B1_v0.y;
+>C0_B1_v0_y : any
+>C0_B1_v0.y : any
+>C0_B1_v0 : C0_B1
+>y : any
+
+const C0_B2_v0 = new C0_B2();
+>C0_B2_v0 : C0_B2
+>new C0_B2() : C0_B2
+>C0_B2 : typeof C0_B2
+
+const C0_B2_v0_y = C0_B2_v0.y;
+>C0_B2_v0_y : any
+>C0_B2_v0.y : any
+>C0_B2_v0 : C0_B2
+>y : any
+
+class C1_B0 extends C1 {}
+>C1_B0 : C1_B0
+>C1 : C1<any, number>
+
+class C1_B1 extends C1 {
+>C1_B1 : C1_B1
+>C1 : C1<any, number>
+
+    constructor() {
+        super();
+>super() : void
+>super : typeof C1
+    }
+}
+class C1_B2 extends C1 {
+>C1_B2 : C1_B2
+>C1 : C1<any, number>
+
+    constructor() {
+        super(1);
+>super(1) : void
+>super : typeof C1
+>1 : 1
+    }
+}
+
+const C1_B0_v0 = new C1_B0();
+>C1_B0_v0 : C1_B0
+>new C1_B0() : C1_B0
+>C1_B0 : typeof C1_B0
+
+const C1_B0_v0_y = C1_B0_v0.y;
+>C1_B0_v0_y : [any, number]
+>C1_B0_v0.y : [any, number]
+>C1_B0_v0 : C1_B0
+>y : [any, number]
+
+const C1_B0_v1 = new C1_B0(1);
+>C1_B0_v1 : C1_B0
+>new C1_B0(1) : C1_B0
+>C1_B0 : typeof C1_B0
+>1 : 1
+
+const C1_B0_v1_y = C1_B0_v1.y;
+>C1_B0_v1_y : [any, number]
+>C1_B0_v1.y : [any, number]
+>C1_B0_v1 : C1_B0
+>y : [any, number]
+
+const C1_B1_v0 = new C1_B1();
+>C1_B1_v0 : C1_B1
+>new C1_B1() : C1_B1
+>C1_B1 : typeof C1_B1
+
+const C1_B1_v0_y = C1_B1_v0.y;
+>C1_B1_v0_y : [any, number]
+>C1_B1_v0.y : [any, number]
+>C1_B1_v0 : C1_B1
+>y : [any, number]
+
+const C1_B2_v0 = new C1_B2();
+>C1_B2_v0 : C1_B2
+>new C1_B2() : C1_B2
+>C1_B2 : typeof C1_B2
+
+const C1_B2_v0_y = C1_B2_v0.y;
+>C1_B2_v0_y : [any, number]
+>C1_B2_v0.y : [any, number]
+>C1_B2_v0 : C1_B2
+>y : [any, number]
+

--- a/tests/cases/compiler/genericDefaultsJs.ts
+++ b/tests/cases/compiler/genericDefaultsJs.ts
@@ -1,0 +1,80 @@
+// @checkJs: true
+// @allowJs: true
+// @noEmit: true
+// @filename: decls.d.ts
+declare function f0<T>(x?: T): T;
+declare function f1<T, U = number>(x?: T): [T, U];
+declare class C0<T> {
+    y: T;
+    constructor(x?: T);
+}
+declare class C1<T, U = number> {
+    y: [T, U];
+    constructor(x?: T);
+}
+// @filename: main.js
+const f0_v0 = f0();
+const f0_v1 = f0(1);
+
+const f1_c0 = f1();
+const f1_c1 = f1(1);
+
+const C0_v0 = new C0();
+const C0_v0_y = C0_v0.y;
+
+const C0_v1 = new C0(1);
+const C0_v1_y = C0_v1.y;
+
+const C1_v0 = new C1();
+const C1_v0_y = C1_v0.y;
+
+const C1_v1 = new C1(1);
+const C1_v1_y = C1_v1.y;
+
+class C0_B0 extends C0 {}
+class C0_B1 extends C0 {
+    constructor() {
+        super();
+    }
+}
+class C0_B2 extends C0 {
+    constructor() {
+        super(1);
+    }
+}
+
+const C0_B0_v0 = new C0_B0();
+const C0_B0_v0_y = C0_B0_v0.y;
+
+const C0_B0_v1 = new C0_B0(1);
+const C0_B0_v1_y = C0_B0_v1.y;
+
+const C0_B1_v0 = new C0_B1();
+const C0_B1_v0_y = C0_B1_v0.y;
+
+const C0_B2_v0 = new C0_B2();
+const C0_B2_v0_y = C0_B2_v0.y;
+
+class C1_B0 extends C1 {}
+class C1_B1 extends C1 {
+    constructor() {
+        super();
+    }
+}
+class C1_B2 extends C1 {
+    constructor() {
+        super(1);
+    }
+}
+
+const C1_B0_v0 = new C1_B0();
+const C1_B0_v0_y = C1_B0_v0.y;
+
+const C1_B0_v1 = new C1_B0(1);
+const C1_B0_v1_y = C1_B0_v1.y;
+
+const C1_B1_v0 = new C1_B1();
+const C1_B1_v0_y = C1_B1_v0.y;
+
+const C1_B2_v0 = new C1_B2();
+const C1_B2_v0_y = C1_B2_v0.y;


### PR DESCRIPTION
*NOTE: this does **not** replace #14396, but instead implements only the JavaScript side of that PR.*

This changes the behavior for unsupplied type arguments in a Type Reference to be the 'any' type.

Partially Fixes #13609
