### PR TITLE
Expose compiler API needed for vue

### DIFF
--- a/src/server/lsHost.ts
+++ b/src/server/lsHost.ts
@@ -11,7 +11,7 @@ namespace ts.server {
 
         private filesWithChangedSetOfUnresolvedImports: Path[];
 
-        private readonly resolveModuleName: typeof resolveModuleName;
+        private resolveModuleName: typeof resolveModuleName;
         readonly trace: (s: string) => void;
         readonly realpath?: (path: string) => string;
 
@@ -44,6 +44,11 @@ namespace ts.server {
             if (this.host.realpath) {
                 this.realpath = path => this.host.realpath(path);
             }
+        }
+
+        public overrideResolveModuleName(plugin: PluginResolveModules) {
+            const prevResolveModuleName = this.resolveModuleName;
+            this.resolveModuleName = plugin(prevResolveModuleName);
         }
 
         public startRecordingFilesWithChangedResolutions() {

--- a/src/server/lsHost.ts
+++ b/src/server/lsHost.ts
@@ -11,7 +11,7 @@ namespace ts.server {
 
         private filesWithChangedSetOfUnresolvedImports: Path[];
 
-        private resolveModuleName: typeof resolveModuleName;
+        private readonly resolveModuleName: typeof resolveModuleName;
         readonly trace: (s: string) => void;
         readonly realpath?: (path: string) => string;
 
@@ -44,11 +44,6 @@ namespace ts.server {
             if (this.host.realpath) {
                 this.realpath = path => this.host.realpath(path);
             }
-        }
-
-        public overrideResolveModuleName(plugin: PluginResolveModules) {
-            const prevResolveModuleName = this.resolveModuleName;
-            this.resolveModuleName = plugin(prevResolveModuleName);
         }
 
         public startRecordingFilesWithChangedResolutions() {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -104,8 +104,6 @@ namespace ts.server {
         getExternalFiles?(proj: Project): string[];
     }
 
-    export type ModuleResolver = (moduleName: string, containingFile: string, compilerOptions: CompilerOptions, host: ModuleResolutionHost, cache?: ModuleResolutionCache) => ResolvedModuleWithFailedLookupLocations;
-
     export interface PluginModuleFactory {
         (mod: { typescript: typeof ts }): PluginModule;
     }

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -102,14 +102,9 @@ namespace ts.server {
     export interface PluginModule {
         create(createInfo: PluginCreateInfo): LanguageService;
         getExternalFiles?(proj: Project): string[];
-        resolveModules?(createInfo: PluginCreateInfo): PluginResolveModules;
     }
 
     export type ModuleResolver = (moduleName: string, containingFile: string, compilerOptions: CompilerOptions, host: ModuleResolutionHost, cache?: ModuleResolutionCache) => ResolvedModuleWithFailedLookupLocations;
-
-    export type PluginResolveModules = {
-        (plugin: ModuleResolver): ModuleResolver;
-    }
 
     export interface PluginModuleFactory {
         (mod: { typescript: typeof ts }): PluginModule;
@@ -911,9 +906,6 @@ namespace ts.server {
 
                 const pluginModule = pluginModuleFactory({ typescript: ts });
                 this.languageService = pluginModule.create(info);
-                if (pluginModule.resolveModules) {
-                    this.lsHost.overrideResolveModuleName(pluginModule.resolveModules(info));
-                }
                 this.plugins.push(pluginModule);
             }
             catch (e) {

--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -102,6 +102,13 @@ namespace ts.server {
     export interface PluginModule {
         create(createInfo: PluginCreateInfo): LanguageService;
         getExternalFiles?(proj: Project): string[];
+        resolveModules?(createInfo: PluginCreateInfo): PluginResolveModules;
+    }
+
+    export type ModuleResolver = (moduleName: string, containingFile: string, compilerOptions: CompilerOptions, host: ModuleResolutionHost, cache?: ModuleResolutionCache) => ResolvedModuleWithFailedLookupLocations;
+
+    export type PluginResolveModules = {
+        (plugin: ModuleResolver): ModuleResolver;
     }
 
     export interface PluginModuleFactory {
@@ -904,6 +911,9 @@ namespace ts.server {
 
                 const pluginModule = pluginModuleFactory({ typescript: ts });
                 this.languageService = pluginModule.create(info);
+                if (pluginModule.resolveModules) {
+                    this.lsHost.overrideResolveModuleName(pluginModule.resolveModules(info));
+                }
                 this.plugins.push(pluginModule);
             }
             catch (e) {

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -899,6 +899,13 @@ namespace ts {
         sourceFile.scriptSnapshot = scriptSnapshot;
     }
 
+    export function overrideCreateupdateLanguageServiceSourceFile(
+        create: (fileName: string, scriptSnapshot: IScriptSnapshot, scriptTarget: ScriptTarget, version: string, setNodeParents: boolean, scriptKind?: ScriptKind, cheat?: string) => SourceFile,
+        update: (sourceFile: SourceFile, scriptSnapshot: IScriptSnapshot, version: string, textChangeRange: TextChangeRange, aggressiveChecks?: boolean, cheat?: string) => SourceFile) {
+        ts.createLanguageServiceSourceFile = create;
+        ts.updateLanguageServiceSourceFile = update;
+    }
+
     export function createLanguageServiceSourceFile(fileName: string, scriptSnapshot: IScriptSnapshot, scriptTarget: ScriptTarget, version: string, setNodeParents: boolean, scriptKind?: ScriptKind): SourceFile {
         const text = scriptSnapshot.getText(0, scriptSnapshot.getLength());
         const sourceFile = createSourceFile(fileName, text, scriptTarget, setNodeParents, scriptKind);

--- a/tests/cases/fourslash/server/vueProxy1.ts
+++ b/tests/cases/fourslash/server/vueProxy1.ts
@@ -1,0 +1,44 @@
+/// <reference path="../fourslash.ts"/>
+
+// @Filename: tsconfig.json
+//// {
+////     "compilerOptions": {
+////         "allowNonTsExtensions": true,
+////         "plugins": [
+////             { "name": "mock-vue" }
+////         ]
+////     },
+////     "files": ["a.vue"]
+//// }
+
+// Note: This test does *not* implement the correct vue transformation.
+// So it's other.data.property, not other.property or other.$data.property
+// @Filename: other.vue
+////<template>
+////</template>
+////<script>
+////export default {
+////    data: { property: "Example" }
+////}
+////</script>
+////<style>
+////</style>
+
+
+// @Filename: a.vue
+////<template>
+////</template>
+////<script>
+////import other from './other.vue'
+//// other.data.property/**/
+////export default {
+////    data: { greeting: "Hello" }
+////}
+////</script>
+////<style>
+////</style>
+
+// LS shouldn't crash/fail if a plugin fails to init correctly
+goTo.marker();
+verify.quickInfoIs('(property) property: string');
+verify.numberOfErrorsInCurrentFile(0);


### PR DESCRIPTION
1. `resolveModuleName`
2. `create/updateLanguageServiceSourceFile`

Note that these are the hooks required to implement a typescript language service plugin as in sandersn/vue-ts-plugin. A plugin like octref/vetur that creates its own language service must also create its own host, so it only needs part (2): the create/updateLanguageServiceSourceFile hook. The host it creates has to provide an implementation of `resolveModuleNames` anyway, so it doesn't need (1).

If/when we decide to add these hooks, vetur will need to update the code added in octref/vetur#94 to avoid overwriting these functions itself.