### PR TITLE
Fix formatting for multi-line object destructuring

### DIFF
--- a/src/services/formatting/rules.ts
+++ b/src/services/formatting/rules.ts
@@ -297,8 +297,8 @@ namespace ts.formatting {
             // Insert a space after { and before } in single-line contexts, but remove space from empty object literals {}.
             this.SpaceAfterOpenBrace = new Rule(RuleDescriptor.create3(SyntaxKind.OpenBraceToken, Shared.TokenRange.Any), RuleOperation.create2(new RuleOperationContext(Rules.IsBraceWrappedContext), RuleAction.Space));
             this.SpaceBeforeCloseBrace = new Rule(RuleDescriptor.create2(Shared.TokenRange.Any, SyntaxKind.CloseBraceToken), RuleOperation.create2(new RuleOperationContext(Rules.IsBraceWrappedContext), RuleAction.Space));
-            this.NoSpaceAfterOpenBrace = new Rule(RuleDescriptor.create3(SyntaxKind.OpenBraceToken, Shared.TokenRange.Any), RuleOperation.create2(new RuleOperationContext(Rules.IsBraceWrappedContext), RuleAction.Delete));
-            this.NoSpaceBeforeCloseBrace = new Rule(RuleDescriptor.create2(Shared.TokenRange.Any, SyntaxKind.CloseBraceToken), RuleOperation.create2(new RuleOperationContext(Rules.IsBraceWrappedContext), RuleAction.Delete));
+            this.NoSpaceAfterOpenBrace = new Rule(RuleDescriptor.create3(SyntaxKind.OpenBraceToken, Shared.TokenRange.Any), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext), RuleAction.Delete));
+            this.NoSpaceBeforeCloseBrace = new Rule(RuleDescriptor.create2(Shared.TokenRange.Any, SyntaxKind.CloseBraceToken), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext), RuleAction.Delete));
             this.NoSpaceBetweenEmptyBraceBrackets = new Rule(RuleDescriptor.create1(SyntaxKind.OpenBraceToken, SyntaxKind.CloseBraceToken), RuleOperation.create2(new RuleOperationContext(Rules.IsNonJsxSameLineTokenContext, Rules.IsObjectContext), RuleAction.Delete));
 
             // Insert new line after { and before } in multi-line contexts.

--- a/tests/cases/fourslash/formattingInDestructuring3.ts
+++ b/tests/cases/fourslash/formattingInDestructuring3.ts
@@ -1,0 +1,17 @@
+/// <reference path='fourslash.ts'/>
+
+/////*1*/const {
+/////*2*/    a,
+/////*3*/    b,
+/////*4*/} = { a: 1, b: 2 };
+
+format.document();
+
+goTo.marker("1");
+verify.currentLineContentIs("const {");
+goTo.marker("2");
+verify.currentLineContentIs("    a,");
+goTo.marker("3");
+verify.currentLineContentIs("    b,");
+goTo.marker("4");
+verify.currentLineContentIs("} = { a: 1, b: 2 };");

--- a/tests/cases/fourslash/formattingInDestructuring3.ts
+++ b/tests/cases/fourslash/formattingInDestructuring3.ts
@@ -3,7 +3,8 @@
 /////*1*/const {
 /////*2*/    a,
 /////*3*/    b,
-/////*4*/} = { a: 1, b: 2 };
+/////*4*/} = {a: 1, b: 2};
+/////*5*/const {a: c} = {a: 1, b: 2};
 
 format.document();
 
@@ -15,3 +16,5 @@ goTo.marker("3");
 verify.currentLineContentIs("    b,");
 goTo.marker("4");
 verify.currentLineContentIs("} = { a: 1, b: 2 };");
+goTo.marker("5");
+verify.currentLineContentIs("const { a: c } = { a: 1, b: 2 };");

--- a/tests/cases/fourslash/formattingInDestructuring4.ts
+++ b/tests/cases/fourslash/formattingInDestructuring4.ts
@@ -1,0 +1,19 @@
+/// <reference path='fourslash.ts'/>
+
+/////*1*/const { 
+/////*2*/    a,
+/////*3*/    b,
+/////*4*/} = { a: 1, b: 2 };
+
+format.setOption('InsertSpaceAfterOpeningAndBeforeClosingNonemptyBraces', false);
+
+format.document();
+
+goTo.marker("1");
+verify.currentLineContentIs("const {");
+goTo.marker("2");
+verify.currentLineContentIs("    a,");
+goTo.marker("3");
+verify.currentLineContentIs("    b,");
+goTo.marker("4");
+verify.currentLineContentIs("} = {a: 1, b: 2};");


### PR DESCRIPTION
This fixes the rule `insertSpaceAfterOpeningAndBeforeClosingNonemptyBraces: false` for multiline object destructurings.

**Input**

```ts
const {
  a,
  b,
} = { a: 1, b: 2 };
```

**Formatted output (actual)**

```ts
const {a,
  b,} = {a: 1, b: 2};
```

**Formatted output (expected)**

```ts
const {
  a,
  b,
} = {a: 1, b: 2};
```