### PR TITLE
Fix #14892: Add undefined check before using the intializer of for-statment

### DIFF
--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -1478,7 +1478,7 @@ namespace ts {
             }
 
             const initializer = node.initializer;
-            if (isVariableDeclarationList(initializer)) {
+            if (initializer && isVariableDeclarationList(initializer)) {
                 for (const variable of initializer.declarations) {
                     hoistVariableDeclaration(<Identifier>variable.name);
                 }

--- a/src/compiler/transformers/module/system.ts
+++ b/src/compiler/transformers/module/system.ts
@@ -1287,6 +1287,10 @@ namespace ts {
          * @param node The node to visit.
          */
         function visitForInitializer(node: ForInitializer): ForInitializer {
+            if (!node) {
+                return node;
+            }
+
             if (shouldHoistForInitializer(node)) {
                 let expressions: Expression[];
                 for (const variable of node.declarations) {

--- a/tests/baselines/reference/SystemModuleForStatementNoInitializer.js
+++ b/tests/baselines/reference/SystemModuleForStatementNoInitializer.js
@@ -1,0 +1,42 @@
+//// [SystemModuleForStatementNoInitializer.ts]
+
+export { };
+
+let i = 0;
+let limit = 10;
+
+for (; i < limit; ++i) {
+    break;
+}
+
+for (; ; ++i) {
+    break;
+}
+
+for (; ;) {
+    break;
+}
+
+
+//// [SystemModuleForStatementNoInitializer.js]
+System.register([], function (exports_1, context_1) {
+    "use strict";
+    var __moduleName = context_1 && context_1.id;
+    var i, limit;
+    return {
+        setters: [],
+        execute: function () {
+            i = 0;
+            limit = 10;
+            for (; i < limit; ++i) {
+                break;
+            }
+            for (;; ++i) {
+                break;
+            }
+            for (;;) {
+                break;
+            }
+        }
+    };
+});

--- a/tests/baselines/reference/SystemModuleForStatementNoInitializer.symbols
+++ b/tests/baselines/reference/SystemModuleForStatementNoInitializer.symbols
@@ -1,0 +1,28 @@
+=== tests/cases/compiler/SystemModuleForStatementNoInitializer.ts ===
+
+export { };
+
+let i = 0;
+>i : Symbol(i, Decl(SystemModuleForStatementNoInitializer.ts, 3, 3))
+
+let limit = 10;
+>limit : Symbol(limit, Decl(SystemModuleForStatementNoInitializer.ts, 4, 3))
+
+for (; i < limit; ++i) {
+>i : Symbol(i, Decl(SystemModuleForStatementNoInitializer.ts, 3, 3))
+>limit : Symbol(limit, Decl(SystemModuleForStatementNoInitializer.ts, 4, 3))
+>i : Symbol(i, Decl(SystemModuleForStatementNoInitializer.ts, 3, 3))
+
+    break;
+}
+
+for (; ; ++i) {
+>i : Symbol(i, Decl(SystemModuleForStatementNoInitializer.ts, 3, 3))
+
+    break;
+}
+
+for (; ;) {
+    break;
+}
+

--- a/tests/baselines/reference/SystemModuleForStatementNoInitializer.types
+++ b/tests/baselines/reference/SystemModuleForStatementNoInitializer.types
@@ -1,0 +1,33 @@
+=== tests/cases/compiler/SystemModuleForStatementNoInitializer.ts ===
+
+export { };
+
+let i = 0;
+>i : number
+>0 : 0
+
+let limit = 10;
+>limit : number
+>10 : 10
+
+for (; i < limit; ++i) {
+>i < limit : boolean
+>i : number
+>limit : number
+>++i : number
+>i : number
+
+    break;
+}
+
+for (; ; ++i) {
+>++i : number
+>i : number
+
+    break;
+}
+
+for (; ;) {
+    break;
+}
+

--- a/tests/baselines/reference/asyncFunctionWithForStatementNoInitializer.js
+++ b/tests/baselines/reference/asyncFunctionWithForStatementNoInitializer.js
@@ -1,0 +1,106 @@
+//// [asyncFunctionWithForStatementNoInitializer.ts]
+async function test1() {
+    let i = 0
+    let limit = 10
+    for (; i < limit; ++i) {
+    }
+}
+
+async function test2() {
+    let i = 0
+    let limit = 10
+    for (i = 1; i < limit; ++i) {
+    }
+}
+
+async function test3() {
+    let i = 0
+    for (;; ++i) {
+    }
+}
+
+async function test4() {
+    for (;;) {
+    }
+}
+
+//// [asyncFunctionWithForStatementNoInitializer.js]
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = y[op[0] & 2 ? "return" : op[0] ? "throw" : "next"]) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [0, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+function test1() {
+    return __awaiter(this, void 0, void 0, function () {
+        var i, limit;
+        return __generator(this, function (_a) {
+            i = 0;
+            limit = 10;
+            for (; i < limit; ++i) {
+            }
+            return [2 /*return*/];
+        });
+    });
+}
+function test2() {
+    return __awaiter(this, void 0, void 0, function () {
+        var i, limit;
+        return __generator(this, function (_a) {
+            i = 0;
+            limit = 10;
+            for (i = 1; i < limit; ++i) {
+            }
+            return [2 /*return*/];
+        });
+    });
+}
+function test3() {
+    return __awaiter(this, void 0, void 0, function () {
+        var i;
+        return __generator(this, function (_a) {
+            i = 0;
+            for (;; ++i) {
+            }
+            return [2 /*return*/];
+        });
+    });
+}
+function test4() {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            for (;;) {
+            }
+            return [2 /*return*/];
+        });
+    });
+}

--- a/tests/baselines/reference/asyncFunctionWithForStatementNoInitializer.symbols
+++ b/tests/baselines/reference/asyncFunctionWithForStatementNoInitializer.symbols
@@ -1,0 +1,51 @@
+=== tests/cases/compiler/asyncFunctionWithForStatementNoInitializer.ts ===
+async function test1() {
+>test1 : Symbol(test1, Decl(asyncFunctionWithForStatementNoInitializer.ts, 0, 0))
+
+    let i = 0
+>i : Symbol(i, Decl(asyncFunctionWithForStatementNoInitializer.ts, 1, 7))
+
+    let limit = 10
+>limit : Symbol(limit, Decl(asyncFunctionWithForStatementNoInitializer.ts, 2, 7))
+
+    for (; i < limit; ++i) {
+>i : Symbol(i, Decl(asyncFunctionWithForStatementNoInitializer.ts, 1, 7))
+>limit : Symbol(limit, Decl(asyncFunctionWithForStatementNoInitializer.ts, 2, 7))
+>i : Symbol(i, Decl(asyncFunctionWithForStatementNoInitializer.ts, 1, 7))
+    }
+}
+
+async function test2() {
+>test2 : Symbol(test2, Decl(asyncFunctionWithForStatementNoInitializer.ts, 5, 1))
+
+    let i = 0
+>i : Symbol(i, Decl(asyncFunctionWithForStatementNoInitializer.ts, 8, 7))
+
+    let limit = 10
+>limit : Symbol(limit, Decl(asyncFunctionWithForStatementNoInitializer.ts, 9, 7))
+
+    for (i = 1; i < limit; ++i) {
+>i : Symbol(i, Decl(asyncFunctionWithForStatementNoInitializer.ts, 8, 7))
+>i : Symbol(i, Decl(asyncFunctionWithForStatementNoInitializer.ts, 8, 7))
+>limit : Symbol(limit, Decl(asyncFunctionWithForStatementNoInitializer.ts, 9, 7))
+>i : Symbol(i, Decl(asyncFunctionWithForStatementNoInitializer.ts, 8, 7))
+    }
+}
+
+async function test3() {
+>test3 : Symbol(test3, Decl(asyncFunctionWithForStatementNoInitializer.ts, 12, 1))
+
+    let i = 0
+>i : Symbol(i, Decl(asyncFunctionWithForStatementNoInitializer.ts, 15, 7))
+
+    for (;; ++i) {
+>i : Symbol(i, Decl(asyncFunctionWithForStatementNoInitializer.ts, 15, 7))
+    }
+}
+
+async function test4() {
+>test4 : Symbol(test4, Decl(asyncFunctionWithForStatementNoInitializer.ts, 18, 1))
+
+    for (;;) {
+    }
+}

--- a/tests/baselines/reference/asyncFunctionWithForStatementNoInitializer.types
+++ b/tests/baselines/reference/asyncFunctionWithForStatementNoInitializer.types
@@ -1,0 +1,63 @@
+=== tests/cases/compiler/asyncFunctionWithForStatementNoInitializer.ts ===
+async function test1() {
+>test1 : () => Promise<void>
+
+    let i = 0
+>i : number
+>0 : 0
+
+    let limit = 10
+>limit : number
+>10 : 10
+
+    for (; i < limit; ++i) {
+>i < limit : boolean
+>i : number
+>limit : number
+>++i : number
+>i : number
+    }
+}
+
+async function test2() {
+>test2 : () => Promise<void>
+
+    let i = 0
+>i : number
+>0 : 0
+
+    let limit = 10
+>limit : number
+>10 : 10
+
+    for (i = 1; i < limit; ++i) {
+>i = 1 : 1
+>i : number
+>1 : 1
+>i < limit : boolean
+>i : number
+>limit : number
+>++i : number
+>i : number
+    }
+}
+
+async function test3() {
+>test3 : () => Promise<void>
+
+    let i = 0
+>i : number
+>0 : 0
+
+    for (;; ++i) {
+>++i : number
+>i : number
+    }
+}
+
+async function test4() {
+>test4 : () => Promise<void>
+
+    for (;;) {
+    }
+}

--- a/tests/cases/compiler/SystemModuleForStatementNoInitializer.ts
+++ b/tests/cases/compiler/SystemModuleForStatementNoInitializer.ts
@@ -1,0 +1,18 @@
+//@module: system
+
+export { };
+
+let i = 0;
+let limit = 10;
+
+for (; i < limit; ++i) {
+    break;
+}
+
+for (; ; ++i) {
+    break;
+}
+
+for (; ;) {
+    break;
+}

--- a/tests/cases/compiler/asyncFunctionWithForStatementNoInitializer.ts
+++ b/tests/cases/compiler/asyncFunctionWithForStatementNoInitializer.ts
@@ -1,0 +1,24 @@
+async function test1() {
+    let i = 0
+    let limit = 10
+    for (; i < limit; ++i) {
+    }
+}
+
+async function test2() {
+    let i = 0
+    let limit = 10
+    for (i = 1; i < limit; ++i) {
+    }
+}
+
+async function test3() {
+    let i = 0
+    for (;; ++i) {
+    }
+}
+
+async function test4() {
+    for (;;) {
+    }
+}


### PR DESCRIPTION
Add undefined check before using forStatement.initializer; also did a quick check on other uses of the initializer property and found another issue with system modules.

Fixes #14892
