### PR TITLE
Fix incorrect formatting in fluent API call

### DIFF
--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -461,6 +461,10 @@ namespace ts.formatting {
                 else {
                     indentation = parentDynamicIndentation.getIndentation() + parentDynamicIndentation.getDelta(node);
                 }
+                if (node.kind === SyntaxKind.OpenParenToken) {
+                    // if an open paren is on a different line from the call expression, indent the arguments one level deeper
+                    delta = options.indentSize;
+                }
             }
 
             return {

--- a/tests/cases/fourslash/formattingOnChainedCallbacks.ts
+++ b/tests/cases/fourslash/formattingOnChainedCallbacks.ts
@@ -20,6 +20,14 @@
 ////    /*n2*/
 ////    .then();
 
+////Promise
+////    .then(
+////        /*cbNoComma*/cb
+////    /*endNoComma*/)
+////    .then(
+////        /*cbComma*/cb,
+////    /*endComma*/)
+////    .then();
 
 goTo.marker('1');
 edit.insertLine('');
@@ -50,3 +58,14 @@ goTo.marker('n1');
 verify.indentationIs(8);
 goTo.marker('n2');
 verify.indentationIs(4);
+
+format.document();
+
+goTo.marker('cbNoComma');
+verify.currentLineContentIs('        cb');
+goTo.marker('cbComma');
+verify.currentLineContentIs('        cb,');
+goTo.marker('endNoComma');
+verify.currentLineContentIs('    )');
+goTo.marker('endComma');
+// verify.currentLineContentIs('    )');


### PR DESCRIPTION
Also add test cases (2nd test case with comma is currently commented out)

Partially fixes #14675
