### PR TITLE
Fix the name of protocol.ts in tsconfig.json

### DIFF
--- a/src/harness/tsconfig.json
+++ b/src/harness/tsconfig.json
@@ -96,7 +96,7 @@
         "rwcRunner.ts",
         "test262Runner.ts",
         "runner.ts",
-        "../server/protocol.d.ts",
+        "../server/protocol.ts",
         "../server/session.ts",
         "../server/client.ts",
         "../server/editorServices.ts",


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

The file name of `protocol.ts` in `src/harness/tsconfig.json` is wrong.
