### PR TITLE
Fix scope checks of class properties

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -717,7 +717,7 @@ namespace ts {
                 }
                 // declaration is after usage
                 // can be legal if usage is deferred (i.e. inside function or in initializer of instance property)
-                if (isUsedInFunctionOrInstanceProperty(usage)) {
+                if (isUsedInFunctionOrInstanceProperty(usage, declaration)) {
                     return true;
                 }
                 const sourceFiles = host.getSourceFiles();
@@ -748,8 +748,7 @@ namespace ts {
             // 1. inside a function
             // 2. inside an instance property initializer, a reference to a non-instance property
             const container = getEnclosingBlockScopeContainer(declaration);
-            const isInstanceProperty = declaration.kind === SyntaxKind.PropertyDeclaration && !(getModifierFlags(declaration) & ModifierFlags.Static);
-            return isUsedInFunctionOrInstanceProperty(usage, isInstanceProperty, container);
+            return isUsedInFunctionOrInstanceProperty(usage, declaration, container);
 
             function isImmediatelyUsedInInitializerOfBlockScopedVariable(declaration: VariableDeclaration, usage: Node): boolean {
                 const container = getEnclosingBlockScopeContainer(declaration);
@@ -778,7 +777,7 @@ namespace ts {
                 return false;
             }
 
-            function isUsedInFunctionOrInstanceProperty(usage: Node, isDeclarationInstanceProperty?: boolean, container?: Node): boolean {
+            function isUsedInFunctionOrInstanceProperty(usage: Node, declaration: Node, container?: Node): boolean {
                 let current = usage;
                 while (current) {
                     if (current === container) {
@@ -795,7 +794,8 @@ namespace ts {
                         (<PropertyDeclaration>current.parent).initializer === current;
 
                     if (initializerOfInstanceProperty) {
-                        return !isDeclarationInstanceProperty;
+                        const isDeclarationInstanceProperty = declaration.kind === SyntaxKind.PropertyDeclaration && !(getModifierFlags(declaration) & ModifierFlags.Static);
+                        return !isDeclarationInstanceProperty || getContainingClass(usage) !== getContainingClass(declaration);
                     }
 
                     current = current.parent;

--- a/tests/baselines/reference/scopeCheckClassProperty.js
+++ b/tests/baselines/reference/scopeCheckClassProperty.js
@@ -1,0 +1,26 @@
+//// [scopeCheckClassProperty.ts]
+class C {
+  constructor() {
+    new A().p; // ok
+  }
+  public x = new A().p; // should also be ok
+}
+class A {
+  public p = '';
+}
+
+
+//// [scopeCheckClassProperty.js]
+var C = (function () {
+    function C() {
+        this.x = new A().p; // should also be ok
+        new A().p; // ok
+    }
+    return C;
+}());
+var A = (function () {
+    function A() {
+        this.p = '';
+    }
+    return A;
+}());

--- a/tests/baselines/reference/scopeCheckClassProperty.symbols
+++ b/tests/baselines/reference/scopeCheckClassProperty.symbols
@@ -1,0 +1,23 @@
+=== tests/cases/compiler/scopeCheckClassProperty.ts ===
+class C {
+>C : Symbol(C, Decl(scopeCheckClassProperty.ts, 0, 0))
+
+  constructor() {
+    new A().p; // ok
+>new A().p : Symbol(A.p, Decl(scopeCheckClassProperty.ts, 6, 9))
+>A : Symbol(A, Decl(scopeCheckClassProperty.ts, 5, 1))
+>p : Symbol(A.p, Decl(scopeCheckClassProperty.ts, 6, 9))
+  }
+  public x = new A().p; // should also be ok
+>x : Symbol(C.x, Decl(scopeCheckClassProperty.ts, 3, 3))
+>new A().p : Symbol(A.p, Decl(scopeCheckClassProperty.ts, 6, 9))
+>A : Symbol(A, Decl(scopeCheckClassProperty.ts, 5, 1))
+>p : Symbol(A.p, Decl(scopeCheckClassProperty.ts, 6, 9))
+}
+class A {
+>A : Symbol(A, Decl(scopeCheckClassProperty.ts, 5, 1))
+
+  public p = '';
+>p : Symbol(A.p, Decl(scopeCheckClassProperty.ts, 6, 9))
+}
+

--- a/tests/baselines/reference/scopeCheckClassProperty.types
+++ b/tests/baselines/reference/scopeCheckClassProperty.types
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/scopeCheckClassProperty.ts ===
+class C {
+>C : C
+
+  constructor() {
+    new A().p; // ok
+>new A().p : string
+>new A() : A
+>A : typeof A
+>p : string
+  }
+  public x = new A().p; // should also be ok
+>x : string
+>new A().p : string
+>new A() : A
+>A : typeof A
+>p : string
+}
+class A {
+>A : A
+
+  public p = '';
+>p : string
+>'' : ""
+}
+

--- a/tests/cases/compiler/scopeCheckClassProperty.ts
+++ b/tests/cases/compiler/scopeCheckClassProperty.ts
@@ -1,0 +1,9 @@
+class C {
+  constructor() {
+    new A().p; // ok
+  }
+  public x = new A().p; // should also be ok
+}
+class A {
+  public p = '';
+}


### PR DESCRIPTION
Properties of class A are usable in property initializers of class B, regardless of the order of declaration of class A and class B.

Fixes #14208