### PR TITLE
Add super to control flow

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -703,6 +703,7 @@ namespace ts {
         function isNarrowableReference(expr: Expression): boolean {
             return expr.kind === SyntaxKind.Identifier ||
                 expr.kind === SyntaxKind.ThisKeyword ||
+                expr.kind === SyntaxKind.SuperKeyword ||
                 expr.kind === SyntaxKind.PropertyAccessExpression && isNarrowableReference((<PropertyAccessExpression>expr).expression);
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10347,6 +10347,8 @@ namespace ts {
                         getExportSymbolOfValueSymbolIfExported(getResolvedSymbol(<Identifier>source)) === getSymbolOfNode(target);
                 case SyntaxKind.ThisKeyword:
                     return target.kind === SyntaxKind.ThisKeyword;
+                case SyntaxKind.SuperKeyword:
+                    return target.kind === SyntaxKind.SuperKeyword;
                 case SyntaxKind.PropertyAccessExpression:
                     return target.kind === SyntaxKind.PropertyAccessExpression &&
                         (<PropertyAccessExpression>source).name.text === (<PropertyAccessExpression>target).name.text &&
@@ -11483,6 +11485,7 @@ namespace ts {
                 switch (expr.kind) {
                     case SyntaxKind.Identifier:
                     case SyntaxKind.ThisKeyword:
+                    case SyntaxKind.SuperKeyword:
                     case SyntaxKind.PropertyAccessExpression:
                         return narrowTypeByTruthiness(type, expr, assumeTrue);
                     case SyntaxKind.CallExpression:

--- a/tests/baselines/reference/controlFlowSuperPropertyAccess.js
+++ b/tests/baselines/reference/controlFlowSuperPropertyAccess.js
@@ -1,0 +1,37 @@
+//// [controlFlowSuperPropertyAccess.ts]
+class B {
+    protected m?(): void;
+}
+class C extends B {
+    body() {
+        super.m && super.m();
+    }
+}
+
+
+//// [controlFlowSuperPropertyAccess.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+var B = (function () {
+    function B() {
+    }
+    return B;
+}());
+var C = (function (_super) {
+    __extends(C, _super);
+    function C() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    C.prototype.body = function () {
+        _super.prototype.m && _super.prototype.m.call(this);
+    };
+    return C;
+}(B));

--- a/tests/baselines/reference/controlFlowSuperPropertyAccess.symbols
+++ b/tests/baselines/reference/controlFlowSuperPropertyAccess.symbols
@@ -1,0 +1,24 @@
+=== tests/cases/conformance/controlFlow/controlFlowSuperPropertyAccess.ts ===
+class B {
+>B : Symbol(B, Decl(controlFlowSuperPropertyAccess.ts, 0, 0))
+
+    protected m?(): void;
+>m : Symbol(B.m, Decl(controlFlowSuperPropertyAccess.ts, 0, 9))
+}
+class C extends B {
+>C : Symbol(C, Decl(controlFlowSuperPropertyAccess.ts, 2, 1))
+>B : Symbol(B, Decl(controlFlowSuperPropertyAccess.ts, 0, 0))
+
+    body() {
+>body : Symbol(C.body, Decl(controlFlowSuperPropertyAccess.ts, 3, 19))
+
+        super.m && super.m();
+>super.m : Symbol(B.m, Decl(controlFlowSuperPropertyAccess.ts, 0, 9))
+>super : Symbol(B, Decl(controlFlowSuperPropertyAccess.ts, 0, 0))
+>m : Symbol(B.m, Decl(controlFlowSuperPropertyAccess.ts, 0, 9))
+>super.m : Symbol(B.m, Decl(controlFlowSuperPropertyAccess.ts, 0, 9))
+>super : Symbol(B, Decl(controlFlowSuperPropertyAccess.ts, 0, 0))
+>m : Symbol(B.m, Decl(controlFlowSuperPropertyAccess.ts, 0, 9))
+    }
+}
+

--- a/tests/baselines/reference/controlFlowSuperPropertyAccess.types
+++ b/tests/baselines/reference/controlFlowSuperPropertyAccess.types
@@ -1,0 +1,26 @@
+=== tests/cases/conformance/controlFlow/controlFlowSuperPropertyAccess.ts ===
+class B {
+>B : B
+
+    protected m?(): void;
+>m : (() => void) | undefined
+}
+class C extends B {
+>C : C
+>B : B
+
+    body() {
+>body : () => void
+
+        super.m && super.m();
+>super.m && super.m() : void | undefined
+>super.m : (() => void) | undefined
+>super : B
+>m : (() => void) | undefined
+>super.m() : void
+>super.m : () => void
+>super : B
+>m : () => void
+    }
+}
+

--- a/tests/cases/conformance/controlFlow/controlFlowSuperPropertyAccess.ts
+++ b/tests/cases/conformance/controlFlow/controlFlowSuperPropertyAccess.ts
@@ -1,0 +1,9 @@
+// @strictNullChecks: true
+class B {
+    protected m?(): void;
+}
+class C extends B {
+    body() {
+        super.m && super.m();
+    }
+}


### PR DESCRIPTION
Add `super` to control flow. It is handled the same was as `this`. 

Fixes #14388
