### PR TITLE
Add -j flag

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -17,6 +17,13 @@ namespace ts {
             showInSimplifiedHelpView: true,
             category: Diagnostics.Command_line_Options,
             description: Diagnostics.Print_this_message,
+        },        {
+            name: "justkidding",
+            shortName: "j",
+            type: "boolean",
+            showInSimplifiedHelpView: true,
+            category: Diagnostics.Command_line_Options,
+            description: Diagnostics.Ignore_all_previous_commandline_options,
         },
         {
             name: "help",
@@ -742,9 +749,9 @@ namespace ts {
     }
 
     export function parseCommandLine(commandLine: string[], readFile?: (path: string) => string): ParsedCommandLine {
-        const options: CompilerOptions = {};
-        const fileNames: string[] = [];
-        const errors: Diagnostic[] = [];
+        let options: CompilerOptions = {};
+        let fileNames: string[] = [];
+        let errors: Diagnostic[] = [];
         const { optionNameMap, shortOptionNames } = getOptionNameMap();
 
         parseStrings(commandLine);
@@ -790,7 +797,14 @@ namespace ts {
                                 case "boolean":
                                     // boolean flag has optional value true, false, others
                                     const optValue = args[i];
-                                    options[opt.name] = optValue !== "false";
+                                    if (opt.name === "justkidding" && optValue === "true") {
+                                        options = {};
+                                        fileNames = [];
+                                        errors = [];
+                                    }
+                                    else {
+                                        options[opt.name] = optValue !== "false";
+                                    }
                                     // consume next argument as boolean flag value
                                     if (optValue === "false" || optValue === "true") {
                                         i++;

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2569,6 +2569,10 @@
         "category": "Message",
         "code": 6017
     },
+    "Ignore all previous commandline options.": {
+        "category": "Message",
+        "code": 6018
+    },
     "Print the compiler's version.": {
         "category": "Message",
         "code": 6019

--- a/src/harness/unittests/commandLineParsing.ts
+++ b/src/harness/unittests/commandLineParsing.ts
@@ -43,6 +43,16 @@ namespace ts {
                 });
         });
 
+        it("Ignore previous arguments ", () => {
+            // --lib es6 0.ts
+            assertParseResult(["--lib", "es6", "0.ts", "-j", "true"],
+                {
+                    errors: [],
+                    fileNames: [],
+                    options: {}
+                });
+        });
+
         it("Parse multiple options of library flags ", () => {
             // --lib es5,es2015.symbol.wellknown 0.ts
             assertParseResult(["--lib", "es5,es2015.symbol.wellknown", "0.ts"],


### PR DESCRIPTION
This PR adds the ability to suppress previous command line arguments.

A common customer scenario is the following. At the command line, you might call `tsc` with a number of options*. There are [many to choose from](https://www.typescriptlang.org/docs/handbook/compiler-options.html). Let us denote the sequence of non-file options by `a1, a2, ..., an`. The the user might compile as follows:
```
tsc file1.ts file2.ts a1 a2 ... _n
```

But the user might want to only conditionally compile their files. That is, *only* compile file2.ts, and only use a subset of their options on this second compilation. This frequently occurs when a user has client- and server-side components in their projects. Specifically, let's say the user wants to omit the first 
![codecogseqn 2](https://cloud.githubusercontent.com/assets/3226984/24573976/9750804e-1640-11e7-870c-23abd96ae5cb.gif) options, with ![codecogseqn 1](https://cloud.githubusercontent.com/assets/3226984/24573977/9abbe660-1640-11e7-972e-f10ec1ac9f20.gif).

Then, using the proposed `--justkidding` flag, the user can write their build commands as follows:
```
tsc file1.ts a1 a2 ... ak file2.ts ak+1 ... an
```
and then later, when compiling just `file2.ts`,
```
tsc file1.ts a1 a2 ... ak --justkidding true file2.ts ak+1 ... an
```

\* eg, the typescript compiler invokes itself with the following command when building itself:
```
node built\local\tsc.js --noImplicitAny --noImplicitThis --noEmitOnError --types  --pretty --declaration --preserveConstEnums --out built\local\typescriptServices.js -sourcemap -mapRoot file:///C:\repo\TypeScript\built\local --stripInternal --target es5 --lib es5 --noUnu
sedLocals --noUnusedParameters src/services/../compiler/core.ts src/services/../compiler/performance.ts src/services/../compiler/sys.ts src/services/../compiler/types.ts src/services/../compiler/scanner.ts src/services/../compiler/parser.ts src/services/../compiler/utili
ties.ts src/services/../compiler/binder.ts src/services/../compiler/checker.ts src/services/../compiler/factory.ts src/services/../compiler/visitor.ts src/services/../compiler/transformers/ts.ts src/services/../compiler/transformers/jsx.ts src/services/../compiler/transf
ormers/esnext.ts src/services/../compiler/transformers/es2017.ts src/services/../compiler/transformers/es2016.ts src/services/../compiler/transformers/es2015.ts src/services/../compiler/transformers/es5.ts src/services/../compiler/transformers/generators.ts src/services/
../compiler/transformers/destructuring.ts src/services/../compiler/transformers/module/module.ts src/services/../compiler/transformers/module/system.ts src/services/../compiler/transformers/module/es2015.ts src/services/../compiler/transformer.ts src/services/../compiler
/comments.ts src/services/../compiler/sourcemap.ts src/services/../compiler/declarationEmitter.ts src/services/../compiler/emitter.ts src/services/../compiler/program.ts src/services/../compiler/commandLineParser.ts src/services/../compiler/diagnosticInformationMap.gener
ated.ts src/services/types.ts src/services/utilities.ts src/services/breakpoints.ts src/services/classifier.ts src/services/completions.ts src/services/documentHighlights.ts src/services/documentRegistry.ts src/services/findAllReferences.ts src/services/goToDefinition.ts
 src/services/goToImplementation.ts src/services/jsDoc.ts src/services/jsTyping.ts src/services/navigateTo.ts src/services/navigationBar.ts src/services/outliningElementsCollector.ts src/services/pathCompletions.ts src/services/patternMatcher.ts src/services/preProcess.t
s src/services/rename.ts src/services/services.ts src/services/transform.ts src/services/transpile.ts src/services/shims.ts src/services/signatureHelp.ts src/services/symbolDisplay.ts src/services/textChanges.ts src/services/formatting/formatting.ts src/services/formatti
ng/formattingContext.ts src/services/formatting/formattingRequestKind.ts src/services/formatting/formattingScanner.ts src/services/formatting/references.ts src/services/formatting/rule.ts src/services/formatting/ruleAction.ts src/services/formatting/ruleDescriptor.ts src
/services/formatting/ruleFlag.ts src/services/formatting/ruleOperation.ts src/services/formatting/ruleOperationContext.ts src/services/formatting/rules.ts src/services/formatting/rulesMap.ts src/services/formatting/rulesProvider.ts src/services/formatting/smartIndenter.t
s src/services/formatting/tokenRange.ts src/services/codeFixProvider.ts src/services/codefixes/fixAddMissingMember.ts src/services/codefixes/fixExtendsInterfaceBecomesImplements.ts src/services/codefixes/fixClassIncorrectlyImplementsInterface.ts src/services/codefixes/fi
xClassDoesntImplementInheritedAbstractMember.ts src/services/codefixes/fixClassSuperMustPrecedeThisAccess.ts src/services/codefixes/fixConstructorForDerivedNeedSuperCall.ts src/services/codefixes/fixForgottenThisPropertyAccess.ts src/services/codefixes/fixes.ts src/servi
ces/codefixes/helpers.ts src/services/codefixes/importFixes.ts src/services/codefixes/unusedIdentifierFixes.ts src/services/codefixes/disableJsDiagnostics.ts
```