### PR TITLE
Clean up literal emit

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1854,7 +1854,7 @@ namespace ts {
         }
 
         function checkStrictModeNumericLiteral(node: NumericLiteral) {
-            if (inStrictMode && node.isOctalLiteral) {
+            if (inStrictMode && node.numericLiteralFlags & NumericLiteralFlags.Octal) {
                 file.bindDiagnostics.push(createDiagnosticForNode(node, Diagnostics.Octal_literals_are_not_allowed_in_strict_mode));
             }
         }
@@ -3325,6 +3325,18 @@ namespace ts {
             case SyntaxKind.MetaProperty:
                 // These nodes are ES6 syntax.
                 transformFlags |= TransformFlags.AssertES2015;
+                break;
+
+            case SyntaxKind.StringLiteral:
+                if ((<StringLiteral>node).hasExtendedUnicodeEscape) {
+                    transformFlags |= TransformFlags.AssertES2015;
+                }
+                break;
+
+            case SyntaxKind.NumericLiteral:
+                if ((<NumericLiteral>node).numericLiteralFlags & NumericLiteralFlags.BinaryOrOctalSpecifier) {
+                    transformFlags |= TransformFlags.AssertES2015;
+                }
                 break;
 
             case SyntaxKind.ForOfStatement:

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -23986,7 +23986,7 @@ namespace ts {
 
         function checkGrammarNumericLiteral(node: NumericLiteral): boolean {
             // Grammar checking
-            if (node.isOctalLiteral) {
+            if (node.numericLiteralFlags & NumericLiteralFlags.Octal) {
                 let diagnosticMessage: DiagnosticMessage | undefined;
                 if (languageVersion >= ScriptTarget.ES5) {
                     diagnosticMessage = Diagnostics.Octal_literals_are_not_available_when_targeting_ECMAScript_5_and_higher_Use_the_syntax_0;

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1455,7 +1455,7 @@ namespace ts {
         return /^\.\.?($|[\\/])/.test(moduleName);
     }
 
-    export function getEmitScriptTarget(compilerOptions: CompilerOptions | PrinterOptions) {
+    export function getEmitScriptTarget(compilerOptions: CompilerOptions) {
         return compilerOptions.target || ScriptTarget.ES3;
     }
 

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -204,7 +204,6 @@ namespace ts {
         } = handlers;
 
         const newLine = getNewLineCharacter(printerOptions);
-        const languageVersion = getEmitScriptTarget(printerOptions);
         const comments = createCommentWriter(printerOptions, onEmitSourceMapOfPosition);
         const {
             emitNodeWithComments,
@@ -1084,7 +1083,7 @@ namespace ts {
                 }
 
                 const preferNewLine = node.multiLine ? ListFormat.PreferNewLine : ListFormat.None;
-                const allowTrailingComma = languageVersion >= ScriptTarget.ES5 ? ListFormat.AllowTrailingComma : ListFormat.None;
+                const allowTrailingComma = currentSourceFile.languageVersion >= ScriptTarget.ES5 ? ListFormat.AllowTrailingComma : ListFormat.None;
                 emitList(node, properties, ListFormat.ObjectLiteralExpressionProperties | allowTrailingComma | preferNewLine);
 
                 if (indentedFlag) {
@@ -1118,11 +1117,11 @@ namespace ts {
         // 1..toString is a valid property access, emit a dot after the literal
         // Also emit a dot if expression is a integer const enum value - it will appear in generated code as numeric literal
         function needsDotDotForPropertyAccess(expression: Expression) {
-            if (expression.kind === SyntaxKind.NumericLiteral) {
+            expression = skipPartiallyEmittedExpressions(expression);
+            if (isNumericLiteral(expression)) {
                 // check if numeric literal is a decimal literal that was originally written with a dot
                 const text = getLiteralTextOfNode(<LiteralExpression>expression);
-                return getNumericLiteralFlags(text, /*hint*/ NumericLiteralFlags.All) === NumericLiteralFlags.None
-                    && !(<LiteralExpression>expression).isOctalLiteral
+                return !expression.numericLiteralFlags
                     && text.indexOf(tokenToString(SyntaxKind.DotToken)) < 0;
             }
             else if (isPropertyAccessExpression(expression) || isElementAccessExpression(expression)) {
@@ -2638,7 +2637,7 @@ namespace ts {
                 }
             }
 
-            return getLiteralText(node, currentSourceFile, languageVersion);
+            return getLiteralText(node, currentSourceFile);
         }
 
         /**

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -88,6 +88,7 @@ namespace ts {
     export function createNumericLiteral(value: string): NumericLiteral {
         const node = <NumericLiteral>createSynthesizedNode(SyntaxKind.NumericLiteral);
         node.text = value;
+        node.numericLiteralFlags = 0;
         return node;
     }
 

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -3365,17 +3365,14 @@ namespace ts {
      */
     export function parenthesizeForAccess(expression: Expression): LeftHandSideExpression {
         // isLeftHandSideExpression is almost the correct criterion for when it is not necessary
-        // to parenthesize the expression before a dot. The known exceptions are:
+        // to parenthesize the expression before a dot. The known exception is:
         //
         //    NewExpression:
         //       new C.x        -> not the same as (new C).x
-        //    NumericLiteral
-        //       1.x            -> not the same as (1).x
         //
         const emittedExpression = skipPartiallyEmittedExpressions(expression);
         if (isLeftHandSideExpression(emittedExpression)
-            && (emittedExpression.kind !== SyntaxKind.NewExpression || (<NewExpression>emittedExpression).arguments)
-            && emittedExpression.kind !== SyntaxKind.NumericLiteral) {
+            && (emittedExpression.kind !== SyntaxKind.NewExpression || (<NewExpression>emittedExpression).arguments)) {
             return <LeftHandSideExpression>expression;
         }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2031,22 +2031,18 @@ namespace ts {
                 node.isUnterminated = true;
             }
 
-            const tokenPos = scanner.getTokenPos();
-            nextToken();
-            finishNode(node);
-
             // Octal literals are not allowed in strict mode or ES5
             // Note that theoretically the following condition would hold true literals like 009,
             // which is not octal.But because of how the scanner separates the tokens, we would
             // never get a token like this. Instead, we would get 00 and 9 as two separate tokens.
             // We also do not need to check for negatives because any prefix operator would be part of a
             // parent unary expression.
-            if (node.kind === SyntaxKind.NumericLiteral
-                && sourceText.charCodeAt(tokenPos) === CharacterCodes._0
-                && isOctalDigit(sourceText.charCodeAt(tokenPos + 1))) {
-
-                node.isOctalLiteral = true;
+            if (node.kind === SyntaxKind.NumericLiteral) {
+                (<NumericLiteral>node).numericLiteralFlags = scanner.getNumericLiteralFlags();
             }
+
+            nextToken();
+            finishNode(node);
 
             return node;
         }

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -23,6 +23,8 @@ namespace ts {
         isIdentifier(): boolean;
         isReservedWord(): boolean;
         isUnterminated(): boolean;
+        /* @internal */
+        getNumericLiteralFlags(): NumericLiteralFlags;
         reScanGreaterToken(): SyntaxKind;
         reScanSlashToken(): SyntaxKind;
         reScanTemplateToken(): SyntaxKind;
@@ -799,6 +801,7 @@ namespace ts {
         let precedingLineBreak: boolean;
         let hasExtendedUnicodeEscape: boolean;
         let tokenIsUnterminated: boolean;
+        let numericLiteralFlags: NumericLiteralFlags;
 
         setText(text, start, length);
 
@@ -814,6 +817,7 @@ namespace ts {
             isIdentifier: () => token === SyntaxKind.Identifier || token > SyntaxKind.LastReservedWord,
             isReservedWord: () => token >= SyntaxKind.FirstReservedWord && token <= SyntaxKind.LastReservedWord,
             isUnterminated: () => tokenIsUnterminated,
+            getNumericLiteralFlags: () => numericLiteralFlags,
             reScanGreaterToken,
             reScanSlashToken,
             reScanTemplateToken,
@@ -850,6 +854,7 @@ namespace ts {
             let end = pos;
             if (text.charCodeAt(pos) === CharacterCodes.E || text.charCodeAt(pos) === CharacterCodes.e) {
                 pos++;
+                numericLiteralFlags = NumericLiteralFlags.Scientific;
                 if (text.charCodeAt(pos) === CharacterCodes.plus || text.charCodeAt(pos) === CharacterCodes.minus) pos++;
                 if (isDigit(text.charCodeAt(pos))) {
                     pos++;
@@ -1221,6 +1226,7 @@ namespace ts {
             hasExtendedUnicodeEscape = false;
             precedingLineBreak = false;
             tokenIsUnterminated = false;
+            numericLiteralFlags = 0;
             while (true) {
                 tokenPos = pos;
                 if (pos >= end) {
@@ -1419,6 +1425,7 @@ namespace ts {
                                 value = 0;
                             }
                             tokenValue = "" + value;
+                            numericLiteralFlags = NumericLiteralFlags.HexSpecifier;
                             return token = SyntaxKind.NumericLiteral;
                         }
                         else if (pos + 2 < end && (text.charCodeAt(pos + 1) === CharacterCodes.B || text.charCodeAt(pos + 1) === CharacterCodes.b)) {
@@ -1429,6 +1436,7 @@ namespace ts {
                                 value = 0;
                             }
                             tokenValue = "" + value;
+                            numericLiteralFlags = NumericLiteralFlags.BinarySpecifier;
                             return token = SyntaxKind.NumericLiteral;
                         }
                         else if (pos + 2 < end && (text.charCodeAt(pos + 1) === CharacterCodes.O || text.charCodeAt(pos + 1) === CharacterCodes.o)) {
@@ -1439,11 +1447,13 @@ namespace ts {
                                 value = 0;
                             }
                             tokenValue = "" + value;
+                            numericLiteralFlags = NumericLiteralFlags.OctalSpecifier;
                             return token = SyntaxKind.NumericLiteral;
                         }
                         // Try to parse as an octal
                         if (pos + 1 < end && isOctalDigit(text.charCodeAt(pos + 1))) {
                             tokenValue = "" + scanOctalDigits();
+                            numericLiteralFlags = NumericLiteralFlags.Octal;
                             return token = SyntaxKind.NumericLiteral;
                         }
                         // This fall-through is a deviation from the EcmaScript grammar. The grammar says that a leading zero

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -466,6 +466,12 @@ namespace ts {
                 case SyntaxKind.TemplateTail:
                     return visitTemplateLiteral(<LiteralExpression>node);
 
+                case SyntaxKind.StringLiteral:
+                    return visitStringLiteral(<StringLiteral>node);
+
+                case SyntaxKind.NumericLiteral:
+                    return visitNumericLiteral(<NumericLiteral>node);
+
                 case SyntaxKind.TaggedTemplateExpression:
                     return visitTaggedTemplateExpression(<TaggedTemplateExpression>node);
 
@@ -3412,6 +3418,30 @@ namespace ts {
          */
         function visitTemplateLiteral(node: LiteralExpression): LeftHandSideExpression {
             return setTextRange(createLiteral(node.text), node);
+        }
+
+        /**
+         * Visits a string literal with an extended unicode escape.
+         *
+         * @param node A string literal.
+         */
+        function visitStringLiteral(node: StringLiteral) {
+            if (node.hasExtendedUnicodeEscape) {
+                return setTextRange(createLiteral(node.text), node);
+            }
+            return node;
+        }
+
+        /**
+         * Visits a binary or octal (ES6) numeric literal.
+         *
+         * @param node A string literal.
+         */
+        function visitNumericLiteral(node: NumericLiteral) {
+            if (node.numericLiteralFlags & NumericLiteralFlags.BinaryOrOctalSpecifier) {
+                return setTextRange(createNumericLiteral(node.text), node);
+            }
+            return node;
         }
 
         /**

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -1313,8 +1313,6 @@ namespace ts {
         text: string;
         isUnterminated?: boolean;
         hasExtendedUnicodeEscape?: boolean;
-        /* @internal */
-        isOctalLiteral?: boolean;
     }
 
     // The text property of a LiteralExpression stores the interpreted value of the literal in text form. For a StringLiteral,
@@ -1332,8 +1330,21 @@ namespace ts {
         kind: SyntaxKind.NoSubstitutionTemplateLiteral;
     }
 
+    /* @internal */
+    export const enum NumericLiteralFlags {
+        None = 0,
+        Scientific = 1 << 1,        // e.g. `10e2`
+        Octal = 1 << 2,             // e.g. `0777`
+        HexSpecifier = 1 << 3,      // e.g. `0x00000000`
+        BinarySpecifier = 1 << 4,   // e.g. `0b0110010000000000`
+        OctalSpecifier = 1 << 5,    // e.g. `0o777`
+        BinaryOrOctalSpecifier = BinarySpecifier | OctalSpecifier,
+    }
+
     export interface NumericLiteral extends LiteralExpression {
         kind: SyntaxKind.NumericLiteral;
+        /* @internal */
+        numericLiteralFlags?: NumericLiteralFlags;
     }
 
     export interface TemplateHead extends LiteralLikeNode {
@@ -4189,7 +4200,6 @@ namespace ts {
     }
 
     export interface PrinterOptions {
-        target?: ScriptTarget;
         removeComments?: boolean;
         newLine?: NewLineKind;
         /*@internal*/ sourceMap?: boolean;

--- a/src/harness/unittests/printer.ts
+++ b/src/harness/unittests/printer.ts
@@ -52,6 +52,9 @@ namespace ts {
 
             printsCorrectly("default", {}, printer => printer.printFile(sourceFile));
             printsCorrectly("removeComments", { removeComments: true }, printer => printer.printFile(sourceFile));
+
+            // github #14948
+            printsCorrectly("templateLiteral", {}, printer => printer.printFile(createSourceFile("source.ts", "let greeting = `Hi ${name}, how are you?`;", ScriptTarget.ES2017)));
         });
 
         describe("printBundle", () => {

--- a/tests/baselines/reference/castExpressionParentheses.js
+++ b/tests/baselines/reference/castExpressionParentheses.js
@@ -24,15 +24,15 @@ declare var a;
 (<any>a[0]);
 (<any>a.b["0"]);
 (<any>a()).x;
-
-declare var A;
-
-// should keep the parentheses in emit
 (<any>1).foo;
 (<any>1.).foo;
 (<any>1.0).foo;
 (<any>12e+34).foo;
 (<any>0xff).foo;
+
+declare var A;
+
+// should keep the parentheses in emit
 (<any>(1.0)); 
 (<any>new A).foo; 
 (<any>typeof A).x; 
@@ -74,12 +74,12 @@ a;
 a[0];
 a.b["0"];
 a().x;
+1..foo;
+1..foo;
+1.0.foo;
+12e+34.foo;
+0xff.foo;
 // should keep the parentheses in emit
-(1).foo;
-(1.).foo;
-(1.0).foo;
-(12e+34).foo;
-(0xff).foo;
 (1.0);
 (new A).foo;
 (typeof A).x;

--- a/tests/baselines/reference/castExpressionParentheses.symbols
+++ b/tests/baselines/reference/castExpressionParentheses.symbols
@@ -37,27 +37,28 @@ declare var a;
 (<any>a()).x;
 >a : Symbol(a, Decl(castExpressionParentheses.ts, 0, 11))
 
-declare var A;
->A : Symbol(A, Decl(castExpressionParentheses.ts, 26, 11))
-
-// should keep the parentheses in emit
 (<any>1).foo;
 (<any>1.).foo;
 (<any>1.0).foo;
 (<any>12e+34).foo;
 (<any>0xff).foo;
+
+declare var A;
+>A : Symbol(A, Decl(castExpressionParentheses.ts, 31, 11))
+
+// should keep the parentheses in emit
 (<any>(1.0)); 
 (<any>new A).foo; 
->A : Symbol(A, Decl(castExpressionParentheses.ts, 26, 11))
+>A : Symbol(A, Decl(castExpressionParentheses.ts, 31, 11))
 
 (<any>typeof A).x; 
->A : Symbol(A, Decl(castExpressionParentheses.ts, 26, 11))
+>A : Symbol(A, Decl(castExpressionParentheses.ts, 31, 11))
 
 (<any>-A).x; 
->A : Symbol(A, Decl(castExpressionParentheses.ts, 26, 11))
+>A : Symbol(A, Decl(castExpressionParentheses.ts, 31, 11))
 
 new (<any>A());
->A : Symbol(A, Decl(castExpressionParentheses.ts, 26, 11))
+>A : Symbol(A, Decl(castExpressionParentheses.ts, 31, 11))
 
 (<Tany>()=> {})();
 >Tany : Symbol(Tany, Decl(castExpressionParentheses.ts, 39, 2))
@@ -66,14 +67,14 @@ new (<any>A());
 >foo : Symbol(foo, Decl(castExpressionParentheses.ts, 40, 6))
 
 (<any><number><any>-A).x; 
->A : Symbol(A, Decl(castExpressionParentheses.ts, 26, 11))
+>A : Symbol(A, Decl(castExpressionParentheses.ts, 31, 11))
 
 // nested cast, should keep one pair of parenthese
 (<any><number>(<any>-A)).x; 
->A : Symbol(A, Decl(castExpressionParentheses.ts, 26, 11))
+>A : Symbol(A, Decl(castExpressionParentheses.ts, 31, 11))
 
 // nested parenthesized expression, should keep one pair of parenthese
 (<any>(A)) 
->A : Symbol(A, Decl(castExpressionParentheses.ts, 26, 11))
+>A : Symbol(A, Decl(castExpressionParentheses.ts, 31, 11))
 
 

--- a/tests/baselines/reference/castExpressionParentheses.types
+++ b/tests/baselines/reference/castExpressionParentheses.types
@@ -125,10 +125,6 @@ declare var a;
 >a : any
 >x : any
 
-declare var A;
->A : any
-
-// should keep the parentheses in emit
 (<any>1).foo;
 >(<any>1).foo : any
 >(<any>1) : any
@@ -164,6 +160,10 @@ declare var A;
 >0xff : 255
 >foo : any
 
+declare var A;
+>A : any
+
+// should keep the parentheses in emit
 (<any>(1.0)); 
 >(<any>(1.0)) : any
 ><any>(1.0) : any

--- a/tests/baselines/reference/destructuringInVariableDeclarations1.js
+++ b/tests/baselines/reference/destructuringInVariableDeclarations1.js
@@ -8,7 +8,7 @@ export let { toString } = 1;
 //// [destructuringInVariableDeclarations1.js]
 "use strict";
 Object.defineProperty(exports, "__esModule", { value: true });
-exports.toString = (1).toString;
+exports.toString = 1..toString;
 {
     let { toFixed } = 1;
 }

--- a/tests/baselines/reference/destructuringInVariableDeclarations3.js
+++ b/tests/baselines/reference/destructuringInVariableDeclarations3.js
@@ -9,7 +9,7 @@ export let { toString } = 1;
 define(["require", "exports"], function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
-    exports.toString = (1).toString;
+    exports.toString = 1..toString;
     {
         let { toFixed } = 1;
     }

--- a/tests/baselines/reference/destructuringInVariableDeclarations5.js
+++ b/tests/baselines/reference/destructuringInVariableDeclarations5.js
@@ -17,7 +17,7 @@ export let { toString } = 1;
 })(function (require, exports) {
     "use strict";
     Object.defineProperty(exports, "__esModule", { value: true });
-    exports.toString = (1).toString;
+    exports.toString = 1..toString;
     {
         let { toFixed } = 1;
     }

--- a/tests/baselines/reference/destructuringInVariableDeclarations7.js
+++ b/tests/baselines/reference/destructuringInVariableDeclarations7.js
@@ -13,7 +13,7 @@ System.register([], function (exports_1, context_1) {
     return {
         setters: [],
         execute: function () {
-            exports_1("toString", toString = (1).toString);
+            exports_1("toString", toString = 1..toString);
             {
                 let { toFixed } = 1;
             }

--- a/tests/baselines/reference/destructuringInVariableDeclarations8.js
+++ b/tests/baselines/reference/destructuringInVariableDeclarations8.js
@@ -14,7 +14,7 @@ System.register([], function (exports_1, context_1) {
     return {
         setters: [],
         execute: function () {
-            toString = (1).toString;
+            toString = 1..toString;
             {
                 let { toFixed } = 1;
             }

--- a/tests/baselines/reference/destructuringTypeAssertionsES5_5.js
+++ b/tests/baselines/reference/destructuringTypeAssertionsES5_5.js
@@ -2,4 +2,4 @@
 var { x } = <any>0;
 
 //// [destructuringTypeAssertionsES5_5.js]
-var x = (0).x;
+var x = 0..x;

--- a/tests/baselines/reference/destructuringWithNumberLiteral.js
+++ b/tests/baselines/reference/destructuringWithNumberLiteral.js
@@ -2,4 +2,4 @@
 var { toExponential } = 0;
 
 //// [destructuringWithNumberLiteral.js]
-var toExponential = (0).toExponential;
+var toExponential = 0..toExponential;

--- a/tests/baselines/reference/duplicateIdentifierDifferentSpelling.js
+++ b/tests/baselines/reference/duplicateIdentifierDifferentSpelling.js
@@ -10,7 +10,7 @@ var X = { 0b11: '', 3: '' };
 //// [duplicateIdentifierDifferentSpelling.js]
 var A = (function () {
     function A() {
-        this[3] = '';
+        this[0b11] = '';
         this[3] = '';
     }
     return A;

--- a/tests/baselines/reference/printerApi/printsFileCorrectly.templateLiteral.js
+++ b/tests/baselines/reference/printerApi/printsFileCorrectly.templateLiteral.js
@@ -1,0 +1,1 @@
+let greeting = `Hi ${name}, how are you?`;

--- a/tests/cases/compiler/castExpressionParentheses.ts
+++ b/tests/cases/compiler/castExpressionParentheses.ts
@@ -23,15 +23,15 @@ declare var a;
 (<any>a[0]);
 (<any>a.b["0"]);
 (<any>a()).x;
-
-declare var A;
-
-// should keep the parentheses in emit
 (<any>1).foo;
 (<any>1.).foo;
 (<any>1.0).foo;
 (<any>12e+34).foo;
 (<any>0xff).foo;
+
+declare var A;
+
+// should keep the parentheses in emit
 (<any>(1.0)); 
 (<any>new A).foo; 
 (<any>typeof A).x; 


### PR DESCRIPTION
This change simplifies some of the logic for emitting string and numeric literals:

* String literals with extended Unicode escape sequences are now handled by the ES2015 transformer rather than the emitter.
* Numeric literals with Binary (`0b`) or Octal (`0o`) specifiers are now handled by the ES2015 transformer rather than the emitter.
* The logic used to detect whether a numeric literal is using Hexadecimal (`0x`), Binary (`0b`), Octal (`0o`), ES3 Octal, or Scientific notation was already present in the scanner, so the result of scanning this literal is now stored on the node as `numericLiteralFlags` rather than re-computed during emit. 
* `isOctalLiteral` was removed as it was replaced by `NumericLiteralFlags.ES3Octal` and the `numericLiteralFlags` property.
* `target` was removed from `PrinterOptions` as it is no longer needed.

Fixes #14948 
