### PR TITLE
Only bind JSDoc typedefs in JavaScript files

### DIFF
--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -1910,7 +1910,9 @@ namespace ts {
             // Here the current node is "foo", which is a container, but the scope of "MyType" should
             // not be inside "foo". Therefore we always bind @typedef before bind the parent node,
             // and skip binding this tag later when binding all the other jsdoc tags.
-            bindJSDocTypedefTagIfAny(node);
+            if (isInJavaScriptFile(node)) {
+                bindJSDocTypedefTagIfAny(node);
+            }
 
             // First we bind declaration nodes to a symbol if possible. We'll both create a symbol
             // and then potentially add the symbol to an appropriate symbol table. Possible

--- a/tests/baselines/reference/jsdocInTypeScript.js
+++ b/tests/baselines/reference/jsdocInTypeScript.js
@@ -1,0 +1,19 @@
+//// [jsdocInTypeScript.ts]
+// JSDoc typedef tags are not bound TypeScript files.
+/** @typedef {function} T */
+declare const x: T;
+
+class T {
+    prop: number;
+}
+
+x.prop;
+
+
+//// [jsdocInTypeScript.js]
+var T = (function () {
+    function T() {
+    }
+    return T;
+}());
+x.prop;

--- a/tests/baselines/reference/jsdocInTypeScript.symbols
+++ b/tests/baselines/reference/jsdocInTypeScript.symbols
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/jsdocInTypeScript.ts ===
+// JSDoc typedef tags are not bound TypeScript files.
+/** @typedef {function} T */
+declare const x: T;
+>x : Symbol(x, Decl(jsdocInTypeScript.ts, 2, 13))
+>T : Symbol(T, Decl(jsdocInTypeScript.ts, 2, 19))
+
+class T {
+>T : Symbol(T, Decl(jsdocInTypeScript.ts, 2, 19))
+
+    prop: number;
+>prop : Symbol(T.prop, Decl(jsdocInTypeScript.ts, 4, 9))
+}
+
+x.prop;
+>x.prop : Symbol(T.prop, Decl(jsdocInTypeScript.ts, 4, 9))
+>x : Symbol(x, Decl(jsdocInTypeScript.ts, 2, 13))
+>prop : Symbol(T.prop, Decl(jsdocInTypeScript.ts, 4, 9))
+

--- a/tests/baselines/reference/jsdocInTypeScript.types
+++ b/tests/baselines/reference/jsdocInTypeScript.types
@@ -1,0 +1,19 @@
+=== tests/cases/compiler/jsdocInTypeScript.ts ===
+// JSDoc typedef tags are not bound TypeScript files.
+/** @typedef {function} T */
+declare const x: T;
+>x : T
+>T : T
+
+class T {
+>T : T
+
+    prop: number;
+>prop : number
+}
+
+x.prop;
+>x.prop : number
+>x : T
+>prop : number
+

--- a/tests/cases/compiler/jsdocInTypeScript.ts
+++ b/tests/cases/compiler/jsdocInTypeScript.ts
@@ -1,0 +1,9 @@
+// JSDoc typedef tags are not bound TypeScript files.
+/** @typedef {function} T */
+declare const x: T;
+
+class T {
+    prop: number;
+}
+
+x.prop;


### PR DESCRIPTION
Fixes #14752
Looks like an `if` statement was forgotten in #14014.