### PR TITLE
charCodeAt defaults to first index: index is optional

### DIFF
--- a/lib/lib.es6.d.ts
+++ b/lib/lib.es6.d.ts
@@ -313,7 +313,7 @@ interface String {
       * Returns the Unicode value of the character at the specified location.
       * @param index The zero-based index of the desired character. If there is no character at the specified index, NaN is returned.
       */
-    charCodeAt(index: number): number;
+    charCodeAt(index?: number): number;
 
     /**
       * Returns a string that contains the concatenation of two or more strings.


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/charCodeAt

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
