### PR TITLE
Update linting to avoid typechecking for booleanTriviaRule

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -175,7 +175,7 @@ for (const i in libraryTargets) {
     const sources = [copyright].concat(entry.sources.map(function(s) {
         return path.join(libraryDirectory, s);
     }));
-    gulp.task(target, false, [], function() {
+    gulp.task(target, /*help*/ false, [], function() {
         return gulp.src(sources)
             .pipe(newer(target))
             .pipe(concat(target, { newLine: "\n\n" }))
@@ -275,7 +275,7 @@ function getCompilerSettings(base: tsc.Settings, useBuiltCompiler?: boolean): ts
     return copy;
 }
 
-gulp.task(configureNightlyJs, false, [], () => {
+gulp.task(configureNightlyJs, /*help*/ false, [], () => {
     const settings: tsc.Settings = {
         declaration: false,
         removeComments: true,
@@ -304,7 +304,7 @@ const importDefinitelyTypedTestsDirectory = path.join(scriptsDirectory, "importD
 const importDefinitelyTypedTestsJs = path.join(importDefinitelyTypedTestsDirectory, "importDefinitelyTypedTests.js");
 const importDefinitelyTypedTestsTs = path.join(importDefinitelyTypedTestsDirectory, "importDefinitelyTypedTests.ts");
 
-gulp.task(importDefinitelyTypedTestsJs, false, [], () => {
+gulp.task(importDefinitelyTypedTestsJs, /*help*/ false, [], () => {
     const settings: tsc.Settings = getCompilerSettings({
         declaration: false,
         removeComments: true,
@@ -335,7 +335,7 @@ const generatedDiagnosticMessagesJSON = path.join(compilerDirectory, "diagnostic
 const builtGeneratedDiagnosticMessagesJSON = path.join(builtLocalDirectory, "diagnosticMessages.generated.json");
 
 // processDiagnosticMessages script
-gulp.task(processDiagnosticMessagesJs, false, [], () => {
+gulp.task(processDiagnosticMessagesJs, /*help*/ false, [], () => {
     const settings: tsc.Settings = getCompilerSettings({
         target: "es5",
         declaration: false,
@@ -383,7 +383,7 @@ function prependCopyright(outputCopyright: boolean = !useDebugMode) {
     return insert.prepend(outputCopyright ? (copyrightContent || (copyrightContent = fs.readFileSync(copyright).toString())) : "");
 }
 
-gulp.task(builtLocalCompiler, false, [servicesFile], () => {
+gulp.task(builtLocalCompiler, /*help*/ false, [servicesFile], () => {
     const localCompilerProject = tsc.createProject("src/compiler/tsconfig.json", getCompilerSettings({}, /*useBuiltCompiler*/true));
     return localCompilerProject.src()
         .pipe(newer(builtLocalCompiler))
@@ -394,7 +394,7 @@ gulp.task(builtLocalCompiler, false, [servicesFile], () => {
         .pipe(gulp.dest("src/compiler"));
 });
 
-gulp.task(servicesFile, false, ["lib", "generate-diagnostics"], () => {
+gulp.task(servicesFile, /*help*/ false, ["lib", "generate-diagnostics"], () => {
     const servicesProject = tsc.createProject("src/services/tsconfig.json", getCompilerSettings({ removeComments: false }, /*useBuiltCompiler*/false));
     const {js, dts} = servicesProject.src()
         .pipe(newer(servicesFile))
@@ -428,7 +428,7 @@ gulp.task(servicesFile, false, ["lib", "generate-diagnostics"], () => {
 
 // cancellationToken.js
 const cancellationTokenJs = path.join(builtLocalDirectory, "cancellationToken.js");
-gulp.task(cancellationTokenJs, false, [servicesFile], () => {
+gulp.task(cancellationTokenJs, /*help*/ false, [servicesFile], () => {
     const cancellationTokenProject = tsc.createProject("src/server/cancellationToken/tsconfig.json", getCompilerSettings({}, /*useBuiltCompiler*/true));
     return cancellationTokenProject.src()
         .pipe(newer(cancellationTokenJs))
@@ -441,7 +441,7 @@ gulp.task(cancellationTokenJs, false, [servicesFile], () => {
 
 // typingsInstallerFile.js
 const typingsInstallerJs = path.join(builtLocalDirectory, "typingsInstaller.js");
-gulp.task(typingsInstallerJs, false, [servicesFile], () => {
+gulp.task(typingsInstallerJs, /*help*/ false, [servicesFile], () => {
     const cancellationTokenProject = tsc.createProject("src/server/typingsInstaller/tsconfig.json", getCompilerSettings({}, /*useBuiltCompiler*/true));
     return cancellationTokenProject.src()
         .pipe(newer(typingsInstallerJs))
@@ -454,7 +454,7 @@ gulp.task(typingsInstallerJs, false, [servicesFile], () => {
 
 const serverFile = path.join(builtLocalDirectory, "tsserver.js");
 
-gulp.task(serverFile, false, [servicesFile, typingsInstallerJs, cancellationTokenJs], () => {
+gulp.task(serverFile, /*help*/ false, [servicesFile, typingsInstallerJs, cancellationTokenJs], () => {
     const serverProject = tsc.createProject("src/server/tsconfig.json", getCompilerSettings({}, /*useBuiltCompiler*/true));
     return serverProject.src()
         .pipe(newer(serverFile))
@@ -468,7 +468,7 @@ gulp.task(serverFile, false, [servicesFile, typingsInstallerJs, cancellationToke
 const tsserverLibraryFile = path.join(builtLocalDirectory, "tsserverlibrary.js");
 const tsserverLibraryDefinitionFile = path.join(builtLocalDirectory, "tsserverlibrary.d.ts");
 
-gulp.task(tsserverLibraryFile, false, [servicesFile], (done) => {
+gulp.task(tsserverLibraryFile, /*help*/ false, [servicesFile], (done) => {
     const serverLibraryProject = tsc.createProject("src/server/tsconfig.library.json", getCompilerSettings({}, /*useBuiltCompiler*/ true));
     const {js, dts}: { js: NodeJS.ReadableStream, dts: NodeJS.ReadableStream } = serverLibraryProject.src()
         .pipe(sourcemaps.init())
@@ -497,7 +497,7 @@ const word2mdTs = path.join(scriptsDirectory, "word2md.ts");
 const specWord = path.join(docDirectory, "TypeScript Language Specification.docx");
 const specMd = path.join(docDirectory, "spec.md");
 
-gulp.task(word2mdJs, false, [], () => {
+gulp.task(word2mdJs, /*help*/ false, [], () => {
     const settings: tsc.Settings = getCompilerSettings({
         outFile: word2mdJs
     }, /*useBuiltCompiler*/ false);
@@ -509,7 +509,7 @@ gulp.task(word2mdJs, false, [], () => {
         .pipe(gulp.dest("."));
 });
 
-gulp.task(specMd, false, [word2mdJs], (done) => {
+gulp.task(specMd, /*help*/ false, [word2mdJs], (done) => {
     const specWordFullPath = path.resolve(specWord);
     const specMDFullPath = path.resolve(specMd);
     const cmd = "cscript //nologo " + word2mdJs + " \"" + specWordFullPath + "\" " + "\"" + specMDFullPath + "\"";
@@ -525,10 +525,10 @@ gulp.task("clean", "Cleans the compiler output, declare files, and tests", [], (
     return del([builtDirectory]);
 });
 
-gulp.task("useDebugMode", false, [], (done) => { useDebugMode = true; done(); });
-gulp.task("dontUseDebugMode", false, [], (done) => { useDebugMode = false; done(); });
+gulp.task("useDebugMode", /*help*/ false, [], (done) => { useDebugMode = true; done(); });
+gulp.task("dontUseDebugMode", /*help*/ false, [], (done) => { useDebugMode = false; done(); });
 
-gulp.task("VerifyLKG", false, [], () => {
+gulp.task("VerifyLKG", /*help*/ false, [], () => {
     const expectedFiles = [builtLocalCompiler, servicesFile, serverFile, nodePackageFile, nodeDefinitionsFile, standaloneDefinitionsFile, tsserverLibraryFile, tsserverLibraryDefinitionFile, typingsInstallerJs, cancellationTokenJs].concat(libraryTargets);
     const missingFiles = expectedFiles.filter(function(f) {
         return !fs.existsSync(f);
@@ -541,7 +541,7 @@ gulp.task("VerifyLKG", false, [], () => {
     return gulp.src(expectedFiles).pipe(gulp.dest(LKGDirectory));
 });
 
-gulp.task("LKGInternal", false, ["lib", "local"]);
+gulp.task("LKGInternal", /*help*/ false, ["lib", "local"]);
 
 gulp.task("LKG", "Makes a new LKG out of the built js files", ["clean", "dontUseDebugMode"], () => {
     return runSequence("LKGInternal", "VerifyLKG");
@@ -550,7 +550,7 @@ gulp.task("LKG", "Makes a new LKG out of the built js files", ["clean", "dontUse
 
 // Task to build the tests infrastructure using the built compiler
 const run = path.join(builtLocalDirectory, "run.js");
-gulp.task(run, false, [servicesFile], () => {
+gulp.task(run, /*help*/ false, [servicesFile], () => {
     const testProject = tsc.createProject("src/harness/tsconfig.json", getCompilerSettings({}, /*useBuiltCompiler*/true));
     return testProject.src()
         .pipe(newer(run))
@@ -724,7 +724,7 @@ gulp.task("runtests",
 
 const nodeServerOutFile = "tests/webTestServer.js";
 const nodeServerInFile = "tests/webTestServer.ts";
-gulp.task(nodeServerOutFile, false, [servicesFile], () => {
+gulp.task(nodeServerOutFile, /*help*/ false, [servicesFile], () => {
     const settings: tsc.Settings = getCompilerSettings({ module: "commonjs" }, /*useBuiltCompiler*/ true);
     return gulp.src(nodeServerInFile)
         .pipe(newer(nodeServerOutFile))
@@ -889,7 +889,7 @@ gulp.task("baseline-accept-test262", "Makes the most recent test262 test results
 // Webhost
 const webhostPath = "tests/webhost/webtsc.ts";
 const webhostJsPath = "tests/webhost/webtsc.js";
-gulp.task(webhostJsPath, false, [servicesFile], () => {
+gulp.task(webhostJsPath, /*help*/ false, [servicesFile], () => {
     const settings: tsc.Settings = getCompilerSettings({
         outFile: webhostJsPath
     }, /*useBuiltCompiler*/ true);
@@ -909,7 +909,7 @@ gulp.task("webhost", "Builds the tsc web host", [webhostJsPath], () => {
 // Perf compiler
 const perftscPath = "tests/perftsc.ts";
 const perftscJsPath = "built/local/perftsc.js";
-gulp.task(perftscJsPath, false, [servicesFile], () => {
+gulp.task(perftscJsPath, /*help*/ false, [servicesFile], () => {
     const settings: tsc.Settings = getCompilerSettings({
         outFile: perftscJsPath
     }, /*useBuiltCompiler*/ true);
@@ -927,10 +927,10 @@ gulp.task("perftsc", "Builds augmented version of the compiler for perf tests", 
 // Instrumented compiler
 const loggedIOpath = path.join(harnessDirectory, "loggedIO.ts");
 const loggedIOJsPath = path.join(builtLocalDirectory, "loggedIO.js");
-gulp.task(loggedIOJsPath, false, [], (done) => {
+gulp.task(loggedIOJsPath, /*help*/ false, [], (done) => {
     const temp = path.join(builtLocalDirectory, "temp");
     mkdirP(temp, (err) => {
-        if (err) { console.error(err); done(err); process.exit(1); };
+        if (err) { console.error(err); done(err); process.exit(1); }
         exec(host, [LKGCompiler, "--types --outdir", temp, loggedIOpath], () => {
             fs.renameSync(path.join(temp, "/harness/loggedIO.js"), loggedIOJsPath);
             del(temp).then(() => done(), done);
@@ -940,7 +940,7 @@ gulp.task(loggedIOJsPath, false, [], (done) => {
 
 const instrumenterPath = path.join(harnessDirectory, "instrumenter.ts");
 const instrumenterJsPath = path.join(builtLocalDirectory, "instrumenter.js");
-gulp.task(instrumenterJsPath, false, [servicesFile], () => {
+gulp.task(instrumenterJsPath, /*help*/ false, [servicesFile], () => {
     const settings: tsc.Settings = getCompilerSettings({
         outFile: instrumenterJsPath
     }, /*useBuiltCompiler*/ true);

--- a/scripts/tslint/booleanTriviaRule.ts
+++ b/scripts/tslint/booleanTriviaRule.ts
@@ -3,7 +3,6 @@ import * as ts from "typescript";
 
 export class Rule extends Lint.Rules.AbstractRule {
     public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
-        // Cheat to get type checker
         return this.applyWithFunction(sourceFile, ctx => walk(ctx));
     }
 }

--- a/scripts/tslint/booleanTriviaRule.ts
+++ b/scripts/tslint/booleanTriviaRule.ts
@@ -18,10 +18,6 @@ function walk(ctx: Lint.WalkContext<void>): void {
     }
 
     function checkCall(node: ts.CallExpression): void {
-        if (!node.arguments) {
-            return;
-        }
-
         for (const arg of node.arguments) {
             if (arg.kind !== ts.SyntaxKind.TrueKeyword && arg.kind !== ts.SyntaxKind.FalseKeyword) {
                 continue;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9680,7 +9680,7 @@ namespace ts {
                 const original = getTypeOfSymbol(property);
                 const updated = f(original);
                 members.set(property.name, updated === original ? property : createSymbolWithType(property, updated));
-            };
+            }
             return members;
         }
 
@@ -9724,7 +9724,7 @@ namespace ts {
                 // Since get accessors already widen their return value there is no need to
                 // widen accessor based properties here.
                 members.set(prop.name, prop.flags & SymbolFlags.Property ? getWidenedProperty(prop) : prop);
-            };
+            }
             const stringIndexInfo = getIndexInfoOfType(type, IndexKind.String);
             const numberIndexInfo = getIndexInfoOfType(type, IndexKind.Number);
             return createAnonymousType(type.symbol, members, emptyArray, emptyArray,
@@ -15100,7 +15100,7 @@ namespace ts {
                         if (!checkApplicableSignature(node, args, candidate, relation, excludeArgument, /*reportErrors*/ false)) {
                             break;
                         }
-                        const index = excludeArgument ? indexOf(excludeArgument, true) : -1;
+                        const index = excludeArgument ? indexOf(excludeArgument, /*value*/ true) : -1;
                         if (index < 0) {
                             return candidate;
                         }
@@ -18728,7 +18728,7 @@ namespace ts {
                         case SyntaxKind.ConstructorType:
                             checkUnusedTypeParameters(<FunctionLikeDeclaration>node);
                             break;
-                    };
+                    }
                 }
             }
         }

--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -1580,7 +1580,7 @@ namespace ts {
                         delete wildcardDirectories[key];
                     }
                 }
-            };
+            }
         }
 
         return wildcardDirectories;

--- a/src/compiler/declarationEmitter.ts
+++ b/src/compiler/declarationEmitter.ts
@@ -590,7 +590,7 @@ namespace ts {
             currentIdentifiers = node.identifiers;
             isCurrentFileExternalModule = isExternalModule(node);
             enclosingDeclaration = node;
-            emitDetachedComments(currentText, currentLineMap, writer, writeCommentRange, node, newLine, true /* remove comments */);
+            emitDetachedComments(currentText, currentLineMap, writer, writeCommentRange, node, newLine, /*removeComents*/ true);
             emitLines(node.statements);
         }
 

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -1845,7 +1845,7 @@ namespace ts {
                 case ParsingContext.JSDocTupleTypes: return Diagnostics.Type_expected;
                 case ParsingContext.JSDocRecordMembers: return Diagnostics.Property_assignment_expected;
             }
-        };
+        }
 
         // Parses a comma-delimited list of elements
         function parseDelimitedList<T extends Node>(kind: ParsingContext, parseElement: () => T, considerSemicolonAsDelimiter?: boolean): NodeArray<T> {

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -54,10 +54,10 @@ namespace ts {
         referenceCount: number;
     }
 
-    declare var require: any;
-    declare var process: any;
-    declare var global: any;
-    declare var __filename: string;
+    declare const require: any;
+    declare const process: any;
+    declare const global: any;
+    declare const __filename: string;
 
     export function getNodeMajorVersion() {
         if (typeof process === "undefined") {
@@ -74,7 +74,7 @@ namespace ts {
         return parseInt(version.substring(1, dot));
     }
 
-    declare var ChakraHost: {
+    declare const ChakraHost: {
         args: string[];
         currentDirectory: string;
         executingFile: string;
@@ -368,7 +368,7 @@ namespace ts {
                             if (eventName === "rename") {
                                 // When deleting a file, the passed baseFileName is null
                                 callback(!relativeFileName ? relativeFileName : normalizePath(combinePaths(directoryName, relativeFileName)));
-                            };
+                            }
                         }
                     );
                 },

--- a/src/compiler/transformers/module/module.ts
+++ b/src/compiler/transformers/module/module.ts
@@ -1162,7 +1162,7 @@ namespace ts {
                 statement = createStatement(
                     createExportExpression(
                         createIdentifier("__esModule"),
-                        createLiteral(true)
+                        createLiteral(/*value*/ true)
                     )
                 );
             }
@@ -1175,7 +1175,7 @@ namespace ts {
                             createIdentifier("exports"),
                             createLiteral("__esModule"),
                             createObjectLiteral([
-                                createPropertyAssignment("value", createLiteral(true))
+                                createPropertyAssignment("value", createLiteral(/*value*/ true))
                             ])
                         ]
                     )

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -336,7 +336,7 @@ namespace ts {
                         // is an absolute file name.
                         directory == "" ? "." : directory,
                         watchedDirectoryChanged, /*recursive*/ true);
-                };
+                }
             }
             return configParseResult;
         }

--- a/src/harness/compilerRunner.ts
+++ b/src/harness/compilerRunner.ts
@@ -51,7 +51,7 @@ class CompilerBaselineRunner extends RunnerBase {
         const path = ts.toPath(name, root, (fileName) => Harness.Compiler.getCanonicalFileName(fileName));
         const pathStart = ts.toPath(Harness.IO.getCurrentDirectory(), "", (fileName) => Harness.Compiler.getCanonicalFileName(fileName));
         return pathStart ? path.replace(pathStart, "/") : path;
-    };
+    }
 
     public checkTestCodeOutput(fileName: string) {
         describe("compiler tests for " + fileName, () => {

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -1694,7 +1694,7 @@ namespace FourSlash {
                 if (ch === "\r") {
                     this.currentCaretPosition--;
                 }
-            };
+            }
         }
 
         private applyEdits(fileName: string, edits: ts.TextChange[], isFormattingEdit = false): number {

--- a/src/harness/unittests/cachingInServerLSHost.ts
+++ b/src/harness/unittests/cachingInServerLSHost.ts
@@ -123,7 +123,7 @@ namespace ts {
                 try {
                     // trigger synchronization to make sure that LSHost will try to find 'f2' module on disk
                     project.getLanguageService().getSemanticDiagnostics(imported.name);
-                    assert.isTrue(false, `should not find file '${imported.name}'`);
+                    assert.fail(false, `should not find file '${imported.name}'`);
                 }
                 catch (e) {
                     assert.isTrue(e.message.indexOf(`Could not find file: '${imported.name}'.`) === 0);

--- a/src/harness/unittests/cachingInServerLSHost.ts
+++ b/src/harness/unittests/cachingInServerLSHost.ts
@@ -123,7 +123,7 @@ namespace ts {
                 try {
                     // trigger synchronization to make sure that LSHost will try to find 'f2' module on disk
                     project.getLanguageService().getSemanticDiagnostics(imported.name);
-                    assert.fail(false, `should not find file '${imported.name}'`);
+                    assert.isTrue(false, `should not find file '${imported.name}'`);
                 }
                 catch (e) {
                     assert.isTrue(e.message.indexOf(`Could not find file: '${imported.name}'.`) === 0);

--- a/src/harness/unittests/convertToBase64.ts
+++ b/src/harness/unittests/convertToBase64.ts
@@ -22,7 +22,7 @@ namespace ts {
             });
 
             it("Converts simple code snippet correctly", () => {
-                runTest(`/// <reference path="file.ts" /> 
+                runTest(`/// <reference path="file.ts" />
 var x: string = "string";
 console.log(x);`);
             });

--- a/src/harness/unittests/moduleResolution.ts
+++ b/src/harness/unittests/moduleResolution.ts
@@ -151,7 +151,7 @@ namespace ts {
         it("module name as directory - handle invalid 'typings'", () => {
             testTypingsIgnored(["a", "b"]);
             testTypingsIgnored({ "a": "b" });
-            testTypingsIgnored(true);
+            testTypingsIgnored(/*typings*/true);
             /* tslint:disable no-null-keyword */
             testTypingsIgnored(null);
             /* tslint:enable no-null-keyword */

--- a/src/harness/unittests/session.ts
+++ b/src/harness/unittests/session.ts
@@ -326,7 +326,7 @@ namespace ts.server {
             send(msg: protocol.Message) {
                 this.lastSent = msg;
             }
-        };
+        }
 
         it("can override methods such as send", () => {
             const session = new TestSession();
@@ -367,7 +367,7 @@ namespace ts.server {
                     assert(this.projectService);
                     expect(this.projectService).to.be.instanceOf(ProjectService);
                 }
-            };
+            }
             new ServiceSession();
         });
     });
@@ -462,7 +462,7 @@ namespace ts.server {
                 });
                 this.callbacks[this.seq] = callback;
             }
-        };
+        }
 
         it("can be constructed and respond to commands", (done) => {
             const cli = new InProcClient();

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -174,7 +174,7 @@ namespace ts.projectSystem {
             request.type = "request";
             return this.executeCommand(<T>request);
         }
-    };
+    }
 
     export function createSession(host: server.ServerHost, typingsInstaller?: server.ITypingsInstaller, projectServiceEventHandler?: server.ProjectServiceEventHandler, cancellationToken?: server.ServerCancellationToken, throttleWaitMilliseconds?: number) {
         if (typingsInstaller === undefined) {
@@ -381,7 +381,7 @@ namespace ts.projectSystem {
         fileExists(s: string) {
             const path = this.toPath(s);
             return this.fs.contains(path) && isFile(this.fs.get(path));
-        };
+        }
 
         getFileSize(s: string) {
             const path = this.toPath(s);
@@ -476,11 +476,11 @@ namespace ts.projectSystem {
         // TOOD: record and invoke callbacks to simulate timer events
         setTimeout(callback: TimeOutCallback, _time: number, ...args: any[]) {
             return this.timeoutCallbacks.register(callback, args);
-        };
+        }
 
         clearTimeout(timeoutId: any): void {
             this.timeoutCallbacks.unregister(timeoutId);
-        };
+        }
 
         checkTimeoutQueueLength(expected: number) {
             const callbacksCount = this.timeoutCallbacks.count();
@@ -501,7 +501,7 @@ namespace ts.projectSystem {
 
         clearImmediate(timeoutId: any): void {
             this.immediateCallbacks.unregister(timeoutId);
-        };
+        }
 
         createDirectory(directoryName: string): void {
             this.createFileOrFolder({ path: directoryName });

--- a/src/server/builder.ts
+++ b/src/server/builder.ts
@@ -191,7 +191,7 @@ namespace ts.server {
             const l = lf.scriptInfo.fileName;
             const r = rf.scriptInfo.fileName;
             return (l < r ? -1 : (l > r ? 1 : 0));
-        };
+        }
 
         static addToReferenceList(array: ModuleBuilderFileInfo[], fileInfo: ModuleBuilderFileInfo) {
             if (array.length === 0) {

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -718,7 +718,7 @@ namespace ts.server {
     }
     catch (e) {
         cancellationToken = nullCancellationToken;
-    };
+    }
 
     let eventPort: number;
     {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -300,7 +300,7 @@ namespace ts.server {
             }
         }
 
-        private setTimerHandle(timerHandle: any) {;
+        private setTimerHandle(timerHandle: any) {
             if (this.timerHandle !== undefined) {
                 this.operationHost.getServerHost().clearTimeout(this.timerHandle);
             }
@@ -1544,17 +1544,17 @@ namespace ts.server {
             [CommandNames.OpenExternalProject]: (request: protocol.OpenExternalProjectRequest) => {
                 this.projectService.openExternalProject(request.arguments, /*suppressRefreshOfInferredProjects*/ false);
                 // TODO: report errors
-                return this.requiredResponse(true);
+                return this.requiredResponse(/*response*/ true);
             },
             [CommandNames.OpenExternalProjects]: (request: protocol.OpenExternalProjectsRequest) => {
                 this.projectService.openExternalProjects(request.arguments.projects);
                 // TODO: report errors
-                return this.requiredResponse(true);
+                return this.requiredResponse(/*response*/ true);
             },
             [CommandNames.CloseExternalProject]: (request: protocol.CloseExternalProjectRequest) => {
                 this.projectService.closeExternalProject(request.arguments.projectFileName);
                 // TODO: report errors
-                return this.requiredResponse(true);
+                return this.requiredResponse(/*response*/ true);
             },
             [CommandNames.SynchronizeProjectList]: (request: protocol.SynchronizeProjectListRequest) => {
                 const result = this.projectService.synchronizeProjectList(request.arguments.knownProjects);
@@ -1578,7 +1578,7 @@ namespace ts.server {
                 this.projectService.applyChangesInOpenFiles(request.arguments.openFiles, request.arguments.changedFiles, request.arguments.closedFiles);
                 this.changeSeq++;
                 // TODO: report errors
-                return this.requiredResponse(true);
+                return this.requiredResponse(/*response*/ true);
             },
             [CommandNames.Exit]: () => {
                 this.exit();
@@ -1689,7 +1689,7 @@ namespace ts.server {
             },
             [CommandNames.Cleanup]: () => {
                 this.cleanup();
-                return this.requiredResponse(true);
+                return this.requiredResponse(/*response*/ true);
             },
             [CommandNames.SemanticDiagnosticsSync]: (request: protocol.SemanticDiagnosticsSyncRequest) => {
                 return this.requiredResponse(this.getSemanticDiagnosticsSync(request.arguments));
@@ -1763,7 +1763,7 @@ namespace ts.server {
             },
             [CommandNames.CompilerOptionsForInferredProjects]: (request: protocol.SetCompilerOptionsForInferredProjectsRequest) => {
                 this.setCompilerOptionsForInferredProjects(request.arguments);
-                return this.requiredResponse(true);
+                return this.requiredResponse(/*response*/ true);
             },
             [CommandNames.ProjectInfo]: (request: protocol.ProjectInfoRequest) => {
                 return this.requiredResponse(this.getProjectInfo(request.arguments));

--- a/src/services/codefixes/importFixes.ts
+++ b/src/services/codefixes/importFixes.ts
@@ -542,12 +542,12 @@ namespace ts.codefix {
                     }
 
                     function getRelativePathIfInDirectory(path: string, directoryPath: string) {
-                        const relativePath = getRelativePathToDirectoryOrUrl(directoryPath, path, directoryPath, getCanonicalFileName, false);
+                        const relativePath = getRelativePathToDirectoryOrUrl(directoryPath, path, directoryPath, getCanonicalFileName, /*isAbsolutePathAnUrl*/ false);
                         return isRootedDiskPath(relativePath) || startsWith(relativePath, "..") ? undefined : relativePath;
                     }
 
                     function getRelativePath(path: string, directoryPath: string) {
-                        const relativePath = getRelativePathToDirectoryOrUrl(directoryPath, path, directoryPath, getCanonicalFileName, false);
+                        const relativePath = getRelativePathToDirectoryOrUrl(directoryPath, path, directoryPath, getCanonicalFileName, /*isAbsolutePathAnUrl*/ false);
                         return moduleHasNonRelativeName(relativePath) ? "./" + relativePath : relativePath;
                     }
                 }

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -173,7 +173,7 @@ namespace ts.Completions {
             // a['/*completion position*/']
             return getStringLiteralCompletionEntriesFromElementAccess(node.parent, typeChecker, compilerOptions.target, log);
         }
-        else if (node.parent.kind === SyntaxKind.ImportDeclaration || isExpressionOfExternalModuleImportEqualsDeclaration(node) || isRequireCall(node.parent, false)) {
+        else if (node.parent.kind === SyntaxKind.ImportDeclaration || isExpressionOfExternalModuleImportEqualsDeclaration(node) || isRequireCall(node.parent, /*checkArgumentIsStringLiteral*/ false)) {
             // Get all known external module names or complete a path to a module
             // i.e. import * as ns from "/*completion position*/";
             //      import x = require("/*completion position*/");

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -701,7 +701,7 @@ namespace ts.FindAllReferences {
                     }
                 });
             }
-        };
+        }
         return result;
     }
 

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -568,7 +568,7 @@ namespace ts.formatting {
 
             function getEffectiveDelta(delta: number, child: TextRangeWithKind) {
                 // Delta value should be zero when the node explicitly prevents indentation of the child node
-                return SmartIndenter.nodeWillIndentChild(node, child, true) ? delta : 0;
+                return SmartIndenter.nodeWillIndentChild(node, child, /*indentByDefault*/ true) ? delta : 0;
             }
         }
 

--- a/src/services/jsTyping.ts
+++ b/src/services/jsTyping.ts
@@ -13,7 +13,7 @@ namespace ts.JsTyping {
         fileExists: (fileName: string) => boolean;
         readFile: (path: string, encoding?: string) => string;
         readDirectory: (rootDir: string, extensions: string[], excludes: string[], includes: string[], depth?: number) => string[];
-    };
+    }
 
     interface PackageJson {
         _requiredBy?: string[];
@@ -23,7 +23,7 @@ namespace ts.JsTyping {
         optionalDependencies?: MapLike<string>;
         peerDependencies?: MapLike<string>;
         typings?: string;
-    };
+    }
 
     // A map of loose file names to library names
     // that we are confident require typings

--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -1226,7 +1226,7 @@ namespace ts {
 
     // Here we expose the TypeScript services as an external module
     // so that it may be consumed easily like a node module.
-    declare var module: any;
+    declare const module: any;
     if (typeof module !== "undefined" && module.exports) {
         module.exports = ts;
     }

--- a/src/services/textChanges.ts
+++ b/src/services/textChanges.ts
@@ -421,7 +421,7 @@ namespace ts.textChanges {
                 let changesInFile = changesPerFile.get(c.sourceFile.path);
                 if (!changesInFile) {
                     changesPerFile.set(c.sourceFile.path, changesInFile = []);
-                };
+                }
                 changesInFile.push(c);
             }
             // convert changes

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1334,7 +1334,7 @@ namespace ts {
             name.charCodeAt(0) === name.charCodeAt(length - 1) &&
             (name.charCodeAt(0) === CharacterCodes.doubleQuote || name.charCodeAt(0) === CharacterCodes.singleQuote)) {
             return name.substring(1, length - 1);
-        };
+        }
         return name;
     }
 

--- a/tslint.json
+++ b/tslint.json
@@ -50,7 +50,7 @@
             "check-else"
         ],
         "no-internal-module": true,
-        "no-trailing-whitespace": true,
+        "no-trailing-whitespace": [true, "ignore-template-strings"],
         "no-inferrable-types": true,
         "no-null-keyword": true,
         "boolean-trivia": true,


### PR DESCRIPTION
I fell down a bit of a rabbit hole! 🐇 

Our boolean trivia rule was... interesting
 * It only could check *intra-file* calls; calls to other files were not checked for comments
 * It created a typechecker *per file*
 * It used a function that is not in the `master` version of TS Lint
 * It consumed approximately 65 of the 85 seconds it takes to lint the project

So given all these things, the new boolean trivia rule
 * Does not enforce that the parameter name matches the comment; the comment must simply exist (please be responsible)
 * No longer uses a typechecker (you can have your 65 seconds back in return)
 * Opts out certain methods and functions whose parameter names are not informative at call sites

As well I fixed all the lint errors that the next version of TS Lint will give us on release since I was `npm link`'d anyway