### PR TITLE
Move ArrayBufferView from es5.d.ts to dom.generated.d.ts

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -14940,3 +14940,4 @@ type IDBValidKey = number | string | Date | IDBArrayKey;
 type BufferSource = ArrayBuffer | ArrayBufferView;
 type MouseWheelEvent = WheelEvent;
 type ScrollRestoration = "auto" | "manual";
+type ArrayBufferView = Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView;

--- a/src/lib/es5.d.ts
+++ b/src/lib/es5.d.ts
@@ -1389,26 +1389,9 @@ interface ArrayBuffer {
 interface ArrayBufferConstructor {
     readonly prototype: ArrayBuffer;
     new (byteLength: number): ArrayBuffer;
-    isView(arg: any): arg is ArrayBufferView;
+    isView(arg: any): arg is (Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView);
 }
 declare const ArrayBuffer: ArrayBufferConstructor;
-
-interface ArrayBufferView {
-    /**
-      * The ArrayBuffer instance referenced by the array.
-      */
-    buffer: ArrayBuffer;
-
-    /**
-      * The length in bytes of the array.
-      */
-    byteLength: number;
-
-    /**
-      * The offset in bytes of the array.
-      */
-    byteOffset: number;
-}
 
 interface DataView {
     readonly buffer: ArrayBuffer;

--- a/src/lib/webworker.generated.d.ts
+++ b/src/lib/webworker.generated.d.ts
@@ -1746,3 +1746,4 @@ type RequestInfo = Request | string;
 type USVString = string;
 type IDBValidKey = number | string | Date | IDBArrayKey;
 type BufferSource = ArrayBuffer | ArrayBufferView;
+type ArrayBufferView = Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView;

--- a/tests/baselines/reference/arrayBufferIsViewNarrowsType.js
+++ b/tests/baselines/reference/arrayBufferIsViewNarrowsType.js
@@ -2,12 +2,12 @@
 var obj: Object;
 if (ArrayBuffer.isView(obj)) {
     // isView should be a guard that narrows type to ArrayBufferView.
-    var ab: ArrayBufferView = obj;
+    var ab: ArrayBuffer = obj.buffer;
 }
 
 //// [arrayBufferIsViewNarrowsType.js]
 var obj;
 if (ArrayBuffer.isView(obj)) {
     // isView should be a guard that narrows type to ArrayBufferView.
-    var ab = obj;
+    var ab = obj.buffer;
 }

--- a/tests/baselines/reference/arrayBufferIsViewNarrowsType.symbols
+++ b/tests/baselines/reference/arrayBufferIsViewNarrowsType.symbols
@@ -10,8 +10,10 @@ if (ArrayBuffer.isView(obj)) {
 >obj : Symbol(obj, Decl(arrayBufferIsViewNarrowsType.ts, 0, 3))
 
     // isView should be a guard that narrows type to ArrayBufferView.
-    var ab: ArrayBufferView = obj;
+    var ab: ArrayBuffer = obj.buffer;
 >ab : Symbol(ab, Decl(arrayBufferIsViewNarrowsType.ts, 3, 7))
->ArrayBufferView : Symbol(ArrayBufferView, Decl(lib.d.ts, --, --))
+>ArrayBuffer : Symbol(ArrayBuffer, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>obj.buffer : Symbol(buffer, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 >obj : Symbol(obj, Decl(arrayBufferIsViewNarrowsType.ts, 0, 3))
+>buffer : Symbol(buffer, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
 }

--- a/tests/baselines/reference/arrayBufferIsViewNarrowsType.types
+++ b/tests/baselines/reference/arrayBufferIsViewNarrowsType.types
@@ -5,14 +5,16 @@ var obj: Object;
 
 if (ArrayBuffer.isView(obj)) {
 >ArrayBuffer.isView(obj) : boolean
->ArrayBuffer.isView : (arg: any) => arg is ArrayBufferView
+>ArrayBuffer.isView : (arg: any) => arg is Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView
 >ArrayBuffer : ArrayBufferConstructor
->isView : (arg: any) => arg is ArrayBufferView
+>isView : (arg: any) => arg is Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView
 >obj : Object
 
     // isView should be a guard that narrows type to ArrayBufferView.
-    var ab: ArrayBufferView = obj;
->ab : ArrayBufferView
->ArrayBufferView : ArrayBufferView
->obj : ArrayBufferView
+    var ab: ArrayBuffer = obj.buffer;
+>ab : ArrayBuffer
+>ArrayBuffer : ArrayBuffer
+>obj.buffer : ArrayBuffer
+>obj : Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView
+>buffer : ArrayBuffer
 }

--- a/tests/cases/compiler/arrayBufferIsViewNarrowsType.ts
+++ b/tests/cases/compiler/arrayBufferIsViewNarrowsType.ts
@@ -1,5 +1,5 @@
 var obj: Object;
 if (ArrayBuffer.isView(obj)) {
     // isView should be a guard that narrows type to ArrayBufferView.
-    var ab: ArrayBufferView = obj;
+    var ab: ArrayBuffer = obj.buffer;
 }


### PR DESCRIPTION
__*Note: This PR modifies dom.generated.d.ts which normally is not permitted.*__

*It is done to solve PR deadlock with TSJS-lib-generator, where removing the type on es5.d.ts errors on TS repo and adding the type on TSJS-lib-generator also errors because of duplication*

This PR is related to https://github.com/Microsoft/TSJS-lib-generator/pull/227 which provides ArrayBufferView type by parsing Web IDL standard specification.

**Expected behavior:**

[ArrayBufferView](https://heycam.github.io/webidl/#ArrayBufferView) is not ECMAScript-defined type but a Web IDL-defined one and thus should be provided by TSJS-lib-generator. It also is defined as a union type rather than an interface.

**Actual behavior:**

ArrayBufferView is in es5.d.ts and is an interface type.