### PR TITLE
Do not walk up control flow containers for `this`

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11009,7 +11009,7 @@ namespace ts {
                     else if (flow.flags & FlowFlags.Start) {
                         // Check if we should continue with the control flow of the containing function.
                         const container = (<FlowStart>flow).container;
-                        if (container && container !== flowContainer && reference.kind !== SyntaxKind.PropertyAccessExpression) {
+                        if (container && container !== flowContainer && reference.kind !== SyntaxKind.PropertyAccessExpression && reference.kind !== SyntaxKind.ThisKeyword) {
                             flow = container.flowNode;
                             continue;
                         }

--- a/tests/baselines/reference/anonymousClassExpression2.errors.txt
+++ b/tests/baselines/reference/anonymousClassExpression2.errors.txt
@@ -1,0 +1,24 @@
+tests/cases/compiler/anonymousClassExpression2.ts(13,18): error TS2339: Property 'methodA' does not exist on type 'B'.
+
+
+==== tests/cases/compiler/anonymousClassExpression2.ts (1 errors) ====
+    // Fixes #14860
+    // note: repros with `while (0);` too
+    // but it's less inscrutable and more obvious to put it *inside* the loop
+    while (0) {
+        class A {
+            methodA() {
+                this; //note: a this reference of some kind is required to trigger the bug
+            }
+        }
+    
+        class B {
+            methodB() {
+                this.methodA; // error
+                     ~~~~~~~
+!!! error TS2339: Property 'methodA' does not exist on type 'B'.
+                this.methodB; // ok
+            }
+        }
+    }
+    

--- a/tests/baselines/reference/anonymousClassExpression2.js
+++ b/tests/baselines/reference/anonymousClassExpression2.js
@@ -1,0 +1,43 @@
+//// [anonymousClassExpression2.ts]
+// Fixes #14860
+// note: repros with `while (0);` too
+// but it's less inscrutable and more obvious to put it *inside* the loop
+while (0) {
+    class A {
+        methodA() {
+            this; //note: a this reference of some kind is required to trigger the bug
+        }
+    }
+
+    class B {
+        methodB() {
+            this.methodA; // error
+            this.methodB; // ok
+        }
+    }
+}
+
+
+//// [anonymousClassExpression2.js]
+// Fixes #14860
+// note: repros with `while (0);` too
+// but it's less inscrutable and more obvious to put it *inside* the loop
+while (0) {
+    var A = (function () {
+        function A() {
+        }
+        A.prototype.methodA = function () {
+            this; //note: a this reference of some kind is required to trigger the bug
+        };
+        return A;
+    }());
+    var B = (function () {
+        function B() {
+        }
+        B.prototype.methodB = function () {
+            this.methodA; // error
+            this.methodB; // ok
+        };
+        return B;
+    }());
+}

--- a/tests/baselines/reference/narrowedConstInMethod.js
+++ b/tests/baselines/reference/narrowedConstInMethod.js
@@ -1,9 +1,10 @@
 //// [narrowedConstInMethod.ts]
+// Fixes #10501, possibly null 'x'
 function f() {
     const x: string | null = <any>{};
     if (x !== null) {
         return {
-            bar() { return x.length; }  // Error: possibly null x
+            bar() { return x.length; }  // ok
         };
     }
 }
@@ -12,17 +13,19 @@ function f2() {
     const x: string | null = <any>{};
     if (x !== null) {
         return class {
-            bar() { return x.length; }  // Error: possibly null x
+            bar() { return x.length; }  // ok
         };
     }
 }
 
+
 //// [narrowedConstInMethod.js]
+// Fixes #10501, possibly null 'x'
 function f() {
     var x = {};
     if (x !== null) {
         return {
-            bar: function () { return x.length; } // Error: possibly null x
+            bar: function () { return x.length; } // ok
         };
     }
 }
@@ -32,7 +35,7 @@ function f2() {
         return (function () {
             function class_1() {
             }
-            class_1.prototype.bar = function () { return x.length; }; // Error: possibly null x
+            class_1.prototype.bar = function () { return x.length; }; // ok
             return class_1;
         }());
     }

--- a/tests/baselines/reference/narrowedConstInMethod.symbols
+++ b/tests/baselines/reference/narrowedConstInMethod.symbols
@@ -1,18 +1,19 @@
 === tests/cases/compiler/narrowedConstInMethod.ts ===
+// Fixes #10501, possibly null 'x'
 function f() {
 >f : Symbol(f, Decl(narrowedConstInMethod.ts, 0, 0))
 
     const x: string | null = <any>{};
->x : Symbol(x, Decl(narrowedConstInMethod.ts, 1, 9))
+>x : Symbol(x, Decl(narrowedConstInMethod.ts, 2, 9))
 
     if (x !== null) {
->x : Symbol(x, Decl(narrowedConstInMethod.ts, 1, 9))
+>x : Symbol(x, Decl(narrowedConstInMethod.ts, 2, 9))
 
         return {
-            bar() { return x.length; }  // Error: possibly null x
->bar : Symbol(bar, Decl(narrowedConstInMethod.ts, 3, 16))
+            bar() { return x.length; }  // ok
+>bar : Symbol(bar, Decl(narrowedConstInMethod.ts, 4, 16))
 >x.length : Symbol(String.length, Decl(lib.d.ts, --, --))
->x : Symbol(x, Decl(narrowedConstInMethod.ts, 1, 9))
+>x : Symbol(x, Decl(narrowedConstInMethod.ts, 2, 9))
 >length : Symbol(String.length, Decl(lib.d.ts, --, --))
 
         };
@@ -20,21 +21,22 @@ function f() {
 }
 
 function f2() {
->f2 : Symbol(f2, Decl(narrowedConstInMethod.ts, 7, 1))
+>f2 : Symbol(f2, Decl(narrowedConstInMethod.ts, 8, 1))
 
     const x: string | null = <any>{};
->x : Symbol(x, Decl(narrowedConstInMethod.ts, 10, 9))
+>x : Symbol(x, Decl(narrowedConstInMethod.ts, 11, 9))
 
     if (x !== null) {
->x : Symbol(x, Decl(narrowedConstInMethod.ts, 10, 9))
+>x : Symbol(x, Decl(narrowedConstInMethod.ts, 11, 9))
 
         return class {
-            bar() { return x.length; }  // Error: possibly null x
->bar : Symbol((Anonymous class).bar, Decl(narrowedConstInMethod.ts, 12, 22))
+            bar() { return x.length; }  // ok
+>bar : Symbol((Anonymous class).bar, Decl(narrowedConstInMethod.ts, 13, 22))
 >x.length : Symbol(String.length, Decl(lib.d.ts, --, --))
->x : Symbol(x, Decl(narrowedConstInMethod.ts, 10, 9))
+>x : Symbol(x, Decl(narrowedConstInMethod.ts, 11, 9))
 >length : Symbol(String.length, Decl(lib.d.ts, --, --))
 
         };
     }
 }
+

--- a/tests/baselines/reference/narrowedConstInMethod.types
+++ b/tests/baselines/reference/narrowedConstInMethod.types
@@ -1,4 +1,5 @@
 === tests/cases/compiler/narrowedConstInMethod.ts ===
+// Fixes #10501, possibly null 'x'
 function f() {
 >f : () => { bar(): number; } | undefined
 
@@ -14,9 +15,9 @@ function f() {
 >null : null
 
         return {
->{            bar() { return x.length; }  // Error: possibly null x        } : { bar(): number; }
+>{            bar() { return x.length; }  // ok        } : { bar(): number; }
 
-            bar() { return x.length; }  // Error: possibly null x
+            bar() { return x.length; }  // ok
 >bar : () => number
 >x.length : number
 >x : string
@@ -41,9 +42,9 @@ function f2() {
 >null : null
 
         return class {
->class {            bar() { return x.length; }  // Error: possibly null x        } : typeof (Anonymous class)
+>class {            bar() { return x.length; }  // ok        } : typeof (Anonymous class)
 
-            bar() { return x.length; }  // Error: possibly null x
+            bar() { return x.length; }  // ok
 >bar : () => number
 >x.length : number
 >x : string
@@ -52,3 +53,4 @@ function f2() {
         };
     }
 }
+

--- a/tests/cases/compiler/anonymousClassExpression2.ts
+++ b/tests/cases/compiler/anonymousClassExpression2.ts
@@ -1,0 +1,17 @@
+// Fixes #14860
+// note: repros with `while (0);` too
+// but it's less inscrutable and more obvious to put it *inside* the loop
+while (0) {
+    class A {
+        methodA() {
+            this; //note: a this reference of some kind is required to trigger the bug
+        }
+    }
+
+    class B {
+        methodB() {
+            this.methodA; // error
+            this.methodB; // ok
+        }
+    }
+}

--- a/tests/cases/compiler/narrowedConstInMethod.ts
+++ b/tests/cases/compiler/narrowedConstInMethod.ts
@@ -1,10 +1,11 @@
 // @strictNullChecks: true
 
+// Fixes #10501, possibly null 'x'
 function f() {
     const x: string | null = <any>{};
     if (x !== null) {
         return {
-            bar() { return x.length; }  // Error: possibly null x
+            bar() { return x.length; }  // ok
         };
     }
 }
@@ -13,7 +14,7 @@ function f2() {
     const x: string | null = <any>{};
     if (x !== null) {
         return class {
-            bar() { return x.length; }  // Error: possibly null x
+            bar() { return x.length; }  // ok
         };
     }
 }


### PR DESCRIPTION
Do not walk up control flow containers for `this`. References to `this` should not continue looking outside their immediate container to narrow. 

Introduced by #11458, which allows narrowing of captured variables inside methods of class expressions. That meant `this` also attempted to narrow outside its container, which meant that references to `this` were cached as if they were references to a single variable named "this", even though they came from different class expressions.

Fixes #14860
