### PR TITLE
Evolving array element type ignores contextual type

### DIFF
--- a/tests/baselines/reference/assignmentToExpandingArrayType.js
+++ b/tests/baselines/reference/assignmentToExpandingArrayType.js
@@ -1,0 +1,56 @@
+//// [assignmentToExpandingArrayType.ts]
+// Fixes exponential time/space in #14628
+let x = []
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' } // previously ran out of memory here
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+
+
+//// [assignmentToExpandingArrayType.js]
+// Fixes exponential time/space in #14628
+var x = [];
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' }; // previously ran out of memory here
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };
+x[0] = { foo: 'hi' };

--- a/tests/baselines/reference/assignmentToExpandingArrayType.symbols
+++ b/tests/baselines/reference/assignmentToExpandingArrayType.symbols
@@ -1,0 +1,101 @@
+=== tests/cases/compiler/assignmentToExpandingArrayType.ts ===
+// Fixes exponential time/space in #14628
+let x = []
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 2, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 3, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 4, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 5, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 6, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 7, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 8, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 9, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 10, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 11, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 12, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 13, 8))
+
+x[0] = { foo: 'hi' } // previously ran out of memory here
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 14, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 15, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 16, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 17, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 18, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 19, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 20, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 21, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 22, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 23, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 24, 8))
+
+x[0] = { foo: 'hi' }
+>x : Symbol(x, Decl(assignmentToExpandingArrayType.ts, 1, 3))
+>foo : Symbol(foo, Decl(assignmentToExpandingArrayType.ts, 25, 8))
+

--- a/tests/baselines/reference/assignmentToExpandingArrayType.types
+++ b/tests/baselines/reference/assignmentToExpandingArrayType.types
@@ -1,0 +1,222 @@
+=== tests/cases/compiler/assignmentToExpandingArrayType.ts ===
+// Fixes exponential time/space in #14628
+let x = []
+>x : any[]
+>[] : undefined[]
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' } // previously ran out of memory here
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+
+x[0] = { foo: 'hi' }
+>x[0] = { foo: 'hi' } : { foo: string; }
+>x[0] : any
+>x : any[]
+>0 : 0
+>{ foo: 'hi' } : { foo: string; }
+>foo : string
+>'hi' : "hi"
+

--- a/tests/cases/compiler/assignmentToExpandingArrayType.ts
+++ b/tests/cases/compiler/assignmentToExpandingArrayType.ts
@@ -1,0 +1,27 @@
+// @noImplicitAny: true
+// Fixes exponential time/space in #14628
+let x = []
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' } // previously ran out of memory here
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }
+x[0] = { foo: 'hi' }


### PR DESCRIPTION
Control flow analysis can easily hit circularities or exponential behaviour when requesting the contextual type of an expression. When adding an element type to an evolving array type, there is no point in checking the contextual type of the new element type because it is unknown -- it is exactly the type of the evolving array, which is in the middle of being found.

Fixes #14628

This is code of the form:

```ts
let x = []
x[0] = { contextual: 'no' }
x[1] = { contextual: 'should not check' }
x[2] = { contextual: 'contextual type' }
// :
// :
```

I considered adding a third parameter to `getTypeOfExpression` and calling `checkExpressionWithContextualType`, but I decided having a new function that delegates to `getTypeOfExpression` is less confusing.