### PR TITLE
boolean-trivia lint rule: Lint for null/undefined too 

### DIFF
--- a/Gulpfile.ts
+++ b/Gulpfile.ts
@@ -775,7 +775,7 @@ gulp.task("browserify", "Runs browserify on run.js to produce a file suitable fo
                     });
                     const finalMap = chain.apply();
                     file.sourceMap = finalMap;
-                    next(undefined, file);
+                    next(/*err*/ undefined, file);
                 });
         }))
         .pipe(sourcemaps.write(".", { includeContent: false }))

--- a/scripts/tslint/booleanTriviaRule.ts
+++ b/scripts/tslint/booleanTriviaRule.ts
@@ -8,36 +8,62 @@ export class Rule extends Lint.Rules.AbstractRule {
 }
 
 function walk(ctx: Lint.WalkContext<void>): void {
-    ts.forEachChild(ctx.sourceFile, recur);
-    function recur(node: ts.Node): void {
+    ts.forEachChild(ctx.sourceFile, function recur(node: ts.Node): void {
         if (node.kind === ts.SyntaxKind.CallExpression) {
             checkCall(node as ts.CallExpression);
         }
         ts.forEachChild(node, recur);
-    }
+    });
 
     function checkCall(node: ts.CallExpression): void {
         for (const arg of node.arguments) {
-            if (arg.kind !== ts.SyntaxKind.TrueKeyword && arg.kind !== ts.SyntaxKind.FalseKeyword) {
-                continue;
+            switch (arg.kind) {
+                case ts.SyntaxKind.TrueKeyword:
+                case ts.SyntaxKind.FalseKeyword:
+                case ts.SyntaxKind.NullKeyword:
+                    break;
+                case ts.SyntaxKind.Identifier:
+                    if ((arg as ts.Identifier).originalKeywordKind !== ts.SyntaxKind.UndefinedKeyword) {
+                        continue;
+                    }
+                    break;
+                default:
+                    continue;
             }
 
             if (node.expression.kind === ts.SyntaxKind.PropertyAccessExpression) {
-                const methodName = (node.expression as ts.PropertyAccessExpression).name.text
+                const methodName = (node.expression as ts.PropertyAccessExpression).name.text;
                 // Skip certain method names whose parameter names are not informative
-                if (methodName === 'set' ||
-                    methodName === 'equal' ||
-                    methodName === 'fail' ||
-                    methodName === 'isTrue' ||
-                    methodName === 'assert') {
+                if (methodName.indexOf("set") === 0) {
                     continue;
+                }
+                switch (methodName) {
+                    case "apply":
+                    case "assert":
+                    case "call":
+                    case "equal":
+                    case "fail":
+                    case "isTrue":
+                    case "output":
+                    case "stringify":
+                        continue;
                 }
             }
             else if (node.expression.kind === ts.SyntaxKind.Identifier) {
                 const functionName = (node.expression as ts.Identifier).text;
                 // Skip certain function names whose parameter names are not informative
-                if (functionName === 'assert') {
+                if (functionName.indexOf("set") === 0) {
                     continue;
+                }
+                switch (functionName) {
+                    case "assert":
+                    case "contains":
+                    case "createAnonymousType":
+                    case "createImportSpecifier":
+                    case "createProperty":
+                    case "createSignature":
+                    case "resolveName":
+                        continue;
                 }
             }
 

--- a/src/compiler/binder.ts
+++ b/src/compiler/binder.ts
@@ -418,7 +418,7 @@ namespace ts {
                     return declareSymbol(container.symbol.exports, container.symbol, node, symbolFlags, symbolExcludes);
                 }
                 else {
-                    return declareSymbol(container.locals, undefined, node, symbolFlags, symbolExcludes);
+                    return declareSymbol(container.locals, /*parent*/ undefined, node, symbolFlags, symbolExcludes);
                 }
             }
             else {
@@ -447,13 +447,13 @@ namespace ts {
                         (symbolFlags & SymbolFlags.Value ? SymbolFlags.ExportValue : 0) |
                         (symbolFlags & SymbolFlags.Type ? SymbolFlags.ExportType : 0) |
                         (symbolFlags & SymbolFlags.Namespace ? SymbolFlags.ExportNamespace : 0);
-                    const local = declareSymbol(container.locals, undefined, node, exportKind, symbolExcludes);
+                    const local = declareSymbol(container.locals, /*parent*/ undefined, node, exportKind, symbolExcludes);
                     local.exportSymbol = declareSymbol(container.symbol.exports, container.symbol, node, symbolFlags, symbolExcludes);
                     node.localSymbol = local;
                     return local;
                 }
                 else {
-                    return declareSymbol(container.locals, undefined, node, symbolFlags, symbolExcludes);
+                    return declareSymbol(container.locals, /*parent*/undefined, node, symbolFlags, symbolExcludes);
                 }
             }
         }
@@ -1545,7 +1545,7 @@ namespace ts {
         function declareSourceFileMember(node: Declaration, symbolFlags: SymbolFlags, symbolExcludes: SymbolFlags) {
             return isExternalModule(file)
                 ? declareModuleMember(node, symbolFlags, symbolExcludes)
-                : declareSymbol(file.locals, undefined, node, symbolFlags, symbolExcludes);
+                : declareSymbol(file.locals, /*parent*/ undefined, node, symbolFlags, symbolExcludes);
         }
 
         function hasExportDeclarations(node: ModuleDeclaration | SourceFile): boolean {
@@ -1721,7 +1721,7 @@ namespace ts {
                         blockScopeContainer.locals = createMap<Symbol>();
                         addToContainerChain(blockScopeContainer);
                     }
-                    declareSymbol(blockScopeContainer.locals, undefined, node, symbolFlags, symbolExcludes);
+                    declareSymbol(blockScopeContainer.locals, /*parent*/ undefined, node, symbolFlags, symbolExcludes);
             }
         }
 

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -4564,7 +4564,7 @@ namespace ts {
         // The outer type parameters are those defined by enclosing generic classes, methods, or functions.
         function getOuterTypeParametersOfClassOrInterface(symbol: Symbol): TypeParameter[] {
             const declaration = symbol.flags & SymbolFlags.Class ? symbol.valueDeclaration : getDeclarationOfKind(symbol, SyntaxKind.InterfaceDeclaration);
-            return appendOuterTypeParameters(undefined, declaration);
+            return appendOuterTypeParameters(/*typeParameters*/ undefined, declaration);
         }
 
         // The local type parameters are the combined set of type parameters from all declarations of the class,
@@ -7702,7 +7702,7 @@ namespace ts {
         }
 
         function createTypeEraser(sources: Type[]): TypeMapper {
-            return createTypeMapper(sources, undefined);
+            return createTypeMapper(sources, /*targets*/ undefined);
         }
 
         /**
@@ -8418,7 +8418,7 @@ namespace ts {
                 }
             }
             if (source.flags & TypeFlags.StructuredOrTypeVariable || target.flags & TypeFlags.StructuredOrTypeVariable) {
-                return checkTypeRelatedTo(source, target, relation, undefined, undefined, undefined);
+                return checkTypeRelatedTo(source, target, relation, /*errorNode*/ undefined);
             }
             return false;
         }
@@ -13665,7 +13665,7 @@ namespace ts {
             const links = getNodeLinks(node);
             if (!links.resolvedJsxElementAttributesType) {
                 const elemClassType = getJsxGlobalElementClassType();
-                return links.resolvedJsxElementAttributesType = resolveCustomJsxElementAttributesType(node, shouldIncludeAllStatelessAttributesType, undefined, elemClassType);
+                return links.resolvedJsxElementAttributesType = resolveCustomJsxElementAttributesType(node, shouldIncludeAllStatelessAttributesType, /*elementType*/ undefined, elemClassType);
             }
             return links.resolvedJsxElementAttributesType;
         }
@@ -15717,7 +15717,7 @@ namespace ts {
                 const parameter = signature.thisParameter;
                 if (!parameter || parameter.valueDeclaration && !(<ParameterDeclaration>parameter.valueDeclaration).type) {
                     if (!parameter) {
-                        signature.thisParameter = createSymbolWithType(context.thisParameter, undefined);
+                        signature.thisParameter = createSymbolWithType(context.thisParameter, /*type*/ undefined);
                     }
                     assignTypeToParameterAndFixTypeParameters(signature.thisParameter, getTypeOfSymbol(context.thisParameter), mapper, checkMode);
                 }
@@ -17300,7 +17300,7 @@ namespace ts {
                             Diagnostics.A_type_predicate_cannot_reference_a_rest_parameter);
                     }
                     else {
-                        const leadingError = chainDiagnosticMessages(undefined, Diagnostics.A_type_predicate_s_type_must_be_assignable_to_its_parameter_s_type);
+                        const leadingError = chainDiagnosticMessages(/*details*/ undefined, Diagnostics.A_type_predicate_s_type_must_be_assignable_to_its_parameter_s_type);
                         checkTypeAssignableTo(typePredicate.type,
                             getTypeOfNode(parent.parameters[typePredicate.parameterIndex]),
                             node.type,
@@ -20507,7 +20507,7 @@ namespace ts {
                             const typeName1 = typeToString(existing.containingType);
                             const typeName2 = typeToString(base);
 
-                            let errorInfo = chainDiagnosticMessages(undefined, Diagnostics.Named_property_0_of_types_1_and_2_are_not_identical, symbolToString(prop), typeName1, typeName2);
+                            let errorInfo = chainDiagnosticMessages(/*details*/ undefined, Diagnostics.Named_property_0_of_types_1_and_2_are_not_identical, symbolToString(prop), typeName1, typeName2);
                             errorInfo = chainDiagnosticMessages(errorInfo, Diagnostics.Interface_0_cannot_simultaneously_extend_types_1_and_2, typeToString(type), typeName1, typeName2);
                             diagnostics.add(createDiagnosticForNodeFromMessageChain(typeNode, errorInfo));
                         }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -30,7 +30,7 @@ namespace ts {
 
     /** Create a MapLike with good performance. */
     function createDictionaryObject<T>(): MapLike<T> {
-        const map = Object.create(null); // tslint:disable-line:no-null-keyword
+        const map = Object.create(/*prototype*/ null); // tslint:disable-line:no-null-keyword
 
         // Using 'delete' on an object causes V8 to put the object in dictionary mode.
         // This disables creation of hidden classes, which are expensive when an object is

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -2130,7 +2130,7 @@ namespace ts {
         function parseParameter(): ParameterDeclaration {
             const node = <ParameterDeclaration>createNode(SyntaxKind.Parameter);
             if (token() === SyntaxKind.ThisKeyword) {
-                node.name = createIdentifier(/*isIdentifier*/true, undefined);
+                node.name = createIdentifier(/*isIdentifier*/ true);
                 node.type = parseParameterType();
                 return finishNode(node);
             }

--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -1218,7 +1218,7 @@ namespace ts {
                 && !file.isDeclarationFile) {
                 // synthesize 'import "tslib"' declaration
                 const externalHelpersModuleReference = createLiteral(externalHelpersModuleNameText);
-                const importDecl = createImportDeclaration(undefined, undefined, undefined);
+                const importDecl = createImportDeclaration(/*decorators*/ undefined, /*modifiers*/ undefined, /*importClause*/ undefined);
                 externalHelpersModuleReference.parent = importDecl;
                 importDecl.parent = file;
                 imports = [externalHelpersModuleReference];

--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -735,11 +735,11 @@ namespace ts {
     }
 
     export function getLeadingCommentRanges(text: string, pos: number): CommentRange[] | undefined {
-        return reduceEachLeadingCommentRange(text, pos, appendCommentRange, undefined, undefined);
+        return reduceEachLeadingCommentRange(text, pos, appendCommentRange, /*state*/ undefined, /*initial*/ undefined);
     }
 
     export function getTrailingCommentRanges(text: string, pos: number): CommentRange[] | undefined {
-        return reduceEachTrailingCommentRange(text, pos, appendCommentRange, undefined, undefined);
+        return reduceEachTrailingCommentRange(text, pos, appendCommentRange, /*state*/ undefined, /*initial*/ undefined);
     }
 
     /** Optionally, get the shebang */

--- a/src/compiler/sys.ts
+++ b/src/compiler/sys.ts
@@ -232,7 +232,7 @@ namespace ts {
 
                 try {
                     fd = _fs.openSync(fileName, "w");
-                    _fs.writeSync(fd, data, undefined, "utf8");
+                    _fs.writeSync(fd, data, /*position*/ undefined, "utf8");
                 }
                 finally {
                     if (fd !== undefined) {

--- a/src/compiler/transformers/destructuring.ts
+++ b/src/compiler/transformers/destructuring.ts
@@ -518,7 +518,7 @@ namespace ts {
         }
         return createCall(
             getHelperName("__rest"),
-            undefined,
+            /*typeArguments*/ undefined,
             [
                 value,
                 setTextRange(

--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -3109,7 +3109,7 @@ namespace ts {
             const ancestorFacts = enterSubtree(HierarchyFacts.BlockScopeExcludes, HierarchyFacts.BlockScopeIncludes);
             let updated: CatchClause;
             if (isBindingPattern(node.variableDeclaration.name)) {
-                const temp = createTempVariable(undefined);
+                const temp = createTempVariable(/*recordTempVariable*/ undefined);
                 const newVariableDeclaration = createVariableDeclaration(temp);
                 setTextRange(newVariableDeclaration, node.variableDeclaration);
                 const vars = flattenDestructuringBinding(

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -3191,7 +3191,7 @@ ${code}
         }
 
         // Add the remaining text
-        flush(undefined);
+        flush(/*lastSafeCharIndex*/ undefined);
 
         if (openRanges.length > 0) {
             const openRange = openRanges[0];

--- a/src/harness/harnessLanguageService.ts
+++ b/src/harness/harnessLanguageService.ts
@@ -795,7 +795,7 @@ namespace Harness.LanguageService {
 
             function makeDefaultProxy(info: ts.server.PluginCreateInfo) {
                 // tslint:disable-next-line:no-null-keyword
-                const proxy = Object.create(null);
+                const proxy = Object.create(/*prototype*/ null);
                 const langSvc: any = info.languageService;
                 for (const k of Object.keys(langSvc)) {
                     proxy[k] = function () {

--- a/src/harness/sourceMapRecorder.ts
+++ b/src/harness/sourceMapRecorder.ts
@@ -422,7 +422,7 @@ namespace Harness.SourceMapRecorder {
                 const jsFileText = getTextOfLine(currentJsLine, jsLineMap, jsFile.code);
                 if (prevEmittedCol < jsFileText.length) {
                     // There is remaining text on this line that will be part of next source span so write marker that continues
-                    writeSourceMapMarker(undefined, spansOnSingleLine.length, /*endColumn*/ jsFileText.length, /*endContinues*/ true);
+                    writeSourceMapMarker(/*currentSpan*/ undefined, spansOnSingleLine.length, /*endColumn*/ jsFileText.length, /*endContinues*/ true);
                 }
 
                 // Emit Source text

--- a/src/harness/unittests/matchFiles.ts
+++ b/src/harness/unittests/matchFiles.ts
@@ -212,7 +212,7 @@ namespace ts {
                     fileNames: [],
                     wildcardDirectories: {},
                 };
-                const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, undefined, caseInsensitiveTsconfigPath);
+                const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, /*existingOptions*/ undefined, caseInsensitiveTsconfigPath);
                 assertParsed(actual, expected);
             });
             it("with missing files are excluded", () => {
@@ -231,7 +231,7 @@ namespace ts {
                     fileNames: [],
                     wildcardDirectories: {},
                 };
-                const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, undefined, caseInsensitiveTsconfigPath);
+                const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, /*existingOptions*/ undefined, caseInsensitiveTsconfigPath);
                 assertParsed(actual, expected);
             });
             it("with literal excludes", () => {
@@ -584,7 +584,7 @@ namespace ts {
                         "c:/dev": ts.WatchDirectoryFlags.Recursive
                     },
                 };
-                const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, undefined, caseInsensitiveTsconfigPath);
+                const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, /*existingOptions*/ undefined, caseInsensitiveTsconfigPath);
                 assertParsed(actual, expected);
             });
             it("always include literal files", () => {
@@ -728,7 +728,7 @@ namespace ts {
                         "c:/dev/js": ts.WatchDirectoryFlags.None
                     }
                 };
-                const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, undefined, caseInsensitiveTsconfigPath);
+                const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, /*existingOptions*/ undefined, caseInsensitiveTsconfigPath);
                 assertParsed(actual, expected);
             });
             it("include .js files when allowJs=true", () => {
@@ -846,7 +846,7 @@ namespace ts {
                     fileNames: [],
                     wildcardDirectories: {}
                 };
-                const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, undefined, caseInsensitiveTsconfigPath);
+                const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, /*existingOptions*/ undefined, caseInsensitiveTsconfigPath);
                 assertParsed(actual, expected);
             });
             it("include files with .. in their name", () => {
@@ -1087,7 +1087,7 @@ namespace ts {
                         fileNames: [],
                         wildcardDirectories: {}
                     };
-                    const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, undefined, caseInsensitiveTsconfigPath);
+                    const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, /*existingOptions*/ undefined, caseInsensitiveTsconfigPath);
                     assertParsed(actual, expected);
                 });
                 it("in excludes", () => {
@@ -1108,7 +1108,7 @@ namespace ts {
                         fileNames: [],
                         wildcardDirectories: {}
                     };
-                    const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, undefined, caseInsensitiveTsconfigPath);
+                    const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, /*existingOptions*/ undefined, caseInsensitiveTsconfigPath);
                     assertParsed(actual, expected);
                 });
             });
@@ -1129,7 +1129,7 @@ namespace ts {
                         fileNames: [],
                         wildcardDirectories: {}
                     };
-                    const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, undefined, caseInsensitiveTsconfigPath);
+                    const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, /*existingOptions*/ undefined, caseInsensitiveTsconfigPath);
                     assertParsed(actual, expected);
                 });
                 it("in excludes", () => {
@@ -1178,7 +1178,7 @@ namespace ts {
                         fileNames: [],
                         wildcardDirectories: {}
                     };
-                    const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, undefined, caseInsensitiveTsconfigPath);
+                    const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, /*existingOptions*/ undefined, caseInsensitiveTsconfigPath);
                     assertParsed(actual, expected);
                 });
 
@@ -1198,7 +1198,7 @@ namespace ts {
                         fileNames: [],
                         wildcardDirectories: {}
                     };
-                    const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, undefined, caseInsensitiveTsconfigPath);
+                    const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveHost, caseInsensitiveBasePath, /*existingOptions*/ undefined, caseInsensitiveTsconfigPath);
                     assertParsed(actual, expected);
                 });
 
@@ -1382,7 +1382,7 @@ namespace ts {
                         fileNames: [],
                         wildcardDirectories: {}
                     };
-                    const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveDottedFoldersHost, caseInsensitiveBasePath, undefined, caseInsensitiveTsconfigPath);
+                    const actual = ts.parseJsonConfigFileContent(json, caseInsensitiveDottedFoldersHost, caseInsensitiveBasePath, /*existingOptions*/ undefined, caseInsensitiveTsconfigPath);
                     assertParsed(actual, expected);
                 });
             });

--- a/src/harness/unittests/moduleResolution.ts
+++ b/src/harness/unittests/moduleResolution.ts
@@ -152,10 +152,8 @@ namespace ts {
             testTypingsIgnored(["a", "b"]);
             testTypingsIgnored({ "a": "b" });
             testTypingsIgnored(/*typings*/true);
-            /* tslint:disable no-null-keyword */
-            testTypingsIgnored(null);
-            /* tslint:enable no-null-keyword */
-            testTypingsIgnored(undefined);
+            testTypingsIgnored(/*typings*/ null); // tslint:disable-line no-null-keyword
+            testTypingsIgnored(/*typings*/ undefined);
         });
         it("module name as directory - load index.d.ts", () => {
             test(/*hasDirectoryExists*/ false);

--- a/src/harness/unittests/printer.ts
+++ b/src/harness/unittests/printer.ts
@@ -80,6 +80,7 @@ namespace ts {
         describe("printNode", () => {
             const printsCorrectly = makePrintsCorrectly("printsNodeCorrectly");
             const sourceFile = createSourceFile("source.ts", "", ScriptTarget.ES2015);
+            // tslint:disable boolean-trivia
             const syntheticNode = createClassDeclaration(
                 undefined,
                 undefined,
@@ -97,6 +98,7 @@ namespace ts {
                     )
                 ])
             );
+            // tslint:enable boolean-trivia
             printsCorrectly("class", {}, printer => printer.printNode(EmitHint.Unspecified, syntheticNode, sourceFile));
         });
     });

--- a/src/harness/unittests/reuseProgramStructure.ts
+++ b/src/harness/unittests/reuseProgramStructure.ts
@@ -323,7 +323,7 @@ namespace ts {
 
             const program_1 = newProgram(files, ["a.ts"], options);
             checkResolvedModulesCache(program_1, "a.ts", createMapFromTemplate({ "b": createResolvedModule("b.ts") }));
-            checkResolvedModulesCache(program_1, "b.ts", undefined);
+            checkResolvedModulesCache(program_1, "b.ts", /*expectedContent*/ undefined);
 
             const program_2 = updateProgram(program_1, ["a.ts"], options, files => {
                 files[0].text = files[0].text.updateProgram("var x = 2");
@@ -332,14 +332,14 @@ namespace ts {
 
             // content of resolution cache should not change
             checkResolvedModulesCache(program_1, "a.ts", createMapFromTemplate({ "b": createResolvedModule("b.ts") }));
-            checkResolvedModulesCache(program_1, "b.ts", undefined);
+            checkResolvedModulesCache(program_1, "b.ts", /*expectedContent*/ undefined);
 
             // imports has changed - program is not reused
             const program_3 = updateProgram(program_2, ["a.ts"], options, files => {
                 files[0].text = files[0].text.updateImportsAndExports("");
             });
             assert.isTrue(!program_2.structureIsReused);
-            checkResolvedModulesCache(program_3, "a.ts", undefined);
+            checkResolvedModulesCache(program_3, "a.ts", /*expectedContent*/ undefined);
 
             const program_4 = updateProgram(program_3, ["a.ts"], options, files => {
                 const newImports = `import x from 'b'
@@ -360,7 +360,7 @@ namespace ts {
 
             const program_1 = newProgram(files, ["/a.ts"], options);
             checkResolvedTypeDirectivesCache(program_1, "/a.ts", createMapFromTemplate({ "typedefs": { resolvedFileName: "/types/typedefs/index.d.ts", primary: true } }));
-            checkResolvedTypeDirectivesCache(program_1, "/types/typedefs/index.d.ts", undefined);
+            checkResolvedTypeDirectivesCache(program_1, "/types/typedefs/index.d.ts", /*expectedContent*/ undefined);
 
             const program_2 = updateProgram(program_1, ["/a.ts"], options, files => {
                 files[0].text = files[0].text.updateProgram("var x = 2");
@@ -369,7 +369,7 @@ namespace ts {
 
             // content of resolution cache should not change
             checkResolvedTypeDirectivesCache(program_1, "/a.ts", createMapFromTemplate({ "typedefs": { resolvedFileName: "/types/typedefs/index.d.ts", primary: true } }));
-            checkResolvedTypeDirectivesCache(program_1, "/types/typedefs/index.d.ts", undefined);
+            checkResolvedTypeDirectivesCache(program_1, "/types/typedefs/index.d.ts", /*expectedContent*/ undefined);
 
             // type reference directives has changed - program is not reused
             const program_3 = updateProgram(program_2, ["/a.ts"], options, files => {
@@ -377,7 +377,7 @@ namespace ts {
             });
 
             assert.isTrue(!program_2.structureIsReused);
-            checkResolvedTypeDirectivesCache(program_3, "/a.ts", undefined);
+            checkResolvedTypeDirectivesCache(program_3, "/a.ts", /*expectedContent*/ undefined);
 
             updateProgram(program_3, ["/a.ts"], options, files => {
                 const newReferences = `/// <reference types="typedefs"/>

--- a/src/harness/unittests/tsserverProjectSystem.ts
+++ b/src/harness/unittests/tsserverProjectSystem.ts
@@ -310,7 +310,7 @@ namespace ts.projectSystem {
         register(cb: (...args: any[]) => void, args: any[]) {
             const timeoutId = this.nextId;
             this.nextId++;
-            this.map[timeoutId] = cb.bind(undefined, ...args);
+            this.map[timeoutId] = cb.bind(/*this*/ undefined, ...args);
             return timeoutId;
         }
         unregister(id: any) {

--- a/src/harness/virtualFileSystem.ts
+++ b/src/harness/virtualFileSystem.ts
@@ -98,7 +98,7 @@ namespace Utils {
         useCaseSensitiveFileNames: boolean;
 
         constructor(currentDirectory: string, useCaseSensitiveFileNames: boolean) {
-            super(undefined, "");
+            super(/*fileSystem*/ undefined, "");
             this.fileSystem = this;
             this.root = new VirtualDirectory(this, "");
             this.currentDirectory = currentDirectory;

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -1,8 +1,6 @@
 /// <reference types="node" />
 /// <reference path="shared.ts" />
 /// <reference path="session.ts" />
-// used in fs.writeSync
-/* tslint:disable:no-null-keyword */
 
 namespace ts.server {
 
@@ -196,7 +194,8 @@ namespace ts.server {
                 }
                 if (this.fd >= 0) {
                     const buf = new Buffer(s);
-                    fs.writeSync(this.fd, buf, 0, buf.length, null);
+                    // tslint:disable-next-line no-null-keyword
+                    fs.writeSync(this.fd, buf, 0, buf.length, /*position*/ null);
                 }
                 if (this.traceToConsole) {
                     console.warn(s);
@@ -702,7 +701,7 @@ namespace ts.server {
     }
 
     sys.require = (initialDir: string, moduleName: string): RequireResult => {
-        const result = nodeModuleNameResolverWorker(moduleName, initialDir + "/program.ts", { moduleResolution: ts.ModuleResolutionKind.NodeJs, allowJs: true }, sys, undefined, /*jsOnly*/ true);
+        const result = nodeModuleNameResolverWorker(moduleName, initialDir + "/program.ts", { moduleResolution: ts.ModuleResolutionKind.NodeJs, allowJs: true }, sys, /*cache*/ undefined, /*jsOnly*/ true);
         try {
             return { module: require(result.resolvedModule.resolvedFileName), error: undefined };
         }

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -915,9 +915,8 @@ namespace ts.server {
                 return combineProjectOutput(
                     projects,
                     project => project.getLanguageService().findReferences(file, position),
-                    undefined,
-                    // TODO: fixme
-                    undefined
+                    /*comparer*/ undefined,
+                    /*areEqual (TODO: fixme)*/ undefined
                 );
             }
 

--- a/src/services/formatting/formatting.ts
+++ b/src/services/formatting/formatting.ts
@@ -388,7 +388,7 @@ namespace ts.formatting {
         if (!formattingScanner.isOnToken()) {
             const leadingTrivia = formattingScanner.getCurrentLeadingTrivia();
             if (leadingTrivia) {
-                processTrivia(leadingTrivia, enclosingNode, enclosingNode, undefined);
+                processTrivia(leadingTrivia, enclosingNode, enclosingNode, /*dynamicIndentation*/ undefined);
                 trimTrailingWhitespacesForRemainingRange();
             }
         }

--- a/src/services/pathCompletions.ts
+++ b/src/services/pathCompletions.ts
@@ -214,7 +214,7 @@ namespace ts.Completions.PathCompletions {
                 // doesn't support. For now, this is safer but slower
                 const includeGlob = normalizedSuffix ? "**/*" : "./*";
 
-                const matches = tryReadDirectory(host, baseDirectory, fileExtensions, undefined, [includeGlob]);
+                const matches = tryReadDirectory(host, baseDirectory, fileExtensions, /*exclude*/ undefined, [includeGlob]);
                 if (matches) {
                     const result: string[] = [];
 


### PR DESCRIPTION
I think this should lint for `null / undefined`, because just like with `true` / `false` it can be hard to remember what they mean. It should probably be renamed of course...
We should also check for the existence/nonexistence of a space after the comment: Should there be a space or not?
