### PR TITLE
parseInt can also operate on numbers.

### DIFF
--- a/lib/lib.es5.d.ts
+++ b/lib/lib.es5.d.ts
@@ -38,7 +38,7 @@ declare function eval(x: string): any;
   * If this argument is not supplied, strings with a prefix of '0x' are considered hexadecimal.
   * All other strings are considered decimal.
   */
-declare function parseInt(s: string, radix?: number): number;
+declare function parseInt(s: string | number, radix?: number): number;
 
 /**
   * Converts a string to a floating-point number.


### PR DESCRIPTION
Not sure if this has been reported already. I've searched in the closed issues and pull requests and couldn't find anything related.

`parseInt(3.5)` is a valid call on JavaScript and has a reasonable return value.

**Example:**

```ts
var rounded = parseInt(3.5);
console.log(rounded);
```

**Expected behaviour:** 

Output `3` in the console.

**Actual behaviour:**

```
Argument of type 'number' is not assignable to parameter of type 'string'.
```

You can see there's also some examples that provides numbers to `parseInt` on Mozilla's documentation: https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/parseInt#Examples