### PR TITLE
Remove `npm update`; add release-2.3 to branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,12 @@ branches:
   - master
   - release-2.1
   - release-2.2
+  - release-2.3
 
 install:
   - npm uninstall typescript
   - npm uninstall tslint
   - npm install
-  - npm update
 
 cache:
   directories:


### PR DESCRIPTION
This command *should* do nothing immediately following an `npm install`, but causes failures due to `tslint` having a dependency on `typescript`.

Also add release-2.3 to our covered branches
