### PR TITLE
Don't access `sys.newLine` inside unit tests

### DIFF
--- a/src/compiler/commandLineParser.ts
+++ b/src/compiler/commandLineParser.ts
@@ -895,7 +895,7 @@ namespace ts {
      * @param fileNames array of filenames to be generated into tsconfig.json
      */
     /* @internal */
-    export function generateTSConfig(options: CompilerOptions, fileNames: string[]): string {
+    export function generateTSConfig(options: CompilerOptions, fileNames: string[], newLine: string): string {
         const compilerOptions = extend(options, defaultInitCompilerOptions);
         const configurations: { compilerOptions: MapLike<CompilerOptionsValue>; files?: string[] } = {
             compilerOptions: serializeCompilerOptions(compilerOptions)
@@ -1053,7 +1053,7 @@ namespace ts {
             }
             result.push(`}`);
 
-            return result.join(sys.newLine);
+            return result.join(newLine);
         }
     }
 

--- a/src/compiler/tsc.ts
+++ b/src/compiler/tsc.ts
@@ -739,7 +739,7 @@ namespace ts {
             reportDiagnostic(createCompilerDiagnostic(Diagnostics.A_tsconfig_json_file_is_already_defined_at_Colon_0, file), /* host */ undefined);
         }
         else {
-            sys.writeFile(file, generateTSConfig(options, fileNames));
+            sys.writeFile(file, generateTSConfig(options, fileNames, sys.newLine));
             reportDiagnostic(createCompilerDiagnostic(Diagnostics.Successfully_created_a_tsconfig_json_file), /* host */ undefined);
         }
 

--- a/src/harness/unittests/initializeTSConfig.ts
+++ b/src/harness/unittests/initializeTSConfig.ts
@@ -6,22 +6,11 @@ namespace ts {
         function initTSConfigCorrectly(name: string, commandLinesArgs: string[]) {
             describe(name, () => {
                 const commandLine = parseCommandLine(commandLinesArgs);
-                const initResult = generateTSConfig(commandLine.options, commandLine.fileNames);
+                const initResult = generateTSConfig(commandLine.options, commandLine.fileNames, "\n");
                 const outputFileName = `tsConfig/${name.replace(/[^a-z0-9\-. ]/ig, "")}/tsconfig.json`;
 
                 it(`Correct output for ${outputFileName}`, () => {
-                    Harness.Baseline.runBaseline(outputFileName, () => {
-                        if (initResult) {
-                            // normalize line endings
-                            return initResult.replace(new RegExp(sys.newLine, "g"), "\n");
-                        }
-                        else {
-                            // This can happen if compiler recieve invalid compiler-options
-                            /* tslint:disable:no-null-keyword */
-                            return null;
-                            /* tslint:enable:no-null-keyword */
-                        }
-                    });
+                    Harness.Baseline.runBaseline(outputFileName, () => initResult);
                 });
             });
         }


### PR DESCRIPTION
This was causing `runtests-browser` to break.
