### PR TITLE
Fix down-level emit for captured loop variable in async function

### DIFF
--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -2875,7 +2875,12 @@ namespace ts {
                 !state.labeledNonLocalContinues;
 
             const call = createCall(loopFunctionExpressionName, /*typeArguments*/ undefined, map(parameters, p => <Identifier>p.name));
-            const callResult = isAsyncBlockContainingAwait ? createYield(createToken(SyntaxKind.AsteriskToken), call) : call;
+            const callResult = isAsyncBlockContainingAwait
+                ? createYield(
+                    createToken(SyntaxKind.AsteriskToken),
+                    setEmitFlags(call, EmitFlags.Iterator)
+                )
+                : call;
             if (isSimpleLoop) {
                 statements.push(createStatement(callResult));
                 copyOutParameters(state.loopOutParameters, CopyDirection.ToOriginal, statements);

--- a/src/compiler/transformers/generators.ts
+++ b/src/compiler/transformers/generators.ts
@@ -939,7 +939,10 @@ namespace ts {
             const resumeLabel = defineLabel();
             const expression = visitNode(node.expression, visitor, isExpression);
             if (node.asteriskToken) {
-                emitYieldStar(createValuesHelper(context, expression, /*location*/ node), /*location*/ node);
+                const iterator = (getEmitFlags(node.expression) & EmitFlags.Iterator) === 0
+                    ? createValuesHelper(context, expression, /*location*/ node)
+                    : expression;
+                emitYieldStar(iterator, /*location*/ node);
             }
             else {
                 emitYield(expression, /*location*/ node);

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3937,6 +3937,7 @@ namespace ts {
         CustomPrologue = 1 << 19,                // Treat the statement as if it were a prologue directive (NOTE: Prologue directives are *not* transformed).
         NoHoisting = 1 << 20,                    // Do not hoist this declaration in --module system
         HasEndOfDeclarationMarker = 1 << 21,     // Declaration has an associated NotEmittedStatement to mark the end of the declaration
+        Iterator = 1 << 22,                      // The expression to a `yield*` should be treated as an Iterator when down-leveling, not an Iterable.
     }
 
     export interface EmitHelper {

--- a/tests/baselines/reference/asyncAwaitWithCapturedBlockScopeVar.js
+++ b/tests/baselines/reference/asyncAwaitWithCapturedBlockScopeVar.js
@@ -58,7 +58,7 @@ function fn1() {
                     _a.label = 1;
                 case 1:
                     if (!(i < 1)) return [3 /*break*/, 4];
-                    return [5 /*yield**/, __values(_loop_1(i))];
+                    return [5 /*yield**/, _loop_1(i)];
                 case 2:
                     _a.sent();
                     _a.label = 3;
@@ -92,7 +92,7 @@ function fn2() {
                     _a.label = 1;
                 case 1:
                     if (!(i < 1)) return [3 /*break*/, 4];
-                    return [5 /*yield**/, __values(_loop_2(i))];
+                    return [5 /*yield**/, _loop_2(i)];
                 case 2:
                     state_1 = _a.sent();
                     if (state_1 === "break")
@@ -128,7 +128,7 @@ function fn3() {
                     _a.label = 1;
                 case 1:
                     if (!(i < 1)) return [3 /*break*/, 4];
-                    return [5 /*yield**/, __values(_loop_3(i))];
+                    return [5 /*yield**/, _loop_3(i)];
                 case 2:
                     _a.sent();
                     _a.label = 3;
@@ -162,7 +162,7 @@ function fn4() {
                     _a.label = 1;
                 case 1:
                     if (!(i < 1)) return [3 /*break*/, 4];
-                    return [5 /*yield**/, __values(_loop_4(i))];
+                    return [5 /*yield**/, _loop_4(i)];
                 case 2:
                     state_2 = _a.sent();
                     if (typeof state_2 === "object")


### PR DESCRIPTION
After adding `--downlevelIteration` support, the generators transformer now always emits a `yield*` with a call to `__values`. While this is fine for cases where the yielded expression is an array or when running in a host environment with `Symbol.iterator`, this change breaks the case where we synthesize a `yield*` in an async function that contains a block-scoped variable captured in a loop body. 

As there is only one case in the transforms where this case can occur, I've added an `EmitFlags` flag to opt out of the new behavior for this one case.

Fixes #14357
