### PR TITLE
Add `as` attribute to HTMLLinkElement

### DIFF
--- a/src/lib/dom.generated.d.ts
+++ b/src/lib/dom.generated.d.ts
@@ -5464,6 +5464,10 @@ declare var HTMLLegendElement: {
 
 interface HTMLLinkElement extends HTMLElement, LinkStyle {
     /**
+     * Sets or retrieves the target attribute.
+     */
+    as: string;
+    /**
       * Sets or retrieves the character set used to encode the object.
       */
     charset: string;


### PR DESCRIPTION
The [rel=preload](https://w3c.github.io/preload) spec adds a non-breaking `as` attribute to `link` elements to define the [targets attribute](https://tools.ietf.org/html/rfc5988#section-5.4).

This PR adds it to the `HTMLLinkElement` interface in lib.dom.
