### PR TITLE
Fix duplication of first comment in file

### DIFF
--- a/src/compiler/scanner.ts
+++ b/src/compiler/scanner.ts
@@ -616,7 +616,11 @@ namespace ts {
         let pendingKind: CommentKind;
         let pendingHasTrailingNewLine: boolean;
         let hasPendingCommentRange = false;
-        let collecting = trailing || pos === 0;
+        const beginningOfFile = /^\s*$/.test(text.substr(0, pos));
+        if (trailing && beginningOfFile) {
+            return initial;
+        }
+        let collecting = trailing || beginningOfFile;
         let accumulator = initial;
         scan: while (pos >= 0 && pos < text.length) {
             const ch = text.charCodeAt(pos);

--- a/tests/baselines/reference/alwaysStrictModule3.js
+++ b/tests/baselines/reference/alwaysStrictModule3.js
@@ -4,5 +4,4 @@ export const a = 1;
 
 //// [alwaysStrictModule3.js]
 // module ES2015
-// module ES2015
 export var a = 1;

--- a/tests/baselines/reference/alwaysStrictModule5.js
+++ b/tests/baselines/reference/alwaysStrictModule5.js
@@ -4,5 +4,4 @@ export const a = 1;
 
 //// [alwaysStrictModule5.js]
 // Targeting ES6
-// Targeting ES6
 export const a = 1;

--- a/tests/baselines/reference/capturedLetConstInLoop4_ES6.js
+++ b/tests/baselines/reference/capturedLetConstInLoop4_ES6.js
@@ -144,7 +144,6 @@ for (const y = 0; y < 1;) {
 
 //// [capturedLetConstInLoop4_ES6.js]
 //======let
-//======let
 export function exportedFoo() {
     return v0 + v00 + v1 + v2 + v3 + v4 + v5 + v6 + v7 + v8;
 }

--- a/tests/baselines/reference/exponentiationOperatorSyntaxError1.js
+++ b/tests/baselines/reference/exponentiationOperatorSyntaxError1.js
@@ -40,8 +40,7 @@ var temp = 10;
 
 //// [exponentiationOperatorSyntaxError1.js]
 // Error: early syntax error using ES7 SimpleUnaryExpression on left-hand side without ()
-Math.pow(// Error: early syntax error using ES7 SimpleUnaryExpression on left-hand side without ()
--1, 2);
+Math.pow(-1, 2);
 Math.pow(+1, 2);
 Math.pow(1, Math.pow(-2, 3));
 Math.pow(1, Math.pow(-2, -3));


### PR DESCRIPTION
I'm not sure this is the "proper" fix, but it does resolve the issue.  `iterateCommentRanges` is called with pos=0 and trailing=true, making the first comment show up twice (as it will be iterated as a leading comment too).

Fixes Microsoft/TypeScript#12979

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->