### PR TITLE
serializeTypeNode handles `object`

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -1707,6 +1707,9 @@ namespace ts {
                 case SyntaxKind.StringKeyword:
                     return createIdentifier("String");
 
+                case SyntaxKind.ObjectKeyword:
+                    return createIdentifier("Object");
+
                 case SyntaxKind.LiteralType:
                     switch ((<LiteralTypeNode>node).literal.kind) {
                         case SyntaxKind.StringLiteral:

--- a/tests/baselines/reference/emitDecoratorMetadata_object.js
+++ b/tests/baselines/reference/emitDecoratorMetadata_object.js
@@ -1,0 +1,38 @@
+//// [emitDecoratorMetadata_object.ts]
+declare const MyClassDecorator: ClassDecorator;
+declare const MyMethodDecorator: MethodDecorator;
+
+@MyClassDecorator
+class A {
+    constructor(hi: object) {}
+    @MyMethodDecorator
+    method(there: object) {}
+}
+
+
+//// [emitDecoratorMetadata_object.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __metadata = (this && this.__metadata) || function (k, v) {
+    if (typeof Reflect === "object" && typeof Reflect.metadata === "function") return Reflect.metadata(k, v);
+};
+var A = (function () {
+    function A(hi) {
+    }
+    A.prototype.method = function (there) { };
+    return A;
+}());
+__decorate([
+    MyMethodDecorator,
+    __metadata("design:type", Function),
+    __metadata("design:paramtypes", [Object]),
+    __metadata("design:returntype", void 0)
+], A.prototype, "method", null);
+A = __decorate([
+    MyClassDecorator,
+    __metadata("design:paramtypes", [Object])
+], A);

--- a/tests/baselines/reference/emitDecoratorMetadata_object.symbols
+++ b/tests/baselines/reference/emitDecoratorMetadata_object.symbols
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/emitDecoratorMetadata_object.ts ===
+declare const MyClassDecorator: ClassDecorator;
+>MyClassDecorator : Symbol(MyClassDecorator, Decl(emitDecoratorMetadata_object.ts, 0, 13))
+>ClassDecorator : Symbol(ClassDecorator, Decl(lib.d.ts, --, --))
+
+declare const MyMethodDecorator: MethodDecorator;
+>MyMethodDecorator : Symbol(MyMethodDecorator, Decl(emitDecoratorMetadata_object.ts, 1, 13))
+>MethodDecorator : Symbol(MethodDecorator, Decl(lib.d.ts, --, --))
+
+@MyClassDecorator
+>MyClassDecorator : Symbol(MyClassDecorator, Decl(emitDecoratorMetadata_object.ts, 0, 13))
+
+class A {
+>A : Symbol(A, Decl(emitDecoratorMetadata_object.ts, 1, 49))
+
+    constructor(hi: object) {}
+>hi : Symbol(hi, Decl(emitDecoratorMetadata_object.ts, 5, 16))
+
+    @MyMethodDecorator
+>MyMethodDecorator : Symbol(MyMethodDecorator, Decl(emitDecoratorMetadata_object.ts, 1, 13))
+
+    method(there: object) {}
+>method : Symbol(A.method, Decl(emitDecoratorMetadata_object.ts, 5, 30))
+>there : Symbol(there, Decl(emitDecoratorMetadata_object.ts, 7, 11))
+}
+

--- a/tests/baselines/reference/emitDecoratorMetadata_object.types
+++ b/tests/baselines/reference/emitDecoratorMetadata_object.types
@@ -1,0 +1,26 @@
+=== tests/cases/compiler/emitDecoratorMetadata_object.ts ===
+declare const MyClassDecorator: ClassDecorator;
+>MyClassDecorator : ClassDecorator
+>ClassDecorator : ClassDecorator
+
+declare const MyMethodDecorator: MethodDecorator;
+>MyMethodDecorator : MethodDecorator
+>MethodDecorator : MethodDecorator
+
+@MyClassDecorator
+>MyClassDecorator : ClassDecorator
+
+class A {
+>A : A
+
+    constructor(hi: object) {}
+>hi : object
+
+    @MyMethodDecorator
+>MyMethodDecorator : MethodDecorator
+
+    method(there: object) {}
+>method : (there: object) => void
+>there : object
+}
+

--- a/tests/cases/compiler/emitDecoratorMetadata_object.ts
+++ b/tests/cases/compiler/emitDecoratorMetadata_object.ts
@@ -1,0 +1,13 @@
+// @experimentaldecorators: true
+// @emitdecoratormetadata: true
+// @target: ES5
+
+declare const MyClassDecorator: ClassDecorator;
+declare const MyMethodDecorator: MethodDecorator;
+
+@MyClassDecorator
+class A {
+    constructor(hi: object) {}
+    @MyMethodDecorator
+    method(there: object) {}
+}


### PR DESCRIPTION
This was just overlooked earlier.

Fixes #15181
