### PR TITLE
Yield in async generator should implicitly unwrap operand

### DIFF
--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -175,7 +175,7 @@
         "category": "Error",
         "code": 1057
     },
-    "Type used as operand to 'await' or the return type of an async function must either be a valid promise or must not contain a callable 'then' member.": {
+    "The return type of an async function must either be a valid promise or must not contain a callable 'then' member.": {
         "category": "Error",
         "code": 1058
     },
@@ -866,6 +866,18 @@
     "A default export can only be used in an ECMAScript-style module.": {
         "category": "Error",
         "code": 1319
+    },
+    "Type of 'await' operand must either be a valid promise or must not contain a callable 'then' member.": {
+        "category": "Error",
+        "code": 1320
+    },
+    "Type of 'yield' operand in an async generator must either be a valid promise or must not contain a callable 'then' member.": {
+        "category": "Error",
+        "code": 1321
+    },
+    "Type of iterated elements of a 'yield*' operand must either be a valid promise or must not contain a callable 'then' member.": {
+        "category": "Error",
+        "code": 1322
     },
     "Duplicate identifier '{0}'.": {
         "category": "Error",

--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -891,7 +891,8 @@ namespace ts {
                 function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
                 function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
                 function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-                function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+                function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+                function yield(value) { settle(c[2], { value: value, done: false }); }
                 function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
                 function fulfill(value) { resume("next", value); }
                 function reject(value) { resume("throw", value); }

--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -891,8 +891,8 @@ namespace ts {
                 function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
                 function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
                 function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-                function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-                function yield(value) { settle(c[2], { value: value, done: false }); }
+                function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+                function _yield(value) { settle(c[2], { value: value, done: false }); }
                 function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
                 function fulfill(value) { resume("next", value); }
                 function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/asyncFunctionDeclaration15_es5.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration15_es5.errors.txt
@@ -8,8 +8,8 @@ tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration1
     Types of property 'then' are incompatible.
       Type '() => void' is not assignable to type '<TResult1 = any, TResult2 = never>(onfulfilled?: (value: any) => TResult1 | PromiseLike<TResult1>, onrejected?: (reason: any) => TResult2 | PromiseLike<TResult2>) => PromiseLike<TResult1 | TResult2>'.
         Type 'void' is not assignable to type 'PromiseLike<any>'.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration15_es5.ts(17,16): error TS1058: Type used as operand to 'await' or the return type of an async function must either be a valid promise or must not contain a callable 'then' member.
-tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration15_es5.ts(23,25): error TS1058: Type used as operand to 'await' or the return type of an async function must either be a valid promise or must not contain a callable 'then' member.
+tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration15_es5.ts(17,16): error TS1058: The return type of an async function must either be a valid promise or must not contain a callable 'then' member.
+tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration15_es5.ts(23,25): error TS1320: Type of 'await' operand must either be a valid promise or must not contain a callable 'then' member.
 
 
 ==== tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration15_es5.ts (8 errors) ====
@@ -47,7 +47,7 @@ tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration1
     async function fn12() { return obj; } // valid: Promise<{ then: string; }>
     async function fn13() { return thenable; } // error
                    ~~~~
-!!! error TS1058: Type used as operand to 'await' or the return type of an async function must either be a valid promise or must not contain a callable 'then' member.
+!!! error TS1058: The return type of an async function must either be a valid promise or must not contain a callable 'then' member.
     async function fn14() { await 1; } // valid: Promise<void>
     async function fn15() { await null; } // valid: Promise<void>
     async function fn16() { await undefined; } // valid: Promise<void>
@@ -55,5 +55,5 @@ tests/cases/conformance/async/es5/functionDeclarations/asyncFunctionDeclaration1
     async function fn18() { await obj; } // valid: Promise<void>
     async function fn19() { await thenable; } // error
                             ~~~~~~~~~~~~~~
-!!! error TS1058: Type used as operand to 'await' or the return type of an async function must either be a valid promise or must not contain a callable 'then' member.
+!!! error TS1320: Type of 'await' operand must either be a valid promise or must not contain a callable 'then' member.
     

--- a/tests/baselines/reference/asyncFunctionDeclaration15_es6.errors.txt
+++ b/tests/baselines/reference/asyncFunctionDeclaration15_es6.errors.txt
@@ -3,8 +3,8 @@ tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration1
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts(8,23): error TS1064: The return type of an async function or method must be the global Promise<T> type.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts(9,23): error TS1064: The return type of an async function or method must be the global Promise<T> type.
 tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts(10,23): error TS1064: The return type of an async function or method must be the global Promise<T> type.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts(17,16): error TS1058: Type used as operand to 'await' or the return type of an async function must either be a valid promise or must not contain a callable 'then' member.
-tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts(23,25): error TS1058: Type used as operand to 'await' or the return type of an async function must either be a valid promise or must not contain a callable 'then' member.
+tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts(17,16): error TS1058: The return type of an async function must either be a valid promise or must not contain a callable 'then' member.
+tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts(23,25): error TS1320: Type of 'await' operand must either be a valid promise or must not contain a callable 'then' member.
 
 
 ==== tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration15_es6.ts (7 errors) ====
@@ -36,7 +36,7 @@ tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration1
     async function fn12() { return obj; } // valid: Promise<{ then: string; }>
     async function fn13() { return thenable; } // error
                    ~~~~
-!!! error TS1058: Type used as operand to 'await' or the return type of an async function must either be a valid promise or must not contain a callable 'then' member.
+!!! error TS1058: The return type of an async function must either be a valid promise or must not contain a callable 'then' member.
     async function fn14() { await 1; } // valid: Promise<void>
     async function fn15() { await null; } // valid: Promise<void>
     async function fn16() { await undefined; } // valid: Promise<void>
@@ -44,5 +44,5 @@ tests/cases/conformance/async/es6/functionDeclarations/asyncFunctionDeclaration1
     async function fn18() { await obj; } // valid: Promise<void>
     async function fn19() { await thenable; } // error
                             ~~~~~~~~~~~~~~
-!!! error TS1058: Type used as operand to 'await' or the return type of an async function must either be a valid promise or must not contain a callable 'then' member.
+!!! error TS1320: Type of 'await' operand must either be a valid promise or must not contain a callable 'then' member.
     

--- a/tests/baselines/reference/emitter.asyncGenerators.classMethods.es2015.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.classMethods.es2015.js
@@ -68,7 +68,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -88,7 +89,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -109,7 +111,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -135,7 +138,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -156,7 +160,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -182,7 +187,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -203,7 +209,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -224,7 +231,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -247,7 +255,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.asyncGenerators.classMethods.es2015.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.classMethods.es2015.js
@@ -68,8 +68,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -89,8 +89,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -111,8 +111,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -138,8 +138,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -160,8 +160,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -187,8 +187,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -209,8 +209,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -231,8 +231,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -255,8 +255,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.asyncGenerators.classMethods.es5.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.classMethods.es5.js
@@ -95,8 +95,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -149,8 +149,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -209,8 +209,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -274,8 +274,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -344,8 +344,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -426,8 +426,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -486,8 +486,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -540,8 +540,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -607,8 +607,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.asyncGenerators.classMethods.es5.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.classMethods.es5.js
@@ -95,7 +95,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -148,7 +149,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -207,7 +209,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -271,7 +274,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -340,7 +344,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -421,7 +426,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -480,7 +486,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -533,7 +540,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -599,7 +607,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es2015.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es2015.js
@@ -37,8 +37,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -56,8 +56,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -76,8 +76,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -101,8 +101,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -121,8 +121,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -146,8 +146,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -166,8 +166,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es2015.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es2015.js
@@ -37,7 +37,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -55,7 +56,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -74,7 +76,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -98,7 +101,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -117,7 +121,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -141,7 +146,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -160,7 +166,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es5.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es5.js
@@ -64,7 +64,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -112,7 +113,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -166,7 +168,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -225,7 +228,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -289,7 +293,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -365,7 +370,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -419,7 +425,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es5.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es5.js
@@ -64,8 +64,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -113,8 +113,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -168,8 +168,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -228,8 +228,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -293,8 +293,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -370,8 +370,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -425,8 +425,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es2015.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es2015.js
@@ -37,8 +37,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -56,8 +56,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -76,8 +76,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -101,8 +101,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -121,8 +121,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -146,8 +146,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -166,8 +166,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es2015.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es2015.js
@@ -37,7 +37,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -55,7 +56,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -74,7 +76,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -98,7 +101,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -117,7 +121,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -141,7 +146,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -160,7 +166,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es5.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es5.js
@@ -64,7 +64,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -112,7 +113,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -166,7 +168,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -225,7 +228,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -289,7 +293,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -365,7 +370,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -419,7 +425,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es5.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es5.js
@@ -64,8 +64,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -113,8 +113,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -168,8 +168,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -228,8 +228,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -293,8 +293,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -370,8 +370,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -425,8 +425,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es2015.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es2015.js
@@ -51,7 +51,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -71,7 +72,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -92,7 +94,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -118,7 +121,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -139,7 +143,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -165,7 +170,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -186,7 +192,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es2015.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es2015.js
@@ -51,8 +51,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -72,8 +72,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -94,8 +94,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -121,8 +121,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -143,8 +143,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -170,8 +170,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -192,8 +192,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es5.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es5.js
@@ -78,8 +78,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -129,8 +129,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -186,8 +186,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -248,8 +248,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -315,8 +315,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -394,8 +394,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -451,8 +451,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es5.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es5.js
@@ -78,7 +78,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -128,7 +129,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -184,7 +186,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -245,7 +248,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -311,7 +315,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -389,7 +394,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -445,7 +451,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.forAwait.es2015.js
+++ b/tests/baselines/reference/emitter.forAwait.es2015.js
@@ -102,8 +102,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -140,8 +140,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.forAwait.es2015.js
+++ b/tests/baselines/reference/emitter.forAwait.es2015.js
@@ -102,7 +102,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -139,7 +140,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.forAwait.es5.js
+++ b/tests/baselines/reference/emitter.forAwait.es5.js
@@ -231,8 +231,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -320,8 +320,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function yield(value) { settle(c[2], { value: value, done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function _yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/emitter.forAwait.es5.js
+++ b/tests/baselines/reference/emitter.forAwait.es5.js
@@ -231,7 +231,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
@@ -319,7 +320,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : r.value[0] === "yield" ? settle(c[2], { value: r.value[1], done: false }) : Promise.resolve(r.value[1]).then(r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
+    function yield(value) { settle(c[2], { value: value, done: false }); }
     function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }

--- a/tests/baselines/reference/types.asyncGenerators.esnext.1.symbols
+++ b/tests/baselines/reference/types.asyncGenerators.esnext.1.symbols
@@ -15,137 +15,276 @@ async function * inferReturnType3() {
 async function * inferReturnType4() {
 >inferReturnType4 : Symbol(inferReturnType4, Decl(types.asyncGenerators.esnext.1.ts, 7, 1))
 
-    yield* [1, 2];
+    yield Promise.resolve(1);
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
 }
 async function * inferReturnType5() {
 >inferReturnType5 : Symbol(inferReturnType5, Decl(types.asyncGenerators.esnext.1.ts, 10, 1))
 
+    yield 1;
+    yield Promise.resolve(2);
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+}
+async function * inferReturnType6() {
+>inferReturnType6 : Symbol(inferReturnType6, Decl(types.asyncGenerators.esnext.1.ts, 14, 1))
+
+    yield* [1, 2];
+}
+async function * inferReturnType7() {
+>inferReturnType7 : Symbol(inferReturnType7, Decl(types.asyncGenerators.esnext.1.ts, 17, 1))
+
+    yield* [Promise.resolve(1)];
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+}
+async function * inferReturnType8() {
+>inferReturnType8 : Symbol(inferReturnType8, Decl(types.asyncGenerators.esnext.1.ts, 20, 1))
+
     yield* (async function * () { yield 1; })();
 }
 const assignability1: () => AsyncIterableIterator<number> = async function * () {
->assignability1 : Symbol(assignability1, Decl(types.asyncGenerators.esnext.1.ts, 14, 5))
+>assignability1 : Symbol(assignability1, Decl(types.asyncGenerators.esnext.1.ts, 24, 5))
 >AsyncIterableIterator : Symbol(AsyncIterableIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
 
     yield 1;
 };
 const assignability2: () => AsyncIterableIterator<number> = async function * () {
->assignability2 : Symbol(assignability2, Decl(types.asyncGenerators.esnext.1.ts, 17, 5))
+>assignability2 : Symbol(assignability2, Decl(types.asyncGenerators.esnext.1.ts, 27, 5))
 >AsyncIterableIterator : Symbol(AsyncIterableIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
 
-    yield* [1, 2];
+    yield Promise.resolve(1);
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
 };
 const assignability3: () => AsyncIterableIterator<number> = async function * () {
->assignability3 : Symbol(assignability3, Decl(types.asyncGenerators.esnext.1.ts, 20, 5))
+>assignability3 : Symbol(assignability3, Decl(types.asyncGenerators.esnext.1.ts, 30, 5))
+>AsyncIterableIterator : Symbol(AsyncIterableIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
+
+    yield* [1, 2];
+};
+const assignability4: () => AsyncIterableIterator<number> = async function * () {
+>assignability4 : Symbol(assignability4, Decl(types.asyncGenerators.esnext.1.ts, 33, 5))
+>AsyncIterableIterator : Symbol(AsyncIterableIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
+
+    yield* [Promise.resolve(1)];
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+};
+const assignability5: () => AsyncIterableIterator<number> = async function * () {
+>assignability5 : Symbol(assignability5, Decl(types.asyncGenerators.esnext.1.ts, 36, 5))
 >AsyncIterableIterator : Symbol(AsyncIterableIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
 
     yield* (async function * () { yield 1; })();
 };
-const assignability4: () => AsyncIterable<number> = async function * () {
->assignability4 : Symbol(assignability4, Decl(types.asyncGenerators.esnext.1.ts, 23, 5))
+const assignability6: () => AsyncIterable<number> = async function * () {
+>assignability6 : Symbol(assignability6, Decl(types.asyncGenerators.esnext.1.ts, 39, 5))
 >AsyncIterable : Symbol(AsyncIterable, Decl(lib.esnext.asynciterable.d.ts, --, --))
 
     yield 1;
 };
-const assignability5: () => AsyncIterable<number> = async function * () {
->assignability5 : Symbol(assignability5, Decl(types.asyncGenerators.esnext.1.ts, 26, 5))
+const assignability7: () => AsyncIterable<number> = async function * () {
+>assignability7 : Symbol(assignability7, Decl(types.asyncGenerators.esnext.1.ts, 42, 5))
+>AsyncIterable : Symbol(AsyncIterable, Decl(lib.esnext.asynciterable.d.ts, --, --))
+
+    yield Promise.resolve(1);
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+};
+const assignability8: () => AsyncIterable<number> = async function * () {
+>assignability8 : Symbol(assignability8, Decl(types.asyncGenerators.esnext.1.ts, 45, 5))
 >AsyncIterable : Symbol(AsyncIterable, Decl(lib.esnext.asynciterable.d.ts, --, --))
 
     yield* [1, 2];
 };
-const assignability6: () => AsyncIterable<number> = async function * () {
->assignability6 : Symbol(assignability6, Decl(types.asyncGenerators.esnext.1.ts, 29, 5))
+const assignability9: () => AsyncIterable<number> = async function * () {
+>assignability9 : Symbol(assignability9, Decl(types.asyncGenerators.esnext.1.ts, 48, 5))
+>AsyncIterable : Symbol(AsyncIterable, Decl(lib.esnext.asynciterable.d.ts, --, --))
+
+    yield* [Promise.resolve(1)];
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+};
+const assignability10: () => AsyncIterable<number> = async function * () {
+>assignability10 : Symbol(assignability10, Decl(types.asyncGenerators.esnext.1.ts, 51, 5))
 >AsyncIterable : Symbol(AsyncIterable, Decl(lib.esnext.asynciterable.d.ts, --, --))
 
     yield* (async function * () { yield 1; })();
 };
-const assignability7: () => AsyncIterator<number> = async function * () {
->assignability7 : Symbol(assignability7, Decl(types.asyncGenerators.esnext.1.ts, 32, 5))
+const assignability11: () => AsyncIterator<number> = async function * () {
+>assignability11 : Symbol(assignability11, Decl(types.asyncGenerators.esnext.1.ts, 54, 5))
 >AsyncIterator : Symbol(AsyncIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
 
     yield 1;
 };
-const assignability8: () => AsyncIterator<number> = async function * () {
->assignability8 : Symbol(assignability8, Decl(types.asyncGenerators.esnext.1.ts, 35, 5))
+const assignability12: () => AsyncIterator<number> = async function * () {
+>assignability12 : Symbol(assignability12, Decl(types.asyncGenerators.esnext.1.ts, 57, 5))
+>AsyncIterator : Symbol(AsyncIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
+
+    yield Promise.resolve(1);
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+};
+const assignability13: () => AsyncIterator<number> = async function * () {
+>assignability13 : Symbol(assignability13, Decl(types.asyncGenerators.esnext.1.ts, 60, 5))
 >AsyncIterator : Symbol(AsyncIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
 
     yield* [1, 2];
 };
-const assignability9: () => AsyncIterator<number> = async function * () {
->assignability9 : Symbol(assignability9, Decl(types.asyncGenerators.esnext.1.ts, 38, 5))
+const assignability14: () => AsyncIterator<number> = async function * () {
+>assignability14 : Symbol(assignability14, Decl(types.asyncGenerators.esnext.1.ts, 63, 5))
+>AsyncIterator : Symbol(AsyncIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
+
+    yield* [Promise.resolve(1)];
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+
+};
+const assignability15: () => AsyncIterator<number> = async function * () {
+>assignability15 : Symbol(assignability15, Decl(types.asyncGenerators.esnext.1.ts, 66, 5))
 >AsyncIterator : Symbol(AsyncIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
 
     yield* (async function * () { yield 1; })();
 };
 async function * explicitReturnType1(): AsyncIterableIterator<number> {
->explicitReturnType1 : Symbol(explicitReturnType1, Decl(types.asyncGenerators.esnext.1.ts, 40, 2))
+>explicitReturnType1 : Symbol(explicitReturnType1, Decl(types.asyncGenerators.esnext.1.ts, 68, 2))
 >AsyncIterableIterator : Symbol(AsyncIterableIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
 
     yield 1;
 }
 async function * explicitReturnType2(): AsyncIterableIterator<number> {
->explicitReturnType2 : Symbol(explicitReturnType2, Decl(types.asyncGenerators.esnext.1.ts, 43, 1))
+>explicitReturnType2 : Symbol(explicitReturnType2, Decl(types.asyncGenerators.esnext.1.ts, 71, 1))
 >AsyncIterableIterator : Symbol(AsyncIterableIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
 
-    yield* [1, 2];
+    yield Promise.resolve(1);
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
 }
 async function * explicitReturnType3(): AsyncIterableIterator<number> {
->explicitReturnType3 : Symbol(explicitReturnType3, Decl(types.asyncGenerators.esnext.1.ts, 46, 1))
+>explicitReturnType3 : Symbol(explicitReturnType3, Decl(types.asyncGenerators.esnext.1.ts, 74, 1))
+>AsyncIterableIterator : Symbol(AsyncIterableIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
+
+    yield* [1, 2];
+}
+async function * explicitReturnType4(): AsyncIterableIterator<number> {
+>explicitReturnType4 : Symbol(explicitReturnType4, Decl(types.asyncGenerators.esnext.1.ts, 77, 1))
+>AsyncIterableIterator : Symbol(AsyncIterableIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
+
+    yield* [Promise.resolve(1)];
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+}
+async function * explicitReturnType5(): AsyncIterableIterator<number> {
+>explicitReturnType5 : Symbol(explicitReturnType5, Decl(types.asyncGenerators.esnext.1.ts, 80, 1))
 >AsyncIterableIterator : Symbol(AsyncIterableIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
 
     yield* (async function * () { yield 1; })();
 }
-async function * explicitReturnType4(): AsyncIterable<number> {
->explicitReturnType4 : Symbol(explicitReturnType4, Decl(types.asyncGenerators.esnext.1.ts, 49, 1))
->AsyncIterable : Symbol(AsyncIterable, Decl(lib.esnext.asynciterable.d.ts, --, --))
-
-    yield 1;
-}
-async function * explicitReturnType5(): AsyncIterable<number> {
->explicitReturnType5 : Symbol(explicitReturnType5, Decl(types.asyncGenerators.esnext.1.ts, 52, 1))
->AsyncIterable : Symbol(AsyncIterable, Decl(lib.esnext.asynciterable.d.ts, --, --))
-
-    yield* [1, 2];
-}
 async function * explicitReturnType6(): AsyncIterable<number> {
->explicitReturnType6 : Symbol(explicitReturnType6, Decl(types.asyncGenerators.esnext.1.ts, 55, 1))
+>explicitReturnType6 : Symbol(explicitReturnType6, Decl(types.asyncGenerators.esnext.1.ts, 83, 1))
+>AsyncIterable : Symbol(AsyncIterable, Decl(lib.esnext.asynciterable.d.ts, --, --))
+
+    yield 1;
+}
+async function * explicitReturnType7(): AsyncIterable<number> {
+>explicitReturnType7 : Symbol(explicitReturnType7, Decl(types.asyncGenerators.esnext.1.ts, 86, 1))
+>AsyncIterable : Symbol(AsyncIterable, Decl(lib.esnext.asynciterable.d.ts, --, --))
+
+    yield Promise.resolve(1);
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+}
+async function * explicitReturnType8(): AsyncIterable<number> {
+>explicitReturnType8 : Symbol(explicitReturnType8, Decl(types.asyncGenerators.esnext.1.ts, 89, 1))
+>AsyncIterable : Symbol(AsyncIterable, Decl(lib.esnext.asynciterable.d.ts, --, --))
+
+    yield* [1, 2];
+}
+async function * explicitReturnType9(): AsyncIterable<number> {
+>explicitReturnType9 : Symbol(explicitReturnType9, Decl(types.asyncGenerators.esnext.1.ts, 92, 1))
+>AsyncIterable : Symbol(AsyncIterable, Decl(lib.esnext.asynciterable.d.ts, --, --))
+
+    yield* [Promise.resolve(1)];
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+}
+async function * explicitReturnType10(): AsyncIterable<number> {
+>explicitReturnType10 : Symbol(explicitReturnType10, Decl(types.asyncGenerators.esnext.1.ts, 95, 1))
 >AsyncIterable : Symbol(AsyncIterable, Decl(lib.esnext.asynciterable.d.ts, --, --))
 
     yield* (async function * () { yield 1; })();
 }
-async function * explicitReturnType7(): AsyncIterator<number> {
->explicitReturnType7 : Symbol(explicitReturnType7, Decl(types.asyncGenerators.esnext.1.ts, 58, 1))
+async function * explicitReturnType11(): AsyncIterator<number> {
+>explicitReturnType11 : Symbol(explicitReturnType11, Decl(types.asyncGenerators.esnext.1.ts, 98, 1))
 >AsyncIterator : Symbol(AsyncIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
 
     yield 1;
 }
-async function * explicitReturnType8(): AsyncIterator<number> {
->explicitReturnType8 : Symbol(explicitReturnType8, Decl(types.asyncGenerators.esnext.1.ts, 61, 1))
+async function * explicitReturnType12(): AsyncIterator<number> {
+>explicitReturnType12 : Symbol(explicitReturnType12, Decl(types.asyncGenerators.esnext.1.ts, 101, 1))
+>AsyncIterator : Symbol(AsyncIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
+
+    yield Promise.resolve(1);
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+}
+async function * explicitReturnType13(): AsyncIterator<number> {
+>explicitReturnType13 : Symbol(explicitReturnType13, Decl(types.asyncGenerators.esnext.1.ts, 104, 1))
 >AsyncIterator : Symbol(AsyncIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
 
     yield* [1, 2];
 }
-async function * explicitReturnType9(): AsyncIterator<number> {
->explicitReturnType9 : Symbol(explicitReturnType9, Decl(types.asyncGenerators.esnext.1.ts, 64, 1))
+async function * explicitReturnType14(): AsyncIterator<number> {
+>explicitReturnType14 : Symbol(explicitReturnType14, Decl(types.asyncGenerators.esnext.1.ts, 107, 1))
+>AsyncIterator : Symbol(AsyncIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
+
+    yield* [Promise.resolve(1)];
+>Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+>Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
+>resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
+}
+async function * explicitReturnType15(): AsyncIterator<number> {
+>explicitReturnType15 : Symbol(explicitReturnType15, Decl(types.asyncGenerators.esnext.1.ts, 110, 1))
 >AsyncIterator : Symbol(AsyncIterator, Decl(lib.esnext.asynciterable.d.ts, --, --))
 
     yield* (async function * () { yield 1; })();
 }
-async function * explicitReturnType10(): {} {
->explicitReturnType10 : Symbol(explicitReturnType10, Decl(types.asyncGenerators.esnext.1.ts, 67, 1))
+async function * explicitReturnType16(): {} {
+>explicitReturnType16 : Symbol(explicitReturnType16, Decl(types.asyncGenerators.esnext.1.ts, 113, 1))
 
     yield 1;
 }
 async function * awaitedType1() {
->awaitedType1 : Symbol(awaitedType1, Decl(types.asyncGenerators.esnext.1.ts, 70, 1))
+>awaitedType1 : Symbol(awaitedType1, Decl(types.asyncGenerators.esnext.1.ts, 116, 1))
 
     const x = await 1;
->x : Symbol(x, Decl(types.asyncGenerators.esnext.1.ts, 72, 9))
+>x : Symbol(x, Decl(types.asyncGenerators.esnext.1.ts, 118, 9))
 }
 async function * awaitedType2() {
->awaitedType2 : Symbol(awaitedType2, Decl(types.asyncGenerators.esnext.1.ts, 73, 1))
+>awaitedType2 : Symbol(awaitedType2, Decl(types.asyncGenerators.esnext.1.ts, 119, 1))
 
     const x = await Promise.resolve(1);
->x : Symbol(x, Decl(types.asyncGenerators.esnext.1.ts, 75, 9))
+>x : Symbol(x, Decl(types.asyncGenerators.esnext.1.ts, 121, 9))
 >Promise.resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))
 >Promise : Symbol(Promise, Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.symbol.wellknown.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.iterable.d.ts, --, --))
 >resolve : Symbol(PromiseConstructor.resolve, Decl(lib.es2015.promise.d.ts, --, --), Decl(lib.es2015.promise.d.ts, --, --))

--- a/tests/baselines/reference/types.asyncGenerators.esnext.1.types
+++ b/tests/baselines/reference/types.asyncGenerators.esnext.1.types
@@ -18,14 +18,52 @@ async function * inferReturnType3() {
 async function * inferReturnType4() {
 >inferReturnType4 : () => AsyncIterableIterator<number>
 
+    yield Promise.resolve(1);
+>yield Promise.resolve(1) : any
+>Promise.resolve(1) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>1 : 1
+}
+async function * inferReturnType5() {
+>inferReturnType5 : () => AsyncIterableIterator<number>
+
+    yield 1;
+>yield 1 : any
+>1 : 1
+
+    yield Promise.resolve(2);
+>yield Promise.resolve(2) : any
+>Promise.resolve(2) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>2 : 2
+}
+async function * inferReturnType6() {
+>inferReturnType6 : () => AsyncIterableIterator<number>
+
     yield* [1, 2];
 >yield* [1, 2] : any
 >[1, 2] : number[]
 >1 : 1
 >2 : 2
 }
-async function * inferReturnType5() {
->inferReturnType5 : () => AsyncIterableIterator<1>
+async function * inferReturnType7() {
+>inferReturnType7 : () => AsyncIterableIterator<number>
+
+    yield* [Promise.resolve(1)];
+>yield* [Promise.resolve(1)] : any
+>[Promise.resolve(1)] : Promise<number>[]
+>Promise.resolve(1) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>1 : 1
+}
+async function * inferReturnType8() {
+>inferReturnType8 : () => AsyncIterableIterator<1>
 
     yield* (async function * () { yield 1; })();
 >yield* (async function * () { yield 1; })() : any
@@ -48,6 +86,20 @@ const assignability1: () => AsyncIterableIterator<number> = async function * () 
 const assignability2: () => AsyncIterableIterator<number> = async function * () {
 >assignability2 : () => AsyncIterableIterator<number>
 >AsyncIterableIterator : AsyncIterableIterator<T>
+>async function * () {    yield Promise.resolve(1);} : () => AsyncIterableIterator<number>
+
+    yield Promise.resolve(1);
+>yield Promise.resolve(1) : any
+>Promise.resolve(1) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>1 : 1
+
+};
+const assignability3: () => AsyncIterableIterator<number> = async function * () {
+>assignability3 : () => AsyncIterableIterator<number>
+>AsyncIterableIterator : AsyncIterableIterator<T>
 >async function * () {    yield* [1, 2];} : () => AsyncIterableIterator<number>
 
     yield* [1, 2];
@@ -57,8 +109,23 @@ const assignability2: () => AsyncIterableIterator<number> = async function * () 
 >2 : 2
 
 };
-const assignability3: () => AsyncIterableIterator<number> = async function * () {
->assignability3 : () => AsyncIterableIterator<number>
+const assignability4: () => AsyncIterableIterator<number> = async function * () {
+>assignability4 : () => AsyncIterableIterator<number>
+>AsyncIterableIterator : AsyncIterableIterator<T>
+>async function * () {    yield* [Promise.resolve(1)];} : () => AsyncIterableIterator<number>
+
+    yield* [Promise.resolve(1)];
+>yield* [Promise.resolve(1)] : any
+>[Promise.resolve(1)] : Promise<number>[]
+>Promise.resolve(1) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>1 : 1
+
+};
+const assignability5: () => AsyncIterableIterator<number> = async function * () {
+>assignability5 : () => AsyncIterableIterator<number>
 >AsyncIterableIterator : AsyncIterableIterator<T>
 >async function * () {    yield* (async function * () { yield 1; })();} : () => AsyncIterableIterator<1>
 
@@ -71,8 +138,8 @@ const assignability3: () => AsyncIterableIterator<number> = async function * () 
 >1 : 1
 
 };
-const assignability4: () => AsyncIterable<number> = async function * () {
->assignability4 : () => AsyncIterable<number>
+const assignability6: () => AsyncIterable<number> = async function * () {
+>assignability6 : () => AsyncIterable<number>
 >AsyncIterable : AsyncIterable<T>
 >async function * () {    yield 1;} : () => AsyncIterableIterator<1>
 
@@ -81,8 +148,22 @@ const assignability4: () => AsyncIterable<number> = async function * () {
 >1 : 1
 
 };
-const assignability5: () => AsyncIterable<number> = async function * () {
->assignability5 : () => AsyncIterable<number>
+const assignability7: () => AsyncIterable<number> = async function * () {
+>assignability7 : () => AsyncIterable<number>
+>AsyncIterable : AsyncIterable<T>
+>async function * () {    yield Promise.resolve(1);} : () => AsyncIterableIterator<number>
+
+    yield Promise.resolve(1);
+>yield Promise.resolve(1) : any
+>Promise.resolve(1) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>1 : 1
+
+};
+const assignability8: () => AsyncIterable<number> = async function * () {
+>assignability8 : () => AsyncIterable<number>
 >AsyncIterable : AsyncIterable<T>
 >async function * () {    yield* [1, 2];} : () => AsyncIterableIterator<number>
 
@@ -93,8 +174,23 @@ const assignability5: () => AsyncIterable<number> = async function * () {
 >2 : 2
 
 };
-const assignability6: () => AsyncIterable<number> = async function * () {
->assignability6 : () => AsyncIterable<number>
+const assignability9: () => AsyncIterable<number> = async function * () {
+>assignability9 : () => AsyncIterable<number>
+>AsyncIterable : AsyncIterable<T>
+>async function * () {    yield* [Promise.resolve(1)];} : () => AsyncIterableIterator<number>
+
+    yield* [Promise.resolve(1)];
+>yield* [Promise.resolve(1)] : any
+>[Promise.resolve(1)] : Promise<number>[]
+>Promise.resolve(1) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>1 : 1
+
+};
+const assignability10: () => AsyncIterable<number> = async function * () {
+>assignability10 : () => AsyncIterable<number>
 >AsyncIterable : AsyncIterable<T>
 >async function * () {    yield* (async function * () { yield 1; })();} : () => AsyncIterableIterator<1>
 
@@ -107,8 +203,8 @@ const assignability6: () => AsyncIterable<number> = async function * () {
 >1 : 1
 
 };
-const assignability7: () => AsyncIterator<number> = async function * () {
->assignability7 : () => AsyncIterator<number>
+const assignability11: () => AsyncIterator<number> = async function * () {
+>assignability11 : () => AsyncIterator<number>
 >AsyncIterator : AsyncIterator<T>
 >async function * () {    yield 1;} : () => AsyncIterableIterator<1>
 
@@ -117,8 +213,22 @@ const assignability7: () => AsyncIterator<number> = async function * () {
 >1 : 1
 
 };
-const assignability8: () => AsyncIterator<number> = async function * () {
->assignability8 : () => AsyncIterator<number>
+const assignability12: () => AsyncIterator<number> = async function * () {
+>assignability12 : () => AsyncIterator<number>
+>AsyncIterator : AsyncIterator<T>
+>async function * () {    yield Promise.resolve(1);} : () => AsyncIterableIterator<number>
+
+    yield Promise.resolve(1);
+>yield Promise.resolve(1) : any
+>Promise.resolve(1) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>1 : 1
+
+};
+const assignability13: () => AsyncIterator<number> = async function * () {
+>assignability13 : () => AsyncIterator<number>
 >AsyncIterator : AsyncIterator<T>
 >async function * () {    yield* [1, 2];} : () => AsyncIterableIterator<number>
 
@@ -129,8 +239,23 @@ const assignability8: () => AsyncIterator<number> = async function * () {
 >2 : 2
 
 };
-const assignability9: () => AsyncIterator<number> = async function * () {
->assignability9 : () => AsyncIterator<number>
+const assignability14: () => AsyncIterator<number> = async function * () {
+>assignability14 : () => AsyncIterator<number>
+>AsyncIterator : AsyncIterator<T>
+>async function * () {    yield* [Promise.resolve(1)];} : () => AsyncIterableIterator<number>
+
+    yield* [Promise.resolve(1)];
+>yield* [Promise.resolve(1)] : any
+>[Promise.resolve(1)] : Promise<number>[]
+>Promise.resolve(1) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>1 : 1
+
+};
+const assignability15: () => AsyncIterator<number> = async function * () {
+>assignability15 : () => AsyncIterator<number>
 >AsyncIterator : AsyncIterator<T>
 >async function * () {    yield* (async function * () { yield 1; })();} : () => AsyncIterableIterator<1>
 
@@ -155,14 +280,39 @@ async function * explicitReturnType2(): AsyncIterableIterator<number> {
 >explicitReturnType2 : () => AsyncIterableIterator<number>
 >AsyncIterableIterator : AsyncIterableIterator<T>
 
+    yield Promise.resolve(1);
+>yield Promise.resolve(1) : any
+>Promise.resolve(1) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>1 : 1
+}
+async function * explicitReturnType3(): AsyncIterableIterator<number> {
+>explicitReturnType3 : () => AsyncIterableIterator<number>
+>AsyncIterableIterator : AsyncIterableIterator<T>
+
     yield* [1, 2];
 >yield* [1, 2] : any
 >[1, 2] : number[]
 >1 : 1
 >2 : 2
 }
-async function * explicitReturnType3(): AsyncIterableIterator<number> {
->explicitReturnType3 : () => AsyncIterableIterator<number>
+async function * explicitReturnType4(): AsyncIterableIterator<number> {
+>explicitReturnType4 : () => AsyncIterableIterator<number>
+>AsyncIterableIterator : AsyncIterableIterator<T>
+
+    yield* [Promise.resolve(1)];
+>yield* [Promise.resolve(1)] : any
+>[Promise.resolve(1)] : Promise<number>[]
+>Promise.resolve(1) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>1 : 1
+}
+async function * explicitReturnType5(): AsyncIterableIterator<number> {
+>explicitReturnType5 : () => AsyncIterableIterator<number>
 >AsyncIterableIterator : AsyncIterableIterator<T>
 
     yield* (async function * () { yield 1; })();
@@ -173,28 +323,53 @@ async function * explicitReturnType3(): AsyncIterableIterator<number> {
 >yield 1 : any
 >1 : 1
 }
-async function * explicitReturnType4(): AsyncIterable<number> {
->explicitReturnType4 : () => AsyncIterable<number>
->AsyncIterable : AsyncIterable<T>
-
-    yield 1;
->yield 1 : any
->1 : 1
-}
-async function * explicitReturnType5(): AsyncIterable<number> {
->explicitReturnType5 : () => AsyncIterable<number>
->AsyncIterable : AsyncIterable<T>
-
-    yield* [1, 2];
->yield* [1, 2] : any
->[1, 2] : number[]
->1 : 1
->2 : 2
-}
 async function * explicitReturnType6(): AsyncIterable<number> {
 >explicitReturnType6 : () => AsyncIterable<number>
 >AsyncIterable : AsyncIterable<T>
 
+    yield 1;
+>yield 1 : any
+>1 : 1
+}
+async function * explicitReturnType7(): AsyncIterable<number> {
+>explicitReturnType7 : () => AsyncIterable<number>
+>AsyncIterable : AsyncIterable<T>
+
+    yield Promise.resolve(1);
+>yield Promise.resolve(1) : any
+>Promise.resolve(1) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>1 : 1
+}
+async function * explicitReturnType8(): AsyncIterable<number> {
+>explicitReturnType8 : () => AsyncIterable<number>
+>AsyncIterable : AsyncIterable<T>
+
+    yield* [1, 2];
+>yield* [1, 2] : any
+>[1, 2] : number[]
+>1 : 1
+>2 : 2
+}
+async function * explicitReturnType9(): AsyncIterable<number> {
+>explicitReturnType9 : () => AsyncIterable<number>
+>AsyncIterable : AsyncIterable<T>
+
+    yield* [Promise.resolve(1)];
+>yield* [Promise.resolve(1)] : any
+>[Promise.resolve(1)] : Promise<number>[]
+>Promise.resolve(1) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>1 : 1
+}
+async function * explicitReturnType10(): AsyncIterable<number> {
+>explicitReturnType10 : () => AsyncIterable<number>
+>AsyncIterable : AsyncIterable<T>
+
     yield* (async function * () { yield 1; })();
 >yield* (async function * () { yield 1; })() : any
 >(async function * () { yield 1; })() : AsyncIterableIterator<1>
@@ -203,16 +378,28 @@ async function * explicitReturnType6(): AsyncIterable<number> {
 >yield 1 : any
 >1 : 1
 }
-async function * explicitReturnType7(): AsyncIterator<number> {
->explicitReturnType7 : () => AsyncIterator<number>
+async function * explicitReturnType11(): AsyncIterator<number> {
+>explicitReturnType11 : () => AsyncIterator<number>
 >AsyncIterator : AsyncIterator<T>
 
     yield 1;
 >yield 1 : any
 >1 : 1
 }
-async function * explicitReturnType8(): AsyncIterator<number> {
->explicitReturnType8 : () => AsyncIterator<number>
+async function * explicitReturnType12(): AsyncIterator<number> {
+>explicitReturnType12 : () => AsyncIterator<number>
+>AsyncIterator : AsyncIterator<T>
+
+    yield Promise.resolve(1);
+>yield Promise.resolve(1) : any
+>Promise.resolve(1) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>1 : 1
+}
+async function * explicitReturnType13(): AsyncIterator<number> {
+>explicitReturnType13 : () => AsyncIterator<number>
 >AsyncIterator : AsyncIterator<T>
 
     yield* [1, 2];
@@ -221,8 +408,21 @@ async function * explicitReturnType8(): AsyncIterator<number> {
 >1 : 1
 >2 : 2
 }
-async function * explicitReturnType9(): AsyncIterator<number> {
->explicitReturnType9 : () => AsyncIterator<number>
+async function * explicitReturnType14(): AsyncIterator<number> {
+>explicitReturnType14 : () => AsyncIterator<number>
+>AsyncIterator : AsyncIterator<T>
+
+    yield* [Promise.resolve(1)];
+>yield* [Promise.resolve(1)] : any
+>[Promise.resolve(1)] : Promise<number>[]
+>Promise.resolve(1) : Promise<number>
+>Promise.resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>Promise : PromiseConstructor
+>resolve : { <T>(value: T | PromiseLike<T>): Promise<T>; (): Promise<void>; }
+>1 : 1
+}
+async function * explicitReturnType15(): AsyncIterator<number> {
+>explicitReturnType15 : () => AsyncIterator<number>
 >AsyncIterator : AsyncIterator<T>
 
     yield* (async function * () { yield 1; })();
@@ -233,8 +433,8 @@ async function * explicitReturnType9(): AsyncIterator<number> {
 >yield 1 : any
 >1 : 1
 }
-async function * explicitReturnType10(): {} {
->explicitReturnType10 : () => {}
+async function * explicitReturnType16(): {} {
+>explicitReturnType16 : () => {}
 
     yield 1;
 >yield 1 : any

--- a/tests/baselines/reference/types.asyncGenerators.esnext.2.errors.txt
+++ b/tests/baselines/reference/types.asyncGenerators.esnext.2.errors.txt
@@ -1,13 +1,14 @@
 tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(2,12): error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(7,7): error TS2322: Type '() => AsyncIterableIterator<"a">' is not assignable to type '() => AsyncIterableIterator<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(8,12): error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(10,7): error TS2322: Type '() => AsyncIterableIterator<"a">' is not assignable to type '() => AsyncIterableIterator<number>'.
   Type 'AsyncIterableIterator<"a">' is not assignable to type 'AsyncIterableIterator<number>'.
     Type '"a"' is not assignable to type 'number'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(10,7): error TS2322: Type '() => AsyncIterableIterator<string>' is not assignable to type '() => AsyncIterableIterator<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(13,7): error TS2322: Type '() => AsyncIterableIterator<string>' is not assignable to type '() => AsyncIterableIterator<number>'.
   Type 'AsyncIterableIterator<string>' is not assignable to type 'AsyncIterableIterator<number>'.
     Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(13,7): error TS2322: Type '() => AsyncIterableIterator<"a">' is not assignable to type '() => AsyncIterableIterator<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(16,7): error TS2322: Type '() => AsyncIterableIterator<"a">' is not assignable to type '() => AsyncIterableIterator<number>'.
   Type 'AsyncIterableIterator<"a">' is not assignable to type 'AsyncIterableIterator<number>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(16,7): error TS2322: Type '() => AsyncIterableIterator<"a">' is not assignable to type '() => AsyncIterable<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(19,7): error TS2322: Type '() => AsyncIterableIterator<"a">' is not assignable to type '() => AsyncIterable<number>'.
   Type 'AsyncIterableIterator<"a">' is not assignable to type 'AsyncIterable<number>'.
     Types of property '[Symbol.asyncIterator]' are incompatible.
       Type '() => AsyncIterableIterator<"a">' is not assignable to type '() => AsyncIterator<number>'.
@@ -17,7 +18,7 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(
               Type 'Promise<IteratorResult<"a">>' is not assignable to type 'Promise<IteratorResult<number>>'.
                 Type 'IteratorResult<"a">' is not assignable to type 'IteratorResult<number>'.
                   Type '"a"' is not assignable to type 'number'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(19,7): error TS2322: Type '() => AsyncIterableIterator<string>' is not assignable to type '() => AsyncIterable<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(22,7): error TS2322: Type '() => AsyncIterableIterator<string>' is not assignable to type '() => AsyncIterable<number>'.
   Type 'AsyncIterableIterator<string>' is not assignable to type 'AsyncIterable<number>'.
     Types of property '[Symbol.asyncIterator]' are incompatible.
       Type '() => AsyncIterableIterator<string>' is not assignable to type '() => AsyncIterator<number>'.
@@ -27,36 +28,36 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(
               Type 'Promise<IteratorResult<string>>' is not assignable to type 'Promise<IteratorResult<number>>'.
                 Type 'IteratorResult<string>' is not assignable to type 'IteratorResult<number>'.
                   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(22,7): error TS2322: Type '() => AsyncIterableIterator<"a">' is not assignable to type '() => AsyncIterable<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(25,7): error TS2322: Type '() => AsyncIterableIterator<"a">' is not assignable to type '() => AsyncIterable<number>'.
   Type 'AsyncIterableIterator<"a">' is not assignable to type 'AsyncIterable<number>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(25,7): error TS2322: Type '() => AsyncIterableIterator<"a">' is not assignable to type '() => AsyncIterator<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(28,7): error TS2322: Type '() => AsyncIterableIterator<"a">' is not assignable to type '() => AsyncIterator<number>'.
   Type 'AsyncIterableIterator<"a">' is not assignable to type 'AsyncIterator<number>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(28,7): error TS2322: Type '() => AsyncIterableIterator<string>' is not assignable to type '() => AsyncIterator<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(31,7): error TS2322: Type '() => AsyncIterableIterator<string>' is not assignable to type '() => AsyncIterator<number>'.
   Type 'AsyncIterableIterator<string>' is not assignable to type 'AsyncIterator<number>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(31,7): error TS2322: Type '() => AsyncIterableIterator<"a">' is not assignable to type '() => AsyncIterator<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(34,7): error TS2322: Type '() => AsyncIterableIterator<"a">' is not assignable to type '() => AsyncIterator<number>'.
   Type 'AsyncIterableIterator<"a">' is not assignable to type 'AsyncIterator<number>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(35,11): error TS2322: Type '"a"' is not assignable to type 'number'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(38,12): error TS2322: Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(41,12): error TS2322: Type '"a"' is not assignable to type 'number'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(44,11): error TS2322: Type '"a"' is not assignable to type 'number'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(47,12): error TS2322: Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(50,12): error TS2322: Type '"a"' is not assignable to type 'number'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(53,11): error TS2322: Type '"a"' is not assignable to type 'number'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(56,12): error TS2322: Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(59,12): error TS2322: Type '"a"' is not assignable to type 'number'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(61,42): error TS2322: Type 'AsyncIterableIterator<any>' is not assignable to type 'IterableIterator<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(38,11): error TS2322: Type '"a"' is not assignable to type 'number'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(41,12): error TS2322: Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(44,12): error TS2322: Type '"a"' is not assignable to type 'number'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(47,11): error TS2322: Type '"a"' is not assignable to type 'number'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(50,12): error TS2322: Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(53,12): error TS2322: Type '"a"' is not assignable to type 'number'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(56,11): error TS2322: Type '"a"' is not assignable to type 'number'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(59,12): error TS2322: Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(62,12): error TS2322: Type '"a"' is not assignable to type 'number'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(64,42): error TS2322: Type 'AsyncIterableIterator<any>' is not assignable to type 'IterableIterator<number>'.
   Property '[Symbol.iterator]' is missing in type 'AsyncIterableIterator<any>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(64,42): error TS2322: Type 'AsyncIterableIterator<any>' is not assignable to type 'Iterable<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(67,42): error TS2322: Type 'AsyncIterableIterator<any>' is not assignable to type 'Iterable<number>'.
   Property '[Symbol.iterator]' is missing in type 'AsyncIterableIterator<any>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(67,42): error TS2322: Type 'AsyncIterableIterator<any>' is not assignable to type 'Iterator<number>'.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(70,42): error TS2322: Type 'AsyncIterableIterator<any>' is not assignable to type 'Iterator<number>'.
   Types of property 'next' are incompatible.
     Type '(value?: any) => Promise<IteratorResult<any>>' is not assignable to type '(value?: any) => IteratorResult<number>'.
       Type 'Promise<IteratorResult<any>>' is not assignable to type 'IteratorResult<number>'.
         Property 'done' is missing in type 'Promise<IteratorResult<any>>'.
-tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(71,12): error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
+tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(74,12): error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
 
 
-==== tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts (23 errors) ====
+==== tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts (24 errors) ====
     async function * inferReturnType1() {
         yield* {};
                ~~
@@ -64,6 +65,11 @@ tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts(
     }
     async function * inferReturnType2() {
         yield* inferReturnType2();
+    }
+    async function * inferReturnType3() {
+        yield* Promise.resolve([1, 2]);
+               ~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2504: Type must have a '[Symbol.asyncIterator]()' method that returns an async iterator.
     }
     const assignability1: () => AsyncIterableIterator<number> = async function * () {
           ~~~~~~~~~~~~~~

--- a/tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.1.ts
+++ b/tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.1.ts
@@ -10,66 +10,112 @@ async function * inferReturnType3() {
     yield 1;
 }
 async function * inferReturnType4() {
-    yield* [1, 2];
+    yield Promise.resolve(1);
 }
 async function * inferReturnType5() {
+    yield 1;
+    yield Promise.resolve(2);
+}
+async function * inferReturnType6() {
+    yield* [1, 2];
+}
+async function * inferReturnType7() {
+    yield* [Promise.resolve(1)];
+}
+async function * inferReturnType8() {
     yield* (async function * () { yield 1; })();
 }
 const assignability1: () => AsyncIterableIterator<number> = async function * () {
     yield 1;
 };
 const assignability2: () => AsyncIterableIterator<number> = async function * () {
-    yield* [1, 2];
+    yield Promise.resolve(1);
 };
 const assignability3: () => AsyncIterableIterator<number> = async function * () {
-    yield* (async function * () { yield 1; })();
-};
-const assignability4: () => AsyncIterable<number> = async function * () {
-    yield 1;
-};
-const assignability5: () => AsyncIterable<number> = async function * () {
     yield* [1, 2];
+};
+const assignability4: () => AsyncIterableIterator<number> = async function * () {
+    yield* [Promise.resolve(1)];
+};
+const assignability5: () => AsyncIterableIterator<number> = async function * () {
+    yield* (async function * () { yield 1; })();
 };
 const assignability6: () => AsyncIterable<number> = async function * () {
-    yield* (async function * () { yield 1; })();
-};
-const assignability7: () => AsyncIterator<number> = async function * () {
     yield 1;
 };
-const assignability8: () => AsyncIterator<number> = async function * () {
+const assignability7: () => AsyncIterable<number> = async function * () {
+    yield Promise.resolve(1);
+};
+const assignability8: () => AsyncIterable<number> = async function * () {
     yield* [1, 2];
 };
-const assignability9: () => AsyncIterator<number> = async function * () {
+const assignability9: () => AsyncIterable<number> = async function * () {
+    yield* [Promise.resolve(1)];
+};
+const assignability10: () => AsyncIterable<number> = async function * () {
+    yield* (async function * () { yield 1; })();
+};
+const assignability11: () => AsyncIterator<number> = async function * () {
+    yield 1;
+};
+const assignability12: () => AsyncIterator<number> = async function * () {
+    yield Promise.resolve(1);
+};
+const assignability13: () => AsyncIterator<number> = async function * () {
+    yield* [1, 2];
+};
+const assignability14: () => AsyncIterator<number> = async function * () {
+    yield* [Promise.resolve(1)];
+};
+const assignability15: () => AsyncIterator<number> = async function * () {
     yield* (async function * () { yield 1; })();
 };
 async function * explicitReturnType1(): AsyncIterableIterator<number> {
     yield 1;
 }
 async function * explicitReturnType2(): AsyncIterableIterator<number> {
-    yield* [1, 2];
+    yield Promise.resolve(1);
 }
 async function * explicitReturnType3(): AsyncIterableIterator<number> {
-    yield* (async function * () { yield 1; })();
-}
-async function * explicitReturnType4(): AsyncIterable<number> {
-    yield 1;
-}
-async function * explicitReturnType5(): AsyncIterable<number> {
     yield* [1, 2];
+}
+async function * explicitReturnType4(): AsyncIterableIterator<number> {
+    yield* [Promise.resolve(1)];
+}
+async function * explicitReturnType5(): AsyncIterableIterator<number> {
+    yield* (async function * () { yield 1; })();
 }
 async function * explicitReturnType6(): AsyncIterable<number> {
-    yield* (async function * () { yield 1; })();
-}
-async function * explicitReturnType7(): AsyncIterator<number> {
     yield 1;
 }
-async function * explicitReturnType8(): AsyncIterator<number> {
+async function * explicitReturnType7(): AsyncIterable<number> {
+    yield Promise.resolve(1);
+}
+async function * explicitReturnType8(): AsyncIterable<number> {
     yield* [1, 2];
 }
-async function * explicitReturnType9(): AsyncIterator<number> {
+async function * explicitReturnType9(): AsyncIterable<number> {
+    yield* [Promise.resolve(1)];
+}
+async function * explicitReturnType10(): AsyncIterable<number> {
     yield* (async function * () { yield 1; })();
 }
-async function * explicitReturnType10(): {} {
+async function * explicitReturnType11(): AsyncIterator<number> {
+    yield 1;
+}
+async function * explicitReturnType12(): AsyncIterator<number> {
+    yield Promise.resolve(1);
+}
+async function * explicitReturnType13(): AsyncIterator<number> {
+    yield* [1, 2];
+}
+async function * explicitReturnType14(): AsyncIterator<number> {
+    yield* [Promise.resolve(1)];
+}
+async function * explicitReturnType15(): AsyncIterator<number> {
+    yield* (async function * () { yield 1; })();
+}
+async function * explicitReturnType16(): {} {
     yield 1;
 }
 async function * awaitedType1() {

--- a/tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts
+++ b/tests/cases/conformance/types/asyncGenerators/types.asyncGenerators.esnext.2.ts
@@ -7,6 +7,9 @@ async function * inferReturnType1() {
 async function * inferReturnType2() {
     yield* inferReturnType2();
 }
+async function * inferReturnType3() {
+    yield* Promise.resolve([1, 2]);
+}
 const assignability1: () => AsyncIterableIterator<number> = async function * () {
     yield "a";
 };


### PR DESCRIPTION
This fixes an issue where we do not implicitly await the operand to `yield` or the iterated elements of the operand to `yield*` as per https://tc39.github.io/proposal-async-iteration/#sec-asyncgenerator-definitions-evaluation.

Fixes #15205 
