### PR TITLE
export interfaces for exported members

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -7,7 +7,7 @@ namespace ts.FindAllReferences {
         references: Entry[];
     }
 
-    type Definition =
+    export type Definition =
         | { type: "symbol"; symbol: Symbol; node: Node }
         | { type: "label"; node: Identifier }
         | { type: "keyword"; node: ts.Node }
@@ -20,7 +20,7 @@ namespace ts.FindAllReferences {
         node: Node;
         isInString?: true;
     }
-    interface SpanEntry {
+    export interface SpanEntry {
         type: "span";
         fileName: string;
         textSpan: TextSpan;


### PR DESCRIPTION
Fixes the following issues: 

```
src/services/findAllReferences.ts(6,21): error TS4033: Property 'definition' of exported interface has or is using private name 'Definition'.
src/services/findAllReferences.ts(17,37): error TS4081: Exported type alias 'Entry' has or is using private name 'SpanEntry'.
```

Sample Build failure : https://travis-ci.org/basarat/byots/builds/222285652#L765

As always :rose: :heart: 🤗 