### PR TITLE
Fix downloads badge (0/month)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Build Status](https://travis-ci.org/Microsoft/TypeScript.svg?branch=master)](https://travis-ci.org/Microsoft/TypeScript)
 [![npm version](https://badge.fury.io/js/typescript.svg)](https://www.npmjs.com/package/typescript)
-[![Downloads](https://img.shields.io/npm/dm/TypeScript.svg)](https://www.npmjs.com/package/typescript)
+[![Downloads](https://img.shields.io/npm/dm/typescript.svg)](https://www.npmjs.com/package/typescript)
 
 # TypeScript
 


### PR DESCRIPTION
Was not very serious, so haven't created an issue, just fixed it quickly.
The downloads badge showed 0/month because it's case sensitive, so changed it from "TypeScript.svg" to "typescript.svg".