### PR TITLE
Unknown properties are assignable to `Object` in union

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -8708,7 +8708,7 @@ namespace ts {
                 if (maybeTypeOfKind(target, TypeFlags.Object) && !(getObjectFlags(target) & ObjectFlags.ObjectLiteralPatternWithComputedProperties)) {
                     const isComparingJsxAttributes = !!(source.flags & TypeFlags.JsxAttributes);
                     if ((relation === assignableRelation || relation === comparableRelation) &&
-                        (target === globalObjectType || (!isComparingJsxAttributes && isEmptyObjectType(target)))) {
+                        (isTypeSubsetOf(globalObjectType, target) || (!isComparingJsxAttributes && isEmptyObjectType(target)))) {
                         return false;
                     }
                     for (const prop of getPropertiesOfObjectType(source)) {

--- a/tests/baselines/reference/unknownPropertiesAreAssignableToObjectUnion.js
+++ b/tests/baselines/reference/unknownPropertiesAreAssignableToObjectUnion.js
@@ -1,0 +1,8 @@
+//// [unknownPropertiesAreAssignableToObjectUnion.ts]
+const x: Object | string = { x: 0 };
+const y: Object | undefined = { x: 0 };
+
+
+//// [unknownPropertiesAreAssignableToObjectUnion.js]
+var x = { x: 0 };
+var y = { x: 0 };

--- a/tests/baselines/reference/unknownPropertiesAreAssignableToObjectUnion.symbols
+++ b/tests/baselines/reference/unknownPropertiesAreAssignableToObjectUnion.symbols
@@ -1,0 +1,11 @@
+=== tests/cases/compiler/unknownPropertiesAreAssignableToObjectUnion.ts ===
+const x: Object | string = { x: 0 };
+>x : Symbol(x, Decl(unknownPropertiesAreAssignableToObjectUnion.ts, 0, 5))
+>Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(unknownPropertiesAreAssignableToObjectUnion.ts, 0, 28))
+
+const y: Object | undefined = { x: 0 };
+>y : Symbol(y, Decl(unknownPropertiesAreAssignableToObjectUnion.ts, 1, 5))
+>Object : Symbol(Object, Decl(lib.d.ts, --, --), Decl(lib.d.ts, --, --))
+>x : Symbol(x, Decl(unknownPropertiesAreAssignableToObjectUnion.ts, 1, 31))
+

--- a/tests/baselines/reference/unknownPropertiesAreAssignableToObjectUnion.types
+++ b/tests/baselines/reference/unknownPropertiesAreAssignableToObjectUnion.types
@@ -1,0 +1,15 @@
+=== tests/cases/compiler/unknownPropertiesAreAssignableToObjectUnion.ts ===
+const x: Object | string = { x: 0 };
+>x : string | Object
+>Object : Object
+>{ x: 0 } : { x: number; }
+>x : number
+>0 : 0
+
+const y: Object | undefined = { x: 0 };
+>y : Object | undefined
+>Object : Object
+>{ x: 0 } : { x: number; }
+>x : number
+>0 : 0
+

--- a/tests/cases/compiler/unknownPropertiesAreAssignableToObjectUnion.ts
+++ b/tests/cases/compiler/unknownPropertiesAreAssignableToObjectUnion.ts
@@ -1,0 +1,3 @@
+// @strictNullChecks: true
+const x: Object | string = { x: 0 };
+const y: Object | undefined = { x: 0 };


### PR DESCRIPTION
For the last week or so they have been treated as excess properties when assigning to a union type containing Object, but not when assigning directly to Object type.

Fixes #15254