### PR TITLE
mergeSymbol uses first declaration, not valueDeclaration

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -574,7 +574,7 @@ namespace ts {
                 recordMergedSymbol(target, source);
             }
             else if (target.flags & SymbolFlags.NamespaceModule) {
-                error(source.valueDeclaration.name, Diagnostics.Cannot_augment_module_0_with_value_exports_because_it_resolves_to_a_non_module_entity, symbolToString(target));
+                error(source.declarations[0].name, Diagnostics.Cannot_augment_module_0_with_value_exports_because_it_resolves_to_a_non_module_entity, symbolToString(target));
             }
             else {
                 const message = target.flags & SymbolFlags.BlockScopedVariable || source.flags & SymbolFlags.BlockScopedVariable

--- a/tests/baselines/reference/noSymbolForMergeCrash.errors.txt
+++ b/tests/baselines/reference/noSymbolForMergeCrash.errors.txt
@@ -1,0 +1,12 @@
+tests/cases/compiler/final.ts(1,6): error TS2649: Cannot augment module 'A' with value exports because it resolves to a non-module entity.
+
+
+==== tests/cases/compiler/initial.ts (0 errors) ====
+    interface A { }
+    namespace A {}
+    
+==== tests/cases/compiler/final.ts (1 errors) ====
+    type A = {}
+         ~
+!!! error TS2649: Cannot augment module 'A' with value exports because it resolves to a non-module entity.
+    

--- a/tests/baselines/reference/noSymbolForMergeCrash.js
+++ b/tests/baselines/reference/noSymbolForMergeCrash.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/noSymbolForMergeCrash.ts] ////
+
+//// [initial.ts]
+interface A { }
+namespace A {}
+
+//// [final.ts]
+type A = {}
+
+
+//// [initial.js]
+//// [final.js]

--- a/tests/cases/compiler/noSymbolForMergeCrash.ts
+++ b/tests/cases/compiler/noSymbolForMergeCrash.ts
@@ -1,0 +1,6 @@
+// @Filename: initial.ts
+interface A { }
+namespace A {}
+
+// @Filename: final.ts
+type A = {}


### PR DESCRIPTION
Previously it assumed valueDeclaration was present, which is not true for type aliases.
Fixes #15128 
