### PR TITLE
Fix capitalization of URL.searchParams in typings

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -11857,7 +11857,7 @@ interface URL {
     protocol: string;
     search: string;
     username: string;
-    readonly searchparams: URLSearchParams;
+    readonly searchParams: URLSearchParams;
     toString(): string;
 }
 


### PR DESCRIPTION
Update interface URL:  should be capitalized as `searchParams` not `searchparams`
