### PR TITLE
Check and emit fixes for async iteration

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -19703,7 +19703,7 @@ namespace ts {
             }
 
             let iteratorMethodSignatures: Signature[];
-            let mayBeIterable = false;
+            let isNonAsyncIterable = false;
             if (isAsyncIterable) {
                 const iteratorMethod = getTypeOfPropertyOfType(type, getPropertyNameForKnownSymbolName("asyncIterator"));
                 if (isTypeAny(iteratorMethod)) {
@@ -19718,17 +19718,17 @@ namespace ts {
                     return undefined;
                 }
                 iteratorMethodSignatures = iteratorMethod && getSignaturesOfType(iteratorMethod, SignatureKind.Call);
-                mayBeIterable = true;
+                isNonAsyncIterable = true;
             }
 
             if (some(iteratorMethodSignatures)) {
                 const iteratorMethodReturnType = getUnionType(map(iteratorMethodSignatures, getReturnTypeOfSignature), /*subtypeReduction*/ true);
-                const iteratedType = getIteratedTypeOfIterator(iteratorMethodReturnType, errorNode, /*isAsyncIterator*/ false);
+                const iteratedType = getIteratedTypeOfIterator(iteratorMethodReturnType, errorNode, /*isAsyncIterator*/ !isNonAsyncIterable);
                 if (checkAssignability && errorNode && iteratedType) {
                     // If `checkAssignability` was specified, we were called from
                     // `checkIteratedTypeOrElementType`. As such, we need to validate that
                     // the type passed in is actually an Iterable.
-                    checkTypeAssignableTo(type, mayBeIterable
+                    checkTypeAssignableTo(type, isNonAsyncIterable
                         ? createIterableType(iteratedType)
                         : createAsyncIterableType(iteratedType), errorNode);
                 }

--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -924,7 +924,7 @@ namespace ts {
             var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
                 var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
                 return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-                function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+                function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
             };
         `
     };

--- a/src/compiler/transformers/esnext.ts
+++ b/src/compiler/transformers/esnext.ts
@@ -891,9 +891,8 @@ namespace ts {
                 function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
                 function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
                 function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-                function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-                function _yield(value) { settle(c[2], { value: value, done: false }); }
-                function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+                function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+                function send(value) { settle(c[2], { value: value, done: false }); }
                 function fulfill(value) { resume("next", value); }
                 function reject(value) { resume("throw", value); }
                 function settle(f, v) { c = void 0, f(v), next(); }
@@ -923,15 +922,16 @@ namespace ts {
         scoped: false,
         text: `
             var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-                var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+                var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
                 return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-                function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+                function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
             };
         `
     };
 
     function createAsyncDelegatorHelper(context: TransformationContext, expression: Expression, location?: TextRange) {
         context.requestEmitHelper(asyncDelegator);
+        context.requestEmitHelper(asyncValues);
         return setTextRange(
             createCall(
                 getHelperName("__asyncDelegator"),

--- a/tests/baselines/reference/emitter.asyncGenerators.classMethods.es2015.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.classMethods.es2015.js
@@ -68,9 +68,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -89,9 +88,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -111,9 +109,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -127,9 +124,14 @@ class C3 {
 }
 //// [C4.js]
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+};
+var __asyncValues = (this && this.__asyncIterator) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
 };
 var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _arguments, generator) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
@@ -138,9 +140,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -160,17 +161,21 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
 };
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+};
+var __asyncValues = (this && this.__asyncIterator) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
 };
 class C5 {
     f() {
@@ -187,9 +192,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -209,9 +213,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -231,9 +234,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -255,9 +257,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }

--- a/tests/baselines/reference/emitter.asyncGenerators.classMethods.es2015.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.classMethods.es2015.js
@@ -126,7 +126,7 @@ class C3 {
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
     var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+    function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
 };
 var __asyncValues = (this && this.__asyncIterator) || function (o) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
@@ -170,7 +170,7 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
     var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+    function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
 };
 var __asyncValues = (this && this.__asyncIterator) || function (o) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");

--- a/tests/baselines/reference/emitter.asyncGenerators.classMethods.es5.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.classMethods.es5.js
@@ -95,9 +95,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -149,9 +148,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -209,9 +207,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -263,9 +260,14 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+};
+var __asyncValues = (this && this.__asyncIterator) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
 };
 var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _arguments, generator) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
@@ -274,9 +276,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -344,17 +345,21 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
 };
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+};
+var __asyncValues = (this && this.__asyncIterator) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
 };
 var __values = (this && this.__values) || function (o) {
     var m = typeof Symbol === "function" && o[Symbol.iterator], i = 0;
@@ -426,9 +431,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -486,9 +490,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -540,9 +543,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -607,9 +609,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }

--- a/tests/baselines/reference/emitter.asyncGenerators.classMethods.es5.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.classMethods.es5.js
@@ -262,7 +262,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
     var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+    function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
 };
 var __asyncValues = (this && this.__asyncIterator) || function (o) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
@@ -354,7 +354,7 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
     var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+    function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
 };
 var __asyncValues = (this && this.__asyncIterator) || function (o) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");

--- a/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es2015.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es2015.js
@@ -89,7 +89,7 @@ function f3() {
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
     var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+    function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
 };
 var __asyncValues = (this && this.__asyncIterator) || function (o) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
@@ -131,7 +131,7 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
     var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+    function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
 };
 var __asyncValues = (this && this.__asyncIterator) || function (o) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");

--- a/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es2015.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es2015.js
@@ -37,9 +37,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -56,9 +55,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -76,9 +74,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -90,9 +87,14 @@ function f3() {
 }
 //// [F4.js]
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+};
+var __asyncValues = (this && this.__asyncIterator) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
 };
 var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _arguments, generator) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
@@ -101,9 +103,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -121,17 +122,21 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
 };
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+};
+var __asyncValues = (this && this.__asyncIterator) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
 };
 function f5() {
     return __asyncGenerator(this, arguments, function* f5_1() {
@@ -146,9 +151,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -166,9 +170,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }

--- a/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es5.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es5.js
@@ -216,7 +216,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
     var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+    function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
 };
 var __asyncValues = (this && this.__asyncIterator) || function (o) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
@@ -303,7 +303,7 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
     var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+    function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
 };
 var __asyncValues = (this && this.__asyncIterator) || function (o) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");

--- a/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es5.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionDeclarations.es5.js
@@ -64,9 +64,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -113,9 +112,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -168,9 +166,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -217,9 +214,14 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+};
+var __asyncValues = (this && this.__asyncIterator) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
 };
 var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _arguments, generator) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
@@ -228,9 +230,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -293,17 +294,21 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
 };
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+};
+var __asyncValues = (this && this.__asyncIterator) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
 };
 var __values = (this && this.__values) || function (o) {
     var m = typeof Symbol === "function" && o[Symbol.iterator], i = 0;
@@ -370,9 +375,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -425,9 +429,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }

--- a/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es2015.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es2015.js
@@ -89,7 +89,7 @@ const f3 = function () {
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
     var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+    function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
 };
 var __asyncValues = (this && this.__asyncIterator) || function (o) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
@@ -131,7 +131,7 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
     var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+    function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
 };
 var __asyncValues = (this && this.__asyncIterator) || function (o) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");

--- a/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es2015.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es2015.js
@@ -37,9 +37,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -56,9 +55,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -76,9 +74,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -90,9 +87,14 @@ const f3 = function () {
 };
 //// [F4.js]
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+};
+var __asyncValues = (this && this.__asyncIterator) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
 };
 var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _arguments, generator) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
@@ -101,9 +103,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -121,17 +122,21 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
 };
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+};
+var __asyncValues = (this && this.__asyncIterator) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
 };
 const f5 = function () {
     return __asyncGenerator(this, arguments, function* () {
@@ -146,9 +151,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -166,9 +170,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }

--- a/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es5.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es5.js
@@ -216,7 +216,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
     var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+    function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
 };
 var __asyncValues = (this && this.__asyncIterator) || function (o) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
@@ -303,7 +303,7 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
     var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+    function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
 };
 var __asyncValues = (this && this.__asyncIterator) || function (o) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");

--- a/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es5.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.functionExpressions.es5.js
@@ -64,9 +64,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -113,9 +112,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -168,9 +166,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -217,9 +214,14 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+};
+var __asyncValues = (this && this.__asyncIterator) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
 };
 var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _arguments, generator) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
@@ -228,9 +230,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -293,17 +294,21 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
 };
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+};
+var __asyncValues = (this && this.__asyncIterator) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
 };
 var __values = (this && this.__values) || function (o) {
     var m = typeof Symbol === "function" && o[Symbol.iterator], i = 0;
@@ -370,9 +375,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -425,9 +429,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }

--- a/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es2015.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es2015.js
@@ -51,9 +51,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -72,9 +71,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -94,9 +92,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -110,9 +107,14 @@ const o3 = {
 };
 //// [O4.js]
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+};
+var __asyncValues = (this && this.__asyncIterator) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
 };
 var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _arguments, generator) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
@@ -121,9 +123,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -143,17 +144,21 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
 };
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+};
+var __asyncValues = (this && this.__asyncIterator) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
 };
 const o5 = {
     f() {
@@ -170,9 +175,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -192,9 +196,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }

--- a/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es2015.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es2015.js
@@ -109,7 +109,7 @@ const o3 = {
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
     var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+    function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
 };
 var __asyncValues = (this && this.__asyncIterator) || function (o) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
@@ -153,7 +153,7 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
     var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+    function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
 };
 var __asyncValues = (this && this.__asyncIterator) || function (o) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");

--- a/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es5.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es5.js
@@ -78,9 +78,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -129,9 +128,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -186,9 +184,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -237,9 +234,14 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
     }
 };
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+};
+var __asyncValues = (this && this.__asyncIterator) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
 };
 var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _arguments, generator) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
@@ -248,9 +250,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -315,17 +316,21 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
 };
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
-    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) };
+    var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return { value: ["delegate", (o[n] || f).call(o, v)], done: false }; }; }
+    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+};
+var __asyncValues = (this && this.__asyncIterator) || function (o) {
+    if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
+    var m = o[Symbol.asyncIterator];
+    return m ? m.call(o) : typeof __values === "function" ? __values(o) : o[Symbol.iterator]();
 };
 var __values = (this && this.__values) || function (o) {
     var m = typeof Symbol === "function" && o[Symbol.iterator], i = 0;
@@ -394,9 +399,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -451,9 +455,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }

--- a/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es5.js
+++ b/tests/baselines/reference/emitter.asyncGenerators.objectLiteralMethods.es5.js
@@ -236,7 +236,7 @@ var __generator = (this && this.__generator) || function (thisArg, body) {
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
     var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+    function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
 };
 var __asyncValues = (this && this.__asyncIterator) || function (o) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");
@@ -325,7 +325,7 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
 var __asyncDelegator = (this && this.__asyncDelegator) || function (o) {
     var i = { next: verb("next"), "throw": verb("throw", function (e) { throw e; }), "return": verb("return", function (v) { return { value: v, done: true }; }) }, p;
     return o = __asyncValues(o), i[Symbol.iterator] = function () { return this; }, i;
-    function verb(n, f) { return function (v) { return v = p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
+    function verb(n, f) { return function (v) { return v = p && n === "throw" ? f(v) : p && v.done ? v : { value: p ? ["yield", v.value] : ["await", (o[n] || f).call(o, v)], done: false }, p = !p, v; }; }
 };
 var __asyncValues = (this && this.__asyncIterator) || function (o) {
     if (!Symbol.asyncIterator) throw new TypeError("Symbol.asyncIterator is not defined.");

--- a/tests/baselines/reference/emitter.forAwait.es2015.js
+++ b/tests/baselines/reference/emitter.forAwait.es2015.js
@@ -102,9 +102,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -140,9 +139,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }

--- a/tests/baselines/reference/emitter.forAwait.es5.js
+++ b/tests/baselines/reference/emitter.forAwait.es5.js
@@ -231,9 +231,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }
@@ -320,9 +319,8 @@ var __asyncGenerator = (this && this.__asyncGenerator) || function (thisArg, _ar
     function verb(n) { return function (v) { return new Promise(function (a, b) { q.push([n, v, a, b]), next(); }); }; }
     function next() { if (!c && q.length) resume((c = q.shift())[0], c[1]); }
     function resume(n, v) { try { step(g[n](v)); } catch (e) { settle(c[3], e); } }
-    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? _yield : r.value[0] === "delegate" ? delegate : fulfill, reject); }
-    function _yield(value) { settle(c[2], { value: value, done: false }); }
-    function delegate(r) { step(r.done ? r : { value: ["yield", r.value], done: false }); }
+    function step(r) { r.done ? settle(c[2], r) : Promise.resolve(r.value[1]).then(r.value[0] === "yield" ? send : fulfill, reject); }
+    function send(value) { settle(c[2], { value: value, done: false }); }
     function fulfill(value) { resume("next", value); }
     function reject(value) { resume("throw", value); }
     function settle(f, v) { c = void 0, f(v), next(); }


### PR DESCRIPTION
This changes the emit for the `__asyncGenerator` and `__asyncDelegator` helpers to fix issues with `yield*` delegation in an async generator. The main change involves modifying `__asyncDelegator` to use a two-phase approach to iteration:

1. Return the iterator result of a `next`/`throw`/`return` to `__asyncGenerator` as if it were an `await` and switch phase. After awaiting the result, `__asyncGenerator` sends it back to the delegator via a call to its `next` method.
2. Process and return the sent value and return an iterator result to `__asyncGenerator` either as a `yield` or a `return` and switch phase.

This also addresses a bug in the checker and correctly emits `__asyncValues` in some cases where it was missing.

This also addresses an issue where a Promise rejection during delegation of an async iterator was not properly handled.

Fixes: #15143, #14725, and #14442
Related: Microsoft/tslib#29