### PR TITLE
Revert changes to WeakSet definitions adding `object` constraint

### DIFF
--- a/src/lib/es2015.collection.d.ts
+++ b/src/lib/es2015.collection.d.ts
@@ -58,7 +58,7 @@ interface ReadonlySet<T> {
     readonly size: number;
 }
 
-interface WeakSet<T extends object> {
+interface WeakSet<T> {
     add(value: T): this;
     delete(value: T): boolean;
     has(value: T): boolean;

--- a/src/lib/es2015.iterable.d.ts
+++ b/src/lib/es2015.iterable.d.ts
@@ -118,7 +118,7 @@ interface SetConstructor {
     new <T>(iterable: Iterable<T>): Set<T>;
 }
 
-interface WeakSet<T extends object> { }
+interface WeakSet<T> { }
 
 interface WeakSetConstructor {
     new <T extends object>(iterable: Iterable<T>): WeakSet<T>;

--- a/src/lib/es2015.symbol.wellknown.d.ts
+++ b/src/lib/es2015.symbol.wellknown.d.ts
@@ -118,7 +118,7 @@ interface Set<T> {
     readonly [Symbol.toStringTag]: "Set";
 }
 
-interface WeakSet<T extends object> {
+interface WeakSet<T> {
     readonly [Symbol.toStringTag]: "WeakSet";
 }
 


### PR DESCRIPTION
This reverts the changes to `WeakSet` done in https://github.com/Microsoft/TypeScript/pull/15124 to avoid breaks in existing @types packages like `@types/lodash`
