### PR TITLE
Emit name for unnamed default exported class with decorated members

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -521,9 +521,10 @@ namespace ts {
             // emit name if
             // - node has a name
             // - node has static initializers
+            // - node has a member that is decorated
             //
             let name = node.name;
-            if (!name && staticProperties.length > 0) {
+            if (!name && (staticProperties.length > 0 || childIsDecorated(node))) {
                 name = getGeneratedNameForNode(node);
             }
 

--- a/tests/baselines/reference/decoratorOnClassAccessor1.es6.js
+++ b/tests/baselines/reference/decoratorOnClassAccessor1.es6.js
@@ -1,0 +1,20 @@
+//// [decoratorOnClassAccessor1.es6.ts]
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+export default class {
+    @dec get accessor() { return 1; }
+}
+
+//// [decoratorOnClassAccessor1.es6.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+export default class default_1 {
+    get accessor() { return 1; }
+}
+__decorate([
+    dec
+], default_1.prototype, "accessor", null);

--- a/tests/baselines/reference/decoratorOnClassAccessor1.es6.symbols
+++ b/tests/baselines/reference/decoratorOnClassAccessor1.es6.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/es6/decorators/class/accessor/decoratorOnClassAccessor1.es6.ts ===
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor1.es6.ts, 0, 0))
+>T : Symbol(T, Decl(decoratorOnClassAccessor1.es6.ts, 0, 21))
+>target : Symbol(target, Decl(decoratorOnClassAccessor1.es6.ts, 0, 24))
+>propertyKey : Symbol(propertyKey, Decl(decoratorOnClassAccessor1.es6.ts, 0, 36))
+>descriptor : Symbol(descriptor, Decl(decoratorOnClassAccessor1.es6.ts, 0, 57))
+>TypedPropertyDescriptor : Symbol(TypedPropertyDescriptor, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(decoratorOnClassAccessor1.es6.ts, 0, 21))
+>TypedPropertyDescriptor : Symbol(TypedPropertyDescriptor, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(decoratorOnClassAccessor1.es6.ts, 0, 21))
+
+export default class {
+    @dec get accessor() { return 1; }
+>dec : Symbol(dec, Decl(decoratorOnClassAccessor1.es6.ts, 0, 0))
+>accessor : Symbol(default.accessor, Decl(decoratorOnClassAccessor1.es6.ts, 2, 22))
+}

--- a/tests/baselines/reference/decoratorOnClassAccessor1.es6.types
+++ b/tests/baselines/reference/decoratorOnClassAccessor1.es6.types
@@ -1,0 +1,18 @@
+=== tests/cases/conformance/es6/decorators/class/accessor/decoratorOnClassAccessor1.es6.ts ===
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>T : T
+>target : any
+>propertyKey : string
+>descriptor : TypedPropertyDescriptor<T>
+>TypedPropertyDescriptor : TypedPropertyDescriptor<T>
+>T : T
+>TypedPropertyDescriptor : TypedPropertyDescriptor<T>
+>T : T
+
+export default class {
+    @dec get accessor() { return 1; }
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>accessor : number
+>1 : 1
+}

--- a/tests/baselines/reference/decoratorOnClassMethod1.es6.js
+++ b/tests/baselines/reference/decoratorOnClassMethod1.es6.js
@@ -1,0 +1,20 @@
+//// [decoratorOnClassMethod1.es6.ts]
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+export default class {
+    @dec method() {}
+}
+
+//// [decoratorOnClassMethod1.es6.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+export default class default_1 {
+    method() { }
+}
+__decorate([
+    dec
+], default_1.prototype, "method", null);

--- a/tests/baselines/reference/decoratorOnClassMethod1.es6.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethod1.es6.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/es6/decorators/class/method/decoratorOnClassMethod1.es6.ts ===
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+>dec : Symbol(dec, Decl(decoratorOnClassMethod1.es6.ts, 0, 0))
+>T : Symbol(T, Decl(decoratorOnClassMethod1.es6.ts, 0, 21))
+>target : Symbol(target, Decl(decoratorOnClassMethod1.es6.ts, 0, 24))
+>propertyKey : Symbol(propertyKey, Decl(decoratorOnClassMethod1.es6.ts, 0, 36))
+>descriptor : Symbol(descriptor, Decl(decoratorOnClassMethod1.es6.ts, 0, 57))
+>TypedPropertyDescriptor : Symbol(TypedPropertyDescriptor, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(decoratorOnClassMethod1.es6.ts, 0, 21))
+>TypedPropertyDescriptor : Symbol(TypedPropertyDescriptor, Decl(lib.es5.d.ts, --, --))
+>T : Symbol(T, Decl(decoratorOnClassMethod1.es6.ts, 0, 21))
+
+export default class {
+    @dec method() {}
+>dec : Symbol(dec, Decl(decoratorOnClassMethod1.es6.ts, 0, 0))
+>method : Symbol(default.method, Decl(decoratorOnClassMethod1.es6.ts, 2, 22))
+}

--- a/tests/baselines/reference/decoratorOnClassMethod1.es6.types
+++ b/tests/baselines/reference/decoratorOnClassMethod1.es6.types
@@ -1,0 +1,17 @@
+=== tests/cases/conformance/es6/decorators/class/method/decoratorOnClassMethod1.es6.ts ===
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>T : T
+>target : any
+>propertyKey : string
+>descriptor : TypedPropertyDescriptor<T>
+>TypedPropertyDescriptor : TypedPropertyDescriptor<T>
+>T : T
+>TypedPropertyDescriptor : TypedPropertyDescriptor<T>
+>T : T
+
+export default class {
+    @dec method() {}
+>dec : <T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>) => TypedPropertyDescriptor<T>
+>method : () => void
+}

--- a/tests/baselines/reference/decoratorOnClassMethodParameter1.es6.js
+++ b/tests/baselines/reference/decoratorOnClassMethodParameter1.es6.js
@@ -1,0 +1,23 @@
+//// [decoratorOnClassMethodParameter1.es6.ts]
+declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
+
+export default class {
+    method(@dec p: number) {}
+}
+
+//// [decoratorOnClassMethodParameter1.es6.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+var __param = (this && this.__param) || function (paramIndex, decorator) {
+    return function (target, key) { decorator(target, key, paramIndex); }
+};
+export default class default_1 {
+    method(p) { }
+}
+__decorate([
+    __param(0, dec)
+], default_1.prototype, "method", null);

--- a/tests/baselines/reference/decoratorOnClassMethodParameter1.es6.symbols
+++ b/tests/baselines/reference/decoratorOnClassMethodParameter1.es6.symbols
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/es6/decorators/class/method/parameter/decoratorOnClassMethodParameter1.es6.ts ===
+declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
+>dec : Symbol(dec, Decl(decoratorOnClassMethodParameter1.es6.ts, 0, 0))
+>target : Symbol(target, Decl(decoratorOnClassMethodParameter1.es6.ts, 0, 21))
+>Object : Symbol(Object, Decl(lib.es5.d.ts, --, --), Decl(lib.es5.d.ts, --, --), Decl(lib.es2015.core.d.ts, --, --))
+>propertyKey : Symbol(propertyKey, Decl(decoratorOnClassMethodParameter1.es6.ts, 0, 36))
+>parameterIndex : Symbol(parameterIndex, Decl(decoratorOnClassMethodParameter1.es6.ts, 0, 66))
+
+export default class {
+    method(@dec p: number) {}
+>method : Symbol(default.method, Decl(decoratorOnClassMethodParameter1.es6.ts, 2, 22))
+>dec : Symbol(dec, Decl(decoratorOnClassMethodParameter1.es6.ts, 0, 0))
+>p : Symbol(p, Decl(decoratorOnClassMethodParameter1.es6.ts, 3, 11))
+}

--- a/tests/baselines/reference/decoratorOnClassMethodParameter1.es6.types
+++ b/tests/baselines/reference/decoratorOnClassMethodParameter1.es6.types
@@ -1,0 +1,14 @@
+=== tests/cases/conformance/es6/decorators/class/method/parameter/decoratorOnClassMethodParameter1.es6.ts ===
+declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
+>dec : (target: Object, propertyKey: string | symbol, parameterIndex: number) => void
+>target : Object
+>Object : Object
+>propertyKey : string | symbol
+>parameterIndex : number
+
+export default class {
+    method(@dec p: number) {}
+>method : (p: number) => void
+>dec : (target: Object, propertyKey: string | symbol, parameterIndex: number) => void
+>p : number
+}

--- a/tests/baselines/reference/decoratorOnClassProperty1.es6.js
+++ b/tests/baselines/reference/decoratorOnClassProperty1.es6.js
@@ -1,0 +1,19 @@
+//// [decoratorOnClassProperty1.es6.ts]
+declare function dec(target: any, propertyKey: string): void;
+
+export default class {
+    @dec prop;
+}
+
+//// [decoratorOnClassProperty1.es6.js]
+var __decorate = (this && this.__decorate) || function (decorators, target, key, desc) {
+    var c = arguments.length, r = c < 3 ? target : desc === null ? desc = Object.getOwnPropertyDescriptor(target, key) : desc, d;
+    if (typeof Reflect === "object" && typeof Reflect.decorate === "function") r = Reflect.decorate(decorators, target, key, desc);
+    else for (var i = decorators.length - 1; i >= 0; i--) if (d = decorators[i]) r = (c < 3 ? d(r) : c > 3 ? d(target, key, r) : d(target, key)) || r;
+    return c > 3 && r && Object.defineProperty(target, key, r), r;
+};
+export default class default_1 {
+}
+__decorate([
+    dec
+], default_1.prototype, "prop", void 0);

--- a/tests/baselines/reference/decoratorOnClassProperty1.es6.symbols
+++ b/tests/baselines/reference/decoratorOnClassProperty1.es6.symbols
@@ -1,0 +1,11 @@
+=== tests/cases/conformance/es6/decorators/class/property/decoratorOnClassProperty1.es6.ts ===
+declare function dec(target: any, propertyKey: string): void;
+>dec : Symbol(dec, Decl(decoratorOnClassProperty1.es6.ts, 0, 0))
+>target : Symbol(target, Decl(decoratorOnClassProperty1.es6.ts, 0, 21))
+>propertyKey : Symbol(propertyKey, Decl(decoratorOnClassProperty1.es6.ts, 0, 33))
+
+export default class {
+    @dec prop;
+>dec : Symbol(dec, Decl(decoratorOnClassProperty1.es6.ts, 0, 0))
+>prop : Symbol(default.prop, Decl(decoratorOnClassProperty1.es6.ts, 2, 22))
+}

--- a/tests/baselines/reference/decoratorOnClassProperty1.es6.types
+++ b/tests/baselines/reference/decoratorOnClassProperty1.es6.types
@@ -1,0 +1,11 @@
+=== tests/cases/conformance/es6/decorators/class/property/decoratorOnClassProperty1.es6.ts ===
+declare function dec(target: any, propertyKey: string): void;
+>dec : (target: any, propertyKey: string) => void
+>target : any
+>propertyKey : string
+
+export default class {
+    @dec prop;
+>dec : (target: any, propertyKey: string) => void
+>prop : any
+}

--- a/tests/cases/conformance/es6/decorators/class/accessor/decoratorOnClassAccessor1.es6.ts
+++ b/tests/cases/conformance/es6/decorators/class/accessor/decoratorOnClassAccessor1.es6.ts
@@ -1,0 +1,8 @@
+// @target: ES2015
+// @module: ES2015
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+export default class {
+    @dec get accessor() { return 1; }
+}

--- a/tests/cases/conformance/es6/decorators/class/method/decoratorOnClassMethod1.es6.ts
+++ b/tests/cases/conformance/es6/decorators/class/method/decoratorOnClassMethod1.es6.ts
@@ -1,0 +1,8 @@
+// @target: ES2015
+// @module: ES2015
+// @experimentaldecorators: true
+declare function dec<T>(target: any, propertyKey: string, descriptor: TypedPropertyDescriptor<T>): TypedPropertyDescriptor<T>;
+
+export default class {
+    @dec method() {}
+}

--- a/tests/cases/conformance/es6/decorators/class/method/parameter/decoratorOnClassMethodParameter1.es6.ts
+++ b/tests/cases/conformance/es6/decorators/class/method/parameter/decoratorOnClassMethodParameter1.es6.ts
@@ -1,0 +1,8 @@
+// @target: ES2015
+// @module: ES2015
+// @experimentaldecorators: true
+declare function dec(target: Object, propertyKey: string | symbol, parameterIndex: number): void;
+
+export default class {
+    method(@dec p: number) {}
+}

--- a/tests/cases/conformance/es6/decorators/class/property/decoratorOnClassProperty1.es6.ts
+++ b/tests/cases/conformance/es6/decorators/class/property/decoratorOnClassProperty1.es6.ts
@@ -1,0 +1,8 @@
+// @target: ES2015
+// @module: ES2015
+// @experimentaldecorators: true
+declare function dec(target: any, propertyKey: string): void;
+
+export default class {
+    @dec prop;
+}


### PR DESCRIPTION
This ensures a name is generated for a class declaration that is the default export and has decorated members. It also adds test cases for this scenario.

Fixes #14591
