### PR TITLE
Fix #15224: Add a `source` property on Diagnostic interface

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3350,6 +3350,7 @@ namespace ts {
         messageText: string | DiagnosticMessageChain;
         category: DiagnosticCategory;
         code: number;
+        source?: string;
     }
 
     export enum DiagnosticCategory {

--- a/src/server/protocol.ts
+++ b/src/server/protocol.ts
@@ -1825,14 +1825,19 @@ namespace ts.server.protocol {
         text: string;
 
         /**
+         * The category of the diagnostic message, e.g. "error" vs. "warning"
+         */
+        category: string;
+
+        /**
          * The error code of the diagnostic message.
          */
         code?: number;
 
         /**
-         * The category of the diagnostic message, e.g. "error" vs. "warning"
+         * The name of the plugin reporting the message.
          */
-        category: string;
+        source?: string;
     }
 
     export interface DiagnosticEventBody {

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -68,7 +68,8 @@ namespace ts.server {
             end: scriptInfo.positionToLineOffset(diag.start + diag.length),
             text: ts.flattenDiagnosticMessageText(diag.messageText, "\n"),
             code: diag.code,
-            category: DiagnosticCategory[diag.category].toLowerCase()
+            category: DiagnosticCategory[diag.category].toLowerCase(),
+            source: diag.source
         };
     }
 
@@ -77,7 +78,8 @@ namespace ts.server {
             start: undefined,
             end: undefined,
             text: ts.flattenDiagnosticMessageText(diag.messageText, "\n"),
-            category: DiagnosticCategory[diag.category].toLowerCase()
+            category: DiagnosticCategory[diag.category].toLowerCase(),
+            source: diag.source
         };
     }
 
@@ -592,6 +594,7 @@ namespace ts.server {
                 length: d.length,
                 category: DiagnosticCategory[d.category].toLowerCase(),
                 code: d.code,
+                source: d.source,
                 startLocation: scriptInfo && scriptInfo.positionToLineOffset(d.start),
                 endLocation: scriptInfo && scriptInfo.positionToLineOffset(d.start + d.length)
             });


### PR DESCRIPTION

Fixes #15224
