### PR TITLE
Allow plugins to provide a list of external files.

### DIFF
--- a/src/server/project.ts
+++ b/src/server/project.ts
@@ -112,6 +112,7 @@ namespace ts.server {
         private rootFiles: ScriptInfo[] = [];
         private rootFilesMap: FileMap<ScriptInfo> = createFileMap<ScriptInfo>();
         private program: ts.Program;
+        private externalFiles: SortedReadonlyArray<string>;
 
         private cachedUnresolvedImportsPerFile = new UnresolvedImportsMap();
         private lastCachedUnresolvedImportsList: SortedReadonlyArray<string>;
@@ -267,8 +268,8 @@ namespace ts.server {
         abstract getProjectRootPath(): string | undefined;
         abstract getTypeAcquisition(): TypeAcquisition;
 
-        getExternalFiles(): string[] {
-            return [];
+        getExternalFiles(): SortedReadonlyArray<string> {
+            return emptyArray as SortedReadonlyArray<string>;
         }
 
         getSourceFile(path: Path) {
@@ -567,6 +568,24 @@ namespace ts.server {
                     }
                 }
             }
+
+            const oldExternalFiles = this.externalFiles || emptyArray as SortedReadonlyArray<string>;
+            this.externalFiles = this.getExternalFiles();
+            enumerateInsertsAndDeletes(this.externalFiles, oldExternalFiles,
+                // Ensure a ScriptInfo is created for new external files. This is performed indirectly
+                // by the LSHost for files in the program when the program is retrieved above but
+                // the program doesn't contain external files so this must be done explicitly.
+                inserted => {
+                    const scriptInfo = this.projectService.getOrCreateScriptInfo(inserted, /*openedByClient*/ false);
+                    scriptInfo.attachToProject(this);
+                },
+                removed => {
+                    const scriptInfoToDetach = this.projectService.getScriptInfo(removed);
+                    if (scriptInfoToDetach) {
+                        scriptInfoToDetach.detachFromProject(this);
+                    }
+                });
+
             return hasChanges;
         }
 
@@ -947,7 +966,7 @@ namespace ts.server {
             return this.typeAcquisition;
         }
 
-        getExternalFiles(): string[] {
+        getExternalFiles(): SortedReadonlyArray<string> {
             const items: string[] = [];
             for (const plugin of this.plugins) {
                 if (typeof plugin.getExternalFiles === "function") {
@@ -959,7 +978,7 @@ namespace ts.server {
                     }
                 }
             }
-            return items;
+            return toSortedReadonlyArray(items);
         }
 
         watchConfigFile(callback: (project: ConfiguredProject) => void) {

--- a/src/server/utilities.ts
+++ b/src/server/utilities.ts
@@ -192,6 +192,37 @@ namespace ts.server {
         return <any>arr;
     }
 
+    export function enumerateInsertsAndDeletes<T>(a: SortedReadonlyArray<T>, b: SortedReadonlyArray<T>, inserted: (item: T) => void, deleted: (item: T) => void, compare?: (a: T, b: T) => Comparison) {
+        compare = compare || ts.compareValues;
+        let aIndex = 0;
+        let bIndex = 0;
+        const aLen = a.length;
+        const bLen = b.length;
+        while (aIndex < aLen && bIndex < bLen) {
+            const aItem = a[aIndex];
+            const bItem = b[bIndex];
+            const compareResult = compare(aItem, bItem);
+            if (compareResult === Comparison.LessThan) {
+                inserted(aItem);
+                aIndex++;
+            }
+            else if (compareResult === Comparison.GreaterThan) {
+                deleted(bItem);
+                bIndex++;
+            }
+            else {
+                aIndex++;
+                bIndex++;
+            }
+        }
+        while (aIndex < aLen) {
+            inserted(a[aIndex++]);
+        }
+        while (bIndex < bLen) {
+            deleted(b[bIndex++]);
+        }
+    }
+
     export class ThrottledOperations {
         private pendingTimeouts: Map<any> = createMap<any>();
         constructor(private readonly host: ServerHost) {


### PR DESCRIPTION
The list of the plugin's external files and request made to
a file in the list will be routed to an instance of the plugin.

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->