### PR TITLE
Allow exporting const variables when `strictNullChecks` is on

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -11807,7 +11807,7 @@ namespace ts {
             // the entire control flow graph from the variable's declaration (i.e. when the flow container and
             // declaration container are the same).
             const assumeInitialized = isParameter || isOuterVariable ||
-                type !== autoType && type !== autoArrayType && (!strictNullChecks || (type.flags & TypeFlags.Any) !== 0 || isInTypeQuery(node)) ||
+                type !== autoType && type !== autoArrayType && (!strictNullChecks || (type.flags & TypeFlags.Any) !== 0 || isInTypeQuery(node) || node.parent.kind === SyntaxKind.ExportSpecifier) ||
                 isInAmbientContext(declaration);
             const initialType = assumeInitialized ? (isParameter ? removeOptionalityFromDeclaredType(type, getRootDeclaration(declaration) as VariableLikeDeclaration) : type) :
                 type === autoType || type === autoArrayType ? undefinedType :

--- a/tests/baselines/reference/exportBinding.errors.txt
+++ b/tests/baselines/reference/exportBinding.errors.txt
@@ -1,0 +1,27 @@
+tests/cases/conformance/es6/modules/exportConsts.ts(3,16): error TS2448: Block-scoped variable 'x' used before its declaration.
+tests/cases/conformance/es6/modules/exportConsts.ts(3,16): error TS2454: Variable 'x' is used before being assigned.
+tests/cases/conformance/es6/modules/exportVars.ts(3,16): error TS2454: Variable 'y' is used before being assigned.
+
+
+==== tests/cases/conformance/es6/modules/exportConsts.ts (2 errors) ====
+    export { x }
+    export { x as xx }
+    export default x;
+                   ~
+!!! error TS2448: Block-scoped variable 'x' used before its declaration.
+                   ~
+!!! error TS2454: Variable 'x' is used before being assigned.
+    
+    const x = 'x'
+    
+    export { Y as Z }
+    class Y {}
+    
+==== tests/cases/conformance/es6/modules/exportVars.ts (1 errors) ====
+    export { y }
+    export { y as yy }
+    export default y;
+                   ~
+!!! error TS2454: Variable 'y' is used before being assigned.
+    var y = 'y'
+    

--- a/tests/baselines/reference/exportBinding.js
+++ b/tests/baselines/reference/exportBinding.js
@@ -1,19 +1,39 @@
-//// [exportBinding.ts]
+//// [tests/cases/conformance/es6/modules/exportBinding.ts] ////
+
+//// [exportConsts.ts]
 export { x }
+export { x as xx }
+export default x;
+
 const x = 'x'
 
 export { Y as Z }
 class Y {}
 
+//// [exportVars.ts]
+export { y }
+export { y as yy }
+export default y;
+var y = 'y'
 
-//// [exportBinding.js]
+
+//// [exportConsts.js]
 "use strict";
 exports.__esModule = true;
+exports["default"] = x;
 var x = 'x';
 exports.x = x;
+exports.xx = x;
 var Y = (function () {
     function Y() {
     }
     return Y;
 }());
 exports.Z = Y;
+//// [exportVars.js]
+"use strict";
+exports.__esModule = true;
+exports["default"] = y;
+var y = 'y';
+exports.y = y;
+exports.yy = y;

--- a/tests/cases/conformance/es6/modules/exportBinding.ts
+++ b/tests/cases/conformance/es6/modules/exportBinding.ts
@@ -1,5 +1,17 @@
+// @filename: exportConsts.ts
+// @strict: true
 export { x }
+export { x as xx }
+export default x;
+
 const x = 'x'
 
 export { Y as Z }
 class Y {}
+
+// @filename: exportVars.ts
+// @strict: true
+export { y }
+export { y as yy }
+export default y;
+var y = 'y'


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #15329
