### PR TITLE
Improve message for untyped module with noImplicitAny

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1641,10 +1641,14 @@ namespace ts {
                     error(errorNode, diag, moduleReference, resolvedModule.resolvedFileName);
                 }
                 else if (noImplicitAny && moduleNotFoundError) {
-                    error(errorNode,
+                    let errorInfo = chainDiagnosticMessages(undefined,
+                        Diagnostics.Try_npm_install_types_Slash_0_if_it_exists_or_adding_declare_module_0_in_a_separate_file,
+                        moduleReference);
+                    errorInfo = chainDiagnosticMessages(errorInfo,
                         Diagnostics.Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type,
                         moduleReference,
                         resolvedModule.resolvedFileName);
+                    diagnostics.add(createDiagnosticForNodeFromMessageChain(errorNode, errorInfo));
                 }
                 // Failed imports and untyped modules are both treated in an untyped manner; only difference is whether we give a diagnostic first.
                 return undefined;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1641,7 +1641,7 @@ namespace ts {
                     error(errorNode, diag, moduleReference, resolvedModule.resolvedFileName);
                 }
                 else if (noImplicitAny && moduleNotFoundError) {
-                    let errorInfo = chainDiagnosticMessages(undefined,
+                    let errorInfo = chainDiagnosticMessages(/*details*/ undefined,
                         Diagnostics.Try_npm_install_types_Slash_0_if_it_exists_or_adding_declare_module_0_in_a_separate_file,
                         moduleReference);
                     errorInfo = chainDiagnosticMessages(errorInfo,

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1642,7 +1642,7 @@ namespace ts {
                 }
                 else if (noImplicitAny && moduleNotFoundError) {
                     let errorInfo = chainDiagnosticMessages(/*details*/ undefined,
-                        Diagnostics.Try_npm_install_types_Slash_0_if_it_exists_or_adding_declare_module_0_in_a_separate_file,
+                        Diagnostics.Try_npm_install_types_Slash_0_if_it_exists_or_add_a_new_declaration_d_ts_file_containing_declare_module_0,
                         moduleReference);
                     errorInfo = chainDiagnosticMessages(errorInfo,
                         Diagnostics.Could_not_find_a_declaration_file_for_module_0_1_implicitly_has_an_any_type,

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3310,6 +3310,10 @@
         "category": "Error",
         "code": 7034
     },
+    "Try `npm install @types/{0}` if it exists or adding `declare module '{0}'` in a separate file.": {
+        "category": "Error",
+        "code": 7035
+    },
     "You cannot rename this element.": {
         "category": "Error",
         "code": 8000

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -3310,7 +3310,7 @@
         "category": "Error",
         "code": 7034
     },
-    "Try `npm install @types/{0}` if it exists or adding `declare module '{0}'` in a separate file.": {
+    "Try `npm install @types/{0}` if it exists or add a new declaration (.d.ts) file containing `declare module '{0}';`": {
         "category": "Error",
         "code": 7035
     },

--- a/tests/baselines/reference/untypedModuleImport_noImplicitAny.errors.txt
+++ b/tests/baselines/reference/untypedModuleImport_noImplicitAny.errors.txt
@@ -1,10 +1,12 @@
 /a.ts(1,22): error TS7016: Could not find a declaration file for module 'foo'. '/node_modules/foo/index.js' implicitly has an 'any' type.
+  Try `npm install @types/foo` if it exists or adding `declare module 'foo'` in a separate file.
 
 
 ==== /a.ts (1 errors) ====
     import * as foo from "foo";
                          ~~~~~
 !!! error TS7016: Could not find a declaration file for module 'foo'. '/node_modules/foo/index.js' implicitly has an 'any' type.
+!!! error TS7016:   Try `npm install @types/foo` if it exists or adding `declare module 'foo'` in a separate file.
     
 ==== /node_modules/foo/index.js (0 errors) ====
     // This tests that `--noImplicitAny` disables untyped modules.

--- a/tests/baselines/reference/untypedModuleImport_noImplicitAny.errors.txt
+++ b/tests/baselines/reference/untypedModuleImport_noImplicitAny.errors.txt
@@ -1,12 +1,12 @@
 /a.ts(1,22): error TS7016: Could not find a declaration file for module 'foo'. '/node_modules/foo/index.js' implicitly has an 'any' type.
-  Try `npm install @types/foo` if it exists or adding `declare module 'foo'` in a separate file.
+  Try `npm install @types/foo` if it exists or add a new declaration (.d.ts) file containing `declare module 'foo';`
 
 
 ==== /a.ts (1 errors) ====
     import * as foo from "foo";
                          ~~~~~
 !!! error TS7016: Could not find a declaration file for module 'foo'. '/node_modules/foo/index.js' implicitly has an 'any' type.
-!!! error TS7016:   Try `npm install @types/foo` if it exists or adding `declare module 'foo'` in a separate file.
+!!! error TS7016:   Try `npm install @types/foo` if it exists or add a new declaration (.d.ts) file containing `declare module 'foo';`
     
 ==== /node_modules/foo/index.js (0 errors) ====
     // This tests that `--noImplicitAny` disables untyped modules.


### PR DESCRIPTION
Add a suggestion to use `npm install @types/foo` or `declare module 'foo'` in a separate file.
As requested by @bterlson to ease the new user experience.

Not sure about Markdown in error messages. @RyanCavanaugh what kind of punctuation is best to use to set off code examples?