### PR TITLE
Fix block-scoped enum declarations

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -2601,14 +2601,16 @@ namespace ts {
          * Adds a leading VariableStatement for a enum or module declaration.
          */
         function addVarForEnumOrModuleDeclaration(statements: Statement[], node: ModuleDeclaration | EnumDeclaration) {
-            // Emit a variable statement for the module.
+            // Emit a variable statement for the module. We emit top-level enums as a `var`
+            // declaration to avoid static errors in global scripts scripts due to redeclaration.
+            // enums in any other scope are emitted as a `let` declaration.
             const statement = createVariableStatement(
                 visitNodes(node.modifiers, modifierVisitor, isModifier),
-                [
+                createVariableDeclarationList([
                     createVariableDeclaration(
                         getLocalName(node, /*allowComments*/ false, /*allowSourceMaps*/ true)
                     )
-                ]
+                ], currentScope.kind === SyntaxKind.SourceFile ? NodeFlags.None : NodeFlags.Let)
             );
 
             setOriginalNode(statement, node);

--- a/tests/baselines/reference/ClassAndModuleWithSameNameAndCommonRootES6.js
+++ b/tests/baselines/reference/ClassAndModuleWithSameNameAndCommonRootES6.js
@@ -59,7 +59,7 @@ var X;
 (function (X) {
     var Y;
     (function (Y) {
-        var Point;
+        let Point;
         (function (Point) {
             Point.Origin = new Point(0, 0);
         })(Point = Y.Point || (Y.Point = {}));

--- a/tests/baselines/reference/errorRecoveryWithDotFollowedByNamespaceKeyword.js
+++ b/tests/baselines/reference/errorRecoveryWithDotFollowedByNamespaceKeyword.js
@@ -16,7 +16,7 @@ var A;
         if (true) {
             B.
             ;
-            var B;
+            var B = void 0;
             (function (B) {
                 function baz() { }
                 B.baz = baz;

--- a/tests/baselines/reference/es6ModuleConstEnumDeclaration2.js
+++ b/tests/baselines/reference/es6ModuleConstEnumDeclaration2.js
@@ -62,13 +62,13 @@ var x = 0 /* a */;
 var y = 0 /* x */;
 export var m1;
 (function (m1) {
-    var e3;
+    let e3;
     (function (e3) {
         e3[e3["a"] = 0] = "a";
         e3[e3["b"] = 1] = "b";
         e3[e3["c"] = 2] = "c";
     })(e3 = m1.e3 || (m1.e3 = {}));
-    var e4;
+    let e4;
     (function (e4) {
         e4[e4["x"] = 0] = "x";
         e4[e4["y"] = 1] = "y";
@@ -81,13 +81,13 @@ export var m1;
 })(m1 || (m1 = {}));
 var m2;
 (function (m2) {
-    var e5;
+    let e5;
     (function (e5) {
         e5[e5["a"] = 0] = "a";
         e5[e5["b"] = 1] = "b";
         e5[e5["c"] = 2] = "c";
     })(e5 = m2.e5 || (m2.e5 = {}));
-    var e6;
+    let e6;
     (function (e6) {
         e6[e6["x"] = 0] = "x";
         e6[e6["y"] = 1] = "y";

--- a/tests/baselines/reference/es6ModuleEnumDeclaration.js
+++ b/tests/baselines/reference/es6ModuleEnumDeclaration.js
@@ -62,13 +62,13 @@ var x = e1.a;
 var y = e2.x;
 export var m1;
 (function (m1) {
-    var e3;
+    let e3;
     (function (e3) {
         e3[e3["a"] = 0] = "a";
         e3[e3["b"] = 1] = "b";
         e3[e3["c"] = 2] = "c";
     })(e3 = m1.e3 || (m1.e3 = {}));
-    var e4;
+    let e4;
     (function (e4) {
         e4[e4["x"] = 0] = "x";
         e4[e4["y"] = 1] = "y";
@@ -81,13 +81,13 @@ export var m1;
 })(m1 || (m1 = {}));
 var m2;
 (function (m2) {
-    var e5;
+    let e5;
     (function (e5) {
         e5[e5["a"] = 0] = "a";
         e5[e5["b"] = 1] = "b";
         e5[e5["c"] = 2] = "c";
     })(e5 = m2.e5 || (m2.e5 = {}));
-    var e6;
+    let e6;
     (function (e6) {
         e6[e6["x"] = 0] = "x";
         e6[e6["y"] = 1] = "y";

--- a/tests/baselines/reference/es6ModuleInternalNamedImports.js
+++ b/tests/baselines/reference/es6ModuleInternalNamedImports.js
@@ -41,7 +41,7 @@ export var M;
     }
     M.M_C = M_C;
     // instantiated module
-    var M_M;
+    let M_M;
     (function (M_M) {
         var x;
     })(M_M = M.M_M || (M.M_M = {}));
@@ -49,7 +49,7 @@ export var M;
     function M_F() { }
     M.M_F = M_F;
     // enum
-    var M_E;
+    let M_E;
     (function (M_E) {
     })(M_E = M.M_E || (M.M_E = {}));
     // alias

--- a/tests/baselines/reference/es6ModuleInternalNamedImports2.js
+++ b/tests/baselines/reference/es6ModuleInternalNamedImports2.js
@@ -43,7 +43,7 @@ export var M;
     }
     M.M_C = M_C;
     // instantiated module
-    var M_M;
+    let M_M;
     (function (M_M) {
         var x;
     })(M_M = M.M_M || (M.M_M = {}));
@@ -51,7 +51,7 @@ export var M;
     function M_F() { }
     M.M_F = M_F;
     // enum
-    var M_E;
+    let M_E;
     (function (M_E) {
     })(M_E = M.M_E || (M.M_E = {}));
     // alias

--- a/tests/baselines/reference/es6ModuleModuleDeclaration.js
+++ b/tests/baselines/reference/es6ModuleModuleDeclaration.js
@@ -29,12 +29,12 @@ export var m1;
 (function (m1) {
     m1.a = 10;
     var b = 10;
-    var innerExportedModule;
+    let innerExportedModule;
     (function (innerExportedModule) {
         innerExportedModule.k = 10;
         var l = 10;
     })(innerExportedModule = m1.innerExportedModule || (m1.innerExportedModule = {}));
-    var innerNonExportedModule;
+    let innerNonExportedModule;
     (function (innerNonExportedModule) {
         innerNonExportedModule.x = 10;
         var y = 10;
@@ -44,12 +44,12 @@ var m2;
 (function (m2) {
     m2.a = 10;
     var b = 10;
-    var innerExportedModule;
+    let innerExportedModule;
     (function (innerExportedModule) {
         innerExportedModule.k = 10;
         var l = 10;
     })(innerExportedModule = m2.innerExportedModule || (m2.innerExportedModule = {}));
-    var innerNonExportedModule;
+    let innerNonExportedModule;
     (function (innerNonExportedModule) {
         innerNonExportedModule.x = 10;
         var y = 10;

--- a/tests/baselines/reference/localTypes1.js
+++ b/tests/baselines/reference/localTypes1.js
@@ -188,7 +188,7 @@ function f2() {
 }
 function f3(b) {
     if (true) {
-        var E;
+        var E = void 0;
         (function (E) {
             E[E["A"] = 0] = "A";
             E[E["B"] = 1] = "B";


### PR DESCRIPTION
This changes the TypeScript transformation for enums to emit enums as `let` declarations everywhere other than the top level of a source file. We still emit `var` for enums at the top level of a source file to avoid static errors caused by redeclaration for global (non-module) scripts.

Fixes #15403.
Fixes #15401.