### PR TITLE
Changed default from ES3 to ES5

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1529,7 +1529,7 @@ namespace ts {
     }
 
     export function getEmitScriptTarget(compilerOptions: CompilerOptions) {
-        return compilerOptions.target || ScriptTarget.ES3;
+        return compilerOptions.target || ScriptTarget.ES5;
     }
 
     export function getEmitModuleKind(compilerOptions: CompilerOptions) {

--- a/src/harness/unittests/compileOnSave.ts
+++ b/src/harness/unittests/compileOnSave.ts
@@ -558,13 +558,13 @@ namespace ts.projectSystem {
 
             const expectedEmittedFileName = "/a/b/f1.js";
             assert.isTrue(host.fileExists(expectedEmittedFileName));
-            assert.equal(host.readFile(expectedEmittedFileName), `"use strict";\r\nexports.__esModule = true;\r\nfunction Foo() { return 10; }\r\nexports.Foo = Foo;\r\n`);
+            assert.equal(host.readFile(expectedEmittedFileName), `"use strict";\r\nObject.defineProperty(exports, "__esModule", { value: true });\r\nfunction Foo() { return 10; }\r\nexports.Foo = Foo;\r\n`);
         });
 
-        it("shoud not emit js files in external projects", () => {
+        it("should not emit js files in external projects", () => {
             const file1 = {
                 path: "/a/b/file1.ts",
-                content: "consonle.log('file1');"
+                content: "console.log('file1');"
             };
             // file2 has errors. The emitting should not be blocked.
             const file2 = {


### PR DESCRIPTION
Fixes #10117

The fix was easy, but then I had to get the tests passing:

```shell
$ gulp runtests # loads of failures, more than 1000 actually.
$ gulp baseline-accept
$ gulp runtests # to make sure they now passed
```

...and then `git add .` to add all the changes. (There were a bunch of new files created when I did it like this; is that correct?)

----

(Regarding the unrelated changes in `compileOnSave.ts`: I happened to see a few typing mistakes there very close to the changes I were making to that files, so I bundled that change along at the same time. Since the tests are passing I think it should be fine.)

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->
