### PR TITLE
Fix canvas getContext signature in lib/lib.dom.d.ts

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -4339,9 +4339,9 @@ interface HTMLCanvasElement extends HTMLElement {
       * Returns an object that provides methods and properties for drawing and manipulating images and graphics on a canvas element in a document. A context object includes information about colors, line widths, fonts, and other graphic parameters that can be drawn on a canvas.
       * @param contextId The identifier (ID) of the type of canvas to create. Internet Explorer 9 and Internet Explorer 10 support only a 2-D context using canvas.getContext("2d"); IE11 Preview also supports 3-D or WebGL context using canvas.getContext("experimental-webgl");
       */
-    getContext(contextId: "2d", contextAttributes?: Canvas2DContextAttributes): CanvasRenderingContext2D | null;
-    getContext(contextId: "webgl" | "experimental-webgl", contextAttributes?: WebGLContextAttributes): WebGLRenderingContext | null;
-    getContext(contextId: string, contextAttributes?: {}): CanvasRenderingContext2D | WebGLRenderingContext | null;
+    getContext(contextId: "2d", contextAttributes?: Canvas2DContextAttributes): CanvasRenderingContext2D;
+    getContext(contextId: "webgl" | "experimental-webgl", contextAttributes?: WebGLContextAttributes): WebGLRenderingContext;
+    getContext(contextId: string, contextAttributes?: {}): null;
     /**
       * Returns a blob object encoded as a Portable Network Graphics (PNG) format from a canvas image or drawing.
       */


### PR DESCRIPTION
According to
https://developer.mozilla.org/en/docs/Web/API/HTMLCanvasElement/getConte
xt, it only returns `null if the context identifier is not supported`
(i.e. not “2d” | "webgl" | "experimental-webgl”, when new non-standard
renderers are omitted).

It used to be that way, but was changed part of this (huge) commit, 1c9df8446a1112d7a9c002293d0040068f706416
I cannot find the originating commit in the PR: https://github.com/Microsoft/TypeScript/pull/9697 but it must be somewhere (my git skills are average).

This fix might make some people happy: this error generates tons of
useless and annoying non-null `!` type casts when working with canvases.

- [ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
- [x] Code is up-to-date with the `master` branch
- [x] You've successfully run `jake runtests` locally
- [x] You've signed the CLA
- [ ] There are new or updated unit tests validating the change
