### PR TITLE
Never elide an `export *` when `--isolatedModules` is set

### DIFF
--- a/src/compiler/transformers/ts.ts
+++ b/src/compiler/transformers/ts.ts
@@ -2922,7 +2922,7 @@ namespace ts {
         function visitExportDeclaration(node: ExportDeclaration): VisitResult<Statement> {
             if (!node.exportClause) {
                 // Elide a star export if the module it references does not export a value.
-                return resolver.moduleExportsSomeValue(node.moduleSpecifier) ? node : undefined;
+                return compilerOptions.isolatedModules || resolver.moduleExportsSomeValue(node.moduleSpecifier) ? node : undefined;
             }
 
             if (!resolver.isValueAliasDeclaration(node)) {

--- a/tests/baselines/reference/isolatedModulesDontElideReExportStar.js
+++ b/tests/baselines/reference/isolatedModulesDontElideReExportStar.js
@@ -1,0 +1,12 @@
+//// [tests/cases/compiler/isolatedModulesDontElideReExportStar.ts] ////
+
+//// [a.ts]
+export type T = number;
+
+//// [b.ts]
+export * from "./a";
+
+
+//// [a.js]
+//// [b.js]
+export * from "./a";

--- a/tests/baselines/reference/isolatedModulesDontElideReExportStar.symbols
+++ b/tests/baselines/reference/isolatedModulesDontElideReExportStar.symbols
@@ -1,0 +1,8 @@
+=== /a.ts ===
+export type T = number;
+>T : Symbol(T, Decl(a.ts, 0, 0))
+
+=== /b.ts ===
+export * from "./a";
+No type information for this code.
+No type information for this code.

--- a/tests/baselines/reference/isolatedModulesDontElideReExportStar.types
+++ b/tests/baselines/reference/isolatedModulesDontElideReExportStar.types
@@ -1,0 +1,8 @@
+=== /a.ts ===
+export type T = number;
+>T : number
+
+=== /b.ts ===
+export * from "./a";
+No type information for this code.
+No type information for this code.

--- a/tests/cases/compiler/isolatedModulesDontElideReExportStar.ts
+++ b/tests/cases/compiler/isolatedModulesDontElideReExportStar.ts
@@ -1,0 +1,8 @@
+// @isolatedModules: true
+// @target: es6
+
+// @filename: /a.ts
+export type T = number;
+
+// @filename: /b.ts
+export * from "./a";


### PR DESCRIPTION
Related to #15231 -- when `--isolatedModules` is set, emit shouldn't depend on knowledge about external modules.
