### PR TITLE
Mark type arguments as used even if used in an invalid way

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -6687,11 +6687,7 @@ namespace ts {
                             ? <EntityNameExpression>(<ExpressionWithTypeArguments>node).expression
                             : undefined;
                     symbol = typeNameOrExpression && resolveEntityName(typeNameOrExpression, SymbolFlags.Type) || unknownSymbol;
-                    const typeArguments = typeArgumentsFromTypeReferenceNode(node);
-                    type = symbol === unknownSymbol ? unknownType :
-                        symbol.flags & (SymbolFlags.Class | SymbolFlags.Interface) ? getTypeFromClassOrInterfaceReference(node, symbol, typeArguments) :
-                            symbol.flags & SymbolFlags.TypeAlias ? getTypeFromTypeAliasReference(node, symbol, typeArguments) :
-                                getTypeFromNonGenericTypeReference(node, symbol);
+                    type = getTypeReferenceType(node, symbol);
                 }
                 // Cache both the resolved symbol and the resolved type. The resolved symbol is needed in when we check the
                 // type reference in checkTypeReferenceOrExpressionWithTypeArguments.

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -14310,7 +14310,8 @@ namespace ts {
         }
 
         function callLikeExpressionMayHaveTypeArguments(node: CallLikeExpression): node is CallExpression | NewExpression {
-            return node.kind === SyntaxKind.CallExpression || node.kind === SyntaxKind.NewExpression;
+            // TODO: Also include tagged templates (https://github.com/Microsoft/TypeScript/issues/11947)
+            return isCallOrNewExpression(node);
         }
 
         function resolveUntypedCall(node: CallLikeExpression): Signature {

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1142,6 +1142,10 @@ namespace ts {
         }
     }
 
+    export function isCallOrNewExpression(node: Node): node is CallExpression | NewExpression {
+        return node.kind === SyntaxKind.CallExpression || node.kind === SyntaxKind.NewExpression;
+    }
+
     export function getInvokedExpression(node: CallLikeExpression): Expression {
         if (node.kind === SyntaxKind.TaggedTemplateExpression) {
             return (<TaggedTemplateExpression>node).tag;

--- a/src/services/formatting/smartIndenter.ts
+++ b/src/services/formatting/smartIndenter.ts
@@ -341,10 +341,7 @@ namespace ts.formatting {
                 return Value.Unknown;
             }
 
-            if (node.parent && (
-                node.parent.kind === SyntaxKind.CallExpression ||
-                node.parent.kind === SyntaxKind.NewExpression) &&
-                (<CallExpression>node.parent).expression !== node) {
+            if (node.parent && isCallOrNewExpression(node.parent) && (<CallExpression>node.parent).expression !== node) {
 
                 const fullCallOrNewExpression = (<CallExpression | NewExpression>node.parent).expression;
                 const startingExpression = getStartingExpression(fullCallOrNewExpression);

--- a/src/services/signatureHelp.ts
+++ b/src/services/signatureHelp.ts
@@ -262,7 +262,7 @@ namespace ts.SignatureHelp {
      * in the argument of an invocation; returns undefined otherwise.
      */
     export function getImmediatelyContainingArgumentInfo(node: Node, position: number, sourceFile: SourceFile): ArgumentListInfo {
-        if (node.parent.kind === SyntaxKind.CallExpression || node.parent.kind === SyntaxKind.NewExpression) {
+        if (isCallOrNewExpression(node.parent)) {
             const callExpression = <CallExpression>node.parent;
             // There are 3 cases to handle:
             //   1. The token introduces a list, and should begin a signature help session

--- a/src/services/symbolDisplay.ts
+++ b/src/services/symbolDisplay.ts
@@ -120,7 +120,7 @@ namespace ts.SymbolDisplay {
 
                 // try get the call/construct signature from the type if it matches
                 let callExpressionLike: CallExpression | NewExpression | JsxOpeningLikeElement;
-                if (location.kind === SyntaxKind.CallExpression || location.kind === SyntaxKind.NewExpression) {
+                if (isCallOrNewExpression(location)) {
                     callExpressionLike = <CallExpression | NewExpression>location;
                 }
                 else if (isCallExpressionTarget(location) || isNewExpressionTarget(location)) {

--- a/tests/baselines/reference/callExpressionWithMissingTypeArgument1.errors.txt
+++ b/tests/baselines/reference/callExpressionWithMissingTypeArgument1.errors.txt
@@ -1,10 +1,16 @@
 tests/cases/compiler/callExpressionWithMissingTypeArgument1.ts(1,1): error TS2304: Cannot find name 'Foo'.
+tests/cases/compiler/callExpressionWithMissingTypeArgument1.ts(1,5): error TS2304: Cannot find name 'a'.
 tests/cases/compiler/callExpressionWithMissingTypeArgument1.ts(1,7): error TS1110: Type expected.
+tests/cases/compiler/callExpressionWithMissingTypeArgument1.ts(1,8): error TS2304: Cannot find name 'b'.
 
 
-==== tests/cases/compiler/callExpressionWithMissingTypeArgument1.ts (2 errors) ====
+==== tests/cases/compiler/callExpressionWithMissingTypeArgument1.ts (4 errors) ====
     Foo<a,,b>();
     ~~~
 !!! error TS2304: Cannot find name 'Foo'.
+        ~
+!!! error TS2304: Cannot find name 'a'.
           ~
 !!! error TS1110: Type expected.
+           ~
+!!! error TS2304: Cannot find name 'b'.

--- a/tests/baselines/reference/functionCalls.errors.txt
+++ b/tests/baselines/reference/functionCalls.errors.txt
@@ -1,6 +1,7 @@
 tests/cases/conformance/expressions/functionCalls/functionCalls.ts(8,1): error TS2347: Untyped function calls may not accept type arguments.
 tests/cases/conformance/expressions/functionCalls/functionCalls.ts(9,1): error TS2347: Untyped function calls may not accept type arguments.
 tests/cases/conformance/expressions/functionCalls/functionCalls.ts(10,1): error TS2347: Untyped function calls may not accept type arguments.
+tests/cases/conformance/expressions/functionCalls/functionCalls.ts(10,8): error TS2304: Cannot find name 'Window'.
 tests/cases/conformance/expressions/functionCalls/functionCalls.ts(25,1): error TS2347: Untyped function calls may not accept type arguments.
 tests/cases/conformance/expressions/functionCalls/functionCalls.ts(26,1): error TS2347: Untyped function calls may not accept type arguments.
 tests/cases/conformance/expressions/functionCalls/functionCalls.ts(27,1): error TS2347: Untyped function calls may not accept type arguments.
@@ -9,7 +10,7 @@ tests/cases/conformance/expressions/functionCalls/functionCalls.ts(33,1): error 
 tests/cases/conformance/expressions/functionCalls/functionCalls.ts(34,1): error TS2347: Untyped function calls may not accept type arguments.
 
 
-==== tests/cases/conformance/expressions/functionCalls/functionCalls.ts (9 errors) ====
+==== tests/cases/conformance/expressions/functionCalls/functionCalls.ts (10 errors) ====
     // Invoke function call on value of type 'any' with no type arguments
     var anyVar: any;
     anyVar(0);
@@ -26,6 +27,8 @@ tests/cases/conformance/expressions/functionCalls/functionCalls.ts(34,1): error 
     anyVar<Window>(undefined);
     ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2347: Untyped function calls may not accept type arguments.
+           ~~~~~~
+!!! error TS2304: Cannot find name 'Window'.
     
     
     // Invoke function call on value of a subtype of Function with no call signatures with no type arguments

--- a/tests/baselines/reference/parserAmbiguity1.errors.txt
+++ b/tests/baselines/reference/parserAmbiguity1.errors.txt
@@ -1,10 +1,16 @@
 tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity1.ts(1,1): error TS2304: Cannot find name 'f'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity1.ts(1,3): error TS2304: Cannot find name 'g'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity1.ts(1,5): error TS2304: Cannot find name 'A'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity1.ts(1,8): error TS2304: Cannot find name 'B'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity1.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguity1.ts (4 errors) ====
     f(g<A, B>(7));
     ~
 !!! error TS2304: Cannot find name 'f'.
       ~
 !!! error TS2304: Cannot find name 'g'.
+        ~
+!!! error TS2304: Cannot find name 'A'.
+           ~
+!!! error TS2304: Cannot find name 'B'.

--- a/tests/baselines/reference/parserAmbiguityWithBinaryOperator4.errors.txt
+++ b/tests/baselines/reference/parserAmbiguityWithBinaryOperator4.errors.txt
@@ -1,10 +1,16 @@
 tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts(3,9): error TS2347: Untyped function calls may not accept type arguments.
+tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts(3,11): error TS2304: Cannot find name 'b'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts(3,14): error TS2304: Cannot find name 'b'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts (1 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/Generics/parserAmbiguityWithBinaryOperator4.ts (3 errors) ====
     function g() {
         var a, b, c;
         if (a<b, b>(c + 1)) { }
             ~~~~~~~~~~~~~~
 !!! error TS2347: Untyped function calls may not accept type arguments.
+              ~
+!!! error TS2304: Cannot find name 'b'.
+                 ~
+!!! error TS2304: Cannot find name 'b'.
     }

--- a/tests/baselines/reference/parserGenericConstraint4.errors.txt
+++ b/tests/baselines/reference/parserGenericConstraint4.errors.txt
@@ -1,8 +1,11 @@
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint4.ts(1,19): error TS2304: Cannot find name 'List'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint4.ts(1,24): error TS2304: Cannot find name 'List'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint4.ts (1 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint4.ts (2 errors) ====
     class C<T extends List<List<T> > > {
                       ~~~~
+!!! error TS2304: Cannot find name 'List'.
+                           ~~~~
 !!! error TS2304: Cannot find name 'List'.
     }

--- a/tests/baselines/reference/parserGenericConstraint5.errors.txt
+++ b/tests/baselines/reference/parserGenericConstraint5.errors.txt
@@ -1,8 +1,11 @@
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint5.ts(1,19): error TS2304: Cannot find name 'List'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint5.ts(1,24): error TS2304: Cannot find name 'List'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint5.ts (1 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint5.ts (2 errors) ====
     class C<T extends List<List<T>> > {
                       ~~~~
+!!! error TS2304: Cannot find name 'List'.
+                           ~~~~
 !!! error TS2304: Cannot find name 'List'.
     }

--- a/tests/baselines/reference/parserGenericConstraint6.errors.txt
+++ b/tests/baselines/reference/parserGenericConstraint6.errors.txt
@@ -1,8 +1,11 @@
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint6.ts(1,19): error TS2304: Cannot find name 'List'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint6.ts(1,24): error TS2304: Cannot find name 'List'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint6.ts (1 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint6.ts (2 errors) ====
     class C<T extends List<List<T> >> {
                       ~~~~
+!!! error TS2304: Cannot find name 'List'.
+                           ~~~~
 !!! error TS2304: Cannot find name 'List'.
     }

--- a/tests/baselines/reference/parserGenericConstraint7.errors.txt
+++ b/tests/baselines/reference/parserGenericConstraint7.errors.txt
@@ -1,8 +1,11 @@
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint7.ts(1,19): error TS2304: Cannot find name 'List'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint7.ts(1,24): error TS2304: Cannot find name 'List'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint7.ts (1 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericConstraint7.ts (2 errors) ====
     class C<T extends List<List<T>>> {
                       ~~~~
+!!! error TS2304: Cannot find name 'List'.
+                           ~~~~
 !!! error TS2304: Cannot find name 'List'.
     }

--- a/tests/baselines/reference/parserGenericsInTypeContexts1.errors.txt
+++ b/tests/baselines/reference/parserGenericsInTypeContexts1.errors.txt
@@ -1,47 +1,71 @@
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(1,17): error TS2304: Cannot find name 'A'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(1,33): error TS2304: Cannot find name 'B'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(1,35): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(4,9): error TS2315: Type 'C' is not generic.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(4,11): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(5,9): error TS2304: Cannot find name 'D'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(5,11): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(6,9): error TS2503: Cannot find namespace 'E'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(6,13): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(7,9): error TS2503: Cannot find namespace 'G'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(7,15): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(8,9): error TS2304: Cannot find name 'K'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(8,11): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(11,16): error TS2304: Cannot find name 'E'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(11,18): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(14,16): error TS2304: Cannot find name 'F'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts(14,18): error TS2304: Cannot find name 'T'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts (9 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts1.ts (17 errors) ====
     class C extends A<T> implements B<T> {
                     ~
 !!! error TS2304: Cannot find name 'A'.
                                     ~
 !!! error TS2304: Cannot find name 'B'.
+                                      ~
+!!! error TS2304: Cannot find name 'T'.
     }
     
     var v1: C<T>;
             ~~~~
 !!! error TS2315: Type 'C' is not generic.
+              ~
+!!! error TS2304: Cannot find name 'T'.
     var v2: D<T> = null;
             ~
 !!! error TS2304: Cannot find name 'D'.
+              ~
+!!! error TS2304: Cannot find name 'T'.
     var v3: E.F<T>;
             ~
 !!! error TS2503: Cannot find namespace 'E'.
+                ~
+!!! error TS2304: Cannot find name 'T'.
     var v3: G.H.I<T>;
             ~
 !!! error TS2503: Cannot find namespace 'G'.
+                  ~
+!!! error TS2304: Cannot find name 'T'.
     var v6: K<T>[];
             ~
 !!! error TS2304: Cannot find name 'K'.
+              ~
+!!! error TS2304: Cannot find name 'T'.
     
     
     function f1(a: E<T>) {
                    ~
 !!! error TS2304: Cannot find name 'E'.
+                     ~
+!!! error TS2304: Cannot find name 'T'.
     }
     
     function f2(): F<T> {
                    ~
 !!! error TS2304: Cannot find name 'F'.
+                     ~
+!!! error TS2304: Cannot find name 'T'.
     }
     
     

--- a/tests/baselines/reference/parserGenericsInTypeContexts2.errors.txt
+++ b/tests/baselines/reference/parserGenericsInTypeContexts2.errors.txt
@@ -1,47 +1,167 @@
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(1,17): error TS2304: Cannot find name 'A'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(1,45): error TS2304: Cannot find name 'B'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(1,47): error TS2304: Cannot find name 'X'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(1,49): error TS2304: Cannot find name 'T'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(1,53): error TS2304: Cannot find name 'Y'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(1,55): error TS2304: Cannot find name 'Z'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(1,57): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(4,9): error TS2315: Type 'C' is not generic.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(4,11): error TS2304: Cannot find name 'X'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(4,13): error TS2304: Cannot find name 'T'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(4,17): error TS2304: Cannot find name 'Y'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(4,19): error TS2304: Cannot find name 'Z'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(4,21): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(5,9): error TS2304: Cannot find name 'D'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(5,11): error TS2304: Cannot find name 'X'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(5,13): error TS2304: Cannot find name 'T'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(5,17): error TS2304: Cannot find name 'Y'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(5,19): error TS2304: Cannot find name 'Z'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(5,21): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(6,9): error TS2503: Cannot find namespace 'E'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(6,13): error TS2304: Cannot find name 'X'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(6,15): error TS2304: Cannot find name 'T'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(6,19): error TS2304: Cannot find name 'Y'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(6,21): error TS2304: Cannot find name 'Z'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(6,23): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(7,9): error TS2503: Cannot find namespace 'G'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(7,15): error TS2304: Cannot find name 'X'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(7,17): error TS2304: Cannot find name 'T'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(7,21): error TS2304: Cannot find name 'Y'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(7,23): error TS2304: Cannot find name 'Z'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(7,25): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(8,9): error TS2304: Cannot find name 'K'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(8,11): error TS2304: Cannot find name 'X'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(8,13): error TS2304: Cannot find name 'T'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(8,17): error TS2304: Cannot find name 'Y'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(8,19): error TS2304: Cannot find name 'Z'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(8,21): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(11,16): error TS2304: Cannot find name 'E'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(11,18): error TS2304: Cannot find name 'X'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(11,20): error TS2304: Cannot find name 'T'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(11,24): error TS2304: Cannot find name 'Y'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(11,26): error TS2304: Cannot find name 'Z'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(11,28): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(14,16): error TS2304: Cannot find name 'F'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(14,18): error TS2304: Cannot find name 'X'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(14,20): error TS2304: Cannot find name 'T'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(14,24): error TS2304: Cannot find name 'Y'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(14,26): error TS2304: Cannot find name 'Z'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts(14,28): error TS2304: Cannot find name 'T'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts (9 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInTypeContexts2.ts (49 errors) ====
     class C extends A<X<T>, Y<Z<T>>> implements B<X<T>, Y<Z<T>>> {
                     ~
 !!! error TS2304: Cannot find name 'A'.
                                                 ~
 !!! error TS2304: Cannot find name 'B'.
+                                                  ~
+!!! error TS2304: Cannot find name 'X'.
+                                                    ~
+!!! error TS2304: Cannot find name 'T'.
+                                                        ~
+!!! error TS2304: Cannot find name 'Y'.
+                                                          ~
+!!! error TS2304: Cannot find name 'Z'.
+                                                            ~
+!!! error TS2304: Cannot find name 'T'.
     }
     
     var v1: C<X<T>, Y<Z<T>>>;
             ~~~~~~~~~~~~~~~~
 !!! error TS2315: Type 'C' is not generic.
+              ~
+!!! error TS2304: Cannot find name 'X'.
+                ~
+!!! error TS2304: Cannot find name 'T'.
+                    ~
+!!! error TS2304: Cannot find name 'Y'.
+                      ~
+!!! error TS2304: Cannot find name 'Z'.
+                        ~
+!!! error TS2304: Cannot find name 'T'.
     var v2: D<X<T>, Y<Z<T>>> = null;
             ~
 !!! error TS2304: Cannot find name 'D'.
+              ~
+!!! error TS2304: Cannot find name 'X'.
+                ~
+!!! error TS2304: Cannot find name 'T'.
+                    ~
+!!! error TS2304: Cannot find name 'Y'.
+                      ~
+!!! error TS2304: Cannot find name 'Z'.
+                        ~
+!!! error TS2304: Cannot find name 'T'.
     var v3: E.F<X<T>, Y<Z<T>>>;
             ~
 !!! error TS2503: Cannot find namespace 'E'.
+                ~
+!!! error TS2304: Cannot find name 'X'.
+                  ~
+!!! error TS2304: Cannot find name 'T'.
+                      ~
+!!! error TS2304: Cannot find name 'Y'.
+                        ~
+!!! error TS2304: Cannot find name 'Z'.
+                          ~
+!!! error TS2304: Cannot find name 'T'.
     var v4: G.H.I<X<T>, Y<Z<T>>>;
             ~
 !!! error TS2503: Cannot find namespace 'G'.
+                  ~
+!!! error TS2304: Cannot find name 'X'.
+                    ~
+!!! error TS2304: Cannot find name 'T'.
+                        ~
+!!! error TS2304: Cannot find name 'Y'.
+                          ~
+!!! error TS2304: Cannot find name 'Z'.
+                            ~
+!!! error TS2304: Cannot find name 'T'.
     var v6: K<X<T>, Y<Z<T>>>[];
             ~
 !!! error TS2304: Cannot find name 'K'.
+              ~
+!!! error TS2304: Cannot find name 'X'.
+                ~
+!!! error TS2304: Cannot find name 'T'.
+                    ~
+!!! error TS2304: Cannot find name 'Y'.
+                      ~
+!!! error TS2304: Cannot find name 'Z'.
+                        ~
+!!! error TS2304: Cannot find name 'T'.
     
     
     function f1(a: E<X<T>, Y<Z<T>>>) {
                    ~
 !!! error TS2304: Cannot find name 'E'.
+                     ~
+!!! error TS2304: Cannot find name 'X'.
+                       ~
+!!! error TS2304: Cannot find name 'T'.
+                           ~
+!!! error TS2304: Cannot find name 'Y'.
+                             ~
+!!! error TS2304: Cannot find name 'Z'.
+                               ~
+!!! error TS2304: Cannot find name 'T'.
     }
     
     function f2(): F<X<T>, Y<Z<T>>> {
                    ~
 !!! error TS2304: Cannot find name 'F'.
+                     ~
+!!! error TS2304: Cannot find name 'X'.
+                       ~
+!!! error TS2304: Cannot find name 'T'.
+                           ~
+!!! error TS2304: Cannot find name 'Y'.
+                             ~
+!!! error TS2304: Cannot find name 'Z'.
+                               ~
+!!! error TS2304: Cannot find name 'T'.
     }
     
     

--- a/tests/baselines/reference/parserGenericsInVariableDeclaration1.errors.txt
+++ b/tests/baselines/reference/parserGenericsInVariableDeclaration1.errors.txt
@@ -1,29 +1,65 @@
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(1,9): error TS2304: Cannot find name 'Foo'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(1,13): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(2,9): error TS2304: Cannot find name 'Foo'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(2,13): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(4,9): error TS2304: Cannot find name 'Foo'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(4,13): error TS2304: Cannot find name 'Bar'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(4,17): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(5,9): error TS2304: Cannot find name 'Foo'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(5,13): error TS2304: Cannot find name 'Bar'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(5,17): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(7,9): error TS2304: Cannot find name 'Foo'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(7,13): error TS2304: Cannot find name 'Bar'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(7,17): error TS2304: Cannot find name 'Quux'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(7,22): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(8,9): error TS2304: Cannot find name 'Foo'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(8,13): error TS2304: Cannot find name 'Bar'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(8,17): error TS2304: Cannot find name 'Quux'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts(8,22): error TS2304: Cannot find name 'T'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts (6 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/Generics/parserGenericsInVariableDeclaration1.ts (18 errors) ====
     var v : Foo<T> = 1;
             ~~~
 !!! error TS2304: Cannot find name 'Foo'.
+                ~
+!!! error TS2304: Cannot find name 'T'.
     var v : Foo<T>= 1;
             ~~~
 !!! error TS2304: Cannot find name 'Foo'.
+                ~
+!!! error TS2304: Cannot find name 'T'.
     
     var v : Foo<Bar<T>> = 1;
             ~~~
 !!! error TS2304: Cannot find name 'Foo'.
+                ~~~
+!!! error TS2304: Cannot find name 'Bar'.
+                    ~
+!!! error TS2304: Cannot find name 'T'.
     var v : Foo<Bar<T>>= 1;
             ~~~
 !!! error TS2304: Cannot find name 'Foo'.
+                ~~~
+!!! error TS2304: Cannot find name 'Bar'.
+                    ~
+!!! error TS2304: Cannot find name 'T'.
     
     var v : Foo<Bar<Quux<T>>> = 1;
             ~~~
 !!! error TS2304: Cannot find name 'Foo'.
+                ~~~
+!!! error TS2304: Cannot find name 'Bar'.
+                    ~~~~
+!!! error TS2304: Cannot find name 'Quux'.
+                         ~
+!!! error TS2304: Cannot find name 'T'.
     var v : Foo<Bar<Quux<T>>>= 1;
             ~~~
 !!! error TS2304: Cannot find name 'Foo'.
+                ~~~
+!!! error TS2304: Cannot find name 'Bar'.
+                    ~~~~
+!!! error TS2304: Cannot find name 'Quux'.
+                         ~
+!!! error TS2304: Cannot find name 'T'.

--- a/tests/baselines/reference/parserMemberAccessExpression1.errors.txt
+++ b/tests/baselines/reference/parserMemberAccessExpression1.errors.txt
@@ -1,25 +1,36 @@
 tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts(1,1): error TS2304: Cannot find name 'Foo'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts(1,5): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts(2,1): error TS2304: Cannot find name 'Foo'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts(2,9): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts(3,1): error TS2304: Cannot find name 'Foo'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts(3,5): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts(3,7): error TS1005: '(' expected.
 tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts(3,8): error TS2304: Cannot find name 'Bar'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts(3,13): error TS1005: ')' expected.
 tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts(4,1): error TS2304: Cannot find name 'Foo'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts(4,5): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts(4,7): error TS1005: '(' expected.
 tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts(4,8): error TS2304: Cannot find name 'Bar'.
+tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts(4,12): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts(4,16): error TS1005: ')' expected.
 
 
-==== tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts (10 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression1.ts (15 errors) ====
     Foo<T>();
     ~~~
 !!! error TS2304: Cannot find name 'Foo'.
+        ~
+!!! error TS2304: Cannot find name 'T'.
     Foo.Bar<T>();
     ~~~
 !!! error TS2304: Cannot find name 'Foo'.
+            ~
+!!! error TS2304: Cannot find name 'T'.
     Foo<T>.Bar();
     ~~~
 !!! error TS2304: Cannot find name 'Foo'.
+        ~
+!!! error TS2304: Cannot find name 'T'.
           ~
 !!! error TS1005: '(' expected.
            ~~~
@@ -29,10 +40,14 @@ tests/cases/conformance/parser/ecmascript5/Generics/parserMemberAccessExpression
     Foo<T>.Bar<T>();
     ~~~
 !!! error TS2304: Cannot find name 'Foo'.
+        ~
+!!! error TS2304: Cannot find name 'T'.
           ~
 !!! error TS1005: '(' expected.
            ~~~
 !!! error TS2304: Cannot find name 'Bar'.
+               ~
+!!! error TS2304: Cannot find name 'T'.
                    ~
 !!! error TS1005: ')' expected.
     

--- a/tests/baselines/reference/parserMissingLambdaOpenBrace1.errors.txt
+++ b/tests/baselines/reference/parserMissingLambdaOpenBrace1.errors.txt
@@ -1,17 +1,23 @@
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserMissingLambdaOpenBrace1.ts(2,19): error TS2304: Cannot find name 'Iterator'.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserMissingLambdaOpenBrace1.ts(2,28): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserMissingLambdaOpenBrace1.ts(2,42): error TS2304: Cannot find name 'Query'.
+tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserMissingLambdaOpenBrace1.ts(2,48): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserMissingLambdaOpenBrace1.ts(3,16): error TS2304: Cannot find name 'fromDoWhile'.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserMissingLambdaOpenBrace1.ts(4,13): error TS1005: '{' expected.
 tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserMissingLambdaOpenBrace1.ts(5,25): error TS2339: Property 'doWhile' does not exist on type 'C'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserMissingLambdaOpenBrace1.ts (5 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/ErrorRecovery/parserMissingLambdaOpenBrace1.ts (7 errors) ====
     class C {
         where(filter: Iterator<T, boolean>): Query<T> {
                       ~~~~~~~~
 !!! error TS2304: Cannot find name 'Iterator'.
+                               ~
+!!! error TS2304: Cannot find name 'T'.
                                              ~~~~~
 !!! error TS2304: Cannot find name 'Query'.
+                                                   ~
+!!! error TS2304: Cannot find name 'T'.
             return fromDoWhile(test =>
                    ~~~~~~~~~~~
 !!! error TS2304: Cannot find name 'fromDoWhile'.

--- a/tests/baselines/reference/parserSkippedTokens20.errors.txt
+++ b/tests/baselines/reference/parserSkippedTokens20.errors.txt
@@ -1,10 +1,13 @@
 tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens20.ts(1,8): error TS2304: Cannot find name 'X'.
+tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens20.ts(1,10): error TS2304: Cannot find name 'T'.
 tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens20.ts(1,12): error TS1127: Invalid character.
 
 
-==== tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens20.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/SkippedTokens/parserSkippedTokens20.ts (3 errors) ====
     var v: X<T \
            ~
 !!! error TS2304: Cannot find name 'X'.
+             ~
+!!! error TS2304: Cannot find name 'T'.
                
 !!! error TS1127: Invalid character.

--- a/tests/baselines/reference/parserSuperExpression2.errors.txt
+++ b/tests/baselines/reference/parserSuperExpression2.errors.txt
@@ -1,8 +1,9 @@
 tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression2.ts(3,5): error TS2335: 'super' can only be referenced in a derived class.
 tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression2.ts(3,10): error TS1034: 'super' must be followed by an argument list or member access.
+tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression2.ts(3,11): error TS2304: Cannot find name 'T'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression2.ts (2 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression2.ts (3 errors) ====
     class C {
       M() {
         super<T>(0);
@@ -10,5 +11,7 @@ tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpressio
 !!! error TS2335: 'super' can only be referenced in a derived class.
              ~
 !!! error TS1034: 'super' must be followed by an argument list or member access.
+              ~
+!!! error TS2304: Cannot find name 'T'.
       }
     }

--- a/tests/baselines/reference/parserSuperExpression3.errors.txt
+++ b/tests/baselines/reference/parserSuperExpression3.errors.txt
@@ -1,11 +1,14 @@
 tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression3.ts(3,10): error TS2339: Property 'super' does not exist on type 'C'.
+tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression3.ts(3,16): error TS2304: Cannot find name 'T'.
 
 
-==== tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression3.ts (1 errors) ====
+==== tests/cases/conformance/parser/ecmascript5/SuperExpressions/parserSuperExpression3.ts (2 errors) ====
     class C {
       M() {
         this.super<T>(0);
              ~~~~~
 !!! error TS2339: Property 'super' does not exist on type 'C'.
+                   ~
+!!! error TS2304: Cannot find name 'T'.
       }
     }

--- a/tests/baselines/reference/unusedInvalidTypeArguments.errors.txt
+++ b/tests/baselines/reference/unusedInvalidTypeArguments.errors.txt
@@ -1,0 +1,78 @@
+/call.ts(1,21): error TS2307: Cannot find module 'unknown'.
+/callAny.ts(3,1): error TS2347: Untyped function calls may not accept type arguments.
+/callAny.ts(4,1): error TS2347: Untyped function calls may not accept type arguments.
+/callAny.ts(4,3): error TS2304: Cannot find name 'InvalidReference'.
+/classReference.ts(4,24): error TS2315: Type 'C' is not generic.
+/interface.ts(1,21): error TS2307: Cannot find module 'unknown'.
+/new.ts(1,21): error TS2307: Cannot find module 'unkown'.
+/super.ts(1,19): error TS2307: Cannot find module 'unknown'.
+/super.ts(8,17): error TS2304: Cannot find name 'InvalidReference'.
+/typeReference.ts(6,17): error TS2315: Type 'U' is not generic.
+
+
+==== /typeReference.ts (1 errors) ====
+    // Tests that types are marked as used, even if used in places that don't accept type arguments.
+    
+    
+    type N = number;
+    type U = number;
+    export type Z = U<N>;
+                    ~~~~
+!!! error TS2315: Type 'U' is not generic.
+    
+==== /classReference.ts (1 errors) ====
+    type N = number;
+    class C { }
+    // This uses getTypeFromClassOrInterfaceReference instead of getTypeFromTypeAliasReference.
+    export class D extends C<N> {}
+                           ~~~~
+!!! error TS2315: Type 'C' is not generic.
+    
+==== /interface.ts (1 errors) ====
+    import { Foo } from "unknown";
+                        ~~~~~~~~~
+!!! error TS2307: Cannot find module 'unknown'.
+    export interface I<T> { x: Foo<T>; }
+    
+==== /call.ts (1 errors) ====
+    import { foo } from "unknown";
+                        ~~~~~~~~~
+!!! error TS2307: Cannot find module 'unknown'.
+    type T = number;
+    foo<T>();
+    
+==== /new.ts (1 errors) ====
+    import { Foo } from "unkown";
+                        ~~~~~~~~
+!!! error TS2307: Cannot find module 'unkown'.
+    type T = number;
+    new Foo<T>();
+    
+==== /callAny.ts (3 errors) ====
+    declare var g: any;
+    type U = number;
+    g<U>();
+    ~~~~~~
+!!! error TS2347: Untyped function calls may not accept type arguments.
+    g<InvalidReference>(); // Should get error for type argument
+    ~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2347: Untyped function calls may not accept type arguments.
+      ~~~~~~~~~~~~~~~~
+!!! error TS2304: Cannot find name 'InvalidReference'.
+    
+==== /super.ts (2 errors) ====
+    import { C } from "unknown";
+                      ~~~~~~~~~
+!!! error TS2307: Cannot find module 'unknown'.
+    
+    type T = number;
+    
+    export class D extends C {
+        m() {
+            super.m<T>(1);
+            super.m<InvalidReference>(); // Should get error for type argument
+                    ~~~~~~~~~~~~~~~~
+!!! error TS2304: Cannot find name 'InvalidReference'.
+        }
+    }
+    

--- a/tests/baselines/reference/unusedInvalidTypeArguments.js
+++ b/tests/baselines/reference/unusedInvalidTypeArguments.js
@@ -1,0 +1,122 @@
+//// [tests/cases/compiler/unusedInvalidTypeArguments.ts] ////
+
+//// [typeReference.ts]
+// Tests that types are marked as used, even if used in places that don't accept type arguments.
+
+
+type N = number;
+type U = number;
+export type Z = U<N>;
+
+//// [classReference.ts]
+type N = number;
+class C { }
+// This uses getTypeFromClassOrInterfaceReference instead of getTypeFromTypeAliasReference.
+export class D extends C<N> {}
+
+//// [interface.ts]
+import { Foo } from "unknown";
+export interface I<T> { x: Foo<T>; }
+
+//// [call.ts]
+import { foo } from "unknown";
+type T = number;
+foo<T>();
+
+//// [new.ts]
+import { Foo } from "unkown";
+type T = number;
+new Foo<T>();
+
+//// [callAny.ts]
+declare var g: any;
+type U = number;
+g<U>();
+g<InvalidReference>(); // Should get error for type argument
+
+//// [super.ts]
+import { C } from "unknown";
+
+type T = number;
+
+export class D extends C {
+    m() {
+        super.m<T>(1);
+        super.m<InvalidReference>(); // Should get error for type argument
+    }
+}
+
+
+//// [typeReference.js]
+"use strict";
+// Tests that types are marked as used, even if used in places that don't accept type arguments.
+exports.__esModule = true;
+//// [classReference.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+exports.__esModule = true;
+var C = (function () {
+    function C() {
+    }
+    return C;
+}());
+// This uses getTypeFromClassOrInterfaceReference instead of getTypeFromTypeAliasReference.
+var D = (function (_super) {
+    __extends(D, _super);
+    function D() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    return D;
+}(C));
+exports.D = D;
+//// [interface.js]
+"use strict";
+exports.__esModule = true;
+//// [call.js]
+"use strict";
+exports.__esModule = true;
+var unknown_1 = require("unknown");
+unknown_1.foo();
+//// [new.js]
+"use strict";
+exports.__esModule = true;
+var unkown_1 = require("unkown");
+new unkown_1.Foo();
+//// [callAny.js]
+g();
+g(); // Should get error for type argument
+//// [super.js]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+exports.__esModule = true;
+var unknown_1 = require("unknown");
+var D = (function (_super) {
+    __extends(D, _super);
+    function D() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    D.prototype.m = function () {
+        _super.prototype.m.call(this, 1);
+        _super.prototype.m.call(this); // Should get error for type argument
+    };
+    return D;
+}(unknown_1.C));
+exports.D = D;

--- a/tests/cases/compiler/unusedInvalidTypeArguments.ts
+++ b/tests/cases/compiler/unusedInvalidTypeArguments.ts
@@ -1,0 +1,46 @@
+// Tests that types are marked as used, even if used in places that don't accept type arguments.
+
+// @noUnusedLocals: true
+
+// @Filename: /typeReference.ts
+type N = number;
+type U = number;
+export type Z = U<N>;
+
+// @Filename: /classReference.ts
+type N = number;
+class C { }
+// This uses getTypeFromClassOrInterfaceReference instead of getTypeFromTypeAliasReference.
+export class D extends C<N> {}
+
+// @Filename: /interface.ts
+import { Foo } from "unknown";
+export interface I<T> { x: Foo<T>; }
+
+// @Filename: /call.ts
+import { foo } from "unknown";
+type T = number;
+foo<T>();
+
+// @Filename: /new.ts
+import { Foo } from "unkown";
+type T = number;
+new Foo<T>();
+
+// @Filename: /callAny.ts
+declare var g: any;
+type U = number;
+g<U>();
+g<InvalidReference>(); // Should get error for type argument
+
+// @Filename: /super.ts
+import { C } from "unknown";
+
+type T = number;
+
+export class D extends C {
+    m() {
+        super.m<T>(1);
+        super.m<InvalidReference>(); // Should get error for type argument
+    }
+}


### PR DESCRIPTION
Fixes #14953
Previously we would only check type arguments if there were matching type parameters. Now we always check type arguments. This gives additional diagnostics and makes sure they are marked as used.