### PR TITLE
Clarify that some node types never have `name` defined.

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -641,10 +641,12 @@ namespace ts {
     }
 
     export interface CallSignatureDeclaration extends SignatureDeclaration, TypeElement {
+        name?: undefined;
         kind: SyntaxKind.CallSignature;
     }
 
     export interface ConstructSignatureDeclaration extends SignatureDeclaration, TypeElement {
+        name?: undefined;
         kind: SyntaxKind.ConstructSignature;
     }
 
@@ -815,6 +817,7 @@ namespace ts {
     }
 
     export interface ConstructorDeclaration extends FunctionLikeDeclaration, ClassElement {
+        name?: undefined;
         kind: SyntaxKind.Constructor;
         parent?: ClassDeclaration | ClassExpression;
         body?: FunctionBody;
@@ -847,6 +850,7 @@ namespace ts {
     export type AccessorDeclaration = GetAccessorDeclaration | SetAccessorDeclaration;
 
     export interface IndexSignatureDeclaration extends SignatureDeclaration, ClassElement, TypeElement {
+        name?: undefined;
         kind: SyntaxKind.IndexSignature;
         parent?: ClassDeclaration | ClassExpression | InterfaceDeclaration | TypeLiteralNode;
     }


### PR DESCRIPTION
`name` is defined on `Declaration`, but these nodes should never have a `name`.