### PR TITLE
Remove @types/gulp-typescript dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
         "@types/gulp-help": "latest",
         "@types/gulp-newer": "latest",
         "@types/gulp-sourcemaps": "latest",
-        "@types/gulp-typescript": "latest",
         "@types/merge2": "latest",
         "@types/minimatch": "latest",
         "@types/minimist": "latest",


### PR DESCRIPTION
gulp-typescript since 2.13 comes with types included

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[x] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #
