### PR TITLE
Add Javascript declarations to index constraint check error reporting

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20233,7 +20233,10 @@ namespace ts {
                 // perform property check if property or indexer is declared in 'type'
                 // this allows to rule out cases when both property and indexer are inherited from the base class
                 let errorNode: Node;
-                if (propDeclaration && (propDeclaration.name.kind === SyntaxKind.ComputedPropertyName || prop.parent === containingType.symbol)) {
+                if (propDeclaration &&
+                    (getSpecialPropertyAssignmentKind(propDeclaration as BinaryExpression) === SpecialPropertyAssignmentKind.ThisProperty ||
+                     propDeclaration.name.kind === SyntaxKind.ComputedPropertyName ||
+                     prop.parent === containingType.symbol)) {
                     errorNode = propDeclaration;
                 }
                 else if (indexDeclaration) {

--- a/tests/baselines/reference/checkIndexConstraintOfJavascriptClassExpression.js
+++ b/tests/baselines/reference/checkIndexConstraintOfJavascriptClassExpression.js
@@ -1,0 +1,32 @@
+//// [weird.js]
+someFunction(function(BaseClass) {
+	class Hello extends BaseClass {
+		constructor() {
+			this.foo = "bar";
+		}
+	}
+});
+
+
+//// [foo.js]
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+someFunction(function (BaseClass) {
+    var Hello = (function (_super) {
+        __extends(Hello, _super);
+        function Hello() {
+            var _this = this;
+            _this.foo = "bar";
+            return _this;
+        }
+        return Hello;
+    }(BaseClass));
+});

--- a/tests/baselines/reference/checkIndexConstraintOfJavascriptClassExpression.symbols
+++ b/tests/baselines/reference/checkIndexConstraintOfJavascriptClassExpression.symbols
@@ -1,0 +1,17 @@
+=== tests/cases/compiler/weird.js ===
+someFunction(function(BaseClass) {
+>BaseClass : Symbol(BaseClass, Decl(weird.js, 0, 22))
+
+	class Hello extends BaseClass {
+>Hello : Symbol(Hello, Decl(weird.js, 0, 34))
+>BaseClass : Symbol(BaseClass, Decl(weird.js, 0, 22))
+
+		constructor() {
+			this.foo = "bar";
+>this.foo : Symbol(Hello.foo, Decl(weird.js, 2, 17))
+>this : Symbol(Hello, Decl(weird.js, 0, 34))
+>foo : Symbol(Hello.foo, Decl(weird.js, 2, 17))
+		}
+	}
+});
+

--- a/tests/baselines/reference/checkIndexConstraintOfJavascriptClassExpression.types
+++ b/tests/baselines/reference/checkIndexConstraintOfJavascriptClassExpression.types
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/weird.js ===
+someFunction(function(BaseClass) {
+>someFunction(function(BaseClass) {	class Hello extends BaseClass {		constructor() {			this.foo = "bar";		}	}}) : any
+>someFunction : any
+>function(BaseClass) {	class Hello extends BaseClass {		constructor() {			this.foo = "bar";		}	}} : (BaseClass: any) => void
+>BaseClass : any
+
+	class Hello extends BaseClass {
+>Hello : Hello
+>BaseClass : any
+
+		constructor() {
+			this.foo = "bar";
+>this.foo = "bar" : "bar"
+>this.foo : string
+>this : this
+>foo : string
+>"bar" : "bar"
+		}
+	}
+});
+

--- a/tests/cases/compiler/checkIndexConstraintOfJavascriptClassExpression.ts
+++ b/tests/cases/compiler/checkIndexConstraintOfJavascriptClassExpression.ts
@@ -1,0 +1,10 @@
+// @Filename: weird.js
+// @allowJs: true
+// @out: foo.js
+someFunction(function(BaseClass) {
+	class Hello extends BaseClass {
+		constructor() {
+			this.foo = "bar";
+		}
+	}
+});


### PR DESCRIPTION
Now Javascript-style declarations like `this.foo = "bar"` are handled
correctly and errors will be reported on the declaration correctly. Previously the code would check the computed property name case and crash because Javascript-style declarations have no `name` property.

Fixes #15525 
