### PR TITLE
Symbol table for homomorphic mapped type: Don't needlessly create twice

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -10022,7 +10022,7 @@ namespace ts {
             const templateType = getTemplateTypeFromMappedType(target);
             const readonlyMask = target.declaration.readonlyToken ? false : true;
             const optionalMask = target.declaration.questionToken ? 0 : SymbolFlags.Optional;
-            const members = createSymbolTable(properties);
+            const members = createMap<Symbol>();
             for (const prop of properties) {
                 const inferredPropType = inferTargetType(getTypeOfSymbol(prop));
                 if (!inferredPropType) {


### PR DESCRIPTION
Noticed that this code was creating a full symbol table, then overwriting everything in the table.