### PR TITLE
Deduplicate jsDocTagNames and sort alphabetically

### DIFF
--- a/src/services/jsDoc.ts
+++ b/src/services/jsDoc.ts
@@ -28,6 +28,7 @@ namespace ts.JsDoc {
         "namespace",
         "param",
         "private",
+        "prop",
         "property",
         "public",
         "requires",
@@ -38,8 +39,6 @@ namespace ts.JsDoc {
         "throws",
         "type",
         "typedef",
-        "property",
-        "prop",
         "version"
     ];
     let jsDocTagNameCompletionEntries: CompletionEntry[];

--- a/tests/cases/fourslash/completionInJsDoc.ts
+++ b/tests/cases/fourslash/completionInJsDoc.ts
@@ -84,23 +84,18 @@ goTo.marker('8');
 verify.completionListContains('number');
 
 goTo.marker('9');
-verify.completionListCount(40);
 verify.completionListContains("@argument");
 
 goTo.marker('10');
-verify.completionListCount(40);
 verify.completionListContains("@returns");
 
 goTo.marker('11');
-verify.completionListCount(40);
 verify.completionListContains("@argument");
 
 goTo.marker('12');
-verify.completionListCount(40);
 verify.completionListContains("@constructor");
 
 goTo.marker('13');
-verify.completionListCount(40);
 verify.completionListContains("@param");
 
 goTo.marker('14');


### PR DESCRIPTION
Fixes https://github.com/Microsoft/TypeScript/commit/4d6bd9df72d584b5bb514a3cc43ae55eaa708535#commitcomment-22021286
