### PR TITLE
[Master] fix 15463

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13909,11 +13909,11 @@ namespace ts {
                 error(openingLikeElement, Diagnostics.JSX_element_class_does_not_support_attributes_because_it_does_not_have_a_0_property, getJsxElementPropertiesName());
             }
             else {
-                checkTypeAssignableTo(sourceAttributesType, targetAttributesType, openingLikeElement.attributes.properties.length > 0 ? openingLikeElement.attributes : openingLikeElement);
+                const isSourceAttributeTypeAssignableToTarget = checkTypeAssignableTo(sourceAttributesType, targetAttributesType, openingLikeElement.attributes.properties.length > 0 ? openingLikeElement.attributes : openingLikeElement);
                 // If sourceAttributesType has spread (e.g the type doesn't have freshness flag) after we check for assignability, we will do another pass to check that
                 // all explicitly specified attributes have correct name corresponding with target (as those will be assignable as spread type allows excess properties)
                 // Note: if the type of these explicitly specified attributes do not match it will be an error during above assignability check.
-                if (sourceAttributesType !== anyType && !(sourceAttributesType.flags & TypeFlags.FreshLiteral)) {
+                if (isSourceAttributeTypeAssignableToTarget && sourceAttributesType !== anyType && !(sourceAttributesType.flags & TypeFlags.FreshLiteral)) {
                     for (const attribute of openingLikeElement.attributes.properties) {
                         if (isJsxAttribute(attribute) && !getPropertyOfType(targetAttributesType, attribute.name.text)) {
                             error(attribute, Diagnostics.Property_0_does_not_exist_on_type_1, attribute.name.text, typeToString(targetAttributesType));

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13356,9 +13356,7 @@ namespace ts {
              */
             function createJsxAttributesType(symbol: Symbol, attributesTable: Map<Symbol>) {
                 const result = createAnonymousType(symbol, attributesTable, emptyArray, emptyArray, /*stringIndexInfo*/ undefined, /*numberIndexInfo*/ undefined);
-                // Spread object doesn't have freshness flag to allow excess attributes as it is very common for parent component to spread its "props" to other components in its render method.
-                const freshObjectLiteralFlag = spread !== emptyObjectType || compilerOptions.suppressExcessPropertyErrors ? 0 : TypeFlags.FreshLiteral;
-                result.flags |= TypeFlags.JsxAttributes | TypeFlags.ContainsObjectLiteral | freshObjectLiteralFlag;
+                result.flags |= TypeFlags.JsxAttributes | TypeFlags.ContainsObjectLiteral;
                 result.objectFlags |= ObjectFlags.ObjectLiteral;
                 return result;
             }
@@ -13877,7 +13875,30 @@ namespace ts {
             checkJsxAttributesAssignableToTagNameAttributes(node);
         }
 
-         /**
+        // Check if a property with the given name is known anywhere in the given type. In an object type, a property
+        // is considered known if the object type is empty and the check is for assignability, if the object type has
+        // index signatures, or if the property is actually declared in the object type. In a union or intersection
+        // type, a property is considered known if it is known in any constituent type.
+        function isKnownProperty(type: Type, name: string, isComparingJsxAttributes: boolean): boolean {
+            if (type.flags & TypeFlags.Object) {
+                const resolved = resolveStructuredTypeMembers(<ObjectType>type);
+                if (resolved.stringIndexInfo || resolved.numberIndexInfo && isNumericLiteralName(name) ||
+                    getPropertyOfType(type, name) || isComparingJsxAttributes && !isUnhyphenatedJsxName(name)) {
+                    // For JSXAttributes, if the attribute has a hyphenated name, consider that the attribute to be known.
+                    return true;
+                }
+            }
+            else if (type.flags & TypeFlags.UnionOrIntersection) {
+                for (const t of (<UnionOrIntersectionType>type).types) {
+                    if (isKnownProperty(t, name, isComparingJsxAttributes)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        /**
           * Check whether the given attributes of JSX opening-like element is assignable to the tagName attributes.
           *      Get the attributes type of the opening-like element through resolving the tagName, "target attributes"
           *      Check assignablity between given attributes property, "source attributes", and the "target attributes"
@@ -13910,12 +13931,12 @@ namespace ts {
             }
             else {
                 const isSourceAttributeTypeAssignableToTarget = checkTypeAssignableTo(sourceAttributesType, targetAttributesType, openingLikeElement.attributes.properties.length > 0 ? openingLikeElement.attributes : openingLikeElement);
-                // If sourceAttributesType has spread (e.g the type doesn't have freshness flag) after we check for assignability, we will do another pass to check that
+                // After we check for assignability, we will do another pass to check that
                 // all explicitly specified attributes have correct name corresponding with target (as those will be assignable as spread type allows excess properties)
                 // Note: if the type of these explicitly specified attributes do not match it will be an error during above assignability check.
-                if (isSourceAttributeTypeAssignableToTarget && sourceAttributesType !== anyType && !(sourceAttributesType.flags & TypeFlags.FreshLiteral)) {
+                if (isSourceAttributeTypeAssignableToTarget && !isTypeAny(sourceAttributesType) && !isTypeAny(targetAttributesType)) {
                     for (const attribute of openingLikeElement.attributes.properties) {
-                        if (isJsxAttribute(attribute) && !getPropertyOfType(targetAttributesType, attribute.name.text)) {
+                        if (isJsxAttribute(attribute) && !isKnownProperty(targetAttributesType, attribute.name.text, /*isComparingJsxAttributes*/ true)) {
                             error(attribute, Diagnostics.Property_0_does_not_exist_on_type_1, attribute.name.text, typeToString(targetAttributesType));
                         }
                     }

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -13330,10 +13330,11 @@ namespace ts {
                     }
                 }
 
-                // Error if there is a attribute named "children" and children element.
-                // This is because children element will overwrite the value from attributes
-                if (explicitlySpecifyChildrenAttribute) {
-                    if (attributesTable.has(jsxChildrenPropertyName)) {
+                if (!hasSpreadAnyType && jsxChildrenPropertyName && jsxChildrenPropertyName !== "") {
+                    // Error if there is a attribute named "children" explicitly specified and children element.
+                    // This is because children element will overwrite the value from attributes.
+                    // Note: we will not warn "children" attribute overwritten if "children" attribute is specified in object spread.
+                    if (explicitlySpecifyChildrenAttribute) {
                         error(attributes, Diagnostics._0_are_specified_twice_The_attribute_named_0_will_be_overwritten, jsxChildrenPropertyName);
                     }
 
@@ -13355,6 +13356,7 @@ namespace ts {
              */
             function createJsxAttributesType(symbol: Symbol, attributesTable: Map<Symbol>) {
                 const result = createAnonymousType(symbol, attributesTable, emptyArray, emptyArray, /*stringIndexInfo*/ undefined, /*numberIndexInfo*/ undefined);
+                // Spread object doesn't have freshness flag to allow excess attributes as it is very common for parent component to spread its "props" to other components in its render method.
                 const freshObjectLiteralFlag = spread !== emptyObjectType || compilerOptions.suppressExcessPropertyErrors ? 0 : TypeFlags.FreshLiteral;
                 result.flags |= TypeFlags.JsxAttributes | TypeFlags.ContainsObjectLiteral | freshObjectLiteralFlag;
                 result.objectFlags |= ObjectFlags.ObjectLiteral;
@@ -13907,9 +13909,11 @@ namespace ts {
                 error(openingLikeElement, Diagnostics.JSX_element_class_does_not_support_attributes_because_it_does_not_have_a_0_property, getJsxElementPropertiesName());
             }
             else {
-                const isAssignableToTargetAttributes = checkTypeAssignableTo(sourceAttributesType, targetAttributesType, openingLikeElement.attributes.properties.length > 0 ? openingLikeElement.attributes : openingLikeElement);
-                // TODO (yuisu): comment
-                if (isAssignableToTargetAttributes && sourceAttributesType !== anyType && !(sourceAttributesType.flags & TypeFlags.FreshLiteral)) {
+                checkTypeAssignableTo(sourceAttributesType, targetAttributesType, openingLikeElement.attributes.properties.length > 0 ? openingLikeElement.attributes : openingLikeElement);
+                // If sourceAttributesType has spread (e.g the type doesn't have freshness flag) after we check for assignability, we will do another pass to check that
+                // all explicitly specified attributes have correct name corresponding with target (as those will be assignable as spread type allows excess properties)
+                // Note: if the type of these explicitly specified attributes do not match it will be an error during above assignability check.
+                if (sourceAttributesType !== anyType && !(sourceAttributesType.flags & TypeFlags.FreshLiteral)) {
                     for (const attribute of openingLikeElement.attributes.properties) {
                         if (isJsxAttribute(attribute) && !getPropertyOfType(targetAttributesType, attribute.name.text)) {
                             error(attribute, Diagnostics.Property_0_does_not_exist_on_type_1, attribute.name.text, typeToString(targetAttributesType));

--- a/tests/baselines/reference/checkJsxChildrenProperty12.js
+++ b/tests/baselines/reference/checkJsxChildrenProperty12.js
@@ -1,0 +1,60 @@
+//// [file.tsx]
+import React = require('react');
+
+interface ButtonProp {
+    a: number,
+    b: string,
+    children: Button;
+}
+
+class Button extends React.Component<ButtonProp, any> {
+    render() {
+        return <InnerButton {...this.props} />
+    }
+}
+
+interface InnerButtonProp {
+	a: number
+}
+
+class InnerButton extends React.Component<InnerButtonProp, any> {
+	render() {
+		return (<button>Hello</button>);
+	}
+}
+
+
+//// [file.jsx]
+"use strict";
+var __extends = (this && this.__extends) || (function () {
+    var extendStatics = Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array && function (d, b) { d.__proto__ = b; }) ||
+        function (d, b) { for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p]; };
+    return function (d, b) {
+        extendStatics(d, b);
+        function __() { this.constructor = d; }
+        d.prototype = b === null ? Object.create(b) : (__.prototype = b.prototype, new __());
+    };
+})();
+exports.__esModule = true;
+var React = require("react");
+var Button = (function (_super) {
+    __extends(Button, _super);
+    function Button() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    Button.prototype.render = function () {
+        return <InnerButton {...this.props}/>;
+    };
+    return Button;
+}(React.Component));
+var InnerButton = (function (_super) {
+    __extends(InnerButton, _super);
+    function InnerButton() {
+        return _super !== null && _super.apply(this, arguments) || this;
+    }
+    InnerButton.prototype.render = function () {
+        return (<button>Hello</button>);
+    };
+    return InnerButton;
+}(React.Component));

--- a/tests/baselines/reference/checkJsxChildrenProperty12.symbols
+++ b/tests/baselines/reference/checkJsxChildrenProperty12.symbols
@@ -26,30 +26,51 @@ class Button extends React.Component<ButtonProp, any> {
     render() {
 >render : Symbol(Button.render, Decl(file.tsx, 8, 55))
 
-        return <InnerButton {...this.props} />
->InnerButton : Symbol(InnerButton, Decl(file.tsx, 16, 1))
+		let condition: boolean;
+>condition : Symbol(condition, Decl(file.tsx, 10, 5))
+
+		if (condition) {
+>condition : Symbol(condition, Decl(file.tsx, 10, 5))
+
+        	return <InnerButton {...this.props} />
+>InnerButton : Symbol(InnerButton, Decl(file.tsx, 24, 1))
 >this.props : Symbol(React.Component.props, Decl(react.d.ts, 166, 37))
 >this : Symbol(Button, Decl(file.tsx, 6, 1))
 >props : Symbol(React.Component.props, Decl(react.d.ts, 166, 37))
+		}
+		else {
+			return (<InnerButton {...this.props} >
+>InnerButton : Symbol(InnerButton, Decl(file.tsx, 24, 1))
+>this.props : Symbol(React.Component.props, Decl(react.d.ts, 166, 37))
+>this : Symbol(Button, Decl(file.tsx, 6, 1))
+>props : Symbol(React.Component.props, Decl(react.d.ts, 166, 37))
+
+				<div>Hello World</div>
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2399, 45))
+>div : Symbol(JSX.IntrinsicElements.div, Decl(react.d.ts, 2399, 45))
+
+				</InnerButton>);
+>InnerButton : Symbol(InnerButton, Decl(file.tsx, 24, 1))
+		}
     }
 }
 
 interface InnerButtonProp {
->InnerButtonProp : Symbol(InnerButtonProp, Decl(file.tsx, 12, 1))
+>InnerButtonProp : Symbol(InnerButtonProp, Decl(file.tsx, 20, 1))
 
 	a: number
->a : Symbol(InnerButtonProp.a, Decl(file.tsx, 14, 27))
+>a : Symbol(InnerButtonProp.a, Decl(file.tsx, 22, 27))
 }
 
 class InnerButton extends React.Component<InnerButtonProp, any> {
->InnerButton : Symbol(InnerButton, Decl(file.tsx, 16, 1))
+>InnerButton : Symbol(InnerButton, Decl(file.tsx, 24, 1))
 >React.Component : Symbol(React.Component, Decl(react.d.ts, 158, 55))
 >React : Symbol(React, Decl(file.tsx, 0, 0))
 >Component : Symbol(React.Component, Decl(react.d.ts, 158, 55))
->InnerButtonProp : Symbol(InnerButtonProp, Decl(file.tsx, 12, 1))
+>InnerButtonProp : Symbol(InnerButtonProp, Decl(file.tsx, 20, 1))
 
 	render() {
->render : Symbol(InnerButton.render, Decl(file.tsx, 18, 65))
+>render : Symbol(InnerButton.render, Decl(file.tsx, 26, 65))
 
 		return (<button>Hello</button>);
 >button : Symbol(JSX.IntrinsicElements.button, Decl(react.d.ts, 2385, 43))

--- a/tests/baselines/reference/checkJsxChildrenProperty12.symbols
+++ b/tests/baselines/reference/checkJsxChildrenProperty12.symbols
@@ -1,0 +1,59 @@
+=== tests/cases/conformance/jsx/file.tsx ===
+import React = require('react');
+>React : Symbol(React, Decl(file.tsx, 0, 0))
+
+interface ButtonProp {
+>ButtonProp : Symbol(ButtonProp, Decl(file.tsx, 0, 32))
+
+    a: number,
+>a : Symbol(ButtonProp.a, Decl(file.tsx, 2, 22))
+
+    b: string,
+>b : Symbol(ButtonProp.b, Decl(file.tsx, 3, 14))
+
+    children: Button;
+>children : Symbol(ButtonProp.children, Decl(file.tsx, 4, 14))
+>Button : Symbol(Button, Decl(file.tsx, 6, 1))
+}
+
+class Button extends React.Component<ButtonProp, any> {
+>Button : Symbol(Button, Decl(file.tsx, 6, 1))
+>React.Component : Symbol(React.Component, Decl(react.d.ts, 158, 55))
+>React : Symbol(React, Decl(file.tsx, 0, 0))
+>Component : Symbol(React.Component, Decl(react.d.ts, 158, 55))
+>ButtonProp : Symbol(ButtonProp, Decl(file.tsx, 0, 32))
+
+    render() {
+>render : Symbol(Button.render, Decl(file.tsx, 8, 55))
+
+        return <InnerButton {...this.props} />
+>InnerButton : Symbol(InnerButton, Decl(file.tsx, 16, 1))
+>this.props : Symbol(React.Component.props, Decl(react.d.ts, 166, 37))
+>this : Symbol(Button, Decl(file.tsx, 6, 1))
+>props : Symbol(React.Component.props, Decl(react.d.ts, 166, 37))
+    }
+}
+
+interface InnerButtonProp {
+>InnerButtonProp : Symbol(InnerButtonProp, Decl(file.tsx, 12, 1))
+
+	a: number
+>a : Symbol(InnerButtonProp.a, Decl(file.tsx, 14, 27))
+}
+
+class InnerButton extends React.Component<InnerButtonProp, any> {
+>InnerButton : Symbol(InnerButton, Decl(file.tsx, 16, 1))
+>React.Component : Symbol(React.Component, Decl(react.d.ts, 158, 55))
+>React : Symbol(React, Decl(file.tsx, 0, 0))
+>Component : Symbol(React.Component, Decl(react.d.ts, 158, 55))
+>InnerButtonProp : Symbol(InnerButtonProp, Decl(file.tsx, 12, 1))
+
+	render() {
+>render : Symbol(InnerButton.render, Decl(file.tsx, 18, 65))
+
+		return (<button>Hello</button>);
+>button : Symbol(JSX.IntrinsicElements.button, Decl(react.d.ts, 2385, 43))
+>button : Symbol(JSX.IntrinsicElements.button, Decl(react.d.ts, 2385, 43))
+	}
+}
+

--- a/tests/baselines/reference/checkJsxChildrenProperty12.types
+++ b/tests/baselines/reference/checkJsxChildrenProperty12.types
@@ -26,12 +26,36 @@ class Button extends React.Component<ButtonProp, any> {
     render() {
 >render : () => JSX.Element
 
-        return <InnerButton {...this.props} />
+		let condition: boolean;
+>condition : boolean
+
+		if (condition) {
+>condition : boolean
+
+        	return <InnerButton {...this.props} />
 ><InnerButton {...this.props} /> : JSX.Element
 >InnerButton : typeof InnerButton
 >this.props : ButtonProp & { children?: React.ReactNode; }
 >this : this
 >props : ButtonProp & { children?: React.ReactNode; }
+		}
+		else {
+			return (<InnerButton {...this.props} >
+>(<InnerButton {...this.props} >				<div>Hello World</div>				</InnerButton>) : JSX.Element
+><InnerButton {...this.props} >				<div>Hello World</div>				</InnerButton> : JSX.Element
+>InnerButton : typeof InnerButton
+>this.props : ButtonProp & { children?: React.ReactNode; }
+>this : this
+>props : ButtonProp & { children?: React.ReactNode; }
+
+				<div>Hello World</div>
+><div>Hello World</div> : JSX.Element
+>div : any
+>div : any
+
+				</InnerButton>);
+>InnerButton : typeof InnerButton
+		}
     }
 }
 

--- a/tests/baselines/reference/checkJsxChildrenProperty12.types
+++ b/tests/baselines/reference/checkJsxChildrenProperty12.types
@@ -1,0 +1,62 @@
+=== tests/cases/conformance/jsx/file.tsx ===
+import React = require('react');
+>React : typeof React
+
+interface ButtonProp {
+>ButtonProp : ButtonProp
+
+    a: number,
+>a : number
+
+    b: string,
+>b : string
+
+    children: Button;
+>children : Button
+>Button : Button
+}
+
+class Button extends React.Component<ButtonProp, any> {
+>Button : Button
+>React.Component : React.Component<ButtonProp, any>
+>React : typeof React
+>Component : typeof React.Component
+>ButtonProp : ButtonProp
+
+    render() {
+>render : () => JSX.Element
+
+        return <InnerButton {...this.props} />
+><InnerButton {...this.props} /> : JSX.Element
+>InnerButton : typeof InnerButton
+>this.props : ButtonProp & { children?: React.ReactNode; }
+>this : this
+>props : ButtonProp & { children?: React.ReactNode; }
+    }
+}
+
+interface InnerButtonProp {
+>InnerButtonProp : InnerButtonProp
+
+	a: number
+>a : number
+}
+
+class InnerButton extends React.Component<InnerButtonProp, any> {
+>InnerButton : InnerButton
+>React.Component : React.Component<InnerButtonProp, any>
+>React : typeof React
+>Component : typeof React.Component
+>InnerButtonProp : InnerButtonProp
+
+	render() {
+>render : () => JSX.Element
+
+		return (<button>Hello</button>);
+>(<button>Hello</button>) : JSX.Element
+><button>Hello</button> : JSX.Element
+>button : any
+>button : any
+	}
+}
+

--- a/tests/baselines/reference/checkJsxChildrenProperty13.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty13.errors.txt
@@ -1,0 +1,33 @@
+tests/cases/conformance/jsx/file.tsx(12,30): error TS2710: 'children' are specified twice. The attribute named 'children' will be overwritten.
+
+
+==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
+    import React = require('react');
+    
+    interface ButtonProp {
+        a: number,
+        b: string,
+        children: Button;
+    }
+    
+    class Button extends React.Component<ButtonProp, any> {
+        render() {
+            // Error children are specified twice
+            return (<InnerButton {...this.props} children="hi">
+                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2710: 'children' are specified twice. The attribute named 'children' will be overwritten.
+                <div>Hello World</div>
+                </InnerButton>);
+        }
+    }
+    
+    interface InnerButtonProp {
+    	a: number
+    }
+    
+    class InnerButton extends React.Component<InnerButtonProp, any> {
+    	render() {
+    		return (<button>Hello</button>);
+    	}
+    }
+    

--- a/tests/baselines/reference/checkJsxChildrenProperty13.js
+++ b/tests/baselines/reference/checkJsxChildrenProperty13.js
@@ -9,15 +9,10 @@ interface ButtonProp {
 
 class Button extends React.Component<ButtonProp, any> {
     render() {
-		let condition: boolean;
-		if (condition) {
-        	return <InnerButton {...this.props} />
-		}
-		else {
-			return (<InnerButton {...this.props} >
-				<div>Hello World</div>
-				</InnerButton>);
-		}
+        // Error children are specified twice
+        return (<InnerButton {...this.props} children="hi">
+            <div>Hello World</div>
+            </InnerButton>);
     }
 }
 
@@ -52,15 +47,10 @@ var Button = (function (_super) {
         return _super !== null && _super.apply(this, arguments) || this;
     }
     Button.prototype.render = function () {
-        var condition;
-        if (condition) {
-            return <InnerButton {...this.props}/>;
-        }
-        else {
-            return (<InnerButton {...this.props}>
-				<div>Hello World</div>
-				</InnerButton>);
-        }
+        // Error children are specified twice
+        return (<InnerButton {...this.props} children="hi">
+            <div>Hello World</div>
+            </InnerButton>);
     };
     return Button;
 }(React.Component));

--- a/tests/baselines/reference/checkJsxChildrenProperty2.errors.txt
+++ b/tests/baselines/reference/checkJsxChildrenProperty2.errors.txt
@@ -2,7 +2,6 @@ tests/cases/conformance/jsx/file.tsx(14,15): error TS2322: Type '{ a: 10; b: "hi
   Type '{ a: 10; b: "hi"; }' is not assignable to type 'Prop'.
     Property 'children' is missing in type '{ a: 10; b: "hi"; }'.
 tests/cases/conformance/jsx/file.tsx(17,11): error TS2710: 'children' are specified twice. The attribute named 'children' will be overwritten.
-tests/cases/conformance/jsx/file.tsx(25,11): error TS2710: 'children' are specified twice. The attribute named 'children' will be overwritten.
 tests/cases/conformance/jsx/file.tsx(31,11): error TS2322: Type '{ a: 10; b: "hi"; children: (Element | ((name: string) => Element))[]; }' is not assignable to type 'IntrinsicAttributes & Prop'.
   Type '{ a: 10; b: "hi"; children: (Element | ((name: string) => Element))[]; }' is not assignable to type 'Prop'.
     Types of property 'children' are incompatible.
@@ -29,7 +28,7 @@ tests/cases/conformance/jsx/file.tsx(49,11): error TS2322: Type '{ a: 10; b: "hi
           Property 'type' is missing in type 'Element[]'.
 
 
-==== tests/cases/conformance/jsx/file.tsx (7 errors) ====
+==== tests/cases/conformance/jsx/file.tsx (6 errors) ====
     import React = require('react');
     
     interface Prop {
@@ -61,8 +60,6 @@ tests/cases/conformance/jsx/file.tsx(49,11): error TS2322: Type '{ a: 10; b: "hi
     }
     let k1 =
         <Comp a={10} b="hi" {...o} >
-              ~~~~~~~~~~~~~~~~~~~~
-!!! error TS2710: 'children' are specified twice. The attribute named 'children' will be overwritten.
             hi hi hi!
         </Comp>;
     

--- a/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
@@ -1,7 +1,6 @@
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(27,24): error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
   Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'LinkProps'.
     Property 'goTo' is missing in type '{ extra: true; onClick: (k: "left" | "right") => void; }'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(27,64): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(28,24): error TS2322: Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
   Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(29,43): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
@@ -11,7 +10,7 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(33,65): err
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,44): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
 
 
-==== tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx (7 errors) ====
+==== tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx (6 errors) ====
     import React = require('react')
     
     export interface ClickableProps {
@@ -43,8 +42,6 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,44): err
 !!! error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
 !!! error TS2322:   Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'LinkProps'.
 !!! error TS2322:     Property 'goTo' is missing in type '{ extra: true; onClick: (k: "left" | "right") => void; }'.
-                                                                   ~~~~~
-!!! error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
     const b2 = <MainButton onClick={(k)=>{console.log(k)}} extra />;  // k has type "left" | "right"
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.

--- a/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
@@ -1,18 +1,17 @@
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(27,24): error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-  Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
+  Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'LinkProps'.
+    Property 'goTo' is missing in type '{ extra: true; onClick: (k: "left" | "right") => void; }'.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(27,64): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(28,24): error TS2322: Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
   Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(29,24): error TS2322: Type '{ extra: true; goTo: "home"; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-  Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(29,43): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(30,24): error TS2322: Type '{ goTo: "home"; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
   Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(33,25): error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
-  Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,25): error TS2322: Type '{ extra: true; goTo: "home"; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-  Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(33,65): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,44): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
 
 
-==== tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx (6 errors) ====
+==== tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx (7 errors) ====
     import React = require('react')
     
     export interface ClickableProps {
@@ -42,15 +41,17 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,25): err
     const b0 = <MainButton {...{onClick: (k) => {console.log(k)}}} extra />;  // k has type "left" | "right"
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-!!! error TS2322:   Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
+!!! error TS2322:   Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'LinkProps'.
+!!! error TS2322:     Property 'goTo' is missing in type '{ extra: true; onClick: (k: "left" | "right") => void; }'.
+                                                                   ~~~~~
+!!! error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
     const b2 = <MainButton onClick={(k)=>{console.log(k)}} extra />;  // k has type "left" | "right"
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
 !!! error TS2322:   Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
     const b3 = <MainButton {...{goTo:"home"}} extra />;  // goTo has type"home" | "contact"
-                           ~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ extra: true; goTo: "home"; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-!!! error TS2322:   Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
+                                              ~~~~~
+!!! error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
     const b4 = <MainButton goTo="home" extra />;  // goTo has type "home" | "contact"
                            ~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ goTo: "home"; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
@@ -58,13 +59,11 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,25): err
     
     export function NoOverload(buttonProps: ButtonProps): JSX.Element { return undefined }
     const c1 = <NoOverload  {...{onClick: (k) => {console.log(k)}}} extra />;  // k has type any
-                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'IntrinsicAttributes & ButtonProps'.
-!!! error TS2322:   Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
+                                                                    ~~~~~
+!!! error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
     
     export function NoOverload1(linkProps: LinkProps): JSX.Element { return undefined }
     const d1 = <NoOverload1 {...{goTo:"home"}} extra  />;  // goTo has type "home" | "contact"
-                            ~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ extra: true; goTo: "home"; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-!!! error TS2322:   Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
+                                               ~~~~~
+!!! error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
     

--- a/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
+++ b/tests/baselines/reference/contextuallyTypedStringLiteralsInJsxAttributes02.errors.txt
@@ -2,10 +2,10 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(27,24): err
   Type '{ extra: true; onClick: (k: "left" | "right") => void; }' is not assignable to type 'LinkProps'.
     Property 'goTo' is missing in type '{ extra: true; onClick: (k: "left" | "right") => void; }'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(28,24): error TS2322: Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-  Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
+  Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'LinkProps'.
+    Property 'goTo' is missing in type '{ onClick: (k: "left" | "right") => void; extra: true; }'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(29,43): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
-tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(30,24): error TS2322: Type '{ goTo: "home"; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-  Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
+tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(30,36): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(33,65): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & ButtonProps'.
 tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,44): error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
 
@@ -45,14 +45,14 @@ tests/cases/conformance/types/contextualTypes/jsxAttributes/file.tsx(36,44): err
     const b2 = <MainButton onClick={(k)=>{console.log(k)}} extra />;  // k has type "left" | "right"
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-!!! error TS2322:   Property 'onClick' does not exist on type 'IntrinsicAttributes & LinkProps'.
+!!! error TS2322:   Type '{ onClick: (k: "left" | "right") => void; extra: true; }' is not assignable to type 'LinkProps'.
+!!! error TS2322:     Property 'goTo' is missing in type '{ onClick: (k: "left" | "right") => void; extra: true; }'.
     const b3 = <MainButton {...{goTo:"home"}} extra />;  // goTo has type"home" | "contact"
                                               ~~~~~
 !!! error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
     const b4 = <MainButton goTo="home" extra />;  // goTo has type "home" | "contact"
-                           ~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ goTo: "home"; extra: true; }' is not assignable to type 'IntrinsicAttributes & LinkProps'.
-!!! error TS2322:   Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
+                                       ~~~~~
+!!! error TS2339: Property 'extra' does not exist on type 'IntrinsicAttributes & LinkProps'.
     
     export function NoOverload(buttonProps: ButtonProps): JSX.Element { return undefined }
     const c1 = <NoOverload  {...{onClick: (k) => {console.log(k)}}} extra />;  // k has type any

--- a/tests/baselines/reference/tsxAttributeResolution1.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution1.errors.txt
@@ -1,15 +1,12 @@
 tests/cases/conformance/jsx/file.tsx(23,8): error TS2322: Type '{ x: "0"; }' is not assignable to type 'Attribs1'.
   Types of property 'x' are incompatible.
     Type '"0"' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(24,8): error TS2322: Type '{ y: 0; }' is not assignable to type 'Attribs1'.
-  Property 'y' does not exist on type 'Attribs1'.
-tests/cases/conformance/jsx/file.tsx(25,8): error TS2322: Type '{ y: "foo"; }' is not assignable to type 'Attribs1'.
-  Property 'y' does not exist on type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(24,8): error TS2339: Property 'y' does not exist on type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(25,8): error TS2339: Property 'y' does not exist on type 'Attribs1'.
 tests/cases/conformance/jsx/file.tsx(26,8): error TS2322: Type '{ x: "32"; }' is not assignable to type 'Attribs1'.
   Types of property 'x' are incompatible.
     Type '"32"' is not assignable to type 'number'.
-tests/cases/conformance/jsx/file.tsx(27,8): error TS2322: Type '{ var: "10"; }' is not assignable to type 'Attribs1'.
-  Property 'var' does not exist on type 'Attribs1'.
+tests/cases/conformance/jsx/file.tsx(27,8): error TS2339: Property 'var' does not exist on type 'Attribs1'.
 tests/cases/conformance/jsx/file.tsx(29,1): error TS2322: Type '{}' is not assignable to type '{ reqd: string; }'.
   Property 'reqd' is missing in type '{}'.
 tests/cases/conformance/jsx/file.tsx(30,8): error TS2322: Type '{ reqd: 10; }' is not assignable to type '{ reqd: string; }'.
@@ -47,12 +44,10 @@ tests/cases/conformance/jsx/file.tsx(30,8): error TS2322: Type '{ reqd: 10; }' i
 !!! error TS2322:     Type '"0"' is not assignable to type 'number'.
     <test1 y={0} />; // Error, no property "y"
            ~~~~~
-!!! error TS2322: Type '{ y: 0; }' is not assignable to type 'Attribs1'.
-!!! error TS2322:   Property 'y' does not exist on type 'Attribs1'.
+!!! error TS2339: Property 'y' does not exist on type 'Attribs1'.
     <test1 y="foo" />; // Error, no property "y"
            ~~~~~~~
-!!! error TS2322: Type '{ y: "foo"; }' is not assignable to type 'Attribs1'.
-!!! error TS2322:   Property 'y' does not exist on type 'Attribs1'.
+!!! error TS2339: Property 'y' does not exist on type 'Attribs1'.
     <test1 x="32" />; // Error, "32" is not number
            ~~~~~~
 !!! error TS2322: Type '{ x: "32"; }' is not assignable to type 'Attribs1'.
@@ -60,8 +55,7 @@ tests/cases/conformance/jsx/file.tsx(30,8): error TS2322: Type '{ reqd: 10; }' i
 !!! error TS2322:     Type '"32"' is not assignable to type 'number'.
     <test1 var="10" />; // Error, no 'var' property
            ~~~~~~~~
-!!! error TS2322: Type '{ var: "10"; }' is not assignable to type 'Attribs1'.
-!!! error TS2322:   Property 'var' does not exist on type 'Attribs1'.
+!!! error TS2339: Property 'var' does not exist on type 'Attribs1'.
     
     <test2 />; // Error, missing reqd
     ~~~~~~~~~

--- a/tests/baselines/reference/tsxAttributeResolution11.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution11.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(11,22): error TS2322: Type '{ bar: "world"; }' is not assignable to type 'IntrinsicAttributes & { ref?: string; }'.
-  Property 'bar' does not exist on type 'IntrinsicAttributes & { ref?: string; }'.
+tests/cases/conformance/jsx/file.tsx(11,22): error TS2339: Property 'bar' does not exist on type 'IntrinsicAttributes & { ref?: string; }'.
 
 
 ==== tests/cases/conformance/jsx/react.d.ts (0 errors) ====
@@ -28,7 +27,6 @@ tests/cases/conformance/jsx/file.tsx(11,22): error TS2322: Type '{ bar: "world";
     // Should be an OK
     var x = <MyComponent bar='world' />;
                          ~~~~~~~~~~~
-!!! error TS2322: Type '{ bar: "world"; }' is not assignable to type 'IntrinsicAttributes & { ref?: string; }'.
-!!! error TS2322:   Property 'bar' does not exist on type 'IntrinsicAttributes & { ref?: string; }'.
+!!! error TS2339: Property 'bar' does not exist on type 'IntrinsicAttributes & { ref?: string; }'.
     
     

--- a/tests/baselines/reference/tsxAttributeResolution15.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution15.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(11,21): error TS2322: Type '{ prop1: "hello"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
-  Property 'prop1' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(11,21): error TS2339: Property 'prop1' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -15,8 +14,7 @@ tests/cases/conformance/jsx/file.tsx(11,21): error TS2322: Type '{ prop1: "hello
     // Error
     let a = <BigGreeter prop1="hello" />
                         ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ prop1: "hello"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
-!!! error TS2322:   Property 'prop1' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
+!!! error TS2339: Property 'prop1' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<BigGreeter> & { children?: ReactNode; }'.
     
     // OK
     let b = <BigGreeter ref={(input) => { this.textInput = input; }} />

--- a/tests/baselines/reference/tsxAttributeResolution3.errors.txt
+++ b/tests/baselines/reference/tsxAttributeResolution3.errors.txt
@@ -6,11 +6,9 @@ tests/cases/conformance/jsx/file.tsx(23,8): error TS2322: Type '{ y: number; }' 
 tests/cases/conformance/jsx/file.tsx(31,8): error TS2322: Type '{ x: number; y: number; }' is not assignable to type 'Attribs1'.
   Types of property 'x' are incompatible.
     Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(35,8): error TS2322: Type '{ x: string; y: number; extra: number; }' is not assignable to type 'Attribs1'.
-  Property 'extra' does not exist on type 'Attribs1'.
 
 
-==== tests/cases/conformance/jsx/file.tsx (4 errors) ====
+==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
     declare module JSX {
     	interface Element { }
     	interface IntrinsicElements {
@@ -54,12 +52,9 @@ tests/cases/conformance/jsx/file.tsx(35,8): error TS2322: Type '{ x: string; y: 
 !!! error TS2322:   Types of property 'x' are incompatible.
 !!! error TS2322:     Type 'number' is not assignable to type 'string'.
     
-    // Error
+    // Ok
     var obj6 = { x: 'ok', y: 32, extra: 100 };
     <test1 {...obj6} />
-           ~~~~~~~~~
-!!! error TS2322: Type '{ x: string; y: number; extra: number; }' is not assignable to type 'Attribs1'.
-!!! error TS2322:   Property 'extra' does not exist on type 'Attribs1'.
     
     // OK (spread override)
     var obj7 = { x: 'foo' };

--- a/tests/baselines/reference/tsxAttributeResolution3.js
+++ b/tests/baselines/reference/tsxAttributeResolution3.js
@@ -31,7 +31,7 @@ var obj4 = { x: 32, y: 32 };
 var obj5 = { x: 32, y: 32 };
 <test1 x="ok" {...obj5} />
 
-// Error
+// Ok
 var obj6 = { x: 'ok', y: 32, extra: 100 };
 <test1 {...obj6} />
 
@@ -56,7 +56,7 @@ var obj4 = { x: 32, y: 32 };
 // Error
 var obj5 = { x: 32, y: 32 };
 <test1 x="ok" {...obj5}/>;
-// Error
+// Ok
 var obj6 = { x: 'ok', y: 32, extra: 100 };
 <test1 {...obj6}/>;
 // OK (spread override)

--- a/tests/baselines/reference/tsxElementResolution11.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution11.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(17,7): error TS2322: Type '{ x: 10; }' is not assignable to type '{ q?: number; }'.
-  Property 'x' does not exist on type '{ q?: number; }'.
+tests/cases/conformance/jsx/file.tsx(17,7): error TS2339: Property 'x' does not exist on type '{ q?: number; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -21,8 +20,7 @@ tests/cases/conformance/jsx/file.tsx(17,7): error TS2322: Type '{ x: 10; }' is n
     var Obj2: Obj2type;
     <Obj2 x={10} />; // Error
           ~~~~~~
-!!! error TS2322: Type '{ x: 10; }' is not assignable to type '{ q?: number; }'.
-!!! error TS2322:   Property 'x' does not exist on type '{ q?: number; }'.
+!!! error TS2339: Property 'x' does not exist on type '{ q?: number; }'.
     
     interface Obj3type {
     	new(n: string): { x: number; };

--- a/tests/baselines/reference/tsxElementResolution3.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution3.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/jsx/file.tsx(12,7): error TS2322: Type '{ w: "err"; }' is not assignable to type '{ n: string; }'.
-  Property 'w' does not exist on type '{ n: string; }'.
+  Property 'n' is missing in type '{ w: "err"; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -17,4 +17,4 @@ tests/cases/conformance/jsx/file.tsx(12,7): error TS2322: Type '{ w: "err"; }' i
     <span w='err' />;
           ~~~~~~~
 !!! error TS2322: Type '{ w: "err"; }' is not assignable to type '{ n: string; }'.
-!!! error TS2322:   Property 'w' does not exist on type '{ n: string; }'.
+!!! error TS2322:   Property 'n' is missing in type '{ w: "err"; }'.

--- a/tests/baselines/reference/tsxElementResolution4.errors.txt
+++ b/tests/baselines/reference/tsxElementResolution4.errors.txt
@@ -1,5 +1,5 @@
 tests/cases/conformance/jsx/file.tsx(16,7): error TS2322: Type '{ q: ""; }' is not assignable to type '{ m: string; }'.
-  Property 'q' does not exist on type '{ m: string; }'.
+  Property 'm' is missing in type '{ q: ""; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
@@ -21,5 +21,5 @@ tests/cases/conformance/jsx/file.tsx(16,7): error TS2322: Type '{ q: ""; }' is n
     <span q='' />;
           ~~~~
 !!! error TS2322: Type '{ q: ""; }' is not assignable to type '{ m: string; }'.
-!!! error TS2322:   Property 'q' does not exist on type '{ m: string; }'.
+!!! error TS2322:   Property 'm' is missing in type '{ q: ""; }'.
     

--- a/tests/baselines/reference/tsxReactComponentWithDefaultTypeParameter3.errors.txt
+++ b/tests/baselines/reference/tsxReactComponentWithDefaultTypeParameter3.errors.txt
@@ -1,7 +1,5 @@
-tests/cases/conformance/jsx/file.tsx(16,17): error TS2322: Type '{ a: 10; b: "hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
-  Property 'a' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
-tests/cases/conformance/jsx/file.tsx(17,18): error TS2322: Type '{ a: "hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
-  Property 'a' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(16,17): error TS2339: Property 'a' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(17,18): error TS2339: Property 'a' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (2 errors) ====
@@ -21,10 +19,8 @@ tests/cases/conformance/jsx/file.tsx(17,18): error TS2322: Type '{ a: "hi"; }' i
     
     // Error
     let x = <MyComp a={10} b="hi" />
-                    ~~~~~~~~~~~~~
-!!! error TS2322: Type '{ a: 10; b: "hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
-!!! error TS2322:   Property 'a' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
+                    ~~~~~~
+!!! error TS2339: Property 'a' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
     let x2 = <MyComp a="hi"/>
                      ~~~~~~
-!!! error TS2322: Type '{ a: "hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
-!!! error TS2322:   Property 'a' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.
+!!! error TS2339: Property 'a' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MyComp<{}>> & { children?: ReactNode; }'.

--- a/tests/baselines/reference/tsxSpreadAttributesResolution12.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution12.errors.txt
@@ -6,9 +6,13 @@ tests/cases/conformance/jsx/file.tsx(28,25): error TS2322: Type '{ y: true; x: 3
   Type '{ y: true; x: 3; overwrite: "hi"; }' is not assignable to type 'Prop'.
     Types of property 'x' are incompatible.
       Type '3' is not assignable to type '2'.
+tests/cases/conformance/jsx/file.tsx(30,25): error TS2322: Type '{ y: true; x: 2; overwrite: "hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
+  Type '{ y: true; x: 2; overwrite: "hi"; }' is not assignable to type 'Prop'.
+    Types of property 'y' are incompatible.
+      Type 'true' is not assignable to type 'false'.
 
 
-==== tests/cases/conformance/jsx/file.tsx (2 errors) ====
+==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
     import React = require('react');
     
     const obj = {};
@@ -48,4 +52,11 @@ tests/cases/conformance/jsx/file.tsx(28,25): error TS2322: Type '{ y: true; x: 3
 !!! error TS2322:     Types of property 'x' are incompatible.
 !!! error TS2322:       Type '3' is not assignable to type '2'.
     let x2 = <OverWriteAttr {...anyobj} x={3} />
+    let x3 = <OverWriteAttr overwrite="hi" {...obj1} {...{y: true}} />
+                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type '{ y: true; x: 2; overwrite: "hi"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<OverWriteAttr> & Prop & { children?: ReactNode; }'.
+!!! error TS2322:   Type '{ y: true; x: 2; overwrite: "hi"; }' is not assignable to type 'Prop'.
+!!! error TS2322:     Types of property 'y' are incompatible.
+!!! error TS2322:       Type 'true' is not assignable to type 'false'.
+    
     

--- a/tests/baselines/reference/tsxSpreadAttributesResolution12.js
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution12.js
@@ -28,6 +28,8 @@ let anyobj: any;
 let x = <OverWriteAttr {...obj} y overwrite="hi" {...obj1} />
 let x1 = <OverWriteAttr overwrite="hi" {...obj1} x={3} {...{y: true}} />
 let x2 = <OverWriteAttr {...anyobj} x={3} />
+let x3 = <OverWriteAttr overwrite="hi" {...obj1} {...{y: true}} />
+
 
 
 //// [file.jsx]
@@ -67,3 +69,4 @@ var anyobj;
 var x = <OverWriteAttr {...obj} y overwrite="hi" {...obj1}/>;
 var x1 = <OverWriteAttr overwrite="hi" {...obj1} x={3} {...{ y: true }}/>;
 var x2 = <OverWriteAttr {...anyobj} x={3}/>;
+var x3 = <OverWriteAttr overwrite="hi" {...obj1} {...{ y: true }}/>;

--- a/tests/baselines/reference/tsxSpreadAttributesResolution13.js
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution13.js
@@ -1,0 +1,36 @@
+//// [file.tsx]
+import React = require('react');
+
+interface ComponentProps {
+    property1: string;
+    property2: number;
+}
+
+export default function Component(props: ComponentProps) {
+    return (
+        <AnotherComponent {...props} />
+    );
+}
+
+interface AnotherComponentProps {
+    property1: string;
+}
+
+function AnotherComponent({ property1 }: AnotherComponentProps) {
+    return (
+        <span>{property1}</span>
+    );
+}
+
+//// [file.jsx]
+"use strict";
+exports.__esModule = true;
+var React = require("react");
+function Component(props) {
+    return (<AnotherComponent {...props}/>);
+}
+exports["default"] = Component;
+function AnotherComponent(_a) {
+    var property1 = _a.property1;
+    return (<span>{property1}</span>);
+}

--- a/tests/baselines/reference/tsxSpreadAttributesResolution13.symbols
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution13.symbols
@@ -17,30 +17,43 @@ export default function Component(props: ComponentProps) {
 >props : Symbol(props, Decl(file.tsx, 7, 34))
 >ComponentProps : Symbol(ComponentProps, Decl(file.tsx, 0, 32))
 
-    return (
-        <AnotherComponent {...props} />
->AnotherComponent : Symbol(AnotherComponent, Decl(file.tsx, 15, 1))
+    let condition1: boolean;
+>condition1 : Symbol(condition1, Decl(file.tsx, 8, 7))
+
+    if (condition1) {
+>condition1 : Symbol(condition1, Decl(file.tsx, 8, 7))
+
+        return (
+            <ChildComponent {...props} />
+>ChildComponent : Symbol(ChildComponent, Decl(file.tsx, 21, 1))
 >props : Symbol(props, Decl(file.tsx, 7, 34))
 
-    );
+        );
+    }
+    else {
+        return (<ChildComponent {...props} property1="NewString" />);
+>ChildComponent : Symbol(ChildComponent, Decl(file.tsx, 21, 1))
+>props : Symbol(props, Decl(file.tsx, 7, 34))
+>property1 : Symbol(property1, Decl(file.tsx, 15, 42))
+    }
 }
 
 interface AnotherComponentProps {
->AnotherComponentProps : Symbol(AnotherComponentProps, Decl(file.tsx, 11, 1))
+>AnotherComponentProps : Symbol(AnotherComponentProps, Decl(file.tsx, 17, 1))
 
     property1: string;
->property1 : Symbol(AnotherComponentProps.property1, Decl(file.tsx, 13, 33))
+>property1 : Symbol(AnotherComponentProps.property1, Decl(file.tsx, 19, 33))
 }
 
-function AnotherComponent({ property1 }: AnotherComponentProps) {
->AnotherComponent : Symbol(AnotherComponent, Decl(file.tsx, 15, 1))
->property1 : Symbol(property1, Decl(file.tsx, 17, 27))
->AnotherComponentProps : Symbol(AnotherComponentProps, Decl(file.tsx, 11, 1))
+function ChildComponent({ property1 }: AnotherComponentProps) {
+>ChildComponent : Symbol(ChildComponent, Decl(file.tsx, 21, 1))
+>property1 : Symbol(property1, Decl(file.tsx, 23, 25))
+>AnotherComponentProps : Symbol(AnotherComponentProps, Decl(file.tsx, 17, 1))
 
     return (
         <span>{property1}</span>
 >span : Symbol(JSX.IntrinsicElements.span, Decl(react.d.ts, 2460, 51))
->property1 : Symbol(property1, Decl(file.tsx, 17, 27))
+>property1 : Symbol(property1, Decl(file.tsx, 23, 25))
 >span : Symbol(JSX.IntrinsicElements.span, Decl(react.d.ts, 2460, 51))
 
     );

--- a/tests/baselines/reference/tsxSpreadAttributesResolution13.symbols
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution13.symbols
@@ -1,0 +1,47 @@
+=== tests/cases/conformance/jsx/file.tsx ===
+import React = require('react');
+>React : Symbol(React, Decl(file.tsx, 0, 0))
+
+interface ComponentProps {
+>ComponentProps : Symbol(ComponentProps, Decl(file.tsx, 0, 32))
+
+    property1: string;
+>property1 : Symbol(ComponentProps.property1, Decl(file.tsx, 2, 26))
+
+    property2: number;
+>property2 : Symbol(ComponentProps.property2, Decl(file.tsx, 3, 22))
+}
+
+export default function Component(props: ComponentProps) {
+>Component : Symbol(Component, Decl(file.tsx, 5, 1))
+>props : Symbol(props, Decl(file.tsx, 7, 34))
+>ComponentProps : Symbol(ComponentProps, Decl(file.tsx, 0, 32))
+
+    return (
+        <AnotherComponent {...props} />
+>AnotherComponent : Symbol(AnotherComponent, Decl(file.tsx, 15, 1))
+>props : Symbol(props, Decl(file.tsx, 7, 34))
+
+    );
+}
+
+interface AnotherComponentProps {
+>AnotherComponentProps : Symbol(AnotherComponentProps, Decl(file.tsx, 11, 1))
+
+    property1: string;
+>property1 : Symbol(AnotherComponentProps.property1, Decl(file.tsx, 13, 33))
+}
+
+function AnotherComponent({ property1 }: AnotherComponentProps) {
+>AnotherComponent : Symbol(AnotherComponent, Decl(file.tsx, 15, 1))
+>property1 : Symbol(property1, Decl(file.tsx, 17, 27))
+>AnotherComponentProps : Symbol(AnotherComponentProps, Decl(file.tsx, 11, 1))
+
+    return (
+        <span>{property1}</span>
+>span : Symbol(JSX.IntrinsicElements.span, Decl(react.d.ts, 2460, 51))
+>property1 : Symbol(property1, Decl(file.tsx, 17, 27))
+>span : Symbol(JSX.IntrinsicElements.span, Decl(react.d.ts, 2460, 51))
+
+    );
+}

--- a/tests/baselines/reference/tsxSpreadAttributesResolution13.types
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution13.types
@@ -1,0 +1,53 @@
+=== tests/cases/conformance/jsx/file.tsx ===
+import React = require('react');
+>React : typeof React
+
+interface ComponentProps {
+>ComponentProps : ComponentProps
+
+    property1: string;
+>property1 : string
+
+    property2: number;
+>property2 : number
+}
+
+export default function Component(props: ComponentProps) {
+>Component : (props: ComponentProps) => JSX.Element
+>props : ComponentProps
+>ComponentProps : ComponentProps
+
+    return (
+>(        <AnotherComponent {...props} />    ) : JSX.Element
+
+        <AnotherComponent {...props} />
+><AnotherComponent {...props} /> : JSX.Element
+>AnotherComponent : ({property1}: AnotherComponentProps) => JSX.Element
+>props : ComponentProps
+
+    );
+}
+
+interface AnotherComponentProps {
+>AnotherComponentProps : AnotherComponentProps
+
+    property1: string;
+>property1 : string
+}
+
+function AnotherComponent({ property1 }: AnotherComponentProps) {
+>AnotherComponent : ({property1}: AnotherComponentProps) => JSX.Element
+>property1 : string
+>AnotherComponentProps : AnotherComponentProps
+
+    return (
+>(        <span>{property1}</span>    ) : JSX.Element
+
+        <span>{property1}</span>
+><span>{property1}</span> : JSX.Element
+>span : any
+>property1 : string
+>span : any
+
+    );
+}

--- a/tests/baselines/reference/tsxSpreadAttributesResolution13.types
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution13.types
@@ -17,15 +17,30 @@ export default function Component(props: ComponentProps) {
 >props : ComponentProps
 >ComponentProps : ComponentProps
 
-    return (
->(        <AnotherComponent {...props} />    ) : JSX.Element
+    let condition1: boolean;
+>condition1 : boolean
 
-        <AnotherComponent {...props} />
-><AnotherComponent {...props} /> : JSX.Element
->AnotherComponent : ({property1}: AnotherComponentProps) => JSX.Element
+    if (condition1) {
+>condition1 : boolean
+
+        return (
+>(            <ChildComponent {...props} />        ) : JSX.Element
+
+            <ChildComponent {...props} />
+><ChildComponent {...props} /> : JSX.Element
+>ChildComponent : ({property1}: AnotherComponentProps) => JSX.Element
 >props : ComponentProps
 
-    );
+        );
+    }
+    else {
+        return (<ChildComponent {...props} property1="NewString" />);
+>(<ChildComponent {...props} property1="NewString" />) : JSX.Element
+><ChildComponent {...props} property1="NewString" /> : JSX.Element
+>ChildComponent : ({property1}: AnotherComponentProps) => JSX.Element
+>props : ComponentProps
+>property1 : string
+    }
 }
 
 interface AnotherComponentProps {
@@ -35,8 +50,8 @@ interface AnotherComponentProps {
 >property1 : string
 }
 
-function AnotherComponent({ property1 }: AnotherComponentProps) {
->AnotherComponent : ({property1}: AnotherComponentProps) => JSX.Element
+function ChildComponent({ property1 }: AnotherComponentProps) {
+>ChildComponent : ({property1}: AnotherComponentProps) => JSX.Element
 >property1 : string
 >AnotherComponentProps : AnotherComponentProps
 

--- a/tests/baselines/reference/tsxSpreadAttributesResolution14.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution14.errors.txt
@@ -1,0 +1,29 @@
+tests/cases/conformance/jsx/file.tsx(11,38): error TS2339: Property 'Property1' does not exist on type 'IntrinsicAttributes & AnotherComponentProps'.
+
+
+==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
+    import React = require('react');
+    
+    interface ComponentProps {
+        property1: string;
+        property2: number;
+    }
+    
+    export default function Component(props: ComponentProps) {
+        return (
+            // Error extra property
+            <AnotherComponent {...props} Property1/>
+                                         ~~~~~~~~~
+!!! error TS2339: Property 'Property1' does not exist on type 'IntrinsicAttributes & AnotherComponentProps'.
+        );
+    }
+    
+    interface AnotherComponentProps {
+        property1: string;
+    }
+    
+    function AnotherComponent({ property1 }: AnotherComponentProps) {
+        return (
+            <span>{property1}</span>
+        );
+    }

--- a/tests/baselines/reference/tsxSpreadAttributesResolution14.js
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution14.js
@@ -1,0 +1,39 @@
+//// [file.tsx]
+import React = require('react');
+
+interface ComponentProps {
+    property1: string;
+    property2: number;
+}
+
+export default function Component(props: ComponentProps) {
+    return (
+        // Error extra property
+        <AnotherComponent {...props} Property1/>
+    );
+}
+
+interface AnotherComponentProps {
+    property1: string;
+}
+
+function AnotherComponent({ property1 }: AnotherComponentProps) {
+    return (
+        <span>{property1}</span>
+    );
+}
+
+//// [file.jsx]
+"use strict";
+exports.__esModule = true;
+var React = require("react");
+function Component(props) {
+    return (
+    // Error extra property
+    <AnotherComponent {...props} Property1/>);
+}
+exports["default"] = Component;
+function AnotherComponent(_a) {
+    var property1 = _a.property1;
+    return (<span>{property1}</span>);
+}

--- a/tests/baselines/reference/tsxSpreadAttributesResolution15.js
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution15.js
@@ -1,0 +1,38 @@
+//// [file.tsx]
+import React = require('react');
+
+interface ComponentProps {
+    property1: string;
+    property2: number;
+}
+
+export default function Component(props: ComponentProps) {
+    return (
+        <AnotherComponent {...props} property2 AnotherProperty1="hi"/>
+    );
+}
+
+interface AnotherComponentProps {
+    property1: string;
+    AnotherProperty1: string;
+    property2: boolean;
+}
+
+function AnotherComponent({ property1 }: AnotherComponentProps) {
+    return (
+        <span>{property1}</span>
+    );
+}
+
+//// [file.jsx]
+"use strict";
+exports.__esModule = true;
+var React = require("react");
+function Component(props) {
+    return (<AnotherComponent {...props} property2 AnotherProperty1="hi"/>);
+}
+exports["default"] = Component;
+function AnotherComponent(_a) {
+    var property1 = _a.property1;
+    return (<span>{property1}</span>);
+}

--- a/tests/baselines/reference/tsxSpreadAttributesResolution15.symbols
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution15.symbols
@@ -1,0 +1,55 @@
+=== tests/cases/conformance/jsx/file.tsx ===
+import React = require('react');
+>React : Symbol(React, Decl(file.tsx, 0, 0))
+
+interface ComponentProps {
+>ComponentProps : Symbol(ComponentProps, Decl(file.tsx, 0, 32))
+
+    property1: string;
+>property1 : Symbol(ComponentProps.property1, Decl(file.tsx, 2, 26))
+
+    property2: number;
+>property2 : Symbol(ComponentProps.property2, Decl(file.tsx, 3, 22))
+}
+
+export default function Component(props: ComponentProps) {
+>Component : Symbol(Component, Decl(file.tsx, 5, 1))
+>props : Symbol(props, Decl(file.tsx, 7, 34))
+>ComponentProps : Symbol(ComponentProps, Decl(file.tsx, 0, 32))
+
+    return (
+        <AnotherComponent {...props} property2 AnotherProperty1="hi"/>
+>AnotherComponent : Symbol(AnotherComponent, Decl(file.tsx, 17, 1))
+>props : Symbol(props, Decl(file.tsx, 7, 34))
+>property2 : Symbol(property2, Decl(file.tsx, 9, 36))
+>AnotherProperty1 : Symbol(AnotherProperty1, Decl(file.tsx, 9, 46))
+
+    );
+}
+
+interface AnotherComponentProps {
+>AnotherComponentProps : Symbol(AnotherComponentProps, Decl(file.tsx, 11, 1))
+
+    property1: string;
+>property1 : Symbol(AnotherComponentProps.property1, Decl(file.tsx, 13, 33))
+
+    AnotherProperty1: string;
+>AnotherProperty1 : Symbol(AnotherComponentProps.AnotherProperty1, Decl(file.tsx, 14, 22))
+
+    property2: boolean;
+>property2 : Symbol(AnotherComponentProps.property2, Decl(file.tsx, 15, 29))
+}
+
+function AnotherComponent({ property1 }: AnotherComponentProps) {
+>AnotherComponent : Symbol(AnotherComponent, Decl(file.tsx, 17, 1))
+>property1 : Symbol(property1, Decl(file.tsx, 19, 27))
+>AnotherComponentProps : Symbol(AnotherComponentProps, Decl(file.tsx, 11, 1))
+
+    return (
+        <span>{property1}</span>
+>span : Symbol(JSX.IntrinsicElements.span, Decl(react.d.ts, 2460, 51))
+>property1 : Symbol(property1, Decl(file.tsx, 19, 27))
+>span : Symbol(JSX.IntrinsicElements.span, Decl(react.d.ts, 2460, 51))
+
+    );
+}

--- a/tests/baselines/reference/tsxSpreadAttributesResolution15.types
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution15.types
@@ -1,0 +1,61 @@
+=== tests/cases/conformance/jsx/file.tsx ===
+import React = require('react');
+>React : typeof React
+
+interface ComponentProps {
+>ComponentProps : ComponentProps
+
+    property1: string;
+>property1 : string
+
+    property2: number;
+>property2 : number
+}
+
+export default function Component(props: ComponentProps) {
+>Component : (props: ComponentProps) => JSX.Element
+>props : ComponentProps
+>ComponentProps : ComponentProps
+
+    return (
+>(        <AnotherComponent {...props} property2 AnotherProperty1="hi"/>    ) : JSX.Element
+
+        <AnotherComponent {...props} property2 AnotherProperty1="hi"/>
+><AnotherComponent {...props} property2 AnotherProperty1="hi"/> : JSX.Element
+>AnotherComponent : ({property1}: AnotherComponentProps) => JSX.Element
+>props : ComponentProps
+>property2 : true
+>AnotherProperty1 : string
+
+    );
+}
+
+interface AnotherComponentProps {
+>AnotherComponentProps : AnotherComponentProps
+
+    property1: string;
+>property1 : string
+
+    AnotherProperty1: string;
+>AnotherProperty1 : string
+
+    property2: boolean;
+>property2 : boolean
+}
+
+function AnotherComponent({ property1 }: AnotherComponentProps) {
+>AnotherComponent : ({property1}: AnotherComponentProps) => JSX.Element
+>property1 : string
+>AnotherComponentProps : AnotherComponentProps
+
+    return (
+>(        <span>{property1}</span>    ) : JSX.Element
+
+        <span>{property1}</span>
+><span>{property1}</span> : JSX.Element
+>span : any
+>property1 : string
+>span : any
+
+    );
+}

--- a/tests/baselines/reference/tsxSpreadAttributesResolution16.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution16.errors.txt
@@ -1,0 +1,35 @@
+tests/cases/conformance/jsx/file.tsx(11,27): error TS2322: Type '{ property1: string; property2: number; }' is not assignable to type 'IntrinsicAttributes & AnotherComponentProps'.
+  Type '{ property1: string; property2: number; }' is not assignable to type 'AnotherComponentProps'.
+    Property 'AnotherProperty1' is missing in type '{ property1: string; property2: number; }'.
+
+
+==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
+    import React = require('react');
+    
+    interface ComponentProps {
+        property1: string;
+        property2: number;
+    }
+    
+    export default function Component(props: ComponentProps) {
+        return (
+            // Error: missing property
+            <AnotherComponent {...props} />
+                              ~~~~~~~~~~
+!!! error TS2322: Type '{ property1: string; property2: number; }' is not assignable to type 'IntrinsicAttributes & AnotherComponentProps'.
+!!! error TS2322:   Type '{ property1: string; property2: number; }' is not assignable to type 'AnotherComponentProps'.
+!!! error TS2322:     Property 'AnotherProperty1' is missing in type '{ property1: string; property2: number; }'.
+        );
+    }
+    
+    interface AnotherComponentProps {
+        property1: string;
+        AnotherProperty1: string;
+        property2: boolean;
+    }
+    
+    function AnotherComponent({ property1 }: AnotherComponentProps) {
+        return (
+            <span>{property1}</span>
+        );
+    }

--- a/tests/baselines/reference/tsxSpreadAttributesResolution16.js
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution16.js
@@ -7,22 +7,19 @@ interface ComponentProps {
 }
 
 export default function Component(props: ComponentProps) {
-    let condition1: boolean;
-    if (condition1) {
-        return (
-            <ChildComponent {...props} />
-        );
-    }
-    else {
-        return (<ChildComponent {...props} property1="NewString" />);
-    }
+    return (
+        // Error: missing property
+        <AnotherComponent {...props} />
+    );
 }
 
 interface AnotherComponentProps {
     property1: string;
+    AnotherProperty1: string;
+    property2: boolean;
 }
 
-function ChildComponent({ property1 }: AnotherComponentProps) {
+function AnotherComponent({ property1 }: AnotherComponentProps) {
     return (
         <span>{property1}</span>
     );
@@ -33,16 +30,12 @@ function ChildComponent({ property1 }: AnotherComponentProps) {
 exports.__esModule = true;
 var React = require("react");
 function Component(props) {
-    var condition1;
-    if (condition1) {
-        return (<ChildComponent {...props}/>);
-    }
-    else {
-        return (<ChildComponent {...props} property1="NewString"/>);
-    }
+    return (
+    // Error: missing property
+    <AnotherComponent {...props}/>);
 }
 exports["default"] = Component;
-function ChildComponent(_a) {
+function AnotherComponent(_a) {
     var property1 = _a.property1;
     return (<span>{property1}</span>);
 }

--- a/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
@@ -16,10 +16,9 @@ tests/cases/conformance/jsx/file.tsx(21,20): error TS2322: Type '{ X: "hi"; x: n
   Type '{ X: "hi"; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
     Types of property 'x' are incompatible.
       Type 'number' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(21,40): error TS2339: Property 'X' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
 
 
-==== tests/cases/conformance/jsx/file.tsx (6 errors) ====
+==== tests/cases/conformance/jsx/file.tsx (5 errors) ====
     import React = require('react');
     
     interface PoisonedProp {
@@ -64,5 +63,3 @@ tests/cases/conformance/jsx/file.tsx(21,40): error TS2339: Property 'X' does not
 !!! error TS2322:   Type '{ X: "hi"; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
 !!! error TS2322:     Types of property 'x' are incompatible.
 !!! error TS2322:       Type 'number' is not assignable to type 'string'.
-                                           ~~~~~~
-!!! error TS2339: Property 'X' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.

--- a/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution2.errors.txt
@@ -8,9 +8,18 @@ tests/cases/conformance/jsx/file.tsx(19,19): error TS2322: Type '{ x: true; y: t
   Type '{ x: true; y: true; }' is not assignable to type 'PoisonedProp'.
     Types of property 'x' are incompatible.
       Type 'true' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(20,19): error TS2322: Type '{ x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
+  Type '{ x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
+    Types of property 'x' are incompatible.
+      Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(21,20): error TS2322: Type '{ X: "hi"; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
+  Type '{ X: "hi"; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
+    Types of property 'x' are incompatible.
+      Type 'number' is not assignable to type 'string'.
+tests/cases/conformance/jsx/file.tsx(21,40): error TS2339: Property 'X' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
 
 
-==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
+==== tests/cases/conformance/jsx/file.tsx (6 errors) ====
     import React = require('react');
     
     interface PoisonedProp {
@@ -43,3 +52,17 @@ tests/cases/conformance/jsx/file.tsx(19,19): error TS2322: Type '{ x: true; y: t
 !!! error TS2322:   Type '{ x: true; y: true; }' is not assignable to type 'PoisonedProp'.
 !!! error TS2322:     Types of property 'x' are incompatible.
 !!! error TS2322:       Type 'true' is not assignable to type 'string'.
+    let w = <Poisoned {...{x: 5, y: "2"}}/>;
+                      ~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type '{ x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
+!!! error TS2322:   Type '{ x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
+!!! error TS2322:     Types of property 'x' are incompatible.
+!!! error TS2322:       Type 'number' is not assignable to type 'string'.
+    let w1 = <Poisoned {...{x: 5, y: "2"}} X="hi" />;
+                       ~~~~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2322: Type '{ X: "hi"; x: number; y: "2"; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.
+!!! error TS2322:   Type '{ X: "hi"; x: number; y: "2"; }' is not assignable to type 'PoisonedProp'.
+!!! error TS2322:     Types of property 'x' are incompatible.
+!!! error TS2322:       Type 'number' is not assignable to type 'string'.
+                                           ~~~~~~
+!!! error TS2339: Property 'X' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<Poisoned> & PoisonedProp & { children?: ReactNode; }'.

--- a/tests/baselines/reference/tsxSpreadAttributesResolution2.js
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution2.js
@@ -18,6 +18,8 @@ const obj = {};
 let p = <Poisoned {...obj} />;
 let y = <Poisoned />;
 let z = <Poisoned x y/>;
+let w = <Poisoned {...{x: 5, y: "2"}}/>;
+let w1 = <Poisoned {...{x: 5, y: "2"}} X="hi" />;
 
 //// [file.jsx]
 "use strict";
@@ -48,3 +50,5 @@ var obj = {};
 var p = <Poisoned {...obj}/>;
 var y = <Poisoned />;
 var z = <Poisoned x y/>;
+var w = <Poisoned {...{ x: 5, y: "2" }}/>;
+var w1 = <Poisoned {...{ x: 5, y: "2" }} X="hi"/>;

--- a/tests/baselines/reference/tsxSpreadAttributesResolution5.errors.txt
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution5.errors.txt
@@ -2,11 +2,9 @@ tests/cases/conformance/jsx/file.tsx(20,19): error TS2322: Type '{ x: string; y:
   Type '{ x: string; y: number; }' is not assignable to type 'PoisonedProp'.
     Types of property 'y' are incompatible.
       Type 'number' is not assignable to type '2'.
-tests/cases/conformance/jsx/file.tsx(33,20): error TS2322: Type '{ prop1: boolean; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<EmptyProp> & { children?: ReactNode; }'.
-  Property 'prop1' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<EmptyProp> & { children?: ReactNode; }'.
 
 
-==== tests/cases/conformance/jsx/file.tsx (2 errors) ====
+==== tests/cases/conformance/jsx/file.tsx (1 errors) ====
     import React = require('react');
     
     interface PoisonedProp {
@@ -43,8 +41,5 @@ tests/cases/conformance/jsx/file.tsx(33,20): error TS2322: Type '{ prop1: boolea
     let o = {
         prop1: false
     }
-    // Error
+    // Ok
     let e = <EmptyProp {...o} />;
-                       ~~~~~~
-!!! error TS2322: Type '{ prop1: boolean; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<EmptyProp> & { children?: ReactNode; }'.
-!!! error TS2322:   Property 'prop1' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<EmptyProp> & { children?: ReactNode; }'.

--- a/tests/baselines/reference/tsxSpreadAttributesResolution5.js
+++ b/tests/baselines/reference/tsxSpreadAttributesResolution5.js
@@ -30,7 +30,7 @@ class EmptyProp extends React.Component<{}, {}> {
 let o = {
     prop1: false
 }
-// Error
+// Ok
 let e = <EmptyProp {...o} />;
 
 //// [file.jsx]
@@ -76,5 +76,5 @@ var EmptyProp = (function (_super) {
 var o = {
     prop1: false
 };
-// Error
+// Ok
 var e = <EmptyProp {...o}/>;

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
@@ -7,10 +7,7 @@ tests/cases/conformance/jsx/file.tsx(14,22): error TS2322: Type '{ yy1: true; yy
   Type '{ yy1: true; yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
     Types of property 'yy1' are incompatible.
       Type 'true' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(15,22): error TS2322: Type '{ extra: string; yy: number; yy1: string; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-  Property 'extra' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-tests/cases/conformance/jsx/file.tsx(16,22): error TS2322: Type '{ y1: 10000; yy: number; yy1: string; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-  Property 'y1' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
+tests/cases/conformance/jsx/file.tsx(16,31): error TS2339: Property 'y1' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
 tests/cases/conformance/jsx/file.tsx(17,22): error TS2322: Type '{ yy: boolean; yy1: string; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
   Type '{ yy: boolean; yy1: string; }' is not assignable to type '{ yy: number; yy1: string; }'.
     Types of property 'yy' are incompatible.
@@ -36,7 +33,7 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2322: Type '{ y1: "hello"; 
   Property 'children' does not exist on type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
 
 
-==== tests/cases/conformance/jsx/file.tsx (12 errors) ====
+==== tests/cases/conformance/jsx/file.tsx (11 errors) ====
     import React = require('react')
     declare function OneThing(): JSX.Element;
     declare function OneThing(l: {yy: number, yy1: string}): JSX.Element;
@@ -63,14 +60,10 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2322: Type '{ y1: "hello"; 
 !!! error TS2322:   Type '{ yy1: true; yy: number; }' is not assignable to type '{ yy: number; yy1: string; }'.
 !!! error TS2322:     Types of property 'yy1' are incompatible.
 !!! error TS2322:       Type 'true' is not assignable to type 'string'.
-    const c3 = <OneThing {...obj} {...{extra: "extra attr"}} />;  // Extra attribute;
-                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ extra: string; yy: number; yy1: string; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-!!! error TS2322:   Property 'extra' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
+    const c3 = <OneThing {...obj} {...{extra: "extra attr"}} />;  //  This is OK becuase all attribute are spread
     const c4 = <OneThing {...obj} y1={10000} />;  // extra property;
-                         ~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ y1: 10000; yy: number; yy1: string; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-!!! error TS2322:   Property 'y1' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
+                                  ~~~~~~~~~~
+!!! error TS2339: Property 'y1' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
     const c5 = <OneThing {...obj} {...{yy: true}} />;  // type incompatible;
                          ~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ yy: boolean; yy1: string; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/conformance/jsx/file.tsx(12,22): error TS2322: Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-  Property 'extraProp' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
+  Type '{ extraProp: true; }' is not assignable to type '{ yy: number; yy1: string; }'.
+    Property 'yy' is missing in type '{ extraProp: true; }'.
 tests/cases/conformance/jsx/file.tsx(13,22): error TS2322: Type '{ yy: 10; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
   Type '{ yy: 10; }' is not assignable to type '{ yy: number; yy1: string; }'.
     Property 'yy1' is missing in type '{ yy: 10; }'.
@@ -28,9 +29,13 @@ tests/cases/conformance/jsx/file.tsx(34,29): error TS2322: Type '{ y1: "hello"; 
     Types of property 'y1' are incompatible.
       Type '"hello"' is not assignable to type 'boolean'.
 tests/cases/conformance/jsx/file.tsx(35,29): error TS2322: Type '{ y1: "hello"; y2: 1000; children: "hi"; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-  Property 'children' does not exist on type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
+  Type '{ y1: "hello"; y2: 1000; children: "hi"; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
+    Types of property 'y1' are incompatible.
+      Type '"hello"' is not assignable to type 'boolean'.
 tests/cases/conformance/jsx/file.tsx(36,29): error TS2322: Type '{ y1: "hello"; y2: 1000; children: string; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-  Property 'children' does not exist on type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
+  Type '{ y1: "hello"; y2: 1000; children: string; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
+    Types of property 'y1' are incompatible.
+      Type '"hello"' is not assignable to type 'boolean'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (11 errors) ====
@@ -48,7 +53,8 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2322: Type '{ y1: "hello"; 
     const c0 = <OneThing extraProp />;  // extra property;
                          ~~~~~~~~~
 !!! error TS2322: Type '{ extraProp: true; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
-!!! error TS2322:   Property 'extraProp' does not exist on type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
+!!! error TS2322:   Type '{ extraProp: true; }' is not assignable to type '{ yy: number; yy1: string; }'.
+!!! error TS2322:     Property 'yy' is missing in type '{ extraProp: true; }'.
     const c1 = <OneThing yy={10}/>;  // missing property;
                          ~~~~~~~
 !!! error TS2322: Type '{ yy: 10; }' is not assignable to type 'IntrinsicAttributes & { yy: number; yy1: string; }'.
@@ -109,9 +115,13 @@ tests/cases/conformance/jsx/file.tsx(36,29): error TS2322: Type '{ y1: "hello"; 
     const e3 = <TestingOptional y1="hello" y2={1000} children="hi" />
                                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ y1: "hello"; y2: 1000; children: "hi"; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:   Property 'children' does not exist on type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
+!!! error TS2322:   Type '{ y1: "hello"; y2: 1000; children: "hi"; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
+!!! error TS2322:     Types of property 'y1' are incompatible.
+!!! error TS2322:       Type '"hello"' is not assignable to type 'boolean'.
     const e4 = <TestingOptional y1="hello" y2={1000}>Hi</TestingOptional>
                                 ~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ y1: "hello"; y2: 1000; children: string; }' is not assignable to type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
-!!! error TS2322:   Property 'children' does not exist on type 'IntrinsicAttributes & { y1: boolean; y2?: number; y3: boolean; }'.
+!!! error TS2322:   Type '{ y1: "hello"; y2: 1000; children: string; }' is not assignable to type '{ y1: boolean; y2?: number; y3: boolean; }'.
+!!! error TS2322:     Types of property 'y1' are incompatible.
+!!! error TS2322:       Type '"hello"' is not assignable to type 'boolean'.
     

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.js
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload4.js
@@ -13,7 +13,7 @@ let obj2: any;
 const c0 = <OneThing extraProp />;  // extra property;
 const c1 = <OneThing yy={10}/>;  // missing property;
 const c2 = <OneThing {...obj} yy1 />; // type incompatible;
-const c3 = <OneThing {...obj} {...{extra: "extra attr"}} />;  // Extra attribute;
+const c3 = <OneThing {...obj} {...{extra: "extra attr"}} />;  //  This is OK becuase all attribute are spread
 const c4 = <OneThing {...obj} y1={10000} />;  // extra property;
 const c5 = <OneThing {...obj} {...{yy: true}} />;  // type incompatible;
 const c6 = <OneThing {...obj2} {...{extra: "extra attr"}} />;  // Should error as there is extra attribute that doesn't match any. Current it is not
@@ -50,7 +50,7 @@ define(["require", "exports", "react"], function (require, exports, React) {
     var c0 = <OneThing extraProp/>; // extra property;
     var c1 = <OneThing yy={10}/>; // missing property;
     var c2 = <OneThing {...obj} yy1/>; // type incompatible;
-    var c3 = <OneThing {...obj} {...{ extra: "extra attr" }}/>; // Extra attribute;
+    var c3 = <OneThing {...obj} {...{ extra: "extra attr" }}/>; //  This is OK becuase all attribute are spread
     var c4 = <OneThing {...obj} y1={10000}/>; // extra property;
     var c5 = <OneThing {...obj} {...{ yy: true }}/>; // type incompatible;
     var c6 = <OneThing {...obj2} {...{ extra: "extra attr" }}/>; // Should error as there is extra attribute that doesn't match any. Current it is not

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
@@ -1,24 +1,31 @@
 tests/cases/conformance/jsx/file.tsx(48,24): error TS2322: Type '{ to: "/some/path"; onClick: (e: MouseEvent<any>) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
   Property 'to' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+tests/cases/conformance/jsx/file.tsx(49,24): error TS2339: Property 'onClick' does not exist on type 'IntrinsicAttributes & HyphenProps'.
 tests/cases/conformance/jsx/file.tsx(49,24): error TS2322: Type '{ to: string; onClick: (e: any) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Property 'to' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+  Type '{ to: string; onClick: (e: any) => void; children: string; }' is not assignable to type 'HyphenProps'.
+    Property '"data-format"' is missing in type '{ to: string; onClick: (e: any) => void; children: string; }'.
 tests/cases/conformance/jsx/file.tsx(50,24): error TS2322: Type '{ onClick: () => void; to: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Property 'onClick' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+  Type '{ onClick: () => void; to: string; }' is not assignable to type 'HyphenProps'.
+    Property '"data-format"' is missing in type '{ onClick: () => void; to: string; }'.
 tests/cases/conformance/jsx/file.tsx(51,24): error TS2322: Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Property 'onClick' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+  Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'HyphenProps'.
+    Property '"data-format"' is missing in type '{ onClick: (k: MouseEvent<any>) => void; to: string; }'.
 tests/cases/conformance/jsx/file.tsx(53,24): error TS2322: Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Property 'to' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+  Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
+    Property '"data-format"' is missing in type '{ to: string; onClick(e: any): void; }'.
 tests/cases/conformance/jsx/file.tsx(54,24): error TS2322: Type '{ children: 10; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Property 'onClick' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+  Type '{ children: 10; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
+    Property '"data-format"' is missing in type '{ children: 10; onClick(e: any): void; }'.
 tests/cases/conformance/jsx/file.tsx(55,24): error TS2322: Type '{ children: "hello"; className: true; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Property 'onClick' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+  Type '{ children: "hello"; className: true; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
+    Property '"data-format"' is missing in type '{ children: "hello"; className: true; onClick(e: any): void; }'.
 tests/cases/conformance/jsx/file.tsx(56,24): error TS2322: Type '{ data-format: true; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
   Type '{ data-format: true; }' is not assignable to type 'HyphenProps'.
     Types of property '"data-format"' are incompatible.
       Type 'true' is not assignable to type 'string'.
 
 
-==== tests/cases/conformance/jsx/file.tsx (8 errors) ====
+==== tests/cases/conformance/jsx/file.tsx (9 errors) ====
     import React = require('react')
     
     export interface ClickableProps {
@@ -71,30 +78,38 @@ tests/cases/conformance/jsx/file.tsx(56,24): error TS2322: Type '{ data-format: 
 !!! error TS2322: Type '{ to: "/some/path"; onClick: (e: MouseEvent<any>) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
 !!! error TS2322:   Property 'to' does not exist on type 'IntrinsicAttributes & HyphenProps'.
     const b1 = <MainButton onClick={(e: any)=> {}} {...obj0}>Hello world</MainButton>;  // extra property;
+                           ~~~~~~~~~~~~~~~~~~~~~~~
+!!! error TS2339: Property 'onClick' does not exist on type 'IntrinsicAttributes & HyphenProps'.
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ to: string; onClick: (e: any) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Property 'to' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+!!! error TS2322:   Type '{ to: string; onClick: (e: any) => void; children: string; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:     Property '"data-format"' is missing in type '{ to: string; onClick: (e: any) => void; children: string; }'.
     const b2 = <MainButton {...{to: "10000"}} {...obj2} />;  // extra property
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ onClick: () => void; to: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Property 'onClick' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+!!! error TS2322:   Type '{ onClick: () => void; to: string; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:     Property '"data-format"' is missing in type '{ onClick: () => void; to: string; }'.
     const b3 = <MainButton {...{to: "10000"}} {...{onClick: (k) => {}}} />;  // extra property
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Property 'onClick' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+!!! error TS2322:   Type '{ onClick: (k: MouseEvent<any>) => void; to: string; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:     Property '"data-format"' is missing in type '{ onClick: (k: MouseEvent<any>) => void; to: string; }'.
     const b4 = <MainButton {...obj3} to />;  // Should error because Incorrect type; but attributes are any so everything is allowed
     const b5 = <MainButton {...{ onClick(e: any) { } }} {...obj0} />;  // Spread retain method declaration (see GitHub #13365), so now there is an extra attributes
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Property 'to' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+!!! error TS2322:   Type '{ to: string; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:     Property '"data-format"' is missing in type '{ to: string; onClick(e: any): void; }'.
     const b6 = <MainButton {...{ onClick(e: any){} }} children={10} />;  // incorrect type for optional attribute
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ children: 10; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Property 'onClick' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+!!! error TS2322:   Type '{ children: 10; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:     Property '"data-format"' is missing in type '{ children: 10; onClick(e: any): void; }'.
     const b7 = <MainButton {...{ onClick(e: any){} }} children="hello" className />;  // incorrect type for optional attribute
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ children: "hello"; className: true; onClick(e: any): void; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Property 'onClick' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+!!! error TS2322:   Type '{ children: "hello"; className: true; onClick(e: any): void; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:     Property '"data-format"' is missing in type '{ children: "hello"; className: true; onClick(e: any): void; }'.
     const b8 = <MainButton data-format />;  // incorrect type for specified hyphanated name
                            ~~~~~~~~~~~
 !!! error TS2322: Type '{ data-format: true; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
@@ -1,5 +1,6 @@
 tests/cases/conformance/jsx/file.tsx(48,24): error TS2322: Type '{ to: "/some/path"; onClick: (e: MouseEvent<any>) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-  Property 'to' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+  Type '{ to: "/some/path"; onClick: (e: MouseEvent<any>) => void; children: string; }' is not assignable to type 'HyphenProps'.
+    Property '"data-format"' is missing in type '{ to: "/some/path"; onClick: (e: MouseEvent<any>) => void; children: string; }'.
 tests/cases/conformance/jsx/file.tsx(49,24): error TS2322: Type '{ to: string; onClick: (e: any) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
   Type '{ to: string; onClick: (e: any) => void; children: string; }' is not assignable to type 'HyphenProps'.
     Property '"data-format"' is missing in type '{ to: string; onClick: (e: any) => void; children: string; }'.
@@ -75,7 +76,8 @@ tests/cases/conformance/jsx/file.tsx(56,24): error TS2322: Type '{ data-format: 
     const b0 = <MainButton to='/some/path' onClick={(e)=>{}}>GO</MainButton>;  // extra property;
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ to: "/some/path"; onClick: (e: MouseEvent<any>) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
-!!! error TS2322:   Property 'to' does not exist on type 'IntrinsicAttributes & HyphenProps'.
+!!! error TS2322:   Type '{ to: "/some/path"; onClick: (e: MouseEvent<any>) => void; children: string; }' is not assignable to type 'HyphenProps'.
+!!! error TS2322:     Property '"data-format"' is missing in type '{ to: "/some/path"; onClick: (e: MouseEvent<any>) => void; children: string; }'.
     const b1 = <MainButton onClick={(e: any)=> {}} {...obj0}>Hello world</MainButton>;  // extra property;
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ to: string; onClick: (e: any) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponentOverload5.errors.txt
@@ -1,6 +1,5 @@
 tests/cases/conformance/jsx/file.tsx(48,24): error TS2322: Type '{ to: "/some/path"; onClick: (e: MouseEvent<any>) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
   Property 'to' does not exist on type 'IntrinsicAttributes & HyphenProps'.
-tests/cases/conformance/jsx/file.tsx(49,24): error TS2339: Property 'onClick' does not exist on type 'IntrinsicAttributes & HyphenProps'.
 tests/cases/conformance/jsx/file.tsx(49,24): error TS2322: Type '{ to: string; onClick: (e: any) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
   Type '{ to: string; onClick: (e: any) => void; children: string; }' is not assignable to type 'HyphenProps'.
     Property '"data-format"' is missing in type '{ to: string; onClick: (e: any) => void; children: string; }'.
@@ -25,7 +24,7 @@ tests/cases/conformance/jsx/file.tsx(56,24): error TS2322: Type '{ data-format: 
       Type 'true' is not assignable to type 'string'.
 
 
-==== tests/cases/conformance/jsx/file.tsx (9 errors) ====
+==== tests/cases/conformance/jsx/file.tsx (8 errors) ====
     import React = require('react')
     
     export interface ClickableProps {
@@ -78,8 +77,6 @@ tests/cases/conformance/jsx/file.tsx(56,24): error TS2322: Type '{ data-format: 
 !!! error TS2322: Type '{ to: "/some/path"; onClick: (e: MouseEvent<any>) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
 !!! error TS2322:   Property 'to' does not exist on type 'IntrinsicAttributes & HyphenProps'.
     const b1 = <MainButton onClick={(e: any)=> {}} {...obj0}>Hello world</MainButton>;  // extra property;
-                           ~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2339: Property 'onClick' does not exist on type 'IntrinsicAttributes & HyphenProps'.
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ to: string; onClick: (e: any) => void; children: string; }' is not assignable to type 'IntrinsicAttributes & HyphenProps'.
 !!! error TS2322:   Type '{ to: string; onClick: (e: any) => void; children: string; }' is not assignable to type 'HyphenProps'.

--- a/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
@@ -1,18 +1,16 @@
 tests/cases/conformance/jsx/file.tsx(19,16): error TS2322: Type '{ naaame: "world"; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
-  Property 'naaame' does not exist on type 'IntrinsicAttributes & { name: string; }'.
+  Type '{ naaame: "world"; }' is not assignable to type '{ name: string; }'.
+    Property 'name' is missing in type '{ naaame: "world"; }'.
 tests/cases/conformance/jsx/file.tsx(27,15): error TS2322: Type '{ name: 42; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
   Type '{ name: 42; }' is not assignable to type '{ name?: string; }'.
     Types of property 'name' are incompatible.
       Type '42' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(29,15): error TS2322: Type '{ naaaaaaame: "no"; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
-  Property 'naaaaaaame' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
+tests/cases/conformance/jsx/file.tsx(29,15): error TS2339: Property 'naaaaaaame' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
 tests/cases/conformance/jsx/file.tsx(34,23): error TS2322: Type '{}' is not assignable to type 'IntrinsicAttributes & { "prop-name": string; }'.
   Type '{}' is not assignable to type '{ "prop-name": string; }'.
     Property '"prop-name"' is missing in type '{}'.
-tests/cases/conformance/jsx/file.tsx(37,23): error TS2322: Type '{ prop1: true; }' is not assignable to type 'IntrinsicAttributes'.
-  Property 'prop1' does not exist on type 'IntrinsicAttributes'.
-tests/cases/conformance/jsx/file.tsx(38,24): error TS2322: Type '{ ref: (x: any) => any; }' is not assignable to type 'IntrinsicAttributes'.
-  Property 'ref' does not exist on type 'IntrinsicAttributes'.
+tests/cases/conformance/jsx/file.tsx(37,23): error TS2339: Property 'prop1' does not exist on type 'IntrinsicAttributes'.
+tests/cases/conformance/jsx/file.tsx(38,24): error TS2339: Property 'ref' does not exist on type 'IntrinsicAttributes'.
 tests/cases/conformance/jsx/file.tsx(41,16): error TS1005: ',' expected.
 
 
@@ -38,7 +36,8 @@ tests/cases/conformance/jsx/file.tsx(41,16): error TS1005: ',' expected.
     let b = <Greet naaame='world' />;
                    ~~~~~~~~~~~~~~
 !!! error TS2322: Type '{ naaame: "world"; }' is not assignable to type 'IntrinsicAttributes & { name: string; }'.
-!!! error TS2322:   Property 'naaame' does not exist on type 'IntrinsicAttributes & { name: string; }'.
+!!! error TS2322:   Type '{ naaame: "world"; }' is not assignable to type '{ name: string; }'.
+!!! error TS2322:     Property 'name' is missing in type '{ naaame: "world"; }'.
     
     // OK
     let c = <Meet />;
@@ -55,8 +54,7 @@ tests/cases/conformance/jsx/file.tsx(41,16): error TS1005: ',' expected.
     // Error
     let f = <Meet naaaaaaame='no' />;
                   ~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ naaaaaaame: "no"; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
-!!! error TS2322:   Property 'naaaaaaame' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
+!!! error TS2339: Property 'naaaaaaame' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
     
     // OK
     let g = <MeetAndGreet prop-name="Bob" />;
@@ -70,12 +68,10 @@ tests/cases/conformance/jsx/file.tsx(41,16): error TS1005: ',' expected.
     // Error
     let i = <EmptyPropSFC prop1 />
                           ~~~~~
-!!! error TS2322: Type '{ prop1: true; }' is not assignable to type 'IntrinsicAttributes'.
-!!! error TS2322:   Property 'prop1' does not exist on type 'IntrinsicAttributes'.
+!!! error TS2339: Property 'prop1' does not exist on type 'IntrinsicAttributes'.
     let i1 = <EmptyPropSFC ref={x => x.greeting.substr(10)} />
                            ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-!!! error TS2322: Type '{ ref: (x: any) => any; }' is not assignable to type 'IntrinsicAttributes'.
-!!! error TS2322:   Property 'ref' does not exist on type 'IntrinsicAttributes'.
+!!! error TS2339: Property 'ref' does not exist on type 'IntrinsicAttributes'.
     
     let o = {
         prop1: true;

--- a/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents1.errors.txt
@@ -14,11 +14,9 @@ tests/cases/conformance/jsx/file.tsx(37,23): error TS2322: Type '{ prop1: true; 
 tests/cases/conformance/jsx/file.tsx(38,24): error TS2322: Type '{ ref: (x: any) => any; }' is not assignable to type 'IntrinsicAttributes'.
   Property 'ref' does not exist on type 'IntrinsicAttributes'.
 tests/cases/conformance/jsx/file.tsx(41,16): error TS1005: ',' expected.
-tests/cases/conformance/jsx/file.tsx(45,24): error TS2322: Type '{ prop1: boolean; }' is not assignable to type 'IntrinsicAttributes'.
-  Property 'prop1' does not exist on type 'IntrinsicAttributes'.
 
 
-==== tests/cases/conformance/jsx/file.tsx (8 errors) ====
+==== tests/cases/conformance/jsx/file.tsx (7 errors) ====
     function EmptyPropSFC() {
         return <div> Default Greeting </div>;
     }
@@ -85,11 +83,8 @@ tests/cases/conformance/jsx/file.tsx(45,24): error TS2322: Type '{ prop1: boolea
 !!! error TS1005: ',' expected.
     }
     
-    // Error
+    // OK as access properties are allow when spread
     let i2 = <EmptyPropSFC {...o} />
-                           ~~~~~~
-!!! error TS2322: Type '{ prop1: boolean; }' is not assignable to type 'IntrinsicAttributes'.
-!!! error TS2322:   Property 'prop1' does not exist on type 'IntrinsicAttributes'.
     
     let o1: any;
     // OK

--- a/tests/baselines/reference/tsxStatelessFunctionComponents1.js
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents1.js
@@ -42,7 +42,7 @@ let o = {
     prop1: true;
 }
 
-// Error
+// OK as access properties are allow when spread
 let i2 = <EmptyPropSFC {...o} />
 
 let o1: any;
@@ -93,7 +93,7 @@ var i1 = <EmptyPropSFC ref={function (x) { return x.greeting.substr(10); }}/>;
 var o = {
     prop1: true
 };
-// Error
+// OK as access properties are allow when spread
 var i2 = <EmptyPropSFC {...o}/>;
 var o1;
 // OK

--- a/tests/baselines/reference/tsxStatelessFunctionComponents2.errors.txt
+++ b/tests/baselines/reference/tsxStatelessFunctionComponents2.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(19,16): error TS2322: Type '{ ref: "myRef"; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
-  Property 'ref' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
+tests/cases/conformance/jsx/file.tsx(19,16): error TS2339: Property 'ref' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
 tests/cases/conformance/jsx/file.tsx(25,42): error TS2339: Property 'subtr' does not exist on type 'string'.
 tests/cases/conformance/jsx/file.tsx(27,33): error TS2339: Property 'notARealProperty' does not exist on type 'BigGreeter'.
 tests/cases/conformance/jsx/file.tsx(35,26): error TS2339: Property 'propertyNotOnHtmlDivElement' does not exist on type 'HTMLDivElement'.
@@ -26,8 +25,7 @@ tests/cases/conformance/jsx/file.tsx(35,26): error TS2339: Property 'propertyNot
     // Error - not allowed to specify 'ref' on SFCs
     let c = <Greet ref="myRef" />;
                    ~~~~~~~~~~~
-!!! error TS2322: Type '{ ref: "myRef"; }' is not assignable to type 'IntrinsicAttributes & { name?: string; }'.
-!!! error TS2322:   Property 'ref' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
+!!! error TS2339: Property 'ref' does not exist on type 'IntrinsicAttributes & { name?: string; }'.
     
     
     // OK - ref is valid for classes

--- a/tests/baselines/reference/tsxUnionElementType4.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType4.errors.txt
@@ -3,10 +3,8 @@ tests/cases/conformance/jsx/file.tsx(32,17): error TS2322: Type '{ x: true; }' i
     Type '{ x: true; }' is not assignable to type '{ x: string; }'.
       Types of property 'x' are incompatible.
         Type 'true' is not assignable to type 'string'.
-tests/cases/conformance/jsx/file.tsx(33,21): error TS2322: Type '{ x: 10; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
-  Property 'x' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
-tests/cases/conformance/jsx/file.tsx(34,22): error TS2322: Type '{ prop: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
-  Property 'prop' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(33,21): error TS2339: Property 'x' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
+tests/cases/conformance/jsx/file.tsx(34,22): error TS2339: Property 'prop' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
 
 
 ==== tests/cases/conformance/jsx/file.tsx (3 errors) ====
@@ -50,10 +48,8 @@ tests/cases/conformance/jsx/file.tsx(34,22): error TS2322: Type '{ prop: true; }
 !!! error TS2322:         Type 'true' is not assignable to type 'string'.
     let b = <PartRCComp x={10} />
                         ~~~~~~
-!!! error TS2322: Type '{ x: 10; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
-!!! error TS2322:   Property 'x' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
+!!! error TS2339: Property 'x' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC4> & { children?: ReactNode; }'.
     let c = <EmptyRCComp prop />;
                          ~~~~
-!!! error TS2322: Type '{ prop: true; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
-!!! error TS2322:   Property 'prop' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
+!!! error TS2339: Property 'prop' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<RC3> & { children?: ReactNode; }'.
     

--- a/tests/baselines/reference/tsxUnionElementType6.errors.txt
+++ b/tests/baselines/reference/tsxUnionElementType6.errors.txt
@@ -1,5 +1,4 @@
-tests/cases/conformance/jsx/file.tsx(18,23): error TS2322: Type '{ x: true; }' is not assignable to type 'IntrinsicAttributes'.
-  Property 'x' does not exist on type 'IntrinsicAttributes'.
+tests/cases/conformance/jsx/file.tsx(18,23): error TS2339: Property 'x' does not exist on type 'IntrinsicAttributes'.
 tests/cases/conformance/jsx/file.tsx(19,27): error TS2322: Type '{ x: "hi"; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.
   Type '{ x: "hi"; }' is not assignable to type '{ x: boolean; }'.
     Types of property 'x' are incompatible.
@@ -32,8 +31,7 @@ tests/cases/conformance/jsx/file.tsx(21,27): error TS2322: Type '{}' is not assi
     // Error
     let a = <EmptySFCComp x />;
                           ~
-!!! error TS2322: Type '{ x: true; }' is not assignable to type 'IntrinsicAttributes'.
-!!! error TS2322:   Property 'x' does not exist on type 'IntrinsicAttributes'.
+!!! error TS2339: Property 'x' does not exist on type 'IntrinsicAttributes'.
     let b = <SFC2AndEmptyComp x="hi" />;
                               ~~~~~~
 !!! error TS2322: Type '{ x: "hi"; }' is not assignable to type 'IntrinsicAttributes & { x: boolean; }'.

--- a/tests/cases/conformance/jsx/checkJsxChildrenProperty12.tsx
+++ b/tests/cases/conformance/jsx/checkJsxChildrenProperty12.tsx
@@ -1,0 +1,28 @@
+// @filename: file.tsx
+// @jsx: preserve
+// @noLib: true
+// @libFiles: react.d.ts,lib.d.ts
+
+import React = require('react');
+
+interface ButtonProp {
+    a: number,
+    b: string,
+    children: Button;
+}
+
+class Button extends React.Component<ButtonProp, any> {
+    render() {
+        return <InnerButton {...this.props} />
+    }
+}
+
+interface InnerButtonProp {
+	a: number
+}
+
+class InnerButton extends React.Component<InnerButtonProp, any> {
+	render() {
+		return (<button>Hello</button>);
+	}
+}

--- a/tests/cases/conformance/jsx/checkJsxChildrenProperty13.tsx
+++ b/tests/cases/conformance/jsx/checkJsxChildrenProperty13.tsx
@@ -13,15 +13,10 @@ interface ButtonProp {
 
 class Button extends React.Component<ButtonProp, any> {
     render() {
-		let condition: boolean;
-		if (condition) {
-        	return <InnerButton {...this.props} />
-		}
-		else {
-			return (<InnerButton {...this.props} >
-				<div>Hello World</div>
-				</InnerButton>);
-		}
+        // Error children are specified twice
+        return (<InnerButton {...this.props} children="hi">
+            <div>Hello World</div>
+            </InnerButton>);
     }
 }
 

--- a/tests/cases/conformance/jsx/tsxAttributeResolution3.tsx
+++ b/tests/cases/conformance/jsx/tsxAttributeResolution3.tsx
@@ -32,7 +32,7 @@ var obj4 = { x: 32, y: 32 };
 var obj5 = { x: 32, y: 32 };
 <test1 x="ok" {...obj5} />
 
-// Error
+// Ok
 var obj6 = { x: 'ok', y: 32, extra: 100 };
 <test1 {...obj6} />
 

--- a/tests/cases/conformance/jsx/tsxSpreadAttributesResolution12.tsx
+++ b/tests/cases/conformance/jsx/tsxSpreadAttributesResolution12.tsx
@@ -32,3 +32,5 @@ let anyobj: any;
 let x = <OverWriteAttr {...obj} y overwrite="hi" {...obj1} />
 let x1 = <OverWriteAttr overwrite="hi" {...obj1} x={3} {...{y: true}} />
 let x2 = <OverWriteAttr {...anyobj} x={3} />
+let x3 = <OverWriteAttr overwrite="hi" {...obj1} {...{y: true}} />
+

--- a/tests/cases/conformance/jsx/tsxSpreadAttributesResolution13.tsx
+++ b/tests/cases/conformance/jsx/tsxSpreadAttributesResolution13.tsx
@@ -1,0 +1,27 @@
+// @filename: file.tsx
+// @jsx: preserve
+// @noLib: true
+// @libFiles: react.d.ts,lib.d.ts
+
+import React = require('react');
+
+interface ComponentProps {
+    property1: string;
+    property2: number;
+}
+
+export default function Component(props: ComponentProps) {
+    return (
+        <AnotherComponent {...props} />
+    );
+}
+
+interface AnotherComponentProps {
+    property1: string;
+}
+
+function AnotherComponent({ property1 }: AnotherComponentProps) {
+    return (
+        <span>{property1}</span>
+    );
+}

--- a/tests/cases/conformance/jsx/tsxSpreadAttributesResolution14.tsx
+++ b/tests/cases/conformance/jsx/tsxSpreadAttributesResolution14.tsx
@@ -1,0 +1,28 @@
+// @filename: file.tsx
+// @jsx: preserve
+// @noLib: true
+// @libFiles: react.d.ts,lib.d.ts
+
+import React = require('react');
+
+interface ComponentProps {
+    property1: string;
+    property2: number;
+}
+
+export default function Component(props: ComponentProps) {
+    return (
+        // Error extra property
+        <AnotherComponent {...props} Property1/>
+    );
+}
+
+interface AnotherComponentProps {
+    property1: string;
+}
+
+function AnotherComponent({ property1 }: AnotherComponentProps) {
+    return (
+        <span>{property1}</span>
+    );
+}

--- a/tests/cases/conformance/jsx/tsxSpreadAttributesResolution15.tsx
+++ b/tests/cases/conformance/jsx/tsxSpreadAttributesResolution15.tsx
@@ -1,0 +1,29 @@
+// @filename: file.tsx
+// @jsx: preserve
+// @noLib: true
+// @libFiles: react.d.ts,lib.d.ts
+
+import React = require('react');
+
+interface ComponentProps {
+    property1: string;
+    property2: number;
+}
+
+export default function Component(props: ComponentProps) {
+    return (
+        <AnotherComponent {...props} property2 AnotherProperty1="hi"/>
+    );
+}
+
+interface AnotherComponentProps {
+    property1: string;
+    AnotherProperty1: string;
+    property2: boolean;
+}
+
+function AnotherComponent({ property1 }: AnotherComponentProps) {
+    return (
+        <span>{property1}</span>
+    );
+}

--- a/tests/cases/conformance/jsx/tsxSpreadAttributesResolution16.tsx
+++ b/tests/cases/conformance/jsx/tsxSpreadAttributesResolution16.tsx
@@ -11,22 +11,19 @@ interface ComponentProps {
 }
 
 export default function Component(props: ComponentProps) {
-    let condition1: boolean;
-    if (condition1) {
-        return (
-            <ChildComponent {...props} />
-        );
-    }
-    else {
-        return (<ChildComponent {...props} property1="NewString" />);
-    }
+    return (
+        // Error: missing property
+        <AnotherComponent {...props} />
+    );
 }
 
 interface AnotherComponentProps {
     property1: string;
+    AnotherProperty1: string;
+    property2: boolean;
 }
 
-function ChildComponent({ property1 }: AnotherComponentProps) {
+function AnotherComponent({ property1 }: AnotherComponentProps) {
     return (
         <span>{property1}</span>
     );

--- a/tests/cases/conformance/jsx/tsxSpreadAttributesResolution2.tsx
+++ b/tests/cases/conformance/jsx/tsxSpreadAttributesResolution2.tsx
@@ -22,3 +22,5 @@ const obj = {};
 let p = <Poisoned {...obj} />;
 let y = <Poisoned />;
 let z = <Poisoned x y/>;
+let w = <Poisoned {...{x: 5, y: "2"}}/>;
+let w1 = <Poisoned {...{x: 5, y: "2"}} X="hi" />;

--- a/tests/cases/conformance/jsx/tsxSpreadAttributesResolution5.tsx
+++ b/tests/cases/conformance/jsx/tsxSpreadAttributesResolution5.tsx
@@ -34,5 +34,5 @@ class EmptyProp extends React.Component<{}, {}> {
 let o = {
     prop1: false
 }
-// Error
+// Ok
 let e = <EmptyProp {...o} />;

--- a/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload4.tsx
+++ b/tests/cases/conformance/jsx/tsxStatelessFunctionComponentOverload4.tsx
@@ -18,7 +18,7 @@ let obj2: any;
 const c0 = <OneThing extraProp />;  // extra property;
 const c1 = <OneThing yy={10}/>;  // missing property;
 const c2 = <OneThing {...obj} yy1 />; // type incompatible;
-const c3 = <OneThing {...obj} {...{extra: "extra attr"}} />;  // Extra attribute;
+const c3 = <OneThing {...obj} {...{extra: "extra attr"}} />;  //  This is OK becuase all attribute are spread
 const c4 = <OneThing {...obj} y1={10000} />;  // extra property;
 const c5 = <OneThing {...obj} {...{yy: true}} />;  // type incompatible;
 const c6 = <OneThing {...obj2} {...{extra: "extra attr"}} />;  // Should error as there is extra attribute that doesn't match any. Current it is not

--- a/tests/cases/conformance/jsx/tsxStatelessFunctionComponents1.tsx
+++ b/tests/cases/conformance/jsx/tsxStatelessFunctionComponents1.tsx
@@ -46,7 +46,7 @@ let o = {
     prop1: true;
 }
 
-// Error
+// OK as access properties are allow when spread
 let i2 = <EmptyPropSFC {...o} />
 
 let o1: any;


### PR DESCRIPTION
Fix #15463 We are now checking attributes according to:

1. Only contain explicitly attributes -> no excess properties allowed

2. Contain spread attributes (even with explicit attributes) -> 1. check type assignability (allow access properties) 2. for each explicit attributes check if the attribute name match the target name.

3. we only report that "children" will get overwritten if it is explicitly specified in the attributes and the element contains JSX.children

- [x] Add more tests