### PR TITLE
Add Log for When Typings Installer Finishes Updating the Types Registry

### DIFF
--- a/src/server/typingsInstaller/nodeTypingsInstaller.ts
+++ b/src/server/typingsInstaller/nodeTypingsInstaller.ts
@@ -96,6 +96,9 @@ namespace ts.server.typingsInstaller {
                     this.log.writeLine(`Updating ${TypesRegistryPackageName} npm package...`);
                 }
                 this.execSync(`${this.npmPath} install ${TypesRegistryPackageName}`, { cwd: globalTypingsCacheLocation, stdio: "ignore" });
+                if (this.log.isEnabled()) {
+                    this.log.writeLine(`Updated ${TypesRegistryPackageName} npm package`);
+                }
             }
             catch (e) {
                 if (this.log.isEnabled()) {


### PR DESCRIPTION
**Bug**
While investigating #15301, I was confused by the typing installer logging `Updating types-registry npm package...`. This was often the last line of the log file, leading me to believe that the types-registry update was still ongoing. After investigating this further, I actually do not think this is the case, but it is hard to tell this from the logs

**Fix**
Add an extra log for when the type-registry update completes successfully

