### PR TITLE
Fix var emit order for converted loops

### DIFF
--- a/src/compiler/transformers/es2015.ts
+++ b/src/compiler/transformers/es2015.ts
@@ -2009,13 +2009,14 @@ namespace ts {
                         }
                         else {
                             assignment = createBinary(<Identifier>decl.name, SyntaxKind.EqualsToken, visitNode(decl.initializer, visitor, isExpression));
+                            setTextRange(assignment, decl);
                         }
 
                         assignments = append(assignments, assignment);
                     }
                 }
                 if (assignments) {
-                    updated = setTextRange(createStatement(reduceLeft(assignments, (acc, v) => createBinary(v, SyntaxKind.CommaToken, acc))), node);
+                    updated = setTextRange(createStatement(inlineExpressions(assignments)), node);
                 }
                 else {
                     // none of declarations has initializer - the entire variable statement can be deleted

--- a/tests/baselines/reference/capturedVarInLoop.js
+++ b/tests/baselines/reference/capturedVarInLoop.js
@@ -1,0 +1,17 @@
+//// [capturedVarInLoop.ts]
+for (var i = 0; i < 10; i++) {
+    var str = 'x', len = str.length;
+    let lambda1 = (y) => { };
+    let lambda2 = () => lambda1(len);
+}
+
+//// [capturedVarInLoop.js]
+var _loop_1 = function () {
+    str = 'x', len = str.length;
+    var lambda1 = function (y) { };
+    var lambda2 = function () { return lambda1(len); };
+};
+var str, len;
+for (var i = 0; i < 10; i++) {
+    _loop_1();
+}

--- a/tests/baselines/reference/capturedVarInLoop.symbols
+++ b/tests/baselines/reference/capturedVarInLoop.symbols
@@ -1,0 +1,22 @@
+=== tests/cases/compiler/capturedVarInLoop.ts ===
+for (var i = 0; i < 10; i++) {
+>i : Symbol(i, Decl(capturedVarInLoop.ts, 0, 8))
+>i : Symbol(i, Decl(capturedVarInLoop.ts, 0, 8))
+>i : Symbol(i, Decl(capturedVarInLoop.ts, 0, 8))
+
+    var str = 'x', len = str.length;
+>str : Symbol(str, Decl(capturedVarInLoop.ts, 1, 7))
+>len : Symbol(len, Decl(capturedVarInLoop.ts, 1, 18))
+>str.length : Symbol(String.length, Decl(lib.d.ts, --, --))
+>str : Symbol(str, Decl(capturedVarInLoop.ts, 1, 7))
+>length : Symbol(String.length, Decl(lib.d.ts, --, --))
+
+    let lambda1 = (y) => { };
+>lambda1 : Symbol(lambda1, Decl(capturedVarInLoop.ts, 2, 7))
+>y : Symbol(y, Decl(capturedVarInLoop.ts, 2, 19))
+
+    let lambda2 = () => lambda1(len);
+>lambda2 : Symbol(lambda2, Decl(capturedVarInLoop.ts, 3, 7))
+>lambda1 : Symbol(lambda1, Decl(capturedVarInLoop.ts, 2, 7))
+>len : Symbol(len, Decl(capturedVarInLoop.ts, 1, 18))
+}

--- a/tests/baselines/reference/capturedVarInLoop.types
+++ b/tests/baselines/reference/capturedVarInLoop.types
@@ -1,0 +1,30 @@
+=== tests/cases/compiler/capturedVarInLoop.ts ===
+for (var i = 0; i < 10; i++) {
+>i : number
+>0 : 0
+>i < 10 : boolean
+>i : number
+>10 : 10
+>i++ : number
+>i : number
+
+    var str = 'x', len = str.length;
+>str : string
+>'x' : "x"
+>len : number
+>str.length : number
+>str : string
+>length : number
+
+    let lambda1 = (y) => { };
+>lambda1 : (y: any) => void
+>(y) => { } : (y: any) => void
+>y : any
+
+    let lambda2 = () => lambda1(len);
+>lambda2 : () => void
+>() => lambda1(len) : () => void
+>lambda1(len) : void
+>lambda1 : (y: any) => void
+>len : number
+}

--- a/tests/cases/compiler/capturedVarInLoop.ts
+++ b/tests/cases/compiler/capturedVarInLoop.ts
@@ -1,0 +1,6 @@
+// @target: es5
+for (var i = 0; i < 10; i++) {
+    var str = 'x', len = str.length;
+    let lambda1 = (y) => { };
+    let lambda2 = () => lambda1(len);
+}


### PR DESCRIPTION
This fixes the `visitVariableStatement` in the es2015 transformer combining the assignment expressions for variables in a converted loop in the wrong order.

Fixes #15603
