### PR TITLE
Add `languages` property to `Navigator` interface

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -8234,6 +8234,7 @@ interface Navigator extends Object, NavigatorID, NavigatorOnLine, NavigatorConte
     readonly cookieEnabled: boolean;
     gamepadInputEmulation: GamepadInputEmulationType;
     readonly language: string;
+    readonly languages?: string[];
     readonly maxTouchPoints: number;
     readonly mimeTypes: MimeTypeArray;
     readonly msManipulationViewsEnabled: boolean;


### PR DESCRIPTION
<!--

Thank you for submitting a pull request!

Here's a checklist you might find useful.
[-] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[+] Code is up-to-date with the `master` branch
[+] You've successfully run `jake runtests` locally
[-] You've signed the CLA
[-] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

`window.navigator.languages` is already supported on [some mainstream browsers](https://developer.mozilla.org/en/docs/Web/API/NavigatorLanguage/languages) and is **ESSENTIAL** for frontend to determine which interface language users prefer. For example, on Chrome, `navigator.languages[0]` indicates a more proper language option than `navigator.language`.
Please consider adding this property. Thank you!
