### PR TITLE
Remove check for static from checkKindsOfPropertyMemberOverrides, which is only called on instance side

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -20678,11 +20678,6 @@ namespace ts {
                             continue;
                         }
 
-                        if ((baseDeclarationFlags & ModifierFlags.Static) !== (derivedDeclarationFlags & ModifierFlags.Static)) {
-                            // value of 'static' is not the same for properties - not override, skip it
-                            continue;
-                        }
-
                         if (isMethodLike(base) && isMethodLike(derived) || base.flags & SymbolFlags.PropertyOrAccessor && derived.flags & SymbolFlags.PropertyOrAccessor) {
                             // method is overridden with method or property/accessor is overridden with property/accessor - correct case
                             continue;


### PR DESCRIPTION
Removes some dead code. This method iterates over the members of the class' instance type, so it never reaches any static methods.

This method shouldn't be called on static methods because this is valid code:
```ts
class A {
    static m = () => {}
}

class B extends A {
    static m() {}
}
```

In contrast, without `static`, attempting to override a property with a method is wrong because the property will always be used instead of the method.