### PR TITLE
In addStringLiteralCompletionsFromType, use getBaseConstraintOfType instead of getApparentType

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -204,7 +204,8 @@ namespace ts {
                 // since we are only interested in declarations of the module itself
                 return tryFindAmbientModule(moduleName, /*withAugmentations*/ false);
             },
-            getApparentType
+            getApparentType,
+            getBaseConstraintOfType,
         };
 
         const tupleTypes: GenericType[] = [];

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2552,6 +2552,7 @@ namespace ts {
 
         tryGetMemberInModuleExports(memberName: string, moduleSymbol: Symbol): Symbol | undefined;
         getApparentType(type: Type): Type;
+        /* @internal */ getBaseConstraintOfType(type: Type): Type;
 
         /* @internal */ tryFindAmbientModuleWithoutAugmentations(moduleName: string): Symbol;
 

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -260,7 +260,7 @@ namespace ts.Completions {
 
     function addStringLiteralCompletionsFromType(type: Type, result: Push<CompletionEntry>, typeChecker: TypeChecker): void {
         if (type && type.flags & TypeFlags.TypeParameter) {
-            type = typeChecker.getApparentType(type);
+            type = typeChecker.getBaseConstraintOfType(type);
         }
         if (!type) {
             return;

--- a/tests/cases/fourslash/completionsKeyof.ts
+++ b/tests/cases/fourslash/completionsKeyof.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+////interface A { a: number; };
+////interface B { a: number; b: number; };
+////function f<T extends keyof A>(key: T) {}
+////f("/*f*/");
+////function g<T extends keyof B>(key: T) {}
+////g("/*g*/");
+
+goTo.marker("f");
+verify.completionListCount(1);
+verify.completionListContains("a");
+
+goTo.marker("g");
+verify.completionListCount(2);
+verify.completionListContains("a");
+verify.completionListContains("b");


### PR DESCRIPTION
Fixes #15623

`getApparentType` will transform a string literal type into `String`, so we should use the more specific `getBaseConstraintOfType` instead.