### PR TITLE
Given `import *` of an `export =` module, raise an error but still return a symbol.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1684,10 +1684,9 @@ namespace ts {
         // references a symbol that is at least declared as a module or a variable. The target of the 'export =' may
         // combine other declarations with the module or variable (e.g. a class/module, function/module, interface/variable).
         function resolveESModuleSymbol(moduleSymbol: Symbol, moduleReferenceExpression: Expression, dontResolveAlias: boolean): Symbol {
-            let symbol = resolveExternalModuleSymbol(moduleSymbol, dontResolveAlias);
+            const symbol = resolveExternalModuleSymbol(moduleSymbol, dontResolveAlias);
             if (!dontResolveAlias && symbol && !(symbol.flags & (SymbolFlags.Module | SymbolFlags.Variable))) {
                 error(moduleReferenceExpression, Diagnostics.Module_0_resolves_to_a_non_module_entity_and_cannot_be_imported_using_this_construct, symbolToString(moduleSymbol));
-                symbol = undefined;
             }
             return symbol;
         }

--- a/tests/baselines/reference/es6ExportEqualsInterop.errors.txt
+++ b/tests/baselines/reference/es6ExportEqualsInterop.errors.txt
@@ -14,11 +14,20 @@ tests/cases/compiler/main.ts(36,8): error TS1192: Module '"class-module"' has no
 tests/cases/compiler/main.ts(39,21): error TS2497: Module '"interface"' resolves to a non-module entity and cannot be imported using this construct.
 tests/cases/compiler/main.ts(45,21): error TS2497: Module '"function"' resolves to a non-module entity and cannot be imported using this construct.
 tests/cases/compiler/main.ts(47,21): error TS2497: Module '"class"' resolves to a non-module entity and cannot be imported using this construct.
+tests/cases/compiler/main.ts(50,1): error TS2693: 'y1' only refers to a type, but is being used as a value here.
+tests/cases/compiler/main.ts(56,4): error TS2339: Property 'a' does not exist on type '() => any'.
+tests/cases/compiler/main.ts(58,4): error TS2339: Property 'a' does not exist on type 'typeof Foo'.
+tests/cases/compiler/main.ts(62,10): error TS2305: Module '"interface"' has no exported member 'a'.
 tests/cases/compiler/main.ts(62,25): error TS2497: Module '"interface"' resolves to a non-module entity and cannot be imported using this construct.
+tests/cases/compiler/main.ts(68,10): error TS2305: Module '"function"' has no exported member 'a'.
 tests/cases/compiler/main.ts(68,25): error TS2497: Module '"function"' resolves to a non-module entity and cannot be imported using this construct.
+tests/cases/compiler/main.ts(70,10): error TS2305: Module '"class"' has no exported member 'a'.
 tests/cases/compiler/main.ts(70,25): error TS2497: Module '"class"' resolves to a non-module entity and cannot be imported using this construct.
+tests/cases/compiler/main.ts(85,10): error TS2305: Module '"interface"' has no exported member 'a'.
 tests/cases/compiler/main.ts(85,25): error TS2497: Module '"interface"' resolves to a non-module entity and cannot be imported using this construct.
+tests/cases/compiler/main.ts(91,10): error TS2305: Module '"function"' has no exported member 'a'.
 tests/cases/compiler/main.ts(91,25): error TS2497: Module '"function"' resolves to a non-module entity and cannot be imported using this construct.
+tests/cases/compiler/main.ts(93,10): error TS2305: Module '"class"' has no exported member 'a'.
 tests/cases/compiler/main.ts(93,25): error TS2497: Module '"class"' resolves to a non-module entity and cannot be imported using this construct.
 tests/cases/compiler/main.ts(97,15): error TS2498: Module '"interface"' uses 'export =' and cannot be used with 'export *'.
 tests/cases/compiler/main.ts(98,15): error TS2498: Module '"variable"' uses 'export =' and cannot be used with 'export *'.
@@ -32,7 +41,7 @@ tests/cases/compiler/main.ts(105,15): error TS2498: Module '"class"' uses 'expor
 tests/cases/compiler/main.ts(106,15): error TS2498: Module '"class-module"' uses 'export =' and cannot be used with 'export *'.
 
 
-==== tests/cases/compiler/main.ts (32 errors) ====
+==== tests/cases/compiler/main.ts (41 errors) ====
     /// <reference path="modules.d.ts"/>
     
     // import-equals
@@ -115,18 +124,26 @@ tests/cases/compiler/main.ts(106,15): error TS2498: Module '"class-module"' uses
     import * as y0 from "class-module";
     
     y1.a;
+    ~~
+!!! error TS2693: 'y1' only refers to a type, but is being used as a value here.
     y2.a;
     y3.a;
     y4.a;
     y5.a;
     y6.a;
     y7.a;
+       ~
+!!! error TS2339: Property 'a' does not exist on type '() => any'.
     y8.a;
     y9.a;
+       ~
+!!! error TS2339: Property 'a' does not exist on type 'typeof Foo'.
     y0.a;
     
     // named import
     import { a as a1 } from "interface";
+             ~
+!!! error TS2305: Module '"interface"' has no exported member 'a'.
                             ~~~~~~~~~~~
 !!! error TS2497: Module '"interface"' resolves to a non-module entity and cannot be imported using this construct.
     import { a as a2 } from "variable";
@@ -135,10 +152,14 @@ tests/cases/compiler/main.ts(106,15): error TS2498: Module '"class-module"' uses
     import { a as a5 } from "interface-module";
     import { a as a6 } from "variable-module";
     import { a as a7 } from "function";
+             ~
+!!! error TS2305: Module '"function"' has no exported member 'a'.
                             ~~~~~~~~~~
 !!! error TS2497: Module '"function"' resolves to a non-module entity and cannot be imported using this construct.
     import { a as a8 } from "function-module";
     import { a as a9 } from "class";
+             ~
+!!! error TS2305: Module '"class"' has no exported member 'a'.
                             ~~~~~~~
 !!! error TS2497: Module '"class"' resolves to a non-module entity and cannot be imported using this construct.
     import { a as a0 } from "class-module";
@@ -156,6 +177,8 @@ tests/cases/compiler/main.ts(106,15): error TS2498: Module '"class-module"' uses
     
     // named export
     export { a as a1 } from "interface";
+             ~
+!!! error TS2305: Module '"interface"' has no exported member 'a'.
                             ~~~~~~~~~~~
 !!! error TS2497: Module '"interface"' resolves to a non-module entity and cannot be imported using this construct.
     export { a as a2 } from "variable";
@@ -164,10 +187,14 @@ tests/cases/compiler/main.ts(106,15): error TS2498: Module '"class-module"' uses
     export { a as a5 } from "interface-module";
     export { a as a6 } from "variable-module";
     export { a as a7 } from "function";
+             ~
+!!! error TS2305: Module '"function"' has no exported member 'a'.
                             ~~~~~~~~~~
 !!! error TS2497: Module '"function"' resolves to a non-module entity and cannot be imported using this construct.
     export { a as a8 } from "function-module";
     export { a as a9 } from "class";
+             ~
+!!! error TS2305: Module '"class"' has no exported member 'a'.
                             ~~~~~~~
 !!! error TS2497: Module '"class"' resolves to a non-module entity and cannot be imported using this construct.
     export { a as a0 } from "class-module";

--- a/tests/baselines/reference/es6ExportEqualsInterop.js
+++ b/tests/baselines/reference/es6ExportEqualsInterop.js
@@ -232,8 +232,6 @@ z7.a;
 z8.a;
 z9.a;
 z0.a;
-// namespace import
-var y1 = require("interface");
 var y2 = require("variable");
 var y3 = require("interface-variable");
 var y4 = require("module");

--- a/tests/cases/fourslash/signatureHelpImportStarFromExportEquals.ts
+++ b/tests/cases/fourslash/signatureHelpImportStarFromExportEquals.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+
+// @Filename: /node_modules/@types/abs/index.d.ts
+////declare function abs(str: string): string;
+////export = abs;
+
+// @Filename: /a.js
+////import * as abs from "abs";
+////abs/**/;
+
+goTo.marker();
+edit.insert('(');
+verify.currentSignatureHelpIs('abs(str: string): string');


### PR DESCRIPTION
Fixes #12923 
We need the symbol information to provide services in JS code. I don't think there's any harm in providing that?