### PR TITLE
findAllReferences: Don't need to check for `symbol.declarations`

### DIFF
--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -108,10 +108,6 @@ namespace ts.FindAllReferences {
             switch (def.type) {
                 case "symbol": {
                     const { symbol, node } = def;
-                    const declarations = symbol.declarations;
-                    if (!declarations || declarations.length === 0) {
-                        return undefined;
-                    }
                     const { displayParts, kind } = getDefinitionKindAndDisplayParts(symbol, node, checker);
                     const name = displayParts.map(p => p.text).join("");
                     return { node, name, kind, displayParts };
@@ -273,7 +269,7 @@ namespace ts.FindAllReferences.Core {
             }
         }
 
-        let symbol = checker.getSymbolAtLocation(node);
+        const symbol = checker.getSymbolAtLocation(node);
 
         // Could not find a symbol e.g. unknown identifier
         if (!symbol) {
@@ -282,14 +278,6 @@ namespace ts.FindAllReferences.Core {
                 return getReferencesForStringLiteral(<StringLiteral>node, sourceFiles, cancellationToken);
             }
             // Can't have references to something that we have no symbol for.
-            return undefined;
-        }
-
-        // If this property is derived from another one, find references on the original property instead.
-        symbol = (symbol as ts.SymbolLinks).syntheticOrigin || symbol;
-
-        // The symbol was an internal symbol and does not have a declaration e.g. undefined symbol
-        if (!symbol.declarations || !symbol.declarations.length) {
             return undefined;
         }
 

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -273,7 +273,7 @@ namespace ts.FindAllReferences.Core {
             }
         }
 
-        const symbol = checker.getSymbolAtLocation(node);
+        let symbol = checker.getSymbolAtLocation(node);
 
         // Could not find a symbol e.g. unknown identifier
         if (!symbol) {
@@ -284,6 +284,9 @@ namespace ts.FindAllReferences.Core {
             // Can't have references to something that we have no symbol for.
             return undefined;
         }
+
+        // If this property is derived from another one, find references on the original property instead.
+        symbol = (symbol as ts.SymbolLinks).syntheticOrigin || symbol;
 
         // The symbol was an internal symbol and does not have a declaration e.g. undefined symbol
         if (!symbol.declarations || !symbol.declarations.length) {

--- a/tests/cases/fourslash/findAllRefsMappedType.ts
+++ b/tests/cases/fourslash/findAllRefsMappedType.ts
@@ -7,4 +7,9 @@
 ////declare const u: U;
 ////u.[|a|];
 
-verify.singleReferenceGroup("(property) T.a: number");
+const ranges = test.ranges();
+const [r0, r1, r2] = ranges;
+verify.referenceGroups([r0, r1], [{ definition: "(property) T.a: number", ranges }]);
+verify.referenceGroups(r2, [
+    { definition: "(property) T.a: number", ranges: [r0, r1] },
+    { definition: "(property) a: string", ranges: [r2] }]);

--- a/tests/cases/fourslash/findAllRefsMappedType.ts
+++ b/tests/cases/fourslash/findAllRefsMappedType.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts'/>
+
+////interface T { [|{| "isWriteAccess": true, "isDefinition": true |}a|]: number; }
+////type U = { readonly [K in keyof T]?: string };
+////declare const t: T;
+////t.[|a|];
+////declare const u: U;
+////u.[|a|];
+
+verify.singleReferenceGroup("(property) T.a: number");


### PR DESCRIPTION
Fixes #13690

