### PR TITLE
Remove ThisKeyword from list of keyword types; we use ThisTypeNode for that instead.

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -2358,7 +2358,7 @@ namespace ts {
                             context.encounteredError = true;
                         }
                     }
-                    return createThis();
+                    return createThisTypeNode();
                 }
 
                 const objectFlags = getObjectFlags(type);
@@ -7615,7 +7615,6 @@ namespace ts {
                 case SyntaxKind.ObjectKeyword:
                     return nonPrimitiveType;
                 case SyntaxKind.ThisType:
-                case SyntaxKind.ThisKeyword:
                     return getTypeFromThisTypeNode(node);
                 case SyntaxKind.LiteralType:
                     return getTypeFromLiteralTypeNode(<LiteralTypeNode>node);
@@ -22184,6 +22183,7 @@ namespace ts {
                     return type.symbol;
 
                 case SyntaxKind.ThisType:
+                case SyntaxKind.ThisKeyword:
                     return getTypeFromTypeNode(<TypeNode>node).symbol;
 
                 case SyntaxKind.ConstructorKeyword:

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -862,7 +862,6 @@ namespace ts {
             | SyntaxKind.BooleanKeyword
             | SyntaxKind.StringKeyword
             | SyntaxKind.SymbolKeyword
-            | SyntaxKind.ThisKeyword
             | SyntaxKind.VoidKeyword
             | SyntaxKind.UndefinedKeyword
             | SyntaxKind.NullKeyword
@@ -1043,7 +1042,7 @@ namespace ts {
         kind: SyntaxKind.TrueKeyword | SyntaxKind.FalseKeyword;
     }
 
-    export interface ThisExpression extends PrimaryExpression, KeywordTypeNode {
+    export interface ThisExpression extends PrimaryExpression {
         kind: SyntaxKind.ThisKeyword;
     }
 


### PR DESCRIPTION
This does make me wonder why we even have a `ThisType` syntax kind, when we don't have e.g. a `NullType`.