### PR TITLE
getOwnPropertyDescriptor return should allow undefined

### DIFF
--- a/src/lib/es2015.proxy.d.ts
+++ b/src/lib/es2015.proxy.d.ts
@@ -3,7 +3,7 @@ interface ProxyHandler<T> {
     setPrototypeOf? (target: T, v: any): boolean;
     isExtensible? (target: T): boolean;
     preventExtensions? (target: T): boolean;
-    getOwnPropertyDescriptor? (target: T, p: PropertyKey): PropertyDescriptor;
+    getOwnPropertyDescriptor? (target: T, p: PropertyKey): PropertyDescriptor | undefined;
     has? (target: T, p: PropertyKey): boolean;
     get? (target: T, p: PropertyKey, receiver: any): any;
     set? (target: T, p: PropertyKey, value: any, receiver: any): boolean;


### PR DESCRIPTION
Fixes #14923 (marked as "Accepting PRs", then fixed, then regressed) and #10904 (remarking on the regression)

getOwnPropertyDescriptor _should_ return undefined in certain situations. This is documented [here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/getOwnPropertyDescriptor).

The [original fix](https://github.com/Microsoft/TypeScript/pull/10550/commits) to 14923 was to the `/lib/lib.es2015.proxy.d.ts` file instead of `/src/lib/lib.es2015.proxy.d.ts`. I think this meant that the change got over-written by a generation script that ran as part of a later commit (see note [here](https://github.com/Microsoft/TypeScript/tree/master/lib)).