### PR TITLE
HTMLMediaElement.play() returns Promise<void>

### DIFF
--- a/lib/lib.dom.d.ts
+++ b/lib/lib.dom.d.ts
@@ -5745,7 +5745,7 @@ interface HTMLMediaElement extends HTMLElement {
     /**
       * Loads and starts playback of a media resource.
       */
-    play(): void;
+    play(): Promise<void>;
     setMediaKeys(mediaKeys: MediaKeys | null): Promise<void>;
     readonly HAVE_CURRENT_DATA: number;
     readonly HAVE_ENOUGH_DATA: number;


### PR DESCRIPTION
* Fix lib.dom.d.ts return type of play from void to Promise<void>

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[x] Code is up-to-date with the `master` branch
[x] You've successfully run `jake runtests` locally
[x] You've signed the CLA
[NA] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #15691
