### PR TITLE
fix #15666: mark file as optional in Diagnostic

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -3355,9 +3355,9 @@ namespace ts {
     }
 
     export interface Diagnostic {
-        file: SourceFile;
-        start: number;
-        length: number;
+        file: SourceFile | undefined;
+        start: number | undefined;
+        length: number | undefined;
         messageText: string | DiagnosticMessageChain;
         category: DiagnosticCategory;
         code: number;

--- a/tests/baselines/reference/APISample_compile.js
+++ b/tests/baselines/reference/APISample_compile.js
@@ -1,6 +1,6 @@
 //// [APISample_compile.ts]
 /*
- * Note: This test is a public API sample. The sample sources can be found 
+ * Note: This test is a public API sample. The sample sources can be found
          at: https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#a-minimal-compiler
  *       Please log a "breaking change" issue for any API breaking change affecting this issue
  */
@@ -18,8 +18,12 @@ export function compile(fileNames: string[], options: ts.CompilerOptions): void 
     var allDiagnostics = ts.getPreEmitDiagnostics(program);
 
     allDiagnostics.forEach(diagnostic => {
-        var { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
         var message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+        if (!diagnostic.file) {
+            console.log(message);
+            return;
+        }
+        var { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!);
         console.log(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
     });
 
@@ -32,6 +36,7 @@ compile(process.argv.slice(2), {
     noEmitOnError: true, noImplicitAny: true,
     target: ts.ScriptTarget.ES5, module: ts.ModuleKind.CommonJS
 });
+
 
 //// [APISample_compile.js]
 "use strict";
@@ -47,8 +52,12 @@ function compile(fileNames, options) {
     var emitResult = program.emit();
     var allDiagnostics = ts.getPreEmitDiagnostics(program);
     allDiagnostics.forEach(function (diagnostic) {
-        var _a = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start), line = _a.line, character = _a.character;
         var message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+        if (!diagnostic.file) {
+            console.log(message);
+            return;
+        }
+        var _a = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start), line = _a.line, character = _a.character;
         console.log(diagnostic.file.fileName + " (" + (line + 1) + "," + (character + 1) + "): " + message);
     });
     var exitCode = emitResult.emitSkipped ? 1 : 0;

--- a/tests/baselines/reference/APISample_watcher.js
+++ b/tests/baselines/reference/APISample_watcher.js
@@ -1,6 +1,6 @@
 //// [APISample_watcher.ts]
 /*
- * Note: This test is a public API sample. The sample sources can be found 
+ * Note: This test is a public API sample. The sample sources can be found
          at: https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#incremental-build-support-using-the-language-services
  *       Please log a "breaking change" issue for any API breaking change affecting this issue
  */
@@ -91,7 +91,7 @@ function watch(rootFileNames: string[], options: ts.CompilerOptions) {
         allDiagnostics.forEach(diagnostic => {
             let message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
             if (diagnostic.file) {
-                let { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+                let { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!);
                 console.log(`  Error ${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
             }
             else {
@@ -107,6 +107,7 @@ const currentDirectoryFiles = fs.readdirSync(process.cwd()).
 
 // Start the watcher
 watch(currentDirectoryFiles, { module: ts.ModuleKind.CommonJS });
+
 
 //// [APISample_watcher.js]
 "use strict";

--- a/tests/cases/compiler/APISample_compile.ts
+++ b/tests/cases/compiler/APISample_compile.ts
@@ -4,7 +4,7 @@
 // @strictNullChecks:true
 
 /*
- * Note: This test is a public API sample. The sample sources can be found 
+ * Note: This test is a public API sample. The sample sources can be found
          at: https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#a-minimal-compiler
  *       Please log a "breaking change" issue for any API breaking change affecting this issue
  */
@@ -22,8 +22,12 @@ export function compile(fileNames: string[], options: ts.CompilerOptions): void 
     var allDiagnostics = ts.getPreEmitDiagnostics(program);
 
     allDiagnostics.forEach(diagnostic => {
-        var { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
         var message = ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n');
+        if (!diagnostic.file) {
+            console.log(message);
+            return;
+        }
+        var { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!);
         console.log(`${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
     });
 

--- a/tests/cases/compiler/APISample_watcher.ts
+++ b/tests/cases/compiler/APISample_watcher.ts
@@ -4,7 +4,7 @@
 // @strictNullChecks:true
 
 /*
- * Note: This test is a public API sample. The sample sources can be found 
+ * Note: This test is a public API sample. The sample sources can be found
          at: https://github.com/Microsoft/TypeScript/wiki/Using-the-Compiler-API#incremental-build-support-using-the-language-services
  *       Please log a "breaking change" issue for any API breaking change affecting this issue
  */
@@ -95,7 +95,7 @@ function watch(rootFileNames: string[], options: ts.CompilerOptions) {
         allDiagnostics.forEach(diagnostic => {
             let message = ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n");
             if (diagnostic.file) {
-                let { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start);
+                let { line, character } = diagnostic.file.getLineAndCharacterOfPosition(diagnostic.start!);
                 console.log(`  Error ${diagnostic.file.fileName} (${line + 1},${character + 1}): ${message}`);
             }
             else {


### PR DESCRIPTION
Fixes #15666 

IMHO, a better alternative is separate `Diagnostic` into `GlobalDiagnostic` which has no file associated and `FileDiagnostic` with source file.
