### PR TITLE
Support find-all-references for a module specifier

### DIFF
--- a/src/compiler/program.ts
+++ b/src/compiler/program.ts
@@ -434,7 +434,8 @@ namespace ts {
             getFileProcessingDiagnostics: () => fileProcessingDiagnostics,
             getResolvedTypeReferenceDirectives: () => resolvedTypeReferenceDirectives,
             isSourceFileFromExternalLibrary,
-            dropDiagnosticsProducingTypeChecker
+            dropDiagnosticsProducingTypeChecker,
+            getSourceFileFromReference,
         };
 
         verifyCompilerOptions();
@@ -1348,46 +1349,58 @@ namespace ts {
             }
         }
 
-        function processSourceFile(fileName: string, isDefaultLib: boolean, refFile?: SourceFile, refPos?: number, refEnd?: number) {
-            let diagnosticArgument: string[];
-            let diagnostic: DiagnosticMessage;
+        /** This should have similar behavior to 'processSourceFile' without diagnostics or mutation. */
+        function getSourceFileFromReference(referencingFile: SourceFile, ref: FileReference): SourceFile | undefined {
+            return getSourceFileFromReferenceWorker(resolveTripleslashReference(ref.fileName, referencingFile.fileName), fileName => filesByName.get(toPath(fileName, currentDirectory, getCanonicalFileName)));
+        }
+
+        function getSourceFileFromReferenceWorker(
+                fileName: string,
+                getSourceFile: (fileName: string) => SourceFile | undefined,
+                fail?: (diagnostic: DiagnosticMessage, ...argument: string[]) => void,
+                refFile?: SourceFile): SourceFile | undefined {
+
             if (hasExtension(fileName)) {
                 if (!options.allowNonTsExtensions && !forEach(supportedExtensions, extension => fileExtensionIs(host.getCanonicalFileName(fileName), extension))) {
-                    diagnostic = Diagnostics.File_0_has_unsupported_extension_The_only_supported_extensions_are_1;
-                    diagnosticArgument = [fileName, "'" + supportedExtensions.join("', '") + "'"];
+                    if (fail) fail(Diagnostics.File_0_has_unsupported_extension_The_only_supported_extensions_are_1, fileName, "'" + supportedExtensions.join("', '") + "'");
+                    return undefined;
                 }
-                else if (!findSourceFile(fileName, toPath(fileName, currentDirectory, getCanonicalFileName), isDefaultLib, refFile, refPos, refEnd)) {
-                    diagnostic = Diagnostics.File_0_not_found;
-                    diagnosticArgument = [fileName];
-                }
-                else if (refFile && host.getCanonicalFileName(fileName) === host.getCanonicalFileName(refFile.fileName)) {
-                    diagnostic = Diagnostics.A_file_cannot_have_a_reference_to_itself;
-                    diagnosticArgument = [fileName];
-                }
-            }
-            else {
-                const nonTsFile: SourceFile = options.allowNonTsExtensions && findSourceFile(fileName, toPath(fileName, currentDirectory, getCanonicalFileName), isDefaultLib, refFile, refPos, refEnd);
-                if (!nonTsFile) {
-                    if (options.allowNonTsExtensions) {
-                        diagnostic = Diagnostics.File_0_not_found;
-                        diagnosticArgument = [fileName];
-                    }
-                    else if (!forEach(supportedExtensions, extension => findSourceFile(fileName + extension, toPath(fileName + extension, currentDirectory, getCanonicalFileName), isDefaultLib, refFile, refPos, refEnd))) {
-                        diagnostic = Diagnostics.File_0_not_found;
-                        fileName += ".ts";
-                        diagnosticArgument = [fileName];
-                    }
-                }
-            }
 
-            if (diagnostic) {
-                if (refFile !== undefined && refEnd !== undefined && refPos !== undefined) {
-                    fileProcessingDiagnostics.add(createFileDiagnostic(refFile, refPos, refEnd - refPos, diagnostic, ...diagnosticArgument));
+                const sourceFile = getSourceFile(fileName);
+                if (fail) {
+                    if (!sourceFile) {
+                        fail(Diagnostics.File_0_not_found, fileName);
+                    }
+                    else if (refFile && host.getCanonicalFileName(fileName) === host.getCanonicalFileName(refFile.fileName)) {
+                        fail(Diagnostics.A_file_cannot_have_a_reference_to_itself, fileName);
+                    }
                 }
-                else {
-                    fileProcessingDiagnostics.add(createCompilerDiagnostic(diagnostic, ...diagnosticArgument));
+                return sourceFile;
+            } else {
+                const sourceFileNoExtension = options.allowNonTsExtensions && getSourceFile(fileName);
+                if (sourceFileNoExtension) return sourceFileNoExtension;
+
+                if (fail && options.allowNonTsExtensions) {
+                    fail(Diagnostics.File_0_not_found, fileName);
+                    return undefined;
                 }
+
+                const sourceFileWithAddedExtension = forEach(supportedExtensions, extension => getSourceFile(fileName + extension));
+                if (fail && !sourceFileWithAddedExtension) fail(Diagnostics.File_0_not_found, fileName + ".ts");
+                return sourceFileWithAddedExtension;
             }
+        }
+
+        /** This has side effects through `findSourceFile`. */
+        function processSourceFile(fileName: string, isDefaultLib: boolean, refFile?: SourceFile, refPos?: number, refEnd?: number): void {
+            getSourceFileFromReferenceWorker(fileName,
+                fileName => findSourceFile(fileName, toPath(fileName, currentDirectory, getCanonicalFileName), isDefaultLib, refFile, refPos, refEnd),
+                (diagnostic, ...args) => {
+                    fileProcessingDiagnostics.add(refFile !== undefined && refEnd !== undefined && refPos !== undefined
+                        ? createFileDiagnostic(refFile, refPos, refEnd - refPos, diagnostic, ...args)
+                        : createCompilerDiagnostic(diagnostic, ...args));
+                },
+                refFile);
         }
 
         function reportFileNamesDifferOnlyInCasingError(fileName: string, existingFileName: string, refFile: SourceFile, refPos: number, refEnd: number): void {

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2411,6 +2411,8 @@ namespace ts {
         /* @internal */ isSourceFileFromExternalLibrary(file: SourceFile): boolean;
         // For testing purposes only.
         /* @internal */ structureIsReused?: StructureIsReused;
+
+        /* @internal */ getSourceFileFromReference(referencingFile: SourceFile, ref: FileReference): SourceFile | undefined;
     }
 
     /* @internal */

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1918,21 +1918,19 @@ namespace ts {
         const isNoDefaultLibRegEx = /^(\/\/\/\s*<reference\s+no-default-lib\s*=\s*)('|")(.+?)\2\s*\/>/gim;
         if (simpleReferenceRegEx.test(comment)) {
             if (isNoDefaultLibRegEx.test(comment)) {
-                return {
-                    isNoDefaultLib: true
-                };
+                return { isNoDefaultLib: true };
             }
             else {
                 const refMatchResult = fullTripleSlashReferencePathRegEx.exec(comment);
                 const refLibResult = !refMatchResult && fullTripleSlashReferenceTypeReferenceDirectiveRegEx.exec(comment);
-                if (refMatchResult || refLibResult) {
-                    const start = commentRange.pos;
-                    const end = commentRange.end;
+                const match = refMatchResult || refLibResult;
+                if (match) {
+                    const pos = commentRange.pos + match[1].length + match[2].length;
                     return {
                         fileReference: {
-                            pos: start,
-                            end: end,
-                            fileName: (refMatchResult || refLibResult)[3]
+                            pos,
+                            end: pos + match[3].length,
+                            fileName: match[3]
                         },
                         isNoDefaultLib: false,
                         isTypeReferenceDirective: !!refLibResult

--- a/src/harness/fourslash.ts
+++ b/src/harness/fourslash.ts
@@ -995,8 +995,7 @@ namespace FourSlash {
 
         public verifyReferenceGroups(startRanges: Range | Range[], parts: Array<{ definition: string, ranges: Range[] }>): void {
             interface ReferenceJson { definition: string; ranges: ts.ReferenceEntry[]; }
-            type ReferencesJson = ReferenceJson[];
-            const fullExpected = parts.map<ReferenceJson>(({ definition, ranges }) => ({ definition, ranges: ranges.map(rangeToReferenceEntry) }));
+            const fullExpected = ts.map(parts, ({ definition, ranges }) => ({ definition, ranges: ranges.map(rangeToReferenceEntry) }));
 
             for (const startRange of toArray(startRanges)) {
                 this.goToRangeStart(startRange);
@@ -1004,7 +1003,7 @@ namespace FourSlash {
                     definition: definition.displayParts.map(d => d.text).join(""),
                     ranges: references
                 }));
-                this.assertObjectsEqual<ReferencesJson>(fullActual, fullExpected);
+                this.assertObjectsEqual(fullActual, fullExpected);
             }
 
             function rangeToReferenceEntry(r: Range): ts.ReferenceEntry {
@@ -1062,6 +1061,14 @@ namespace FourSlash {
                     }
                 }
             };
+            if (fullActual === undefined || fullExpected === undefined) {
+                if (fullActual === fullExpected) {
+                    return;
+                }
+                console.log("Expected:", stringify(fullExpected));
+                console.log("Actual: ", stringify(fullActual));
+                this.raiseError(msgPrefix);
+            }
             recur(fullActual, fullExpected, "");
 
         }

--- a/src/harness/unittests/services/preProcessFile.ts
+++ b/src/harness/unittests/services/preProcessFile.ts
@@ -37,8 +37,8 @@ describe("PreProcessFile:", function () {
                 /*readImportFile*/ true,
                 /*detectJavaScriptImports*/ false,
                 {
-                    referencedFiles: [{ fileName: "refFile1.ts", pos: 0, end: 37 }, { fileName: "refFile2.ts", pos: 38, end: 73 },
-                        { fileName: "refFile3.ts", pos: 74, end: 109 }, { fileName: "..\\refFile4d.ts", pos: 110, end: 150 }],
+                    referencedFiles: [{ fileName: "refFile1.ts", pos: 22, end: 33 }, { fileName: "refFile2.ts", pos: 59, end: 70 },
+                        { fileName: "refFile3.ts", pos: 94, end: 105 }, { fileName: "..\\refFile4d.ts", pos: 131, end: 146 }],
                     importedFiles: <ts.FileReference[]>[],
                     typeReferenceDirectives: [],
                     ambientExternalModules: undefined,
@@ -104,7 +104,7 @@ describe("PreProcessFile:", function () {
                 /*readImportFile*/ true,
                 /*detectJavaScriptImports*/ false,
                 {
-                    referencedFiles: [{ fileName: "refFile1.ts", pos: 0, end: 35 }, { fileName: "refFile2.ts", pos: 36, end: 71 }],
+                    referencedFiles: [{ fileName: "refFile1.ts", pos: 20, end: 31 }, { fileName: "refFile2.ts", pos: 57, end: 68 }],
                     typeReferenceDirectives: [],
                     importedFiles: [{ fileName: "r1.ts", pos: 92, end: 97 }, { fileName: "r2.ts", pos: 121, end: 126 }],
                     ambientExternalModules: undefined,
@@ -117,7 +117,7 @@ describe("PreProcessFile:", function () {
                 /*readImportFile*/ true,
                 /*detectJavaScriptImports*/ false,
                 {
-                    referencedFiles: [{ fileName: "refFile1.ts", pos: 0, end: 35 }],
+                    referencedFiles: [{ fileName: "refFile1.ts", pos: 20, end: 31 }],
                     typeReferenceDirectives: [],
                     importedFiles: [{ fileName: "r1.ts", pos: 91, end: 96 }, { fileName: "r3.ts", pos: 148, end: 153 }],
                     ambientExternalModules: undefined,
@@ -442,12 +442,12 @@ describe("PreProcessFile:", function () {
             /*detectJavaScriptImports*/ false,
             {
                 referencedFiles: [
-                    { "pos": 13, "end": 38, "fileName": "a" },
-                    { "pos": 91, "end": 117, "fileName": "a2" }
+                    { "pos": 34, "end": 35, "fileName": "a" },
+                    { "pos": 112, "end": 114, "fileName": "a2" }
                 ],
                 typeReferenceDirectives: [
-                    { "pos": 51, "end": 78, "fileName": "a1" },
-                    { "pos": 130, "end": 157, "fileName": "a3" }
+                    { "pos": 73, "end": 75, "fileName": "a1" },
+                    { "pos": 152, "end": 154, "fileName": "a3" }
                 ],
                 importedFiles: [],
                 ambientExternalModules: undefined,

--- a/src/services/documentHighlights.ts
+++ b/src/services/documentHighlights.ts
@@ -1,8 +1,8 @@
 /* @internal */
 namespace ts.DocumentHighlights {
-    export function getDocumentHighlights(typeChecker: TypeChecker, cancellationToken: CancellationToken, sourceFile: SourceFile, position: number, sourceFilesToSearch: SourceFile[]): DocumentHighlights[] {
+    export function getDocumentHighlights(program: Program, cancellationToken: CancellationToken, sourceFile: SourceFile, position: number, sourceFilesToSearch: SourceFile[]): DocumentHighlights[] {
         const node = getTouchingWord(sourceFile, position);
-        return node && (getSemanticDocumentHighlights(node, typeChecker, cancellationToken, sourceFilesToSearch) || getSyntacticDocumentHighlights(node, sourceFile));
+        return node && (getSemanticDocumentHighlights(node, program, cancellationToken, sourceFilesToSearch) || getSyntacticDocumentHighlights(node, sourceFile));
     }
 
     function getHighlightSpanForNode(node: Node, sourceFile: SourceFile): HighlightSpan {
@@ -16,8 +16,8 @@ namespace ts.DocumentHighlights {
         };
     }
 
-    function getSemanticDocumentHighlights(node: Node, typeChecker: TypeChecker, cancellationToken: CancellationToken, sourceFilesToSearch: SourceFile[]): DocumentHighlights[] {
-        const referenceEntries = FindAllReferences.getReferenceEntriesForNode(node, sourceFilesToSearch, typeChecker, cancellationToken);
+    function getSemanticDocumentHighlights(node: Node, program: Program, cancellationToken: CancellationToken, sourceFilesToSearch: SourceFile[]): DocumentHighlights[] {
+        const referenceEntries = FindAllReferences.getReferenceEntriesForNode(node, program, sourceFilesToSearch, cancellationToken);
         return referenceEntries && convertReferencedSymbols(referenceEntries);
     }
 

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -334,7 +334,7 @@ namespace ts.FindAllReferences.Core {
                     references.push({ type: "node", node: (decl as ts.ModuleDeclaration).name });
                     break;
                 default:
-                    Debug.assert(false);
+                    Debug.fail("Expected a module symbol to be declared by a SourceFile or ModuleDeclaration.");
             }
         }
 

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -41,14 +41,15 @@ namespace ts.FindAllReferences {
         readonly implementations?: boolean;
     }
 
-    export function findReferencedSymbols(checker: TypeChecker, cancellationToken: CancellationToken, sourceFiles: SourceFile[], sourceFile: SourceFile, position: number): ReferencedSymbol[] | undefined {
-        const referencedSymbols = findAllReferencedSymbols(checker, cancellationToken, sourceFiles, sourceFile, position);
+    export function findReferencedSymbols(program: Program, cancellationToken: CancellationToken, sourceFiles: SourceFile[], sourceFile: SourceFile, position: number): ReferencedSymbol[] | undefined {
+        const referencedSymbols = findAllReferencedSymbols(program, cancellationToken, sourceFiles, sourceFile, position);
 
         if (!referencedSymbols || !referencedSymbols.length) {
             return undefined;
         }
 
         const out: ReferencedSymbol[] = [];
+        const checker = program.getTypeChecker();
         for (const { definition, references } of referencedSymbols) {
             // Only include referenced symbols that have a valid definition.
             if (definition) {
@@ -59,44 +60,46 @@ namespace ts.FindAllReferences {
         return out;
     }
 
-    export function getImplementationsAtPosition(checker: TypeChecker, cancellationToken: CancellationToken, sourceFiles: SourceFile[], sourceFile: SourceFile, position: number): ImplementationLocation[] {
+    export function getImplementationsAtPosition(program: Program, cancellationToken: CancellationToken, sourceFiles: SourceFile[], sourceFile: SourceFile, position: number): ImplementationLocation[] {
         const node = getTouchingPropertyName(sourceFile, position);
-        const referenceEntries = getImplementationReferenceEntries(checker, cancellationToken, sourceFiles, node);
+        const referenceEntries = getImplementationReferenceEntries(program, cancellationToken, sourceFiles, node);
+        const checker = program.getTypeChecker();
         return map(referenceEntries, entry => toImplementationLocation(entry, checker));
     }
 
-    function getImplementationReferenceEntries(typeChecker: TypeChecker, cancellationToken: CancellationToken, sourceFiles: SourceFile[], node: Node): Entry[] | undefined {
+    function getImplementationReferenceEntries(program: Program, cancellationToken: CancellationToken, sourceFiles: SourceFile[], node: Node): Entry[] | undefined {
+        const checker = program.getTypeChecker();
         // If invoked directly on a shorthand property assignment, then return
         // the declaration of the symbol being assigned (not the symbol being assigned to).
         if (node.parent.kind === SyntaxKind.ShorthandPropertyAssignment) {
             const result: NodeEntry[] = [];
-            Core.getReferenceEntriesForShorthandPropertyAssignment(node, typeChecker, node => result.push(nodeEntry(node)));
+            Core.getReferenceEntriesForShorthandPropertyAssignment(node, checker, node => result.push(nodeEntry(node)));
             return result;
         }
         else if (node.kind === SyntaxKind.SuperKeyword || isSuperProperty(node.parent)) {
             // References to and accesses on the super keyword only have one possible implementation, so no
             // need to "Find all References"
-            const symbol = typeChecker.getSymbolAtLocation(node);
+            const symbol = checker.getSymbolAtLocation(node);
             return symbol.valueDeclaration && [nodeEntry(symbol.valueDeclaration)];
         }
         else {
             // Perform "Find all References" and retrieve only those that are implementations
-            return getReferenceEntriesForNode(node, sourceFiles, typeChecker, cancellationToken, { implementations: true });
+            return getReferenceEntriesForNode(node, program, sourceFiles, cancellationToken, { implementations: true });
         }
     }
 
-    export function findReferencedEntries(checker: TypeChecker, cancellationToken: CancellationToken, sourceFiles: SourceFile[], sourceFile: SourceFile, position: number, options?: Options): ReferenceEntry[] | undefined {
-        const x = flattenEntries(findAllReferencedSymbols(checker, cancellationToken, sourceFiles, sourceFile, position, options));
+    export function findReferencedEntries(program: Program, cancellationToken: CancellationToken, sourceFiles: SourceFile[], sourceFile: SourceFile, position: number, options?: Options): ReferenceEntry[] | undefined {
+        const x = flattenEntries(findAllReferencedSymbols(program, cancellationToken, sourceFiles, sourceFile, position, options));
         return map(x, toReferenceEntry);
     }
 
-    export function getReferenceEntriesForNode(node: Node, sourceFiles: SourceFile[], checker: TypeChecker, cancellationToken: CancellationToken, options: Options = {}): Entry[] | undefined {
-        return flattenEntries(Core.getReferencedSymbolsForNode(node, sourceFiles, checker, cancellationToken, options));
+    export function getReferenceEntriesForNode(node: Node, program: Program, sourceFiles: SourceFile[], cancellationToken: CancellationToken, options: Options = {}): Entry[] | undefined {
+        return flattenEntries(Core.getReferencedSymbolsForNode(node, program, sourceFiles, cancellationToken, options));
     }
 
-    function findAllReferencedSymbols(checker: TypeChecker, cancellationToken: CancellationToken, sourceFiles: SourceFile[], sourceFile: SourceFile, position: number, options?: Options): SymbolAndEntries[] | undefined {
+    function findAllReferencedSymbols(program: Program, cancellationToken: CancellationToken, sourceFiles: SourceFile[], sourceFile: SourceFile, position: number, options?: Options): SymbolAndEntries[] | undefined {
         const node = getTouchingPropertyName(sourceFile, position, /*includeJsDocComment*/ true);
-        return Core.getReferencedSymbolsForNode(node, sourceFiles, checker, cancellationToken, options);
+        return Core.getReferencedSymbolsForNode(node, program, sourceFiles, cancellationToken, options);
     }
 
     function flattenEntries(referenceSymbols: SymbolAndEntries[]): Entry[] {
@@ -257,7 +260,7 @@ namespace ts.FindAllReferences {
 /* @internal */
 namespace ts.FindAllReferences.Core {
     /** Core find-all-references algorithm. Handles special cases before delegating to `getReferencedSymbolsForSymbol`. */
-    export function getReferencedSymbolsForNode(node: Node, sourceFiles: SourceFile[], checker: TypeChecker, cancellationToken: CancellationToken, options: Options = {}): SymbolAndEntries[] | undefined {
+    export function getReferencedSymbolsForNode(node: Node, program: Program, sourceFiles: SourceFile[], cancellationToken: CancellationToken, options: Options = {}): SymbolAndEntries[] | undefined {
         if (node.kind === ts.SyntaxKind.SourceFile) {
             return undefined;
         }
@@ -269,6 +272,7 @@ namespace ts.FindAllReferences.Core {
             }
         }
 
+        const checker = program.getTypeChecker();
         const symbol = checker.getSymbolAtLocation(node);
 
         // Could not find a symbol e.g. unknown identifier
@@ -281,7 +285,63 @@ namespace ts.FindAllReferences.Core {
             return undefined;
         }
 
+        if (symbol.flags & SymbolFlags.Module && isModuleReferenceLocation(node)) {
+            return getReferencedSymbolsForModule(program, symbol, sourceFiles);
+        }
+
         return getReferencedSymbolsForSymbol(symbol, node, sourceFiles, checker, cancellationToken, options);
+    }
+
+    function isModuleReferenceLocation(node: ts.Node): boolean {
+        if (node.kind !== SyntaxKind.StringLiteral) {
+            return false;
+        }
+        switch (node.parent.kind) {
+            case SyntaxKind.ModuleDeclaration:
+            case SyntaxKind.ExternalModuleReference:
+            case SyntaxKind.ImportDeclaration:
+            case SyntaxKind.ExportDeclaration:
+                return true;
+            case SyntaxKind.CallExpression:
+                return isRequireCall(node.parent as CallExpression, /*checkArgumentIsStringLiteral*/ false);
+            default:
+                return false;
+        }
+    }
+
+    function getReferencedSymbolsForModule(program: Program, symbol: Symbol, sourceFiles: SourceFile[]): SymbolAndEntries[] {
+        Debug.assert(!!symbol.valueDeclaration);
+
+        const references = findModuleReferences(program, sourceFiles, symbol).map<Entry>(reference => {
+            if (reference.kind === "import") {
+                return { type: "node", node: reference.literal };
+            }
+            else {
+                return {
+                    type: "span",
+                    fileName: reference.referencingFile.fileName,
+                    textSpan: createTextSpanFromRange(reference.ref),
+                };
+            }
+        });
+
+        for (const decl of symbol.declarations) {
+            switch (decl.kind) {
+                case ts.SyntaxKind.SourceFile:
+                    // Don't include the source file itself. (This may not be ideal behavior, but awkward to include an entire file as a reference.)
+                    break;
+                case ts.SyntaxKind.ModuleDeclaration:
+                    references.push({ type: "node", node: (decl as ts.ModuleDeclaration).name });
+                    break;
+                default:
+                    Debug.assert(false);
+            }
+        }
+
+        return [{
+            definition: { type: "symbol", symbol, node: symbol.valueDeclaration },
+            references
+        }];
     }
 
     /** getReferencedSymbols for special node kinds. */

--- a/src/services/goToDefinition.ts
+++ b/src/services/goToDefinition.ts
@@ -266,7 +266,7 @@ namespace ts.GoToDefinition {
 
     function findReferenceInPosition(refs: FileReference[], pos: number): FileReference {
         for (const ref of refs) {
-            if (ref.pos <= pos && pos < ref.end) {
+            if (ref.pos <= pos && pos <= ref.end) {
                 return ref;
             }
         }

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -405,7 +405,7 @@ namespace ts.FindAllReferences {
             case SyntaxKind.ExternalModuleReference:
                 return (decl as ExternalModuleReference).parent;
             default:
-                Debug.assert(false);
+                Debug.fail(`Unexpected module specifier parent: ${decl.kind}`);
         }
     }
 

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -300,6 +300,40 @@ namespace ts.FindAllReferences {
         });
     }
 
+    type ModuleReference =
+        /** "import" also includes require() calls. */
+        | { kind: "import", literal: StringLiteral }
+        /** <reference path> or <reference types> */
+        | { kind: "reference", referencingFile: SourceFile, ref: FileReference };
+    export function findModuleReferences(program: Program, sourceFiles: SourceFile[], searchModuleSymbol: Symbol): ModuleReference[] {
+        const refs: ModuleReference[] = [];
+        const checker = program.getTypeChecker();
+        for (const referencingFile of sourceFiles) {
+            const searchSourceFile = searchModuleSymbol.valueDeclaration;
+            if (searchSourceFile.kind === ts.SyntaxKind.SourceFile) {
+                for (const ref of referencingFile.referencedFiles) {
+                    if (program.getSourceFileFromReference(referencingFile, ref) === searchSourceFile) {
+                        refs.push({ kind: "reference", referencingFile, ref });
+                    }
+                }
+                for (const ref of referencingFile.typeReferenceDirectives) {
+                    const referenced = program.getResolvedTypeReferenceDirectives().get(ref.fileName);
+                    if (referenced !== undefined && referenced.resolvedFileName === (searchSourceFile as ts.SourceFile).fileName) {
+                        refs.push({ kind: "reference", referencingFile, ref });
+                    }
+                }
+            }
+
+            forEachImport(referencingFile, (_importDecl, moduleSpecifier) => {
+                const moduleSymbol = checker.getSymbolAtLocation(moduleSpecifier);
+                if (moduleSymbol === searchModuleSymbol) {
+                    refs.push({ kind: "import", literal: moduleSpecifier });
+                }
+            });
+        }
+        return refs;
+    }
+
     /** Returns a map from a module symbol Id to all import statements that directly reference the module. */
     function getDirectImportsMap(sourceFiles: SourceFile[], checker: TypeChecker, cancellationToken: CancellationToken): Map<ImporterOrCallExpression[]> {
         const map = createMap<ImporterOrCallExpression[]>();

--- a/src/services/services.ts
+++ b/src/services/services.ts
@@ -1416,7 +1416,7 @@ namespace ts {
         /// Goto implementation
         function getImplementationAtPosition(fileName: string, position: number): ImplementationLocation[] {
             synchronizeHostData();
-            return FindAllReferences.getImplementationsAtPosition(program.getTypeChecker(), cancellationToken, program.getSourceFiles(), getValidSourceFile(fileName), position);
+            return FindAllReferences.getImplementationsAtPosition(program, cancellationToken, program.getSourceFiles(), getValidSourceFile(fileName), position);
         }
 
         /// References and Occurrences
@@ -1438,7 +1438,7 @@ namespace ts {
             synchronizeHostData();
             const sourceFilesToSearch = map(filesToSearch, f => program.getSourceFile(f));
             const sourceFile = getValidSourceFile(fileName);
-            return DocumentHighlights.getDocumentHighlights(program.getTypeChecker(), cancellationToken, sourceFile, position, sourceFilesToSearch);
+            return DocumentHighlights.getDocumentHighlights(program, cancellationToken, sourceFile, position, sourceFilesToSearch);
         }
 
         function getOccurrencesAtPositionCore(fileName: string, position: number): ReferenceEntry[] {
@@ -1476,12 +1476,12 @@ namespace ts {
 
         function getReferences(fileName: string, position: number, options?: FindAllReferences.Options) {
             synchronizeHostData();
-            return FindAllReferences.findReferencedEntries(program.getTypeChecker(), cancellationToken, program.getSourceFiles(), getValidSourceFile(fileName), position, options);
+            return FindAllReferences.findReferencedEntries(program, cancellationToken, program.getSourceFiles(), getValidSourceFile(fileName), position, options);
         }
 
         function findReferences(fileName: string, position: number): ReferencedSymbol[] {
             synchronizeHostData();
-            return FindAllReferences.findReferencedSymbols(program.getTypeChecker(), cancellationToken, program.getSourceFiles(), getValidSourceFile(fileName), position);
+            return FindAllReferences.findReferencedSymbols(program, cancellationToken, program.getSourceFiles(), getValidSourceFile(fileName), position);
         }
 
         /// NavigateTo

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -1112,6 +1112,10 @@ namespace ts {
         return createTextSpanFromBounds(node.getStart(sourceFile), node.getEnd());
     }
 
+    export function createTextSpanFromRange(range: TextRange): TextSpan {
+        return createTextSpanFromBounds(range.pos, range.end);
+    }
+
     export function isTypeKeyword(kind: SyntaxKind): boolean {
         switch (kind) {
             case SyntaxKind.AnyKeyword:

--- a/tests/baselines/reference/declarationEmitInvalidReference2.errors.txt
+++ b/tests/baselines/reference/declarationEmitInvalidReference2.errors.txt
@@ -1,8 +1,8 @@
-tests/cases/compiler/declarationEmitInvalidReference2.ts(1,1): error TS6053: File 'tests/cases/compiler/invalid.ts' not found.
+tests/cases/compiler/declarationEmitInvalidReference2.ts(1,22): error TS6053: File 'tests/cases/compiler/invalid.ts' not found.
 
 
 ==== tests/cases/compiler/declarationEmitInvalidReference2.ts (1 errors) ====
     /// <reference path="invalid.ts" />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                         ~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/compiler/invalid.ts' not found.
     var x = 0;

--- a/tests/baselines/reference/invalidTripleSlashReference.errors.txt
+++ b/tests/baselines/reference/invalidTripleSlashReference.errors.txt
@@ -1,13 +1,13 @@
-tests/cases/compiler/invalidTripleSlashReference.ts(1,1): error TS6053: File 'tests/cases/compiler/filedoesnotexist.ts' not found.
-tests/cases/compiler/invalidTripleSlashReference.ts(2,1): error TS6053: File 'tests/cases/compiler/otherdoesnotexist.d.ts' not found.
+tests/cases/compiler/invalidTripleSlashReference.ts(1,22): error TS6053: File 'tests/cases/compiler/filedoesnotexist.ts' not found.
+tests/cases/compiler/invalidTripleSlashReference.ts(2,22): error TS6053: File 'tests/cases/compiler/otherdoesnotexist.d.ts' not found.
 
 
 ==== tests/cases/compiler/invalidTripleSlashReference.ts (2 errors) ====
     /// <reference path='filedoesnotexist.ts'/>
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                         ~~~~~~~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/compiler/filedoesnotexist.ts' not found.
     /// <reference path='otherdoesnotexist.d.ts'/>
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                         ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/compiler/otherdoesnotexist.d.ts' not found.
     
     // this test doesn't actually give the errors you want due to the way the compiler reports errors

--- a/tests/baselines/reference/library-reference-5.errors.txt
+++ b/tests/baselines/reference/library-reference-5.errors.txt
@@ -1,4 +1,4 @@
-/node_modules/bar/index.d.ts(1,1): message TS4090: Conflicting definitions for 'alpha' found at '/node_modules/bar/node_modules/alpha/index.d.ts' and '/node_modules/foo/node_modules/alpha/index.d.ts'. Consider installing a specific version of this library to resolve the conflict.
+/node_modules/bar/index.d.ts(1,23): message TS4090: Conflicting definitions for 'alpha' found at '/node_modules/bar/node_modules/alpha/index.d.ts' and '/node_modules/foo/node_modules/alpha/index.d.ts'. Consider installing a specific version of this library to resolve the conflict.
 
 
 ==== /src/root.ts (0 errors) ====
@@ -16,7 +16,7 @@
     
 ==== /node_modules/bar/index.d.ts (1 errors) ====
     /// <reference types="alpha" />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                          ~~~~~
 !!! message TS4090: Conflicting definitions for 'alpha' found at '/node_modules/bar/node_modules/alpha/index.d.ts' and '/node_modules/foo/node_modules/alpha/index.d.ts'. Consider installing a specific version of this library to resolve the conflict.
     declare var bar: any;
     

--- a/tests/baselines/reference/parserRealSource1.errors.txt
+++ b/tests/baselines/reference/parserRealSource1.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/parserRealSource1.ts(4,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
+tests/cases/conformance/parser/ecmascript5/parserRealSource1.ts(4,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/parserRealSource1.ts (1 errors) ====
@@ -6,7 +6,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource1.ts(4,1): error TS60
     // See LICENSE.txt in the project root for complete license information.
     
     ///<reference path='typescript.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
     
     module TypeScript {

--- a/tests/baselines/reference/parserRealSource10.errors.txt
+++ b/tests/baselines/reference/parserRealSource10.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(4,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
+tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(4,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
 tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(127,33): error TS2449: Class 'TokenInfo' used before its declaration.
 tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(127,42): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
 tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(128,36): error TS2693: 'string' only refers to a type, but is being used as a value here.
@@ -348,7 +348,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource10.ts(449,40): error 
     // See LICENSE.txt in the project root for complete license information.
     
     ///<reference path='typescript.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
     
     module TypeScript {

--- a/tests/baselines/reference/parserRealSource11.errors.txt
+++ b/tests/baselines/reference/parserRealSource11.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(4,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
+tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(4,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(13,22): error TS2304: Cannot find name 'Type'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(14,24): error TS2304: Cannot find name 'ASTFlags'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(17,38): error TS2304: Cannot find name 'CompilerDiagnostics'.
@@ -522,7 +522,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource11.ts(2356,48): error
     // See LICENSE.txt in the project root for complete license information.
     
     ///<reference path='typescript.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
     
     module TypeScript {

--- a/tests/baselines/reference/parserRealSource12.errors.txt
+++ b/tests/baselines/reference/parserRealSource12.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/parserRealSource12.ts(4,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
+tests/cases/conformance/parser/ecmascript5/parserRealSource12.ts(4,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
 tests/cases/conformance/parser/ecmascript5/parserRealSource12.ts(8,19): error TS2304: Cannot find name 'AST'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource12.ts(8,32): error TS2304: Cannot find name 'AST'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource12.ts(8,38): error TS2304: Cannot find name 'AST'.
@@ -214,7 +214,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource12.ts(524,30): error 
     // See LICENSE.txt in the project root for complete license information.
     
     ///<reference path='typescript.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
     
     module TypeScript {

--- a/tests/baselines/reference/parserRealSource13.errors.txt
+++ b/tests/baselines/reference/parserRealSource13.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/parserRealSource13.ts(4,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
+tests/cases/conformance/parser/ecmascript5/parserRealSource13.ts(4,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
 tests/cases/conformance/parser/ecmascript5/parserRealSource13.ts(8,35): error TS2304: Cannot find name 'AST'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource13.ts(9,39): error TS2304: Cannot find name 'AST'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource13.ts(10,34): error TS2304: Cannot find name 'AST'.
@@ -121,7 +121,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource13.ts(135,36): error 
     // See LICENSE.txt in the project root for complete license information.
     
     ///<reference path='typescript.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
     
     module TypeScript.AstWalkerWithDetailCallback {

--- a/tests/baselines/reference/parserRealSource14.errors.txt
+++ b/tests/baselines/reference/parserRealSource14.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/parserRealSource14.ts(4,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
+tests/cases/conformance/parser/ecmascript5/parserRealSource14.ts(4,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
 tests/cases/conformance/parser/ecmascript5/parserRealSource14.ts(24,33): error TS2694: Namespace 'TypeScript' has no exported member 'AST'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource14.ts(38,34): error TS2694: Namespace 'TypeScript' has no exported member 'AST'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource14.ts(48,37): error TS2694: Namespace 'TypeScript' has no exported member 'AST'.
@@ -165,7 +165,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource14.ts(572,20): error 
     // See LICENSE.txt in the project root for complete license information.
     
     ///<reference path='typescript.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
     
     module TypeScript {

--- a/tests/baselines/reference/parserRealSource2.errors.txt
+++ b/tests/baselines/reference/parserRealSource2.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/parserRealSource2.ts(4,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
+tests/cases/conformance/parser/ecmascript5/parserRealSource2.ts(4,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/parserRealSource2.ts (1 errors) ====
@@ -6,7 +6,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource2.ts(4,1): error TS60
     // See LICENSE.txt in the project root for complete license information.
     
     ///<reference path='typescript.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
     
     module TypeScript {

--- a/tests/baselines/reference/parserRealSource3.errors.txt
+++ b/tests/baselines/reference/parserRealSource3.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/parserRealSource3.ts(4,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
+tests/cases/conformance/parser/ecmascript5/parserRealSource3.ts(4,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
 
 
 ==== tests/cases/conformance/parser/ecmascript5/parserRealSource3.ts (1 errors) ====
@@ -6,7 +6,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource3.ts(4,1): error TS60
     // See LICENSE.txt in the project root for complete license information.
     
     ///<reference path='typescript.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
     
     module TypeScript {

--- a/tests/baselines/reference/parserRealSource4.errors.txt
+++ b/tests/baselines/reference/parserRealSource4.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/parserRealSource4.ts(4,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
+tests/cases/conformance/parser/ecmascript5/parserRealSource4.ts(4,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
 tests/cases/conformance/parser/ecmascript5/parserRealSource4.ts(195,37): error TS1150: 'new T[]' cannot be used to create an array. Use 'new Array<T>()' instead.
 
 
@@ -7,7 +7,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource4.ts(195,37): error T
     // See LICENSE.txt in the project root for complete license information.
     
     ///<reference path='typescript.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
     
     module TypeScript {

--- a/tests/baselines/reference/parserRealSource5.errors.txt
+++ b/tests/baselines/reference/parserRealSource5.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/parserRealSource5.ts(4,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
+tests/cases/conformance/parser/ecmascript5/parserRealSource5.ts(4,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
 tests/cases/conformance/parser/ecmascript5/parserRealSource5.ts(14,38): error TS2304: Cannot find name 'ITextWriter'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource5.ts(14,66): error TS2304: Cannot find name 'Parser'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource5.ts(27,17): error TS2304: Cannot find name 'CompilerDiagnostics'.
@@ -15,7 +15,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource5.ts(61,65): error TS
     // See LICENSE.txt in the project root for complete license information.
     
     ///<reference path='typescript.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
     
     module TypeScript {

--- a/tests/baselines/reference/parserRealSource6.errors.txt
+++ b/tests/baselines/reference/parserRealSource6.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(4,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
+tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(4,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
 tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(8,24): error TS2304: Cannot find name 'Script'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(10,41): error TS2304: Cannot find name 'ScopeChain'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(10,69): error TS2304: Cannot find name 'TypeChecker'.
@@ -66,7 +66,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource6.ts(215,20): error T
     // See LICENSE.txt in the project root for complete license information.
     
     ///<reference path='typescript.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
     
     module TypeScript {

--- a/tests/baselines/reference/parserRealSource7.errors.txt
+++ b/tests/baselines/reference/parserRealSource7.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(4,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
+tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(4,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(12,38): error TS2304: Cannot find name 'ASTList'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(12,62): error TS2304: Cannot find name 'TypeLink'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(16,37): error TS2552: Cannot find name 'TypeLink'. Did you mean 'typeLink'?
@@ -308,7 +308,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource7.ts(828,13): error T
     // See LICENSE.txt in the project root for complete license information.
     
     ///<reference path='typescript.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
     
     module TypeScript {

--- a/tests/baselines/reference/parserRealSource8.errors.txt
+++ b/tests/baselines/reference/parserRealSource8.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(4,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
+tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(4,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(9,41): error TS2304: Cannot find name 'ScopeChain'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(10,39): error TS2304: Cannot find name 'TypeFlow'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(11,43): error TS2304: Cannot find name 'ModuleDeclaration'.
@@ -139,7 +139,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource8.ts(454,35): error T
     // See LICENSE.txt in the project root for complete license information.
     
     ///<reference path='typescript.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
     
     module TypeScript {

--- a/tests/baselines/reference/parserRealSource9.errors.txt
+++ b/tests/baselines/reference/parserRealSource9.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(4,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
+tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(4,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(8,38): error TS2304: Cannot find name 'TypeChecker'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(9,48): error TS2304: Cannot find name 'TypeLink'.
 tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(9,67): error TS2304: Cannot find name 'SymbolScope'.
@@ -38,7 +38,7 @@ tests/cases/conformance/parser/ecmascript5/parserRealSource9.ts(200,48): error T
     // See LICENSE.txt in the project root for complete license information.
     
     ///<reference path='typescript.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/typescript.ts' not found.
     
     module TypeScript {

--- a/tests/baselines/reference/parserharness.errors.txt
+++ b/tests/baselines/reference/parserharness.errors.txt
@@ -1,7 +1,7 @@
-tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(16,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/compiler/io.ts' not found.
-tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(17,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/compiler/typescript.ts' not found.
-tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(18,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/services/typescriptServices.ts' not found.
-tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(19,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/RealWorld/diff.ts' not found.
+tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(16,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/compiler/io.ts' not found.
+tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(17,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/compiler/typescript.ts' not found.
+tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(18,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/services/typescriptServices.ts' not found.
+tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(19,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/RealWorld/diff.ts' not found.
 tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(21,29): error TS2694: Namespace 'Harness' has no exported member 'Assert'.
 tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(25,17): error TS2304: Cannot find name 'IIO'.
 tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(41,12): error TS2304: Cannot find name 'ActiveXObject'.
@@ -127,16 +127,16 @@ tests/cases/conformance/parser/ecmascript5/RealWorld/parserharness.ts(2030,32): 
     //
     
     ///<reference path='..\compiler\io.ts'/>
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/compiler/io.ts' not found.
     ///<reference path='..\compiler\typescript.ts'/>
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/compiler/typescript.ts' not found.
     ///<reference path='..\services\typescriptServices.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/services/typescriptServices.ts' not found.
     ///<reference path='diff.ts'/>
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/RealWorld/diff.ts' not found.
     
     declare var assert: Harness.Assert;

--- a/tests/baselines/reference/parserindenter.errors.txt
+++ b/tests/baselines/reference/parserindenter.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/parser/ecmascript5/RealWorld/parserindenter.ts(16,1): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/RealWorld/formatting.ts' not found.
+tests/cases/conformance/parser/ecmascript5/RealWorld/parserindenter.ts(16,21): error TS6053: File 'tests/cases/conformance/parser/ecmascript5/RealWorld/formatting.ts' not found.
 tests/cases/conformance/parser/ecmascript5/RealWorld/parserindenter.ts(20,38): error TS2304: Cannot find name 'ILineIndenationResolver'.
 tests/cases/conformance/parser/ecmascript5/RealWorld/parserindenter.ts(22,33): error TS2304: Cannot find name 'IndentationBag'.
 tests/cases/conformance/parser/ecmascript5/RealWorld/parserindenter.ts(24,42): error TS2304: Cannot find name 'Dictionary_int_int'.
@@ -145,7 +145,7 @@ tests/cases/conformance/parser/ecmascript5/RealWorld/parserindenter.ts(736,38): 
     //
     
     ///<reference path='formatting.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/parser/ecmascript5/RealWorld/formatting.ts' not found.
     
     

--- a/tests/baselines/reference/project/visibilityOfTypeUsedAcrossModules2/amd/visibilityOfTypeUsedAcrossModules2.errors.txt
+++ b/tests/baselines/reference/project/visibilityOfTypeUsedAcrossModules2/amd/visibilityOfTypeUsedAcrossModules2.errors.txt
@@ -1,15 +1,15 @@
-main.ts(1,1): error TS1006: A file cannot have a reference to itself.
-main.ts(2,1): error TS6053: File 'nonExistingFile1.ts' not found.
-main.ts(3,1): error TS6053: File 'nonExistingFile2.ts' not found.
+main.ts(1,22): error TS1006: A file cannot have a reference to itself.
+main.ts(2,22): error TS6053: File 'nonExistingFile1.ts' not found.
+main.ts(3,22): error TS6053: File 'nonExistingFile2.ts' not found.
 
 
 ==== main.ts (3 errors) ====
     /// <reference path="main.ts" />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                         ~~~~~~~
 !!! error TS1006: A file cannot have a reference to itself.
     /// <reference path="nonExistingFile1.ts" />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                         ~~~~~~~~~~~~~~~~~~~
 !!! error TS6053: File 'nonExistingFile1.ts' not found.
     /// <reference path="nonExistingFile2.ts" />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                         ~~~~~~~~~~~~~~~~~~~
 !!! error TS6053: File 'nonExistingFile2.ts' not found.

--- a/tests/baselines/reference/project/visibilityOfTypeUsedAcrossModules2/node/visibilityOfTypeUsedAcrossModules2.errors.txt
+++ b/tests/baselines/reference/project/visibilityOfTypeUsedAcrossModules2/node/visibilityOfTypeUsedAcrossModules2.errors.txt
@@ -1,15 +1,15 @@
-main.ts(1,1): error TS1006: A file cannot have a reference to itself.
-main.ts(2,1): error TS6053: File 'nonExistingFile1.ts' not found.
-main.ts(3,1): error TS6053: File 'nonExistingFile2.ts' not found.
+main.ts(1,22): error TS1006: A file cannot have a reference to itself.
+main.ts(2,22): error TS6053: File 'nonExistingFile1.ts' not found.
+main.ts(3,22): error TS6053: File 'nonExistingFile2.ts' not found.
 
 
 ==== main.ts (3 errors) ====
     /// <reference path="main.ts" />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                         ~~~~~~~
 !!! error TS1006: A file cannot have a reference to itself.
     /// <reference path="nonExistingFile1.ts" />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                         ~~~~~~~~~~~~~~~~~~~
 !!! error TS6053: File 'nonExistingFile1.ts' not found.
     /// <reference path="nonExistingFile2.ts" />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                         ~~~~~~~~~~~~~~~~~~~
 !!! error TS6053: File 'nonExistingFile2.ts' not found.

--- a/tests/baselines/reference/scannertest1.errors.txt
+++ b/tests/baselines/reference/scannertest1.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/conformance/scanner/ecmascript5/scannertest1.ts(1,1): error TS6053: File 'tests/cases/conformance/scanner/ecmascript5/References.ts' not found.
+tests/cases/conformance/scanner/ecmascript5/scannertest1.ts(1,21): error TS6053: File 'tests/cases/conformance/scanner/ecmascript5/References.ts' not found.
 tests/cases/conformance/scanner/ecmascript5/scannertest1.ts(5,21): error TS2304: Cannot find name 'CharacterCodes'.
 tests/cases/conformance/scanner/ecmascript5/scannertest1.ts(5,47): error TS2304: Cannot find name 'CharacterCodes'.
 tests/cases/conformance/scanner/ecmascript5/scannertest1.ts(9,16): error TS2662: Cannot find name 'isDecimalDigit'. Did you mean the static member 'CharacterInfo.isDecimalDigit'?
@@ -18,7 +18,7 @@ tests/cases/conformance/scanner/ecmascript5/scannertest1.ts(20,23): error TS2304
 
 ==== tests/cases/conformance/scanner/ecmascript5/scannertest1.ts (16 errors) ====
     ///<reference path='References.ts' />
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/conformance/scanner/ecmascript5/References.ts' not found.
     
     class CharacterInfo {

--- a/tests/baselines/reference/selfReferencingFile.errors.txt
+++ b/tests/baselines/reference/selfReferencingFile.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/selfReferencingFile.ts(1,1): error TS1006: A file cannot have a reference to itself.
+tests/cases/compiler/selfReferencingFile.ts(1,21): error TS1006: A file cannot have a reference to itself.
 
 
 ==== tests/cases/compiler/selfReferencingFile.ts (1 errors) ====
     ///<reference path='selfReferencingFile.ts'/>
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1006: A file cannot have a reference to itself.
     
     class selfReferencingFile {

--- a/tests/baselines/reference/selfReferencingFile2.errors.txt
+++ b/tests/baselines/reference/selfReferencingFile2.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/selfReferencingFile2.ts(1,1): error TS6053: File 'tests/cases/selfReferencingFile2.ts' not found.
+tests/cases/compiler/selfReferencingFile2.ts(1,21): error TS6053: File 'tests/cases/selfReferencingFile2.ts' not found.
 
 
 ==== tests/cases/compiler/selfReferencingFile2.ts (1 errors) ====
     ///<reference path='../selfReferencingFile2.ts'/>
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS6053: File 'tests/cases/selfReferencingFile2.ts' not found.
     
     class selfReferencingFile2 {

--- a/tests/baselines/reference/selfReferencingFile3.errors.txt
+++ b/tests/baselines/reference/selfReferencingFile3.errors.txt
@@ -1,9 +1,9 @@
-tests/cases/compiler/selfReferencingFile3.ts(1,1): error TS1006: A file cannot have a reference to itself.
+tests/cases/compiler/selfReferencingFile3.ts(1,21): error TS1006: A file cannot have a reference to itself.
 
 
 ==== tests/cases/compiler/selfReferencingFile3.ts (1 errors) ====
     ///<reference path='./selfReferencingFile3.ts'/>
-    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+                        ~~~~~~~~~~~~~~~~~~~~~~~~~
 !!! error TS1006: A file cannot have a reference to itself.
     
     class selfReferencingFile3 {

--- a/tests/cases/fourslash/findAllRefsForModule.ts
+++ b/tests/cases/fourslash/findAllRefsForModule.ts
@@ -1,0 +1,23 @@
+/// <reference path="fourslash.ts" />
+
+// @allowJs: true
+
+// @Filename: /a.ts
+////export const x = 0;
+
+// @Filename: /b.ts
+////import { x } from "[|./a|]";
+
+// @Filename: /c/sub.js
+////const a = require("[|../a|]");
+
+// @Filename: /d.ts
+//// /// <reference path="[|./a|]" />
+
+verify.noErrors();
+
+const ranges = test.ranges();
+const [r0, r1, r2] = ranges;
+verify.referenceGroups([r0, r1], [{ definition: 'module "/a"', ranges: [r0, r2, r1] }]);
+// TODO:GH#15736
+verify.referenceGroups(r2, undefined);

--- a/tests/cases/fourslash/findAllRefsForModuleGlobal.ts
+++ b/tests/cases/fourslash/findAllRefsForModuleGlobal.ts
@@ -1,0 +1,17 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /node_modules/foo/index.d.ts
+////export const x = 0;
+
+// @Filename: /b.ts
+/////// <reference types="[|foo|]" />
+////import { x } from "[|foo|]";
+////declare module "[|{| "isDefinition": true |}foo|]" {}
+
+verify.noErrors();
+
+const ranges = test.ranges();
+const [r0, r1, r2] = ranges;
+verify.referenceGroups([r1, r2], [{ definition: 'module "/node_modules/foo/index"', ranges: [r0, r1, r2] }]);
+// TODO:GH#15736
+verify.referenceGroups(r0, undefined);

--- a/tests/cases/fourslash/getOccurrencesIsDefinitionOfComputedProperty.ts
+++ b/tests/cases/fourslash/getOccurrencesIsDefinitionOfComputedProperty.ts
@@ -6,4 +6,4 @@
 const ranges = test.ranges();
 const [r0, r1, r2] = ranges;
 verify.referenceGroups(r0, [{ definition: '(property) ["foo"]: number', ranges }]);
-verify.referenceGroups([r1, r2], []); // TODO: fix
+verify.referenceGroups([r1, r2], undefined); // TODO: fix

--- a/tests/cases/fourslash/getPreProcessedFile.ts
+++ b/tests/cases/fourslash/getPreProcessedFile.ts
@@ -5,12 +5,12 @@
 //// class D { }
 
 // @Filename: refFile2.ts
-//// export class E {} 
+//// export class E {}
 
 // @Filename: main.ts
 // @ResolveReference: true
 //// ///<reference path="refFile1.ts" />
-//// /*1*////<reference path = "NotExistRef.ts" />/*2*/
+//// ///<reference path = "/*1*/NotExistRef.ts/*2*/" />
 //// /*3*////<reference path "invalidRefFile1.ts" />/*4*/
 //// import ref2 = require("refFile2");
 //// import noExistref2 = require(/*5*/"NotExistRefFile2"/*6*/);

--- a/tests/cases/fourslash/quickInfoForRequire.ts
+++ b/tests/cases/fourslash/quickInfoForRequire.ts
@@ -8,4 +8,3 @@
 
 goTo.marker("1");
 verify.quickInfoIs("module a");
-verify.noReferences();

--- a/tests/cases/fourslash/referencesForAmbients.ts
+++ b/tests/cases/fourslash/referencesForAmbients.ts
@@ -15,7 +15,7 @@
 ////}
 
 const [moduleFoo0, f0, moduleBar0, foo0, moduleFoo1, foo1, f1, moduleBar1, foo2] = test.ranges();
-verify.singleReferenceGroup('module "foo"', [moduleFoo0, moduleFoo1]);
-verify.singleReferenceGroup('module "bar"', [moduleBar0, moduleBar1]);
+verify.singleReferenceGroup('module "foo"', [moduleFoo1, moduleFoo0]);
+verify.singleReferenceGroup('module "bar"', [moduleBar1, moduleBar0]);
 verify.singleReferenceGroup('import foo = require("foo")', [foo0, foo1, foo2]);
 verify.singleReferenceGroup("var f: number", [f0, f1]);

--- a/tests/cases/fourslash/referencesForExternalModuleNames.ts
+++ b/tests/cases/fourslash/referencesForExternalModuleNames.ts
@@ -13,5 +13,4 @@
 
 const ranges = test.ranges();
 const [r0, r1] = ranges;
-verify.referenceGroups(r0, [{ definition: 'module "foo"', ranges }]);
-verify.referenceGroups(r1, [{ definition: 'module f', ranges }]);
+verify.referenceGroups(ranges, [{ definition: 'module "foo"', ranges: [r1, r0] }]);

--- a/tests/cases/fourslash/shims-pp/getPreProcessedFile.ts
+++ b/tests/cases/fourslash/shims-pp/getPreProcessedFile.ts
@@ -5,12 +5,12 @@
 //// class D { }
 
 // @Filename: refFile2.ts
-//// export class E {} 
+//// export class E {}
 
 // @Filename: main.ts
 // @ResolveReference: true
 //// ///<reference path="refFile1.ts" />
-//// /*1*////<reference path = "NotExistRef.ts" />/*2*/
+//// ///<reference path = "/*1*/NotExistRef.ts/*2*/" />
 //// /*3*////<reference path "invalidRefFile1.ts" />/*4*/
 //// import ref2 = require("refFile2");
 //// import noExistref2 = require(/*5*/"NotExistRefFile2"/*6*/);

--- a/tests/cases/fourslash/shims/getPreProcessedFile.ts
+++ b/tests/cases/fourslash/shims/getPreProcessedFile.ts
@@ -5,12 +5,12 @@
 //// class D { }
 
 // @Filename: refFile2.ts
-//// export class E {} 
+//// export class E {}
 
 // @Filename: main.ts
 // @ResolveReference: true
 //// ///<reference path="refFile1.ts" />
-//// /*1*////<reference path = "NotExistRef.ts" />/*2*/
+//// ///<reference path = "/*1*/NotExistRef.ts/*2*/" />
 //// /*3*////<reference path "invalidRefFile1.ts" />/*4*/
 //// import ref2 = require("refFile2");
 //// import noExistref2 = require(/*5*/"NotExistRefFile2"/*6*/);


### PR DESCRIPTION
Fixes #14780

The basic fix is relatively simple if not for `/// <reference paths>` directives.
There was previously no exposed way to find what file it pointed to. Added a method on `Program` to do that. `tryResolveScriptReference` was unreliable as it didn't handle extensions.
This also changes the range for a reference comment to be just the text of the module identifier.
We also now need to pass the `Program` to findAllReferences instead of just the checker.

Does not yet solve #15736.