### PR TITLE
isDeclarationName: Return false for LHS of `import { x as y }` and `e…

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -22254,7 +22254,7 @@ namespace ts {
                 return undefined;
             }
 
-            if (isDeclarationName(node)) {
+            if (isDeclarationNameOrImportPropertyName(node)) {
                 // This is a declaration, call getSymbolOfNode
                 return getSymbolOfNode(node.parent);
             }
@@ -22401,7 +22401,7 @@ namespace ts {
                 return getTypeOfSymbol(symbol);
             }
 
-            if (isDeclarationName(node)) {
+            if (isDeclarationNameOrImportPropertyName(node)) {
                 const symbol = getSymbolAtLocation(node);
                 return symbol && getTypeOfSymbol(symbol);
             }
@@ -24428,6 +24428,21 @@ namespace ts {
                 }
             });
             return result;
+        }
+    }
+
+    /** Like 'isDeclarationName', but returns true for LHS of `import { x as y }` or `export { x as y }`. */
+    function isDeclarationNameOrImportPropertyName(name: Node): boolean {
+        switch (name.parent.kind) {
+            case SyntaxKind.ImportSpecifier:
+            case SyntaxKind.ExportSpecifier:
+                if ((name.parent as ImportOrExportSpecifier).propertyName) {
+                    return true;
+                }
+                // falls through
+            default:
+                return isDeclarationName(name);
+
         }
     }
 }

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -1758,22 +1758,14 @@ namespace ts {
 
     // True if the given identifier, string literal, or number literal is the name of a declaration node
     export function isDeclarationName(name: Node): boolean {
-        if (name.kind !== SyntaxKind.Identifier && name.kind !== SyntaxKind.StringLiteral && name.kind !== SyntaxKind.NumericLiteral) {
-            return false;
+        switch (name.kind) {
+            case SyntaxKind.Identifier:
+            case SyntaxKind.StringLiteral:
+            case SyntaxKind.NumericLiteral:
+                return isDeclaration(name.parent) && name.parent.name === name;
+            default:
+                return false;
         }
-
-        const parent = name.parent;
-        if (parent.kind === SyntaxKind.ImportSpecifier || parent.kind === SyntaxKind.ExportSpecifier) {
-            if ((<ImportOrExportSpecifier>parent).propertyName) {
-                return true;
-            }
-        }
-
-        if (isDeclaration(parent)) {
-            return parent.name === name;
-        }
-
-        return false;
     }
 
     export function getNameOfDeclaration(declaration: Declaration): DeclarationName {

--- a/tests/cases/fourslash/findAllRefsOnImportAliases2.ts
+++ b/tests/cases/fourslash/findAllRefsOnImportAliases2.ts
@@ -1,16 +1,14 @@
 /// <reference path="fourslash.ts" />
 
 //@Filename: a.ts
-////export class [|{| "isWriteAccess": true, "isDefinition": true |}Class|] {
-////}
+////export class [|{| "isWriteAccess": true, "isDefinition": true |}Class|] {}
 
 //@Filename: b.ts
-////import { [|{| "isWriteAccess": true, "isDefinition": true |}Class|] as [|{| "isWriteAccess": true, "isDefinition": true |}C2|] } from "./a";
-////
+////import { [|Class|] as [|{| "isWriteAccess": true, "isDefinition": true |}C2|] } from "./a";
 ////var c = new [|C2|]();
 
 //@Filename: c.ts
-////export { [|{| "isWriteAccess": true, "isDefinition": true |}Class|] as [|{| "isWriteAccess": true, "isDefinition": true |}C3|] } from "./a";
+////export { [|Class|] as [|{| "isWriteAccess": true, "isDefinition": true |}C3|] } from "./a";
 
 const ranges = test.rangesByText();
 const classRanges = ranges.get("Class");

--- a/tests/cases/fourslash/findAllRefsReExportLocal.ts
+++ b/tests/cases/fourslash/findAllRefsReExportLocal.ts
@@ -5,7 +5,7 @@
 // @Filename: /a.ts
 ////var [|{| "isWriteAccess": true, "isDefinition": true |}x|];
 ////export { [|{| "isWriteAccess": true, "isDefinition": true |}x|] };
-////export { [|{| "isWriteAccess": true, "isDefinition": true |}x|] as [|{| "isWriteAccess": true, "isDefinition": true |}y|] };
+////export { [|x|] as [|{| "isWriteAccess": true, "isDefinition": true |}y|] };
 
 // @Filename: /b.ts
 ////import { [|{| "isWriteAccess": true, "isDefinition": true |}x|], [|{| "isWriteAccess": true, "isDefinition": true |}y|] } from "./a";

--- a/tests/cases/fourslash/findAllRefsReExports.ts
+++ b/tests/cases/fourslash/findAllRefsReExports.ts
@@ -4,10 +4,10 @@
 ////export function [|{| "isWriteAccess": true, "isDefinition": true |}foo|](): void {}
 
 // @Filename: /b.ts
-////export { [|{| "isWriteAccess": true, "isDefinition": true |}foo|] as [|{| "isWriteAccess": true, "isDefinition": true |}bar|] } from "./a";
+////export { [|foo|] as [|{| "isWriteAccess": true, "isDefinition": true |}bar|] } from "./a";
 
 // @Filename: /c.ts
-////export { [|{| "isWriteAccess": true, "isDefinition": true |}foo|] as [|{| "isWriteAccess": true, "isDefinition": true |}default|] } from "./a";
+////export { [|foo|] as [|{| "isWriteAccess": true, "isDefinition": true |}default|] } from "./a";
 
 // @Filename: /d.ts
 ////export { [|{| "isWriteAccess": true, "isDefinition": true |}default|] } from "./c";
@@ -15,7 +15,7 @@
 // @Filename: /e.ts
 ////import { [|{| "isWriteAccess": true, "isDefinition": true |}bar|] } from "./b";
 ////import [|{| "isWriteAccess": true, "isDefinition": true |}baz|] from "./c";
-////import { [|{| "isWriteAccess": true, "isDefinition": true |}default|] as [|{| "isWriteAccess": true, "isDefinition": true |}bang|] } from "./c";
+////import { [|default|] as [|{| "isWriteAccess": true, "isDefinition": true |}bang|] } from "./c";
 ////import [|{| "isWriteAccess": true, "isDefinition": true |}boom|] from "./d";
 ////[|bar|](); [|baz|](); [|bang|](); [|boom|]();
 

--- a/tests/cases/fourslash/findAllRefsReExports2.ts
+++ b/tests/cases/fourslash/findAllRefsReExports2.ts
@@ -1,0 +1,14 @@
+/// <reference path="fourslash.ts" />
+
+// @Filename: /a.ts
+////export function [|{| "isWriteAccess": true, "isDefinition": true |}foo|](): void {}
+
+// @Filename: /b.ts
+////import { [|foo|] as [|{| "isWriteAccess": true, "isDefinition": true |}oof|] } from "./a";
+
+verify.noErrors();
+const [r0, r1, r2] = test.ranges();
+verify.referenceGroups(r0, [
+    { definition: "function foo(): void", ranges: [r0, r1] },
+    { definition: "import oof", ranges: [r2] }
+]);

--- a/tests/cases/fourslash/findAllRefsRenameImportWithSameName.ts
+++ b/tests/cases/fourslash/findAllRefsRenameImportWithSameName.ts
@@ -4,7 +4,7 @@
 ////export const [|{| "isWriteAccess": true, "isDefinition": true |}x|] = 0;
 
 //@Filename: /b.ts
-////import { [|{| "isWriteAccess": true, "isDefinition": true |}x|] as [|{| "isWriteAccess": true, "isDefinition": true |}x|] } from "./a";
+////import { [|x|] as [|{| "isWriteAccess": true, "isDefinition": true |}x|] } from "./a";
 ////[|x|];
 
 verify.noErrors();

--- a/tests/cases/fourslash/renameImportOfExportEquals2.ts
+++ b/tests/cases/fourslash/renameImportOfExportEquals2.ts
@@ -8,10 +8,10 @@
 ////}
 ////declare module "a" {
 ////    import * as [|{| "isWriteAccess": true, "isDefinition": true |}O|] from "mod";
-////    export { [|{| "isWriteAccess": true, "isDefinition": true |}O|] as [|{| "isWriteAccess": true, "isDefinition": true |}P|] }; // Renaming N here would rename
+////    export { [|O|] as [|{| "isWriteAccess": true, "isDefinition": true |}P|] }; // Renaming N here would rename
 ////}
 ////declare module "b" {
-////    import { [|{| "isWriteAccess": true, "isDefinition": true |}P|] as [|{| "isWriteAccess": true, "isDefinition": true |}Q|] } from "a";
+////    import { [|P|] as [|{| "isWriteAccess": true, "isDefinition": true |}Q|] } from "a";
 ////    export const y: typeof [|Q|].x;
 ////}
 

--- a/tests/cases/fourslash/renameImportOfReExport2.ts
+++ b/tests/cases/fourslash/renameImportOfReExport2.ts
@@ -4,7 +4,7 @@
 ////    export class [|{| "isWriteAccess": true, "isDefinition": true |}C|] {}
 ////}
 ////declare module "b" {
-////    export { [|{| "isWriteAccess": true, "isDefinition": true |}C|] as [|{| "isWriteAccess": true, "isDefinition": true |}D|] } from "a";
+////    export { [|C|] as [|{| "isWriteAccess": true, "isDefinition": true |}D|] } from "a";
 ////}
 ////declare module "c" {
 ////    import { [|{| "isWriteAccess": true, "isDefinition": true |}D|] } from "b";

--- a/tests/cases/fourslash/transitiveExportImports3.ts
+++ b/tests/cases/fourslash/transitiveExportImports3.ts
@@ -4,7 +4,7 @@
 ////export function [|{| "isWriteAccess": true, "isDefinition": true |}f|]() {}
 
 // @Filename: b.ts
-////export { [|{| "isWriteAccess": true, "isDefinition": true |}f|] as [|{| "isWriteAccess": true, "isDefinition": true |}g|] } from "./a";
+////export { [|f|] as [|{| "isWriteAccess": true, "isDefinition": true |}g|] } from "./a";
 ////import { [|{| "isWriteAccess": true, "isDefinition": true |}f|] } from "./a";
 ////import { [|{| "isWriteAccess": true, "isDefinition": true |}g|] } from "./b";
 


### PR DESCRIPTION
Fixes #14005.
`x` in `import { x as y }` isn't the name of the declaration, `y` is.
Two places in `checker.ts` rely on the old behavior, so created `isDeclarationNameOrImportPropertyName` for those cases.
