### PR TITLE
An enum should include a Namespace SemanticMeaning, and an enum member should have Type SemanticMeaning

### DIFF
--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -21,7 +21,6 @@ namespace ts {
             case SyntaxKind.PropertySignature:
             case SyntaxKind.PropertyAssignment:
             case SyntaxKind.ShorthandPropertyAssignment:
-            case SyntaxKind.EnumMember:
             case SyntaxKind.MethodDeclaration:
             case SyntaxKind.MethodSignature:
             case SyntaxKind.Constructor:
@@ -40,6 +39,7 @@ namespace ts {
             case SyntaxKind.TypeLiteral:
                 return SemanticMeaning.Type;
 
+            case SyntaxKind.EnumMember:
             case SyntaxKind.ClassDeclaration:
                 return SemanticMeaning.Value | SemanticMeaning.Type;
 
@@ -63,7 +63,7 @@ namespace ts {
             case SyntaxKind.ImportDeclaration:
             case SyntaxKind.ExportAssignment:
             case SyntaxKind.ExportDeclaration:
-                return SemanticMeaning.Value | SemanticMeaning.Type | SemanticMeaning.Namespace;
+                return SemanticMeaning.All;
 
             // An external module can be a Value
             case SyntaxKind.SourceFile:

--- a/src/services/utilities.ts
+++ b/src/services/utilities.ts
@@ -41,8 +41,10 @@ namespace ts {
                 return SemanticMeaning.Type;
 
             case SyntaxKind.ClassDeclaration:
-            case SyntaxKind.EnumDeclaration:
                 return SemanticMeaning.Value | SemanticMeaning.Type;
+
+            case SyntaxKind.EnumDeclaration:
+                return SemanticMeaning.All;
 
             case SyntaxKind.ModuleDeclaration:
                 if (isAmbientModule(<ModuleDeclaration>node)) {

--- a/tests/cases/fourslash/findAllRefsEnumAsNamespace.ts
+++ b/tests/cases/fourslash/findAllRefsEnumAsNamespace.ts
@@ -1,0 +1,6 @@
+/// <reference path='fourslash.ts' />
+
+////enum [|{| "isWriteAccess": true, "isDefinition": true |}E|] { A }
+////let e: [|E|].A;
+
+verify.singleReferenceGroup("enum E");

--- a/tests/cases/fourslash/findAllRefsEnumMember.ts
+++ b/tests/cases/fourslash/findAllRefsEnumMember.ts
@@ -1,0 +1,6 @@
+/// <reference path="fourslash.ts"/>
+
+////enum E { [|{| "isWriteAccess": true, "isDefinition": true |}A|], B }
+////const e: E.[|A|] = E.[|A|];
+
+verify.singleReferenceGroup("(enum member) E.A = 0");


### PR DESCRIPTION
Fixes #14427, #10732, and #11574.
We weren't detecting the reference because in `let e: E.A`, `E` has `Namespace` meaning, but we only considered the declaration `enum E {}` to have `Value | Type` meaning.
Also, `E.A` should have `Type` meaning in addition to `Value`.