### PR TITLE
Fix bug for goto-definition on a TSX constructor using an alias declaration

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -12755,7 +12755,7 @@ namespace ts {
          * @param node the expression whose contextual type will be returned.
          * @returns the contextual type of an expression.
          */
-        function getContextualType(node: Expression): Type {
+        function getContextualType(node: Expression): Type | undefined {
             if (isInsideWithStatementBody(node)) {
                 // We cannot answer semantic questions within a with block, do not proceed any further
                 return undefined;

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2528,7 +2528,7 @@ namespace ts {
         getFullyQualifiedName(symbol: Symbol): string;
         getAugmentedPropertiesOfType(type: Type): Symbol[];
         getRootSymbols(symbol: Symbol): Symbol[];
-        getContextualType(node: Expression): Type;
+        getContextualType(node: Expression): Type | undefined;
         getResolvedSignature(node: CallLikeExpression, candidatesOutArray?: Signature[]): Signature;
         getSignatureFromDeclaration(declaration: SignatureDeclaration): Signature;
         isImplementationOfOverload(node: FunctionLikeDeclaration): boolean;

--- a/tests/cases/fourslash/tsxGoToDefinitionClassInDifferentFile.ts
+++ b/tests/cases/fourslash/tsxGoToDefinitionClassInDifferentFile.ts
@@ -1,0 +1,15 @@
+/// <reference path="fourslash.ts" />
+
+// @jsx: preserve
+
+// @Filename: C.tsx
+////export default class C {}
+
+// @Filename: a.tsx
+////import /*def*/C from "./C";
+////const foo = </*use*/C />;
+
+verify.noErrors();
+
+goTo.marker("use");
+verify.goToDefinitionIs("def");


### PR DESCRIPTION
Fixes #15723

Given a default import, we currently don't get the aliased symbol (see section under `if (symbol.flags & SymbolFlags.Alias) {` in `goToDefinition.ts`), so `symbol.valueDeclaration` is `undefined`. This caused an exception in `createDefinitionInfo`.
All tests pass even with this piece of code commented out. Are there any tests that we are missing but should have? 
 