### PR TITLE
Port Compile On Save Fix to Release-2.3

### DIFF
--- a/src/services/shims.ts
+++ b/src/services/shims.ts
@@ -1038,7 +1038,11 @@ namespace ts {
             return this.forwardJSONCall(`resolveModuleName('${fileName}')`, () => {
                 const compilerOptions = <CompilerOptions>JSON.parse(compilerOptionsJson);
                 const result = resolveModuleName(moduleName, normalizeSlashes(fileName), compilerOptions, this.host);
-                const resolvedFileName = result.resolvedModule ? result.resolvedModule.resolvedFileName : undefined;
+                let resolvedFileName = result.resolvedModule ? result.resolvedModule.resolvedFileName : undefined;
+                if (result.resolvedModule && result.resolvedModule.extension !== Extension.Ts && result.resolvedModule.extension !== Extension.Tsx && result.resolvedModule.extension !== Extension.Dts) {
+                    resolvedFileName = undefined;
+                }
+
                 return {
                     resolvedFileName,
                     failedLookupLocations: result.failedLookupLocations


### PR DESCRIPTION
Issue: in VS 2015 (after release 2.1.5) there have been reports that Compile on save stopped working for tsconfig projects. When VS 2015 computes the context for TS config projects it gets the closure of all files referenced by files in the tsconfig. In doing so there is a call made to shim's resolveModuleNames. Starting in release 2.2.0, resolveModuleNames began returning the js files for external modules if a ts file wasn't found. These are now getting included in the list of root files for the project. This breaks compile on save as external module js files are now included in the list of source files to emit.

Fix:
 In the shim layer's resolveModuleName, only return resolvedFileNames for TS files (.ts, .tsx, .d.ts)

Issue:
 #15083 Compile on save stopped working after typescript v2.1.5 in Visual Studio 2015 
