### PR TITLE
Prevent Duplicate String Literal Completions

### DIFF
--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -221,7 +221,7 @@ namespace ts.Completions {
     function getStringLiteralCompletionEntriesFromCallExpression(argumentInfo: SignatureHelp.ArgumentListInfo, typeChecker: TypeChecker): CompletionInfo | undefined {
         const candidates: Signature[] = [];
         const entries: CompletionEntry[] = [];
-        const uniques = createMap<string>();
+        const uniques = createMap<true>();
 
         typeChecker.getResolvedSignature(argumentInfo.invocation, candidates);
 
@@ -259,7 +259,7 @@ namespace ts.Completions {
         return undefined;
     }
 
-    function addStringLiteralCompletionsFromType(type: Type, result: Push<CompletionEntry>, typeChecker: TypeChecker, uniques = createMap<string>()): void {
+    function addStringLiteralCompletionsFromType(type: Type, result: Push<CompletionEntry>, typeChecker: TypeChecker, uniques = createMap<true>()): void {
         if (type && type.flags & TypeFlags.TypeParameter) {
             type = typeChecker.getBaseConstraintOfType(type);
         }
@@ -273,8 +273,8 @@ namespace ts.Completions {
         }
         else if (type.flags & TypeFlags.StringLiteral) {
             const name = (<LiteralType>type).text;
-            if (!uniques.get(name)) {
-                uniques.set(name, name);
+            if (!uniques.has(name)) {
+                uniques.set(name, true);
                 result.push({
                     name,
                     kindModifiers: ScriptElementKindModifier.none,

--- a/src/services/completions.ts
+++ b/src/services/completions.ts
@@ -221,11 +221,12 @@ namespace ts.Completions {
     function getStringLiteralCompletionEntriesFromCallExpression(argumentInfo: SignatureHelp.ArgumentListInfo, typeChecker: TypeChecker): CompletionInfo | undefined {
         const candidates: Signature[] = [];
         const entries: CompletionEntry[] = [];
+        const uniques = createMap<string>();
 
         typeChecker.getResolvedSignature(argumentInfo.invocation, candidates);
 
         for (const candidate of candidates) {
-            addStringLiteralCompletionsFromType(typeChecker.getParameterType(candidate, argumentInfo.argumentIndex), entries, typeChecker);
+            addStringLiteralCompletionsFromType(typeChecker.getParameterType(candidate, argumentInfo.argumentIndex), entries, typeChecker, uniques);
         }
 
         if (entries.length) {
@@ -258,7 +259,7 @@ namespace ts.Completions {
         return undefined;
     }
 
-    function addStringLiteralCompletionsFromType(type: Type, result: Push<CompletionEntry>, typeChecker: TypeChecker): void {
+    function addStringLiteralCompletionsFromType(type: Type, result: Push<CompletionEntry>, typeChecker: TypeChecker, uniques = createMap<string>()): void {
         if (type && type.flags & TypeFlags.TypeParameter) {
             type = typeChecker.getBaseConstraintOfType(type);
         }
@@ -267,16 +268,20 @@ namespace ts.Completions {
         }
         if (type.flags & TypeFlags.Union) {
             for (const t of (<UnionType>type).types) {
-                addStringLiteralCompletionsFromType(t, result, typeChecker);
+                addStringLiteralCompletionsFromType(t, result, typeChecker, uniques);
             }
         }
         else if (type.flags & TypeFlags.StringLiteral) {
-            result.push({
-                name: (<LiteralType>type).text,
-                kindModifiers: ScriptElementKindModifier.none,
-                kind: ScriptElementKind.variableElement,
-                sortText: "0"
-            });
+            const name = (<LiteralType>type).text;
+            if (!uniques.get(name)) {
+                uniques.set(name, name);
+                result.push({
+                    name,
+                    kindModifiers: ScriptElementKindModifier.none,
+                    kind: ScriptElementKind.variableElement,
+                    sortText: "0"
+                });
+            }
         }
     }
 

--- a/tests/cases/fourslash/completionForStringLiteral12.ts
+++ b/tests/cases/fourslash/completionForStringLiteral12.ts
@@ -1,0 +1,10 @@
+/// <reference path='fourslash.ts' />
+
+////function foo(x: "bla"): void;
+////function foo(x: "bla"): void;
+////function foo(x: string) {}
+////foo("/**/")
+
+goTo.marker();
+verify.completionListContains("bla");
+verify.completionListCount(1);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #15622 

Added optional `uniques` parameter to `addStringLiteralCompletionsFromType` to allow for tracking which string literal values have already been added to the list of completions. It appears the only way this could happen would be for function calls with overloads (as given in the original issue).
