### PR TITLE
Ambient block scoped references in different files

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -737,7 +737,8 @@ namespace ts {
             const useFile = getSourceFileOfNode(usage);
             if (declarationFile !== useFile) {
                 if ((modulekind && (declarationFile.externalModuleIndicator || useFile.externalModuleIndicator)) ||
-                    (!compilerOptions.outFile && !compilerOptions.out)) {
+                    (!compilerOptions.outFile && !compilerOptions.out) ||
+                    isInAmbientContext(declaration)) {
                     // nodes are in different files and order cannot be determined
                     return true;
                 }

--- a/tests/baselines/reference/blockScopedNamespaceDifferentFile.js
+++ b/tests/baselines/reference/blockScopedNamespaceDifferentFile.js
@@ -1,0 +1,35 @@
+//// [tests/cases/compiler/blockScopedNamespaceDifferentFile.ts] ////
+
+//// [test.ts]
+// #15734 failed when test.ts comes before typings.d.ts
+namespace C {
+    export class Name {
+        static funcData = A.AA.func();
+        static someConst = A.AA.foo;
+
+        constructor(parameters) {}
+    }
+}
+
+//// [typings.d.ts]
+declare namespace A {
+    namespace AA {
+        function func(): number;
+        const foo = "";
+    }
+}
+
+
+//// [out.js]
+// #15734 failed when test.ts comes before typings.d.ts
+var C;
+(function (C) {
+    var Name = (function () {
+        function Name(parameters) {
+        }
+        return Name;
+    }());
+    Name.funcData = A.AA.func();
+    Name.someConst = A.AA.foo;
+    C.Name = Name;
+})(C || (C = {}));

--- a/tests/baselines/reference/blockScopedNamespaceDifferentFile.symbols
+++ b/tests/baselines/reference/blockScopedNamespaceDifferentFile.symbols
@@ -1,0 +1,44 @@
+=== tests/cases/compiler/test.ts ===
+// #15734 failed when test.ts comes before typings.d.ts
+namespace C {
+>C : Symbol(C, Decl(test.ts, 0, 0))
+
+    export class Name {
+>Name : Symbol(Name, Decl(test.ts, 1, 13))
+
+        static funcData = A.AA.func();
+>funcData : Symbol(Name.funcData, Decl(test.ts, 2, 23))
+>A.AA.func : Symbol(A.AA.func, Decl(typings.d.ts, 1, 18))
+>A.AA : Symbol(A.AA, Decl(typings.d.ts, 0, 21))
+>A : Symbol(A, Decl(typings.d.ts, 0, 0))
+>AA : Symbol(A.AA, Decl(typings.d.ts, 0, 21))
+>func : Symbol(A.AA.func, Decl(typings.d.ts, 1, 18))
+
+        static someConst = A.AA.foo;
+>someConst : Symbol(Name.someConst, Decl(test.ts, 3, 38))
+>A.AA.foo : Symbol(A.AA.foo, Decl(typings.d.ts, 3, 13))
+>A.AA : Symbol(A.AA, Decl(typings.d.ts, 0, 21))
+>A : Symbol(A, Decl(typings.d.ts, 0, 0))
+>AA : Symbol(A.AA, Decl(typings.d.ts, 0, 21))
+>foo : Symbol(A.AA.foo, Decl(typings.d.ts, 3, 13))
+
+        constructor(parameters) {}
+>parameters : Symbol(parameters, Decl(test.ts, 6, 20))
+    }
+}
+
+=== tests/cases/compiler/typings.d.ts ===
+declare namespace A {
+>A : Symbol(A, Decl(typings.d.ts, 0, 0))
+
+    namespace AA {
+>AA : Symbol(AA, Decl(typings.d.ts, 0, 21))
+
+        function func(): number;
+>func : Symbol(func, Decl(typings.d.ts, 1, 18))
+
+        const foo = "";
+>foo : Symbol(foo, Decl(typings.d.ts, 3, 13))
+    }
+}
+

--- a/tests/baselines/reference/blockScopedNamespaceDifferentFile.types
+++ b/tests/baselines/reference/blockScopedNamespaceDifferentFile.types
@@ -1,0 +1,46 @@
+=== tests/cases/compiler/test.ts ===
+// #15734 failed when test.ts comes before typings.d.ts
+namespace C {
+>C : typeof C
+
+    export class Name {
+>Name : Name
+
+        static funcData = A.AA.func();
+>funcData : number
+>A.AA.func() : number
+>A.AA.func : () => number
+>A.AA : typeof A.AA
+>A : typeof A
+>AA : typeof A.AA
+>func : () => number
+
+        static someConst = A.AA.foo;
+>someConst : string
+>A.AA.foo : ""
+>A.AA : typeof A.AA
+>A : typeof A
+>AA : typeof A.AA
+>foo : ""
+
+        constructor(parameters) {}
+>parameters : any
+    }
+}
+
+=== tests/cases/compiler/typings.d.ts ===
+declare namespace A {
+>A : typeof A
+
+    namespace AA {
+>AA : typeof AA
+
+        function func(): number;
+>func : () => number
+
+        const foo = "";
+>foo : ""
+>"" : ""
+    }
+}
+

--- a/tests/cases/compiler/blockScopedNamespaceDifferentFile.ts
+++ b/tests/cases/compiler/blockScopedNamespaceDifferentFile.ts
@@ -1,0 +1,22 @@
+// @target: es5
+// @outFile: out.js
+// @module: amd
+
+// #15734 failed when test.ts comes before typings.d.ts
+// @Filename: test.ts
+namespace C {
+    export class Name {
+        static funcData = A.AA.func();
+        static someConst = A.AA.foo;
+
+        constructor(parameters) {}
+    }
+}
+
+// @Filename: typings.d.ts
+declare namespace A {
+    namespace AA {
+        function func(): number;
+        const foo = "";
+    }
+}


### PR DESCRIPTION
Allow references to ambient block scoped variables even when

1. --out or --outfile is specified
2. The block scoped variable's file is after the referrer's file.

Previously these properties would use order of the files in the project to figure out if the reference was legal.

Fixes #15734 

