### PR TITLE
findAllReferences: Clean up uses of `getWidth` and `getStart`

### DIFF
--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -571,7 +571,11 @@ namespace ts {
 
     export interface Identifier extends PrimaryExpression {
         kind: SyntaxKind.Identifier;
-        text: string;                                  // Text of identifier (with escapes converted to characters)
+        /**
+         * Text of identifier (with escapes converted to characters).
+         * If the identifier begins with two underscores, this will begin with three.
+         */
+        text: string;
         originalKeywordKind?: SyntaxKind;              // Original syntaxKind which get set so that we can report an error later
         /*@internal*/ autoGenerateKind?: GeneratedIdentifierKind; // Specifies whether to auto-generate the text for an identifier.
         /*@internal*/ autoGenerateId?: number;         // Ensures unique generated identifiers get unique names, but clones get the same name.

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -637,7 +637,9 @@ namespace ts.FindAllReferences.Core {
         return parent ? scope.getSourceFile() : scope;
     }
 
-    function getPossibleSymbolReferencePositions(sourceFile: SourceFile, symbolName: string, start: number, end: number): number[] {
+    function getPossibleSymbolReferencePositions(sourceFile: SourceFile, symbolName: string, container: Node = sourceFile, fullStart = false): number[] {
+        const start = fullStart ? container.getFullStart() : container.getStart(sourceFile);
+        const end = container.getEnd();
         const positions: number[] = [];
 
         /// TODO: Cache symbol existence for files to save text search
@@ -676,16 +678,11 @@ namespace ts.FindAllReferences.Core {
         const references: Entry[] = [];
         const sourceFile = container.getSourceFile();
         const labelName = targetLabel.text;
-        const possiblePositions = getPossibleSymbolReferencePositions(sourceFile, labelName, container.getStart(), container.getEnd());
+        const possiblePositions = getPossibleSymbolReferencePositions(sourceFile, labelName, container);
         for (const position of possiblePositions) {
             const node = getTouchingWord(sourceFile, position);
-            if (!node || node.getWidth() !== labelName.length) {
-                continue;
-            }
-
             // Only pick labels that are either the target label, or have a target that is the target label
-            if (node === targetLabel ||
-                (isJumpStatementTarget(node) && getTargetLabel(node, labelName) === targetLabel)) {
+            if (node && (node === targetLabel || (isJumpStatementTarget(node) && getTargetLabel(node, labelName) === targetLabel))) {
                 references.push(nodeEntry(node));
             }
         }
@@ -697,15 +694,14 @@ namespace ts.FindAllReferences.Core {
         // Compare the length so we filter out strict superstrings of the symbol we are looking for
         switch (node && node.kind) {
             case SyntaxKind.Identifier:
-                return node.getWidth() === searchSymbolName.length;
+                return (node as Identifier).text.length === searchSymbolName.length;
 
             case SyntaxKind.StringLiteral:
                 return (isLiteralNameOfPropertyDeclarationOrIndexAccess(node) || isNameOfExternalModuleImportOrDeclaration(node)) &&
-                    // For string literals we have two additional chars for the quotes
-                    node.getWidth() === searchSymbolName.length + 2;
+                    (node as StringLiteral).text.length === searchSymbolName.length;
 
             case SyntaxKind.NumericLiteral:
-                return isLiteralNameOfPropertyDeclarationOrIndexAccess(node) && node.getWidth() === searchSymbolName.length;
+                return isLiteralNameOfPropertyDeclarationOrIndexAccess(node) && (node as NumericLiteral).text.length === searchSymbolName.length;
 
             default:
                 return false;
@@ -722,7 +718,7 @@ namespace ts.FindAllReferences.Core {
     }
 
     function addReferencesForKeywordInFile(sourceFile: SourceFile, kind: SyntaxKind, searchText: string, references: Push<NodeEntry>): void {
-        const possiblePositions = getPossibleSymbolReferencePositions(sourceFile, searchText, sourceFile.getStart(), sourceFile.getEnd());
+        const possiblePositions = getPossibleSymbolReferencePositions(sourceFile, searchText);
         for (const position of possiblePositions) {
             const referenceLocation = getTouchingPropertyName(sourceFile, position);
             if (referenceLocation.kind === kind) {
@@ -746,9 +742,7 @@ namespace ts.FindAllReferences.Core {
             return;
         }
 
-        const start = state.findInComments ? container.getFullStart() : container.getStart();
-        const possiblePositions = getPossibleSymbolReferencePositions(sourceFile, search.text, start, container.getEnd());
-        for (const position of possiblePositions) {
+        for (const position of getPossibleSymbolReferencePositions(sourceFile, search.text, container, /*fullStart*/ state.findInComments)) {
             getReferencesAtLocation(sourceFile, position, search, state);
         }
     }
@@ -1192,7 +1186,7 @@ namespace ts.FindAllReferences.Core {
         const references: Entry[] = [];
 
         const sourceFile = searchSpaceNode.getSourceFile();
-        const possiblePositions = getPossibleSymbolReferencePositions(sourceFile, "super", searchSpaceNode.getStart(), searchSpaceNode.getEnd());
+        const possiblePositions = getPossibleSymbolReferencePositions(sourceFile, "super", searchSpaceNode);
         for (const position of possiblePositions) {
             const node = getTouchingWord(sourceFile, position);
 
@@ -1254,13 +1248,13 @@ namespace ts.FindAllReferences.Core {
         if (searchSpaceNode.kind === SyntaxKind.SourceFile) {
             forEach(sourceFiles, sourceFile => {
                 cancellationToken.throwIfCancellationRequested();
-                possiblePositions = getPossibleSymbolReferencePositions(sourceFile, "this", sourceFile.getStart(), sourceFile.getEnd());
+                possiblePositions = getPossibleSymbolReferencePositions(sourceFile, "this");
                 getThisReferencesInFile(sourceFile, sourceFile, possiblePositions, references);
             });
         }
         else {
             const sourceFile = searchSpaceNode.getSourceFile();
-            possiblePositions = getPossibleSymbolReferencePositions(sourceFile, "this", searchSpaceNode.getStart(), searchSpaceNode.getEnd());
+            possiblePositions = getPossibleSymbolReferencePositions(sourceFile, "this", searchSpaceNode);
             getThisReferencesInFile(sourceFile, searchSpaceNode, possiblePositions, references);
         }
 
@@ -1314,7 +1308,7 @@ namespace ts.FindAllReferences.Core {
 
         for (const sourceFile of sourceFiles) {
             cancellationToken.throwIfCancellationRequested();
-            const possiblePositions = getPossibleSymbolReferencePositions(sourceFile, node.text, sourceFile.getStart(), sourceFile.getEnd());
+            const possiblePositions = getPossibleSymbolReferencePositions(sourceFile, node.text);
             getReferencesForStringLiteralInFile(sourceFile, node.text, possiblePositions, references);
         }
 

--- a/src/services/findAllReferences.ts
+++ b/src/services/findAllReferences.ts
@@ -694,7 +694,7 @@ namespace ts.FindAllReferences.Core {
         // Compare the length so we filter out strict superstrings of the symbol we are looking for
         switch (node && node.kind) {
             case SyntaxKind.Identifier:
-                return (node as Identifier).text.length === searchSymbolName.length;
+                return unescapeIdentifier((node as Identifier).text).length === searchSymbolName.length;
 
             case SyntaxKind.StringLiteral:
                 return (isLiteralNameOfPropertyDeclarationOrIndexAccess(node) || isNameOfExternalModuleImportOrDeclaration(node)) &&


### PR DESCRIPTION
Fixes #14004
