### PR TITLE
if a JSSpecialPropertyDeclaration has a JSDoc type, use it

### DIFF
--- a/tests/baselines/reference/checkJsFiles7.symbols
+++ b/tests/baselines/reference/checkJsFiles7.symbols
@@ -1,0 +1,20 @@
+=== tests/cases/compiler/a.js ===
+class C {
+>C : Symbol(C, Decl(a.js, 0, 0))
+
+	constructor() {
+		/** @type {boolean} */
+		this.a = true;
+>this.a : Symbol(C.a, Decl(a.js, 1, 16), Decl(a.js, 3, 16))
+>this : Symbol(C, Decl(a.js, 0, 0))
+>a : Symbol(C.a, Decl(a.js, 1, 16), Decl(a.js, 3, 16))
+
+		this.a = !!this.a;
+>this.a : Symbol(C.a, Decl(a.js, 1, 16), Decl(a.js, 3, 16))
+>this : Symbol(C, Decl(a.js, 0, 0))
+>a : Symbol(C.a, Decl(a.js, 1, 16), Decl(a.js, 3, 16))
+>this.a : Symbol(C.a, Decl(a.js, 1, 16), Decl(a.js, 3, 16))
+>this : Symbol(C, Decl(a.js, 0, 0))
+>a : Symbol(C.a, Decl(a.js, 1, 16), Decl(a.js, 3, 16))
+	}
+}

--- a/tests/baselines/reference/checkJsFiles7.types
+++ b/tests/baselines/reference/checkJsFiles7.types
@@ -1,0 +1,25 @@
+=== tests/cases/compiler/a.js ===
+class C {
+>C : C
+
+	constructor() {
+		/** @type {boolean} */
+		this.a = true;
+>this.a = true : true
+>this.a : boolean
+>this : this
+>a : boolean
+>true : true
+
+		this.a = !!this.a;
+>this.a = !!this.a : boolean
+>this.a : boolean
+>this : this
+>a : boolean
+>!!this.a : boolean
+>!this.a : boolean
+>this.a : true
+>this : this
+>a : true
+	}
+}

--- a/tests/cases/compiler/checkJsFiles7.ts
+++ b/tests/cases/compiler/checkJsFiles7.ts
@@ -1,0 +1,12 @@
+// @allowJs: true
+// @checkJs: true
+// @noEmit: true
+// @noImplicitAny: true
+// @fileName: a.js
+class C {
+	constructor() {
+		/** @type {boolean} */
+		this.a = true;
+		this.a = !!this.a;
+	}
+}


### PR DESCRIPTION
For a JSSpecialPropertyDeclaration (e.g. `this.x = y`) in a JavaScript file, we currently create a union of the types of all of the locations of the declaration, where each type is either the type from a JSDocTypeTag or the type of the expression. In this change, we treat the JSDocTypeTag in a fashion similar to a type annotation:

* Always use the type of the first declaration with a JSDocTypeTag (if present).
* Subsequent declarations with a JSDocTypeTag **must** have an identical type.
* If no declaration has a JSDocTypeTag, we follow the existing behavior and create a union of types of the expressions on the right-hand side.

Fixes #15707
