### PR TITLE
Adds CommaList to avoid large deeply nested comma expressions

### DIFF
--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -491,6 +491,35 @@ namespace ts {
     }
 
     /**
+     * Maps an array. If the mapped value is an array, it is spread into the result.
+     * Avoids allocation if all elements map to themselves.
+     *
+     * @param array The array to map.
+     * @param mapfn The callback used to map the result into one or more values.
+     */
+    export function sameFlatMap<T>(array: T[], mapfn: (x: T, i: number) => T | T[]): T[] {
+        let result: T[];
+        if (array) {
+            for (let i = 0; i < array.length; i++) {
+                const item = array[i];
+                const mapped = mapfn(item, i);
+                if (result || item !== mapped || isArray(mapped)) {
+                    if (!result) {
+                        result = array.slice(0, i);
+                    }
+                    if (isArray(mapped)) {
+                        addRange(result, mapped);
+                    }
+                    else {
+                        result.push(mapped);
+                    }
+                }
+            }
+        }
+        return result || array;
+    }
+
+    /**
      * Computes the first matching span of elements and returns a tuple of the first span
      * and the remaining elements.
      */

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -734,8 +734,8 @@ namespace ts {
                 case SyntaxKind.PartiallyEmittedExpression:
                     return emitPartiallyEmittedExpression(<PartiallyEmittedExpression>node);
 
-                case SyntaxKind.CommaList:
-                    return emitCommaList(<CommaList>node);
+                case SyntaxKind.CommaListExpression:
+                    return emitCommaList(<CommaListExpression>node);
             }
         }
 
@@ -2104,7 +2104,7 @@ namespace ts {
             emitExpression(node.expression);
         }
 
-        function emitCommaList(node: CommaList) {
+        function emitCommaList(node: CommaListExpression) {
             emitExpressionList(node, node.elements, ListFormat.CommaListElements);
         }
 

--- a/src/compiler/emitter.ts
+++ b/src/compiler/emitter.ts
@@ -733,6 +733,9 @@ namespace ts {
                 // Transformation nodes
                 case SyntaxKind.PartiallyEmittedExpression:
                     return emitPartiallyEmittedExpression(<PartiallyEmittedExpression>node);
+
+                case SyntaxKind.CommaList:
+                    return emitCommaList(<CommaList>node);
             }
         }
 
@@ -2101,6 +2104,10 @@ namespace ts {
             emitExpression(node.expression);
         }
 
+        function emitCommaList(node: CommaList) {
+            emitExpressionList(node, node.elements, ListFormat.CommaListElements);
+        }
+
         /**
          * Emits any prologue directives at the start of a Statement list, returning the
          * number of prologue directives written to the output.
@@ -2951,6 +2958,7 @@ namespace ts {
         ArrayBindingPatternElements = SingleLine | AllowTrailingComma | CommaDelimited | SpaceBetweenSiblings,
         ObjectLiteralExpressionProperties = PreserveLines | CommaDelimited | SpaceBetweenSiblings | SpaceBetweenBraces | Indented | Braces,
         ArrayLiteralExpressionElements = PreserveLines | CommaDelimited | SpaceBetweenSiblings | AllowTrailingComma | Indented | SquareBrackets,
+        CommaListElements = CommaDelimited | SpaceBetweenSiblings | SingleLine,
         CallExpressionArguments = CommaDelimited | SpaceBetweenSiblings | SingleLine | Parenthesis,
         NewExpressionArguments = CommaDelimited | SpaceBetweenSiblings | SingleLine | Parenthesis | OptionalIfUndefined,
         TemplateExpressionSpans = SingleLine | NoInterveningComments,

--- a/src/compiler/factory.ts
+++ b/src/compiler/factory.ts
@@ -2077,6 +2077,18 @@ namespace ts {
         return node;
     }
 
+    export function createCommaList(elements: Expression[]) {
+        const node = <CommaList>createSynthesizedNode(SyntaxKind.CommaList);
+        node.elements = createNodeArray(elements);
+        return node;
+    }
+
+    export function updateCommaList(node: CommaList, elements: Expression[]) {
+        return node.elements !== elements
+            ? updateNode(createCommaList(elements), node)
+            : node;
+    }
+
     export function createBundle(sourceFiles: SourceFile[]) {
         const node = <Bundle>createNode(SyntaxKind.Bundle);
         node.sourceFiles = sourceFiles;
@@ -2865,7 +2877,9 @@ namespace ts {
     }
 
     export function inlineExpressions(expressions: Expression[]) {
-        return reduceLeft(expressions, createComma);
+        return expressions.length > 10
+            ? createCommaList(expressions)
+            : reduceLeft(expressions, createComma);
     }
 
     export function createExpressionFromEntityName(node: EntityName | Expression): Expression {

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -362,6 +362,8 @@ namespace ts {
                 return visitNode(cbNode, (<ExternalModuleReference>node).expression);
             case SyntaxKind.MissingDeclaration:
                 return visitNodes(cbNodes, node.decorators);
+            case SyntaxKind.CommaList:
+                return visitNodes(cbNodes, (<CommaList>node).elements);
 
             case SyntaxKind.JsxElement:
                 return visitNode(cbNode, (<JsxElement>node).openingElement) ||

--- a/src/compiler/parser.ts
+++ b/src/compiler/parser.ts
@@ -362,8 +362,8 @@ namespace ts {
                 return visitNode(cbNode, (<ExternalModuleReference>node).expression);
             case SyntaxKind.MissingDeclaration:
                 return visitNodes(cbNodes, node.decorators);
-            case SyntaxKind.CommaList:
-                return visitNodes(cbNodes, (<CommaList>node).elements);
+            case SyntaxKind.CommaListExpression:
+                return visitNodes(cbNodes, (<CommaListExpression>node).elements);
 
             case SyntaxKind.JsxElement:
                 return visitNode(cbNode, (<JsxElement>node).openingElement) ||

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -391,6 +391,7 @@ namespace ts {
         PartiallyEmittedExpression,
         MergeDeclarationMarker,
         EndOfDeclarationMarker,
+        CommaList,
 
         // Enum value count
         Count,
@@ -1601,6 +1602,11 @@ namespace ts {
     /* @internal */
     export interface EndOfDeclarationMarker extends Statement {
         kind: SyntaxKind.EndOfDeclarationMarker;
+    }
+
+    export interface CommaList extends Expression {
+        kind: SyntaxKind.CommaList;
+        elements: NodeArray<Expression>;
     }
 
     /**

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -389,9 +389,9 @@ namespace ts {
         // Transformation nodes
         NotEmittedStatement,
         PartiallyEmittedExpression,
+        CommaListExpression,
         MergeDeclarationMarker,
         EndOfDeclarationMarker,
-        CommaList,
 
         // Enum value count
         Count,
@@ -1604,8 +1604,11 @@ namespace ts {
         kind: SyntaxKind.EndOfDeclarationMarker;
     }
 
-    export interface CommaList extends Expression {
-        kind: SyntaxKind.CommaList;
+    /**
+     * A list of comma-seperated expressions. This node is only created by transformations.
+     */
+    export interface CommaListExpression extends Expression {
+        kind: SyntaxKind.CommaListExpression;
         elements: NodeArray<Expression>;
     }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2327,7 +2327,7 @@ namespace ts {
             case SyntaxKind.SpreadElement:
                 return 1;
 
-            case SyntaxKind.CommaList:
+            case SyntaxKind.CommaListExpression:
                 return 0;
 
             default:
@@ -3918,7 +3918,7 @@ namespace ts {
             || kind === SyntaxKind.SpreadElement
             || kind === SyntaxKind.AsExpression
             || kind === SyntaxKind.OmittedExpression
-            || kind === SyntaxKind.CommaList
+            || kind === SyntaxKind.CommaListExpression
             || isUnaryExpressionKind(kind);
     }
 

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -2327,6 +2327,9 @@ namespace ts {
             case SyntaxKind.SpreadElement:
                 return 1;
 
+            case SyntaxKind.CommaList:
+                return 0;
+
             default:
                 return -1;
         }
@@ -3915,6 +3918,7 @@ namespace ts {
             || kind === SyntaxKind.SpreadElement
             || kind === SyntaxKind.AsExpression
             || kind === SyntaxKind.OmittedExpression
+            || kind === SyntaxKind.CommaList
             || isUnaryExpressionKind(kind);
     }
 

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -876,6 +876,10 @@ namespace ts {
                 return updatePartiallyEmittedExpression(<PartiallyEmittedExpression>node,
                     visitNode((<PartiallyEmittedExpression>node).expression, visitor, isExpression));
 
+            case SyntaxKind.CommaList:
+                return updateCommaList(<CommaList>node,
+                    nodesVisitor((<CommaList>node).elements, visitor, isExpression));
+
             default:
                 // No need to visit nodes with no children.
                 return node;
@@ -1387,6 +1391,10 @@ namespace ts {
             // Transformation nodes
             case SyntaxKind.PartiallyEmittedExpression:
                 result = reduceNode((<PartiallyEmittedExpression>node).expression, cbNode, result);
+                break;
+
+            case SyntaxKind.CommaList:
+                result = reduceNodes((<CommaList>node).elements, cbNodes, result);
                 break;
 
             default:

--- a/src/compiler/visitor.ts
+++ b/src/compiler/visitor.ts
@@ -876,9 +876,9 @@ namespace ts {
                 return updatePartiallyEmittedExpression(<PartiallyEmittedExpression>node,
                     visitNode((<PartiallyEmittedExpression>node).expression, visitor, isExpression));
 
-            case SyntaxKind.CommaList:
-                return updateCommaList(<CommaList>node,
-                    nodesVisitor((<CommaList>node).elements, visitor, isExpression));
+            case SyntaxKind.CommaListExpression:
+                return updateCommaList(<CommaListExpression>node,
+                    nodesVisitor((<CommaListExpression>node).elements, visitor, isExpression));
 
             default:
                 // No need to visit nodes with no children.
@@ -1393,8 +1393,8 @@ namespace ts {
                 result = reduceNode((<PartiallyEmittedExpression>node).expression, cbNode, result);
                 break;
 
-            case SyntaxKind.CommaList:
-                result = reduceNodes((<CommaList>node).elements, cbNodes, result);
+            case SyntaxKind.CommaListExpression:
+                result = reduceNodes((<CommaListExpression>node).elements, cbNodes, result);
                 break;
 
             default:


### PR DESCRIPTION
When transforming a ObjectLiteralExpression with a large number of computed property names, we currently create a very large tree of binary expressions that is deeply nested along the right hand side. In some extreme cases, when we attempt to print the tree we end up exhausting all of the available stack space.

This change introduces a synthetic `CommaList` node which flattens a large number of comma expressions into a single list to reduce the overall tree depth.

Fixes #13935 
