### PR TITLE
Allow const enum to be used before declaration

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1280,7 +1280,7 @@ namespace ts {
                 else if (result.flags & SymbolFlags.Class) {
                     error(errorLocation, Diagnostics.Class_0_used_before_its_declaration, declarationNameToString(getNameOfDeclaration(declaration)));
                 }
-                else if (result.flags & SymbolFlags.Enum) {
+                else if (result.flags & SymbolFlags.RegularEnum) {
                     error(errorLocation, Diagnostics.Enum_0_used_before_its_declaration, declarationNameToString(getNameOfDeclaration(declaration)));
                 }
             }

--- a/tests/baselines/reference/enumUsedBeforeDeclaration.errors.txt
+++ b/tests/baselines/reference/enumUsedBeforeDeclaration.errors.txt
@@ -1,14 +1,11 @@
 tests/cases/compiler/enumUsedBeforeDeclaration.ts(1,18): error TS2450: Enum 'Color' used before its declaration.
-tests/cases/compiler/enumUsedBeforeDeclaration.ts(2,24): error TS2450: Enum 'ConstColor' used before its declaration.
 
 
-==== tests/cases/compiler/enumUsedBeforeDeclaration.ts (2 errors) ====
+==== tests/cases/compiler/enumUsedBeforeDeclaration.ts (1 errors) ====
     const v: Color = Color.Green;
                      ~~~~~
 !!! error TS2450: Enum 'Color' used before its declaration.
     const v2: ConstColor = ConstColor.Green;
-                           ~~~~~~~~~~
-!!! error TS2450: Enum 'ConstColor' used before its declaration.
     enum Color { Red, Green, Blue }
     const enum ConstColor { Red, Green, Blue }
     


### PR DESCRIPTION
Allow const enum to be used before declaration, fixes #15828 

