### PR TITLE
findAllReferences: In `export default foo`, symbol name is `foo`

### DIFF
--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4032,6 +4032,10 @@ namespace ts {
         return node.kind === SyntaxKind.ExportSpecifier;
     }
 
+    export function isExportAssignment(node: Node): node is ExportAssignment {
+        return node.kind === SyntaxKind.ExportAssignment;
+    }
+
     export function isModuleOrEnumDeclaration(node: Node): node is ModuleDeclaration | EnumDeclaration {
         return node.kind === SyntaxKind.ModuleDeclaration || node.kind === SyntaxKind.EnumDeclaration;
     }

--- a/src/services/importTracker.ts
+++ b/src/services/importTracker.ts
@@ -526,17 +526,18 @@ namespace ts.FindAllReferences {
         return isExternalModuleSymbol(exportingModuleSymbol) ? { exportingModuleSymbol, exportKind } : undefined;
     }
 
-    function symbolName(symbol: Symbol): string {
+    function symbolName(symbol: Symbol): string | undefined {
         if (symbol.name !== "default") {
             return symbol.name;
         }
 
-        const name = forEach(symbol.declarations, decl => {
+        return forEach(symbol.declarations, decl => {
+            if (isExportAssignment(decl)) {
+                return isIdentifier(decl.expression) ? decl.expression.text : undefined;
+            }
             const name = getNameOfDeclaration(decl);
             return name && name.kind === SyntaxKind.Identifier && name.text;
         });
-        Debug.assert(!!name);
-        return name;
     }
 
     /** If at an export specifier, go to the symbol it refers to. */

--- a/tests/cases/fourslash/findAllRefsForDefaultExport04.ts
+++ b/tests/cases/fourslash/findAllRefsForDefaultExport04.ts
@@ -1,0 +1,16 @@
+/// <reference path='fourslash.ts' />
+
+// @Filename: /a.ts
+////const [|{| "isWriteAccess": true, "isDefinition": true |}a|] = 0;
+////export default [|a|];
+
+// @Filename: /b.ts
+////import [|{| "isWriteAccess": true, "isDefinition": true |}a|] from "./a";
+////[|a|];
+
+const [r0, r1, r2, r3] = test.ranges();
+verify.referenceGroups([r0, r1], [
+    { definition: "const a: 0", ranges: [r0, r1] },
+    { definition: "import a", ranges: [r2, r3] }
+]);
+verify.singleReferenceGroup("import a", [r2, r3]);


### PR DESCRIPTION
Fixes #15814

Also, should be OK to return `undefined` from `symbolName`, since the result is just compared to the current search name to determine whether we should recursively search.