### PR TITLE
Allow spreading arrays after required parameters

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9598,10 +9598,6 @@ namespace ts {
             return signature.hasRestParameter && parameterIndex >= signature.parameters.length - 1;
         }
 
-        function areAllParametersOptionalAfter(signature: Signature, parameterIndex: number) {
-            return parameterIndex >= signature.minArgumentCount;
-        }
-
         function isSupertypeOfEach(candidate: Type, types: Type[]): boolean {
             for (const t of types) {
                 if (candidate !== t && !isTypeSubtypeOf(t, candidate)) return false;
@@ -14653,7 +14649,7 @@ namespace ts {
             // If spread arguments are present, check that they correspond to a rest parameter. If so, no
             // further checking is necessary.
             if (spreadArgIndex >= 0) {
-                return isRestParameterIndex(signature, spreadArgIndex) || areAllParametersOptionalAfter(signature, spreadArgIndex);
+                return isRestParameterIndex(signature, spreadArgIndex) || spreadArgIndex >= signature.minArgumentCount;
             }
 
             // Too many arguments implies incorrect arity.

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -9598,6 +9598,10 @@ namespace ts {
             return signature.hasRestParameter && parameterIndex >= signature.parameters.length - 1;
         }
 
+        function areAllParametersOptionalAfter(signature: Signature, parameterIndex: number) {
+            return parameterIndex >= signature.minArgumentCount;
+        }
+
         function isSupertypeOfEach(candidate: Type, types: Type[]): boolean {
             for (const t of types) {
                 if (candidate !== t && !isTypeSubtypeOf(t, candidate)) return false;
@@ -14649,7 +14653,7 @@ namespace ts {
             // If spread arguments are present, check that they correspond to a rest parameter. If so, no
             // further checking is necessary.
             if (spreadArgIndex >= 0) {
-                return isRestParameterIndex(signature, spreadArgIndex);
+                return isRestParameterIndex(signature, spreadArgIndex) || areAllParametersOptionalAfter(signature, spreadArgIndex);
             }
 
             // Too many arguments implies incorrect arity.

--- a/tests/baselines/reference/callWithSpread2.errors.txt
+++ b/tests/baselines/reference/callWithSpread2.errors.txt
@@ -1,32 +1,22 @@
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(40,5): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(30,5): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(41,5): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(31,5): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(42,13): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(32,13): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(43,13): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(33,13): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(44,11): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(34,11): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(45,11): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(35,11): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
   Type 'string' is not assignable to type 'number'.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(46,1): error TS2346: Supplied parameters do not match any signature of call target.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(46,11): error TS2461: Type '(a?: number, b?: number) => void' is not an array type.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(47,1): error TS2346: Supplied parameters do not match any signature of call target.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(48,1): error TS2346: Supplied parameters do not match any signature of call target.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(36,1): error TS2346: Supplied parameters do not match any signature of call target.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(36,11): error TS2461: Type '(a?: number, b?: number) => void' is not an array type.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(37,1): error TS2346: Supplied parameters do not match any signature of call target.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(38,1): error TS2346: Supplied parameters do not match any signature of call target.
 
 
 ==== tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts (10 errors) ====
-    // Desired semantics: take type of array that is spread,
-    // allow it to be applied to a
-    // *trailing* set of optional parameters whose types match.
-    // Length is *not* checked, the parameters it's applied to just have to be optional.
-    
-    // that means that tuples are non-starters because their array element type
-    // is a union like string | number.
-    
-    // with exceptions for JS functions that use arguments, or maybe all JS functions
-    
     declare function all(a?: number, b?: number): void;
     declare function weird(a?: number | string, b?: number | string): void;
     declare function prefix(s: string, a?: number, b?: number): void;

--- a/tests/baselines/reference/callWithSpread2.errors.txt
+++ b/tests/baselines/reference/callWithSpread2.errors.txt
@@ -11,12 +11,11 @@ tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(34,11): err
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(35,11): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
   Type 'string' is not assignable to type 'number'.
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(36,1): error TS2346: Supplied parameters do not match any signature of call target.
-tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(36,11): error TS2461: Type '(a?: number, b?: number) => void' is not an array type.
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(37,1): error TS2346: Supplied parameters do not match any signature of call target.
 tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(38,1): error TS2346: Supplied parameters do not match any signature of call target.
 
 
-==== tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts (10 errors) ====
+==== tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts (9 errors) ====
     declare function all(a?: number, b?: number): void;
     declare function weird(a?: number | string, b?: number | string): void;
     declare function prefix(s: string, a?: number, b?: number): void;
@@ -70,11 +69,9 @@ tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(38,1): erro
               ~~~~~~~~
 !!! error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
 !!! error TS2345:   Type 'string' is not assignable to type 'number'.
-    prefix(...all) // required parameters are required
-    ~~~~~~~~~~~~~~
+    prefix(...ns) // required parameters are required
+    ~~~~~~~~~~~~~
 !!! error TS2346: Supplied parameters do not match any signature of call target.
-              ~~~
-!!! error TS2461: Type '(a?: number, b?: number) => void' is not an array type.
     prefix(...mixed)
     ~~~~~~~~~~~~~~~~
 !!! error TS2346: Supplied parameters do not match any signature of call target.

--- a/tests/baselines/reference/callWithSpread2.errors.txt
+++ b/tests/baselines/reference/callWithSpread2.errors.txt
@@ -1,0 +1,94 @@
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(40,5): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(41,5): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(42,13): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(43,13): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(44,11): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(45,11): error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+  Type 'string' is not assignable to type 'number'.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(46,1): error TS2346: Supplied parameters do not match any signature of call target.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(46,11): error TS2461: Type '(a?: number, b?: number) => void' is not an array type.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(47,1): error TS2346: Supplied parameters do not match any signature of call target.
+tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts(48,1): error TS2346: Supplied parameters do not match any signature of call target.
+
+
+==== tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts (10 errors) ====
+    // Desired semantics: take type of array that is spread,
+    // allow it to be applied to a
+    // *trailing* set of optional parameters whose types match.
+    // Length is *not* checked, the parameters it's applied to just have to be optional.
+    
+    // that means that tuples are non-starters because their array element type
+    // is a union like string | number.
+    
+    // with exceptions for JS functions that use arguments, or maybe all JS functions
+    
+    declare function all(a?: number, b?: number): void;
+    declare function weird(a?: number | string, b?: number | string): void;
+    declare function prefix(s: string, a?: number, b?: number): void;
+    declare function rest(s: string, a?: number, b?: number,  ...rest: number[]): void;
+    declare function normal(s: string): void;
+    declare function thunk(): string;
+    
+    declare var ns: number[];
+    declare var mixed: (number | string)[];
+    declare var tuple: [number, string];
+    
+    // good
+    all(...ns)
+    weird(...ns)
+    weird(...mixed)
+    weird(...tuple)
+    prefix("a", ...ns)
+    rest("d", ...ns)
+    
+    
+    // this covers the arguments case
+    normal("g", ...ns)
+    normal("h", ...mixed)
+    normal("i", ...tuple)
+    thunk(...ns)
+    thunk(...mixed)
+    thunk(...tuple)
+    
+    // bad
+    all(...mixed)
+        ~~~~~~~~
+!!! error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+!!! error TS2345:   Type 'string' is not assignable to type 'number'.
+    all(...tuple)
+        ~~~~~~~~
+!!! error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+!!! error TS2345:   Type 'string' is not assignable to type 'number'.
+    prefix("b", ...mixed)
+                ~~~~~~~~
+!!! error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+!!! error TS2345:   Type 'string' is not assignable to type 'number'.
+    prefix("c", ...tuple)
+                ~~~~~~~~
+!!! error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+!!! error TS2345:   Type 'string' is not assignable to type 'number'.
+    rest("e", ...mixed)
+              ~~~~~~~~
+!!! error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+!!! error TS2345:   Type 'string' is not assignable to type 'number'.
+    rest("f", ...tuple)
+              ~~~~~~~~
+!!! error TS2345: Argument of type 'string | number' is not assignable to parameter of type 'number'.
+!!! error TS2345:   Type 'string' is not assignable to type 'number'.
+    prefix(...all) // required parameters are required
+    ~~~~~~~~~~~~~~
+!!! error TS2346: Supplied parameters do not match any signature of call target.
+              ~~~
+!!! error TS2461: Type '(a?: number, b?: number) => void' is not an array type.
+    prefix(...mixed)
+    ~~~~~~~~~~~~~~~~
+!!! error TS2346: Supplied parameters do not match any signature of call target.
+    prefix(...tuple)
+    ~~~~~~~~~~~~~~~~
+!!! error TS2346: Supplied parameters do not match any signature of call target.
+    

--- a/tests/baselines/reference/callWithSpread2.js
+++ b/tests/baselines/reference/callWithSpread2.js
@@ -34,7 +34,7 @@ prefix("b", ...mixed)
 prefix("c", ...tuple)
 rest("e", ...mixed)
 rest("f", ...tuple)
-prefix(...all) // required parameters are required
+prefix(...ns) // required parameters are required
 prefix(...mixed)
 prefix(...tuple)
 
@@ -61,6 +61,6 @@ prefix.apply(void 0, ["b"].concat(mixed));
 prefix.apply(void 0, ["c"].concat(tuple));
 rest.apply(void 0, ["e"].concat(mixed));
 rest.apply(void 0, ["f"].concat(tuple));
-prefix.apply(void 0, all); // required parameters are required
+prefix.apply(void 0, ns); // required parameters are required
 prefix.apply(void 0, mixed);
 prefix.apply(void 0, tuple);

--- a/tests/baselines/reference/callWithSpread2.js
+++ b/tests/baselines/reference/callWithSpread2.js
@@ -1,14 +1,4 @@
 //// [callWithSpread2.ts]
-// Desired semantics: take type of array that is spread,
-// allow it to be applied to a
-// *trailing* set of optional parameters whose types match.
-// Length is *not* checked, the parameters it's applied to just have to be optional.
-
-// that means that tuples are non-starters because their array element type
-// is a union like string | number.
-
-// with exceptions for JS functions that use arguments, or maybe all JS functions
-
 declare function all(a?: number, b?: number): void;
 declare function weird(a?: number | string, b?: number | string): void;
 declare function prefix(s: string, a?: number, b?: number): void;
@@ -50,10 +40,6 @@ prefix(...tuple)
 
 
 //// [callWithSpread2.js]
-// Desired semantics: take type of array that is spread,
-// allow it to be applied to a
-// *trailing* set of optional parameters whose types match.
-// Length is *not* checked, the parameters it's applied to just have to be optional.
 // good
 all.apply(void 0, ns);
 weird.apply(void 0, ns);

--- a/tests/baselines/reference/callWithSpread2.js
+++ b/tests/baselines/reference/callWithSpread2.js
@@ -1,0 +1,80 @@
+//// [callWithSpread2.ts]
+// Desired semantics: take type of array that is spread,
+// allow it to be applied to a
+// *trailing* set of optional parameters whose types match.
+// Length is *not* checked, the parameters it's applied to just have to be optional.
+
+// that means that tuples are non-starters because their array element type
+// is a union like string | number.
+
+// with exceptions for JS functions that use arguments, or maybe all JS functions
+
+declare function all(a?: number, b?: number): void;
+declare function weird(a?: number | string, b?: number | string): void;
+declare function prefix(s: string, a?: number, b?: number): void;
+declare function rest(s: string, a?: number, b?: number,  ...rest: number[]): void;
+declare function normal(s: string): void;
+declare function thunk(): string;
+
+declare var ns: number[];
+declare var mixed: (number | string)[];
+declare var tuple: [number, string];
+
+// good
+all(...ns)
+weird(...ns)
+weird(...mixed)
+weird(...tuple)
+prefix("a", ...ns)
+rest("d", ...ns)
+
+
+// this covers the arguments case
+normal("g", ...ns)
+normal("h", ...mixed)
+normal("i", ...tuple)
+thunk(...ns)
+thunk(...mixed)
+thunk(...tuple)
+
+// bad
+all(...mixed)
+all(...tuple)
+prefix("b", ...mixed)
+prefix("c", ...tuple)
+rest("e", ...mixed)
+rest("f", ...tuple)
+prefix(...all) // required parameters are required
+prefix(...mixed)
+prefix(...tuple)
+
+
+//// [callWithSpread2.js]
+// Desired semantics: take type of array that is spread,
+// allow it to be applied to a
+// *trailing* set of optional parameters whose types match.
+// Length is *not* checked, the parameters it's applied to just have to be optional.
+// good
+all.apply(void 0, ns);
+weird.apply(void 0, ns);
+weird.apply(void 0, mixed);
+weird.apply(void 0, tuple);
+prefix.apply(void 0, ["a"].concat(ns));
+rest.apply(void 0, ["d"].concat(ns));
+// this covers the arguments case
+normal.apply(void 0, ["g"].concat(ns));
+normal.apply(void 0, ["h"].concat(mixed));
+normal.apply(void 0, ["i"].concat(tuple));
+thunk.apply(void 0, ns);
+thunk.apply(void 0, mixed);
+thunk.apply(void 0, tuple);
+// bad
+all.apply(void 0, mixed);
+all.apply(void 0, tuple);
+prefix.apply(void 0, ["b"].concat(mixed));
+prefix.apply(void 0, ["c"].concat(tuple));
+rest.apply(void 0, ["e"].concat(mixed));
+rest.apply(void 0, ["f"].concat(tuple));
+prefix.apply(void 0, all); // required parameters are required
+prefix.apply(void 0, mixed);
+prefix.apply(void 0, tuple);

--- a/tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts
+++ b/tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts
@@ -1,0 +1,48 @@
+// Desired semantics: take type of array that is spread,
+// allow it to be applied to a
+// *trailing* set of optional parameters whose types match.
+// Length is *not* checked, the parameters it's applied to just have to be optional.
+
+// that means that tuples are non-starters because their array element type
+// is a union like string | number.
+
+// with exceptions for JS functions that use arguments, or maybe all JS functions
+
+declare function all(a?: number, b?: number): void;
+declare function weird(a?: number | string, b?: number | string): void;
+declare function prefix(s: string, a?: number, b?: number): void;
+declare function rest(s: string, a?: number, b?: number,  ...rest: number[]): void;
+declare function normal(s: string): void;
+declare function thunk(): string;
+
+declare var ns: number[];
+declare var mixed: (number | string)[];
+declare var tuple: [number, string];
+
+// good
+all(...ns)
+weird(...ns)
+weird(...mixed)
+weird(...tuple)
+prefix("a", ...ns)
+rest("d", ...ns)
+
+
+// this covers the arguments case
+normal("g", ...ns)
+normal("h", ...mixed)
+normal("i", ...tuple)
+thunk(...ns)
+thunk(...mixed)
+thunk(...tuple)
+
+// bad
+all(...mixed)
+all(...tuple)
+prefix("b", ...mixed)
+prefix("c", ...tuple)
+rest("e", ...mixed)
+rest("f", ...tuple)
+prefix(...all) // required parameters are required
+prefix(...mixed)
+prefix(...tuple)

--- a/tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts
+++ b/tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts
@@ -1,13 +1,3 @@
-// Desired semantics: take type of array that is spread,
-// allow it to be applied to a
-// *trailing* set of optional parameters whose types match.
-// Length is *not* checked, the parameters it's applied to just have to be optional.
-
-// that means that tuples are non-starters because their array element type
-// is a union like string | number.
-
-// with exceptions for JS functions that use arguments, or maybe all JS functions
-
 declare function all(a?: number, b?: number): void;
 declare function weird(a?: number | string, b?: number | string): void;
 declare function prefix(s: string, a?: number, b?: number): void;

--- a/tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts
+++ b/tests/cases/conformance/expressions/functionCalls/callWithSpread2.ts
@@ -33,6 +33,6 @@ prefix("b", ...mixed)
 prefix("c", ...tuple)
 rest("e", ...mixed)
 rest("f", ...tuple)
-prefix(...all) // required parameters are required
+prefix(...ns) // required parameters are required
 prefix(...mixed)
 prefix(...tuple)


### PR DESCRIPTION
Fixes #5296 using the simple method described briefly in at the bottom #15747.

Specifically, this treats arrays that are spread as an infinite list of all-optional arguments.  This lets you spread arrays into all-optional parameters whose types match.

This simple definition has a few more implications:

1. You can spread arrays into parameter lists that are too short (and whose body presumably uses `arguments`) [1].
1. Length is not checked, even if it is known.
2. Tuples are not treated specially.

Both of these might come later, but would probably require #6629, @Igorbek's strict-length tuple proposal. And *much* more code, since this is a one-line change.

[1]

```ts
declare function mungeArguments(): string;
declare const stuff: string[];
mungeArguments(...stuff) // ok!
```