### PR TITLE
Fix #15540: Throw error when importing @types

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1642,6 +1642,11 @@ namespace ts {
                 return;
             }
 
+            if (moduleReference.substr(0, 7) === "@types/") {
+                const diag = Diagnostics.Cannot_import_type_declaration_files_Consider_importing_0_instead_of_1;
+                error(errorNode, diag, moduleReference.substr(7), moduleReference);
+            }
+
             const ambientModule = tryFindAmbientModule(moduleName, /*withAugmentations*/ true);
             if (ambientModule) {
                 return ambientModule;

--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1642,9 +1642,10 @@ namespace ts {
                 return;
             }
 
-            if (moduleReference.substr(0, 7) === "@types/") {
+            if (startsWith(moduleReference, "@types/")) {
                 const diag = Diagnostics.Cannot_import_type_declaration_files_Consider_importing_0_instead_of_1;
-                error(errorNode, diag, moduleReference.substr(7), moduleReference);
+                const withoutAtTypePrefix = removePrefix(moduleReference, "@types/");
+                error(errorNode, diag, withoutAtTypePrefix, moduleReference);
             }
 
             const ambientModule = tryFindAmbientModule(moduleName, /*withAugmentations*/ true);

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -1763,6 +1763,11 @@ namespace ts {
     }
 
     /* @internal */
+    export function removePrefix(str: string, prefix: string): string {
+        return startsWith(str, prefix) ? str.substr(prefix.length) : str;
+    }
+
+    /* @internal */
     export function endsWith(str: string, suffix: string): boolean {
         const expectedPos = str.length - suffix.length;
         return expectedPos >= 0 && str.indexOf(suffix, expectedPos) === expectedPos;

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2135,6 +2135,10 @@
         "category": "Error",
         "code": 2710
     },
+    "Cannot import type declaration files. Consider importing '{0}' instead of '{1}'.": {
+        "category": "Error",
+        "code": 2711
+    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",

--- a/src/compiler/diagnosticMessages.json
+++ b/src/compiler/diagnosticMessages.json
@@ -2135,10 +2135,6 @@
         "category": "Error",
         "code": 2710
     },
-    "Cannot import type declaration files. Consider importing '{0}' instead of '{1}'.": {
-        "category": "Error",
-        "code": 2711
-    },
 
     "Import declaration '{0}' is using private name '{1}'.": {
         "category": "Error",
@@ -3040,6 +3036,10 @@
     "The maximum dependency depth to search under node_modules and load JavaScript files.": {
         "category": "Message",
         "code": 6136
+    },
+    "Cannot import type declaration files. Consider importing '{0}' instead of '{1}'.": {
+        "category": "Error",
+        "code": 6137
     },
     "Property '{0}' is declared but never used.": {
         "category": "Error",

--- a/tests/baselines/reference/importDeclTypes.errors.txt
+++ b/tests/baselines/reference/importDeclTypes.errors.txt
@@ -1,0 +1,14 @@
+tests/cases/compiler/a.ts(1,21): error TS2711: Cannot import type declaration files. Consider importing 'foo-bar' instead of '@types/foo-bar'.
+
+
+==== /node_modules/@types/foo-bar/index.d.ts (0 errors) ====
+    export interface Foo {
+        bar: string;
+    }
+    
+    // This should error
+==== tests/cases/compiler/a.ts (1 errors) ====
+    import { Foo } from "@types/foo-bar";
+                        ~~~~~~~~~~~~~~~~
+!!! error TS2711: Cannot import type declaration files. Consider importing 'foo-bar' instead of '@types/foo-bar'.
+    

--- a/tests/baselines/reference/importDeclTypes.errors.txt
+++ b/tests/baselines/reference/importDeclTypes.errors.txt
@@ -1,4 +1,4 @@
-tests/cases/compiler/a.ts(1,21): error TS2711: Cannot import type declaration files. Consider importing 'foo-bar' instead of '@types/foo-bar'.
+tests/cases/compiler/a.ts(1,21): error TS6137: Cannot import type declaration files. Consider importing 'foo-bar' instead of '@types/foo-bar'.
 
 
 ==== /node_modules/@types/foo-bar/index.d.ts (0 errors) ====
@@ -10,5 +10,5 @@ tests/cases/compiler/a.ts(1,21): error TS2711: Cannot import type declaration fi
 ==== tests/cases/compiler/a.ts (1 errors) ====
     import { Foo } from "@types/foo-bar";
                         ~~~~~~~~~~~~~~~~
-!!! error TS2711: Cannot import type declaration files. Consider importing 'foo-bar' instead of '@types/foo-bar'.
+!!! error TS6137: Cannot import type declaration files. Consider importing 'foo-bar' instead of '@types/foo-bar'.
     

--- a/tests/baselines/reference/importDeclTypes.js
+++ b/tests/baselines/reference/importDeclTypes.js
@@ -1,0 +1,15 @@
+//// [tests/cases/compiler/importDeclTypes.ts] ////
+
+//// [index.d.ts]
+export interface Foo {
+    bar: string;
+}
+
+// This should error
+//// [a.ts]
+import { Foo } from "@types/foo-bar";
+
+
+//// [a.js]
+"use strict";
+exports.__esModule = true;

--- a/tests/cases/compiler/importDeclTypes.ts
+++ b/tests/cases/compiler/importDeclTypes.ts
@@ -1,0 +1,9 @@
+
+// @filename: /node_modules/@types/foo-bar/index.d.ts
+export interface Foo {
+    bar: string;
+}
+
+// This should error
+// @filename: a.ts
+import { Foo } from "@types/foo-bar";


### PR DESCRIPTION
Fix issue: #15540 

- Modify checker; external imports to account for imported modules
containing '@types/'.
- Add diagnostic message.
- Add test case

<!--
Thank you for submitting a pull request!

Here's a checklist you might find useful.
[ ] There is an associated issue that is labelled
  'Bug' or 'Accepting PRs' or is in the Community milestone
[ ] Code is up-to-date with the `master` branch
[ ] You've successfully run `jake runtests` locally
[ ] You've signed the CLA
[ ] There are new or updated unit tests validating the change

Refer to CONTRIBUTING.MD for more details.
  https://github.com/Microsoft/TypeScript/blob/master/CONTRIBUTING.md
-->

Fixes #15540
