### PR TITLE
findAncestor: Add generic overload for use with type predicates

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -1300,7 +1300,7 @@ namespace ts {
                     return <ImportEqualsDeclaration>node;
                 }
 
-                return findAncestor(node, n => n.kind === SyntaxKind.ImportDeclaration) as ImportDeclaration;
+                return findAncestor(node, isImportDeclaration);
             }
         }
 
@@ -22638,7 +22638,7 @@ namespace ts {
                             const symbolIsUmdExport = symbolFile !== referenceFile;
                             return symbolIsUmdExport ? undefined : symbolFile;
                         }
-                        return findAncestor(node.parent, n => isModuleOrEnumDeclaration(n) && getSymbolOfNode(n) === parentSymbol) as ModuleDeclaration | EnumDeclaration;
+                        return findAncestor(node.parent, (n): n is ModuleDeclaration | EnumDeclaration => isModuleOrEnumDeclaration(n) && getSymbolOfNode(n) === parentSymbol);
                     }
                 }
             }

--- a/src/compiler/core.ts
+++ b/src/compiler/core.ts
@@ -230,6 +230,8 @@ namespace ts {
      * If no such value is found, it applies the callback until the parent pointer is undefined or the callback returns "quit"
      * At that point findAncestor returns undefined.
      */
+    export function findAncestor<T extends Node>(node: Node, callback: (element: Node) => element is T): T | undefined;
+    export function findAncestor(node: Node, callback: (element: Node) => boolean | "quit"): Node | undefined;
     export function findAncestor(node: Node, callback: (element: Node) => boolean | "quit"): Node {
         while (node) {
             const result = callback(node);

--- a/src/compiler/utilities.ts
+++ b/src/compiler/utilities.ts
@@ -4010,6 +4010,10 @@ namespace ts {
         return node.kind === SyntaxKind.ImportEqualsDeclaration;
     }
 
+    export function isImportDeclaration(node: Node): node is ImportDeclaration {
+        return node.kind === SyntaxKind.ImportDeclaration;
+    }
+
     export function isImportClause(node: Node): node is ImportClause {
         return node.kind === SyntaxKind.ImportClause;
     }


### PR DESCRIPTION
Haven't got a lot of use out of this yet as the function is normally used just to detect whether the ancestor exists, without actually using the value.