### PR TITLE
getAllPossiblePropertiesOfTypes: Skip primitives

### DIFF
--- a/src/compiler/checker.ts
+++ b/src/compiler/checker.ts
@@ -5785,6 +5785,10 @@ namespace ts {
             if (type.flags & TypeFlags.Union) {
                 const props = createMap<Symbol>();
                 for (const memberType of (type as UnionType).types) {
+                    if (memberType.flags & TypeFlags.Primitive) {
+                        continue;
+                    }
+
                     for (const { name } of getPropertiesOfType(memberType)) {
                         if (!props.has(name)) {
                             props.set(name, createUnionOrIntersectionProperty(type as UnionType, name));

--- a/src/compiler/types.ts
+++ b/src/compiler/types.ts
@@ -2587,6 +2587,7 @@ namespace ts {
         /**
          * For a union, will include a property if it's defined in *any* of the member types.
          * So for `{ a } | { b }`, this will include both `a` and `b`.
+         * Does not include properties of primitive types.
          */
         /* @internal */ getAllPossiblePropertiesOfType(type: Type): Symbol[];
     }

--- a/tests/cases/fourslash/completionListOfUnion.ts
+++ b/tests/cases/fourslash/completionListOfUnion.ts
@@ -10,9 +10,11 @@
 ////f({ /*f*/ });
 
 goTo.marker("x");
+verify.completionListCount(3);
 verify.completionListContains("a", "(property) a: string | number");
 verify.completionListContains("b", "(property) b: number | boolean");
 verify.completionListContains("c", "(property) c: string");
 
 goTo.marker("f");
 verify.completionListContains("a", "(property) a: number");
+// Also contains array members

--- a/tests/cases/fourslash/completionListOfUnion.ts
+++ b/tests/cases/fourslash/completionListOfUnion.ts
@@ -2,8 +2,8 @@
 
 // @strictNullChecks: true
 
-// Non-objects should be skipped, so `| number | null` should have no effect on completions.
-////const x: { a: number, b: number } | { a: string, c: string } | { b: boolean } | number | null = { /*x*/ };
+// Primitives should be skipped, so `| number | null | undefined` should have no effect on completions.
+////const x: { a: number, b: number } | { a: string, c: string } | { b: boolean } | number | null | undefined = { /*x*/ };
 
 ////interface I { a: number; }
 ////function f(...args: Array<I | I[]>) {}


### PR DESCRIPTION
Fixes #15894
